### PR TITLE
Market Structure tab — GEX levels, bias, profile, history, max-pain

### DIFF
--- a/src/uw_scan/api/routers/stock.py
+++ b/src/uw_scan/api/routers/stock.py
@@ -2,14 +2,42 @@
 
 from __future__ import annotations
 
+from datetime import date as _date
+from decimal import Decimal
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from uw_scan.api.deps import get_repo
-from uw_scan.models import SingleStockReport
+from uw_scan.cards.gex import classify_bias, find_flip_strike
+from uw_scan.models import (
+    SingleStockReport,
+    StockHistoryResponse,
+    StockHistoryRow,
+    StrikeGexBucket,
+)
 from uw_scan.reports.single_stock import assemble_single_stock_report
 from uw_scan.storage.repository import Repository
 
 router = APIRouter()
+
+
+def _dec(v: object) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def _build_curve(raw: list[dict]) -> list[StrikeGexBucket]:
+    return [
+        StrikeGexBucket(
+            strike=Decimal(str(row["strike"])),
+            expiry=_date.fromisoformat(row["expiry"]),
+            net_gex=_dec(row.get("net_gex")),
+            call_gex=_dec(row.get("call_gex")),
+            put_gex=_dec(row.get("put_gex")),
+        )
+        for row in raw
+    ]
 
 
 @router.get("/stock/{ticker}", response_model=SingleStockReport)
@@ -19,6 +47,38 @@ def get_stock(ticker: str, repo: Repository = Depends(get_repo)) -> SingleStockR
     if run_id == 0:
         raise HTTPException(status_code=404, detail=f"no runs for {t}")
     return assemble_single_stock_report(t, run_id, repo)
+
+
+@router.get("/stock/{ticker}/history", response_model=StockHistoryResponse)
+def get_stock_history(
+    ticker: str, repo: Repository = Depends(get_repo)
+) -> StockHistoryResponse:
+    """Daily rollup for the Market Structure tab's history table.
+
+    One row per trading day, sorted newest-first. Today's row may have
+    spot=None if the post-close OHLC pull hasn't fired yet.
+    """
+    t = ticker.upper()
+    raw_rows = repo.fetch_stock_history_rollup(t, limit=30)
+    rows: list[StockHistoryRow] = []
+    for r in raw_rows:
+        curve = _build_curve(r["strike_gex_curve"] or [])
+        net_gex = sum((b.net_gex for b in curve if b.net_gex is not None), Decimal("0"))
+        flip = find_flip_strike(curve)
+        spot = _dec(r.get("spot"))
+        rows.append(
+            StockHistoryRow(
+                market_date=r["market_date"],
+                spot=spot,
+                gex_flip=flip,
+                net_gex=net_gex if curve else None,
+                net_dex=None,
+                iv30d=_dec(r.get("iv30d")),
+                pcr_vol=_dec(r.get("pcr_vol")),
+                bias=classify_bias(spot, flip, net_gex if curve else None),
+            )
+        )
+    return StockHistoryResponse(ticker=t, rows=rows)
 
 
 @router.get("/stock/{ticker}/runs")

--- a/src/uw_scan/cards/gex.py
+++ b/src/uw_scan/cards/gex.py
@@ -6,7 +6,26 @@ from collections import defaultdict
 from datetime import date
 from decimal import Decimal
 
-from uw_scan.models import StrikeGexBucket
+from uw_scan.models import GexLevel, MarketStructureLevels, StrikeGexBucket
+
+
+def _aggregate_per_strike(
+    curve: list[StrikeGexBucket],
+) -> dict[Decimal, tuple[Decimal, Decimal, Decimal]]:
+    """Sum each strike's gamma fields across expiries. Returns
+    {strike -> (net_gex, call_gex, put_gex)}."""
+    net: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    call: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    put: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    for b in curve:
+        if b.net_gex is not None:
+            net[b.strike] += b.net_gex
+        if b.call_gex is not None:
+            call[b.strike] += b.call_gex
+        if b.put_gex is not None:
+            put[b.strike] += b.put_gex
+    strikes = set(net) | set(call) | set(put)
+    return {s: (net[s], call[s], put[s]) for s in strikes}
 
 
 def find_flip_strike(curve: list[StrikeGexBucket]) -> Decimal | None:
@@ -71,3 +90,100 @@ def nearest_expiry(curve: list[StrikeGexBucket]) -> date | None:
     if not curve:
         return None
     return min(b.expiry for b in curve)
+
+
+def _make_level(
+    strike: Decimal,
+    spot: Decimal | None,
+    net_gex: Decimal,
+) -> GexLevel:
+    pct = ((strike - spot) / spot) if spot else None
+    return GexLevel(
+        strike=strike,
+        net_gex=net_gex,
+        pct_from_spot=pct,
+        gamma_per_dollar=net_gex,
+    )
+
+
+def compute_market_structure_levels(
+    curve: list[StrikeGexBucket],
+    spot: Decimal | None,
+) -> MarketStructureLevels:
+    """Derive the 6 reference levels used by the Market Structure tab.
+
+    See MarketStructureLevels docstring for definitions. All None when the curve
+    is empty or spot is missing.
+    """
+    levels = MarketStructureLevels()
+    if not curve or spot is None:
+        return levels
+
+    agg = _aggregate_per_strike(curve)
+    if not agg:
+        return levels
+
+    flip_strike = find_flip_strike(curve)
+    if flip_strike is not None and flip_strike in agg:
+        levels.gex_flip = _make_level(flip_strike, spot, agg[flip_strike][0])
+
+    # CALL WALL: largest call-side gamma — typically above spot, acts as resistance.
+    call_candidates = [(s, c) for s, (_, c, _) in agg.items() if c > 0]
+    if call_candidates:
+        s, _ = max(call_candidates, key=lambda kv: kv[1])
+        levels.call_wall = _make_level(s, spot, agg[s][0])
+
+    # PUT WALL: largest put-side gamma magnitude — typically below spot, acts as support.
+    # put_gex is stored as a positive magnitude in our data; if it's signed, abs() handles both.
+    put_candidates = [(s, p) for s, (_, _, p) in agg.items() if p != 0]
+    if put_candidates:
+        s, _ = max(put_candidates, key=lambda kv: abs(kv[1]))
+        levels.put_wall = _make_level(s, spot, agg[s][0])
+
+    # MAGNETS: positive net_gex strikes ABOVE spot, ranked by net_gex desc.
+    above_pos = sorted(
+        ((s, n) for s, (n, _, _) in agg.items() if s > spot and n > 0),
+        key=lambda kv: kv[1],
+        reverse=True,
+    )
+    if above_pos:
+        levels.max_magnet = _make_level(above_pos[0][0], spot, above_pos[0][1])
+    if len(above_pos) > 1:
+        levels.second_magnet = _make_level(above_pos[1][0], spot, above_pos[1][1])
+
+    # MAX ACCEL: most-negative net_gex below the flip (where moves accelerate).
+    # Falls back to "below spot" when there's no flip yet.
+    floor = flip_strike if flip_strike is not None else spot
+    below_neg = sorted(
+        ((s, n) for s, (n, _, _) in agg.items() if s < floor and n < 0),
+        key=lambda kv: kv[1],
+    )
+    if below_neg:
+        levels.max_accel = _make_level(below_neg[0][0], spot, below_neg[0][1])
+
+    return levels
+
+
+def classify_bias(
+    spot: Decimal | None,
+    gex_flip: Decimal | None,
+    net_gex: Decimal | None,
+) -> str:
+    """Directional regime label from spot relative to flip + net gamma sign.
+
+    BULL = above flip + positive gamma (stabilizing).
+    BEAR = below flip + negative gamma (destabilizing).
+    CAUTIOUS_BULL / CAUTIOUS_BEAR = direction matches, gamma sign doesn't.
+    NEUTRAL = any input missing.
+    """
+    if spot is None or gex_flip is None or net_gex is None:
+        return "NEUTRAL"
+    above = spot > gex_flip
+    stabilizing = net_gex > 0
+    if above and stabilizing:
+        return "BULL"
+    if not above and not stabilizing:
+        return "BEAR"
+    if above:
+        return "CAUTIOUS_BULL"
+    return "CAUTIOUS_BEAR"

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -476,6 +476,62 @@ class StrikeGexBucket(_UwBase):
     put_gex: Decimal | None = None
 
 
