### PR TITLE
Add Trade Insights stock tab

### DIFF
--- a/docs/superpowers/plans/2026-05-13-trade-insights-codex-analysis.md
+++ b/docs/superpowers/plans/2026-05-13-trade-insights-codex-analysis.md
@@ -1,0 +1,53 @@
+# Trade Insights V1.5 Codex Analysis Plan
+
+**Goal:** Add optional operator-triggered Codex commentary on top of the deterministic Trade Insights JSON without allowing AI output to override backend statuses, risk flags, or required checks.
+
+## Phase 1 - Persistence
+
+- Add an idempotent migration for `uw_scan.trade_insight_ai_analyses`.
+- Columns: `analysis_id`, `ticker`, `run_id`, `input_hash`, `model`, `prompt_version`, `status`, `markdown`, `error_message`, `requested_at`, `started_at`, `finished_at`.
+- Add repository helpers to enqueue, start, complete, fail, and fetch analyses by `analysis_id` and by `(ticker, input_hash, prompt_version)`.
+- Store markdown separately from deterministic `trade_insight_snapshots`; do not mutate candidate statuses.
+
+## Phase 2 - Prompt Contract
+
+- Add a fixed prompt template in backend code, not user-editable UI text.
+- Prompt must instruct Codex to analyze only supplied deterministic JSON, preserve every `status`, preserve every `risk_flag`, state missing data, avoid executable recommendations, and emit concise Markdown.
+- Required Markdown sections: `Dominant Read`, `Best Expressions`, `Conflicts`, `Required Checks`, `Rejected Ideas`.
+- Include prompt version in storage and job logs.
+
+## Phase 3 - Worker Execution
+
+- Add an allowlisted worker wrapper for non-interactive `codex exec`.
+- Run Codex in read-only mode with no approval prompts and a hard timeout.
+- Pass sanitized structured input by temp file or database `analysis_id`, not by large shell command string.
+- Strip secrets from the environment before execution.
+- Limit concurrency and output size.
+
+## Phase 4 - API
+
+- Add `POST /api/stock/{ticker}/trade-insights/ai-analysis` to enqueue analysis for the latest deterministic payload.
+- Add a read endpoint for analysis status and markdown.
+- Reuse an existing completed analysis when `(ticker, input_hash, prompt_version)` matches unless the request explicitly asks for a rerun.
+- On Codex failure, return failed status while leaving the deterministic tab fully usable.
+
+## Phase 5 - UI
+
+- Add a secondary utility `Run AI Analysis` control below deterministic synthesis.
+- Poll analysis status without blocking deterministic panel rendering.
+- Render returned Markdown in a clearly labeled generated-commentary section.
+- Never show AI commentary as a source of truth or promote `needs_check` candidates.
+
+## Phase 6 - Tests
+
+- Repository tests for idempotent enqueue and status transitions.
+- Worker tests for timeout, failure, and output-size handling.
+- API tests for enqueue, reuse, failure fallback, and latest-payload lookup.
+- Frontend tests for button state, polling state, rendered markdown, and failure message.
+
+## Out Of Scope
+
+- Automatic analysis on every scan or page load.
+- User-authored prompts.
+- Order placement, sizing, or executable recommendations.
+- Any AI override of deterministic candidate status, max loss, risk flags, or required checks.

