### PR TITLE
Argon sidebar + dev hydration fix + sticky-height layout

### DIFF
--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -21,6 +21,19 @@ class HealthResponse(BaseModel):
     scheduler_lag_seconds: float | None = None
     last_full_scan_at: datetime | None = None
     reason: str | None = None
+    # Extra fields surfaced in the sidebar HealthPanel. Decoupled from the
+    # ok/reason gating above so a benign "no scans yet" still returns lag /
+    # watchlist size for the UI.
+    worker_lag_seconds: float | None = None
+    watchlist_size: int | None = None
+    source: str = "massive.com"
+    # Placeholders — wired up when we add request-metric collection.
+    latency_p95_ms: int | None = None
+    http_2xx: int | None = None
+    http_4xx: int | None = None
+    http_5xx: int | None = None
+    uw_today: int | None = None
+    cache_hit_pct: float | None = None
 
 
 def _full_scan_interval_seconds(cron_expr: str, tz: str) -> float:
@@ -56,12 +69,24 @@ def health(
             reason="database unreachable",
         )
 
+    # Sidebar fields — always populated when DB is up so the panel renders
+    # correctly even before the first full scan has fired.
+    heartbeat = repo.get_heartbeat("rescan_tick")
+    worker_lag = (
+        (datetime.now(timezone.utc) - heartbeat).total_seconds()
+        if heartbeat is not None
+        else None
+    )
+    watchlist_size = repo.count_active_watchlist()
+
     last_scan = repo.get_last_full_scan_finished_at()
     if last_scan is None:
         return HealthResponse(
             ok=False,
             db=db_status,
             reason="no successful full scan yet",
+            worker_lag_seconds=worker_lag,
+            watchlist_size=watchlist_size,
         )
 
     lag = (datetime.now(timezone.utc) - last_scan).total_seconds()