+class GexLevel(_UwBase):
+    """One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).
+
+    `gamma_per_dollar` is the per-strike net_gex used as the "$N per $1" sensitivity
+    figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
+    """
+
+    strike: Decimal
+    net_gex: Decimal | None = None
+    pct_from_spot: Decimal | None = None
+    gamma_per_dollar: Decimal | None = None
+
+
+class MarketStructureLevels(_UwBase):
+    """Derived strike-level reference points used by the Market Structure tab.
+
+    Conventions follow FlashAlpha / SpotGamma:
+      - gex_flip: lowest strike where running cumulative net_gex flips sign
+      - call_wall: strike with largest call-side gamma (typically above spot)
+      - put_wall: strike with largest put-side gamma magnitude (typically below spot)
+      - max_magnet: strike with largest positive net_gex above spot (pulls price up)
+      - second_magnet: strike with second-largest positive net_gex above spot
+      - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
+    """
+
+    gex_flip: GexLevel | None = None
+    call_wall: GexLevel | None = None
+    put_wall: GexLevel | None = None
+    max_magnet: GexLevel | None = None
+    second_magnet: GexLevel | None = None
+    max_accel: GexLevel | None = None
+
+
+class StockHistoryRow(_UwBase):
+    """One per-trading-day rollup of a ticker's market structure.
+
+    Built from the latest successful scan_run on that date. spot comes from
+    daily_ohlc.close so it's a stable end-of-day reference (NULL for the
+    current trading day until the OHLC pull fires post-close).
+    """
+
+    market_date: _date
+    spot: Decimal | None = None
+    gex_flip: Decimal | None = None
+    net_gex: Decimal | None = None
+    net_dex: Decimal | None = None
+    iv30d: Decimal | None = None
+    pcr_vol: Decimal | None = None
+    bias: str = "NEUTRAL"
+
+
+class StockHistoryResponse(_UwBase):
+    ticker: str
+    rows: list[StockHistoryRow] = []
+
+
 class SingleStockReport(_UwBase):
     run_id: int
     ticker: str
@@ -494,3 +550,4 @@ class SingleStockReport(_UwBase):
     oi_change_top: list[OiChangeRow] = []
     aggregates: MarketAggregates | None = None
     strike_gex_curve: list[StrikeGexBucket] = []
+    market_structure_levels: MarketStructureLevels | None = None

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from datetime import date as _date
 from decimal import Decimal
 
+from ..cards.gex import compute_market_structure_levels
 from ..models import (
     FlowAlert,
     FlowSnapshot,
@@ -411,6 +412,10 @@ def assemble_single_stock_report(
     ]
     aggregates = repo.get_aggregates(run_id)
 
+    market_structure_levels = compute_market_structure_levels(
+        strike_gex_curve, market_structure.spot
+    )
+
     return SingleStockReport(
         run_id=run_id,
         ticker=ticker,
@@ -428,6 +433,7 @@ def assemble_single_stock_report(
         oi_change_top=oi_change_top,
         strike_gex_curve=strike_gex_curve,
         aggregates=aggregates,
+        market_structure_levels=market_structure_levels,
     )
 
 

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1552,6 +1552,52 @@ class Repository:
             row = cur.fetchone()
         return PcrHistoryRow(*row) if row else None
 
+    # ---- stock history rollup (for Market Structure history table) ----
+    def fetch_stock_history_rollup(self, ticker: str, limit: int = 30) -> list[dict]:
+        """One row per trading day, latest successful scan_run on that date.
+
+        Joins to daily_ohlc for end-of-day spot. Returns dicts shaped for
+        api.routers.stock to wrap in StockHistoryRow models.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                WITH daily_runs AS (
+                    SELECT DISTINCT ON (started_at::date)
+                        started_at::date AS market_date,
+                        strike_gex_curve,
+                        aggregates
+                    FROM {self._schema}.scan_runs
+                    WHERE ticker = %s
+                      AND status = 'ok'
+                      AND strike_gex_curve IS NOT NULL
+                    ORDER BY started_at::date DESC, started_at DESC
+                )
+                SELECT
+                    r.market_date,
+                    d.close AS spot,
+                    r.aggregates->>'iv30d' AS iv30d,
+                    r.aggregates->>'pcr_vol' AS pcr_vol,
+                    r.strike_gex_curve
+                FROM daily_runs r
+                LEFT JOIN {self._schema}.daily_ohlc d
+                  ON d.ticker = %s AND d.date = r.market_date
+                ORDER BY r.market_date DESC
+                LIMIT %s
+                """,
+                (ticker, ticker, limit),
+            )
+            return [
+                {
+                    "market_date": row[0],
+                    "spot": row[1],
+                    "iv30d": row[2],
+                    "pcr_vol": row[3],
+                    "strike_gex_curve": row[4],
+                }
+                for row in cur.fetchall()
+            ]
+
     # ---- watchlist count (for HealthPanel) ----
     def count_active_watchlist(self) -> int:
         with self._conn.cursor() as cur:

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -280,6 +280,49 @@
         }
       }
     },
+    "/api/stock/{ticker}/history": {
+      "get": {
+        "tags": [
+          "stock"
+        ],
+        "summary": "Get Stock History",
+        "description": "Daily rollup for the Market Structure tab's history table.\n\nOne row per trading day, sorted newest-first. Today's row may have\nspot=None if the post-close OHLC pull hasn't fired yet.",
+        "operationId": "get_stock_history_api_stock__ticker__history_get",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Ticker"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StockHistoryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/stock/{ticker}/runs": {
       "get": {
         "tags": [
@@ -988,6 +1031,57 @@
         "type": "object",
         "title": "GammaBlock"
       },
+      "GexLevel": {
+        "properties": {
+          "strike": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike"
+          },
+          "net_gex": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Gex"
+          },
+          "pct_from_spot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pct From Spot"
+          },
+          "gamma_per_dollar": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gamma Per Dollar"
+          }
+        },
+        "type": "object",
+        "required": [
+          "strike"
+        ],
+        "title": "GexLevel",
+        "description": "One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).\n\n`gamma_per_dollar` is the per-strike net_gex used as the \"$N per $1\" sensitivity\nfigure on the tile \u2014 the dollar value of dealer hedging triggered by a $1 move."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -1044,6 +1138,99 @@
               }
             ],
             "title": "Reason"