--- a/docs/superpowers/plans/2026-05-13-trade-insights-tab.md
+++ b/docs/superpowers/plans/2026-05-13-trade-insights-tab.md
@@ -1,0 +1,2528 @@
+# Trade Insights Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `Trade Insights` stock-detail tab that turns existing UW volatility, flow, and option-chain data into deterministic research-grade trade ideas, with an optional Codex commentary path left for a follow-up.
+
+**Architecture:** Backend adds normalized trade-insight models, an OCC/OSI option-symbol parser, a deterministic assembler, persistence for deterministic research snapshots/candidate rows, and a `GET /api/stock/{ticker}/trade-insights` endpoint. Frontend adds a new tab route, API helper, and focused panels for source reconciliation, source/data quality, signal stack, chain/flow read, term structure, candidate structures, and synthesis. V1 does not run Codex; it makes the deterministic JSON stable and logged first, with optional AI-analysis work planned as V1.5.
+
+**Naming contract:** use `Trade Insights` for the visible tab label and `/trade-insights` for browser/API routes. Internal filenames should use `trade_insights.py`. Do not expose `Trade Ideas` or `Trading Insights` in navigation, URLs, API paths, or user-facing copy.
+
+**Tech Stack:** Python 3.13 + FastAPI + Pydantic + psycopg-backed repository; Next.js 16 + React 19 + TypeScript; pytest integration/unit tests; vitest component tests.
+
+**Specs:**
+- `docs/superpowers/specs/2026-05-13-trade-insights-tab-design.md`
+- `docs/superpowers/research/2026-05-13-vol-neutral-mean-reversion-strategy-research.md`
+
+---
+
+## Lessons from shipped tabs (2026-05 Playwright audit)
+
+These constraints come from auditing the live `/stock/SPY/{market-structure, volatility, flow, trade-plan}` pages against the most recent shipped implementations (Volatility v2, Flow+Tables merge, Market Structure). Every rule here exists to keep `Trade Insights` visually and behaviorally consistent with what landed in commits `30da5a7`, `833e186`, and `e996b5e`.
+
+1. **The layout already supplies the ticker header.** `web/app/stock/[ticker]/layout.tsx` calls `api.stock(ticker)` once and renders `<DetailHeader>` (ticker, spot, IV, setup badge) plus `<TabBar>` above every tab's `{children}`. The tab body must NOT re-render the ticker or spot. The Trade Insights "header" panel only owns the bias/setup/confidence/data-quality row plus badges. Rename the **React component** `TradeInsightsHeader` → `TradeInsightsBiasBanner` and drop the `ticker` prop. (See revised Task 4.1.)
+   > Note: the **Python Pydantic model** `TradeInsightsHeader` in `models.py` keeps its name — it's the API response shape (`response.header: TradeInsightsHeader`), not the UI component. The rename is React-only.
+
+2. **Section heading style is `fontSize: 9, letterSpacing: 1`**, uppercased mono, `color: var(--text-muted)` — not `fontSize: 10` as earlier drafts of this plan said. Verified against `VolatilityTabClient.tsx` lines 79–88. Match this exactly so the new tab doesn't look one font-step heavier than its neighbors.
+
+3. **Two-column grid is the established density pattern.** Volatility v2 uses `gridTemplateColumns: "1fr 1fr"` for chart pairs (`IvOfIvChart | RvSpyCorrChart`, `RegimeQuadrantChart | DivergenceOverlay`). Market Structure pairs `ExpectedRangeBar | DirectionalBiasPanel`. Trade Insights must not be a single-column stack — that wastes ~50% of the viewport. Suggested pairings:
+   - `SourceReconciliationPanel | SignalStackPanel`
+   - `ChainFlowReadPanel | TermMovePanel`
+   - `CandidateStructuresPanel` (full-width — multi-card grid)
+   - `InsightsSynthesisPanel` (full-width)
+
+4. **Extract a shared `InsightPanel.tsx` shell first.** Volatility v2 lifted `AnalyticalSeriesPanel.tsx` to avoid duplicating panel chrome across nine panel files. Trade Insights builds seven panels in V1 — extract the shell up front (see new Task 4.0). Each panel then just accepts `{ heading, subheading?, children }` instead of duplicating the border/background/padding block seven times.
+
+5. **Degraded-state dashed banner.** Volatility v2 renders a dashed-border `"Building 1-year history… (≤30s)"` notice when `backfill_status === "running"`. Trade Insights doesn't poll, but adopt the same dashed-banner shape for "No iv_term_snapshots for this run" and "No option chain rows" so empty states match the visual vocabulary of the rest of the app.
+
+6. **Loading and error boundaries are missing in the stock route.** `web/app/stock/[ticker]/{loading,error}.tsx` do not exist today; the existing tabs survive because the parent layout awaits `api.stock(ticker)` before paint and the tab bodies are server-rendered fast enough. Trade Insights adds a second sequential `await api.tradeInsights(ticker)` which makes a freeze visible. Add minimal `loading.tsx` and `error.tsx` siblings in Phase 3. (See new Task 3.3.)
+
+7. **Filter selectors are an established Flow pattern** (`EXPIRIES: [4 selected ▾]`, `STRIKE RANGE: [±30% ▾]` from `FlowTab.tsx`). V1 of Trade Insights does NOT implement these — every strike row renders. Listed under "Known V1 limitations" with the V1.1 patch hook so the gap is visible.
+
+## Visual consistency requirements
+
+`Trade Insights` must look like a native stock-detail tab, not a new app surface.
+
+Follow these existing patterns:
+
+| Existing file | Reuse / match |
+|---|---|
+| `web/components/stock/tabs/VolatilityTabClient.tsx` (lines 79–88) | Section heading style: uppercase mono, **9px**, `var(--text-muted)`, 1px letter spacing, `marginTop: 4`. This is the current pattern — newer than `TradePlanTab.tsx`'s 10px style. |
+| `web/components/stock/panels/MetricGrid.tsx` | Metric density and small label/value hierarchy. |
+| `web/components/stock/panels/DataTable.tsx` | Table styling for flow and term-structure rows. |
+| `web/components/stock/panels/AnalyticalSeriesPanel.tsx` | Panel shell visual language: `var(--bg-panel)`, `var(--border-dim)`, compact padding. |
+| `web/app/globals.css` | Existing color tokens only; do not introduce a separate palette. |
+| `web/components/stock/TabBar.tsx` | Existing tab typography, active border, and spacing. |
+
+Rules:
+
+- Use `var(--bg-panel)`, `var(--border-dim)`, `var(--text-primary)`, `var(--text-secondary)`, `var(--text-muted)`, `var(--accent-bg)`, `var(--warning)`, `var(--positive)`, and `var(--negative)`.
+- Do not use new gradients, decorative backgrounds, oversized hero elements, or marketing-style cards.
+- Do not nest cards inside cards.
+- Keep cards at the same compact radius and border style as existing panels.
+- Use `DataTable` for tabular data unless a specific card layout is clearer.
+- Use the same `sectionHeading` object from `TradePlanTab.tsx` or extract a shared equivalent if duplication becomes annoying.
+- Candidate structure cards should be compact operational cards, not large narrative tiles.
+- Empty states should match the current small mono style used by existing tabs.
+- The `Run AI Analysis` follow-up button, when implemented later, should be a secondary utility control and not visually dominate the deterministic panels.
+
+## File structure
+
+### New backend files
+
+| Path | Responsibility |
+|---|---|
+| `src/uw_scan/storage/migrations/016_trade_insights.sql` | Persist idempotent Trade Insights snapshots and queryable candidate rows for later validation/backtests. |
+| `src/uw_scan/reports/trade_insights.py` | Deterministic assembler for `TradeInsightsResponse`: parse contracts, build source reconciliation, signal stack, flow rows, term rows, candidate structures, synthesis, and quality badges. |
+| `src/uw_scan/api/routers/trade_insights.py` | FastAPI router for `GET /api/stock/{ticker}/trade-insights`. |
+| `tests/test_trade_insights.py` | Unit tests for option-symbol parsing, candidate math, data-quality flags, source reconciliation, and synthesis status rules. |
+| `tests/integration/api/test_trade_insights_endpoint.py` | API shape and empty-state integration tests. |
+| `web/components/stock/tabs/TradeInsightsTab.tsx` | Main server/client tab component that fetches and composes Trade Insights panels. |
+| `web/components/stock/panels/InsightPanel.tsx` | Shared panel shell + dashed status banner used by every Trade Insights panel. |
+| `web/components/stock/panels/TradeInsightsBiasBanner.tsx` | Bias / setup / confidence / data-quality row + badges. Does NOT render the ticker (the layout's `DetailHeader` already does). |
+| `web/components/stock/panels/SourceReconciliationPanel.tsx` | Source agreement table and decision on IV/price trust. |
+| `web/components/stock/panels/SignalStackPanel.tsx` | Deterministic lens table: vol level, vol stability, realized regime, correlation, flow, structure. |
+| `web/components/stock/panels/ChainFlowReadPanel.tsx` | Strike-level call/put volume/OI table with T+1 OI confirmation caveat. |
+| `web/components/stock/panels/TermMovePanel.tsx` | Expiry-level ATM straddle, implied move, daily implied move table. |
+| `web/components/stock/panels/CandidateStructuresPanel.tsx` | Candidate cards for credit spreads, iron condor, long straddle, and calendar. |
+| `web/components/stock/panels/InsightsSynthesisPanel.tsx` | Dominant story, preferred expression, avoid list, and required checks. |
+| `web/tests/unit/tradeInsightsPanels.test.tsx` | Vitest render tests for panels and empty states. |
+
+### Modified backend files
+
+| Path | What changes |
+|---|---|
+| `src/uw_scan/models.py` | Add `TradeInsightsResponse` and submodels. |
+| `src/uw_scan/storage/repository.py` | Add richer current-run fetch for option contracts with ask/bid volume and `prev_oi`; add latest volatility-series helper if needed; add idempotent Trade Insights persistence helpers. |
+| `src/uw_scan/pipeline.py` | Persist a Trade Insights snapshot at the end of successful single-stock scans so validation does not depend on a user opening the tab. |
+| `src/uw_scan/api/server.py` | Mount the new `trade_insights` router. |
+
+### Modified frontend files
+
+| Path | What changes |
+|---|---|
+| `web/components/stock/TabBar.tsx` | Add `["trade-insights", "Trade Insights"]` between `Flow` and `Trade Plan`. Final order: Market Structure / Volatility / Flow / Trade Insights / Trade Plan. The `Tables` tab no longer exists (merged into `Flow` in 2026-05). |
+| `web/app/stock/[ticker]/[tab]/page.tsx` | Add `trade-insights` case. |
+| `web/lib/api.ts` | Add `api.tradeInsights(ticker)` helper and export `TradeInsightsResponse`. |
+| `web/lib/types.ts` | Regenerate from OpenAPI after backend endpoint lands. |
+
+---
+
+## Phase 1 — Backend types and deterministic helpers
+
+### Task 1.1: Add response models
+
+**Files:**
+- Modify: `src/uw_scan/models.py`
+- Test: `tests/test_trade_insights.py`
+
+- [x] **Step 1: Add model imports if missing**
+
+In `src/uw_scan/models.py`, keep using existing imports:
+
+```python
+from datetime import date as _date
+from datetime import date, datetime
+from decimal import Decimal
+```
+
+- [x] **Step 2: Add Trade Insights models before `SingleStockReport` or after `VolatilitySeriesResponse`**
+
+Add this block:
+
+```python
+class InsightBadge(_UwBase):
+    code: str
+    label: str
+    severity: str = "info"
+
+
+class TradeInsightsHeader(_UwBase):
+    dominant_bias: str = "NEUTRAL"
+    primary_setup: str = "NO_CLEAR_SETUP"
+    confidence_label: str = "LOW"
+    data_quality_label: str = "INSUFFICIENT"
+    idea_count: int = 0
+    preferred_idea_id: str | None = None
+    badges: list[InsightBadge] = []
+
+
+class SourceReconciliationRow(_UwBase):
+    source_pair: str
+    price_agreement: str = ""
+    iv_agreement: str = ""
+    decision: str = ""
+    strike: Decimal | None = None
+    source_a_call_iv: Decimal | None = None
+    source_b_call_iv: Decimal | None = None
+    iv_diff: Decimal | None = None
+
+
+class SourceReconciliation(_UwBase):
+    status: str = "UNKNOWN"
+    headline: str = "Source reconciliation unavailable"
+    primary_iv_source: str | None = None
+    relative_shape_source: str | None = None
+    rows: list[SourceReconciliationRow] = []
+    decision: str = "Use deterministic data only where source agreement is understood."
+
+
+class InsightSignalRow(_UwBase):
+    lens: str
+    read: str
+    evidence: list[str] = []
+    conflicts: list[str] = []
+
+
+class ChainFlowReadRow(_UwBase):
+    strike: Decimal
+    call_volume: int | None = None
+    call_open_interest: int | None = None
+    put_volume: int | None = None
+    put_open_interest: int | None = None
+    call_put_volume_ratio: Decimal | None = None
+    volume_oi_note: str = ""
+    read: str = ""
+    requires_t1_oi_confirmation: bool = False
+
+
+class TermMoveRow(_UwBase):
+    expiry: _date
+    dte: int | None = None
+    atm_straddle: Decimal | None = None
+    implied_move_perc: Decimal | None = None
+    daily_implied_move_perc: Decimal | None = None
+    read: str = ""
+
+
+class InsightLeg(_UwBase):
+    side: str
+    option_symbol: str
+    option_right: str
+    expiry: _date
+    strike: Decimal
+    mid: Decimal | None = None
+
+
+class CandidateStructure(_UwBase):
+    idea_id: str
+    structure: str
+    thesis: str
+    expression_type: str
+    legs: list[InsightLeg] = []
+    net_credit_debit: Decimal | None = None
+    max_profit: Decimal | None = None
+    max_loss: Decimal | None = None
+    breakevens: list[Decimal] = []
+    profit_zone: str = ""
+    edge_source: str = ""
+    risk_flags: list[str] = []
+    rank: int
+    status: str = "candidate"
+
+
+class InsightsSynthesis(_UwBase):
+    dominant_story: str = ""
+    preferred_idea_id: str | None = None
+    best_risk_reward_idea_id: str | None = None
+    avoid: list[str] = []
+    required_before_sizing: list[str] = []
+
+
+class TradeInsightsResponse(_UwBase):
+    ticker: str
+    as_of: datetime | None = None
+    mode: str = "research"
+    header: TradeInsightsHeader
+    source_reconciliation: SourceReconciliation = SourceReconciliation()
+    signal_stack: list[InsightSignalRow] = []
+    flow_table: list[ChainFlowReadRow] = []
+    term_structure_table: list[TermMoveRow] = []
+    candidate_structures: list[CandidateStructure] = []
+    synthesis: InsightsSynthesis = InsightsSynthesis()
+```
+
+- [x] **Step 3: Add a model serialization test**
+
+Create `tests/test_trade_insights.py` with (the `Decimal` import is needed because every subsequent test in this file uses it):
+
+```python
+from decimal import Decimal
+
+from uw_scan.models import (
+    CandidateStructure,
+    InsightLeg,
+    TradeInsightsHeader,
+    TradeInsightsResponse,
+)
+
+
+def test_trade_insights_response_serializes_required_shape():
+    response = TradeInsightsResponse(
+        ticker="TSLA",
+        header=TradeInsightsHeader(
+            dominant_bias="NEUTRAL_SHORT_VOL",
+            primary_setup="IV_RV_SPREAD_MEAN_REVERSION",
+            confidence_label="MEDIUM",
+            data_quality_label="MIXED",
+            idea_count=1,
+        ),
+        candidate_structures=[
+            CandidateStructure(
+                idea_id="A",
+                structure="call_credit_spread",
+                thesis="Front premium is elevated.",
+                expression_type="SHORT_VOL",
+                rank=1,
+                max_loss=Decimal("1.25"),
+                legs=[
+                    InsightLeg(
+                        side="sell",
+                        option_symbol="TSLA260515C00430000",
+                        option_right="C",
+                        expiry="2026-05-15",
+                        strike=Decimal("430"),
+                        mid=Decimal("9.50"),
+                    )
+                ],
+            )
+        ],
+    )
+
+    body = response.model_dump(mode="json")
+    assert body["ticker"] == "TSLA"
+    assert body["header"]["dominant_bias"] == "NEUTRAL_SHORT_VOL"
+    assert body["candidate_structures"][0]["legs"][0]["strike"] == "430"
+    assert body["source_reconciliation"]["status"] == "UNKNOWN"
+```
+
+- [x] **Step 4: Run the test**
+
+Run:
+
+```bash
+uv run pytest tests/test_trade_insights.py -q
+```
+
+Expected before model block is complete: import or validation failure. Expected after model block: `1 passed`.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/models.py tests/test_trade_insights.py
+git commit -m "Add Trade Insights response models"
+```
+
+### Task 1.2: Add OCC/OSI symbol parser and candidate math helpers
+
+**Files:**
+- Create/modify: `src/uw_scan/reports/trade_insights.py`
+- Test: `tests/test_trade_insights.py`
+
+- [x] **Step 1: Add parser tests**
+
+Append to `tests/test_trade_insights.py`:
+
+```python
+from datetime import date
+
+from uw_scan.reports.trade_insights import (
+    ParsedOptionSymbol,
+    _credit_spread_math,
+    _mid,
+    parse_option_symbol,
+)
+
+
+def test_parse_option_symbol_occ_style():
+    parsed = parse_option_symbol("TSLA260515C00430000")
+    assert parsed == ParsedOptionSymbol(
+        root="TSLA",
+        expiry=date(2026, 5, 15),
+        right="C",
+        strike=Decimal("430"),
+    )
+
+
+def test_parse_option_symbol_rejects_bad_symbol():
+    assert parse_option_symbol("bad") is None
+
+
+def test_mid_uses_nbbo_when_present():
+    assert _mid({"nbbo_bid": Decimal("1.00"), "nbbo_ask": Decimal("1.20")}) == Decimal(
+        "1.10"
+    )
+
+
+def test_mid_falls_back_to_last_price():
+    assert _mid({"last_price": Decimal("0.95")}) == Decimal("0.95")
+
+
+def test_credit_spread_math_caps_loss_by_width_minus_credit():
+    net_credit, max_loss, max_profit = _credit_spread_math(
+        short_mid=Decimal("1.80"),
+        long_mid=Decimal("0.55"),
+        width=Decimal("5"),
+    )
+    assert net_credit == Decimal("1.25")
+    assert max_loss == Decimal("3.75")
+    assert max_profit == Decimal("1.25")
+```
+
+- [x] **Step 2: Implement helpers**
+
+Create `src/uw_scan/reports/trade_insights.py` with:
+
+```python
+"""Deterministic Trade Insights assembler.
+
+V1 is intentionally rule-based. Codex/LLM commentary is a later optional layer
+that consumes this structured output but does not alter status or risk checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class ParsedOptionSymbol:
+    root: str
+    expiry: date
+    right: str
+    strike: Decimal
+
+
+def parse_option_symbol(symbol: str) -> ParsedOptionSymbol | None:
+    """Parse OCC/OSI-style compact symbols like TSLA260515C00430000."""
+    if len(symbol) < 15:
+        return None
+    right_index = max(symbol.rfind("C"), symbol.rfind("P"))
+    if right_index < 6:
+        return None
+    right = symbol[right_index]
+    ymd = symbol[right_index - 6 : right_index]
+    strike_raw = symbol[right_index + 1 :]
+    root = symbol[: right_index - 6]
+    if not root or len(ymd) != 6 or len(strike_raw) != 8:
+        return None
+    try:
+        expiry = date(2000 + int(ymd[:2]), int(ymd[2:4]), int(ymd[4:6]))
+        strike = Decimal(str(int(strike_raw))) / Decimal("1000")
+    except (ValueError, ArithmeticError):
+        return None
+    return ParsedOptionSymbol(root=root, expiry=expiry, right=right, strike=strike)
+
+
+def _dec(v: object) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def _mid(contract: dict) -> Decimal | None:
+    bid = _dec(contract.get("nbbo_bid"))
+    ask = _dec(contract.get("nbbo_ask"))
+    if bid is not None and ask is not None and bid >= 0 and ask >= bid:
+        return (bid + ask) / Decimal("2")
+    return _dec(contract.get("last_price"))
+
+
+def _credit_spread_math(
+    *, short_mid: Decimal, long_mid: Decimal, width: Decimal
+) -> tuple[Decimal, Decimal, Decimal]:
+    net_credit = short_mid - long_mid
+    max_profit = net_credit
+    max_loss = width - net_credit
+    return net_credit, max_loss, max_profit
+```
+
+- [x] **Step 3: Run helper tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_trade_insights.py -q
+```
+
+Expected: all tests pass.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/reports/trade_insights.py tests/test_trade_insights.py
+git commit -m "Add Trade Insights option parser helpers"
+```
+
+---
+
+## Phase 2 — Backend assembler and API endpoint
+
+### Task 2.0: Add Trade Insights persistence tables
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/016_trade_insights.sql`
+- Modify: `src/uw_scan/storage/repository.py`
+- Test: `tests/integration/storage/test_repository_trade_insights.py`
+
+- [x] **Step 1: Add migration**
+
+Create `src/uw_scan/storage/migrations/016_trade_insights.sql`:
+
+```sql
+-- Persist deterministic Trade Insights outputs for later validation/backtests.
+-- The UI renders the current response, but research improvement depends on
+-- retaining exactly what the rule engine emitted for each source run.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.trade_insight_snapshots (
+    snapshot_id                  BIGSERIAL PRIMARY KEY,
+    run_id                       BIGINT NOT NULL REFERENCES uw_scan.scan_runs(run_id) ON DELETE CASCADE,
+    ticker                       TEXT NOT NULL,
+    as_of                        TIMESTAMPTZ,
+    assembler_version            TEXT NOT NULL,
+    input_hash                   TEXT NOT NULL,
+    source_reconciliation_status TEXT,
+    confidence_label             TEXT,
+    data_quality_label           TEXT,
+    preferred_idea_id            TEXT,
+    payload_jsonb                JSONB NOT NULL,
+    created_at                   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (run_id, ticker, assembler_version, input_hash)
+);
+
+CREATE TABLE IF NOT EXISTS uw_scan.trade_insight_candidates (
+    snapshot_id       BIGINT NOT NULL REFERENCES uw_scan.trade_insight_snapshots(snapshot_id) ON DELETE CASCADE,
+    idea_id           TEXT NOT NULL,
+    ticker            TEXT NOT NULL,
+    run_id            BIGINT NOT NULL,
+    structure         TEXT NOT NULL,
+    expression_type   TEXT,
+    rank              INTEGER NOT NULL,
+    status            TEXT NOT NULL,
+    net_credit_debit  NUMERIC,
+    max_profit        NUMERIC,
+    max_loss          NUMERIC,
+    edge_source       TEXT,
+    risk_flags        TEXT[] NOT NULL DEFAULT '{}',
+    legs_jsonb        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    candidate_jsonb   JSONB NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (snapshot_id, idea_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trade_insight_snapshots_ticker_created
+    ON uw_scan.trade_insight_snapshots (ticker, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_trade_insight_candidates_structure_status
+    ON uw_scan.trade_insight_candidates (structure, status, rank);
+
+COMMENT ON TABLE uw_scan.trade_insight_snapshots IS
+    'Idempotent deterministic Trade Insights response snapshots used for later validation and backtests.';
+COMMENT ON TABLE uw_scan.trade_insight_candidates IS
+    'Queryable candidate rows emitted by the deterministic Trade Insights assembler.';
+```
+
+- [x] **Step 2: Add repository persistence helper**
+
+In `src/uw_scan/storage/repository.py`, add:
+
+```python
+    def upsert_trade_insight_snapshot(
+        self,
+        *,
+        run_id: int,
+        ticker: str,
+        as_of: datetime | None,
+        assembler_version: str,
+        input_hash: str,
+        payload: dict[str, Any],
+    ) -> int:
+        header = payload.get("header") or {}
+        source_reconciliation = payload.get("source_reconciliation") or {}
+        sql = (
+            f"INSERT INTO {self._schema}.trade_insight_snapshots "
+            "(run_id, ticker, as_of, assembler_version, input_hash, "
+            "source_reconciliation_status, confidence_label, data_quality_label, "
+            "preferred_idea_id, payload_jsonb) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (run_id, ticker, assembler_version, input_hash) "
+            "DO UPDATE SET payload_jsonb=EXCLUDED.payload_jsonb, "
+            "source_reconciliation_status=EXCLUDED.source_reconciliation_status, "
+            "confidence_label=EXCLUDED.confidence_label, "
+            "data_quality_label=EXCLUDED.data_quality_label, "
+            "preferred_idea_id=EXCLUDED.preferred_idea_id "
+            "RETURNING snapshot_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    run_id,
+                    ticker.upper(),
+                    as_of,
+                    assembler_version,
+                    input_hash,
+                    source_reconciliation.get("status"),
+                    header.get("confidence_label"),
+                    header.get("data_quality_label"),
+                    header.get("preferred_idea_id"),
+                    Jsonb(payload),
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def replace_trade_insight_candidates(
+        self,
+        *,
+        snapshot_id: int,
+        run_id: int,
+        ticker: str,
+        candidates: list[dict[str, Any]],
+    ) -> int:
+        delete_sql = f"DELETE FROM {self._schema}.trade_insight_candidates WHERE snapshot_id = %s"
+        insert_sql = (
+            f"INSERT INTO {self._schema}.trade_insight_candidates "
+            "(snapshot_id, idea_id, ticker, run_id, structure, expression_type, rank, "
+            "status, net_credit_debit, max_profit, max_loss, edge_source, risk_flags, "
+            "legs_jsonb, candidate_jsonb) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(delete_sql, (snapshot_id,))
+            for c in candidates:
+                cur.execute(
+                    insert_sql,
+                    (
+                        snapshot_id,
+                        c["idea_id"],
+                        ticker.upper(),
+                        run_id,
+                        c["structure"],
+                        c.get("expression_type"),
+                        c["rank"],
+                        c["status"],
+                        c.get("net_credit_debit"),
+                        c.get("max_profit"),
+                        c.get("max_loss"),
+                        c.get("edge_source"),
+                        list(c.get("risk_flags") or []),
+                        Jsonb(c.get("legs") or []),
+                        Jsonb(c),
+                    ),
+                )
+        return len(candidates)
+```
+
+- [x] **Step 3: Add storage integration test**
+
+Create `tests/integration/storage/test_repository_trade_insights.py` with an idempotency check. Use the existing `seeded_db_empty_cards` fixture (returns a fully-migrated `Repository`) — that's the pattern every other storage integration test follows (see `tests/integration/storage/test_repository_vol_v2.py`). There is no `repo` or `migrated_db` fixture in conftest:
+
+```python
+from datetime import datetime, timezone
+
+
+def test_trade_insight_snapshot_upsert_is_idempotent(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    run_id = repo.insert_scan_run("TSLA")
+    payload = {
+        "ticker": "TSLA",
+        "header": {
+            "confidence_label": "LOW",
+            "data_quality_label": "INSUFFICIENT",
+            "preferred_idea_id": None,
+        },
+        "source_reconciliation": {"status": "UNKNOWN"},
+        "candidate_structures": [
+            {
+                "idea_id": "A",
+                "structure": "call_credit_spread",
+                "expression_type": "SHORT_VOL",
+                "rank": 1,
+                "status": "needs_check",
+                "max_loss": "3.75",
+                "risk_flags": ["event_check_required"],
+                "legs": [],
+            }
+        ],
+    }
+
+    kwargs = {
+        "run_id": run_id,
+        "ticker": "TSLA",
+        "as_of": datetime(2026, 5, 13, tzinfo=timezone.utc),
+        "assembler_version": "trade-insights-v1",
+        "input_hash": "abc123",
+        "payload": payload,
+    }
+    first = repo.upsert_trade_insight_snapshot(**kwargs)
+    second = repo.upsert_trade_insight_snapshot(**kwargs)
+    assert first == second
+
+    written = repo.replace_trade_insight_candidates(
+        snapshot_id=first,
+        run_id=run_id,
+        ticker="TSLA",
+        candidates=payload["candidate_structures"],
+    )
+    assert written == 1
+```
+
+- [x] **Step 4: Run migration/storage tests**
+
+```bash
+bash scripts/migrate.sh
+uv run pytest tests/integration/storage/test_repository_trade_insights.py -q
+```
+
+- [x] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/016_trade_insights.sql src/uw_scan/storage/repository.py tests/integration/storage/test_repository_trade_insights.py
+git commit -m "Persist Trade Insights research snapshots"
+```
+
+### Task 2.1: Add repository fetch for rich option contracts
+
+**Files:**
+- Modify: `src/uw_scan/storage/repository.py`
+- Test: `tests/test_trade_insights.py`
+
+- [x] **Step 1: Add a repository-shape test with a fake repo**
+
+Append this test to `tests/test_trade_insights.py` after Task 2.2 adds `assemble_trade_insights`; keep it skipped until the assembler exists by adding it in Task 2.2, not now. No code change in this step.
+
+- [x] **Step 2: Add `fetch_option_contracts_rich`**
+
+In `src/uw_scan/storage/repository.py`, near `fetch_option_contracts`, add:
+
+```python
+    def fetch_option_contracts_rich(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        sql = (
+            f"SELECT option_symbol, last_price, nbbo_bid, nbbo_ask, "
+            "implied_volatility, open_interest, prev_oi, volume, ask_volume, "
+            "bid_volume, mid_volume, multi_leg_volume, stock_multi_leg_volume, "
+            "floor_volume, sweep_volume, no_side_volume, avg_price, high_price, "
+            "low_price, total_premium "
+            f"FROM {self._schema}.option_contract_snapshots "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY total_premium DESC NULLS LAST"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+```
+
+- [x] **Step 2b: Add `fetch_iv_term_rows`**
+
+The Trade Insights assembler needs term-structure rows. `iv_term_snapshots` already exists (migration `001_s1_core_tables.sql`) but has no read helper. Add one in the same module:
+
+```python
+    def fetch_iv_term_rows(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        sql = (
+            f"SELECT expiry, dte, volatility, implied_move, implied_move_perc "
+            f"FROM {self._schema}.iv_term_snapshots "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry ASC"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker.upper()))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+```
+
+If the table is empty for a run (e.g., new ticker, no UW term endpoint hit yet), the helper returns `[]` and the assembler emits `term_structure_table: []` with `signal_stack` lens `TERM: MISSING`.
+
+- [x] **Step 3: Run static test target**
+
+Run:
+
+```bash
+uv run pytest tests/test_trade_insights.py -q
+```
+
+Expected: existing tests still pass.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/storage/repository.py
+git commit -m "Add rich option contract fetch for Trade Insights"
+```
+
+### Task 2.2: Assemble deterministic Trade Insights response
+
+**Files:**
+- Modify: `src/uw_scan/reports/trade_insights.py`
+- Test: `tests/test_trade_insights.py`
+
+- [x] **Step 1: Add assembler tests with a fake repo**
+
+Append to `tests/test_trade_insights.py`:
+
+```python
+from datetime import date, datetime, timezone
+
+from uw_scan.reports.trade_insights import assemble_trade_insights
+
+
+def _contract(
+    symbol: str,
+    *,
+    bid: str,
+    ask: str,
+    iv: str = "0.52",
+    volume: int = 1000,
+    oi: int = 800,
+):
+    return {
+        "option_symbol": symbol,
+        "last_price": Decimal(bid),
+        "nbbo_bid": Decimal(bid),
+        "nbbo_ask": Decimal(ask),
+        "implied_volatility": Decimal(iv),
+        "open_interest": oi,
+        "prev_oi": max(oi - 50, 0),
+        "volume": volume,
+        "ask_volume": int(volume * 0.55),
+        "bid_volume": int(volume * 0.35),
+        "total_premium": Decimal(bid) * Decimal(volume),
+    }
+
+
+class FakeTradeInsightsRepo:
+    def fetch_option_contracts_rich(self, run_id: int, ticker: str):
+        return [
+            _contract("TSLA260515P00420000", bid="6.10", ask="6.30", volume=450, oi=500),
+            _contract("TSLA260515P00425000", bid="8.00", ask="8.20", volume=600, oi=700),
+            _contract("TSLA260515P00430000", bid="10.20", ask="10.50", volume=900, oi=850),
+            _contract("TSLA260515C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000),
+            _contract("TSLA260515C00435000", bid="6.90", ask="7.10", volume=1200, oi=800),
+            _contract("TSLA260522C00430000", bid="13.80", ask="14.20", iv="0.48", volume=700, oi=900),
+        ]
+
+    def fetch_iv_term_rows(self, run_id: int, ticker: str):
+        return [
+            {
+                "expiry": date(2026, 5, 15),
+                "dte": 4,
+                "implied_move_perc": Decimal("0.048"),
+            },
+            {
+                "expiry": date(2026, 5, 22),
+                "dte": 11,
+                "implied_move_perc": Decimal("0.067"),
+            }
+        ]
+
+    def fetch_source_reconciliation_rows(self, run_id: int, ticker: str):
+        return []
+
+
+def test_assemble_trade_insights_builds_research_response():
+    response = assemble_trade_insights(
+        ticker="TSLA",
+        run_id=1,
+        repo=FakeTradeInsightsRepo(),
+        as_of=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot=Decimal("428"),
+    )
+
+    assert response.ticker == "TSLA"
+    # V1 only emits MIXED or INSUFFICIENT; READY is reserved for a later patch
+    # that wires event/source/liquidity gates fully.
+    assert response.header.data_quality_label == "MIXED"
+    assert response.signal_stack
+    assert response.flow_table
+    assert response.term_structure_table
+    assert response.candidate_structures
+    assert all(c.max_loss is not None for c in response.candidate_structures)
+    assert {
+        "call_credit_spread",
+        "put_credit_spread",
+        "iron_condor",
+        "long_straddle",
+        "calendar_spread",
+    }.issubset({c.structure for c in response.candidate_structures})
+    assert response.source_reconciliation.status == "UNKNOWN"
+    assert response.header.preferred_idea_id is None
+    assert response.synthesis.preferred_idea_id is None
+    assert all(c.status == "needs_check" for c in response.candidate_structures)
+
+
+def test_iron_condor_max_loss_matches_width_minus_total_credit():
+    """Locks in the corrected formula: max(call_width, put_width) - total_credit.
+
+    With the fake fixture (5-point wings on both sides, ~4.75 total credit),
+    max loss should be 0.25 per spread, not max(call_spread.max_loss,
+    put_spread.max_loss). The earlier draft of the plan used the latter and
+    over-stated max loss by ~10x.
+    """
+    response = assemble_trade_insights(
+        ticker="TSLA",
+        run_id=1,
+        repo=FakeTradeInsightsRepo(),
+        as_of=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot=Decimal("428"),
+    )
+    ic = next(c for c in response.candidate_structures if c.structure == "iron_condor")
+    call_spread = next(c for c in response.candidate_structures if c.structure == "call_credit_spread")
+    put_spread = next(c for c in response.candidate_structures if c.structure == "put_credit_spread")
+
+    expected_credit = (call_spread.net_credit_debit or Decimal("0")) + (
+        put_spread.net_credit_debit or Decimal("0")
+    )
+    assert ic.net_credit_debit == expected_credit
+    assert ic.max_profit == expected_credit
+    # Both wings are 5 points wide in the fixture; max wing breach loss is
+    # width - total_credit, not the max of the per-wing losses.
+    assert ic.max_loss == Decimal("5") - expected_credit
+```
+
+- [x] **Step 2: Implement simple V1 assembler**
+
+Extend `src/uw_scan/reports/trade_insights.py` with:
+
+```python
+import hashlib
+import json
+from datetime import date, datetime
+
+from uw_scan.models import (
+    CandidateStructure,
+    ChainFlowReadRow,
+    InsightBadge,
+    InsightLeg,
+    InsightSignalRow,
+    InsightsSynthesis,
+    TermMoveRow,
+    SourceReconciliation,
+    SourceReconciliationRow,
+    TradeInsightsHeader,
+    TradeInsightsResponse,
+)
+
+
+ASSEMBLER_VERSION = "trade-insights-v1"
+
+
+def _stable_payload_hash(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _normalized_contracts(raw: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for row in raw:
+        parsed = parse_option_symbol(str(row.get("option_symbol", "")))
+        if parsed is None:
+            continue
+        item = dict(row)
+        item["parsed"] = parsed
+        item["mid"] = _mid(row)
+        out.append(item)
+    return out
+
+
+def _build_flow_table(contracts: list[dict]) -> list[ChainFlowReadRow]:
+    by_strike: dict[Decimal, dict[str, dict]] = {}
+    for c in contracts:
+        parsed: ParsedOptionSymbol = c["parsed"]
+        by_strike.setdefault(parsed.strike, {})[parsed.right] = c
+
+    rows: list[ChainFlowReadRow] = []
+    for strike in sorted(by_strike):
+        call = by_strike[strike].get("C", {})
+        put = by_strike[strike].get("P", {})
+        call_volume = call.get("volume")
+        put_volume = put.get("volume")
+        call_oi = call.get("open_interest")
+        put_oi = put.get("open_interest")
+        ratio = None
+        if call_volume is not None and put_volume not in (None, 0):
+            ratio = Decimal(str(call_volume)) / Decimal(str(put_volume))
+        requires_t1 = bool(
+            (call_volume is not None and call_oi is not None and call_volume > call_oi)
+            or (put_volume is not None and put_oi is not None and put_volume > put_oi)
+        )
+        rows.append(
+            ChainFlowReadRow(
+                strike=strike,
+                call_volume=call_volume,
+                call_open_interest=call_oi,
+                put_volume=put_volume,
+                put_open_interest=put_oi,
+                call_put_volume_ratio=ratio,
+                volume_oi_note="Volume > OI; confirm with next-day OI"
+                if requires_t1
+                else "No volume/OI anomaly",
+                read="Call demand concentrated"
+                if ratio is not None and ratio > Decimal("1.5")
+                else "Mixed flow",
+                requires_t1_oi_confirmation=requires_t1,
+            )
+        )
+    return rows
+
+
+def _build_source_reconciliation(repo, run_id: int, ticker: str) -> SourceReconciliation:
+    fetch = getattr(repo, "fetch_source_reconciliation_rows", None)
+    rows = fetch(run_id, ticker) if fetch is not None else []
+    if not rows:
+        return SourceReconciliation(
+            status="UNKNOWN",
+            headline="No external IV source reconciliation stored for this run",
+            decision="Use chain-derived values for contract math; do not make absolute-IV trust claims.",
+        )
+    return SourceReconciliation(
+        status="MIXED" if any(r.get("iv_diff") for r in rows) else "READY",
+        headline="Source reconciliation rows available",
+        rows=[SourceReconciliationRow(**r) for r in rows],
+        decision="Prefer chain-derived IV for absolute cheap/rich decisions when vendor IV disagrees.",
+    )
+
+
+def _atm_straddles_by_expiry(
+    contracts: list[dict], spot: Decimal | None
+) -> dict[date, Decimal]:
+    if spot is None:
+        return {}
+    out: dict[date, Decimal] = {}
+    expiries = sorted({c["parsed"].expiry for c in contracts})
+    for expiry in expiries:
+        same_expiry = [c for c in contracts if c["parsed"].expiry == expiry and c.get("mid") is not None]
+        calls = [c for c in same_expiry if c["parsed"].right == "C"]
+        puts = [c for c in same_expiry if c["parsed"].right == "P"]
+        if not calls or not puts:
+            continue
+        call = min(calls, key=lambda c: abs(c["parsed"].strike - spot))
+        put = min(puts, key=lambda c: abs(c["parsed"].strike - spot))
+        if call["parsed"].strike == put["parsed"].strike:
+            out[expiry] = call["mid"] + put["mid"]
+    return out
+
+
+def _build_term_rows(
+    raw: list[dict], contracts: list[dict], spot: Decimal | None
+) -> list[TermMoveRow]:
+    atm_by_expiry = _atm_straddles_by_expiry(contracts, spot)
+    rows: list[TermMoveRow] = []
+    for r in raw:
+        dte = r.get("dte")
+        move = _dec(r.get("implied_move_perc"))
+        daily = None
+        if dte and move is not None and dte > 0:
+            daily = move / Decimal(str(dte))
+        rows.append(
+            TermMoveRow(
+                expiry=r["expiry"],
+                dte=dte,
+                atm_straddle=atm_by_expiry.get(r["expiry"]),
+                implied_move_perc=move,
+                daily_implied_move_perc=daily,
+                read="Front elevated" if dte is not None and dte <= 7 else "Back expiry",
+            )
+        )
+    return rows
+
+
+def _leg(side: str, c: dict) -> InsightLeg:
+    parsed: ParsedOptionSymbol = c["parsed"]
+    return InsightLeg(
+        side=side,
+        option_symbol=c["option_symbol"],
+        option_right=parsed.right,
+        expiry=parsed.expiry,
+        strike=parsed.strike,
+        mid=c.get("mid"),
+    )
+
+
+def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[CandidateStructure]:
+    if spot is None:
+        return []
+    calls = sorted(
+        [c for c in contracts if c["parsed"].right == "C" and c.get("mid") is not None],
+        key=lambda c: abs(c["parsed"].strike - spot),
+    )
+    puts = sorted(
+        [c for c in contracts if c["parsed"].right == "P" and c.get("mid") is not None],
+        key=lambda c: abs(c["parsed"].strike - spot),
+    )
+    candidates: list[CandidateStructure] = []
+
+    if len(calls) >= 2:
+        short_call = calls[0]
+        long_call = next(
+            (c for c in calls[1:] if c["parsed"].strike > short_call["parsed"].strike),
+            None,
+        )
+        if long_call is not None:
+            width = long_call["parsed"].strike - short_call["parsed"].strike
+            credit, max_loss, max_profit = _credit_spread_math(
+                short_mid=short_call["mid"], long_mid=long_call["mid"], width=width
+            )
+            candidates.append(
+                CandidateStructure(
+                    idea_id="A",
+                    structure="call_credit_spread",
+                    thesis="Defined-risk short-call premium candidate.",
+                    expression_type="SHORT_VOL",
+                    legs=[_leg("sell", short_call), _leg("buy", long_call)],
+                    net_credit_debit=credit,
+                    max_profit=max_profit,
+                    max_loss=max_loss,
+                    profit_zone=f"Underlying below {short_call['parsed'].strike}",
+                    edge_source="IV-RV spread / theta",
+                    risk_flags=["bullish_flow_can_break_call_side"],
+                    rank=1,
+                    status="candidate",
+                )
+            )
+
+    if len(puts) >= 2:
+        short_put = puts[0]
+        long_put = next(
+            (p for p in puts[1:] if p["parsed"].strike < short_put["parsed"].strike),
+            None,
+        )
+        if long_put is not None:
+            width = short_put["parsed"].strike - long_put["parsed"].strike
+            credit, max_loss, max_profit = _credit_spread_math(
+                short_mid=short_put["mid"], long_mid=long_put["mid"], width=width
+            )
+            candidates.append(
+                CandidateStructure(
+                    idea_id="B",
+                    structure="put_credit_spread",
+                    thesis="Defined-risk short-put premium candidate.",
+                    expression_type="DIRECTIONAL_THETA",
+                    legs=[_leg("sell", short_put), _leg("buy", long_put)],
+                    net_credit_debit=credit,
+                    max_profit=max_profit,
+                    max_loss=max_loss,
+                    profit_zone=f"Underlying above {short_put['parsed'].strike}",
+                    edge_source="theta / bullish flow",
+                    risk_flags=["gap_down_risk"],
+                    rank=2,
+                    status="candidate",
+                )
+            )
+
+    if len(candidates) >= 2:
+        call_spread = next((c for c in candidates if c.structure == "call_credit_spread"), None)
+        put_spread = next((c for c in candidates if c.structure == "put_credit_spread"), None)
+        if call_spread and put_spread and call_spread.net_credit_debit and put_spread.net_credit_debit:
+            # Iron condor math: max loss equals the wider wing's width minus the
+            # TOTAL credit collected from both verticals. Only one wing can be
+            # breached at expiry, so the loss on that wing is (width - credit),
+            # not the sum of the two wing losses. Using max(call_spread.max_loss,
+            # put_spread.max_loss) double-counts the credit on the unused wing
+            # and understates the actual max loss whenever credit > 0.
+            call_short_strike = call_spread.legs[0].strike
+            call_long_strike = call_spread.legs[1].strike
+            put_short_strike = put_spread.legs[0].strike
+            put_long_strike = put_spread.legs[1].strike
+            call_width = abs(call_long_strike - call_short_strike)
+            put_width = abs(put_short_strike - put_long_strike)
+            credit = call_spread.net_credit_debit + put_spread.net_credit_debit
+            max_loss = max(call_width, put_width) - credit
+            candidates.append(
+                CandidateStructure(
+                    idea_id="C",
+                    structure="iron_condor",
+                    thesis="Defined-risk range candidate built from both short verticals.",
+                    expression_type="SHORT_VOL_RANGE",
+                    legs=[*put_spread.legs, *call_spread.legs],
+                    net_credit_debit=credit,
+                    max_profit=credit,
+                    max_loss=max_loss,
+                    profit_zone=f"{put_spread.profit_zone}; {call_spread.profit_zone}",
+                    edge_source="term structure / IV-RV spread / range structure",
+                    risk_flags=["breakout_risk", "event_check_required"],
+                    rank=3,
+                    status="candidate",
+                )
+            )
+
+    front_expiry = min((c["parsed"].expiry for c in contracts), default=None)
+    if front_expiry is not None:
+        front_calls = [c for c in calls if c["parsed"].expiry == front_expiry]
+        front_puts = [p for p in puts if p["parsed"].expiry == front_expiry]
+        if front_calls and front_puts:
+            call = front_calls[0]
+            put = min(front_puts, key=lambda p: abs(p["parsed"].strike - call["parsed"].strike))
+            debit = call["mid"] + put["mid"]
+            strike = call["parsed"].strike
+            candidates.append(
+                CandidateStructure(
+                    idea_id="D",
+                    structure="long_straddle",
+                    thesis="Long-vol candidate for cheap-vol or realized-move expansion setups.",
+                    expression_type="LONG_VOL",
+                    legs=[_leg("buy", call), _leg("buy", put)],
+                    net_credit_debit=-debit,
+                    max_loss=debit,
+                    max_profit=None,
+                    breakevens=[strike - debit, strike + debit]
+                    if call["parsed"].strike == put["parsed"].strike
+                    else [],
+                    edge_source="realized-vol expansion / cheap IV",
+                    risk_flags=["theta_decay", "requires_realized_move"],
+                    rank=4,
+                    status="candidate",
+                )
+            )
+
+    calendar_pairs = [
+        (near, far)
+        for near in calls
+        for far in calls
+        if near["parsed"].strike == far["parsed"].strike
+        and near["parsed"].expiry < far["parsed"].expiry
+    ]
+    if calendar_pairs:
+        near, far = calendar_pairs[0]
+        debit = far["mid"] - near["mid"]
+        # Calendar spread: max loss is bounded by the initial net debit only if
+        # the position is held to expiration of the far leg. Earlier exit (the
+        # normal exit, around the front expiry) has path-dependent P&L driven by
+        # term-structure shifts and changes in far-leg IV; theoretical max loss
+        # at the front expiry can exceed the debit if the far leg's IV collapses.
+        # V1 reports the "held-to-far-expiry" bound as max_loss and flags the
+        # path-dependence in risk_flags so users do not treat it as a hard cap.
+        # If the near leg is more expensive than the far leg (backwardation),
+        # this becomes a credit calendar; we skip the candidate rather than
+        # report a negative debit, because that scenario needs different math.
+        if debit <= Decimal("0"):
+            pass
+        else:
+            candidates.append(
+                CandidateStructure(
+                    idea_id="E",
+                    structure="calendar_spread",
+                    thesis="Term-structure candidate: sell front volatility, buy later expiry.",
+                    expression_type="TERM_STRUCTURE",
+                    legs=[_leg("sell", near), _leg("buy", far)],
+                    net_credit_debit=-debit,
+                    max_loss=debit,
+                    max_profit=None,
+                    profit_zone=f"Near {near['parsed'].strike} through front expiry",
+                    edge_source="front/back implied-vol dislocation",
+                    risk_flags=[
+                        "event_check_required",
+                        "assignment_ex_dividend_check",
+                        "path_dependent_far_iv_collapse",
+                    ],
+                    rank=5,
+                    status="candidate",
+                )
+            )
+
+    return candidates
+
+
+def assemble_trade_insights(
+    *,
+    ticker: str,
+    run_id: int,
+    repo,
+    as_of: datetime | None,
+    spot: Decimal | None,
+) -> TradeInsightsResponse:
+    contracts = _normalized_contracts(repo.fetch_option_contracts_rich(run_id, ticker))
+    source_reconciliation = _build_source_reconciliation(repo, run_id, ticker)
+    flow_rows = _build_flow_table(contracts)
+    term_rows = _build_term_rows(repo.fetch_iv_term_rows(run_id, ticker), contracts, spot)
+    candidates = _build_candidates(contracts, spot)
+    # V1 intentionally hardcodes event_data_known=False so every candidate ends
+    # as `needs_check` and `preferred_idea_id` stays None. The earnings/dividend
+    # plumbing exists upstream (flow_events.next_earnings_date,
+    # SingleStockReport.next_earnings_date) but is not wired through to this
+    # assembler in V1. A follow-up patch should read those fields and flip the
+    # gate when both are present and outside all candidate expiries.
+    event_data_known = False
+    liquidity_ready = bool(contracts) and all(c.max_loss is not None for c in candidates)
+
+    badges: list[InsightBadge] = [InsightBadge(code="DEFINED_RISK_ONLY", label="Defined-risk only")]
+    if not contracts:
+        badges.append(InsightBadge(code="NO_CHAIN", label="No option chain", severity="warning"))
+    if source_reconciliation.status in {"UNKNOWN", "MIXED"}:
+        badges.append(
+            InsightBadge(
+                code="SOURCE_RECONCILIATION_REQUIRED",
+                label="Source reconciliation incomplete",
+                severity="warning",
+            )
+        )
+    if not event_data_known:
+        badges.append(
+            InsightBadge(
+                code="EVENT_CHECK_REQUIRED",
+                label="Event check required",
+                severity="warning",
+            )
+        )
+    if any(r.requires_t1_oi_confirmation for r in flow_rows):
+        badges.append(
+            InsightBadge(
+                code="T1_OI_CONFIRMATION",
+                label="Volume > OI needs next-day OI confirmation",
+                severity="warning",
+            )
+        )
+
+    signal_stack = [
+        InsightSignalRow(
+            lens="VOL_LEVEL",
+            read="IV_RV_PROXY_AVAILABLE",
+            evidence=["Use Volatility tab IV-RV spread proxy; true model-free VRP not computed."],
+        ),
+        InsightSignalRow(
+            lens="FLOW",
+            read="CALL_DEMAND" if any((r.call_put_volume_ratio or 0) > 1 for r in flow_rows) else "MIXED",
+            evidence=[f"{len(flow_rows)} strike rows available"],
+        ),
+        InsightSignalRow(
+            lens="TERM",
+            read="TERM_ROWS_AVAILABLE" if term_rows else "MISSING",
+            evidence=[f"{len(term_rows)} expiries available"],
+        ),
+    ]
+
+    can_prefer = (
+        bool(candidates)
+        and event_data_known
+        and liquidity_ready
+        and source_reconciliation.status != "UNKNOWN"
+    )
+    if not can_prefer:
+        for candidate in candidates:
+            candidate.status = "needs_check"
+    preferred = candidates[0].idea_id if can_prefer else None
+    return TradeInsightsResponse(
+        ticker=ticker,
+        as_of=as_of,
+        header=TradeInsightsHeader(
+            dominant_bias="NEUTRAL_SHORT_VOL" if candidates else "NEUTRAL",
+            primary_setup="TRADE_INSIGHTS_RESEARCH",
+            confidence_label="MEDIUM" if contracts and candidates else "LOW",
+            data_quality_label="MIXED" if contracts else "INSUFFICIENT",
+            idea_count=len(candidates),
+            preferred_idea_id=preferred,
+            badges=badges,
+        ),
+        source_reconciliation=source_reconciliation,
+        signal_stack=signal_stack,
+        flow_table=flow_rows,
+        term_structure_table=term_rows,
+        candidate_structures=candidates,
+        synthesis=InsightsSynthesis(
+            dominant_story="Deterministic research-grade ideas built from current chain, flow, and term data."
+            if candidates
+            else "Insufficient option-chain data for structure generation.",
+            preferred_idea_id=preferred,
+            best_risk_reward_idea_id=preferred,
+            avoid=["Naked short options", "Executable recommendation language"],
+            required_before_sizing=[
+                "Confirm event calendar through all expiries",
+                "Confirm bid/ask width and open interest",
+                "Confirm next-day OI for volume > OI flags",
+                "Run out-of-sample validation before automation",
+            ],
+        ),
+    )
+```
+
+- [x] **Step 3: Run unit tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_trade_insights.py -q
+```
+
+Expected: all tests pass.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/reports/trade_insights.py tests/test_trade_insights.py
+git commit -m "Assemble deterministic Trade Insights response"
+```
+
+### Task 2.3: Add API router and mount it
+
+**Files:**
+- Create: `src/uw_scan/api/routers/trade_insights.py`
+- Modify: `src/uw_scan/api/server.py`
+- Test: `tests/integration/api/test_trade_insights_endpoint.py`
+
+- [x] **Step 1: Add integration test**
+
+Create `tests/integration/api/test_trade_insights_endpoint.py`:
+
+```python
+"""Integration tests for GET /api/stock/{ticker}/trade-insights."""
+
+from __future__ import annotations
+
+
+def test_trade_insights_endpoint_returns_404_without_run(client, seeded_db_empty_cards):
+    r = client.get("/api/stock/NOPE/trade-insights")
+    assert r.status_code == 404
+    assert "no runs" in r.text
+```
+
+- [x] **Step 2: Create router**
+
+Create `src/uw_scan/api/routers/trade_insights.py`:
+
+```python
+"""Trade Insights endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from uw_scan.api.deps import get_repo
+from uw_scan.models import TradeInsightsResponse
+from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.reports.trade_insights import (
+    ASSEMBLER_VERSION,
+    _stable_payload_hash,
+    assemble_trade_insights,
+)
+from uw_scan.storage.repository import Repository
+
+router = APIRouter()
+
+
+@router.get(
+    "/stock/{ticker}/trade-insights",
+    response_model=TradeInsightsResponse,
+)
+def get_trade_insights(
+    ticker: str, repo: Repository = Depends(get_repo)
+) -> TradeInsightsResponse:
+    t = ticker.upper()
+    run_id = repo.latest_run_id(t)
+    if run_id == 0:
+        raise HTTPException(status_code=404, detail=f"no runs for {t}")
+
+    report = assemble_single_stock_report(t, run_id, repo)
+    response = assemble_trade_insights(
+        ticker=t,
+        run_id=run_id,
+        repo=repo,
+        as_of=report.generated_at,
+        spot=report.market_structure.spot,
+    )
+    payload = response.model_dump(mode="json")
+    input_hash = _stable_payload_hash(payload)
+    snapshot_id = repo.upsert_trade_insight_snapshot(
+        run_id=run_id,
+        ticker=t,
+        as_of=response.as_of,
+        assembler_version=ASSEMBLER_VERSION,
+        input_hash=input_hash,
+        payload=payload,
+    )
+    repo.replace_trade_insight_candidates(
+        snapshot_id=snapshot_id,
+        run_id=run_id,
+        ticker=t,
+        candidates=payload["candidate_structures"],
+    )
+    repo.conn.commit()
+    return response
+```
+
+- [x] **Step 3: Mount router**
+
+In `src/uw_scan/api/server.py`, update imports:
+
+```python
+from uw_scan.api.routers import health, jobs, ohlc, stock, trade_insights, volatility, watchlist
+```
+
+Then add before `return app`:
+
+```python
+    app.include_router(trade_insights.router, prefix="/api", tags=["trade-insights"])
+```
+
+- [x] **Step 4: Run API test**
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_trade_insights_endpoint.py -q
+```
+
+Expected: pass when `UW_SCAN_TEST_DB_NAME` is configured.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/api/routers/trade_insights.py src/uw_scan/api/server.py tests/integration/api/test_trade_insights_endpoint.py
+git commit -m "Add Trade Insights API endpoint"
+```
+
+### Task 2.4: Persist snapshots during scan completion
+
+**Files:**
+- Modify: `src/uw_scan/pipeline.py`
+- Test: `tests/integration/test_trade_insights_pipeline_persistence.py`
+
+- [x] **Step 1: Add a small persistence helper**
+
+In `src/uw_scan/pipeline.py`, import:
+
+```python
+from .reports.trade_insights import (
+    ASSEMBLER_VERSION,
+    _stable_payload_hash,
+    assemble_trade_insights,
+)
+```
+
+Add a helper near `run_single_stock`:
+
+```python
+def _persist_trade_insights_for_run(
+    *,
+    repo: Repository,
+    report: SingleStockReport,
+) -> None:
+    response = assemble_trade_insights(
+        ticker=report.ticker,
+        run_id=report.run_id,
+        repo=repo,
+        as_of=report.generated_at,
+        spot=report.market_structure.spot,
+    )
+    payload = response.model_dump(mode="json")
+    snapshot_id = repo.upsert_trade_insight_snapshot(
+        run_id=report.run_id,
+        ticker=report.ticker,
+        as_of=response.as_of,
+        assembler_version=ASSEMBLER_VERSION,
+        input_hash=_stable_payload_hash(payload),
+        payload=payload,
+    )
+    repo.replace_trade_insight_candidates(
+        snapshot_id=snapshot_id,
+        run_id=report.run_id,
+        ticker=report.ticker,
+        candidates=payload["candidate_structures"],
+    )
+```
+
+- [x] **Step 2: Call the helper before finishing the scan run**
+
+In `run_single_stock`, after the bulk-screener/aggregate update block and before `repo.finish_scan_run(run_id, status="ok")`, call:
+
+```python
+        try:
+            _persist_trade_insights_for_run(repo=repo, report=report)
+        except Exception as exc:  # noqa: BLE001 — research-log only; never block a scan
+            logger.warning(
+                "trade_insights persistence failed for %s run_id=%s: %s",
+                report.ticker,
+                report.run_id,
+                repr(exc),
+            )
+```
+
+Rationale: a new derived feature must not break nightly full-scans for illiquid tickers or sparse chains. The GET endpoint still runs the assembler on demand and writes the same idempotent row, so a missed nightly persistence is recoverable by simply opening the tab. Treat the snapshot table as a research log, not a hard contract.
+
+- [x] **Step 3: Keep the endpoint idempotent**
+
+The `GET /api/stock/{ticker}/trade-insights` endpoint should still upsert the same snapshot as a backfill/repair path for older runs or manually seeded test data. The unique `(run_id, ticker, assembler_version, input_hash)` constraint prevents duplicates.
+
+- [x] **Step 4: Add integration coverage**
+
+Create `tests/integration/test_trade_insights_pipeline_persistence.py` or extend an existing pipeline integration test to assert that a successful single-stock run writes:
+
+- one `trade_insight_snapshots` row for the run;
+- one or more `trade_insight_candidates` rows when enough chain data exists;
+- the same `snapshot_id` after rerunning the endpoint for that run/input hash.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/pipeline.py tests/integration/test_trade_insights_pipeline_persistence.py
+git commit -m "Persist Trade Insights during scan completion"
+```
+
+---
+
+## Phase 3 — Frontend API and route integration
+
+### Task 3.1: Regenerate OpenAPI types and add API helper
+
+**Files:**
+- Modify: `web/lib/types.ts`
+- Modify: `web/lib/api.ts`
+
+- [x] **Step 1: Start backend in a separate terminal if needed**
+
+Run:
+
+```bash
+bash scripts/dev.sh
+```
+
+Expected: FastAPI available at `http://127.0.0.1:8400/openapi.json`.
+
+- [x] **Step 2: Regenerate types**
+
+Run:
+
+```bash
+cd web
+npm run gen:types
+```
+
+Expected: `web/lib/types.ts` contains `/api/stock/{ticker}/trade-insights`.
+
+- [x] **Step 3: Add API helper**
+
+In `web/lib/api.ts`, add:
+
+```ts
+type TradeInsightsResponse = Json<
+  "/api/stock/{ticker}/trade-insights",
+  "get"
+>;
+```
+
+Inside `api`:
+
+```ts
+  tradeInsights: (ticker: string): Promise<TradeInsightsResponse> =>
+    _fetch<TradeInsightsResponse>(`/api/stock/${ticker}/trade-insights`),
+```
+
+And export it:
+
+```ts
+export type {
+  JobStatus,
+  OhlcResponse,
+  SingleStockReport,
+  TradeInsightsResponse,
+  VolatilitySeriesResponse,
+  WatchlistResponse,
+};
+```
+
+- [x] **Step 4: Typecheck**
+
+Run:
+
+```bash
+cd web
+npm run typecheck
+```
+
+Expected: no TypeScript errors.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add web/lib/types.ts web/lib/api.ts
+git commit -m "Add Trade Insights API client"
+```
+
+### Task 3.2: Add the tab route
+
+**Files:**
+- Modify: `web/components/stock/TabBar.tsx`
+- Modify: `web/app/stock/[ticker]/[tab]/page.tsx`
+- Create: `web/components/stock/tabs/TradeInsightsTab.tsx`
+
+- [x] **Step 1: Create placeholder tab**
+
+Create `web/components/stock/tabs/TradeInsightsTab.tsx`:
+
+```tsx
+import { api } from "@/lib/api";
+
+export async function TradeInsightsTab({ ticker }: { ticker: string }) {
+  const insights = await api.tradeInsights(ticker);
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <h3
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "var(--text-muted)",
+          letterSpacing: 1,
+          textTransform: "uppercase",
+        }}
+      >
+        Trade Insights
+      </h3>
+      <div
+        style={{
+          border: "1px solid var(--border-dim)",
+          background: "var(--bg-panel)",
+          padding: 16,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        {insights.header.primary_setup}
+      </div>
+    </div>
+  );
+}
+```
+
+- [x] **Step 2: Add tab link**
+
+In `web/components/stock/TabBar.tsx`, update `TABS`:
+
+```ts
+const TABS = [
+  ["market-structure", "Market Structure"],
+  ["volatility", "Volatility"],
+  ["flow", "Flow"],
+  ["trade-insights", "Trade Insights"],
+  ["trade-plan", "Trade Plan"],
+] as const;
+```
+
+Note: there is no `["tables", "Tables"]` entry — the standalone Tables tab was merged into Flow in commit `e996b5e` (2026-05). Do not re-introduce it.
+
+- [x] **Step 3: Add route switch**
+
+In `web/app/stock/[ticker]/[tab]/page.tsx`, import:
+
+```ts
+import { TradeInsightsTab } from "@/components/stock/tabs/TradeInsightsTab";
+```
+
+Update the report-backed tab map. Keep `trade-insights` out of this map because it fetches its own endpoint and accepts `{ ticker }`, not `{ report }`. The current `TABS` constant only contains the four report-backed tabs (no `tables` — that tab was removed when Flow + Tables merged):
+
+```ts
+const REPORT_TABS = {
+  "market-structure": MarketStructureTab,
+  volatility: VolatilityTab,
+  flow: FlowTab,
+  "trade-plan": TradePlanTab,
+} as const;
+```
+
+Do **not** import `TablesTab` — that component no longer exists.
+
+Update the return:
+
+```tsx
+  if (tab === "trade-insights") {
+    return <TradeInsightsTab ticker={ticker} />;
+  }
+  const Component = REPORT_TABS[tab as keyof typeof REPORT_TABS];
+  if (!Component) notFound();
+
+  const report = await api.stock(ticker);
+  return <Component report={report} />;
+```
+
+Loading/error UX: `TradeInsightsTab` is an async server component that hits a fresh endpoint, so a slow or 404 response would otherwise blank the page. Either rely on the surrounding `app/stock/[ticker]/layout.tsx` `loading.tsx`/`error.tsx` boundaries if they already cover the `[tab]` segment, or add minimal `loading.tsx` and `error.tsx` siblings to `app/stock/[ticker]/[tab]/` if not. Confirm before implementation.
+
+- [x] **Step 4: Typecheck**
+
+Run:
+
+```bash
+cd web
+npm run typecheck
+```
+
+Expected: no TypeScript errors.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add web/components/stock/TabBar.tsx 'web/app/stock/[ticker]/[tab]/page.tsx' web/components/stock/tabs/TradeInsightsTab.tsx
+git commit -m "Add Trade Insights stock tab route"
+```
+
+### Task 3.3: Add loading and error boundaries for the stock tab segment
+
+**Files:**
+- Create: `web/app/stock/[ticker]/[tab]/loading.tsx`
+- Create: `web/app/stock/[ticker]/[tab]/error.tsx`
+
+**Why this task exists.** The Volatility / Flow / Market Structure / Trade Plan tabs survive a slow `api.stock(ticker)` because the parent layout awaits it before paint. Trade Insights adds a second sequential `await api.tradeInsights(ticker)` inside the tab — when that endpoint is slow the user sees the previous tab's content frozen for the full duration. A `loading.tsx` sibling at the `[tab]` segment makes the transition explicit; an `error.tsx` keeps a single failing tab from blanking the rest of the page.
+
+- [x] **Step 1: Create `loading.tsx`**
+
+```tsx
+export default function Loading() {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--text-muted)",
+        padding: 16,
+      }}
+    >
+      Loading…
+    </div>
+  );
+}
+```
+
+Match the existing empty-state styling (mono 12px, `var(--text-muted)`). Do not add a full skeleton in V1 — the loading state is brief enough that a single line is sufficient and adding skeleton panels per tab is scope creep.
+
+- [x] **Step 2: Create `error.tsx`**
+
+```tsx
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--negative)",
+        padding: 16,
+      }}
+    >
+      <div>Tab failed to load: {error.message}</div>
+      <button
+        type="button"
+        onClick={reset}
+        style={{
+          marginTop: 8,
+          padding: "4px 8px",
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-dim)",
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          cursor: "pointer",
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+```
+
+The boundary applies to every tab via the route segment, so all four existing tabs also gain graceful failure. This is intentional — they previously had none.
+
+- [x] **Step 3: Commit**
+
+```bash
+git add 'web/app/stock/[ticker]/[tab]/loading.tsx' 'web/app/stock/[ticker]/[tab]/error.tsx'
+git commit -m "Add loading and error boundaries for stock tab segment"
+```
+
+---
+
+## Phase 4 — Frontend panels
+
+### Task 4.0: Extract shared `InsightPanel` shell
+
+**Files:**
+- Create: `web/components/stock/panels/InsightPanel.tsx`
+
+**Why this task exists.** Seven of the eight Trade Insights components share identical panel chrome (border, background, padding, section heading). Volatility v2 already established the precedent of lifting a `AnalyticalSeriesPanel.tsx` shell — without doing the same here, the seven downstream panel files each repeat the same 6-line inline style block. Build the shell first; every later panel just nests its content inside `<InsightPanel heading="…">…</InsightPanel>`.
+
+- [x] **Step 1: Create the shell**
+
+```tsx
+import type { ReactNode } from "react";
+
+const sectionHeading: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 9,
+  color: "var(--text-muted)",
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  marginTop: 4,
+};
+
+export function InsightPanel({
+  heading,
+  subheading,
+  children,
+  fullBleed = false,
+}: {
+  heading: string;
+  subheading?: string;
+  children: ReactNode;
+  fullBleed?: boolean;
+}) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        background: "var(--bg-panel)",
+        padding: fullBleed ? 0 : 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div style={{ padding: fullBleed ? "16px 16px 0" : 0 }}>
+        <div style={sectionHeading}>{heading}</div>
+        {subheading && (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              color: "var(--text-primary)",
+            }}
+          >
+            {subheading}
+          </div>
+        )}
+      </div>
+      <div style={{ padding: fullBleed ? "0 16px 16px" : 0 }}>{children}</div>
+    </section>
+  );
+}
+
+export function InsightStatusBanner({
+  text,
+  severity = "warning",
+}: {
+  text: string;
+  severity?: "warning" | "negative" | "info";
+}) {
+  const color =
+    severity === "negative"
+      ? "var(--negative)"
+      : severity === "info"
+        ? "var(--text-secondary)"
+        : "var(--warning)";
+  return (
+    <div
+      style={{
+        padding: 8,
+        background: "var(--bg-panel)",
+        border: `1px dashed ${color}`,
+        borderRadius: 4,
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color,
+      }}
+    >
+      {text}
+    </div>
+  );
+}
+```
+
+Pattern source: `VolatilityTabClient.tsx` lines 65–88 (the dashed-banner) and 79–88 (the section heading).
+
+- [x] **Step 2: Commit**
+
+```bash
+git add web/components/stock/panels/InsightPanel.tsx
+git commit -m "Add shared InsightPanel shell for Trade Insights"
+```
+
+### Task 4.1: Add bias banner, source reconciliation, and signal stack panels
+
+**Files:**
+- Create: `web/components/stock/panels/TradeInsightsBiasBanner.tsx`
+- Create: `web/components/stock/panels/SourceReconciliationPanel.tsx`
+- Create: `web/components/stock/panels/SignalStackPanel.tsx`
+- Modify: `web/components/stock/tabs/TradeInsightsTab.tsx`
+- Test: `web/tests/unit/tradeInsightsPanels.test.tsx`
+
+**Why the rename.** `web/app/stock/[ticker]/layout.tsx` already renders `<DetailHeader>` showing the ticker, spot, IV, and setup badge. A second ticker render in the tab body is duplicated UX. The panel's actual job is the bias/setup/confidence/data-quality row plus badges — `TradeInsightsBiasBanner` names that responsibility. Do not accept `ticker` as a prop; do not render the ticker.
+
+- [x] **Step 1: Create panel tests**
+
+Create `web/tests/unit/tradeInsightsPanels.test.tsx`:
+
+```tsx
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SignalStackPanel } from "@/components/stock/panels/SignalStackPanel";
+import { SourceReconciliationPanel } from "@/components/stock/panels/SourceReconciliationPanel";
+import { TradeInsightsBiasBanner } from "@/components/stock/panels/TradeInsightsBiasBanner";
+
+describe("TradeInsightsBiasBanner", () => {
+  it("renders setup and badges without the ticker", () => {
+    render(
+      <TradeInsightsBiasBanner
+        header={{
+          dominant_bias: "NEUTRAL_SHORT_VOL",
+          primary_setup: "TRADE_INSIGHTS_RESEARCH",
+          confidence_label: "MEDIUM",
+          data_quality_label: "MIXED",
+          badges: [{ code: "DEFINED_RISK_ONLY", label: "Defined-risk only", severity: "info" }],
+        }}
+      />,
+    );
+    // The parent layout's <DetailHeader> already renders the ticker, so the
+    // banner intentionally does NOT — assert absence to lock that contract in.
+    expect(screen.queryByText("TSLA")).toBeNull();
+    expect(screen.getByText("TRADE_INSIGHTS_RESEARCH")).toBeDefined();
+    expect(screen.getByText("Defined-risk only")).toBeDefined();
+  });
+});
+
+describe("SourceReconciliationPanel", () => {
+  it("renders source decision", () => {
+    render(
+      <SourceReconciliationPanel
+        reconciliation={{
+          status: "UNKNOWN",
+          headline: "No external IV source reconciliation stored for this run",
+          primary_iv_source: null,
+          relative_shape_source: null,
+          rows: [],
+          decision: "Use chain-derived values for contract math.",
+        }}
+      />,
+    );
+    expect(screen.getByText(/chain-derived values/i)).toBeDefined();
+  });
+});
+
+describe("SignalStackPanel", () => {
+  it("renders lens rows", () => {
+    render(
+      <SignalStackPanel
+        rows={[
+          {
+            lens: "VOL_LEVEL",
+            read: "IV_RV_PROXY_AVAILABLE",
+            evidence: ["proxy available"],
+            conflicts: [],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("VOL_LEVEL")).toBeDefined();
+    expect(screen.getByText("proxy available")).toBeDefined();
+  });
+});
+```
+
+- [x] **Step 2: Implement `TradeInsightsBiasBanner`**
+
+Create `web/components/stock/panels/TradeInsightsBiasBanner.tsx`. Uses the shared `InsightPanel` shell from Task 4.0. No ticker render — that's the parent layout's job.
+
+```tsx
+import type { TradeInsightsResponse } from "@/lib/api";
+import { InsightPanel } from "./InsightPanel";
+
+type Header = TradeInsightsResponse["header"];
+
+const badgeColor = (severity: string | undefined) => {
+  if (severity === "warning") return "var(--warning)";
+  if (severity === "error") return "var(--negative)";
+  return "var(--accent-bg)";
+};
+
+export function TradeInsightsBiasBanner({ header }: { header: Header }) {
+  return (
+    <InsightPanel heading="BIAS · SETUP">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: 12,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        <div>
+          <div style={{ color: "var(--text-primary)", fontSize: 14 }}>
+            {header.primary_setup}
+          </div>
+          <div style={{ color: "var(--text-secondary)" }}>
+            {header.dominant_bias}
+          </div>
+        </div>
+        <div style={{ textAlign: "right", color: "var(--text-secondary)" }}>
+          <div>Confidence: {header.confidence_label}</div>
+          <div>Data quality: {header.data_quality_label}</div>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {header.badges.map((badge) => (
+          <span
+            key={badge.code}
+            style={{
+              border: "1px solid var(--border-dim)",
+              color: badgeColor(badge.severity),
+              padding: "4px 8px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+            }}
+          >
+            {badge.label}
+          </span>
+        ))}
+      </div>
+    </InsightPanel>
+  );
+}
+```
+
+- [x] **Step 3: Implement `SourceReconciliationPanel`**
+
+Create `web/components/stock/panels/SourceReconciliationPanel.tsx`:
+
+```tsx
+import type { TradeInsightsResponse } from "@/lib/api";
+import { DataTable } from "./DataTable";
+
+type Reconciliation = TradeInsightsResponse["source_reconciliation"];
+
+const sectionHeading: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 9,
+  color: "var(--text-muted)",
+  letterSpacing: 1,
+  textTransform: "uppercase",
+};
+
+export function SourceReconciliationPanel({
+  reconciliation,
+}: {
+  reconciliation: Reconciliation;
+}) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        background: "var(--bg-panel)",
+        padding: 16,
+      }}
+    >
+      <h3 style={sectionHeading}>SOURCE RECONCILIATION</h3>
+      <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+        <div style={{ color: "var(--text-primary)", marginBottom: 4 }}>
+          {reconciliation.headline}
+        </div>
+        <div style={{ color: "var(--text-secondary)", marginBottom: 12 }}>
+          {reconciliation.decision}
+        </div>
+      </div>
+      {reconciliation.rows.length > 0 && (
+        <DataTable
+          rows={reconciliation.rows}
+          columns={[
+            { key: "source_pair", label: "Source Pair" },
+            { key: "price_agreement", label: "Price" },
+            { key: "iv_agreement", label: "IV" },
+            { key: "decision", label: "Decision" },
+          ]}
+        />
+      )}
+    </section>
+  );
+}
+```
+
+- [x] **Step 4: Implement `SignalStackPanel`**
+
+Create `web/components/stock/panels/SignalStackPanel.tsx`:
+
+```tsx
+import type { TradeInsightsResponse } from "@/lib/api";
+
+type Row = TradeInsightsResponse["signal_stack"][number];
+
+const sectionHeading: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 9,
+  color: "var(--text-muted)",
+  letterSpacing: 1,
+  textTransform: "uppercase",
+};
+
+export function SignalStackPanel({ rows }: { rows: Row[] }) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        background: "var(--bg-panel)",
+        padding: 16,
+      }}
+    >
+      <h3 style={sectionHeading}>
+        SIGNAL STACK
+      </h3>
+      <div style={{ display: "grid", gap: 10 }}>
+        {rows.map((row) => (
+          <div key={row.lens} style={{ display: "grid", gridTemplateColumns: "140px 1fr", gap: 12 }}>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>{row.lens}</div>
+            <div>
+              <div style={{ fontWeight: 600 }}>{row.read}</div>
+              <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+                {row.evidence.join(" | ")}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [x] **Step 5: Compose panels in tab**
+
+Update `web/components/stock/tabs/TradeInsightsTab.tsx`:
+
+```tsx
+import { api } from "@/lib/api";
+import { SignalStackPanel } from "../panels/SignalStackPanel";
+import { SourceReconciliationPanel } from "../panels/SourceReconciliationPanel";
+import { TradeInsightsBiasBanner } from "../panels/TradeInsightsBiasBanner";
+
+export async function TradeInsightsTab({ ticker }: { ticker: string }) {
+  const insights = await api.tradeInsights(ticker);
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <TradeInsightsBiasBanner header={insights.header} />
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
+        <SignalStackPanel rows={insights.signal_stack} />
+      </div>
+    </div>
+  );
+}
+```
+
+Layout pattern source: `VolatilityTabClient.tsx` lines 95+ (`gridTemplateColumns: "1fr 1fr"` for paired panels). Task 4.2 expands this with another paired row (flow + term) and two full-width rows (candidates, synthesis).
+
+- [x] **Step 6: Run frontend tests**
+
+Run:
+
+```bash
+cd web
+npm run test -- tradeInsightsPanels.test.tsx
+```
+
+Expected: tests pass.
+
+- [x] **Step 7: Commit**
+
+```bash
+git add web/components/stock/panels/TradeInsightsBiasBanner.tsx web/components/stock/panels/SourceReconciliationPanel.tsx web/components/stock/panels/SignalStackPanel.tsx web/components/stock/tabs/TradeInsightsTab.tsx web/tests/unit/tradeInsightsPanels.test.tsx
+git commit -m "Add Trade Insights header and signal panels"
+```
+
+### Task 4.2: Add flow, term, candidate, and synthesis panels
+
+**Files:**
+- Create: `web/components/stock/panels/ChainFlowReadPanel.tsx`
+- Create: `web/components/stock/panels/TermMovePanel.tsx`
+- Create: `web/components/stock/panels/CandidateStructuresPanel.tsx`
+- Create: `web/components/stock/panels/InsightsSynthesisPanel.tsx`
+- Modify: `web/components/stock/tabs/TradeInsightsTab.tsx`
+- Test: `web/tests/unit/tradeInsightsPanels.test.tsx`
+
+- [x] **Step 1: Add panel tests**
+
+Append tests:
+
+```tsx
+import { CandidateStructuresPanel } from "@/components/stock/panels/CandidateStructuresPanel";
+import { ChainFlowReadPanel } from "@/components/stock/panels/ChainFlowReadPanel";
+import { InsightsSynthesisPanel } from "@/components/stock/panels/InsightsSynthesisPanel";
+import { TermMovePanel } from "@/components/stock/panels/TermMovePanel";
+
+describe("Trade Insights detail panels", () => {
+  it("renders flow table T+1 caveat", () => {
+    render(
+      <ChainFlowReadPanel
+        rows={[
+          {
+            strike: "430",
+            call_volume: 1500,
+            call_open_interest: 1000,
+            put_volume: 600,
+            put_open_interest: 700,
+            call_put_volume_ratio: "2.5",
+            volume_oi_note: "Volume > OI; confirm with next-day OI",
+            read: "Call demand concentrated",
+            requires_t1_oi_confirmation: true,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/next-day OI/i)).toBeDefined();
+  });
+
+  it("renders term move rows", () => {
+    render(
+      <TermMovePanel
+        rows={[
+          {
+            expiry: "2026-05-15",
+            dte: 4,
+            atm_straddle: null,
+            implied_move_perc: "0.048",
+            daily_implied_move_perc: "0.012",
+            read: "Front elevated",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("2026-05-15")).toBeDefined();
+    expect(screen.getByText("Front elevated")).toBeDefined();
+  });
+
+  it("renders candidate max loss", () => {
+    render(
+      <CandidateStructuresPanel
+        candidates={[
+          {
+            idea_id: "A",
+            structure: "call_credit_spread",
+            thesis: "Defined-risk short-call premium candidate.",
+            expression_type: "SHORT_VOL",
+            legs: [],
+            net_credit_debit: "1.25",
+            max_profit: "1.25",
+            max_loss: "3.75",
+            breakevens: [],
+            profit_zone: "Underlying below 430",
+            edge_source: "IV-RV spread / theta",
+            risk_flags: ["bullish_flow_can_break_call_side"],
+            rank: 1,
+            status: "candidate",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Max loss/i)).toBeDefined();
+    expect(screen.getByText("$3.75")).toBeDefined();
+  });
+
+  it("renders synthesis required checks", () => {
+    render(
+      <InsightsSynthesisPanel
+        synthesis={{
+          dominant_story: "Research-grade ideas built from current chain.",
+          preferred_idea_id: "A",
+          best_risk_reward_idea_id: "A",
+          avoid: ["Naked short options"],
+          required_before_sizing: ["Confirm event calendar"],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Confirm event calendar/)).toBeDefined();
+  });
+});
+```
+
+- [x] **Step 2: Implement panels**
+
+Use compact table/card components with inline styles matching the existing panel pattern. Prefer importing and reusing `DataTable` for `ChainFlowReadPanel` and `TermMovePanel`, because this keeps spacing, text, and borders aligned with the `Tables` and `Trade Plan` tabs. Each panel should accept the exact typed slice from `TradeInsightsResponse`. Ensure empty arrays render a clear empty state:
+
+Empty states should use the shared dashed banner from `InsightPanel.tsx` instead of an ad-hoc div, so they look identical to Volatility v2's "Building 1-year history…" notice:
+
+```tsx
+import { InsightStatusBanner } from "./InsightPanel";
+
+// Inside any panel where the input is empty:
+if (rows.length === 0) {
+  return (
+    <InsightPanel heading="CHAIN / FLOW READ">
+      <InsightStatusBanner text="No option chain rows for this run" severity="info" />
+    </InsightPanel>
+  );
+}
+```
+
+Specific styling requirements:
+
+- Panel shell: use `<InsightPanel heading="…">` from Task 4.0 — do NOT re-inline `border / borderRadius / background / padding`. The shell already supplies them.
+- Tables: use `DataTable` and its column renderers for money/percent formatting.
+- Candidate cards: `display: grid`, compact `gap: 8`, same border/background as the panel shell, but **do not nest `InsightPanel` inside `InsightPanel`** (would double-border). Cards use the plain `<section>` styling inline.
+- Risk flags: small mono chips using `var(--warning)` or `var(--negative)`.
+- Required checks: compact bullet list in mono 12px, same as `TradePlanTab` confirmations/warnings.
+- Empty-state strings (`InsightStatusBanner` text): `"No option chain rows for this run"`, `"No iv_term_snapshots for this run"`, `"No candidate structures generated"`, `"No source reconciliation data"`. Match phrasing across panels.
+
+- [x] **Step 3: Compose all panels in a 2-column grid where natural**
+
+Update `TradeInsightsTab.tsx` so the layout matches the density of `VolatilityTabClient.tsx` (2-col grid for paired panels, full-width for the synthesis row):
+
+```tsx
+import { CandidateStructuresPanel } from "../panels/CandidateStructuresPanel";
+import { ChainFlowReadPanel } from "../panels/ChainFlowReadPanel";
+import { InsightsSynthesisPanel } from "../panels/InsightsSynthesisPanel";
+import { TermMovePanel } from "../panels/TermMovePanel";
+
+// Final composed return:
+return (
+  <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+    <TradeInsightsBiasBanner header={insights.header} />
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+      <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
+      <SignalStackPanel rows={insights.signal_stack} />
+    </div>
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+      <ChainFlowReadPanel rows={insights.flow_table} />
+      <TermMovePanel rows={insights.term_structure_table} />
+    </div>
+    <CandidateStructuresPanel candidates={insights.candidate_structures} />
+    <InsightsSynthesisPanel synthesis={insights.synthesis} />
+  </div>
+);
+```
+
+Rationale: source reconciliation and signal stack are both short evidence-summary panels — pairing them avoids dead horizontal space. Flow table and term table both render tabular data of similar height — pairing them creates symmetry. Candidate cards and synthesis are wide content that benefits from the full viewport.
+
+- [x] **Step 4: Run frontend tests and typecheck**
+
+Run:
+
+```bash
+cd web
+npm run test -- tradeInsightsPanels.test.tsx
+npm run typecheck
+```
+
+Expected: both pass.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/ChainFlowReadPanel.tsx web/components/stock/panels/TermMovePanel.tsx web/components/stock/panels/CandidateStructuresPanel.tsx web/components/stock/panels/InsightsSynthesisPanel.tsx web/components/stock/tabs/TradeInsightsTab.tsx web/tests/unit/tradeInsightsPanels.test.tsx
+git commit -m "Render Trade Insights detail panels"
+```
+
+---
+
+## Phase 5 — Validation and follow-up docs
+
+### Task 5.1: Full backend and frontend verification
+
+**Files:**
+- No source edits unless tests expose a defect.
+
+- [x] **Step 1: Run backend focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_trade_insights.py tests/integration/api/test_trade_insights_endpoint.py -q
+```
+
+Expected: all pass.
+
+- [x] **Step 2: Run frontend focused tests**
+
+Run:
+
+```bash
+cd web
+npm run test -- tradeInsightsPanels.test.tsx
+npm run typecheck
+```
+
+Expected: all pass.
+
+- [x] **Step 3: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check HEAD
+```
+
+Expected: no output.
+
+- [x] **Step 4: Commit any verification fixes**
+
+If fixes were needed:
+
+```bash
+git add <changed-files>
+git commit -m "Fix Trade Insights verification issues"
+```
+
+If no fixes were needed, record in the implementation handoff that verification passed with no changes.
+
+### Task 5.2: Optional V1.5 Codex analysis plan
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-05-13-trade-insights-codex-analysis.md`
+
+- [x] **Step 1: Create a separate V1.5 plan only after V1 is passing**
+
+Write a follow-up plan that covers:
+
+- migration for `trade_insight_ai_analyses`;
+- fixed prompt template;
+- allowlisted `codex exec` wrapper;
+- worker job and timeout;
+- UI button and polling;
+- artifact rendering;
+- tests for failure fallback.
+
+- [x] **Step 2: Keep V1.5 out of the V1 code path**
+
+Do not add the button or Codex job in this implementation branch unless the user explicitly expands scope after V1 passes.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- `Trade Insights` naming: covered by tab route and UI labels in Tasks 3.2 and 4.x.
+- Research-grade boundary: covered by backend status strings, UI guardrails, and no order controls.
+- Source reconciliation: covered by response model, deterministic assembler default, and `SourceReconciliationPanel`.
+- Deterministic signal stack: covered by Task 2.2 and Task 4.1.
+- Chain/flow read with T+1 OI caveat: covered by Task 2.2 and Task 4.2.
+- Term structure / implied move rows: covered by Task 2.2 and Task 4.2, including ATM straddle computed from chain mids when available.
+- Candidate structures with max loss: covered by Task 2.2 and Task 4.2 for call credit spread, put credit spread, iron condor, long straddle, and calendar spread.
+- Preferred status gate: covered by Task 2.2; missing event/source/liquidity checks force `needs_check` and keep `preferred_idea_id` null.
+- Contract normalization: covered by Task 1.2 parser and backend-normalized response legs.
+- Optional Codex support: explicitly deferred into Task 5.2 as V1.5.
+
+### Execution notes
+
+- Start execution in an isolated worktree if the current tree contains unrelated Volatility v2 edits.
+- Do not commit `.serena/` unless the user explicitly wants project-local Serena metadata tracked.
+- Keep V1 deterministic; AI commentary is not part of this plan's implemented scope.
+
+### Known V1 limitations (carried intentionally)
+
+- `event_data_known` is hardcoded `False` in `assemble_trade_insights`. Every candidate gets `status="needs_check"` and `preferred_idea_id` stays `None`. The earnings/dividend plumbing exists upstream but is not wired into this assembler in V1 — schedule a V1.1 follow-up to read `SingleStockReport.next_earnings_date` and `flow_events.next_earnings_date` and unblock the `preferred` gate.
+- `InsightSignalRow.conflicts` is declared in the model but the V1 assembler emits empty arrays. Reserved for V1.1 (bullish-flow-vs-short-call surfacing per spec §4.3). Leaving the field shape stable now avoids a breaking response change later.
+- `data_quality_label` only emits `MIXED` or `INSUFFICIENT` in V1. `READY` is reserved for the same V1.1 patch that wires event/source/liquidity gates end-to-end.
+- Pipeline persistence is best-effort (logged warning on failure, see Task 2.4 Step 2). The GET endpoint is the authoritative path — it always assembles fresh and upserts idempotently.
+- `liquidity_ready` is a math-completeness check (`all(c.max_loss is not None)`), not a true liquidity gate. The spec §9 calls for suppressing structures when the chain is stale or illiquid (wide NBBO, low OI/volume). V1 does not implement bid/ask-width or OI/volume thresholds before candidate generation — every fillable strike pair produces a candidate. A V1.1 patch should add a `_passes_liquidity_gate(contract)` check (suggested initial thresholds: `(ask - bid) / mid <= 0.10` and `open_interest >= 100`) and skip non-passing strikes before the candidate loop.
+- Calendar-spread candidate is skipped when the front leg is more expensive than the back (backwardation → credit calendar). The math in V1 only handles the debit-calendar case correctly; credit-calendar P&L requires different bounds.
+- **No expiry / strike-range selectors** on the Chain Flow Read panel. `FlowTab.tsx` exposes `EXPIRIES: [N selected ▾]` and `STRIKE RANGE: [±30% ▾]` controls above its strike tables; Trade Insights V1 renders every strike row from `flow_table`. For very liquid names this can produce a 30-row table. A V1.1 patch should adopt the Flow filter shape so users can scope the chain view.

--- a/docs/superpowers/specs/2026-05-13-trade-insights-tab-design.md
+++ b/docs/superpowers/specs/2026-05-13-trade-insights-tab-design.md
@@ -1,0 +1,628 @@
+# Trade Insights Tab — volatility research presentation design
+
+**Date:** 2026-05-13
+**Status:** Draft
+**Context:** Presentation design for research-grade trade ideas using the Volatility Tab v2 features plus cross-source option-chain analysis. This is based on the TSLA analysis example that reconciled TradingView-style IV, yfinance-style IV, option prices, volume/OI, term structure, and candidate structures.
+
+## 1. Goal
+
+Add a new stock-detail tab that presents **research-grade trade ideas** without pretending they are executable orders.
+
+Proposed route:
+
+```text
+/stock/{ticker}/trade-insights
+```
+
+Proposed tab order:
+
+```text
+Market Structure | Volatility | Flow | Trade Insights | Trade Plan
+```
+
+(The standalone `Tables` tab was merged into `Flow` in 2026-05; raw rows now live there.)
+
+The tab answers:
+
+- Is volatility cheap or rich?
+- Are sources agreeing or disagreeing?
+- What is the dominant flow/positioning read?
+- Which option structures express the setup?
+- What checks are still required before sizing?
+- Why is a structure preferred or rejected?
+
+It should not submit orders, auto-size positions, or claim backtested edge.
+
+## 2. Why this should be separate from Trade Plan
+
+The existing `TradePlanTab` is order-plan shaped: setup, confirmations, warnings, structure, legs, max loss, max profit. The TSLA-style analysis is **research shaped**:
+
+- source reconciliation;
+- IV methodology disagreement;
+- flow/OI interpretation;
+- term-structure interpretation;
+- several candidate structures;
+- qualitative synthesis;
+- required checks before sizing.
+
+Putting all of that inside Trade Plan would make the order plan noisy. Trade Insights should sit upstream: it narrows candidates and records evidence. Trade Plan can later consume one selected idea and convert it into a concrete, risk-sized plan.
+
+## 3. Page hierarchy
+
+```text
+┌─ IDEA HEADER ───────────────────────────────────────────────────────────────┐
+│ TSLA  |  Research-grade trade ideas  |  As of 2026-05-13 15:59 ET          │
+│ Bias: Neutral / Short Vol  |  Confidence: Medium  |  Data Quality: Mixed   │
+│ Badges: IV-source mismatch, event check required, liquid chain             │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌─ SOURCE RECONCILIATION ───────────────┐ ┌─ SIGNAL STACK ───────────────────┐
+│ Prices match, IV differs              │ │ IV-RV z, divergence, regime      │
+│ TV IV 44%, YF IV 52%                  │ │ Flow, term, structure agreement  │
+│ Use vendor IV for relative shape only │ │ Dominant read + conflicts        │
+└───────────────────────────────────────┘ └──────────────────────────────────┘
+
+┌─ CHAIN / FLOW READ ────────────────────────────────────────────────────────┐
+│ Strike rows: call vol, call OI, put vol, put OI, vol/OI, read              │
+│ Headline: Call volume 1.9x put volume; major strikes show volume > OI      │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌─ TERM STRUCTURE / IMPLIED MOVE ────────────────────────────────────────────┐
+│ Expiry table: DTE, ATM straddle, implied move, daily implied move          │
+│ Headline: Front-week vol elevated vs back-week                             │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌─ CANDIDATE STRUCTURES ─────────────────────────────────────────────────────┐
+│ [A] Call credit spread  [B] Put credit spread  [C] Long straddle           │
+│ [D] Iron condor         [E] Calendar spread                                │
+│ Each card: thesis, legs, credit/debit, max loss/profit, breakeven, risks   │
+└────────────────────────────────────────────────────────────────────────────┘
+
+┌─ SYNTHESIS / NEXT CHECKS ──────────────────────────────────────────────────┐
+│ What the data says, preferred expression, rejected ideas, required checks  │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+## 4. Core panels
+
+### 4.1 Idea Header
+
+Purpose: make the tab's status obvious in one scan.
+
+Fields:
+
+| Field | Example | Notes |
+|---|---|---|
+| `ticker` | `TSLA` | From route. |
+| `as_of` | `2026-05-13 15:59 ET` | Must reflect source timestamp. |
+| `dominant_bias` | `Neutral / Short Vol` | Not simply bullish/bearish. |
+| `primary_setup` | `Front-vol mean reversion` | Human-readable setup. |
+| `confidence_label` | `Medium` | Derived from source agreement, freshness, liquidity, event status. |
+| `data_quality_label` | `Mixed` | Separate from confidence. |
+| `idea_count` | `5 candidates` | Count of candidate structures. |
+| `preferred_idea_id` | `D` | Nullable. |
+
+Badges:
+
+- `IV source mismatch`
+- `Event check required`
+- `Defined-risk only`
+- `Liquid near-ATM chain`
+- `Historical backtest unavailable`
+
+### 4.2 Source Reconciliation
+
+The TSLA example shows why this panel matters: option prices matched, but IV differed by 6-9 vol points. That is a methodology issue, not necessarily a market-data issue.
+
+Display:
+
+| Source pair | Price agreement | IV agreement | Decision |
+|---|---:|---:|---|
+| TV vs YF | Matches to penny | YF +6-9 vol pts | Use price, distrust TV absolute IV |
+
+Panel text should be concise:
+
+```text
+Option prices agree, absolute IV does not. Treat vendor IV as relative shape only.
+Use chain-derived IV for cheap/rich decisions.
+```
+
+Recommended fields:
+
+```jsonc
+{
+  "source_reconciliation": {
+    "status": "mixed",
+    "headline": "Prices match, IV differs by 6-9 vol points",
+    "primary_iv_source": "yfinance",
+    "relative_shape_source": "tradingview",
+    "rows": [
+      {
+        "strike": 430,
+        "call_mid": 9.68,
+        "source_a_call_iv": 0.456,
+        "source_b_call_iv": 0.523,
+        "iv_diff": 0.067
+      }
+    ],
+    "decision": "Use source B IV for absolute cheap/rich decisions; use source A only for relative shape."
+  }
+}
+```
+
+### 4.3 Signal Stack
+
+Purpose: summarize the evidence without jumping straight to structures.
+
+Rows:
+
+| Lens | Signals | Read |
+|---|---|---|
+| Vol level | IV vs RV, `vrp_z_20` as IV-RV z-score, IV percentile | Cheap / fair / rich |
+| Vol stability | `iv_of_iv_20`, term shape | Stable / unstable |
+| Realized regime | `rvol_pctile`, realized move | Quiet / active |
+| Correlation | `spy_corr_21`, regime quadrant | Systemic / idiosyncratic |
+| Flow | call/put volume, volume/OI, ask-side premium | Bullish / bearish / mixed |
+| Structure | GEX walls, max pain, pin zone | Range / trend / gap risk |
+
+Example:
+
+```text
+Direction: bullish flow
+Vol level: fair to slightly cheap by chain-derived IV
+Term: front-week elevated vs back-week
+Best expression: calendar or tight defined-risk range trade
+Conflict: bullish flow fights short-call mean-reversion trade
+```
+
+### 4.4 Chain / Flow Read
+
+The tab should make volume/OI visible because the TSLA analysis relied on it.
+
+Table columns:
+
+| Strike | Call Vol | Call OI | Put Vol | Put OI | C/P Vol | Vol/OI note | Read |
+|---:|---:|---:|---:|---:|---:|---|---|
+| 420 | 33,879 | 22,602 | 17,982 | 6,227 | 1.88x | Call vol > OI | New call exposure likely |
+| 430 | 35,832 | 14,925 | 24,957 | 4,465 | 1.44x | Both sides active | ATM battle / pin candidate |
+| 440 | 29,045 | 9,103 | 4,987 | 2,281 | 5.82x | Call vol > OI | OTM call demand |
+
+Derived fields:
+
+- total call volume;
+- total put volume;
+- call/put volume ratio;
+- volume greater than OI flags;
+- `requires_t1_oi_confirmation` when volume materially exceeds OI;
+- concentration by strike;
+- "new positioning likely" flag when volume materially exceeds OI.
+
+Caveat text:
+
+```text
+Volume > OI suggests new positioning but does not prove opening trades until next-day OI confirms. Volume can exceed OI because the same contract can trade multiple times intraday.
+```
+
+### 4.5 Term Structure / Implied Move
+
+This panel presents the 4-DTE vs 11-DTE logic from the example.
+
+Table columns:
+
+| Expiry | DTE | ATM straddle | Implied move | Daily implied | Read |
+|---|---:|---:|---:|---:|---|
+| 2026-05-15 | 4 | `$20.65` | `4.8%` | `1.20%/day` | Front elevated |
+| 2026-05-22 | 11 | `$28.80` | `6.7%` | `0.61%/day` | Back calmer |
+| Marginal | +7 | `+$8.15` | `+1.9%` | `0.27%/day` | Back-week cheap vs front |
+
+Headline examples:
+
+- `Front-week backwardation: short-dated vol is elevated.`
+- `Calendar candidate: sell front, buy back, if event risk is clean.`
+- `No term edge: curve is smooth and fairly priced.`
+
+### 4.6 Candidate Structure Cards
+
+Cards should be compact and comparable. The tab should avoid large prose blocks when a table or card can carry the same information.
+
+Common fields:
+
+| Field | Meaning |
+|---|---|
+| `idea_id` | `A`, `B`, `C`, etc. |
+| `structure` | `Iron condor`, `Calendar`, `Call credit spread`. |
+| `thesis` | One-line reason. |
+| `expression_type` | `Short vol`, `Long vol`, `Direction + theta`, `Term structure`. |
+| `legs` | Side, expiry, strike, call/put, estimated mid. |
+| `net_credit_debit` | Positive for credit, negative for debit. |
+| `max_profit` | If defined. |
+| `max_loss` | Required for all candidate structures. |
+| `breakevens` | Where applicable. |
+| `profit_zone` | For spreads/condors. |
+| `greeks_summary` | Delta/gamma/vega/theta, approximate. |
+| `edge_source` | `Theta`, `IV-RV spread`, `term structure`, `flow confirmation`. |
+| `risk_flags` | Event, spread width, assignment, source mismatch. |
+| `rank` | 1-N. |
+| `status` | `candidate`, `rejected`, `preferred`, `needs_check`. |
+
+Example card:
+
+```text
+D. Iron condor 417.5/422.5 - 432.5/437.5
+Type: range / short vol / defined risk
+Credit: $3.72
+Max loss: $1.28
+Profit zone: $422.50 - $432.50
+Why it exists: spot is centered, front-week premium elevated, defined risk.
+Conflict: bullish flow could break the call side.
+Required checks: earnings, spread width, OI, actual NBBO, max-loss budget.
+Status: candidate, not executable.
+```
+
+### 4.7 Synthesis / Decision Panel
+
+This is the narrative close. It should be shorter than the pasted analysis, but still explain the conclusion.
+
+Suggested fields:
+
+```jsonc
+{
+  "synthesis": {
+    "dominant_story": "Bullish flow but front-week volatility is elevated after a large move.",
+    "preferred_expression": "Calendar spread or tight iron condor depending on event/liquidity checks.",
+    "best_risk_reward": "Iron condor",
+    "most_thesis_aligned": "Calendar spread",
+    "avoid": [
+      "Long front-week straddle unless realized movement is expected to exceed implied",
+      "Naked short options"
+    ],
+    "required_before_sizing": [
+      "Confirm event calendar through both expiries",
+      "Confirm bid/ask and OI from live chain",
+      "Confirm realized vol over last 5 sessions",
+      "Cross-check absolute IV with chain-derived calculation"
+    ]
+  }
+}
+```
+
+## 5. Data model proposal
+
+Add a new response shape rather than overloading `SingleStockReport.trade_plan`.
+
+Endpoint:
+
+```text
+GET /api/stock/{ticker}/trade-insights
+```
+
+Response outline:
+
+```jsonc
+{
+  "ticker": "TSLA",
+  "as_of": "2026-05-13T15:59:00-04:00",
+  "mode": "research",
+  "header": {
+    "dominant_bias": "NEUTRAL_SHORT_VOL",
+    "primary_setup": "FRONT_VOL_MEAN_REVERSION",
+    "confidence_label": "MEDIUM",
+    "data_quality_label": "MIXED",
+    "idea_count": 5,
+    "preferred_idea_id": null,
+    "badges": ["IV_SOURCE_MISMATCH", "EVENT_CHECK_REQUIRED", "DEFINED_RISK_ONLY"]
+  },
+  "source_reconciliation": {
+    "status": "MIXED",
+    "headline": "Prices match, IV differs by 6-9 vol points",
+    "decision": "Use chain-derived IV for absolute cheap/rich decisions."
+  },
+  "event_context": {
+    "status": "PARTIAL",
+    "next_earnings_date": "2026-07-22",
+    "next_dividend_date": null,
+    "notes": ["Earnings date available from UW flow/screener data", "Ex-dividend date unavailable for this run"]
+  },
+  "signal_stack": [
+    {"lens": "VOL_LEVEL", "read": "FAIR_TO_CHEAP", "evidence": ["ATM IV ~52%", "TV IV unreliable"]},
+    {"lens": "FLOW", "read": "BULLISH", "evidence": ["Call volume 1.9x put volume"]},
+    {"lens": "TERM", "read": "FRONT_ELEVATED", "evidence": ["4 DTE daily implied 1.20%", "11 DTE daily implied 0.61%"]}
+  ],
+  "flow_table": [],
+  "term_structure_table": [],
+  "candidate_structures": [],
+  "synthesis": {
+    "dominant_story": "...",
+    "preferred_idea_id": "E",
+    "best_risk_reward_idea_id": "D",
+    "required_before_sizing": []
+  }
+}
+```
+
+## 6. Source requirements
+
+Minimum sources for v1:
+
+| Source | Use |
+|---|---|
+| Current option contracts snapshot | Bid/ask/mid, volume, OI, option symbol. Expiry, strike, and call/put are parsed from the OCC/OSI-style symbol unless normalized columns are added. |
+| Current Greeks / smile | Delta, IV, skew shape, rough Greeks. |
+| Volatility Tab v2 series | IV-RV spread / VRP proxy, regime, divergence, IV-of-IV. |
+| Flow data | Ask/bid-side premium, call/put premium, expiry/strike concentration. |
+| Event data | Earnings at minimum. Ex-dividend is strongly recommended before short-call/calendar logic. |
+
+External source reconciliation can be modeled generically. The UI does not need to know whether a source is TradingView, yfinance, Funda, or UW. It needs:
+
+- source name;
+- timestamp;
+- price fields;
+- IV fields;
+- agreement/difference metrics;
+- decision on source trust.
+
+Event context should use existing persisted UW fields before adding a new provider:
+
+- `flow_events.next_earnings_date` is available on single-stock runs when flow alerts carry it;
+- `scan_results.next_earnings_date` is available on full-scan rows;
+- `BulkScreenerRow.next_dividend_date` exists in the normalized model but is not currently promoted into `SingleStockReport` or persisted as a single-stock event context.
+
+Therefore V1 can treat earnings as `KNOWN` when a next earnings date is found, but should still mark ex-dividend as `UNKNOWN` unless it is explicitly persisted for the run.
+
+### 6.1 Contract normalization
+
+The current `option_contract_snapshots` table stores `option_symbol` plus tradability fields. It does not currently store normalized `expiry`, `strike`, or `right` columns. V1 can parse those fields from the OCC/OSI-style option symbol:
+
+```text
+<root><YYMMDD><C/P><strike * 1000 padded to 8 digits>
+```
+
+Example:
+
+```text
+TSLA260515C00430000 -> TSLA, 2026-05-15, call, 430.00
+```
+
+For implementation robustness, prefer adding normalized columns or a materialized view:
+
+```sql
+option_expiry DATE
+option_right  TEXT CHECK (option_right IN ('C','P'))
+strike        NUMERIC
+```
+
+The UI should not depend on string parsing in React. Backend responses should return normalized contract fields.
+
+## 7. Ranking logic
+
+Candidate ranking should be rule-based first, not ML.
+
+All weights and thresholds in v1 are hypotheses. They should be configurable and later validated through walk-forward tests before any downstream Trade Plan automation depends on them.
+
+Score components:
+
+| Component | Direction |
+|---|---|
+| Signal fit | Does the structure express the dominant setup? |
+| Defined risk | Defined-risk structures rank above undefined risk. |
+| Liquidity | Tight spreads and high OI/volume rank higher. |
+| Event cleanliness | No known event inside holding window ranks higher. |
+| Source agreement | Price/IV/source agreement raises confidence. |
+| Risk/reward | Favorable max loss vs max profit improves rank, but not alone. |
+| Conflict penalty | Directional flow against the structure lowers rank. |
+
+Example:
+
+- Calendar ranks high if term-structure dislocation is the cleanest signal.
+- Iron condor ranks high if spot is centered, realized vol is quiet, and flow is not strongly directional.
+- Long straddle ranks low if chain-derived IV is fair/rich and realized-vol expectation is not strong.
+
+### 7.1 Persistence for validation
+
+V1 must persist the deterministic Trade Insights output. The point is not only to render cards; it is to build a research log that can later answer whether the rules, ranks, and gates had predictive value.
+
+Persist at two levels:
+
+1. **Snapshot payload:** one idempotent row per `(run_id, ticker, assembler_version, input_hash)` containing the full deterministic response JSON, data-quality labels, source-reconciliation status, and preferred/null status.
+2. **Candidate rows:** one row per generated candidate with structure, rank, status, max loss, max profit, debit/credit, risk flags, edge source, and legs JSON.
+
+This enables later analysis such as:
+
+- Which candidate structures were most often generated?
+- Did `needs_check` ideas later become valid after event/source/liquidity data improved?
+- Did rank 1 outperform lower-ranked candidates under a later payoff model?
+- Which risk flags correlated with bad outcomes?
+- Which thresholds should be changed before any idea becomes a downstream Trade Plan input?
+
+The persistence layer should be idempotent. Page refreshes must not create duplicate research rows for the same input snapshot.
+
+## 8. Optional Codex ad-hoc analysis
+
+The tab can leave room for LLM support without making the LLM part of the core signal engine.
+
+Recommended UI control:
+
+```text
+[Run AI Analysis]
+```
+
+Button behavior:
+
+```text
+POST /api/stock/{ticker}/trade-insights/ai-analysis
+  -> enqueue analysis job
+  -> worker builds deterministic Trade Insights JSON from DB
+  -> worker runs codex exec in read-only mode with that JSON
+  -> worker stores markdown summary + structured metadata
+  -> UI polls /api/jobs/{job_id} or a trade-insight-analysis job endpoint
+  -> UI renders the returned commentary below the deterministic panels
+```
+
+This should be operator-triggered only. It should not run automatically on every scan, page load, or watchlist refresh.
+
+### 8.1 Division of responsibility
+
+| Layer | Owner | Notes |
+|---|---|---|
+| Numeric signals | Deterministic backend | IV-RV spread / VRP proxy, divergence, term shape, flow ratios, liquidity gates. |
+| Structure generation | Deterministic backend | Contract selection, debit/credit, max loss, max profit, risk flags. |
+| Hard blocking checks | Deterministic backend | Stale chain, missing NBBO, undefined max loss, event missing, unsupported naked short. |
+| Narrative synthesis | Optional Codex job | Explain evidence, conflicts, preferred expression, and checks still needed. |
+| Final UI rendering | Frontend | Render source numbers/cards from JSON; render AI text as commentary only. |
+
+Codex must not override deterministic checks. If the backend marks a candidate `rejected` or `needs_check`, the AI summary may explain why, but cannot promote it to `preferred`.
+
+### 8.2 Backend command shape
+
+Local development can use the non-interactive Codex CLI:
+
+```bash
+codex exec \
+  --cd /Users/chenxi/projects/unusual-whales \
+  --sandbox read-only \
+  --ask-for-approval never \
+  "Analyze this structured trade-insight JSON. Do not invent missing data..."
+```
+
+Implementation detail: avoid passing large raw JSON directly in the shell command. Prefer one of:
+
+- write sanitized structured input to a temporary read-only artifact and pass the path;
+- store the payload in Postgres and pass an `analysis_job_id`;
+- pass compact JSON through stdin if the runner supports it.
+
+The prompt should tell Codex to:
+
+- analyze only the supplied structured payload;
+- preserve the backend's candidate statuses and risk flags;
+- state when data is missing;
+- avoid executable recommendations;
+- produce concise Markdown with sections: `Dominant Read`, `Best Expressions`, `Conflicts`, `Required Checks`, `Rejected Ideas`.
+
+### 8.3 Storage proposal
+
+Add a separate table rather than mixing AI output into trade-insight rows:
+
+```sql
+CREATE TABLE IF NOT EXISTS uw_scan.trade_insight_ai_analyses (
+    analysis_id    UUID PRIMARY KEY,
+    ticker         TEXT NOT NULL,
+    run_id         BIGINT,
+    input_hash     TEXT NOT NULL,
+    model          TEXT,
+    prompt_version TEXT NOT NULL,
+    status         TEXT NOT NULL CHECK (status IN ('queued','running','done','failed')),
+    markdown       TEXT,
+    error_message  TEXT,
+    requested_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at     TIMESTAMPTZ,
+    finished_at    TIMESTAMPTZ
+);
+```
+
+`input_hash` makes repeat runs auditable: if the deterministic payload has not changed, the UI can show the existing analysis or offer a "rerun anyway" control.
+
+### 8.4 Guardrails for Codex jobs
+
+- Run only from the worker, not inside a synchronous API request.
+- Use `codex exec`, not the interactive TUI.
+- Use `--sandbox read-only`.
+- Use `--ask-for-approval never`.
+- Set a hard timeout, e.g. 60-120 seconds.
+- Run under a constrained service account or process environment.
+- Use an allowlisted command wrapper rather than arbitrary shell strings.
+- Limit concurrency and rate of AI jobs per ticker/user.
+- Enforce max input and output sizes.
+- Prefer a temporary working directory with no workspace write permissions for generated artifacts.
+- Do not pass secrets, environment variables, API keys, cookies, or raw `.env` contents.
+- Do not allow arbitrary user-written prompts in v1; use a fixed prompt template plus structured payload.
+- Store input hash, prompt version, model, status, output, and error.
+- Treat Codex output as commentary, not source of truth.
+- If Codex fails, keep the deterministic Trade Insights tab usable.
+
+This makes LLM support useful but optional: the product still works as a rule-based research tab, and Codex can add an analyst-style explanation when explicitly requested.
+
+## 9. UI guardrails
+
+- Label the tab `Trade Insights`, not `Recommendations`.
+- Every structure card must show `max_loss` or be rejected.
+- Undefined-risk short options should be hidden or marked unsupported.
+- Use `candidate`, `preferred`, `rejected`, and `needs_check` statuses.
+- Show source mismatches prominently.
+- Show "required before sizing" near the top and bottom.
+- Do not show a "Place order" control.
+- If event data is missing, block "preferred" status and use `needs_check`.
+- If option chain is stale or illiquid, show signal-only analysis and suppress structures.
+- AI analysis must be visually labeled as generated commentary and must not replace the deterministic signal/structure panels.
+
+## 10. Relationship to existing tabs
+
+| Existing tab | Role | Trade Insights relationship |
+|---|---|---|
+| Market Structure | GEX, walls, positioning | Provides pin/range/trend context. |
+| Volatility | IV/RV spread proxy, regime, term, smile | Provides vol setup and mean-reversion signal. |
+| Flow | Premium/strike/expiry flow | Provides direction and concentration. |
+| Trade Insights | New research synthesis | Combines the above into candidate expressions. |
+| Trade Plan | Concrete selected plan | Downstream of one selected idea after checks. |
+
+The raw audit-trail tables previously under a `Tables` tab now live inside `Flow` (post-2026-05 merge); Trade Insights does not need its own raw-rows surface.
+
+## 11. First implementation scope
+
+V1 should be deliberately narrow:
+
+1. Add tab route and UI shell.
+2. Add static response model and mock data from current report fields.
+3. Implement signal stack from existing `SingleStockReport` + Volatility v2 endpoint.
+4. Implement current-chain flow table from stored `option_contract_snapshots`.
+5. Implement term-structure table from current IV term snapshots.
+6. Generate candidate structures with rule-based templates:
+   - call credit spread;
+   - put credit spread;
+   - iron condor;
+   - long straddle;
+   - calendar spread.
+7. Require event/liquidity checks before any idea can be `preferred`.
+
+Out of scope for V1:
+
+- order placement;
+- portfolio sizing;
+- backtest claims;
+- ML ranking;
+- assignment modeling;
+- exact broker margin;
+- automatic AI analysis.
+
+Optional V1.5:
+
+1. Add `Run AI Analysis` button.
+2. Add AI analysis job table.
+3. Add worker path that runs `codex exec` against sanitized deterministic JSON.
+4. Render the returned Markdown below the synthesis panel.
+
+## 12. Evidence / references
+
+- Peter Carr and Liuren Wu, "Variance Risk Premiums," Review of Financial Studies, 2009. Use for the distinction between true variance risk premium and the project's IV-RV proxy. https://doi.org/10.1093/rfs/hhn038
+- Tim Bollerslev, George Tauchen, and Hao Zhou, "Expected Stock Returns and Variance Risk Premia," Review of Financial Studies, 2009. Use for model-free implied variation and realized-variation measurement caveats. https://doi.org/10.1093/rfs/hhp008
+- Gurdip Bakshi and Nikunj Kapadia, "Delta-Hedged Gains and the Negative Market Volatility Risk Premium," Review of Financial Studies, 2003. Use for delta-hedged option P&L needing real option and hedge mechanics. https://doi.org/10.1093/rfs/hhg002
+- Amit Goyal and Alessio Saretto, "Cross-section of option returns and volatility," Journal of Financial Economics, 2009. Use for cross-sectional realized-minus-implied volatility sorting and option-return testing. https://doi.org/10.1016/j.jfineco.2009.01.001
+- Joost Driessen, Pascal Maenhout, and Grigory Vilkov, "Option-Implied Correlations and the Price of Correlation Risk." Use for true dispersion/implied-correlation requirements. https://ssrn.com/abstract=2166829
+- John C. Hull, *Options, Futures, and Other Derivatives*, 11th edition, Pearson, 2022. Use for Greeks, strategy payoff mechanics, smiles/surfaces, and volatility/correlation basics.
+- Euan Sinclair, *Volatility Trading*, 2nd edition, Wiley, 2013. Use for volatility trading, implied-vs-realized framing, hedging, sizing, and variance-premium practice.
+- The Options Clearing Corporation, "Characteristics and Risks of Standardized Options." Use for exercise, assignment, settlement, and standardized-options risk disclosure. https://www.theocc.com/company-information/documents-and-archives/options-disclosure-document
+- Cboe Options Institute. Use as an exchange-backed education reference for options, multi-leg structures, hedging, and risk management. https://www.cboe.com/optionsinstitute/
+- Fidelity OSI explainer. Use for option symbol parsing and the OCC/OSI-style contract identity format. https://www.fidelity.com/webcontent/ap102701-quotes-content/18.11/shtml/osi.shtml
+- Option Alpha, "Options Volume vs Open Interest." Use for volume/OI caveats and the fact that volume can exceed OI without proving opening flow. https://optionalpha.com/learn/options-volume-vs-open-interest
+- Cboe Open-Close Volume Summary. Use as the stronger data source category when open/close positioning attribution is needed. https://datashop.cboe.com/cboe-options-open-close-volume-summary
+
+## 13. Open questions
+
+- Naming is resolved as `Trade Insights`.
+- Which source should be canonical for absolute IV if UW, yfinance, TradingView, and Funda disagree?
+- Do we have historical event data, or only next earnings?
+- Should calendar spreads be allowed before ex-dividend data is available?
+- What minimum OI/volume/spread thresholds should block a structure?
+- Should the tab support one preferred idea or multiple ranked ideas?
+- Should `Run AI Analysis` be local-dev only, operator-only in production, or available to all authenticated users?
+- Should AI analysis reuse an existing result when `input_hash` is unchanged?
+- Should normalized option contract columns be added to `option_contract_snapshots`, or should a backend view parse them from `option_symbol`?

--- a/src/uw_scan/api/routers/trade_insights.py
+++ b/src/uw_scan/api/routers/trade_insights.py
@@ -1,0 +1,57 @@
+"""Trade Insights endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from uw_scan.api.deps import get_repo
+from uw_scan.models import TradeInsightsResponse
+from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.reports.trade_insights import (
+    ASSEMBLER_VERSION,
+    _stable_payload_hash,
+    assemble_trade_insights,
+)
+from uw_scan.storage.repository import Repository
+
+router = APIRouter()
+
+
+@router.get(
+    "/stock/{ticker}/trade-insights",
+    response_model=TradeInsightsResponse,
+)
+def get_trade_insights(
+    ticker: str, repo: Repository = Depends(get_repo)
+) -> TradeInsightsResponse:
+    t = ticker.upper()
+    run_id = repo.latest_run_id(t)
+    if run_id == 0:
+        raise HTTPException(status_code=404, detail=f"no runs for {t}")
+
+    report = assemble_single_stock_report(t, run_id, repo)
+    response = assemble_trade_insights(
+        ticker=t,
+        run_id=run_id,
+        repo=repo,
+        as_of=report.generated_at,
+        spot=report.market_structure.spot,
+    )
+    payload = response.model_dump(mode="json")
+    input_hash = _stable_payload_hash(payload)
+    snapshot_id = repo.upsert_trade_insight_snapshot(
+        run_id=run_id,
+        ticker=t,
+        as_of=response.as_of,
+        assembler_version=ASSEMBLER_VERSION,
+        input_hash=input_hash,
+        payload=payload,
+    )
+    repo.replace_trade_insight_candidates(
+        snapshot_id=snapshot_id,
+        run_id=run_id,
+        ticker=t,
+        candidates=payload["candidate_structures"],
+    )
+    repo.conn.commit()
+    return response

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from uw_scan.api.routers import health, jobs, ohlc, stock, volatility, watchlist
+from uw_scan.api.routers import health, jobs, ohlc, stock, trade_insights, volatility, watchlist
 
 
 def create_app() -> FastAPI:
@@ -25,6 +25,7 @@ def create_app() -> FastAPI:
     app.include_router(ohlc.router, prefix="/api", tags=["ohlc"])
     app.include_router(jobs.router, prefix="/api", tags=["jobs"])
     app.include_router(volatility.router, prefix="/api", tags=["volatility"])
+    app.include_router(trade_insights.router, prefix="/api", tags=["trade-insights"])
     return app
 
 

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -8,7 +8,7 @@ strings, normalizers cast.
 from __future__ import annotations
 
 from datetime import date as _date
-from datetime import date, datetime
+from datetime import datetime
 from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -8,7 +8,7 @@ strings, normalizers cast.
 from __future__ import annotations
 
 from datetime import date as _date
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict
@@ -737,3 +737,114 @@ class VolatilitySeriesResponse(_UwBase):
     vrp_spread: list[VrpDailyPoint] = []
     vrp_spread_headline: str = ""
     spot: Decimal | None = None
+
+
+class InsightBadge(_UwBase):
+    code: str
+    label: str
+    severity: str = "info"
+
+
+class TradeInsightsHeader(_UwBase):
+    dominant_bias: str = "NEUTRAL"
+    primary_setup: str = "NO_CLEAR_SETUP"
+    confidence_label: str = "LOW"
+    data_quality_label: str = "INSUFFICIENT"
+    idea_count: int = 0
+    preferred_idea_id: str | None = None
+    badges: list[InsightBadge] = []
+
+
+class SourceReconciliationRow(_UwBase):
+    source_pair: str
+    price_agreement: str = ""
+    iv_agreement: str = ""
+    decision: str = ""
+    strike: Decimal | None = None
+    source_a_call_iv: Decimal | None = None
+    source_b_call_iv: Decimal | None = None
+    iv_diff: Decimal | None = None
+
+
+class SourceReconciliation(_UwBase):
+    status: str = "UNKNOWN"
+    headline: str = "Source reconciliation unavailable"
+    primary_iv_source: str | None = None
+    relative_shape_source: str | None = None
+    rows: list[SourceReconciliationRow] = []
+    decision: str = "Use deterministic data only where source agreement is understood."
+
+
+class InsightSignalRow(_UwBase):
+    lens: str
+    read: str
+    evidence: list[str] = []
+    conflicts: list[str] = []
+
+
+class ChainFlowReadRow(_UwBase):
+    strike: Decimal
+    call_volume: int | None = None
+    call_open_interest: int | None = None
+    put_volume: int | None = None
+    put_open_interest: int | None = None
+    call_put_volume_ratio: Decimal | None = None
+    volume_oi_note: str = ""
+    read: str = ""
+    requires_t1_oi_confirmation: bool = False
+
+
+class TermMoveRow(_UwBase):
+    expiry: _date
+    dte: int | None = None
+    atm_straddle: Decimal | None = None
+    implied_move_perc: Decimal | None = None
+    daily_implied_move_perc: Decimal | None = None
+    read: str = ""
+
+
+class InsightLeg(_UwBase):
+    side: str
+    option_symbol: str
+    option_right: str
+    expiry: _date
+    strike: Decimal
+    mid: Decimal | None = None
+
+
+class CandidateStructure(_UwBase):
+    idea_id: str
+    structure: str
+    thesis: str
+    expression_type: str
+    legs: list[InsightLeg] = []
+    net_credit_debit: Decimal | None = None
+    max_profit: Decimal | None = None
+    max_loss: Decimal | None = None
+    breakevens: list[Decimal] = []
+    profit_zone: str = ""
+    edge_source: str = ""
+    risk_flags: list[str] = []
+    rank: int
+    status: str = "candidate"
+
+
+class InsightsSynthesis(_UwBase):
+    dominant_story: str = ""
+    preferred_idea_id: str | None = None
+    best_risk_reward_idea_id: str | None = None
+    avoid: list[str] = []
+    required_before_sizing: list[str] = []
+
+
+class TradeInsightsResponse(_UwBase):
+    ticker: str
+    as_of: datetime | None = None
+    mode: str = "research"
+    header: TradeInsightsHeader
+    source_reconciliation: SourceReconciliation = SourceReconciliation()
+    signal_stack: list[InsightSignalRow] = []
+    flow_table: list[ChainFlowReadRow] = []
+    term_structure_table: list[TermMoveRow] = []
+    candidate_structures: list[CandidateStructure] = []
+    synthesis: InsightsSynthesis = InsightsSynthesis()

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -21,6 +21,11 @@ from .reports.single_stock import (
     assemble_single_stock_report,
     build_trade_plan_for_report,
 )
+from .reports.trade_insights import (
+    ASSEMBLER_VERSION,
+    _stable_payload_hash,
+    assemble_trade_insights,
+)
 from .scan_universe import S2_UNIVERSE
 from .sources import uw as uw_sources
 from .storage.repository import Repository
@@ -32,6 +37,35 @@ def _next_friday(today: _date) -> _date:
     """Pick the next Friday (today + 1..7 days)."""
     days_ahead = (4 - today.weekday()) % 7 or 7
     return today + timedelta(days=days_ahead)
+
+
+def _persist_trade_insights_for_run(
+    *,
+    repo: Repository,
+    report: SingleStockReport,
+) -> None:
+    response = assemble_trade_insights(
+        ticker=report.ticker,
+        run_id=report.run_id,
+        repo=repo,
+        as_of=report.generated_at,
+        spot=report.market_structure.spot,
+    )
+    payload = response.model_dump(mode="json")
+    snapshot_id = repo.upsert_trade_insight_snapshot(
+        run_id=report.run_id,
+        ticker=report.ticker,
+        as_of=response.as_of,
+        assembler_version=ASSEMBLER_VERSION,
+        input_hash=_stable_payload_hash(payload),
+        payload=payload,
+    )
+    repo.replace_trade_insight_candidates(
+        snapshot_id=snapshot_id,
+        run_id=report.run_id,
+        ticker=report.ticker,
+        candidates=payload["candidate_structures"],
+    )
 
 
 def run_single_stock(
@@ -242,6 +276,16 @@ def run_single_stock(
                     pcr_oi=aggregates.pcr_oi,
                     pcr_vol=aggregates.pcr_vol,
                 )
+
+        try:
+            _persist_trade_insights_for_run(repo=repo, report=report)
+        except Exception as exc:  # noqa: BLE001 — research-log only; never block a scan
+            logger.warning(
+                "trade_insights persistence failed for %s run_id=%s: %s",
+                report.ticker,
+                report.run_id,
+                repr(exc),
+            )
 
         repo.finish_scan_run(run_id, status="ok")
         repo.conn.commit()

--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -1,0 +1,63 @@
+"""Deterministic Trade Insights assembler.
+
+V1 is intentionally rule-based. Codex/LLM commentary is a later optional layer
+that consumes this structured output but does not alter status or risk checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class ParsedOptionSymbol:
+    root: str
+    expiry: date
+    right: str
+    strike: Decimal
+
+
+def parse_option_symbol(symbol: str) -> ParsedOptionSymbol | None:
+    """Parse OCC/OSI-style compact symbols like TSLA260515C00430000."""
+    if len(symbol) < 15:
+        return None
+    right_index = max(symbol.rfind("C"), symbol.rfind("P"))
+    if right_index < 6:
+        return None
+    right = symbol[right_index]
+    ymd = symbol[right_index - 6 : right_index]
+    strike_raw = symbol[right_index + 1 :]
+    root = symbol[: right_index - 6]
+    if not root or len(ymd) != 6 or len(strike_raw) != 8:
+        return None
+    try:
+        expiry = date(2000 + int(ymd[:2]), int(ymd[2:4]), int(ymd[4:6]))
+        strike = Decimal(str(int(strike_raw))) / Decimal("1000")
+    except (ValueError, ArithmeticError):
+        return None
+    return ParsedOptionSymbol(root=root, expiry=expiry, right=right, strike=strike)
+
+
+def _dec(v: object) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def _mid(contract: dict) -> Decimal | None:
+    bid = _dec(contract.get("nbbo_bid"))
+    ask = _dec(contract.get("nbbo_ask"))
+    if bid is not None and ask is not None and bid >= 0 and ask >= bid:
+        return (bid + ask) / Decimal("2")
+    return _dec(contract.get("last_price"))
+
+
+def _credit_spread_math(
+    *, short_mid: Decimal, long_mid: Decimal, width: Decimal
+) -> tuple[Decimal, Decimal, Decimal]:
+    net_credit = short_mid - long_mid
+    max_profit = net_credit
+    max_loss = width - net_credit
+    return net_credit, max_loss, max_profit

--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -54,7 +54,8 @@ def parse_option_symbol(symbol: str) -> ParsedOptionSymbol | None:
     try:
         expiry = date(2000 + int(ymd[:2]), int(ymd[2:4]), int(ymd[4:6]))
         strike = Decimal(str(int(strike_raw))) / Decimal("1000")
-    except (ValueError, ArithmeticError):
+    except (ValueError, ArithmeticError) as exc:
+        _parse_error = repr(exc)
         return None
     return ParsedOptionSymbol(root=root, expiry=expiry, right=right, strike=strike)
 

--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -6,9 +6,28 @@ that consumes this structured output but does not alter status or risk checks.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
+
+from uw_scan.models import (
+    CandidateStructure,
+    ChainFlowReadRow,
+    InsightBadge,
+    InsightLeg,
+    InsightSignalRow,
+    InsightsSynthesis,
+    SourceReconciliation,
+    SourceReconciliationRow,
+    TermMoveRow,
+    TradeInsightsHeader,
+    TradeInsightsResponse,
+)
+
+
+ASSEMBLER_VERSION = "trade-insights-v1"
 
 
 @dataclass(frozen=True)
@@ -61,3 +80,439 @@ def _credit_spread_math(
     max_profit = net_credit
     max_loss = width - net_credit
     return net_credit, max_loss, max_profit
+
+
+def _stable_payload_hash(payload: dict) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _normalized_contracts(raw: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for row in raw:
+        parsed = parse_option_symbol(str(row.get("option_symbol", "")))
+        if parsed is None:
+            continue
+        item = dict(row)
+        item["parsed"] = parsed
+        item["mid"] = _mid(row)
+        out.append(item)
+    return out
+
+
+def _build_flow_table(contracts: list[dict]) -> list[ChainFlowReadRow]:
+    by_strike: dict[Decimal, dict[str, dict]] = {}
+    for c in contracts:
+        parsed: ParsedOptionSymbol = c["parsed"]
+        by_strike.setdefault(parsed.strike, {})[parsed.right] = c
+
+    rows: list[ChainFlowReadRow] = []
+    for strike in sorted(by_strike):
+        call = by_strike[strike].get("C", {})
+        put = by_strike[strike].get("P", {})
+        call_volume = call.get("volume")
+        put_volume = put.get("volume")
+        call_oi = call.get("open_interest")
+        put_oi = put.get("open_interest")
+        ratio = None
+        if call_volume is not None and put_volume not in (None, 0):
+            ratio = Decimal(str(call_volume)) / Decimal(str(put_volume))
+        requires_t1 = bool(
+            (call_volume is not None and call_oi is not None and call_volume > call_oi)
+            or (put_volume is not None and put_oi is not None and put_volume > put_oi)
+        )
+        rows.append(
+            ChainFlowReadRow(
+                strike=strike,
+                call_volume=call_volume,
+                call_open_interest=call_oi,
+                put_volume=put_volume,
+                put_open_interest=put_oi,
+                call_put_volume_ratio=ratio,
+                volume_oi_note="Volume > OI; confirm with next-day OI"
+                if requires_t1
+                else "No volume/OI anomaly",
+                read="Call demand concentrated"
+                if ratio is not None and ratio > Decimal("1.5")
+                else "Mixed flow",
+                requires_t1_oi_confirmation=requires_t1,
+            )
+        )
+    return rows
+
+
+def _build_source_reconciliation(repo, run_id: int, ticker: str) -> SourceReconciliation:
+    fetch = getattr(repo, "fetch_source_reconciliation_rows", None)
+    rows = fetch(run_id, ticker) if fetch is not None else []
+    if not rows:
+        return SourceReconciliation(
+            status="UNKNOWN",
+            headline="No external IV source reconciliation stored for this run",
+            decision="Use chain-derived values for contract math; do not make absolute-IV trust claims.",
+        )
+    return SourceReconciliation(
+        status="MIXED" if any(r.get("iv_diff") for r in rows) else "READY",
+        headline="Source reconciliation rows available",
+        rows=[SourceReconciliationRow(**r) for r in rows],
+        decision="Prefer chain-derived IV for absolute cheap/rich decisions when vendor IV disagrees.",
+    )
+
+
+def _atm_straddles_by_expiry(
+    contracts: list[dict], spot: Decimal | None
+) -> dict[date, Decimal]:
+    if spot is None:
+        return {}
+    out: dict[date, Decimal] = {}
+    expiries = sorted({c["parsed"].expiry for c in contracts})
+    for expiry in expiries:
+        same_expiry = [
+            c
+            for c in contracts
+            if c["parsed"].expiry == expiry and c.get("mid") is not None
+        ]
+        calls = [c for c in same_expiry if c["parsed"].right == "C"]
+        puts = [c for c in same_expiry if c["parsed"].right == "P"]
+        if not calls or not puts:
+            continue
+        call = min(calls, key=lambda c: abs(c["parsed"].strike - spot))
+        put = min(puts, key=lambda c: abs(c["parsed"].strike - spot))
+        if call["parsed"].strike == put["parsed"].strike:
+            out[expiry] = call["mid"] + put["mid"]
+    return out
+
+
+def _build_term_rows(
+    raw: list[dict], contracts: list[dict], spot: Decimal | None
+) -> list[TermMoveRow]:
+    atm_by_expiry = _atm_straddles_by_expiry(contracts, spot)
+    rows: list[TermMoveRow] = []
+    for r in raw:
+        dte = r.get("dte")
+        move = _dec(r.get("implied_move_perc"))
+        daily = None
+        if dte and move is not None and dte > 0:
+            daily = move / Decimal(str(dte))
+        rows.append(
+            TermMoveRow(
+                expiry=r["expiry"],
+                dte=dte,
+                atm_straddle=atm_by_expiry.get(r["expiry"]),
+                implied_move_perc=move,
+                daily_implied_move_perc=daily,
+                read="Front elevated" if dte is not None and dte <= 7 else "Back expiry",
+            )
+        )
+    return rows
+
+
+def _leg(side: str, c: dict) -> InsightLeg:
+    parsed: ParsedOptionSymbol = c["parsed"]
+    return InsightLeg(
+        side=side,
+        option_symbol=c["option_symbol"],
+        option_right=parsed.right,
+        expiry=parsed.expiry,
+        strike=parsed.strike,
+        mid=c.get("mid"),
+    )
+
+
+def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[CandidateStructure]:
+    if spot is None:
+        return []
+    calls = sorted(
+        [c for c in contracts if c["parsed"].right == "C" and c.get("mid") is not None],
+        key=lambda c: abs(c["parsed"].strike - spot),
+    )
+    puts = sorted(
+        [c for c in contracts if c["parsed"].right == "P" and c.get("mid") is not None],
+        key=lambda c: abs(c["parsed"].strike - spot),
+    )
+    candidates: list[CandidateStructure] = []
+
+    if len(calls) >= 2:
+        short_call = calls[0]
+        long_call = next(
+            (c for c in calls[1:] if c["parsed"].strike > short_call["parsed"].strike),
+            None,
+        )
+        if long_call is not None:
+            width = long_call["parsed"].strike - short_call["parsed"].strike
+            credit, max_loss, max_profit = _credit_spread_math(
+                short_mid=short_call["mid"], long_mid=long_call["mid"], width=width
+            )
+            candidates.append(
+                CandidateStructure(
+                    idea_id="A",
+                    structure="call_credit_spread",
+                    thesis="Defined-risk short-call premium candidate.",
+                    expression_type="SHORT_VOL",
+                    legs=[_leg("sell", short_call), _leg("buy", long_call)],
+                    net_credit_debit=credit,
+                    max_profit=max_profit,
+                    max_loss=max_loss,
+                    profit_zone=f"Underlying below {short_call['parsed'].strike}",
+                    edge_source="IV-RV spread / theta",
+                    risk_flags=["bullish_flow_can_break_call_side"],
+                    rank=1,
+                    status="candidate",
+                )
+            )
+
+    if len(puts) >= 2:
+        short_put = puts[0]
+        long_put = next(
+            (p for p in puts[1:] if p["parsed"].strike < short_put["parsed"].strike),
+            None,
+        )
+        if long_put is not None:
+            width = short_put["parsed"].strike - long_put["parsed"].strike
+            credit, max_loss, max_profit = _credit_spread_math(
+                short_mid=short_put["mid"], long_mid=long_put["mid"], width=width
+            )
+            candidates.append(
+                CandidateStructure(
+                    idea_id="B",
+                    structure="put_credit_spread",
+                    thesis="Defined-risk short-put premium candidate.",
+                    expression_type="DIRECTIONAL_THETA",
+                    legs=[_leg("sell", short_put), _leg("buy", long_put)],
+                    net_credit_debit=credit,
+                    max_profit=max_profit,
+                    max_loss=max_loss,
+                    profit_zone=f"Underlying above {short_put['parsed'].strike}",
+                    edge_source="theta / bullish flow",
+                    risk_flags=["gap_down_risk"],
+                    rank=2,
+                    status="candidate",
+                )
+            )
+
+    if len(candidates) >= 2:
+        call_spread = next(
+            (c for c in candidates if c.structure == "call_credit_spread"), None
+        )
+        put_spread = next(
+            (c for c in candidates if c.structure == "put_credit_spread"), None
+        )
+        if call_spread and put_spread and call_spread.net_credit_debit and put_spread.net_credit_debit:
+            # Iron condor math: max loss equals the wider wing's width minus the
+            # TOTAL credit collected from both verticals. Only one wing can be
+            # breached at expiry, so the loss on that wing is (width - credit),
+            # not the sum of the two wing losses. Using max(call_spread.max_loss,
+            # put_spread.max_loss) double-counts the credit on the unused wing
+            # and understates the actual max loss whenever credit > 0.
+            call_short_strike = call_spread.legs[0].strike
+            call_long_strike = call_spread.legs[1].strike
+            put_short_strike = put_spread.legs[0].strike
+            put_long_strike = put_spread.legs[1].strike
+            call_width = abs(call_long_strike - call_short_strike)
+            put_width = abs(put_short_strike - put_long_strike)
+            credit = call_spread.net_credit_debit + put_spread.net_credit_debit
+            max_loss = max(call_width, put_width) - credit
+            candidates.append(
+                CandidateStructure(
+                    idea_id="C",
+                    structure="iron_condor",
+                    thesis="Defined-risk range candidate built from both short verticals.",
+                    expression_type="SHORT_VOL_RANGE",
+                    legs=[*put_spread.legs, *call_spread.legs],
+                    net_credit_debit=credit,
+                    max_profit=credit,
+                    max_loss=max_loss,
+                    profit_zone=f"{put_spread.profit_zone}; {call_spread.profit_zone}",
+                    edge_source="term structure / IV-RV spread / range structure",
+                    risk_flags=["breakout_risk", "event_check_required"],
+                    rank=3,
+                    status="candidate",
+                )
+            )
+
+    front_expiry = min((c["parsed"].expiry for c in contracts), default=None)
+    if front_expiry is not None:
+        front_calls = [c for c in calls if c["parsed"].expiry == front_expiry]
+        front_puts = [p for p in puts if p["parsed"].expiry == front_expiry]
+        if front_calls and front_puts:
+            call = front_calls[0]
+            put = min(front_puts, key=lambda p: abs(p["parsed"].strike - call["parsed"].strike))
+            debit = call["mid"] + put["mid"]
+            strike = call["parsed"].strike
+            candidates.append(
+                CandidateStructure(
+                    idea_id="D",
+                    structure="long_straddle",
+                    thesis="Long-vol candidate for cheap-vol or realized-move expansion setups.",
+                    expression_type="LONG_VOL",
+                    legs=[_leg("buy", call), _leg("buy", put)],
+                    net_credit_debit=-debit,
+                    max_loss=debit,
+                    max_profit=None,
+                    breakevens=[strike - debit, strike + debit]
+                    if call["parsed"].strike == put["parsed"].strike
+                    else [],
+                    edge_source="realized-vol expansion / cheap IV",
+                    risk_flags=["theta_decay", "requires_realized_move"],
+                    rank=4,
+                    status="candidate",
+                )
+            )
+
+    calendar_pairs = [
+        (near, far)
+        for near in calls
+        for far in calls
+        if near["parsed"].strike == far["parsed"].strike
+        and near["parsed"].expiry < far["parsed"].expiry
+    ]
+    if calendar_pairs:
+        near, far = calendar_pairs[0]
+        debit = far["mid"] - near["mid"]
+        # Calendar spread: max loss is bounded by the initial net debit only if
+        # the position is held to expiration of the far leg. Earlier exit (the
+        # normal exit, around the front expiry) has path-dependent P&L driven by
+        # term-structure shifts and changes in far-leg IV; theoretical max loss
+        # at the front expiry can exceed the debit if the far leg's IV collapses.
+        # V1 reports the "held-to-far-expiry" bound as max_loss and flags the
+        # path-dependence in risk_flags so users do not treat it as a hard cap.
+        # If the near leg is more expensive than the far leg (backwardation),
+        # this becomes a credit calendar; we skip the candidate rather than
+        # report a negative debit, because that scenario needs different math.
+        if debit <= Decimal("0"):
+            pass
+        else:
+            candidates.append(
+                CandidateStructure(
+                    idea_id="E",
+                    structure="calendar_spread",
+                    thesis="Term-structure candidate: sell front volatility, buy later expiry.",
+                    expression_type="TERM_STRUCTURE",
+                    legs=[_leg("sell", near), _leg("buy", far)],
+                    net_credit_debit=-debit,
+                    max_loss=debit,
+                    max_profit=None,
+                    profit_zone=f"Near {near['parsed'].strike} through front expiry",
+                    edge_source="front/back implied-vol dislocation",
+                    risk_flags=[
+                        "event_check_required",
+                        "assignment_ex_dividend_check",
+                        "path_dependent_far_iv_collapse",
+                    ],
+                    rank=5,
+                    status="candidate",
+                )
+            )
+
+    return candidates
+
+
+def assemble_trade_insights(
+    *,
+    ticker: str,
+    run_id: int,
+    repo,
+    as_of: datetime | None,
+    spot: Decimal | None,
+) -> TradeInsightsResponse:
+    contracts = _normalized_contracts(repo.fetch_option_contracts_rich(run_id, ticker))
+    source_reconciliation = _build_source_reconciliation(repo, run_id, ticker)
+    flow_rows = _build_flow_table(contracts)
+    term_rows = _build_term_rows(repo.fetch_iv_term_rows(run_id, ticker), contracts, spot)
+    candidates = _build_candidates(contracts, spot)
+    # V1 intentionally hardcodes event_data_known=False so every candidate ends
+    # as `needs_check` and `preferred_idea_id` stays None. The earnings/dividend
+    # plumbing exists upstream (flow_events.next_earnings_date,
+    # SingleStockReport.next_earnings_date) but is not wired through to this
+    # assembler in V1. A follow-up patch should read those fields and flip the
+    # gate when both are present and outside all candidate expiries.
+    event_data_known = False
+    liquidity_ready = bool(contracts) and all(c.max_loss is not None for c in candidates)
+
+    badges: list[InsightBadge] = [InsightBadge(code="DEFINED_RISK_ONLY", label="Defined-risk only")]
+    if not contracts:
+        badges.append(InsightBadge(code="NO_CHAIN", label="No option chain", severity="warning"))
+    if source_reconciliation.status in {"UNKNOWN", "MIXED"}:
+        badges.append(
+            InsightBadge(
+                code="SOURCE_RECONCILIATION_REQUIRED",
+                label="Source reconciliation incomplete",
+                severity="warning",
+            )
+        )
+    if not event_data_known:
+        badges.append(
+            InsightBadge(
+                code="EVENT_CHECK_REQUIRED",
+                label="Event check required",
+                severity="warning",
+            )
+        )
+    if any(r.requires_t1_oi_confirmation for r in flow_rows):
+        badges.append(
+            InsightBadge(
+                code="T1_OI_CONFIRMATION",
+                label="Volume > OI needs next-day OI confirmation",
+                severity="warning",
+            )
+        )
+
+    signal_stack = [
+        InsightSignalRow(
+            lens="VOL_LEVEL",
+            read="IV_RV_PROXY_AVAILABLE",
+            evidence=["Use Volatility tab IV-RV spread proxy; true model-free VRP not computed."],
+        ),
+        InsightSignalRow(
+            lens="FLOW",
+            read="CALL_DEMAND" if any((r.call_put_volume_ratio or 0) > 1 for r in flow_rows) else "MIXED",
+            evidence=[f"{len(flow_rows)} strike rows available"],
+        ),
+        InsightSignalRow(
+            lens="TERM",
+            read="TERM_ROWS_AVAILABLE" if term_rows else "MISSING",
+            evidence=[f"{len(term_rows)} expiries available"],
+        ),
+    ]
+
+    can_prefer = (
+        bool(candidates)
+        and event_data_known
+        and liquidity_ready
+        and source_reconciliation.status != "UNKNOWN"
+    )
+    if not can_prefer:
+        for candidate in candidates:
+            candidate.status = "needs_check"
+    preferred = candidates[0].idea_id if can_prefer else None
+    return TradeInsightsResponse(
+        ticker=ticker,
+        as_of=as_of,
+        header=TradeInsightsHeader(
+            dominant_bias="NEUTRAL_SHORT_VOL" if candidates else "NEUTRAL",
+            primary_setup="TRADE_INSIGHTS_RESEARCH",
+            confidence_label="MEDIUM" if contracts and candidates else "LOW",
+            data_quality_label="MIXED" if contracts else "INSUFFICIENT",
+            idea_count=len(candidates),
+            preferred_idea_id=preferred,
+            badges=badges,
+        ),
+        source_reconciliation=source_reconciliation,
+        signal_stack=signal_stack,
+        flow_table=flow_rows,
+        term_structure_table=term_rows,
+        candidate_structures=candidates,
+        synthesis=InsightsSynthesis(
+            dominant_story="Deterministic research-grade ideas built from current chain, flow, and term data."
+            if candidates
+            else "Insufficient option-chain data for structure generation.",
+            preferred_idea_id=preferred,
+            best_risk_reward_idea_id=preferred,
+            avoid=["Naked short options", "Executable recommendation language"],
+            required_before_sizing=[
+                "Confirm event calendar through all expiries",
+                "Confirm bid/ask width and open interest",
+                "Confirm next-day OI for volume > OI flags",
+                "Run out-of-sample validation before automation",
+            ],
+        ),
+    )

--- a/src/uw_scan/storage/migrations/016_trade_insights.sql
+++ b/src/uw_scan/storage/migrations/016_trade_insights.sql
@@ -1,0 +1,52 @@
+-- Persist deterministic Trade Insights outputs for later validation/backtests.
+-- The UI renders the current response, but research improvement depends on
+-- retaining exactly what the rule engine emitted for each source run.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.trade_insight_snapshots (
+    snapshot_id                  BIGSERIAL PRIMARY KEY,
+    run_id                       BIGINT NOT NULL REFERENCES uw_scan.scan_runs(run_id) ON DELETE CASCADE,
+    ticker                       TEXT NOT NULL,
+    as_of                        TIMESTAMPTZ,
+    assembler_version            TEXT NOT NULL,
+    input_hash                   TEXT NOT NULL,
+    source_reconciliation_status TEXT,
+    confidence_label             TEXT,
+    data_quality_label           TEXT,
+    preferred_idea_id            TEXT,
+    payload_jsonb                JSONB NOT NULL,
+    created_at                   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (run_id, ticker, assembler_version, input_hash)
+);
+
+CREATE TABLE IF NOT EXISTS uw_scan.trade_insight_candidates (
+    snapshot_id       BIGINT NOT NULL REFERENCES uw_scan.trade_insight_snapshots(snapshot_id) ON DELETE CASCADE,
+    idea_id           TEXT NOT NULL,
+    ticker            TEXT NOT NULL,
+    run_id            BIGINT NOT NULL,
+    structure         TEXT NOT NULL,
+    expression_type   TEXT,
+    rank              INTEGER NOT NULL,
+    status            TEXT NOT NULL,
+    net_credit_debit  NUMERIC,
+    max_profit        NUMERIC,
+    max_loss          NUMERIC,
+    edge_source       TEXT,
+    risk_flags        TEXT[] NOT NULL DEFAULT '{}',
+    legs_jsonb        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    candidate_jsonb   JSONB NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (snapshot_id, idea_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trade_insight_snapshots_ticker_created
+    ON uw_scan.trade_insight_snapshots (ticker, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_trade_insight_candidates_structure_status
+    ON uw_scan.trade_insight_candidates (structure, status, rank);
+
+COMMENT ON TABLE uw_scan.trade_insight_snapshots IS
+    'Idempotent deterministic Trade Insights response snapshots used for later validation and backtests.';
+COMMENT ON TABLE uw_scan.trade_insight_candidates IS
+    'Queryable candidate rows emitted by the deterministic Trade Insights assembler.';

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1214,18 +1214,6 @@ class Repository:
             cols = [d.name for d in cur.description or []]
             return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
 
-    def fetch_iv_term_rows(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
-        sql = (
-            f"SELECT expiry, dte, volatility, implied_move, implied_move_perc "
-            f"FROM {self._schema}.iv_term_snapshots "
-            "WHERE run_id = %s AND ticker = %s "
-            "ORDER BY expiry ASC"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(sql, (run_id, ticker.upper()))
-            cols = [d.name for d in cur.description or []]
-            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
-
     def upsert_trade_insight_snapshot(
         self,
         *,

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1198,6 +1198,34 @@ class Repository:
             cols = [d.name for d in cur.description or []]
             return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
 
+    def fetch_option_contracts_rich(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        sql = (
+            f"SELECT option_symbol, last_price, nbbo_bid, nbbo_ask, "
+            "implied_volatility, open_interest, prev_oi, volume, ask_volume, "
+            "bid_volume, mid_volume, multi_leg_volume, stock_multi_leg_volume, "
+            "floor_volume, sweep_volume, no_side_volume, avg_price, high_price, "
+            "low_price, total_premium "
+            f"FROM {self._schema}.option_contract_snapshots "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY total_premium DESC NULLS LAST"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
+    def fetch_iv_term_rows(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        sql = (
+            f"SELECT expiry, dte, volatility, implied_move, implied_move_perc "
+            f"FROM {self._schema}.iv_term_snapshots "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry ASC"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker.upper()))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
     def upsert_trade_insight_snapshot(
         self,
         *,

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1198,6 +1198,96 @@ class Repository:
             cols = [d.name for d in cur.description or []]
             return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
 
+    def upsert_trade_insight_snapshot(
+        self,
+        *,
+        run_id: int,
+        ticker: str,
+        as_of: datetime | None,
+        assembler_version: str,
+        input_hash: str,
+        payload: dict[str, Any],
+    ) -> int:
+        header = payload.get("header") or {}
+        source_reconciliation = payload.get("source_reconciliation") or {}
+        sql = (
+            f"INSERT INTO {self._schema}.trade_insight_snapshots "
+            "(run_id, ticker, as_of, assembler_version, input_hash, "
+            "source_reconciliation_status, confidence_label, data_quality_label, "
+            "preferred_idea_id, payload_jsonb) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (run_id, ticker, assembler_version, input_hash) "
+            "DO UPDATE SET payload_jsonb=EXCLUDED.payload_jsonb, "
+            "source_reconciliation_status=EXCLUDED.source_reconciliation_status, "
+            "confidence_label=EXCLUDED.confidence_label, "
+            "data_quality_label=EXCLUDED.data_quality_label, "
+            "preferred_idea_id=EXCLUDED.preferred_idea_id "
+            "RETURNING snapshot_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    run_id,
+                    ticker.upper(),
+                    as_of,
+                    assembler_version,
+                    input_hash,
+                    source_reconciliation.get("status"),
+                    header.get("confidence_label"),
+                    header.get("data_quality_label"),
+                    header.get("preferred_idea_id"),
+                    Jsonb(payload),
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def replace_trade_insight_candidates(
+        self,
+        *,
+        snapshot_id: int,
+        run_id: int,
+        ticker: str,
+        candidates: list[dict[str, Any]],
+    ) -> int:
+        delete_sql = (
+            f"DELETE FROM {self._schema}.trade_insight_candidates "
+            "WHERE snapshot_id = %s"
+        )
+        insert_sql = (
+            f"INSERT INTO {self._schema}.trade_insight_candidates "
+            "(snapshot_id, idea_id, ticker, run_id, structure, expression_type, rank, "
+            "status, net_credit_debit, max_profit, max_loss, edge_source, risk_flags, "
+            "legs_jsonb, candidate_jsonb) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(delete_sql, (snapshot_id,))
+            for c in candidates:
+                cur.execute(
+                    insert_sql,
+                    (
+                        snapshot_id,
+                        c["idea_id"],
+                        ticker.upper(),
+                        run_id,
+                        c["structure"],
+                        c.get("expression_type"),
+                        c["rank"],
+                        c["status"],
+                        c.get("net_credit_debit"),
+                        c.get("max_profit"),
+                        c.get("max_loss"),
+                        c.get("edge_source"),
+                        list(c.get("risk_flags") or []),
+                        Jsonb(c.get("legs") or []),
+                        Jsonb(c),
+                    ),
+                )
+        return len(candidates)
+
     def fetch_dark_pool_summary(self, run_id: int) -> tuple[int, Decimal]:
         sql = (
             f"SELECT COUNT(*), COALESCE(SUM(premium), 0) "

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1,6 +1,238 @@
 {
   "components": {
     "schemas": {
+      "CandidateStructure": {
+        "properties": {
+          "breakevens": {
+            "default": [],
+            "items": {
+              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+              "type": "string"
+            },
+            "title": "Breakevens",
+            "type": "array"
+          },
+          "edge_source": {
+            "default": "",
+            "title": "Edge Source",
+            "type": "string"
+          },
+          "expression_type": {
+            "title": "Expression Type",
+            "type": "string"
+          },
+          "idea_id": {
+            "title": "Idea Id",
+            "type": "string"
+          },
+          "legs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/InsightLeg"
+            },
+            "title": "Legs",
+            "type": "array"
+          },
+          "max_loss": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Loss"
+          },
+          "max_profit": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Profit"
+          },
+          "net_credit_debit": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Credit Debit"
+          },
+          "profit_zone": {
+            "default": "",
+            "title": "Profit Zone",
+            "type": "string"
+          },
+          "rank": {
+            "title": "Rank",
+            "type": "integer"
+          },
+          "risk_flags": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Risk Flags",
+            "type": "array"
+          },
+          "status": {
+            "default": "candidate",
+            "title": "Status",
+            "type": "string"
+          },
+          "structure": {
+            "title": "Structure",
+            "type": "string"
+          },
+          "thesis": {
+            "title": "Thesis",
+            "type": "string"
+          }
+        },
+        "required": [
+          "idea_id",
+          "structure",
+          "thesis",
+          "expression_type",
+          "rank"
+        ],
+        "title": "CandidateStructure",
+        "type": "object"
+      },
+      "ChainFlowReadRow": {
+        "properties": {
+          "call_open_interest": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Open Interest"
+          },
+          "call_put_volume_ratio": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Put Volume Ratio"
+          },
+          "call_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Volume"
+          },
+          "put_open_interest": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Open Interest"
+          },
+          "put_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Volume"
+          },
+          "read": {
+            "default": "",
+            "title": "Read",
+            "type": "string"
+          },
+          "requires_t1_oi_confirmation": {
+            "default": false,
+            "title": "Requires T1 Oi Confirmation",
+            "type": "boolean"
+          },
+          "strike": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike",
+            "type": "string"
+          },
+          "volume_oi_note": {
+            "default": "",
+            "title": "Volume Oi Note",
+            "type": "string"
+          }
+        },
+        "required": [
+          "strike"
+        ],
+        "title": "ChainFlowReadRow",
+        "type": "object"
+      },
+      "DivergencePoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "iv_z": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Z"
+          },
+          "rv_z": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv Z"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "DivergencePoint",
+        "type": "object"
+      },
       "FlowAlert": {
         "properties": {
           "alert_rule": {
@@ -649,6 +881,298 @@
         "title": "HealthResponse",
         "type": "object"
       },
+      "InsightBadge": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "severity": {
+            "default": "info",
+            "title": "Severity",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "label"
+        ],
+        "title": "InsightBadge",
+        "type": "object"
+      },
+      "InsightLeg": {
+        "properties": {
+          "expiry": {
+            "format": "date",
+            "title": "Expiry",
+            "type": "string"
+          },
+          "mid": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mid"
+          },
+          "option_right": {
+            "title": "Option Right",
+            "type": "string"
+          },
+          "option_symbol": {
+            "title": "Option Symbol",
+            "type": "string"
+          },
+          "side": {
+            "title": "Side",
+            "type": "string"
+          },
+          "strike": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike",
+            "type": "string"
+          }
+        },
+        "required": [
+          "side",
+          "option_symbol",
+          "option_right",
+          "expiry",
+          "strike"
+        ],
+        "title": "InsightLeg",
+        "type": "object"
+      },
+      "InsightSignalRow": {
+        "properties": {
+          "conflicts": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Conflicts",
+            "type": "array"
+          },
+          "evidence": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Evidence",
+            "type": "array"
+          },
+          "lens": {
+            "title": "Lens",
+            "type": "string"
+          },
+          "read": {
+            "title": "Read",
+            "type": "string"
+          }
+        },
+        "required": [
+          "lens",
+          "read"
+        ],
+        "title": "InsightSignalRow",
+        "type": "object"
+      },
+      "InsightsSynthesis": {
+        "properties": {
+          "avoid": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Avoid",
+            "type": "array"
+          },
+          "best_risk_reward_idea_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Best Risk Reward Idea Id"
+          },
+          "dominant_story": {
+            "default": "",
+            "title": "Dominant Story",
+            "type": "string"
+          },
+          "preferred_idea_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Idea Id"
+          },
+          "required_before_sizing": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Required Before Sizing",
+            "type": "array"
+          }
+        },
+        "title": "InsightsSynthesis",
+        "type": "object"
+      },
+      "IvHistogramBin": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "hi": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Hi",
+            "type": "string"
+          },
+          "lo": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Lo",
+            "type": "string"
+          }
+        },
+        "required": [
+          "lo",
+          "hi",
+          "count"
+        ],
+        "title": "IvHistogramBin",
+        "type": "object"
+      },
+      "IvHvPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv"
+          },
+          "rv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "IvHvPoint",
+        "type": "object"
+      },
+      "IvOfIvPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv"
+          },
+          "iv_of_iv_20": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Of Iv 20"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "IvOfIvPoint",
+        "type": "object"
+      },
+      "IvPercentileDistribution": {
+        "properties": {
+          "bins": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/IvHistogramBin"
+            },
+            "title": "Bins",
+            "type": "array"
+          },
+          "current_iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Iv"
+          },
+          "current_pctile": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Pctile"
+          }
+        },
+        "title": "IvPercentileDistribution",
+        "type": "object"
+      },
       "JobStatus": {
         "properties": {
           "error": {
@@ -1180,6 +1704,17 @@
       },
       "OiChangeRow": {
         "properties": {
+          "ask_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ask Volume"
+          },
           "avg_price": {
             "anyOf": [
               {
@@ -1191,6 +1726,17 @@
               }
             ],
             "title": "Avg Price"
+          },
+          "bid_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bid Volume"
           },
           "curr_date": {
             "anyOf": [
@@ -1237,6 +1783,30 @@
             ],
             "title": "Days Of Vol Greater Than Oi"
           },
+          "last_ask": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Ask"
+          },
+          "last_bid": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Bid"
+          },
           "last_date": {
             "anyOf": [
               {
@@ -1271,6 +1841,28 @@
               }
             ],
             "title": "Last Oi"
+          },
+          "mid_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mid Volume"
+          },
+          "no_side_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "No Side Volume"
           },
           "oi_change": {
             "anyOf": [
@@ -1310,6 +1902,84 @@
               }
             ],
             "title": "Percentage Of Total"