@@ -75,6 +100,8 @@ def health(
             scheduler_lag_seconds=lag,
             last_full_scan_at=last_scan,
             reason=f"scheduler lag {lag:.0f}s exceeds 2x interval ({threshold:.0f}s)",
+            worker_lag_seconds=worker_lag,
+            watchlist_size=watchlist_size,
         )
 
     return HealthResponse(
@@ -82,4 +109,6 @@ def health(
         db=db_status,
         scheduler_lag_seconds=lag,
         last_full_scan_at=last_scan,
+        worker_lag_seconds=worker_lag,
+        watchlist_size=watchlist_size,
     )

--- a/src/uw_scan/storage/migrations/013_worker_heartbeat.sql
+++ b/src/uw_scan/storage/migrations/013_worker_heartbeat.sql
@@ -1,0 +1,13 @@
+-- Migration 013: worker_heartbeat
+--
+-- One row per scheduled worker job. The job upserts its row each tick;
+-- the API computes lag as now() - last_beat_at to surface worker liveness
+-- (rendered in the sidebar HealthPanel).
+--
+-- Keyed by job_name so we can add more heartbeats later (full_scan,
+-- ohlc_pull, spot_refresh) without schema changes.
+
+CREATE TABLE IF NOT EXISTS uw_scan.worker_heartbeat (
+    job_name      text         PRIMARY KEY,
+    last_beat_at  timestamptz  NOT NULL DEFAULT now()
+);

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1552,6 +1552,37 @@ class Repository:
             row = cur.fetchone()
         return PcrHistoryRow(*row) if row else None
 
+    # ---- watchlist count (for HealthPanel) ----
+    def count_active_watchlist(self) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT COUNT(*) FROM {self._schema}.watchlist WHERE removed_at IS NULL"
+            )
+            row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+    # ---- worker_heartbeat ----
+    def upsert_heartbeat(self, job_name: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.worker_heartbeat (job_name, last_beat_at)
+                VALUES (%s, now())
+                ON CONFLICT (job_name) DO UPDATE SET last_beat_at = now()
+                """,
+                (job_name,),
+            )
+        self._conn.commit()
+
+    def get_heartbeat(self, job_name: str) -> datetime | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT last_beat_at FROM {self._schema}.worker_heartbeat WHERE job_name=%s",
+                (job_name,),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+
     # ---- strike_gex_curve (JSONB on scan_runs) ----
     def set_strike_gex_curve(self, run_id: int, curve: list[dict]) -> None:
         """Persist the per-strike, per-expiry GEX curve as JSONB on the run row."""

--- a/src/uw_scan/worker/jobs/rescan_loop.py
+++ b/src/uw_scan/worker/jobs/rescan_loop.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 def rescan_tick(repo, uw_client, ohlc_provider: OhlcProvider) -> bool:
     """Process one queued rescan. Returns True if a job ran, False if the queue was empty."""
     _ = ohlc_provider  # unused here; cards derive uses repo's persisted OHLC
+    # Heartbeat unconditionally — this loop fires every 1s, so its liveness
+    # is the closest signal we have to "worker is up." Sidebar HealthPanel
+    # reads now() - last_beat_at to render the worker dot.
+    repo.upsert_heartbeat("rescan_tick")
     job = repo.claim_next_queued_job()
     if job is None:
         return False

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -20,10 +20,25 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" data-theme="dark">
-      <body style={{ fontFamily: "var(--font-sans)", margin: 0 }}>
-        <div style={{ display: "flex", minHeight: "100vh" }}>
+      <body
+        style={{
+          fontFamily: "var(--font-sans)",
+          margin: 0,
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ display: "flex", height: "100vh" }}>
           <Sidebar />
-          <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
+          <main
+            style={{
+              flex: 1,
+              minWidth: 0,
+              height: "100vh",
+              overflowY: "auto",
+            }}
+          >
+            {children}
+          </main>
         </div>
       </body>
     </html>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,16 +6,26 @@ import "@fontsource/ibm-plex-mono/400.css";
 import "@fontsource/ibm-plex-mono/500.css";
 import "@fontsource/ibm-plex-mono/700.css";
 import "./globals.css";
+import { Sidebar } from "@/components/shared/Sidebar";
 
 export const metadata = {
-  title: "UW Watchlist",
+  title: "Argon",
   description: "Per-ticker options analytics, watchlist-driven",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en" data-theme="dark">
-      <body style={{ fontFamily: "var(--font-sans)" }}>{children}</body>
+      <body style={{ fontFamily: "var(--font-sans)", margin: 0 }}>
+        <div style={{ display: "flex", minHeight: "100vh" }}>
+          <Sidebar />
+          <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
+        </div>
+      </body>
     </html>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -35,7 +35,7 @@ export default async function DashboardPage({
     Object.fromEntries(sparklineEntries);
 
   return (
-    <main style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
       <header
         style={{
           display: "flex",
@@ -60,6 +60,6 @@ export default async function DashboardPage({
       </header>
       <FilterBar current={sp} />
       <CardGrid data={data} sparklines={sparklines} />
-    </main>
+    </div>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,4 +1,65 @@
-import { redirect } from "next/navigation";
-export default function Home() {
-  redirect("/watchlist");
+import { api } from "@/lib/api";
+import { CardGrid } from "@/components/watchlist/CardGrid";
+import { FilterBar } from "@/components/watchlist/FilterBar";
+import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
+import { ScanAllButton } from "@/components/shared/ScanAllButton";
+
+// Skip the Router Cache so sector/setup chip clicks refetch with new
+// searchParams instead of reusing the unfiltered RSC payload.
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | undefined>>;
+}) {
+  const sp = await searchParams;
+  const qs = new URLSearchParams();
+  if (sp.sector) qs.set("sector", sp.sector);
+  if (sp.setup) qs.set("setup", sp.setup);
+  if (sp.fresh) qs.set("fresh_within_minutes", sp.fresh);
+  const data = await api.watchlist(qs);
+
+  const sparklineEntries = await Promise.all(
+    data.tickers.map(async (t) => {
+      try {
+        const bars = await api.ohlc(t.ticker, 30);
+        const closes = bars.map((b) => Number(b.close)).reverse();
+        return [t.ticker, closes] as const;
+      } catch {
+        return [t.ticker, [] as number[]] as const;
+      }
+    }),
+  );
+  const sparklines: Record<string, number[]> =
+    Object.fromEntries(sparklineEntries);
+
+  return (
+    <main style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: 16,
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 24,
+            letterSpacing: 1,
+          }}
+        >
+          DASHBOARD
+        </h1>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <ScanAllButton />
+          <AddTickerDialog />
+        </div>
+      </header>
+      <FilterBar current={sp} />
+      <CardGrid data={data} sparklines={sparklines} />
+    </main>
+  );
 }

--- a/web/app/scanner/page.tsx
+++ b/web/app/scanner/page.tsx
@@ -1,0 +1,31 @@
+export const dynamic = "force-dynamic";
+
+export default function ScannerPage() {
+  return (
+    <main style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
+      <h1
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 24,
+          letterSpacing: 1,
+          marginBottom: 16,
+        }}
+      >
+        SCANNER
+      </h1>
+      <div
+        style={{
+          padding: 24,
+          border: "1px dashed var(--border-dim)",
+          borderRadius: 4,
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          textAlign: "center",
+        }}
+      >
+        scanner — coming soon
+      </div>
+    </main>
+  );
+}

--- a/web/app/scanner/page.tsx
+++ b/web/app/scanner/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 export default function ScannerPage() {
   return (
-    <main style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
+    <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
       <h1
         style={{
           fontFamily: "var(--font-mono)",
@@ -26,6 +26,6 @@ export default function ScannerPage() {
       >
         scanner — coming soon
       </div>
-    </main>
+    </div>
   );
 }

--- a/web/app/stock/[ticker]/layout.tsx
+++ b/web/app/stock/[ticker]/layout.tsx
@@ -14,7 +14,7 @@ export default async function StockLayout({
   const report = await api.stock(ticker);
 
   return (
-    <main style={{ minHeight: "100vh", background: "var(--bg-base)" }}>
+    <div style={{ minHeight: "100%", background: "var(--bg-base)" }}>
       <DetailHeader
         ticker={report.ticker}
         spot={toNum(report.market_structure.spot)}
@@ -27,6 +27,6 @@ export default async function StockLayout({
       />
       <TabBar ticker={ticker} />
       <div style={{ padding: 16 }}>{children}</div>
-    </main>
+    </div>
   );
 }

--- a/web/app/watchlist/page.tsx
+++ b/web/app/watchlist/page.tsx
@@ -1,74 +1,7 @@
-import { api } from "@/lib/api";
-import { CardGrid } from "@/components/watchlist/CardGrid";
-import { FilterBar } from "@/components/watchlist/FilterBar";
-import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
-import { ScanAllButton } from "@/components/shared/ScanAllButton";
+import { redirect } from "next/navigation";
 
-export default async function WatchlistPage({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string | undefined>>;
-}) {
-  const sp = await searchParams;
-  const qs = new URLSearchParams();
-  if (sp.sector) qs.set("sector", sp.sector);
-  if (sp.setup) qs.set("setup", sp.setup);
-  if (sp.fresh) qs.set("fresh_within_minutes", sp.fresh);
-  const data = await api.watchlist(qs);
-
-  const sparklineEntries = await Promise.all(
-    data.tickers.map(async (t) => {
-      try {
-        const bars = await api.ohlc(t.ticker, 30);
-        // /api/ohlc returns newest-first; sparkline draws left-to-right
-        // chronological, so reverse to oldest-first.
-        const closes = bars.map((b) => Number(b.close)).reverse();
-        return [t.ticker, closes] as const;
-      } catch {
-        return [t.ticker, [] as number[]] as const;
-      }
-    }),
-  );
-  const sparklines: Record<string, number[]> =
-    Object.fromEntries(sparklineEntries);
-
-  return (
-    <main style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
-      <header
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "baseline",
-          marginBottom: 16,
-        }}
-      >
-        <h1
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 24,
-            letterSpacing: 1,
-          }}
-        >
-          WATCHLIST
-        </h1>
-        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <span
-            style={{
-              color: "var(--text-muted)",
-              fontSize: 12,
-              fontFamily: "var(--font-mono)",
-            }}
-          >
-            {data.scheduler_lag_seconds != null
-              ? `scheduler: ${Math.round(data.scheduler_lag_seconds)}s lag`
-              : "scheduler: unknown"}
-          </span>
-          <ScanAllButton />
-          <AddTickerDialog />
-        </div>
-      </header>
-      <FilterBar current={sp} />
-      <CardGrid data={data} sparklines={sparklines} />
-    </main>
-  );
+// Watchlist content moved to / (root). Keep /watchlist as a permanent
+// redirect so existing bookmarks still land on the dashboard.
+export default function WatchlistRedirect() {
+  redirect("/");
 }

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -1,0 +1,127 @@
+"use client";
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import type { components } from "@/lib/types";
+
+type Health = components["schemas"]["HealthResponse"];
+
+// Worker is considered healthy if its last heartbeat is within this window.
+// rescan_tick fires every 1s, so anything > 5s means the loop is stalled.
+const WORKER_HEALTHY_LAG_S = 5;
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  padding: "3px 0",
+  color: "var(--text-muted)",
+};
+const valStyle: React.CSSProperties = {
+  color: "var(--text-secondary)",
+};
+
+function dash(v: number | string | null | undefined, suffix = ""): string {
+  if (v == null || v === "") return "—";
+  return `${v}${suffix}`;
+}
+
+function timeOnly(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleTimeString(undefined, { hour12: false });
+}
+
+export function HealthPanel() {
+  const [h, setH] = useState<Health | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const r = await api.health();
+        if (!cancelled) setH(r);
+      } catch {
+        if (!cancelled) setH(null);
+      }
+    };
+    fetchOnce();
+    const t = setInterval(fetchOnce, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const workerOnline =
+    h?.worker_lag_seconds != null &&
+    h.worker_lag_seconds <= WORKER_HEALTHY_LAG_S;
+  const workerColor = workerOnline ? "var(--positive)" : "var(--negative)";
+  const workerLabel =
+    h?.worker_lag_seconds == null
+      ? "UNKNOWN"
+      : workerOnline
+        ? "ONLINE"
+        : "OFFLINE";
+
+  return (
+    <div
+      style={{
+        borderTop: "1px solid var(--border-dim)",
+        padding: "12px 16px",
+      }}
+    >
+      <div style={rowStyle}>
+        <span>Worker</span>
+        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              background: workerColor,
+              display: "inline-block",
+            }}
+          />
+          <span style={valStyle}>{workerLabel}</span>
+        </span>
+      </div>
+      <div style={rowStyle}>
+        <span>Last Scan</span>
+        <span style={valStyle}>{timeOnly(h?.last_full_scan_at)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>Source</span>
+        <span style={valStyle}>{h?.source ?? "massive.com"}</span>
+      </div>
+      <div
+        style={{
+          borderTop: "1px solid var(--border-dim)",
+          margin: "8px 0",
+        }}
+      />
+      <div style={rowStyle}>
+        <span>Watchlist</span>
+        <span style={valStyle}>{dash(h?.watchlist_size)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>Cache Hit</span>
+        <span style={valStyle}>{dash(h?.cache_hit_pct, "%")}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>Latency p95</span>
+        <span style={valStyle}>{dash(h?.latency_p95_ms, "ms")}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>2xx</span>
+        <span style={valStyle}>{dash(h?.http_2xx)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>4xx</span>
+        <span style={valStyle}>{dash(h?.http_4xx)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span>5xx</span>
+        <span style={valStyle}>{dash(h?.http_5xx)}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/components/shared/RescanButton.tsx
+++ b/web/components/shared/RescanButton.tsx
@@ -12,7 +12,15 @@ export function RescanButton({ ticker }: { ticker: string }) {
 
   useEffect(() => {
     if (!jobId) return;
+    // Self-cancel after 60s so a zombie 'running' job (worker crashed mid-scan)
+    // doesn't keep polling forever and refreshing the page.
+    const startedAt = Date.now();
     const t = setInterval(async () => {
+      if (Date.now() - startedAt > 60_000) {
+        clearInterval(t);
+        setStatus("failed");
+        return;
+      }
       try {
         const r = await api.job(jobId);
         setStatus(r.status as Status);

--- a/web/components/shared/ScanAllButton.tsx
+++ b/web/components/shared/ScanAllButton.tsx
@@ -13,7 +13,16 @@ export function ScanAllButton() {
 
   useEffect(() => {
     if (phase !== "polling" || pendingIds.length === 0) return;
+    // Bail after 10 min so a zombie 'running' job can't keep this polling
+    // indefinitely. A full 97-ticker scan typically finishes well under this.
+    const startedAt = Date.now();
     const t = setInterval(async () => {
+      if (Date.now() - startedAt > 600_000) {
+        clearInterval(t);
+        setPhase("failed");
+        router.refresh();
+        return;
+      }
       try {
         const results = await Promise.all(
           pendingIds.map((id) => api.job(id).catch(() => null)),

--- a/web/components/shared/Sidebar.tsx
+++ b/web/components/shared/Sidebar.tsx
@@ -20,7 +20,8 @@ export function Sidebar() {
         borderRight: "1px solid var(--border-dim)",
         display: "flex",
         flexDirection: "column",
-        minHeight: "100vh",
+        height: "100vh",
+        overflowY: "auto",
       }}
     >
       <div

--- a/web/components/shared/Sidebar.tsx
+++ b/web/components/shared/Sidebar.tsx
@@ -1,0 +1,91 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { LayoutDashboard, ScanLine } from "lucide-react";
+import { HealthPanel } from "./HealthPanel";
+
+const NAV = [
+  { href: "/", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/scanner", label: "Scanner", icon: ScanLine },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside
+      style={{
+        width: 220,
+        flexShrink: 0,
+        background: "var(--bg-panel)",
+        borderRight: "1px solid var(--border-dim)",
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100vh",
+      }}
+    >
+      <div
+        style={{
+          padding: "20px 16px",
+          borderBottom: "1px solid var(--border-dim)",
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+        }}
+      >
+        <span
+          style={{
+            width: 14,
+            height: 14,
+            background: "var(--text-primary)",
+            display: "inline-block",
+          }}
+        />
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontWeight: 700,
+            letterSpacing: 2,
+            fontSize: 14,
+            color: "var(--text-primary)",
+          }}
+        >
+          ARGON
+        </span>
+      </div>
+
+      <nav style={{ padding: "8px 0", flex: 1 }}>
+        {NAV.map(({ href, label, icon: Icon }) => {
+          const active =
+            href === "/" ? pathname === "/" : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "10px 16px",
+                fontFamily: "var(--font-mono)",
+                fontSize: 13,
+                color: active ? "var(--text-primary)" : "var(--text-muted)",
+                background: active
+                  ? "var(--bg-active, rgba(255,255,255,0.04))"
+                  : "transparent",
+                borderLeft: active
+                  ? "2px solid var(--text-primary)"
+                  : "2px solid transparent",
+                textDecoration: "none",
+              }}
+            >
+              <Icon size={16} strokeWidth={1.5} />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <HealthPanel />
+    </aside>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -15,6 +15,7 @@ type WatchlistResponse = Json<"/api/watchlist", "get">;
 type SingleStockReport = Json<"/api/stock/{ticker}", "get">;
 type JobStatus = Json<"/api/jobs/{job_id}", "get">;
 type OhlcResponse = Json<"/api/ohlc/{ticker}", "get">;
+type HealthResponse = Json<"/api/health", "get">;
 
 async function _fetch<T>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(`${API}${path}`, {
@@ -50,6 +51,7 @@ export const api = {
     _fetch<JobStatus[]>(`/api/watchlist/rescan-all`, { method: "POST" }),
   job: (jobId: string): Promise<JobStatus> =>
     _fetch<JobStatus>(`/api/jobs/${jobId}`),
+  health: (): Promise<HealthResponse> => _fetch<HealthResponse>(`/api/health`),
   addTicker: (body: {
     ticker: string;
     sector: string;

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -294,6 +294,27 @@ export interface components {
             last_full_scan_at?: string | null;
             /** Reason */
             reason?: string | null;
+            /** Worker Lag Seconds */
+            worker_lag_seconds?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
+            /**
+             * Source
+             * @default massive.com
+             */
+            source: string;
+            /** Latency P95 Ms */
+            latency_p95_ms?: number | null;
+            /** Http 2Xx */
+            http_2xx?: number | null;
+            /** Http 4Xx */
+            http_4xx?: number | null;
+            /** Http 5Xx */
+            http_5xx?: number | null;
+            /** Uw Today */
+            uw_today?: number | null;
+            /** Cache Hit Pct */
+            cache_hit_pct?: number | null;
         };
         /** JobStatus */
         JobStatus: {

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Next 16 blocks cross-origin requests to dev resources (incl. the HMR
+  // WebSocket) by default. Without this, hydration silently fails and the
+  // page renders as static HTML. Add the hosts dev.sh actually serves on.
+  allowedDevOrigins: ["127.0.0.1", "localhost"],
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary

Three loosely-related improvements bundled because they were uncovered diagnosing the same symptom (\"filter chips don't filter\"):

- **Fix dev hydration** — `next.config.mjs` now sets `allowedDevOrigins`. Next 16 blocks the HMR WebSocket by default, which aborts the dev runtime before `React.hydrateRoot()` runs. Result: every page rendered as static HTML with no event handlers, and the HMR retry loop force-reloaded the tab every 1–2s (the \"blink\").
- **Argon sidebar with live HealthPanel** — App-wide sidebar with Dashboard + Scanner nav. Bottom panel polls `/api/health` every 5s for `worker_lag_seconds`, `last_full_scan_at`, `watchlist_size`, plus placeholder rows for cache/latency/HTTP counts. Worker liveness backed by a new `uw_scan.worker_heartbeat` table; `rescan_tick` (1 Hz) upserts its row each tick.
- **Sticky-height layout** — Sidebar now stays glued to the viewport at full height; main pane is its own scroll container. Two independent scroll regions instead of one document-level scroll.

## Other changes

- Dashboard moved from `/watchlist` to `/` (root). `/watchlist` now redirects.
- `/scanner` placeholder route added.
- Polling watchdogs: `RescanButton` (60s cap), `ScanAllButton` (10min cap) — prevents stuck polling against zombie `running` jobs.
- DB migration 013: `worker_heartbeat (job_name PK, last_beat_at)`.
- API `HealthResponse` extended with sidebar fields (decoupled from the `ok` gate so the panel always renders).

## Test plan

- [ ] Hard-reload `/` after pulling. Confirm sidebar renders with brand \"ARGON\", Dashboard + Scanner nav, HealthPanel at bottom.
- [ ] Worker dot turns green within 5 seconds (worker_lag_seconds < 5).
- [ ] Click sector chips (M7, Memory, Power) — grid filters correctly, URL updates to `?sector=X`.
- [ ] Scroll the dashboard. Sidebar stays visible, doesn't scroll with content.
- [ ] Visit `/stock/AAPL` — sidebar still visible, page scrolls inside its own container.
- [ ] Visit `/watchlist` — redirects to `/`.
- [ ] Visit `/scanner` — placeholder \"coming soon\" page.
- [ ] CI: ruff + pytest + integration tests all green (no schema-count drift; migration 013 is purely additive).