+          },
+          "worker_lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Lag Seconds"
+          },
+          "watchlist_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Watchlist Size"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "massive.com"
+          },
+          "latency_p95_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency P95 Ms"
+          },
+          "http_2xx": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http 2Xx"
+          },
+          "http_4xx": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http 4Xx"
+          },
+          "http_5xx": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http 5Xx"
+          },
+          "uw_today": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uw Today"
+          },
+          "cache_hit_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Hit Pct"
           }
         },
         "type": "object",
@@ -1373,6 +1560,73 @@
         },
         "type": "object",
         "title": "MarketStructure"
+      },
+      "MarketStructureLevels": {
+        "properties": {
+          "gex_flip": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "call_wall": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "put_wall": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_magnet": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "second_magnet": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_accel": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "MarketStructureLevels",
+        "description": "Derived strike-level reference points used by the Market Structure tab.\n\nConventions follow FlashAlpha / SpotGamma:\n  - gex_flip: lowest strike where running cumulative net_gex flips sign\n  - call_wall: strike with largest call-side gamma (typically above spot)\n  - put_wall: strike with largest put-side gamma magnitude (typically below spot)\n  - max_magnet: strike with largest positive net_gex above spot (pulls price up)\n  - second_magnet: strike with second-largest positive net_gex above spot\n  - max_accel: strike with most-negative net_gex below the flip (movement accelerator)"
       },
       "MaxPainRow": {
         "properties": {
@@ -2067,6 +2321,16 @@
             "type": "array",
             "title": "Strike Gex Curve",
             "default": []
+          },
+          "market_structure_levels": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MarketStructureLevels"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -2098,6 +2362,119 @@
         },
         "type": "object",
         "title": "SkewBlock"
+      },
+      "StockHistoryResponse": {
+        "properties": {
+          "ticker": {
+            "type": "string",
+            "title": "Ticker"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/StockHistoryRow"
+            },
+            "type": "array",
+            "title": "Rows",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "ticker"
+        ],
+        "title": "StockHistoryResponse"
+      },
+      "StockHistoryRow": {
+        "properties": {
+          "market_date": {
+            "type": "string",
+            "format": "date",
+            "title": "Market Date"
+          },
+          "spot": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
+          "gex_flip": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gex Flip"
+          },
+          "net_gex": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Gex"
+          },
+          "net_dex": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Dex"
+          },
+          "iv30d": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv30D"
+          },
+          "pcr_vol": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pcr Vol"
+          },
+          "bias": {
+            "type": "string",
+            "title": "Bias",
+            "default": "NEUTRAL"
+          }
+        },
+        "type": "object",
+        "required": [
+          "market_date"
+        ],
+        "title": "StockHistoryRow",
+        "description": "One per-trading-day rollup of a ticker's market structure.\n\nBuilt from the latest successful scan_run on that date. spot comes from\ndaily_ohlc.close so it's a stable end-of-day reference (NULL for the\ncurrent trading day until the OHLC pull fires post-close)."
       },
       "StrikeGexBucket": {
         "properties": {

--- a/web/components/stock/panels/DirectionalBiasPanel.tsx
+++ b/web/components/stock/panels/DirectionalBiasPanel.tsx
@@ -1,0 +1,178 @@
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+type HistoryRow = components["schemas"]["StockHistoryRow"];
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: 16,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  marginBottom: 12,
+};
+
+const biasColors: Record<string, string> = {
+  BULL: "var(--positive)",
+  BEAR: "var(--negative)",
+  CAUTIOUS_BULL: "var(--warning)",
+  CAUTIOUS_BEAR: "var(--warning)",
+  NEUTRAL: "var(--text-secondary)",
+};
+
+const biasArrows: Record<string, string> = {
+  BULL: "↗",
+  BEAR: "↘",
+  CAUTIOUS_BULL: "↗",
+  CAUTIOUS_BEAR: "↘",
+  NEUTRAL: "→",
+};
+
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function classifyClient(
+  spot: number | null,
+  flip: number | null,
+  netGex: number | null,
+): string {
+  if (spot == null || flip == null || netGex == null) return "NEUTRAL";
+  const above = spot > flip;
+  const stab = netGex > 0;
+  if (above && stab) return "BULL";
+  if (!above && !stab) return "BEAR";
+  return above ? "CAUTIOUS_BULL" : "CAUTIOUS_BEAR";
+}
+
+function buildRationale(report: Report): string[] {
+  const m = report.market_structure;
+  const lv = report.market_structure_levels;
+  const spot = toNum(m.spot);
+  const flip = lv?.gex_flip ? toNum(lv.gex_flip.strike) : null;
+  const netGex = toNum(m.net_gex);
+  const maxMagnet = lv?.max_magnet ? toNum(lv.max_magnet.strike) : null;
+
+  const out: string[] = [];
+  if (spot != null && flip != null) {
+    out.push(
+      spot > flip
+        ? `Spot above flip (${fmtNum(flip, 2)})`
+        : `Spot below flip (${fmtNum(flip, 2)})`,
+    );
+  }
+  if (netGex != null) {
+    out.push(
+      netGex > 0
+        ? "Net GEX positive (stabilizing)"
+        : "Net GEX negative (destabilizing)",
+    );
+  }
+  if (maxMagnet != null && spot != null) {
+    out.push(
+      maxMagnet > spot
+        ? `Max magnet at ${fmtNum(maxMagnet, 2)} pulls higher`
+        : `Max magnet at ${fmtNum(maxMagnet, 2)} pulls lower`,
+    );
+  }
+  return out;
+}
+
+function flipMigration(rows: HistoryRow[]): string {
+  // Last 5 daily flips, oldest → newest with arrows.
+  const recent = rows.slice(0, 5).reverse();
+  const flips = recent
+    .map((r) => (r.gex_flip != null ? fmtNum(Number(r.gex_flip), 2) : "—"))
+    .join(" → ");
+  return flips || "—";
+}
+
+export function DirectionalBiasPanel({
+  report,
+  history,
+}: {
+  report: Report;
+  history: HistoryRow[];
+}) {
+  const m = report.market_structure;
+  const lv = report.market_structure_levels;
+  const spot = toNum(m.spot);
+  const flip = lv?.gex_flip ? toNum(lv.gex_flip.strike) : null;
+  const netGex = toNum(m.net_gex);
+  const bias = classifyClient(spot, flip, netGex);
+  const color = biasColors[bias] ?? biasColors.NEUTRAL;
+  const arrow = biasArrows[bias] ?? "→";
+  const rationale = buildRationale(report);
+
+  // "Days above flip": consecutive history rows (newest-first) where spot > flip.
+  let consecutive = 0;
+  for (const r of history) {
+    const rs = toNum(r.spot);
+    const rf = toNum(r.gex_flip);
+    if (rs == null || rf == null) break;
+    if (rs > rf) consecutive++;
+    else break;
+  }
+
+  return (
+    <div style={panelStyle}>
+      <div style={labelStyle}>Directional Bias</div>
+      <div
+        style={{
+          fontSize: 36,
+          fontWeight: 700,
+          color,
+          letterSpacing: 1,
+          marginBottom: 12,
+        }}
+      >
+        {bias.replace("_", " ")} <span style={{ fontSize: 24 }}>{arrow}</span>
+      </div>
+
+      <ul
+        style={{
+          fontSize: 12,
+          color: "var(--text-secondary)",
+          paddingLeft: 16,
+          margin: 0,
+          marginBottom: 12,
+          lineHeight: 1.7,
+        }}
+      >
+        {rationale.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+        {consecutive > 0 && (
+          <li>
+            {consecutive} consecutive {consecutive === 1 ? "day" : "days"} above
+            flip
+          </li>
+        )}
+      </ul>
+
+      <div
+        style={{
+          fontSize: 10,
+          color: "var(--text-muted)",
+          borderTop: "1px solid var(--border-dim)",
+          paddingTop: 8,
+        }}
+      >
+        Flip migration: {flipMigration(history)}
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/panels/ExpectedRangeBar.tsx
+++ b/web/components/stock/panels/ExpectedRangeBar.tsx
@@ -1,0 +1,158 @@
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: 16,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+};
+
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+/**
+ * Horizontal range bar:
+ *  - leftmost = MAX_ACCEL strike
+ *  - rightmost = MAX_MAGNET strike
+ *  - markers: GEX FLIP, current SPOT (close), MAX_MAGNET
+ */
+export function ExpectedRangeBar({ report }: { report: Report }) {
+  const m = report.market_structure;
+  const lv = report.market_structure_levels;
+  const spot = toNum(m.spot);
+  const flip = lv?.gex_flip ? toNum(lv.gex_flip.strike) : null;
+  const lo = lv?.max_accel ? toNum(lv.max_accel.strike) : null;
+  const hi = lv?.max_magnet ? toNum(lv.max_magnet.strike) : null;
+
+  const haveRange = lo != null && hi != null && hi > lo;
+  const xOf = (v: number | null) => {
+    if (v == null || !haveRange) return null;
+    return ((v - lo!) / (hi! - lo!)) * 100;
+  };
+
+  return (
+    <div style={panelStyle}>
+      <div style={{ ...labelStyle, marginBottom: 16 }}>
+        Expected Range —{" "}
+        {new Date(report.generated_at).toISOString().slice(0, 10)}
+      </div>
+
+      <div style={{ position: "relative", height: 36, marginBottom: 28 }}>
+        {/* Range bar */}
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: 16,
+            height: 4,
+            background: "var(--positive)",
+            opacity: 0.35,
+            borderRadius: 2,
+          }}
+        />
+        {/* Markers */}
+        {flip != null && xOf(flip) != null && (
+          <Marker x={xOf(flip)!} color="var(--warning)" label="GEX FLIP" />
+        )}
+        {spot != null && xOf(spot) != null && (
+          <Marker x={xOf(spot)!} color="var(--text-primary)" label="CLOSE" />
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: 11,
+          color: "var(--text-secondary)",
+        }}
+      >
+        <div>
+          <div style={{ color: "var(--text-primary)", fontWeight: 700 }}>
+            {fmtNum(lo, 2)}
+          </div>
+          <div style={labelStyle}>Max Accel</div>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ color: "var(--warning)", fontWeight: 700 }}>
+            {fmtNum(flip, 2)}
+          </div>
+          <div style={labelStyle}>GEX Flip</div>
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ color: "var(--text-primary)", fontWeight: 700 }}>
+            {fmtNum(spot, 2)}
+          </div>
+          <div style={labelStyle}>Close</div>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <div style={{ color: "var(--positive)", fontWeight: 700 }}>
+            {fmtNum(hi, 2)}
+          </div>
+          <div style={labelStyle}>Max Magnet</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Marker({
+  x,
+  color,
+  label,
+}: {
+  x: number;
+  color: string;
+  label: string;
+}) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: `${Math.max(0, Math.min(100, x))}%`,
+        top: 6,
+        transform: "translateX(-50%)",
+        textAlign: "center",
+      }}
+    >
+      <div
+        style={{
+          width: 2,
+          height: 24,
+          background: color,
+          margin: "0 auto",
+        }}
+      />
+      <div
+        style={{
+          fontSize: 9,
+          color,
+          letterSpacing: 1,
+          textTransform: "uppercase",
+          marginTop: 2,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/panels/GexLevelTiles.tsx
+++ b/web/components/stock/panels/GexLevelTiles.tsx
@@ -1,0 +1,207 @@
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+type Level = components["schemas"]["GexLevel"];
+
+const tileStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: "12px 14px",
+  display: "flex",
+  flexDirection: "column",
+  gap: 6,
+  minWidth: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+};
+
+const valueStyle: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontWeight: 700,
+  fontSize: 22,
+  color: "var(--text-primary)",
+  lineHeight: 1,
+};
+
+const subStyle: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--text-muted)",
+};
+
+function signedColor(v: number | null): string {
+  if (v == null) return "var(--text-primary)";
+  if (v > 0) return "var(--positive)";
+  if (v < 0) return "var(--negative)";
+  return "var(--text-primary)";
+}
+
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function fmtMoneyCompact(v: number | null): string {
+  if (v == null) return "—";
+  const abs = Math.abs(v);
+  const sign = v >= 0 ? "+" : "-";
+  if (abs >= 1e9)
+    return `${sign}$${(abs / 1e9).toLocaleString("en-US", { maximumFractionDigits: 1 })}B`;
+  if (abs >= 1e6)
+    return `${sign}$${(abs / 1e6).toLocaleString("en-US", { maximumFractionDigits: 1 })}M`;
+  if (abs >= 1e3)
+    return `${sign}$${(abs / 1e3).toLocaleString("en-US", { maximumFractionDigits: 1 })}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
+function fmtPct(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return `${v >= 0 ? "+" : ""}${(v * 100).toFixed(digits)}%`;
+}
+
+function Tile({
+  label,
+  value,
+  sub,
+  valueColor,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  valueColor?: string;
+}) {
+  return (
+    <div style={tileStyle}>
+      <div style={labelStyle}>{label}</div>
+      <div style={{ ...valueStyle, color: valueColor ?? valueStyle.color }}>
+        {value}
+      </div>
+      <div style={subStyle}>{sub ?? " "}</div>
+    </div>
+  );
+}
+
+function levelSub(level: Level | null | undefined): string {
+  if (!level) return "—";
+  const pct = toNum(level.pct_from_spot);
+  const sens = toNum(level.gamma_per_dollar);
+  const pctStr = pct != null ? fmtPct(pct, 2) : "—";
+  const sensStr = sens != null ? `${fmtMoneyCompact(sens)} per $1` : "—";
+  return `${pctStr} — ${sensStr}`;
+}
+
+export function GexLevelTiles({ report }: { report: Report }) {
+  const m = report.market_structure;
+  const a = report.aggregates;
+  const v = report.volatility;
+  const lv = report.market_structure_levels;
+
+  const spot = toNum(m.spot);
+  const netGex = toNum(m.net_gex);
+  // NET DEX in $: (call_dex_oi + put_dex_oi) * spot. The signs of the two
+  // OI components already encode dealer-side direction.
+  const callDex = toNum(m.total_call_dex_oi);
+  const putDex = toNum(m.total_put_dex_oi);
+  const netDexDollars =
+    callDex != null && putDex != null && spot != null
+      ? (callDex + putDex) * spot
+      : null;
+  const iv = toNum(v.iv);
+  const ivRank = toNum(v.iv_rank);
+  const pcrVol = toNum(a?.pcr_vol);
+  const flip = lv?.gex_flip;
+  const flipPct = toNum(flip?.pct_from_spot);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Top row: 6 wide tiles */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+          gap: 12,
+        }}
+      >
+        <Tile label="Spot" value={fmtNum(spot, 2)} sub=" " />
+        <Tile
+          label="GEX Flip"
+          value={flip ? fmtNum(toNum(flip.strike), 2) : "—"}
+          sub={flipPct != null ? `${fmtPct(flipPct, 2)} from spot` : "—"}
+          valueColor="var(--warning)"
+        />
+        <Tile
+          label="Net GEX"
+          value={netGex != null ? fmtMoneyCompact(netGex) : "—"}
+          valueColor={signedColor(netGex)}
+        />
+        <Tile
+          label="Net DEX"
+          value={netDexDollars != null ? fmtMoneyCompact(netDexDollars) : "—"}
+          valueColor={signedColor(netDexDollars)}
+        />
+        <Tile
+          label="IV 30D"
+          value={iv != null ? `${(iv * 100).toFixed(1)}%` : "—"}
+          sub={ivRank != null ? `rank ${Math.round(ivRank)}%` : ""}
+        />
+        <Tile
+          label="Vol P/C"
+          value={fmtNum(pcrVol, 2)}
+          valueColor="var(--warning)"
+        />
+      </div>
+
+      {/* Bottom row: 5 level tiles */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
+          gap: 12,
+        }}
+      >
+        <Tile
+          label="GEX Flip (support)"
+          value={lv?.gex_flip ? fmtNum(toNum(lv.gex_flip.strike), 2) : "—"}
+          sub={levelSub(lv?.gex_flip)}
+          valueColor="var(--warning)"
+        />
+        <Tile
+          label="Max Magnet"
+          value={lv?.max_magnet ? fmtNum(toNum(lv.max_magnet.strike), 2) : "—"}
+          sub={levelSub(lv?.max_magnet)}
+          valueColor="var(--positive)"
+        />
+        <Tile
+          label="2nd Magnet"
+          value={
+            lv?.second_magnet ? fmtNum(toNum(lv.second_magnet.strike), 2) : "—"
+          }
+          sub={levelSub(lv?.second_magnet)}
+        />
+        <Tile
+          label="Max Accel (below flip)"
+          value={lv?.max_accel ? fmtNum(toNum(lv.max_accel.strike), 2) : "—"}
+          sub={levelSub(lv?.max_accel)}
+          valueColor="var(--negative)"
+        />
+        <Tile
+          label="Put Wall"
+          value={lv?.put_wall ? fmtNum(toNum(lv.put_wall.strike), 2) : "—"}
+          sub={levelSub(lv?.put_wall)}
+          valueColor="var(--negative)"
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/panels/GexProfileChart.tsx
+++ b/web/components/stock/panels/GexProfileChart.tsx
@@ -1,0 +1,267 @@
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+// Drop strikes whose aggregated net_gex is too small to render as a meaningful
+// bar — keeps the chart from looking like a wall of "+$0" rows on quiet days.
+const MIN_ABS_GEX = 100;
+// Window around spot to render. Wider = more context, narrower = denser bars.
+const WINDOW_PCT = 0.15;
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: 20,
+  fontFamily: "var(--font-mono)",
+};
+
+const headingStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-secondary)",
+};
+
+function fmtPct(v: number, digits = 2): string {
+  return `${v >= 0 ? "+" : ""}${(v * 100).toFixed(digits)}%`;
+}
+
+function fmtMoney(v: number): string {
+  const abs = Math.abs(v);
+  const sign = v >= 0 ? "+" : "-";
+  if (abs >= 1e6)
+    return `${sign}$${(abs / 1e6).toLocaleString("en-US", { maximumFractionDigits: 1 })}M`;
+  if (abs >= 1e3)
+    return `${sign}$${(abs / 1e3).toLocaleString("en-US", { maximumFractionDigits: 1 })}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
+export function GexProfileChart({ report }: { report: Report }) {
+  const curve = report.strike_gex_curve;
+  const spot = toNum(report.market_structure.spot);
+  const lv = report.market_structure_levels;
+  const callWall = lv?.call_wall ? toNum(lv.call_wall.strike) : null;
+  const putWall = lv?.put_wall ? toNum(lv.put_wall.strike) : null;
+
+  // 1) Aggregate per strike across expiries.
+  const perStrike = new Map<number, number>();
+  for (const b of curve) {
+    const s = toNum(b.strike);
+    const g = toNum(b.net_gex);
+    if (s == null || g == null) continue;
+    perStrike.set(s, (perStrike.get(s) ?? 0) + g);
+  }
+
+  // 2) Pre-compute the strike closest to spot — independent of the gex
+  // threshold, so spot is always represented even when its strike has thin
+  // gamma. We restrict the search to the render window to avoid picking up
+  // far-OTM noise on stocks with sparse chains.
+  const center = spot ?? 0;
+  const winLo = center * (1 - WINDOW_PCT);
+  const winHi = center * (1 + WINDOW_PCT);
+  let closestToSpot: number | null = null;
+  if (spot != null) {
+    let bestDist = Infinity;
+    for (const s of perStrike.keys()) {
+      if (s < winLo || s > winHi) continue;
+      const d = Math.abs(s - spot);
+      if (d < bestDist) {
+        bestDist = d;
+        closestToSpot = s;
+      }
+    }
+  }
+
+  // 3) Filter: keep strikes within ±WINDOW_PCT of spot AND with |gex| >= threshold.
+  // Always keep walls AND the spot-anchor strike even if below threshold.
+  const strikes = Array.from(perStrike.entries())
+    .filter(([s, g]) => {
+      if (s < winLo || s > winHi) return false;
+      const isWall = s === callWall || s === putWall;
+      const isSpotAnchor = s === closestToSpot;
+      return isWall || isSpotAnchor || Math.abs(g) >= MIN_ABS_GEX;
+    })
+    .sort((a, b) => b[0] - a[0]); // descending — highest strike at top
+
+  const maxAbs = Math.max(...strikes.map(([, g]) => Math.abs(g)), 1);
+  const ROW_H = 22;
+  const LABEL_W = 110;
+  const BAR_W = 280;
+  const VALUE_W = 90;
+  const TAG_W = 110;
+
+  return (
+    <div style={panelStyle}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 16,
+        }}
+      >
+        <div style={headingStyle}>GEX Profile — Net gamma by strike</div>
+        <div style={{ display: "flex", gap: 16, fontSize: 11 }}>
+          <span style={{ color: "var(--positive)" }}>
+            ■ Positive (stabilizing)
+          </span>
+          <span style={{ color: "var(--negative)" }}>
+            ■ Negative (destabilizing)
+          </span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          maxWidth: LABEL_W + BAR_W + VALUE_W + TAG_W,
+          margin: "0 auto",
+        }}
+      >
+        {strikes.map(([strike, gex]) => {
+          const pct = spot != null ? (strike - spot) / spot : 0;
+          const widthPct = (Math.abs(gex) / maxAbs) * 50;
+          const isPos = gex >= 0;
+          const isCallWall = callWall != null && strike === callWall;
+          const isPutWall = putWall != null && strike === putWall;
+          const isSpotRow = closestToSpot != null && strike === closestToSpot;
+
+          // Strike-label color: wall identity wins (green/red) for the level
+          // semantics; spot-only rows get yellow. Spot rows always carry a
+          // dashed yellow border, so a green/red wall that also is spot is
+          // unambiguous (green text + yellow border + both tags stacked).
+          const strikeColor = isCallWall
+            ? "var(--positive)"
+            : isPutWall
+              ? "var(--negative)"
+              : isSpotRow
+                ? "var(--warning)"
+                : "var(--text-primary)";
+          const strikeBold = isCallWall || isPutWall || isSpotRow;
+
+          const tags: { label: string; color: string }[] = [];
+          if (isCallWall)
+            tags.push({ label: "◀ CALL WALL", color: "var(--positive)" });
+          if (isPutWall)
+            tags.push({ label: "◀ PUT WALL", color: "var(--negative)" });
+          if (isSpotRow)
+            tags.push({ label: "◀ SPOT", color: "var(--warning)" });
+
+          return (
+            <div
+              key={strike}
+              style={{
+                display: "grid",
+                gridTemplateColumns: `${LABEL_W}px ${BAR_W}px ${VALUE_W}px ${TAG_W}px`,
+                alignItems: "center",
+                height: ROW_H,
+                fontSize: 11,
+                borderTop: isSpotRow ? "1px dashed var(--warning)" : undefined,
+                borderBottom: isSpotRow
+                  ? "1px dashed var(--warning)"
+                  : undefined,
+              }}
+            >
+              {/* Strike label */}
+              <div
+                style={{
+                  textAlign: "right",
+                  paddingRight: 12,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                }}
+              >
+                <span style={{ color: "var(--text-muted)" }}>
+                  {fmtPct(pct, 2)}
+                </span>{" "}
+                <span
+                  style={{
+                    color: strikeColor,
+                    fontWeight: strikeBold ? 700 : 400,
+                  }}
+                >
+                  {strike}
+                </span>
+              </div>
+
+              {/* Bar canvas with centerline */}
+              <div
+                style={{
+                  position: "relative",
+                  height: ROW_H,
+                }}
+              >
+                <div
+                  style={{
+                    position: "absolute",
+                    left: "50%",
+                    top: 0,
+                    bottom: 0,
+                    width: 1,
+                    background: "var(--border-dim)",
+                  }}
+                />
+                <div
+                  style={{
+                    position: "absolute",
+                    top: 3,
+                    bottom: 3,
+                    left: isPos ? "50%" : `${50 - widthPct}%`,
+                    width: `${widthPct}%`,
+                    background: isPos ? "var(--positive)" : "var(--negative)",
+                    opacity: 0.85,
+                  }}
+                />
+              </div>
+
+              {/* $ value */}
+              <div
+                style={{
+                  paddingLeft: 12,
+                  color: isPos ? "var(--positive)" : "var(--negative)",
+                  whiteSpace: "nowrap",
+                  textAlign: "left",
+                }}
+              >
+                {fmtMoney(gex)}
+              </div>
+
+              {/* Tag column — stacks multiple labels when a strike is both a
+                  wall and the spot anchor. Each tag carries its own color so
+                  the reader can match it to the strike-label color at a glance. */}
+              <div
+                style={{
+                  paddingLeft: 8,
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center",
+                  gap: 1,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {tags.map((t) => (
+                  <div
+                    key={t.label}
+                    style={{
+                      fontSize: 9,
+                      letterSpacing: 1,
+                      color: t.color,
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {t.label}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+        {strikes.length === 0 && (
+          <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+            No strike-gamma data in the ±{(WINDOW_PCT * 100).toFixed(0)}% window
+            around spot.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/panels/MarketStructureHistoryTable.tsx
+++ b/web/components/stock/panels/MarketStructureHistoryTable.tsx
@@ -1,0 +1,173 @@
+"use client";
+import { useState } from "react";
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type HistoryRow = components["schemas"]["StockHistoryRow"];
+
+const biasColors: Record<string, string> = {
+  BULL: "var(--positive)",
+  BEAR: "var(--negative)",
+  CAUTIOUS_BULL: "var(--warning)",
+  CAUTIOUS_BEAR: "var(--warning)",
+  NEUTRAL: "var(--text-muted)",
+};
+
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function fmtMoney(v: number | null): string {
+  if (v == null) return "—";
+  const abs = Math.abs(v);
+  const sign = v >= 0 ? "+" : "-";
+  if (abs >= 1e6)
+    return `${sign}$${(abs / 1e6).toLocaleString("en-US", { maximumFractionDigits: 1 })}M`;
+  if (abs >= 1e3)
+    return `${sign}$${(abs / 1e3).toLocaleString("en-US", { maximumFractionDigits: 1 })}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
+function fmtPct(v: number | null, digits = 1): string {
+  if (v == null) return "—";
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+const headerStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  textAlign: "left",
+  fontWeight: 400,
+  padding: "8px 12px",
+  borderBottom: "1px solid var(--border-dim)",
+};
+
+const cellStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  color: "var(--text-primary)",
+  borderBottom: "1px solid var(--border-dim)",
+};
+
+export function MarketStructureHistoryTable({ rows }: { rows: HistoryRow[] }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ fontFamily: "var(--font-mono)" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          background: "transparent",
+          color: "var(--text-secondary)",
+          border: "none",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          letterSpacing: 0.5,
+          padding: "8px 0",
+          cursor: "pointer",
+        }}
+      >
+        History ({rows.length} sessions) {open ? "▲" : "▼"}
+      </button>
+
+      {open && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th style={headerStyle}>Date</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Spot</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>GEX Flip</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Net GEX</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Net DEX</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>IV 30D</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Vol P/C</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Bias</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const netGex = toNum(r.net_gex);
+                const netDex = toNum(r.net_dex);
+                const iv = toNum(r.iv30d);
+                const pcr = toNum(r.pcr_vol);
+                return (
+                  <tr key={r.market_date}>
+                    <td style={cellStyle}>{r.market_date}</td>
+                    <td style={{ ...cellStyle, textAlign: "right" }}>
+                      {fmtNum(toNum(r.spot), 2)}
+                    </td>
+                    <td style={{ ...cellStyle, textAlign: "right" }}>
+                      {fmtNum(toNum(r.gex_flip), 2)}
+                    </td>
+                    <td
+                      style={{
+                        ...cellStyle,
+                        textAlign: "right",
+                        color:
+                          netGex == null
+                            ? "var(--text-muted)"
+                            : netGex >= 0
+                              ? "var(--positive)"
+                              : "var(--negative)",
+                      }}
+                    >
+                      {fmtMoney(netGex)}
+                    </td>
+                    <td
+                      style={{
+                        ...cellStyle,
+                        textAlign: "right",
+                        color:
+                          netDex == null
+                            ? "var(--text-muted)"
+                            : netDex >= 0
+                              ? "var(--positive)"
+                              : "var(--negative)",
+                      }}
+                    >
+                      {fmtMoney(netDex)}
+                    </td>
+                    <td style={{ ...cellStyle, textAlign: "right" }}>
+                      {fmtPct(iv, 1)}
+                    </td>
+                    <td style={{ ...cellStyle, textAlign: "right" }}>
+                      {fmtNum(pcr, 2)}
+                    </td>
+                    <td
+                      style={{
+                        ...cellStyle,
+                        textAlign: "right",
+                        color: biasColors[r.bias] ?? biasColors.NEUTRAL,
+                        fontWeight: 700,
+                      }}
+                    >
+                      {r.bias.replace("_", " ")}
+                    </td>
+                  </tr>
+                );
+              })}
+              {rows.length === 0 && (
+                <tr>
+                  <td
+                    style={{ ...cellStyle, color: "var(--text-muted)" }}
+                    colSpan={8}
+                  >
+                    No history yet — sessions accumulate from scan_runs.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/stock/panels/MaxPainTable.tsx
+++ b/web/components/stock/panels/MaxPainTable.tsx
@@ -1,0 +1,122 @@
+"use client";
+import { useState } from "react";
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type MaxPainRow = components["schemas"]["MaxPainRow"];
+
+const headerStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  textAlign: "left",
+  fontWeight: 400,
+  padding: "8px 12px",
+  borderBottom: "1px solid var(--border-dim)",
+};
+
+const cellStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  color: "var(--text-primary)",
+  borderBottom: "1px solid var(--border-dim)",
+};
+
+function fmtNum(v: number | null, digits = 2): string {
+  if (v == null) return "—";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+export function MaxPainTable({ rows }: { rows: MaxPainRow[] }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ fontFamily: "var(--font-mono)" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          background: "transparent",
+          color: "var(--text-secondary)",
+          border: "none",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          letterSpacing: 0.5,
+          padding: "8px 0",
+          cursor: "pointer",
+        }}
+      >
+        Max Pain ({rows.length} expiries) {open ? "▲" : "▼"}
+      </button>
+
+      {open && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th style={headerStyle}>Expiry</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Max Pain</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Close</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>Open</th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>
+                  Next Lower
+                </th>
+                <th style={{ ...headerStyle, textAlign: "right" }}>
+                  Next Upper
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.expiry}>
+                  <td style={cellStyle}>{r.expiry}</td>
+                  <td style={{ ...cellStyle, textAlign: "right" }}>
+                    {fmtNum(toNum(r.max_pain), 2)}
+                  </td>
+                  <td style={{ ...cellStyle, textAlign: "right" }}>
+                    {fmtNum(toNum(r.close), 2)}
+                  </td>
+                  <td style={{ ...cellStyle, textAlign: "right" }}>
+                    {fmtNum(toNum(r.open), 2)}
+                  </td>
+                  <td
+                    style={{
+                      ...cellStyle,
+                      textAlign: "right",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    {fmtNum(toNum(r.next_lower_strike), 2)}
+                  </td>
+                  <td
+                    style={{
+                      ...cellStyle,
+                      textAlign: "right",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    {fmtNum(toNum(r.next_upper_strike), 2)}
+                  </td>
+                </tr>
+              ))}
+              {rows.length === 0 && (
+                <tr>
+                  <td
+                    style={{ ...cellStyle, color: "var(--text-muted)" }}
+                    colSpan={6}
+                  >
+                    No max-pain rows in the latest scan.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/stock/tabs/MarketStructureTab.tsx
+++ b/web/components/stock/tabs/MarketStructureTab.tsx
@@ -1,93 +1,39 @@
 import type { components } from "@/lib/types";
-import { MetricGrid, Metric } from "../panels/MetricGrid";
-import { DataTable } from "../panels/DataTable";
-import { fmtDecimal, toNum } from "@/lib/formatters";
+import { api } from "@/lib/api";
+import { GexLevelTiles } from "../panels/GexLevelTiles";
+import { ExpectedRangeBar } from "../panels/ExpectedRangeBar";
+import { DirectionalBiasPanel } from "../panels/DirectionalBiasPanel";
+import { MarketStructureHistoryTable } from "../panels/MarketStructureHistoryTable";
+import { GexProfileChart } from "../panels/GexProfileChart";
+import { MaxPainTable } from "../panels/MaxPainTable";
 
 type Report = components["schemas"]["SingleStockReport"];
-type MaxPainRow = components["schemas"]["MaxPainRow"];
 
-const sectionHeading: React.CSSProperties = {
-  fontFamily: "var(--font-mono)",
-  fontSize: 10,
-  color: "var(--text-secondary)",
-  letterSpacing: 1,
-  textTransform: "uppercase",
-};
+export async function MarketStructureTab({ report }: { report: Report }) {
+  let historyRows: components["schemas"]["StockHistoryRow"][] = [];
+  try {
+    const h = await api.stockHistory(report.ticker);
+    historyRows = h.rows;
+  } catch {
+    historyRows = [];
+  }
 
-export function MarketStructureTab({ report }: { report: Report }) {
-  const m = report.market_structure;
   return (
-    <div>
-      <h3 style={sectionHeading}>Gamma Exposure</h3>
-      <MetricGrid cols={4}>
-        <Metric label="Net GEX" value={fmtDecimal(toNum(m.net_gex), 0)} />
-        <Metric
-          label="Call GEX"
-          value={fmtDecimal(toNum(m.total_call_gex), 0)}
-        />
-        <Metric label="Put GEX" value={fmtDecimal(toNum(m.total_put_gex), 0)} />
-        <Metric
-          label="Max Pain (nearest)"
-          value={`$${fmtDecimal(toNum(m.max_pain), 2)}`}
-        />
-      </MetricGrid>
-
-      <h3 style={{ ...sectionHeading, marginTop: 24 }}>Top OI Strikes</h3>
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <GexLevelTiles report={report} />
       <div
         style={{
-          display: "flex",
-          gap: 32,
-          fontFamily: "var(--font-mono)",
-          fontSize: 12,
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
         }}
       >
-        <div>
-          <div style={{ color: "var(--text-muted)" }}>Calls</div>
-          {m.top_call_oi_strikes?.length
-            ? m.top_call_oi_strikes.map((s) => <div key={s}>${s}</div>)
-            : "—"}
-        </div>
-        <div>
-          <div style={{ color: "var(--text-muted)" }}>Puts</div>
-          {m.top_put_oi_strikes?.length
-            ? m.top_put_oi_strikes.map((s) => <div key={s}>${s}</div>)
-            : "—"}
-        </div>
+        <ExpectedRangeBar report={report} />
+        <DirectionalBiasPanel report={report} history={historyRows} />
       </div>
-
-      {report.max_pain_rows.length > 0 && (
-        <>
-          <h3 style={{ ...sectionHeading, marginTop: 24 }}>
-            Max Pain by Expiry
-          </h3>
-          <DataTable<MaxPainRow>
-            rows={report.max_pain_rows}
-            columns={[
-              { key: "expiry", label: "Expiry" },
-              {
-                key: "max_pain",
-                label: "Max Pain",
-                render: (v) => (v != null ? `$${v}` : "—"),
-              },
-              {
-                key: "close",
-                label: "Close",
-                render: (v) => (v != null ? `$${v}` : "—"),
-              },
-              {
-                key: "next_upper_strike",
-                label: "Upper",
-                render: (v) => (v != null ? `$${v}` : "—"),
-              },
-              {
-                key: "next_lower_strike",
-                label: "Lower",
-                render: (v) => (v != null ? `$${v}` : "—"),
-              },
-            ]}
-          />
-        </>
-      )}
+      <GexProfileChart report={report} />
+      <MarketStructureHistoryTable rows={historyRows} />
+      <MaxPainTable rows={report.max_pain_rows} />
     </div>
   );
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -13,6 +13,7 @@ type Json<
 
 type WatchlistResponse = Json<"/api/watchlist", "get">;
 type SingleStockReport = Json<"/api/stock/{ticker}", "get">;
+type StockHistoryResponse = Json<"/api/stock/{ticker}/history", "get">;
 type JobStatus = Json<"/api/jobs/{job_id}", "get">;
 type OhlcResponse = Json<"/api/ohlc/{ticker}", "get">;
 type HealthResponse = Json<"/api/health", "get">;
@@ -43,6 +44,8 @@ export const api = {
   },
   stock: (ticker: string): Promise<SingleStockReport> =>
     _fetch<SingleStockReport>(`/api/stock/${ticker}`),
+  stockHistory: (ticker: string): Promise<StockHistoryResponse> =>
+    _fetch<StockHistoryResponse>(`/api/stock/${ticker}/history`),
   ohlc: (ticker: string, days = 30): Promise<OhlcResponse> =>
     _fetch<OhlcResponse>(`/api/ohlc/${ticker}?days=${days}`),
   rescan: (ticker: string): Promise<JobStatus> =>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -74,6 +74,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/stock/{ticker}/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Stock History
+         * @description Daily rollup for the Market Structure tab's history table.
+         *
+         *     One row per trading day, sorted newest-first. Today's row may have
+         *     spot=None if the post-close OHLC pull hasn't fired yet.
+         */
+        get: operations["get_stock_history_api_stock__ticker__history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/stock/{ticker}/runs": {
         parameters: {
             query?: never;
@@ -277,6 +300,23 @@ export interface components {
             /** Expiring Date */
             expiring_date?: string | null;
         };
+        /**
+         * GexLevel
+         * @description One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).
+         *
+         *     `gamma_per_dollar` is the per-strike net_gex used as the "$N per $1" sensitivity
+         *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
+         */
+        GexLevel: {
+            /** Strike */
+            strike: string;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pct From Spot */
+            pct_from_spot?: string | null;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -395,6 +435,26 @@ export interface components {
              * @default []
              */
             top_put_oi_strikes: string[];
+        };
+        /**
+         * MarketStructureLevels
+         * @description Derived strike-level reference points used by the Market Structure tab.
+         *
+         *     Conventions follow FlashAlpha / SpotGamma:
+         *       - gex_flip: lowest strike where running cumulative net_gex flips sign
+         *       - call_wall: strike with largest call-side gamma (typically above spot)
+         *       - put_wall: strike with largest put-side gamma magnitude (typically below spot)
+         *       - max_magnet: strike with largest positive net_gex above spot (pulls price up)
+         *       - second_magnet: strike with second-largest positive net_gex above spot
+         *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
+         */
+        MarketStructureLevels: {
+            gex_flip?: components["schemas"]["GexLevel"] | null;
+            call_wall?: components["schemas"]["GexLevel"] | null;
+            put_wall?: components["schemas"]["GexLevel"] | null;
+            max_magnet?: components["schemas"]["GexLevel"] | null;
+            second_magnet?: components["schemas"]["GexLevel"] | null;
+            max_accel?: components["schemas"]["GexLevel"] | null;
         };
         /** MaxPainRow */
         MaxPainRow: {
@@ -592,11 +652,54 @@ export interface components {
              * @default []
              */
             strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
+            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
         };
         /** SkewBlock */
         SkewBlock: {
             /** Rr25D 30Dte */
             rr25d_30dte?: string | null;
+        };
+        /** StockHistoryResponse */
+        StockHistoryResponse: {
+            /** Ticker */
+            ticker: string;
+            /**
+             * Rows
+             * @default []
+             */
+            rows: components["schemas"]["StockHistoryRow"][];
+        };
+        /**
+         * StockHistoryRow
+         * @description One per-trading-day rollup of a ticker's market structure.
+         *
+         *     Built from the latest successful scan_run on that date. spot comes from
+         *     daily_ohlc.close so it's a stable end-of-day reference (NULL for the
+         *     current trading day until the OHLC pull fires post-close).
+         */
+        StockHistoryRow: {
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Spot */
+            spot?: string | null;
+            /** Gex Flip */
+            gex_flip?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Net Dex */
+            net_dex?: string | null;
+            /** Iv30D */
+            iv30d?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /**
+             * Bias
+             * @default NEUTRAL
+             */
+            bias: string;
         };
         /**
          * StrikeGexBucket
@@ -959,6 +1062,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SingleStockReport"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_stock_history_api_stock__ticker__history_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StockHistoryResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Rebuilds the per-stock **Market Structure** tab from a one-row metric grid into five purpose-built panels: 11-tile level grid, expected-range bar + directional bias readout, GEX-by-strike profile chart, and collapsible History + Max Pain tables.
- Centralises level math (`gex_flip`, `call_wall`, `put_wall`, `max_magnet`, `max_accel`, `gex_flip_support`, etc.) in `uw_scan.cards.gex.compute_market_structure_levels` so the live report and the history rollup classify bias identically.
- Adds `GET /api/stock/{ticker}/history` — one row per session via `DISTINCT ON (started_at::date)` joined to `daily_ohlc` for end-of-day spot, with server-computed `BULL/BEAR/CAUTIOUS_*/NEUTRAL` bias.

## GEX Profile chart notes

- Filters strikes whose aggregated `|net_gex| < $100` so quiet days don't render a wall of `+$0` rows. Walls and the spot-anchor strike are always kept.
- Spot anchor = strike closest to current spot (not a fixed tolerance) — so granular (\$1) and sparse (\$2.50/\$5) chains both render a spot marker.
- Coloring is two-channel: wall identity (green call / red put) on the strike text and tag; spot identity (yellow) on the row border and tag. They stack when a strike is both — e.g. AAPL at 295 = CALL WALL + SPOT.

## Test plan

- [ ] Reload `/stock/AAPL` → 11 tiles populate; range bar shows FLIP and CLOSE markers; bias reads BULL with rationale bullets; GEX chart has yellow-bordered 295 row with stacked CALL WALL (green) + SPOT (yellow) tags
- [ ] Reload `/stock/SPY` → 738 row yellow-bordered with SPOT tag, 739 green CALL WALL, 737 red PUT WALL
- [ ] Try a wide-strike ticker (e.g. BRK.B / GOOG) → spot still rendered on the closest strike, even if its gex is below the noise threshold
- [ ] Expand History — sessions accumulate from `scan_runs`; today's row may show — for spot until daily OHLC is pulled, prior sessions show close + BULL/BEAR bias
- [ ] Expand Max Pain — one row per expiry from the latest scan