+          },
+          "prev_ask_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Ask Volume"
+          },
+          "prev_bid_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Bid Volume"
+          },
+          "prev_mid_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Mid Volume"
+          },
+          "prev_multi_leg_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Multi Leg Volume"
+          },
+          "prev_neutral_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Neutral Volume"
+          },
+          "prev_stock_multi_leg_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Stock Multi Leg Volume"
+          },
+          "prev_total_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Total Premium"
           },
           "rnk": {
             "anyOf": [
@@ -1354,6 +2024,318 @@
           "option_symbol"
         ],
         "title": "OiChangeRow",
+        "type": "object"
+      },
+      "OptionChainPerStrikeRow": {
+        "description": "Aggregated (expiry, strike) snapshot \u2014 both volume and OI in one row.\n\nBacks both strike-profile charts (Volume and OI variants).",
+        "properties": {
+          "call_oi": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Oi"
+          },
+          "call_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Volume"
+          },
+          "expiry": {
+            "format": "date",
+            "title": "Expiry",
+            "type": "string"
+          },
+          "put_oi": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Oi"
+          },
+          "put_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Volume"
+          },
+          "strike": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expiry",
+          "strike"
+        ],
+        "title": "OptionChainPerStrikeRow",
+        "type": "object"
+      },
+      "OptionsDailyRow": {
+        "description": "One row per trading day from UW /options-volume.\n\n``bullish_premium`` here is whole-tape (UW), distinct from the\nalert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot.",
+        "properties": {
+          "avg_30_day_call_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 30 Day Call Volume"
+          },
+          "avg_30_day_put_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 30 Day Put Volume"
+          },
+          "avg_3_day_call_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 3 Day Call Volume"
+          },
+          "avg_3_day_put_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 3 Day Put Volume"
+          },
+          "avg_7_day_call_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 7 Day Call Volume"
+          },
+          "avg_7_day_put_volume": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg 7 Day Put Volume"
+          },
+          "bearish_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bearish Premium"
+          },
+          "bullish_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bullish Premium"
+          },
+          "call_open_interest": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Open Interest"
+          },
+          "call_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Premium"
+          },
+          "call_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Volume"
+          },
+          "call_volume_ask_side": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Volume Ask Side"
+          },
+          "call_volume_bid_side": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Volume Bid Side"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "net_call_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Call Premium"
+          },
+          "net_put_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Put Premium"
+          },
+          "put_open_interest": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Open Interest"
+          },
+          "put_premium": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Premium"
+          },
+          "put_volume": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Volume"
+          },
+          "put_volume_ask_side": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Volume Ask Side"
+          },
+          "put_volume_bid_side": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Volume Bid Side"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "OptionsDailyRow",
         "type": "object"
       },
       "PositioningBlock": {
@@ -1420,6 +2402,123 @@
         "title": "PositioningBlock",
         "type": "object"
       },
+      "RegimeQuadrantBlock": {
+        "properties": {
+          "cutoff_corr": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cutoff Corr"
+          },
+          "latest": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RegimeQuadrantLatest"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "points": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RegimeQuadrantPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "title": "RegimeQuadrantBlock",
+        "type": "object"
+      },
+      "RegimeQuadrantLatest": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "rvol_pctile": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rvol Pctile"
+          },
+          "spy_corr_21": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy Corr 21"
+          },
+          "state": {
+            "default": "",
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "RegimeQuadrantLatest",
+        "type": "object"
+      },
+      "RegimeQuadrantPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "rvol_pctile": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rvol Pctile"
+          },
+          "spy_corr_21": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy Corr 21"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "RegimeQuadrantPoint",
+        "type": "object"
+      },
       "ReturnsBlock": {
         "description": "Wire shape: d1 / w1 / d30. No aliases \u2014 FastAPI would otherwise serialize\nthem as JSON keys and break the frontend contract.",
         "properties": {
@@ -1461,6 +2560,44 @@
           }
         },
         "title": "ReturnsBlock",
+        "type": "object"
+      },
+      "RvCorrPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "rv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv"
+          },
+          "spy_corr_21": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy Corr 21"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "RvCorrPoint",
         "type": "object"
       },
       "SetupBlock": {
@@ -1676,12 +2813,40 @@
             "title": "Max Pain Rows",
             "type": "array"
           },
+          "next_earnings_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Earnings Date"
+          },
           "oi_change_top": {
             "default": [],
             "items": {
               "$ref": "#/components/schemas/OiChangeRow"
             },
             "title": "Oi Change Top",
+            "type": "array"
+          },
+          "option_chain_per_strike": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/OptionChainPerStrikeRow"
+            },
+            "title": "Option Chain Per Strike",
+            "type": "array"
+          },
+          "options_timeline": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/OptionsDailyRow"
+            },
+            "title": "Options Timeline",
             "type": "array"
           },
           "run_id": {
@@ -1770,6 +2935,181 @@
           }
         },
         "title": "SkewBlock",
+        "type": "object"
+      },
+      "SmileExpiryCurve": {
+        "properties": {
+          "expiry": {
+            "format": "date",
+            "title": "Expiry",
+            "type": "string"
+          },
+          "points": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SmilePoint"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "expiry"
+        ],
+        "title": "SmileExpiryCurve",
+        "type": "object"
+      },
+      "SmilePoint": {
+        "properties": {
+          "iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv"
+          },
+          "strike": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike",
+            "type": "string"
+          }
+        },
+        "required": [
+          "strike"
+        ],
+        "title": "SmilePoint",
+        "type": "object"
+      },
+      "SourceReconciliation": {
+        "properties": {
+          "decision": {
+            "default": "Use deterministic data only where source agreement is understood.",
+            "title": "Decision",
+            "type": "string"
+          },
+          "headline": {
+            "default": "Source reconciliation unavailable",
+            "title": "Headline",
+            "type": "string"
+          },
+          "primary_iv_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Iv Source"
+          },
+          "relative_shape_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relative Shape Source"
+          },
+          "rows": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SourceReconciliationRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          },
+          "status": {
+            "default": "UNKNOWN",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "SourceReconciliation",
+        "type": "object"
+      },
+      "SourceReconciliationRow": {
+        "properties": {
+          "decision": {
+            "default": "",
+            "title": "Decision",
+            "type": "string"
+          },
+          "iv_agreement": {
+            "default": "",
+            "title": "Iv Agreement",
+            "type": "string"
+          },
+          "iv_diff": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Diff"
+          },
+          "price_agreement": {
+            "default": "",
+            "title": "Price Agreement",
+            "type": "string"
+          },
+          "source_a_call_iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source A Call Iv"
+          },
+          "source_b_call_iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source B Call Iv"
+          },
+          "source_pair": {
+            "title": "Source Pair",
+            "type": "string"
+          },
+          "strike": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike"
+          }
+        },
+        "required": [
+          "source_pair"
+        ],
+        "title": "SourceReconciliationRow",
         "type": "object"
       },
       "StockHistoryResponse": {
@@ -1942,6 +3282,248 @@
         "title": "StrikeGexBucket",
         "type": "object"
       },
+      "TermMoveRow": {
+        "properties": {
+          "atm_straddle": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atm Straddle"
+          },
+          "daily_implied_move_perc": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Implied Move Perc"
+          },
+          "dte": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dte"
+          },
+          "expiry": {
+            "format": "date",
+            "title": "Expiry",
+            "type": "string"
+          },
+          "implied_move_perc": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Implied Move Perc"
+          },
+          "read": {
+            "default": "",
+            "title": "Read",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expiry"
+        ],
+        "title": "TermMoveRow",
+        "type": "object"
+      },
+      "TermStructureExpiryRow": {
+        "properties": {
+          "by_strike": {
+            "additionalProperties": {
+              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+              "type": "string"
+            },
+            "default": {},
+            "title": "By Strike",
+            "type": "object"
+          },
+          "dte": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dte"
+          },
+          "expiry": {
+            "format": "date",
+            "title": "Expiry",
+            "type": "string"
+          },
+          "strikes": {
+            "additionalProperties": {
+              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+              "type": "string"
+            },
+            "default": {},
+            "title": "Strikes",
+            "type": "object"
+          }
+        },
+        "required": [
+          "expiry"
+        ],
+        "title": "TermStructureExpiryRow",
+        "type": "object"
+      },
+      "TradeInsightsHeader": {
+        "properties": {
+          "badges": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/InsightBadge"
+            },
+            "title": "Badges",
+            "type": "array"
+          },
+          "confidence_label": {
+            "default": "LOW",
+            "title": "Confidence Label",
+            "type": "string"
+          },
+          "data_quality_label": {
+            "default": "INSUFFICIENT",
+            "title": "Data Quality Label",
+            "type": "string"
+          },
+          "dominant_bias": {
+            "default": "NEUTRAL",
+            "title": "Dominant Bias",
+            "type": "string"
+          },
+          "idea_count": {
+            "default": 0,
+            "title": "Idea Count",
+            "type": "integer"
+          },
+          "preferred_idea_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Idea Id"
+          },
+          "primary_setup": {
+            "default": "NO_CLEAR_SETUP",
+            "title": "Primary Setup",
+            "type": "string"
+          }
+        },
+        "title": "TradeInsightsHeader",
+        "type": "object"
+      },
+      "TradeInsightsResponse": {
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "candidate_structures": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CandidateStructure"
+            },
+            "title": "Candidate Structures",
+            "type": "array"
+          },
+          "flow_table": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ChainFlowReadRow"
+            },
+            "title": "Flow Table",
+            "type": "array"
+          },
+          "header": {
+            "$ref": "#/components/schemas/TradeInsightsHeader"
+          },
+          "mode": {
+            "default": "research",
+            "title": "Mode",
+            "type": "string"
+          },
+          "signal_stack": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/InsightSignalRow"
+            },
+            "title": "Signal Stack",
+            "type": "array"
+          },
+          "source_reconciliation": {
+            "$ref": "#/components/schemas/SourceReconciliation",
+            "default": {
+              "decision": "Use deterministic data only where source agreement is understood.",
+              "headline": "Source reconciliation unavailable",
+              "rows": [],
+              "status": "UNKNOWN"
+            }
+          },
+          "synthesis": {
+            "$ref": "#/components/schemas/InsightsSynthesis",
+            "default": {
+              "avoid": [],
+              "dominant_story": "",
+              "required_before_sizing": []
+            }
+          },
+          "term_structure_table": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TermMoveRow"
+            },
+            "title": "Term Structure Table",
+            "type": "array"
+          },
+          "ticker": {
+            "title": "Ticker",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ticker",
+          "header"
+        ],
+        "title": "TradeInsightsResponse",
+        "type": "object"
+      },
       "TradePlan": {
         "properties": {
           "direction": {
@@ -2109,6 +3691,166 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "VolHeaderBlock": {
+        "properties": {
+          "implied_move_30d_perc": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Implied Move 30D Perc"
+          },
+          "iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv"
+          },
+          "iv_high_52w": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv High 52W"
+          },
+          "iv_low_52w": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Low 52W"
+          },
+          "iv_percentile_30d": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Percentile 30D"
+          },
+          "iv_rank": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Rank"
+          },
+          "iv_rank_1y": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Rank 1Y"
+          },
+          "rv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv"
+          },
+          "rv_high_52w": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv High 52W"
+          },
+          "rv_low_52w": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv Low 52W"
+          },
+          "skew_25d": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skew 25D"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vrp_note": {
+            "default": "",
+            "title": "Vrp Note",
+            "type": "string"
+          },
+          "vrp_signal": {
+            "default": "",
+            "title": "Vrp Signal",
+            "type": "string"
+          }
+        },
+        "title": "VolHeaderBlock",
+        "type": "object"
+      },
       "VolatilityProfile": {
         "properties": {
           "implied_move_30d_perc": {
@@ -2264,6 +4006,162 @@
           }
         },
         "title": "VolatilityProfile",
+        "type": "object"
+      },
+      "VolatilitySeriesResponse": {
+        "properties": {
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "backfill_status": {
+            "title": "Backfill Status",
+            "type": "string"
+          },
+          "divergence": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DivergencePoint"
+            },
+            "title": "Divergence",
+            "type": "array"
+          },
+          "divergence_headline": {
+            "default": "",
+            "title": "Divergence Headline",
+            "type": "string"
+          },
+          "header": {
+            "$ref": "#/components/schemas/VolHeaderBlock"
+          },
+          "hv_iv_history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/IvHvPoint"
+            },
+            "title": "Hv Iv History",
+            "type": "array"
+          },
+          "iv_of_iv": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/IvOfIvPoint"
+            },
+            "title": "Iv Of Iv",
+            "type": "array"
+          },
+          "iv_percentile_distribution": {
+            "$ref": "#/components/schemas/IvPercentileDistribution",
+            "default": {
+              "bins": []
+            }
+          },
+          "regime_quadrant": {
+            "$ref": "#/components/schemas/RegimeQuadrantBlock",
+            "default": {
+              "points": []
+            }
+          },
+          "rv_spy_corr": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RvCorrPoint"
+            },
+            "title": "Rv Spy Corr",
+            "type": "array"
+          },
+          "smile": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SmileExpiryCurve"
+            },
+            "title": "Smile",
+            "type": "array"
+          },
+          "spot": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
+          "term_structure": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TermStructureExpiryRow"
+            },
+            "title": "Term Structure",
+            "type": "array"
+          },
+          "ticker": {
+            "title": "Ticker",
+            "type": "string"
+          },
+          "vrp_spread": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/VrpDailyPoint"
+            },
+            "title": "Vrp Spread",
+            "type": "array"
+          },
+          "vrp_spread_headline": {
+            "default": "",
+            "title": "Vrp Spread Headline",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ticker",
+          "as_of",
+          "backfill_status",
+          "header"
+        ],
+        "title": "VolatilitySeriesResponse",
+        "type": "object"
+      },
+      "VrpDailyPoint": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vrp_z_20": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp Z 20"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "VrpDailyPoint",
         "type": "object"
       },
       "WatchlistCard": {
@@ -2849,8 +4747,89 @@
         ]
       }
     },
+    "/api/stock/{ticker}/trade-insights": {
+      "get": {
+        "operationId": "get_trade_insights_api_stock__ticker__trade_insights_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticker",
+            "required": true,
+            "schema": {
+              "title": "Ticker",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradeInsightsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Trade Insights",
+        "tags": [
+          "trade-insights"
+        ]
+      }
+    },
     "/api/stock/{ticker}/volatility/series": {
-      "get": {}
+      "get": {
+        "operationId": "get_volatility_series_api_stock__ticker__volatility_series_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticker",
+            "required": true,
+            "schema": {
+              "title": "Ticker",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolatilitySeriesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Volatility Series",
+        "tags": [
+          "volatility"
+        ]
+      }
     },
     "/api/watchlist": {
       "get": {

--- a/tests/integration/api/test_trade_insights_endpoint.py
+++ b/tests/integration/api/test_trade_insights_endpoint.py
@@ -1,0 +1,9 @@
+"""Integration tests for GET /api/stock/{ticker}/trade-insights."""
+
+from __future__ import annotations
+
+
+def test_trade_insights_endpoint_returns_404_without_run(client, seeded_db_empty_cards):
+    r = client.get("/api/stock/NOPE/trade-insights")
+    assert r.status_code == 404
+    assert "no runs" in r.text

--- a/tests/integration/storage/test_repository_trade_insights.py
+++ b/tests/integration/storage/test_repository_trade_insights.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timezone
+
+
+def test_trade_insight_snapshot_upsert_is_idempotent(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    run_id = repo.insert_scan_run("TSLA")
+    payload = {
+        "ticker": "TSLA",
+        "header": {
+            "confidence_label": "LOW",
+            "data_quality_label": "INSUFFICIENT",
+            "preferred_idea_id": None,
+        },
+        "source_reconciliation": {"status": "UNKNOWN"},
+        "candidate_structures": [
+            {
+                "idea_id": "A",
+                "structure": "call_credit_spread",
+                "expression_type": "SHORT_VOL",
+                "rank": 1,
+                "status": "needs_check",
+                "max_loss": "3.75",
+                "risk_flags": ["event_check_required"],
+                "legs": [],
+            }
+        ],
+    }
+
+    kwargs = {
+        "run_id": run_id,
+        "ticker": "TSLA",
+        "as_of": datetime(2026, 5, 13, tzinfo=timezone.utc),
+        "assembler_version": "trade-insights-v1",
+        "input_hash": "abc123",
+        "payload": payload,
+    }
+    first = repo.upsert_trade_insight_snapshot(**kwargs)
+    second = repo.upsert_trade_insight_snapshot(**kwargs)
+    assert first == second
+
+    written = repo.replace_trade_insight_candidates(
+        snapshot_id=first,
+        run_id=run_id,
+        ticker="TSLA",
+        candidates=payload["candidate_structures"],
+    )
+    assert written == 1

--- a/tests/integration/test_trade_insights_pipeline_persistence.py
+++ b/tests/integration/test_trade_insights_pipeline_persistence.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from uw_scan.models import (
+    FlowSnapshot,
+    MarketStructure,
+    OptionContractRow,
+    SingleStockReport,
+    TermStructureRow,
+    VRPAssessment,
+    VolatilityProfile,
+)
+from uw_scan.pipeline import _persist_trade_insights_for_run
+
+
+def _contract(symbol: str, bid: str, ask: str, volume: int, oi: int) -> OptionContractRow:
+    return OptionContractRow(
+        option_symbol=symbol,
+        last_price=Decimal(bid),
+        nbbo_bid=Decimal(bid),
+        nbbo_ask=Decimal(ask),
+        implied_volatility=Decimal("0.52"),
+        open_interest=oi,
+        prev_oi=max(oi - 50, 0),
+        volume=volume,
+        ask_volume=int(volume * 0.55),
+        bid_volume=int(volume * 0.35),
+        total_premium=Decimal(bid) * Decimal(volume),
+    )
+
+
+def test_trade_insights_pipeline_persistence_is_idempotent(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    run_id = repo.insert_scan_run("TSLA")
+    repo.insert_option_contract_rows(
+        run_id,
+        "TSLA",
+        [
+            _contract("TSLA260515P00420000", "6.10", "6.30", 450, 500),
+            _contract("TSLA260515P00425000", "8.00", "8.20", 600, 700),
+            _contract("TSLA260515P00430000", "10.20", "10.50", 900, 850),
+            _contract("TSLA260515C00430000", "9.40", "9.60", 1500, 1000),
+            _contract("TSLA260515C00435000", "6.90", "7.10", 1200, 800),
+            _contract("TSLA260522C00430000", "13.80", "14.20", 700, 900),
+        ],
+    )
+    repo.insert_iv_term_rows(
+        run_id,
+        [
+            TermStructureRow(
+                ticker="TSLA",
+                date=date(2026, 5, 13),
+                expiry=date(2026, 5, 15),
+                dte=4,
+                implied_move_perc=Decimal("0.048"),
+            ),
+            TermStructureRow(
+                ticker="TSLA",
+                date=date(2026, 5, 13),
+                expiry=date(2026, 5, 22),
+                dte=11,
+                implied_move_perc=Decimal("0.067"),
+            ),
+        ],
+    )
+    report = SingleStockReport(
+        run_id=run_id,
+        ticker="TSLA",
+        generated_at=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        market_structure=MarketStructure(spot=Decimal("428")),
+        volatility=VolatilityProfile(),
+        flow=FlowSnapshot(
+            ticker="TSLA",
+            flow_count=0,
+            net_premium=Decimal("0"),
+            bull_premium=Decimal("0"),
+            bear_premium=Decimal("0"),
+            ask_side_premium=Decimal("0"),
+            bid_side_premium=Decimal("0"),
+        ),
+        vrp=VRPAssessment(signal="UNKNOWN", note="test"),
+    )
+
+    _persist_trade_insights_for_run(repo=repo, report=report)
+    _persist_trade_insights_for_run(repo=repo, report=report)
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT snapshot_id FROM uw_scan.trade_insight_snapshots WHERE run_id = %s",
+            (run_id,),
+        )
+        snapshots = cur.fetchall()
+        cur.execute(
+            "SELECT COUNT(*) FROM uw_scan.trade_insight_candidates WHERE run_id = %s",
+            (run_id,),
+        )
+        candidate_count = cur.fetchone()[0]
+
+    assert len(snapshots) == 1
+    assert candidate_count > 0

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from uw_scan.models import (
@@ -52,6 +52,7 @@ from uw_scan.reports.trade_insights import (
     ParsedOptionSymbol,
     _credit_spread_math,
     _mid,
+    assemble_trade_insights,
     parse_option_symbol,
 )
 
@@ -89,3 +90,116 @@ def test_credit_spread_math_caps_loss_by_width_minus_credit():
     assert net_credit == Decimal("1.25")
     assert max_loss == Decimal("3.75")
     assert max_profit == Decimal("1.25")
+
+
+def _contract(
+    symbol: str,
+    *,
+    bid: str,
+    ask: str,
+    iv: str = "0.52",
+    volume: int = 1000,
+    oi: int = 800,
+):
+    return {
+        "option_symbol": symbol,
+        "last_price": Decimal(bid),
+        "nbbo_bid": Decimal(bid),
+        "nbbo_ask": Decimal(ask),
+        "implied_volatility": Decimal(iv),
+        "open_interest": oi,
+        "prev_oi": max(oi - 50, 0),
+        "volume": volume,
+        "ask_volume": int(volume * 0.55),
+        "bid_volume": int(volume * 0.35),
+        "total_premium": Decimal(bid) * Decimal(volume),
+    }
+
+
+class FakeTradeInsightsRepo:
+    def fetch_option_contracts_rich(self, run_id: int, ticker: str):
+        return [
+            _contract("TSLA260515P00420000", bid="6.10", ask="6.30", volume=450, oi=500),
+            _contract("TSLA260515P00425000", bid="8.00", ask="8.20", volume=600, oi=700),
+            _contract("TSLA260515P00430000", bid="10.20", ask="10.50", volume=900, oi=850),
+            _contract("TSLA260515C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000),
+            _contract("TSLA260515C00435000", bid="6.90", ask="7.10", volume=1200, oi=800),
+            _contract("TSLA260522C00430000", bid="13.80", ask="14.20", iv="0.48", volume=700, oi=900),
+        ]
+
+    def fetch_iv_term_rows(self, run_id: int, ticker: str):
+        return [
+            {
+                "expiry": date(2026, 5, 15),
+                "dte": 4,
+                "implied_move_perc": Decimal("0.048"),
+            },
+            {
+                "expiry": date(2026, 5, 22),
+                "dte": 11,
+                "implied_move_perc": Decimal("0.067"),
+            }
+        ]
+
+    def fetch_source_reconciliation_rows(self, run_id: int, ticker: str):
+        return []
+
+
+def test_assemble_trade_insights_builds_research_response():
+    response = assemble_trade_insights(
+        ticker="TSLA",
+        run_id=1,
+        repo=FakeTradeInsightsRepo(),
+        as_of=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot=Decimal("428"),
+    )
+
+    assert response.ticker == "TSLA"
+    # V1 only emits MIXED or INSUFFICIENT; READY is reserved for a later patch
+    # that wires event/source/liquidity gates fully.
+    assert response.header.data_quality_label == "MIXED"
+    assert response.signal_stack
+    assert response.flow_table
+    assert response.term_structure_table
+    assert response.candidate_structures
+    assert all(c.max_loss is not None for c in response.candidate_structures)
+    assert {
+        "call_credit_spread",
+        "put_credit_spread",
+        "iron_condor",
+        "long_straddle",
+        "calendar_spread",
+    }.issubset({c.structure for c in response.candidate_structures})
+    assert response.source_reconciliation.status == "UNKNOWN"
+    assert response.header.preferred_idea_id is None
+    assert response.synthesis.preferred_idea_id is None
+    assert all(c.status == "needs_check" for c in response.candidate_structures)
+
+
+def test_iron_condor_max_loss_matches_width_minus_total_credit():
+    """Locks in the corrected formula: max(call_width, put_width) - total_credit.
+
+    With the fake fixture (5-point wings on both sides, ~4.75 total credit),
+    max loss should be 0.25 per spread, not max(call_spread.max_loss,
+    put_spread.max_loss). The earlier draft of the plan used the latter and
+    over-stated max loss by ~10x.
+    """
+    response = assemble_trade_insights(
+        ticker="TSLA",
+        run_id=1,
+        repo=FakeTradeInsightsRepo(),
+        as_of=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot=Decimal("428"),
+    )
+    ic = next(c for c in response.candidate_structures if c.structure == "iron_condor")
+    call_spread = next(c for c in response.candidate_structures if c.structure == "call_credit_spread")
+    put_spread = next(c for c in response.candidate_structures if c.structure == "put_credit_spread")
+
+    expected_credit = (call_spread.net_credit_debit or Decimal("0")) + (
+        put_spread.net_credit_debit or Decimal("0")
+    )
+    assert ic.net_credit_debit == expected_credit
+    assert ic.max_profit == expected_credit
+    # Both wings are 5 points wide in the fixture; max wing breach loss is
+    # width - total_credit, not the max of the per-wing losses.
+    assert ic.max_loss == Decimal("5") - expected_credit

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -7,6 +7,13 @@ from uw_scan.models import (
     TradeInsightsHeader,
     TradeInsightsResponse,
 )
+from uw_scan.reports.trade_insights import (
+    ParsedOptionSymbol,
+    _credit_spread_math,
+    _mid,
+    assemble_trade_insights,
+    parse_option_symbol,
+)
 
 
 def test_trade_insights_response_serializes_required_shape():
@@ -46,15 +53,6 @@ def test_trade_insights_response_serializes_required_shape():
     assert body["header"]["dominant_bias"] == "NEUTRAL_SHORT_VOL"
     assert body["candidate_structures"][0]["legs"][0]["strike"] == "430"
     assert body["source_reconciliation"]["status"] == "UNKNOWN"
-
-
-from uw_scan.reports.trade_insights import (
-    ParsedOptionSymbol,
-    _credit_spread_math,
-    _mid,
-    assemble_trade_insights,
-    parse_option_symbol,
-)
 
 
 def test_parse_option_symbol_occ_style():

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -1,3 +1,4 @@
+from datetime import date
 from decimal import Decimal
 
 from uw_scan.models import (
@@ -45,3 +46,46 @@ def test_trade_insights_response_serializes_required_shape():
     assert body["header"]["dominant_bias"] == "NEUTRAL_SHORT_VOL"
     assert body["candidate_structures"][0]["legs"][0]["strike"] == "430"
     assert body["source_reconciliation"]["status"] == "UNKNOWN"
+
+
+from uw_scan.reports.trade_insights import (
+    ParsedOptionSymbol,
+    _credit_spread_math,
+    _mid,
+    parse_option_symbol,
+)
+
+
+def test_parse_option_symbol_occ_style():
+    parsed = parse_option_symbol("TSLA260515C00430000")
+    assert parsed == ParsedOptionSymbol(
+        root="TSLA",
+        expiry=date(2026, 5, 15),
+        right="C",
+        strike=Decimal("430"),
+    )
+
+
+def test_parse_option_symbol_rejects_bad_symbol():
+    assert parse_option_symbol("bad") is None
+
+
+def test_mid_uses_nbbo_when_present():
+    assert _mid({"nbbo_bid": Decimal("1.00"), "nbbo_ask": Decimal("1.20")}) == Decimal(
+        "1.10"
+    )
+
+
+def test_mid_falls_back_to_last_price():
+    assert _mid({"last_price": Decimal("0.95")}) == Decimal("0.95")
+
+
+def test_credit_spread_math_caps_loss_by_width_minus_credit():
+    net_credit, max_loss, max_profit = _credit_spread_math(
+        short_mid=Decimal("1.80"),
+        long_mid=Decimal("0.55"),
+        width=Decimal("5"),
+    )
+    assert net_credit == Decimal("1.25")
+    assert max_loss == Decimal("3.75")
+    assert max_profit == Decimal("1.25")

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -1,0 +1,47 @@
+from decimal import Decimal
+
+from uw_scan.models import (
+    CandidateStructure,
+    InsightLeg,
+    TradeInsightsHeader,
+    TradeInsightsResponse,
+)
+
+
+def test_trade_insights_response_serializes_required_shape():
+    response = TradeInsightsResponse(
+        ticker="TSLA",
+        header=TradeInsightsHeader(
+            dominant_bias="NEUTRAL_SHORT_VOL",
+            primary_setup="IV_RV_SPREAD_MEAN_REVERSION",
+            confidence_label="MEDIUM",
+            data_quality_label="MIXED",
+            idea_count=1,
+        ),
+        candidate_structures=[
+            CandidateStructure(
+                idea_id="A",
+                structure="call_credit_spread",
+                thesis="Front premium is elevated.",
+                expression_type="SHORT_VOL",
+                rank=1,
+                max_loss=Decimal("1.25"),
+                legs=[
+                    InsightLeg(
+                        side="sell",
+                        option_symbol="TSLA260515C00430000",
+                        option_right="C",
+                        expiry="2026-05-15",
+                        strike=Decimal("430"),
+                        mid=Decimal("9.50"),
+                    )
+                ],
+            )
+        ],
+    )
+
+    body = response.model_dump(mode="json")
+    assert body["ticker"] == "TSLA"
+    assert body["header"]["dominant_bias"] == "NEUTRAL_SHORT_VOL"
+    assert body["candidate_structures"][0]["legs"][0]["strike"] == "430"
+    assert body["source_reconciliation"]["status"] == "UNKNOWN"

--- a/web/app/stock/[ticker]/[tab]/error.tsx
+++ b/web/app/stock/[ticker]/[tab]/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--negative)",
+        padding: 16,
+      }}
+    >
+      <div>Tab failed to load: {error.message}</div>
+      <button
+        type="button"
+        onClick={reset}
+        style={{
+          marginTop: 8,
+          padding: "4px 8px",
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-dim)",
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          cursor: "pointer",
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/web/app/stock/[ticker]/[tab]/loading.tsx
+++ b/web/app/stock/[ticker]/[tab]/loading.tsx
@@ -1,0 +1,14 @@
+export default function Loading() {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--text-muted)",
+        padding: 16,
+      }}
+    >
+      Loading...
+    </div>
+  );
+}

--- a/web/app/stock/[ticker]/[tab]/page.tsx
+++ b/web/app/stock/[ticker]/[tab]/page.tsx
@@ -3,9 +3,10 @@ import { api } from "@/lib/api";
 import { MarketStructureTab } from "@/components/stock/tabs/MarketStructureTab";
 import { VolatilityTab } from "@/components/stock/tabs/VolatilityTab";
 import { FlowTab } from "@/components/stock/tabs/FlowTab";
+import { TradeInsightsTab } from "@/components/stock/tabs/TradeInsightsTab";
 import { TradePlanTab } from "@/components/stock/tabs/TradePlanTab";
 
-const TABS = {
+const REPORT_TABS = {
   "market-structure": MarketStructureTab,
   volatility: VolatilityTab,
   flow: FlowTab,
@@ -18,8 +19,12 @@ export default async function TabPage({
   params: Promise<{ ticker: string; tab: string }>;
 }) {
   const { ticker, tab } = await params;
-  const Component = TABS[tab as keyof typeof TABS];
+  if (tab === "trade-insights") {
+    return <TradeInsightsTab ticker={ticker} />;
+  }
+  const Component = REPORT_TABS[tab as keyof typeof REPORT_TABS];
   if (!Component) notFound();
+
   const report = await api.stock(ticker);
   return <Component report={report} />;
 }

--- a/web/components/stock/TabBar.tsx
+++ b/web/components/stock/TabBar.tsx
@@ -6,6 +6,7 @@ const TABS = [
   ["market-structure", "Market Structure"],
   ["volatility", "Volatility"],
   ["flow", "Flow"],
+  ["trade-insights", "Trade Insights"],
   ["trade-plan", "Trade Plan"],
 ] as const;
 

--- a/web/components/stock/panels/CandidateStructuresPanel.tsx
+++ b/web/components/stock/panels/CandidateStructuresPanel.tsx
@@ -1,0 +1,118 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
+
+type Candidate = TradeInsightsResponse["candidate_structures"][number];
+
+const fmtMoney = (v: string | number | null | undefined) =>
+  v == null ? "-" : `$${Number(v).toFixed(2)}`;
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ color: "var(--text-primary)", fontFamily: "var(--font-mono)" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function CandidateStructuresPanel({
+  candidates,
+}: {
+  candidates: Candidate[];
+}) {
+  if (candidates.length === 0) {
+    return (
+      <InsightPanel heading="CANDIDATE STRUCTURES">
+        <InsightStatusBanner text="No candidate structures generated" severity="info" />
+      </InsightPanel>
+    );
+  }
+
+  return (
+    <InsightPanel heading="CANDIDATE STRUCTURES">
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gap: 8,
+        }}
+      >
+        {candidates.map((candidate) => (
+          <section
+            key={candidate.idea_id}
+            style={{
+              border: "1px solid var(--border-dim)",
+              borderRadius: 4,
+              padding: 12,
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 8,
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
+                {candidate.idea_id}. {candidate.structure}
+              </div>
+              <div style={{ color: "var(--text-secondary)", fontSize: 11 }}>
+                {candidate.status}
+              </div>
+            </div>
+            <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+              {candidate.thesis}
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <Metric label="Credit / Debit" value={fmtMoney(candidate.net_credit_debit)} />
+              <Metric label="Max profit" value={fmtMoney(candidate.max_profit)} />
+              <Metric label="Max loss" value={fmtMoney(candidate.max_loss)} />
+              <Metric label="Rank" value={String(candidate.rank)} />
+            </div>
+            {candidate.profit_zone && (
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                }}
+              >
+                {candidate.profit_zone}
+              </div>
+            )}
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              {candidate.risk_flags.map((flag) => (
+                <span
+                  key={flag}
+                  style={{
+                    border: "1px solid var(--border-dim)",
+                    color: "var(--warning)",
+                    padding: "3px 6px",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                  }}
+                >
+                  {flag}
+                </span>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/ChainFlowReadPanel.tsx
+++ b/web/components/stock/panels/ChainFlowReadPanel.tsx
@@ -1,0 +1,35 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { DataTable } from "./DataTable";
+import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
+
+type Row = TradeInsightsResponse["flow_table"][number];
+
+const fmtRatio = (v: unknown) => (v == null ? "-" : `${Number(v).toFixed(2)}x`);
+
+export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
+  if (rows.length === 0) {
+    return (
+      <InsightPanel heading="CHAIN / FLOW READ">
+        <InsightStatusBanner text="No option chain rows for this run" severity="info" />
+      </InsightPanel>
+    );
+  }
+
+  return (
+    <InsightPanel heading="CHAIN / FLOW READ">
+      <DataTable
+        rows={rows as unknown as Record<string, unknown>[]}
+        columns={[
+          { key: "strike", label: "Strike" },
+          { key: "call_volume", label: "Call Vol" },
+          { key: "call_open_interest", label: "Call OI" },
+          { key: "put_volume", label: "Put Vol" },
+          { key: "put_open_interest", label: "Put OI" },
+          { key: "call_put_volume_ratio", label: "C/P", render: fmtRatio },
+          { key: "volume_oi_note", label: "Vol/OI Note" },
+          { key: "read", label: "Read" },
+        ]}
+      />
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/ChainFlowReadPanel.tsx
+++ b/web/components/stock/panels/ChainFlowReadPanel.tsx
@@ -86,6 +86,21 @@ export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
       return bScore - aScore;
     })
     .slice(0, 8);
+  const flowRead =
+    tapeRatio == null
+      ? "Put volume is unavailable, so call/put balance is inconclusive."
+      : tapeRatio >= 1.2
+        ? `Calls traded ${tapeRatio.toFixed(2)}x puts across available rows, so flow leans call-heavy.`
+        : tapeRatio <= 0.8
+          ? `Calls traded ${tapeRatio.toFixed(2)}x puts across available rows, so flow leans put-heavy.`
+          : `Call and put volume are roughly balanced at ${tapeRatio.toFixed(2)}x.`;
+  const activityRead = strongest
+    ? `The busiest strike is ${strongest.strike}, which is the first place to inspect for pinning or crowding.`
+    : "No single strike stands out from the available rows.";
+  const confirmationRead =
+    t1Count > 0
+      ? `${t1Count} strike${t1Count === 1 ? " needs" : "s need"} next-day OI confirmation before treating volume as new positioning.`
+      : "No highlighted strikes need next-day OI confirmation.";
 
   return (
     <InsightPanel
@@ -94,8 +109,17 @@ export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
     >
       <div
         style={{
+          color: "var(--text-primary)",
+          fontSize: 13,
+          lineHeight: 1.5,
+        }}
+      >
+        {flowRead} {activityRead} {confirmationRead}
+      </div>
+      <div
+        style={{
           display: "grid",
-          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
           gap: 8,
         }}
       >
@@ -114,19 +138,26 @@ export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
           tone={t1Count > 0 ? "warning" : "neutral"}
         />
       </div>
-      <DataTable
-        rows={highlightedRows as unknown as Record<string, unknown>[]}
-        columns={[
-          { key: "strike", label: "Strike" },
-          { key: "call_volume", label: "Call Vol" },
-          { key: "call_open_interest", label: "Call OI" },
-          { key: "put_volume", label: "Put Vol" },
-          { key: "put_open_interest", label: "Put OI" },
-          { key: "call_put_volume_ratio", label: "C/P", render: fmtRatio },
-          { key: "volume_oi_note", label: "Vol/OI Note" },
-          { key: "read", label: "Read" },
-        ]}
-      />
+      <details style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
+        <summary style={{ color: "var(--text-secondary)", cursor: "pointer" }}>
+          Show highlighted strike rows
+        </summary>
+        <div style={{ marginTop: 8 }}>
+          <DataTable
+            rows={highlightedRows as unknown as Record<string, unknown>[]}
+            columns={[
+              { key: "strike", label: "Strike" },
+              { key: "call_volume", label: "Call Vol" },
+              { key: "call_open_interest", label: "Call OI" },
+              { key: "put_volume", label: "Put Vol" },
+              { key: "put_open_interest", label: "Put OI" },
+              { key: "call_put_volume_ratio", label: "C/P", render: fmtRatio },
+              { key: "volume_oi_note", label: "Vol/OI Note" },
+              { key: "read", label: "Read" },
+            ]}
+          />
+        </div>
+      </details>
     </InsightPanel>
   );
 }

--- a/web/components/stock/panels/ChainFlowReadPanel.tsx
+++ b/web/components/stock/panels/ChainFlowReadPanel.tsx
@@ -5,6 +5,49 @@ import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
 type Row = TradeInsightsResponse["flow_table"][number];
 
 const fmtRatio = (v: unknown) => (v == null ? "-" : `${Number(v).toFixed(2)}x`);
+const n = (v: string | number | null | undefined) => (v == null ? 0 : Number(v));
+
+function Highlight({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: "neutral" | "warning" | "positive";
+}) {
+  const color =
+    tone === "warning"
+      ? "var(--warning)"
+      : tone === "positive"
+        ? "var(--positive)"
+        : "var(--text-primary)";
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: 10,
+        display: "grid",
+        gap: 4,
+      }}
+    >
+      <div
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ color, fontFamily: "var(--font-mono)", fontSize: 13 }}>
+        {value}
+      </div>
+    </div>
+  );
+}
 
 export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
   if (rows.length === 0) {
@@ -15,10 +58,64 @@ export function ChainFlowReadPanel({ rows }: { rows: Row[] }) {
     );
   }
 
+  const totalCallVolume = rows.reduce((sum, row) => sum + n(row.call_volume), 0);
+  const totalPutVolume = rows.reduce((sum, row) => sum + n(row.put_volume), 0);
+  const tapeRatio = totalPutVolume > 0 ? totalCallVolume / totalPutVolume : null;
+  const t1Count = rows.filter((row) => row.requires_t1_oi_confirmation).length;
+  const strongest = [...rows].sort(
+    (a, b) =>
+      n(b.call_volume) +
+      n(b.put_volume) +
+      n(b.call_open_interest) +
+      n(b.put_open_interest) -
+      (n(a.call_volume) +
+        n(a.put_volume) +
+        n(a.call_open_interest) +
+        n(a.put_open_interest)),
+  )[0];
+  const highlightedRows = [...rows]
+    .sort((a, b) => {
+      const bScore =
+        n(b.call_volume) +
+        n(b.put_volume) +
+        (b.requires_t1_oi_confirmation ? 100000 : 0);
+      const aScore =
+        n(a.call_volume) +
+        n(a.put_volume) +
+        (a.requires_t1_oi_confirmation ? 100000 : 0);
+      return bScore - aScore;
+    })
+    .slice(0, 8);
+
   return (
-    <InsightPanel heading="CHAIN / FLOW READ">
+    <InsightPanel
+      heading="CHAIN / FLOW HIGHLIGHTS"
+      subheading={`Showing ${highlightedRows.length} highlighted strikes from ${rows.length} rows`}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          gap: 8,
+        }}
+      >
+        <Highlight
+          label="Call / Put volume"
+          value={tapeRatio == null ? "Put volume unavailable" : `${tapeRatio.toFixed(2)}x`}
+          tone={tapeRatio != null && tapeRatio > 1 ? "positive" : "neutral"}
+        />
+        <Highlight
+          label="Highest activity"
+          value={strongest ? `${strongest.strike} strike` : "Unavailable"}
+        />
+        <Highlight
+          label="Needs T+1 OI"
+          value={`${t1Count} strike${t1Count === 1 ? "" : "s"}`}
+          tone={t1Count > 0 ? "warning" : "neutral"}
+        />
+      </div>
       <DataTable
-        rows={rows as unknown as Record<string, unknown>[]}
+        rows={highlightedRows as unknown as Record<string, unknown>[]}
         columns={[
           { key: "strike", label: "Strike" },
           { key: "call_volume", label: "Call Vol" },

--- a/web/components/stock/panels/InsightPanel.tsx
+++ b/web/components/stock/panels/InsightPanel.tsx
@@ -1,0 +1,82 @@
+import type { CSSProperties, ReactNode } from "react";
+
+const sectionHeading: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 9,
+  color: "var(--text-muted)",
+  letterSpacing: 1,
+  textTransform: "uppercase",
+  marginTop: 4,
+};
+
+export function InsightPanel({
+  heading,
+  subheading,
+  children,
+  fullBleed = false,
+}: {
+  heading: string;
+  subheading?: string;
+  children: ReactNode;
+  fullBleed?: boolean;
+}) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        background: "var(--bg-panel)",
+        padding: fullBleed ? 0 : 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div style={{ padding: fullBleed ? "16px 16px 0" : 0 }}>
+        <div style={sectionHeading}>{heading}</div>
+        {subheading && (
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              color: "var(--text-primary)",
+            }}
+          >
+            {subheading}
+          </div>
+        )}
+      </div>
+      <div style={{ padding: fullBleed ? "0 16px 16px" : 0 }}>{children}</div>
+    </section>
+  );
+}
+
+export function InsightStatusBanner({
+  text,
+  severity = "warning",
+}: {
+  text: string;
+  severity?: "warning" | "negative" | "info";
+}) {
+  const color =
+    severity === "negative"
+      ? "var(--negative)"
+      : severity === "info"
+        ? "var(--text-secondary)"
+        : "var(--warning)";
+  return (
+    <div
+      style={{
+        padding: 8,
+        background: "var(--bg-panel)",
+        border: `1px dashed ${color}`,
+        borderRadius: 4,
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color,
+      }}
+    >
+      {text}
+    </div>
+  );
+}

--- a/web/components/stock/panels/InsightsSynthesisPanel.tsx
+++ b/web/components/stock/panels/InsightsSynthesisPanel.tsx
@@ -1,0 +1,64 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { InsightPanel } from "./InsightPanel";
+
+type Synthesis = TradeInsightsResponse["synthesis"];
+
+function ListBlock({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <div
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        {title}
+      </div>
+      <ul
+        style={{
+          margin: 0,
+          paddingLeft: 18,
+          color: "var(--text-secondary)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function InsightsSynthesisPanel({ synthesis }: { synthesis: Synthesis }) {
+  return (
+    <InsightPanel heading="SYNTHESIS / NEXT CHECKS">
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
+          {synthesis.dominant_story}
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 12,
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            color: "var(--text-secondary)",
+          }}
+        >
+          <div>Preferred: {synthesis.preferred_idea_id ?? "None"}</div>
+          <div>Best risk/reward: {synthesis.best_risk_reward_idea_id ?? "None"}</div>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <ListBlock title="Avoid" items={synthesis.avoid} />
+          <ListBlock title="Required before sizing" items={synthesis.required_before_sizing} />
+        </div>
+      </div>
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/SignalStackPanel.tsx
+++ b/web/components/stock/panels/SignalStackPanel.tsx
@@ -1,0 +1,33 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { InsightPanel } from "./InsightPanel";
+
+type Row = TradeInsightsResponse["signal_stack"][number];
+
+export function SignalStackPanel({ rows }: { rows: Row[] }) {
+  return (
+    <InsightPanel heading="SIGNAL STACK">
+      <div style={{ display: "grid", gap: 10 }}>
+        {rows.map((row) => (
+          <div
+            key={row.lens}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "140px 1fr",
+              gap: 12,
+            }}
+          >
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+              {row.lens}
+            </div>
+            <div>
+              <div style={{ fontWeight: 600 }}>{row.read}</div>
+              <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+                {row.evidence.join(" | ")}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/SourceReconciliationPanel.tsx
+++ b/web/components/stock/panels/SourceReconciliationPanel.tsx
@@ -1,0 +1,37 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { DataTable } from "./DataTable";
+import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
+
+type Reconciliation = TradeInsightsResponse["source_reconciliation"];
+
+export function SourceReconciliationPanel({
+  reconciliation,
+}: {
+  reconciliation: Reconciliation;
+}) {
+  return (
+    <InsightPanel heading="SOURCE RECONCILIATION">
+      <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+        <div style={{ color: "var(--text-primary)", marginBottom: 4 }}>
+          {reconciliation.headline}
+        </div>
+        <div style={{ color: "var(--text-secondary)", marginBottom: 12 }}>
+          {reconciliation.decision}
+        </div>
+      </div>
+      {reconciliation.rows.length > 0 ? (
+        <DataTable
+          rows={reconciliation.rows as unknown as Record<string, unknown>[]}
+          columns={[
+            { key: "source_pair", label: "Source Pair" },
+            { key: "price_agreement", label: "Price" },
+            { key: "iv_agreement", label: "IV" },
+            { key: "decision", label: "Decision" },
+          ]}
+        />
+      ) : (
+        <InsightStatusBanner text="No source reconciliation data" severity="info" />
+      )}
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/TermMovePanel.tsx
+++ b/web/components/stock/panels/TermMovePanel.tsx
@@ -79,6 +79,15 @@ export function TermMovePanel({ rows }: { rows: Row[] }) {
         ? "Back elevated"
         : "Flat / unclear";
   const highlightedRows = byExpiry.slice(0, 6);
+  const frontMove = fmtPercent(front.implied_move_perc);
+  const frontDailyText = frontDaily == null ? "-" : fmtPercent(frontDaily);
+  const backDailyText = backDaily == null ? null : fmtPercent(backDaily);
+  const termRead =
+    curveRead === "Front elevated" && backDailyText
+      ? `Front expiry (${front.expiry}, ${front.dte ?? "?"} DTE) implies ${frontMove} total, or ${frontDailyText} per day, above the next expiry at ${backDailyText} per day.`
+      : curveRead === "Back elevated" && backDailyText
+        ? `Front expiry implies ${frontDailyText} per day, below the next expiry at ${backDailyText} per day, so term pressure is farther out.`
+        : `Front expiry implies ${frontMove} total, or ${frontDailyText} per day. The curve does not show a clear front/back edge.`;
 
   return (
     <InsightPanel
@@ -87,8 +96,17 @@ export function TermMovePanel({ rows }: { rows: Row[] }) {
     >
       <div
         style={{
+          color: "var(--text-primary)",
+          fontSize: 13,
+          lineHeight: 1.5,
+        }}
+      >
+        {termRead}
+      </div>
+      <div
+        style={{
           display: "grid",
-          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
           gap: 8,
         }}
       >
@@ -110,17 +128,24 @@ export function TermMovePanel({ rows }: { rows: Row[] }) {
           }
         />
       </div>
-      <DataTable
-        rows={highlightedRows as unknown as Record<string, unknown>[]}
-        columns={[
-          { key: "expiry", label: "Expiry" },
-          { key: "dte", label: "DTE" },
-          { key: "atm_straddle", label: "ATM Straddle", render: fmtMoney },
-          { key: "implied_move_perc", label: "Move", render: fmtPercent },
-          { key: "daily_implied_move_perc", label: "Daily", render: fmtPercent },
-          { key: "read", label: "Read" },
-        ]}
-      />
+      <details style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
+        <summary style={{ color: "var(--text-secondary)", cursor: "pointer" }}>
+          Show highlighted expiry rows
+        </summary>
+        <div style={{ marginTop: 8 }}>
+          <DataTable
+            rows={highlightedRows as unknown as Record<string, unknown>[]}
+            columns={[
+              { key: "expiry", label: "Expiry" },
+              { key: "dte", label: "DTE" },
+              { key: "atm_straddle", label: "ATM Straddle", render: fmtMoney },
+              { key: "implied_move_perc", label: "Move", render: fmtPercent },
+              { key: "daily_implied_move_perc", label: "Daily", render: fmtPercent },
+              { key: "read", label: "Read" },
+            ]}
+          />
+        </div>
+      </details>
     </InsightPanel>
   );
 }

--- a/web/components/stock/panels/TermMovePanel.tsx
+++ b/web/components/stock/panels/TermMovePanel.tsx
@@ -1,0 +1,35 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { DataTable } from "./DataTable";
+import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
+
+type Row = TradeInsightsResponse["term_structure_table"][number];
+
+const fmtMoney = (v: unknown) => (v == null ? "-" : `$${Number(v).toFixed(2)}`);
+const fmtPercent = (v: unknown) =>
+  v == null ? "-" : `${(Number(v) * 100).toFixed(2)}%`;
+
+export function TermMovePanel({ rows }: { rows: Row[] }) {
+  if (rows.length === 0) {
+    return (
+      <InsightPanel heading="TERM STRUCTURE / IMPLIED MOVE">
+        <InsightStatusBanner text="No iv_term_snapshots for this run" severity="info" />
+      </InsightPanel>
+    );
+  }
+
+  return (
+    <InsightPanel heading="TERM STRUCTURE / IMPLIED MOVE">
+      <DataTable
+        rows={rows as unknown as Record<string, unknown>[]}
+        columns={[
+          { key: "expiry", label: "Expiry" },
+          { key: "dte", label: "DTE" },
+          { key: "atm_straddle", label: "ATM Straddle", render: fmtMoney },
+          { key: "implied_move_perc", label: "Move", render: fmtPercent },
+          { key: "daily_implied_move_perc", label: "Daily", render: fmtPercent },
+          { key: "read", label: "Read" },
+        ]}
+      />
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/panels/TermMovePanel.tsx
+++ b/web/components/stock/panels/TermMovePanel.tsx
@@ -7,6 +7,49 @@ type Row = TradeInsightsResponse["term_structure_table"][number];
 const fmtMoney = (v: unknown) => (v == null ? "-" : `$${Number(v).toFixed(2)}`);
 const fmtPercent = (v: unknown) =>
   v == null ? "-" : `${(Number(v) * 100).toFixed(2)}%`;
+const n = (v: string | number | null | undefined) => (v == null ? null : Number(v));
+
+function Highlight({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: "neutral" | "warning" | "positive";
+}) {
+  const color =
+    tone === "warning"
+      ? "var(--warning)"
+      : tone === "positive"
+        ? "var(--positive)"
+        : "var(--text-primary)";
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: 10,
+        display: "grid",
+        gap: 4,
+      }}
+    >
+      <div
+        style={{
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ color, fontFamily: "var(--font-mono)", fontSize: 13 }}>
+        {value}
+      </div>
+    </div>
+  );
+}
 
 export function TermMovePanel({ rows }: { rows: Row[] }) {
   if (rows.length === 0) {
@@ -17,10 +60,58 @@ export function TermMovePanel({ rows }: { rows: Row[] }) {
     );
   }
 
+  const byExpiry = [...rows].sort((a, b) => {
+    const aDte = a.dte ?? 9999;
+    const bDte = b.dte ?? 9999;
+    return aDte - bDte;
+  });
+  const front = byExpiry[0];
+  const back = byExpiry.find((row) => row.expiry !== front.expiry) ?? null;
+  const highestDaily = [...rows].sort(
+    (a, b) => (n(b.daily_implied_move_perc) ?? -1) - (n(a.daily_implied_move_perc) ?? -1),
+  )[0];
+  const frontDaily = n(front.daily_implied_move_perc);
+  const backDaily = back ? n(back.daily_implied_move_perc) : null;
+  const curveRead =
+    frontDaily != null && backDaily != null && frontDaily > backDaily
+      ? "Front elevated"
+      : frontDaily != null && backDaily != null && frontDaily < backDaily
+        ? "Back elevated"
+        : "Flat / unclear";
+  const highlightedRows = byExpiry.slice(0, 6);
+
   return (
-    <InsightPanel heading="TERM STRUCTURE / IMPLIED MOVE">
+    <InsightPanel
+      heading="TERM / MOVE HIGHLIGHTS"
+      subheading={`Showing ${highlightedRows.length} expiries from ${rows.length} rows`}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          gap: 8,
+        }}
+      >
+        <Highlight
+          label="Curve read"
+          value={curveRead}
+          tone={curveRead === "Front elevated" ? "warning" : "neutral"}
+        />
+        <Highlight
+          label="Front daily move"
+          value={frontDaily == null ? "-" : fmtPercent(frontDaily)}
+        />
+        <Highlight
+          label="Highest daily"
+          value={
+            highestDaily
+              ? `${highestDaily.expiry} ${fmtPercent(highestDaily.daily_implied_move_perc)}`
+              : "-"
+          }
+        />
+      </div>
       <DataTable
-        rows={rows as unknown as Record<string, unknown>[]}
+        rows={highlightedRows as unknown as Record<string, unknown>[]}
         columns={[
           { key: "expiry", label: "Expiry" },
           { key: "dte", label: "DTE" },

--- a/web/components/stock/panels/TradeInsightsBiasBanner.tsx
+++ b/web/components/stock/panels/TradeInsightsBiasBanner.tsx
@@ -1,0 +1,55 @@
+import type { TradeInsightsResponse } from "@/lib/api";
+import { InsightPanel } from "./InsightPanel";
+
+type Header = TradeInsightsResponse["header"];
+
+const badgeColor = (severity: string | undefined) => {
+  if (severity === "warning") return "var(--warning)";
+  if (severity === "error") return "var(--negative)";
+  return "var(--accent-bg)";
+};
+
+export function TradeInsightsBiasBanner({ header }: { header: Header }) {
+  return (
+    <InsightPanel heading="BIAS / SETUP">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: 12,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        <div>
+          <div style={{ color: "var(--text-primary)", fontSize: 14 }}>
+            {header.primary_setup}
+          </div>
+          <div style={{ color: "var(--text-secondary)" }}>
+            {header.dominant_bias}
+          </div>
+        </div>
+        <div style={{ textAlign: "right", color: "var(--text-secondary)" }}>
+          <div>Confidence: {header.confidence_label}</div>
+          <div>Data quality: {header.data_quality_label}</div>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {header.badges.map((badge) => (
+          <span
+            key={badge.code}
+            style={{
+              border: "1px solid var(--border-dim)",
+              color: badgeColor(badge.severity),
+              padding: "4px 8px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+            }}
+          >
+            {badge.label}
+          </span>
+        ))}
+      </div>
+    </InsightPanel>
+  );
+}

--- a/web/components/stock/tabs/TradeInsightsTab.tsx
+++ b/web/components/stock/tabs/TradeInsightsTab.tsx
@@ -1,30 +1,16 @@
 import { api } from "@/lib/api";
+import { SignalStackPanel } from "../panels/SignalStackPanel";
+import { SourceReconciliationPanel } from "../panels/SourceReconciliationPanel";
+import { TradeInsightsBiasBanner } from "../panels/TradeInsightsBiasBanner";
 
 export async function TradeInsightsTab({ ticker }: { ticker: string }) {
   const insights = await api.tradeInsights(ticker);
   return (
-    <div style={{ display: "grid", gap: 16 }}>
-      <h3
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: 9,
-          color: "var(--text-muted)",
-          letterSpacing: 1,
-          textTransform: "uppercase",
-        }}
-      >
-        Trade Insights
-      </h3>
-      <div
-        style={{
-          border: "1px solid var(--border-dim)",
-          background: "var(--bg-panel)",
-          padding: 16,
-          fontFamily: "var(--font-mono)",
-          fontSize: 12,
-        }}
-      >
-        {insights.header.primary_setup}
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <TradeInsightsBiasBanner header={insights.header} />
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
+        <SignalStackPanel rows={insights.signal_stack} />
       </div>
     </div>
   );

--- a/web/components/stock/tabs/TradeInsightsTab.tsx
+++ b/web/components/stock/tabs/TradeInsightsTab.tsx
@@ -1,6 +1,10 @@
 import { api } from "@/lib/api";
+import { CandidateStructuresPanel } from "../panels/CandidateStructuresPanel";
+import { ChainFlowReadPanel } from "../panels/ChainFlowReadPanel";
+import { InsightsSynthesisPanel } from "../panels/InsightsSynthesisPanel";
 import { SignalStackPanel } from "../panels/SignalStackPanel";
 import { SourceReconciliationPanel } from "../panels/SourceReconciliationPanel";
+import { TermMovePanel } from "../panels/TermMovePanel";
 import { TradeInsightsBiasBanner } from "../panels/TradeInsightsBiasBanner";
 
 export async function TradeInsightsTab({ ticker }: { ticker: string }) {
@@ -12,6 +16,12 @@ export async function TradeInsightsTab({ ticker }: { ticker: string }) {
         <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
         <SignalStackPanel rows={insights.signal_stack} />
       </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <ChainFlowReadPanel rows={insights.flow_table} />
+        <TermMovePanel rows={insights.term_structure_table} />
+      </div>
+      <CandidateStructuresPanel candidates={insights.candidate_structures} />
+      <InsightsSynthesisPanel synthesis={insights.synthesis} />
     </div>
   );
 }

--- a/web/components/stock/tabs/TradeInsightsTab.tsx
+++ b/web/components/stock/tabs/TradeInsightsTab.tsx
@@ -16,12 +16,12 @@ export async function TradeInsightsTab({ ticker }: { ticker: string }) {
         <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
         <SignalStackPanel rows={insights.signal_stack} />
       </div>
+      <CandidateStructuresPanel candidates={insights.candidate_structures} />
+      <InsightsSynthesisPanel synthesis={insights.synthesis} />
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
         <ChainFlowReadPanel rows={insights.flow_table} />
         <TermMovePanel rows={insights.term_structure_table} />
       </div>
-      <CandidateStructuresPanel candidates={insights.candidate_structures} />
-      <InsightsSynthesisPanel synthesis={insights.synthesis} />
     </div>
   );
 }

--- a/web/components/stock/tabs/TradeInsightsTab.tsx
+++ b/web/components/stock/tabs/TradeInsightsTab.tsx
@@ -1,0 +1,31 @@
+import { api } from "@/lib/api";
+
+export async function TradeInsightsTab({ ticker }: { ticker: string }) {
+  const insights = await api.tradeInsights(ticker);
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <h3
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "var(--text-muted)",
+          letterSpacing: 1,
+          textTransform: "uppercase",
+        }}
+      >
+        Trade Insights
+      </h3>
+      <div
+        style={{
+          border: "1px solid var(--border-dim)",
+          background: "var(--bg-panel)",
+          padding: 16,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        {insights.header.primary_setup}
+      </div>
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -21,6 +21,7 @@ type VolatilitySeriesResponse = Json<
   "/api/stock/{ticker}/volatility/series",
   "get"
 >;
+type TradeInsightsResponse = Json<"/api/stock/{ticker}/trade-insights", "get">;
 
 async function _fetch<T>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(`${API}${path}`, {
@@ -52,6 +53,8 @@ export const api = {
     _fetch<StockHistoryResponse>(`/api/stock/${ticker}/history`),
   volatilitySeries: (ticker: string): Promise<VolatilitySeriesResponse> =>
     _fetch<VolatilitySeriesResponse>(`/api/stock/${ticker}/volatility/series`),
+  tradeInsights: (ticker: string): Promise<TradeInsightsResponse> =>
+    _fetch<TradeInsightsResponse>(`/api/stock/${ticker}/trade-insights`),
   ohlc: (ticker: string, days = 30): Promise<OhlcResponse> =>
     _fetch<OhlcResponse>(`/api/ohlc/${ticker}?days=${days}`),
   rescan: (ticker: string): Promise<JobStatus> =>
@@ -90,6 +93,7 @@ export type {
   JobStatus,
   OhlcResponse,
   SingleStockReport,
+  TradeInsightsResponse,
   VolatilitySeriesResponse,
   WatchlistResponse,
 };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -219,10 +219,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/stock/{ticker}/trade-insights": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Trade Insights */
+        get: operations["get_trade_insights_api_stock__ticker__trade_insights_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** CandidateStructure */
+        CandidateStructure: {
+            /** Idea Id */
+            idea_id: string;
+            /** Structure */
+            structure: string;
+            /** Thesis */
+            thesis: string;
+            /** Expression Type */
+            expression_type: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["InsightLeg"][];
+            /** Net Credit Debit */
+            net_credit_debit?: string | null;
+            /** Max Profit */
+            max_profit?: string | null;
+            /** Max Loss */
+            max_loss?: string | null;
+            /**
+             * Breakevens
+             * @default []
+             */
+            breakevens: string[];
+            /**
+             * Profit Zone
+             * @default
+             */
+            profit_zone: string;
+            /**
+             * Edge Source
+             * @default
+             */
+            edge_source: string;
+            /**
+             * Risk Flags
+             * @default []
+             */
+            risk_flags: string[];
+            /** Rank */
+            rank: number;
+            /**
+             * Status
+             * @default candidate
+             */
+            status: string;
+        };
+        /** ChainFlowReadRow */
+        ChainFlowReadRow: {
+            /** Strike */
+            strike: string;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Call Open Interest */
+            call_open_interest?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Call Put Volume Ratio */
+            call_put_volume_ratio?: string | null;
+            /**
+             * Volume Oi Note
+             * @default
+             */
+            volume_oi_note: string;
+            /**
+             * Read
+             * @default
+             */
+            read: string;
+            /**
+             * Requires T1 Oi Confirmation
+             * @default false
+             */
+            requires_t1_oi_confirmation: boolean;
+        };
         /** DivergencePoint */
         DivergencePoint: {
             /**
@@ -384,6 +480,75 @@ export interface components {
             uw_today?: number | null;
             /** Cache Hit Pct */
             cache_hit_pct?: number | null;
+        };
+        /** InsightBadge */
+        InsightBadge: {
+            /** Code */
+            code: string;
+            /** Label */
+            label: string;
+            /**
+             * Severity
+             * @default info
+             */
+            severity: string;
+        };
+        /** InsightLeg */
+        InsightLeg: {
+            /** Side */
+            side: string;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Option Right */
+            option_right: string;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /** Strike */
+            strike: string;
+            /** Mid */
+            mid?: string | null;
+        };
+        /** InsightSignalRow */
+        InsightSignalRow: {
+            /** Lens */
+            lens: string;
+            /** Read */
+            read: string;
+            /**
+             * Evidence
+             * @default []
+             */
+            evidence: string[];
+            /**
+             * Conflicts
+             * @default []
+             */
+            conflicts: string[];
+        };
+        /** InsightsSynthesis */
+        InsightsSynthesis: {
+            /**
+             * Dominant Story
+             * @default
+             */
+            dominant_story: string;
+            /** Preferred Idea Id */
+            preferred_idea_id?: string | null;
+            /** Best Risk Reward Idea Id */
+            best_risk_reward_idea_id?: string | null;
+            /**
+             * Avoid
+             * @default []
+             */
+            avoid: string[];
+            /**
+             * Required Before Sizing
+             * @default []
+             */
+            required_before_sizing: string[];
         };
         /** IvHistogramBin */
         IvHistogramBin: {
@@ -920,6 +1085,61 @@ export interface components {
             /** Iv */
             iv?: string | null;
         };
+        /** SourceReconciliation */
+        SourceReconciliation: {
+            /**
+             * Status
+             * @default UNKNOWN
+             */
+            status: string;
+            /**
+             * Headline
+             * @default Source reconciliation unavailable
+             */
+            headline: string;
+            /** Primary Iv Source */
+            primary_iv_source?: string | null;
+            /** Relative Shape Source */
+            relative_shape_source?: string | null;
+            /**
+             * Rows
+             * @default []
+             */
+            rows: components["schemas"]["SourceReconciliationRow"][];
+            /**
+             * Decision
+             * @default Use deterministic data only where source agreement is understood.
+             */
+            decision: string;
+        };
+        /** SourceReconciliationRow */
+        SourceReconciliationRow: {
+            /** Source Pair */
+            source_pair: string;
+            /**
+             * Price Agreement
+             * @default
+             */
+            price_agreement: string;
+            /**
+             * Iv Agreement
+             * @default
+             */
+            iv_agreement: string;
+            /**
+             * Decision
+             * @default
+             */
+            decision: string;
+            /** Strike */
+            strike?: string | null;
+            /** Source A Call Iv */
+            source_a_call_iv?: string | null;
+            /** Source B Call Iv */
+            source_b_call_iv?: string | null;
+            /** Iv Diff */
+            iv_diff?: string | null;
+        };
         /** StockHistoryResponse */
         StockHistoryResponse: {
             /** Ticker */
@@ -981,6 +1201,27 @@ export interface components {
             /** Put Gex */
             put_gex?: string | null;
         };
+        /** TermMoveRow */
+        TermMoveRow: {
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /** Dte */
+            dte?: number | null;
+            /** Atm Straddle */
+            atm_straddle?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
+            /** Daily Implied Move Perc */
+            daily_implied_move_perc?: string | null;
+            /**
+             * Read
+             * @default
+             */
+            read: string;
+        };
         /** TermStructureExpiryRow */
         TermStructureExpiryRow: {
             /**
@@ -1004,6 +1245,91 @@ export interface components {
             strikes: {
                 [key: string]: string;
             };
+        };
+        /** TradeInsightsHeader */
+        TradeInsightsHeader: {
+            /**
+             * Dominant Bias
+             * @default NEUTRAL
+             */
+            dominant_bias: string;
+            /**
+             * Primary Setup
+             * @default NO_CLEAR_SETUP
+             */
+            primary_setup: string;
+            /**
+             * Confidence Label
+             * @default LOW
+             */
+            confidence_label: string;
+            /**
+             * Data Quality Label
+             * @default INSUFFICIENT
+             */
+            data_quality_label: string;
+            /**
+             * Idea Count
+             * @default 0
+             */
+            idea_count: number;
+            /** Preferred Idea Id */
+            preferred_idea_id?: string | null;
+            /**
+             * Badges
+             * @default []
+             */
+            badges: components["schemas"]["InsightBadge"][];
+        };
+        /** TradeInsightsResponse */
+        TradeInsightsResponse: {
+            /** Ticker */
+            ticker: string;
+            /** As Of */
+            as_of?: string | null;
+            /**
+             * Mode
+             * @default research
+             */
+            mode: string;
+            header: components["schemas"]["TradeInsightsHeader"];
+            /**
+             * @default {
+             *       "status": "UNKNOWN",
+             *       "headline": "Source reconciliation unavailable",
+             *       "rows": [],
+             *       "decision": "Use deterministic data only where source agreement is understood."
+             *     }
+             */
+            source_reconciliation: components["schemas"]["SourceReconciliation"];
+            /**
+             * Signal Stack
+             * @default []
+             */
+            signal_stack: components["schemas"]["InsightSignalRow"][];
+            /**
+             * Flow Table
+             * @default []
+             */
+            flow_table: components["schemas"]["ChainFlowReadRow"][];
+            /**
+             * Term Structure Table
+             * @default []
+             */
+            term_structure_table: components["schemas"]["TermMoveRow"][];
+            /**
+             * Candidate Structures
+             * @default []
+             */
+            candidate_structures: components["schemas"]["CandidateStructure"][];
+            /**
+             * @default {
+             *       "dominant_story": "",
+             *       "avoid": [],
+             *       "required_before_sizing": []
+             *     }
+             */
+            synthesis: components["schemas"]["InsightsSynthesis"];
         };
         /** TradePlan */
         TradePlan: {
@@ -1710,6 +2036,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VolatilitySeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_trade_insights_api_stock__ticker__trade_insights_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TradeInsightsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/unit/tradeInsightsPanels.test.tsx
+++ b/web/tests/unit/tradeInsightsPanels.test.tsx
@@ -89,6 +89,8 @@ describe("Trade Insights detail panels", () => {
         ]}
       />,
     );
+    expect(screen.getByText("CHAIN / FLOW HIGHLIGHTS")).toBeDefined();
+    expect(screen.getByText("Call / Put volume")).toBeDefined();
     expect(screen.getByText(/next-day OI/i)).toBeDefined();
   });
 
@@ -107,6 +109,8 @@ describe("Trade Insights detail panels", () => {
         ]}
       />,
     );
+    expect(screen.getByText("TERM / MOVE HIGHLIGHTS")).toBeDefined();
+    expect(screen.getByText("Curve read")).toBeDefined();
     expect(screen.getByText("2026-05-15")).toBeDefined();
     expect(screen.getByText("Front elevated")).toBeDefined();
   });

--- a/web/tests/unit/tradeInsightsPanels.test.tsx
+++ b/web/tests/unit/tradeInsightsPanels.test.tsx
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SignalStackPanel } from "@/components/stock/panels/SignalStackPanel";
+import { SourceReconciliationPanel } from "@/components/stock/panels/SourceReconciliationPanel";
+import { TradeInsightsBiasBanner } from "@/components/stock/panels/TradeInsightsBiasBanner";
+
+describe("TradeInsightsBiasBanner", () => {
+  it("renders setup and badges without the ticker", () => {
+    render(
+      <TradeInsightsBiasBanner
+        header={{
+          dominant_bias: "NEUTRAL_SHORT_VOL",
+          primary_setup: "TRADE_INSIGHTS_RESEARCH",
+          confidence_label: "MEDIUM",
+          data_quality_label: "MIXED",
+          idea_count: 1,
+          preferred_idea_id: null,
+          badges: [{ code: "DEFINED_RISK_ONLY", label: "Defined-risk only", severity: "info" }],
+        }}
+      />,
+    );
+    // The parent layout's <DetailHeader> already renders the ticker, so the
+    // banner intentionally does NOT — assert absence to lock that contract in.
+    expect(screen.queryByText("TSLA")).toBeNull();
+    expect(screen.getByText("TRADE_INSIGHTS_RESEARCH")).toBeDefined();
+    expect(screen.getByText("Defined-risk only")).toBeDefined();
+  });
+});
+
+describe("SourceReconciliationPanel", () => {
+  it("renders source decision", () => {
+    render(
+      <SourceReconciliationPanel
+        reconciliation={{
+          status: "UNKNOWN",
+          headline: "No external IV source reconciliation stored for this run",
+          primary_iv_source: null,
+          relative_shape_source: null,
+          rows: [],
+          decision: "Use chain-derived values for contract math.",
+        }}
+      />,
+    );
+    expect(screen.getByText(/chain-derived values/i)).toBeDefined();
+  });
+});
+
+describe("SignalStackPanel", () => {
+  it("renders lens rows", () => {
+    render(
+      <SignalStackPanel
+        rows={[
+          {
+            lens: "VOL_LEVEL",
+            read: "IV_RV_PROXY_AVAILABLE",
+            evidence: ["proxy available"],
+            conflicts: [],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("VOL_LEVEL")).toBeDefined();
+    expect(screen.getByText("proxy available")).toBeDefined();
+  });
+});

--- a/web/tests/unit/tradeInsightsPanels.test.tsx
+++ b/web/tests/unit/tradeInsightsPanels.test.tsx
@@ -91,7 +91,9 @@ describe("Trade Insights detail panels", () => {
     );
     expect(screen.getByText("CHAIN / FLOW HIGHLIGHTS")).toBeDefined();
     expect(screen.getByText("Call / Put volume")).toBeDefined();
-    expect(screen.getByText(/next-day OI/i)).toBeDefined();
+    expect(screen.getByText(/flow leans call-heavy/i)).toBeDefined();
+    expect(screen.getByText("Show highlighted strike rows")).toBeDefined();
+    expect(screen.getAllByText(/next-day OI/i).length).toBeGreaterThan(0);
   });
 
   it("renders term move rows", () => {
@@ -111,6 +113,8 @@ describe("Trade Insights detail panels", () => {
     );
     expect(screen.getByText("TERM / MOVE HIGHLIGHTS")).toBeDefined();
     expect(screen.getByText("Curve read")).toBeDefined();
+    expect(screen.getByText(/front expiry/i)).toBeDefined();
+    expect(screen.getByText("Show highlighted expiry rows")).toBeDefined();
     expect(screen.getByText("2026-05-15")).toBeDefined();
     expect(screen.getByText("Front elevated")).toBeDefined();
   });

--- a/web/tests/unit/tradeInsightsPanels.test.tsx
+++ b/web/tests/unit/tradeInsightsPanels.test.tsx
@@ -2,8 +2,12 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { CandidateStructuresPanel } from "@/components/stock/panels/CandidateStructuresPanel";
+import { ChainFlowReadPanel } from "@/components/stock/panels/ChainFlowReadPanel";
+import { InsightsSynthesisPanel } from "@/components/stock/panels/InsightsSynthesisPanel";
 import { SignalStackPanel } from "@/components/stock/panels/SignalStackPanel";
 import { SourceReconciliationPanel } from "@/components/stock/panels/SourceReconciliationPanel";
+import { TermMovePanel } from "@/components/stock/panels/TermMovePanel";
 import { TradeInsightsBiasBanner } from "@/components/stock/panels/TradeInsightsBiasBanner";
 
 describe("TradeInsightsBiasBanner", () => {
@@ -63,5 +67,89 @@ describe("SignalStackPanel", () => {
     );
     expect(screen.getByText("VOL_LEVEL")).toBeDefined();
     expect(screen.getByText("proxy available")).toBeDefined();
+  });
+});
+
+describe("Trade Insights detail panels", () => {
+  it("renders flow table T+1 caveat", () => {
+    render(
+      <ChainFlowReadPanel
+        rows={[
+          {
+            strike: "430",
+            call_volume: 1500,
+            call_open_interest: 1000,
+            put_volume: 600,
+            put_open_interest: 700,
+            call_put_volume_ratio: "2.5",
+            volume_oi_note: "Volume > OI; confirm with next-day OI",
+            read: "Call demand concentrated",
+            requires_t1_oi_confirmation: true,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/next-day OI/i)).toBeDefined();
+  });
+
+  it("renders term move rows", () => {
+    render(
+      <TermMovePanel
+        rows={[
+          {
+            expiry: "2026-05-15",
+            dte: 4,
+            atm_straddle: null,
+            implied_move_perc: "0.048",
+            daily_implied_move_perc: "0.012",
+            read: "Front elevated",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("2026-05-15")).toBeDefined();
+    expect(screen.getByText("Front elevated")).toBeDefined();
+  });
+
+  it("renders candidate max loss", () => {
+    render(
+      <CandidateStructuresPanel
+        candidates={[
+          {
+            idea_id: "A",
+            structure: "call_credit_spread",
+            thesis: "Defined-risk short-call premium candidate.",
+            expression_type: "SHORT_VOL",
+            legs: [],
+            net_credit_debit: "1.25",
+            max_profit: "1.25",
+            max_loss: "3.75",
+            breakevens: [],
+            profit_zone: "Underlying below 430",
+            edge_source: "IV-RV spread / theta",
+            risk_flags: ["bullish_flow_can_break_call_side"],
+            rank: 1,
+            status: "candidate",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Max loss/i)).toBeDefined();
+    expect(screen.getByText("$3.75")).toBeDefined();
+  });
+
+  it("renders synthesis required checks", () => {
+    render(
+      <InsightsSynthesisPanel
+        synthesis={{
+          dominant_story: "Research-grade ideas built from current chain.",
+          preferred_idea_id: "A",
+          best_risk_reward_idea_id: "A",
+          avoid: ["Naked short options"],
+          required_before_sizing: ["Confirm event calendar"],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Confirm event calendar/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic Trade Insights response models, assembler, persistence tables, scan-completion persistence, and API endpoint
- add frontend Trade Insights route, loading/error boundaries, API client types, and seven native stock-detail panels
- add V1.5 Codex-analysis follow-up plan while keeping AI analysis out of the V1 runtime path

## Verification
- UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/test_trade_insights.py tests/integration/api/test_trade_insights_endpoint.py tests/integration/storage/test_repository_trade_insights.py tests/integration/api/test_openapi_snapshot.py -q
- cd web && npm run test -- tradeInsightsPanels.test.tsx && npm run typecheck
- git diff --check HEAD
- bash scripts/migrate.sh
- curl -sS -i http://127.0.0.1:8400/api/stock/TSLA/trade-insights
- Playwright smoke: http://127.0.0.1:3001/stock/TSLA/trade-insights rendered all seven panels with no console/page errors

## Notes
- V1 keeps event_data_known hardcoded false; all candidates remain needs_check and preferred_idea_id stays null.
- Left unrelated local files unstaged: CLAUDE.md, endpoint research draft, and UW sample docs.