### PR TITLE
Fix dashboard runtime errors and quote refresh behavior

### DIFF
--- a/src/uw_scan/api/routers/stock.py
+++ b/src/uw_scan/api/routers/stock.py
@@ -46,7 +46,7 @@ def get_stock(ticker: str, repo: Repository = Depends(get_repo)) -> SingleStockR
     run_id = repo.latest_run_id(t)
     if run_id == 0:
         raise HTTPException(status_code=404, detail=f"no runs for {t}")
-    return assemble_single_stock_report(t, run_id, repo)
+    return _with_latest_spot(assemble_single_stock_report(t, run_id, repo), repo)
 
 
 @router.get("/stock/{ticker}/history", response_model=StockHistoryResponse)
@@ -90,4 +90,30 @@ def list_runs(ticker: str, repo: Repository = Depends(get_repo)) -> list[dict]:
 def get_specific_run(
     ticker: str, run_id: int, repo: Repository = Depends(get_repo)
 ) -> SingleStockReport:
-    return assemble_single_stock_report(ticker.upper(), run_id, repo)
+    report = assemble_single_stock_report(ticker.upper(), run_id, repo)
+    return _with_latest_spot(report, repo)
+
+
+def _with_latest_spot(report: SingleStockReport, repo: Repository) -> SingleStockReport:
+    """Keep the detail header aligned with the dashboard card's delayed quote."""
+    card = repo.get_watchlist_card(report.ticker)
+    quote = repo.get_intraday_quote(report.ticker)
+
+    best_spot = report.market_structure.spot
+    best_at = report.spot_quoted_at or report.generated_at
+    best_source = report.spot_source or "uw_scan"
+
+    if card is not None and card.spot is not None:
+        best_spot = card.spot
+        best_at = card.spot_quoted_at or best_at
+        best_source = card.spot_source or best_source
+
+    if quote is not None and (best_at is None or quote.quoted_at >= best_at):
+        best_spot = quote.price
+        best_at = quote.quoted_at
+        best_source = "massive.com_intraday"
+
+    report.market_structure.spot = best_spot
+    report.spot_quoted_at = best_at
+    report.spot_source = best_source
+    return report

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -602,6 +602,8 @@ class SingleStockReport(_UwBase):
     run_id: int
     ticker: str
     generated_at: datetime
+    spot_quoted_at: datetime | None = None
+    spot_source: str | None = None
     short_int_note: str = "n/a (UW endpoint does not expose %)"
     market_structure: MarketStructure
     volatility: VolatilityProfile

--- a/src/uw_scan/sources/ohlc.py
+++ b/src/uw_scan/sources/ohlc.py
@@ -37,7 +37,9 @@ class IntradayQuote:
 
 class OhlcProvider(Protocol):
     def fetch_daily(self, ticker: str, start: date, end: date) -> list[OhlcBar]: ...
-    def fetch_intraday_quote(self, ticker: str) -> IntradayQuote | None: ...
+    def fetch_intraday_quote(
+        self, ticker: str, *, market_date: date | None = None
+    ) -> IntradayQuote | None: ...
 
 
 class MassiveOhlcProvider:
@@ -99,7 +101,9 @@ class MassiveOhlcProvider:
             )
         return bars
 
-    def fetch_intraday_quote(self, ticker: str) -> IntradayQuote | None:
+    def fetch_intraday_quote(
+        self, ticker: str, *, market_date: date | None = None
+    ) -> IntradayQuote | None:
         """Latest 15-min-delayed intraday price.
 
         massive.com's /v3/quotes endpoint requires a paid plan; on our tier it
@@ -107,7 +111,7 @@ class MassiveOhlcProvider:
         and returns the same data shape with status="DELAYED". Spike on
         2026-05-12 verified the substitution.
         """
-        today = date.today()
+        today = market_date or datetime.now(timezone.utc).date()
         tomorrow = today + timedelta(days=1)
         path = (
             f"/v2/aggs/ticker/{ticker}/range/1/minute/"

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1940,9 +1940,24 @@ class Repository:
                 SELECT
                   w.ticker, w.sector, w.pinned, w.sort_rank,
                   c.run_id, c.scanned_at,
-                  COALESCE(c.spot, q.price)                                AS spot,
-                  COALESCE(c.spot_quoted_at, q.quoted_at)                  AS spot_quoted_at,
-                  COALESCE(c.spot_source, CASE WHEN q.price IS NOT NULL THEN 'massive.com_intraday' END) AS spot_source,
+                  CASE
+                    WHEN q.price IS NOT NULL
+                      AND (c.spot_quoted_at IS NULL OR q.quoted_at >= c.spot_quoted_at)
+                      THEN q.price
+                    ELSE c.spot
+                  END                                                       AS spot,
+                  CASE
+                    WHEN q.price IS NOT NULL
+                      AND (c.spot_quoted_at IS NULL OR q.quoted_at >= c.spot_quoted_at)
+                      THEN q.quoted_at
+                    ELSE c.spot_quoted_at
+                  END                                                       AS spot_quoted_at,
+                  CASE
+                    WHEN q.price IS NOT NULL
+                      AND (c.spot_quoted_at IS NULL OR q.quoted_at >= c.spot_quoted_at)
+                      THEN 'massive.com_intraday'
+                    ELSE c.spot_source
+                  END                                                       AS spot_source,
                   c.iv_atm, c.iv_rank,
                   c.setup_type, c.setup_direction, c.setup_score,
                   c.aggression_pct,

--- a/src/uw_scan/worker/jobs/spot_refresh.py
+++ b/src/uw_scan/worker/jobs/spot_refresh.py
@@ -10,6 +10,7 @@ the card row. The next full scan resets them — acceptable per spec.
 from __future__ import annotations
 
 import logging
+from datetime import date
 
 from uw_scan.cards.returns import compute_returns
 from uw_scan.sources.ohlc import OhlcProvider
@@ -17,12 +18,17 @@ from uw_scan.sources.ohlc import OhlcProvider
 logger = logging.getLogger(__name__)
 
 
-def spot_refresh_once(repo, provider: OhlcProvider) -> int:
+def spot_refresh_once(
+    repo,
+    provider: OhlcProvider,
+    *,
+    market_date: date | None = None,
+) -> int:
     """One pass over the active watchlist. Returns the number of cards updated."""
     updated = 0
     for w in repo.list_active_watchlist():
         try:
-            quote = provider.fetch_intraday_quote(w.ticker)
+            quote = provider.fetch_intraday_quote(w.ticker, market_date=market_date)
             if quote is None:
                 continue
             repo.upsert_intraday_quote(w.ticker, quote.price, quote.quoted_at)

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -11,6 +11,7 @@ from datetime import date, datetime, time
 from zoneinfo import ZoneInfo
 
 import psycopg
+from apscheduler.schedulers import SchedulerNotRunningError
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
@@ -221,9 +222,18 @@ def main() -> int:
             misfire_grace_time=max(30, settings.trade_insights_ai_poll_seconds * 5),
         )
 
+    stopping = False
+
     def _stop(_sig, _frame):
+        nonlocal stopping
+        if stopping:
+            sys.exit(0)
+        stopping = True
         logger.info("received signal, shutting down scheduler")
-        sched.shutdown(wait=False)
+        try:
+            sched.shutdown(wait=False)
+        except SchedulerNotRunningError:
+            pass
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, _stop)

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -232,8 +232,8 @@ def main() -> int:
         logger.info("received signal, shutting down scheduler")
         try:
             sched.shutdown(wait=False)
-        except SchedulerNotRunningError:
-            pass
+        except SchedulerNotRunningError as exc:
+            logger.debug("scheduler already stopped during shutdown: %s", repr(exc))
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, _stop)

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -7,6 +7,8 @@ import signal
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo
 
 import psycopg
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -33,6 +35,17 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger("uw_scan.worker")
+
+
+def _spot_refresh_market_date(now: datetime) -> date | None:
+    """Return the ET market date when delayed minute bars are worth polling."""
+    local = now if now.tzinfo is not None else now.replace(tzinfo=ZoneInfo("UTC"))
+    if local.weekday() >= 5:
+        return None
+    current = local.time()
+    if time(9, 30) <= current <= time(16, 15):
+        return local.date()
+    return None
 
 
 @contextmanager
@@ -86,12 +99,17 @@ def main() -> int:
     sched = BlockingScheduler(timezone=settings.rth_tz)
 
     def _spot_refresh() -> None:
+        now = datetime.now(ZoneInfo(settings.rth_tz))
+        market_date = _spot_refresh_market_date(now)
+        if market_date is None:
+            logger.debug("spot_refresh skipped outside market hours")
+            return
         provider = _ohlc_provider(settings)
         if provider is None:
             return
         try:
             with _repo(settings) as repo:
-                n = spot_refresh_once(repo, provider)
+                n = spot_refresh_once(repo, provider, market_date=market_date)
                 logger.info("spot_refresh updated %d cards", n)
         finally:
             provider.close()

--- a/tests/integration/storage/test_repository_watchlist.py
+++ b/tests/integration/storage/test_repository_watchlist.py
@@ -91,6 +91,29 @@ def test_upsert_watchlist_card_idempotent(repo):
     assert card.spot == Decimal("101.0000")
 
 
+def test_list_watchlist_cards_prefers_newer_intraday_quote(repo):
+    repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
+    run_id = repo.insert_scan_run("ZZTEST", notes="t")
+    repo.upsert_watchlist_card(
+        ticker="ZZTEST",
+        run_id=run_id,
+        scanned_at=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot=Decimal("100.00"),
+        spot_quoted_at=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        spot_source="uw_scan",
+    )
+    repo.upsert_intraday_quote(
+        "ZZTEST",
+        Decimal("101.25"),
+        datetime(2026, 5, 13, 20, 15, tzinfo=timezone.utc),
+    )
+
+    cards = {card.ticker: card for card in repo.list_watchlist_cards()}
+
+    assert cards["ZZTEST"].spot == Decimal("101.2500")
+    assert cards["ZZTEST"].spot_source == "massive.com_intraday"
+
+
 def test_upsert_daily_ohlc_dedupe_by_date(repo):
     repo.upsert_daily_ohlc(
         ticker="ZZTEST",

--- a/tests/integration/worker/test_worker_jobs.py
+++ b/tests/integration/worker/test_worker_jobs.py
@@ -43,7 +43,7 @@ def test_spot_refresh_updates_quote_and_card(seeded_db_with_cards):
     from uw_scan.worker.jobs.spot_refresh import spot_refresh_once
 
     fake = MagicMock()
-    fake.fetch_intraday_quote.side_effect = lambda t: IntradayQuote(
+    fake.fetch_intraday_quote.side_effect = lambda t, **_kw: IntradayQuote(
         ticker=t,
         price=Decimal("999.99"),
         quoted_at=datetime(2026, 5, 8, 13, 0, tzinfo=timezone.utc),
@@ -63,6 +63,20 @@ def test_spot_refresh_skips_when_no_quote(seeded_db_with_cards):
     fake = MagicMock()
     fake.fetch_intraday_quote.return_value = None
     assert spot_refresh_once(seeded_db_with_cards, fake) == 0
+
+
+def test_spot_refresh_passes_market_date_to_provider(seeded_db_with_cards):
+    from uw_scan.worker.jobs.spot_refresh import spot_refresh_once
+
+    fake = MagicMock()
+    fake.fetch_intraday_quote.return_value = None
+    spot_refresh_once(
+        seeded_db_with_cards,
+        fake,
+        market_date=date(2026, 5, 13),
+    )
+
+    fake.fetch_intraday_quote.assert_any_call("TSLA", market_date=date(2026, 5, 13))
 
 
 # ---- full_scan -----------------------------------------------------------

--- a/tests/unit/api/test_stock_router.py
+++ b/tests/unit/api/test_stock_router.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+from uw_scan.api.routers.stock import _with_latest_spot
+from uw_scan.models import (
+    FlowSnapshot,
+    MarketStructure,
+    SingleStockReport,
+    VolatilityProfile,
+    VRPAssessment,
+)
+from uw_scan.storage.repository import IntradayQuoteRow
+
+
+def _report() -> SingleStockReport:
+    return SingleStockReport(
+        run_id=1,
+        ticker="TSLA",
+        generated_at=datetime(2026, 5, 13, 20, 0, tzinfo=timezone.utc),
+        market_structure=MarketStructure(spot=Decimal("100")),
+        volatility=VolatilityProfile(),
+        flow=FlowSnapshot(
+            ticker="TSLA",
+            flow_count=0,
+            net_premium=Decimal("0"),
+            bull_premium=Decimal("0"),
+            bear_premium=Decimal("0"),
+            ask_side_premium=Decimal("0"),
+            bid_side_premium=Decimal("0"),
+        ),
+        vrp=VRPAssessment(vrp=None, signal="neutral", note=""),
+    )
+
+
+def test_with_latest_spot_prefers_newer_intraday_quote() -> None:
+    repo = SimpleNamespace(
+        get_watchlist_card=lambda _ticker: SimpleNamespace(
+            spot=Decimal("101"),
+            spot_quoted_at=datetime(2026, 5, 13, 20, 5, tzinfo=timezone.utc),
+            spot_source="massive.com_intraday",
+        ),
+        get_intraday_quote=lambda _ticker: IntradayQuoteRow(
+            ticker="TSLA",
+            price=Decimal("102"),
+            quoted_at=datetime(2026, 5, 13, 20, 10, tzinfo=timezone.utc),
+            fetched_at=datetime(2026, 5, 13, 20, 11, tzinfo=timezone.utc),
+        ),
+    )
+
+    report = _with_latest_spot(_report(), repo)
+
+    assert report.market_structure.spot == Decimal("102")
+    assert report.spot_quoted_at == datetime(2026, 5, 13, 20, 10, tzinfo=timezone.utc)
+    assert report.spot_source == "massive.com_intraday"

--- a/tests/unit/sources/test_ohlc_provider.py
+++ b/tests/unit/sources/test_ohlc_provider.py
@@ -96,6 +96,15 @@ def test_fetch_intraday_quote_uses_latest_minute_bar():
     assert q.quoted_at.tzinfo is timezone.utc
 
 
+def test_fetch_intraday_quote_uses_supplied_market_date():
+    def handler(req):
+        assert req.url.path == "/v2/aggs/ticker/TSLA/range/1/minute/2026-05-13/2026-05-14"
+        return httpx.Response(200, json={"results": []})
+
+    p = _provider_with(handler)
+    assert p.fetch_intraday_quote("TSLA", market_date=date(2026, 5, 13)) is None
+
+
 def test_fetch_intraday_quote_empty_results():
     p = _provider_with(lambda req: httpx.Response(200, json={"results": []}))
     assert p.fetch_intraday_quote("ZZZZ") is None

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from uw_scan.worker.scheduler import _spot_refresh_market_date
+
+
+def test_spot_refresh_market_date_skips_after_hours() -> None:
+    now = datetime(2026, 5, 13, 20, 54, tzinfo=ZoneInfo("America/New_York"))
+
+    assert _spot_refresh_market_date(now) is None
+
+
+def test_spot_refresh_market_date_uses_rth_date() -> None:
+    now = datetime(2026, 5, 13, 10, 0, tzinfo=ZoneInfo("America/New_York"))
+
+    assert _spot_refresh_market_date(now).isoformat() == "2026-05-13"

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -152,6 +152,10 @@
   border-radius: 0;
 }
 
+dialog::backdrop {
+  background: rgba(10, 15, 20, 0.72);
+}
+
 html,
 body,
 #__next {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,8 +1,8 @@
-import { api } from "@/lib/api";
 import { CardGrid } from "@/components/watchlist/CardGrid";
 import { FilterBar } from "@/components/watchlist/FilterBar";
 import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
 import { ScanAllButton } from "@/components/shared/ScanAllButton";
+import { loadDashboardData } from "@/lib/dashboardData";
 
 // Skip the Router Cache so sector/setup chip clicks refetch with new
 // searchParams instead of reusing the unfiltered RSC payload.
@@ -18,21 +18,7 @@ export default async function DashboardPage({
   if (sp.sector) qs.set("sector", sp.sector);
   if (sp.setup) qs.set("setup", sp.setup);
   if (sp.fresh) qs.set("fresh_within_minutes", sp.fresh);
-  const data = await api.watchlist(qs);
-
-  const sparklineEntries = await Promise.all(
-    data.tickers.map(async (t) => {
-      try {
-        const bars = await api.ohlc(t.ticker, 30);
-        const closes = bars.map((b) => Number(b.close)).reverse();
-        return [t.ticker, closes] as const;
-      } catch {
-        return [t.ticker, [] as number[]] as const;
-      }
-    }),
-  );
-  const sparklines: Record<string, number[]> =
-    Object.fromEntries(sparklineEntries);
+  const { data, sparklines, apiUnavailable } = await loadDashboardData(qs);
 
   return (
     <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
@@ -58,6 +44,21 @@ export default async function DashboardPage({
           <AddTickerDialog />
         </div>
       </header>
+      {apiUnavailable && (
+        <div
+          style={{
+            marginBottom: 12,
+            padding: "10px 12px",
+            border: "1px solid var(--border-dim)",
+            background: "var(--bg-panel)",
+            color: "var(--warning)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+          }}
+        >
+          API unavailable. Start-up is still warming; refresh when the API is ready.
+        </div>
+      )}
       <FilterBar current={sp} />
       <CardGrid data={data} sparklines={sparklines} />
     </div>

--- a/web/app/stock/[ticker]/layout.tsx
+++ b/web/app/stock/[ticker]/layout.tsx
@@ -19,7 +19,7 @@ export default async function StockLayout({
         ticker={report.ticker}
         spot={toNum(report.market_structure.spot)}
         iv_atm={toNum(report.volatility.iv)}
-        spotQuotedAt={null}
+        spotQuotedAt={report.spot_quoted_at ?? null}
         scannedAt={report.generated_at}
         setupType={report.setup?.setup_type ?? null}
         setupDirection={report.setup?.direction ?? null}

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -20,6 +20,7 @@ const rowStyle: React.CSSProperties = {
 };
 const valStyle: React.CSSProperties = {
   color: "var(--text-secondary)",
+  whiteSpace: "nowrap",
 };
 
 function dash(v: number | string | null | undefined, suffix = ""): string {

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { fmtDateTimeWithZone } from "@/lib/formatters";
 import type { components } from "@/lib/types";
 
 type Health = components["schemas"]["HealthResponse"];
@@ -24,11 +25,6 @@ const valStyle: React.CSSProperties = {
 function dash(v: number | string | null | undefined, suffix = ""): string {
   if (v == null || v === "") return "—";
   return `${v}${suffix}`;
-}
-
-function timeOnly(iso: string | null | undefined): string {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleTimeString(undefined, { hour12: false });
 }
 
 export function HealthPanel() {
@@ -86,7 +82,7 @@ export function HealthPanel() {
       </div>
       <div style={rowStyle}>
         <span>Last Scan</span>
-        <span style={valStyle}>{timeOnly(h?.last_full_scan_at)}</span>
+        <span style={valStyle}>{fmtDateTimeWithZone(h?.last_full_scan_at)}</span>
       </div>
       <div style={rowStyle}>
         <span>Source</span>

--- a/web/components/stock/DetailHeader.tsx
+++ b/web/components/stock/DetailHeader.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { SetupBadge } from "@/components/watchlist/SetupBadge";
-import { fmtDecimal, fmtSigned } from "@/lib/formatters";
+import {
+  fmtDateTimeWithZone,
+  fmtDecimal,
+  fmtSigned,
+} from "@/lib/formatters";
 
 type Props = {
   ticker: string;
@@ -27,7 +31,7 @@ export function DetailHeader(p: Props) {
     >
       <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
         <Link
-          href="/watchlist"
+          href="/"
           style={{ color: "var(--text-muted)", fontSize: 12 }}
         >
           ← back
@@ -60,12 +64,10 @@ export function DetailHeader(p: Props) {
         }}
       >
         <div>
-          spot:{" "}
-          {p.spotQuotedAt ? new Date(p.spotQuotedAt).toLocaleTimeString() : "—"}
+          spot: {fmtDateTimeWithZone(p.spotQuotedAt)}
         </div>
         <div>
-          analytics:{" "}
-          {p.scannedAt ? new Date(p.scannedAt).toLocaleTimeString() : "—"}
+          analytics: {fmtDateTimeWithZone(p.scannedAt)}
         </div>
       </div>
     </header>

--- a/web/components/watchlist/AddTickerDialog.tsx
+++ b/web/components/watchlist/AddTickerDialog.tsx
@@ -31,6 +31,8 @@ export function AddTickerDialog() {
     router.refresh();
   };
 
+  const close = () => ref.current?.close();
+
   return (
     <>
       <button
@@ -50,30 +52,67 @@ export function AddTickerDialog() {
       </button>
       <dialog
         ref={ref}
+        aria-label="Add ticker"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) close();
+        }}
         style={{
-          padding: 16,
+          padding: 0,
           background: "var(--bg-panel)",
           color: "var(--text-primary)",
           border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          boxShadow: "0 24px 64px rgba(0, 0, 0, 0.36)",
         }}
       >
         <form
           onSubmit={submit}
+          onClick={(e) => e.stopPropagation()}
           style={{
             display: "flex",
             flexDirection: "column",
-            gap: 8,
-            minWidth: 280,
+            gap: 12,
+            minWidth: 320,
+            padding: 16,
           }}
         >
+          <div
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: 1,
+              textTransform: "uppercase",
+            }}
+          >
+            Add Ticker
+          </div>
           <input
             required
             placeholder="TICKER"
             value={ticker}
             onChange={(e) => setTicker(e.target.value)}
-            style={{ fontFamily: "var(--font-mono)", padding: 4 }}
+            style={{
+              fontFamily: "var(--font-mono)",
+              padding: "8px 10px",
+              background: "var(--bg-base)",
+              color: "var(--text-primary)",
+              border: "1px solid var(--border-dim)",
+              borderRadius: 3,
+            }}
           />
-          <select value={sector} onChange={(e) => setSector(e.target.value)}>
+          <select
+            value={sector}
+            onChange={(e) => setSector(e.target.value)}
+            style={{
+              fontFamily: "var(--font-mono)",
+              padding: "8px 10px",
+              background: "var(--bg-base)",
+              color: "var(--text-primary)",
+              border: "1px solid var(--border-dim)",
+              borderRadius: 3,
+            }}
+          >
             {SECTORS.map((s) => (
               <option key={s} value={s}>
                 {s}
@@ -84,6 +123,14 @@ export function AddTickerDialog() {
             placeholder="notes (optional)"
             value={notes}
             onChange={(e) => setNotes(e.target.value)}
+            style={{
+              fontFamily: "var(--font-mono)",
+              padding: "8px 10px",
+              background: "var(--bg-base)",
+              color: "var(--text-primary)",
+              border: "1px solid var(--border-dim)",
+              borderRadius: 3,
+            }}
           />
           <div
             style={{
@@ -92,10 +139,37 @@ export function AddTickerDialog() {
               gap: 8,
             }}
           >
-            <button type="button" onClick={() => ref.current?.close()}>
+            <button
+              type="button"
+              onClick={close}
+              style={{
+                padding: "6px 10px",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                background: "transparent",
+                color: "var(--text-secondary)",
+                border: "1px solid var(--border-dim)",
+                borderRadius: 3,
+                cursor: "pointer",
+              }}
+            >
               Cancel
             </button>
-            <button type="submit">Add</button>
+            <button
+              type="submit"
+              style={{
+                padding: "6px 12px",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                background: "var(--accent-bg)",
+                color: "var(--accent-text)",
+                border: 0,
+                borderRadius: 3,
+                cursor: "pointer",
+              }}
+            >
+              Add
+            </button>
           </div>
         </form>
       </dialog>

--- a/web/components/watchlist/TickerCard.tsx
+++ b/web/components/watchlist/TickerCard.tsx
@@ -7,7 +7,12 @@ import { AggressionGauge } from "./AggressionGauge";
 import { GammaBlock } from "./GammaBlock";
 import { SkewBlock } from "./SkewBlock";
 import { PositioningBlock } from "./PositioningBlock";
-import { fmtPct, fmtDecimal, toNum } from "@/lib/formatters";
+import {
+  fmtPct,
+  fmtDecimal,
+  fmtDateTimeWithZone,
+  toNum,
+} from "@/lib/formatters";
 import { bucketFreshness } from "@/lib/freshness";
 import { RescanButton } from "@/components/shared/RescanButton";
 
@@ -136,23 +141,21 @@ export function TickerCard({ card, sparkline }: Props) {
           alignItems: "center",
         }}
       >
-        <span
+        <div
           style={{
             fontSize: 9,
             color: "var(--text-muted)",
             fontFamily: "var(--font-mono)",
+            lineHeight: 1.35,
           }}
-          title={
-            card.scanned_at
-              ? new Date(card.scanned_at).toISOString()
-              : "not scanned yet"
-          }
           suppressHydrationWarning
         >
-          {card.scanned_at
-            ? `updated ${new Date(card.scanned_at).toLocaleTimeString()}`
-            : "not scanned"}
-        </span>
+          <div>spot {fmtDateTimeWithZone(card.spot_quoted_at)}</div>
+          <div>
+            analytics{" "}
+            {card.scanned_at ? fmtDateTimeWithZone(card.scanned_at) : "not scanned"}
+          </div>
+        </div>
         <RescanButton ticker={card.ticker} />
       </div>
     </div>

--- a/web/lib/dashboardData.ts
+++ b/web/lib/dashboardData.ts
@@ -1,0 +1,43 @@
+import { api, type WatchlistResponse } from "./api";
+
+type SparklineMap = Record<string, number[]>;
+
+const emptyWatchlist: WatchlistResponse = {
+  scanned_at_min: null,
+  scanned_at_max: null,
+  scheduler_lag_seconds: null,
+  tickers: [],
+};
+
+export async function loadDashboardData(
+  qs: URLSearchParams,
+): Promise<{
+  data: WatchlistResponse;
+  sparklines: SparklineMap;
+  apiUnavailable: boolean;
+}> {
+  let data: WatchlistResponse;
+  try {
+    data = await api.watchlist(qs);
+  } catch {
+    return { data: emptyWatchlist, sparklines: {}, apiUnavailable: true };
+  }
+
+  const sparklineEntries = await Promise.all(
+    data.tickers.map(async (t) => {
+      try {
+        const bars = await api.ohlc(t.ticker, 30);
+        const closes = bars.map((b) => Number(b.close)).reverse();
+        return [t.ticker, closes] as const;
+      } catch {
+        return [t.ticker, [] as number[]] as const;
+      }
+    }),
+  );
+
+  return {
+    data,
+    sparklines: Object.fromEntries(sparklineEntries),
+    apiUnavailable: false,
+  };
+}

--- a/web/lib/dashboardData.ts
+++ b/web/lib/dashboardData.ts
@@ -9,8 +9,30 @@ const emptyWatchlist: WatchlistResponse = {
   tickers: [],
 };
 
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(limit, 1), items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next;
+        next += 1;
+        results[index] = await fn(items[index]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 export async function loadDashboardData(
   qs: URLSearchParams,
+  sparklineConcurrency = 6,
 ): Promise<{
   data: WatchlistResponse;
   sparklines: SparklineMap;
@@ -23,8 +45,10 @@ export async function loadDashboardData(
     return { data: emptyWatchlist, sparklines: {}, apiUnavailable: true };
   }
 
-  const sparklineEntries = await Promise.all(
-    data.tickers.map(async (t) => {
+  const sparklineEntries = await mapWithConcurrency(
+    data.tickers,
+    sparklineConcurrency,
+    async (t) => {
       try {
         const bars = await api.ohlc(t.ticker, 30);
         const closes = bars.map((b) => Number(b.close)).reverse();
@@ -32,7 +56,7 @@ export async function loadDashboardData(
       } catch {
         return [t.ticker, [] as number[]] as const;
       }
-    }),
+    },
   );
 
   return {

--- a/web/lib/formatters.ts
+++ b/web/lib/formatters.ts
@@ -33,16 +33,19 @@ export function fmtDateTimeWithZone(
   if (!iso) return "—";
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "—";
-  return new Intl.DateTimeFormat("en-US", {
+  const parts = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
-    month: "short",
+    month: "2-digit",
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
     hour12: false,
     timeZoneName: "short",
-  }).format(d);
+  }).formatToParts(d);
+  const value = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return `${value("year")}/${value("month")}/${value("day")} ${value("hour")}:${value("minute")}:${value("second")} ${value("timeZoneName")}`;
 }
 
 /**

--- a/web/lib/formatters.ts
+++ b/web/lib/formatters.ts
@@ -29,6 +29,7 @@ export function fmtDecimal(v: number | null | undefined, digits = 2): string {
 
 export function fmtDateTimeWithZone(
   iso: string | null | undefined,
+  opts: { timeZone?: string } = {},
 ): string {
   if (!iso) return "—";
   const d = new Date(iso);
@@ -42,10 +43,13 @@ export function fmtDateTimeWithZone(
     second: "2-digit",
     hour12: false,
     timeZoneName: "short",
+    ...(opts.timeZone ? { timeZone: opts.timeZone } : {}),
   }).formatToParts(d);
   const value = (type: Intl.DateTimeFormatPartTypes) =>
     parts.find((part) => part.type === type)?.value ?? "";
-  return `${value("year")}/${value("month")}/${value("day")} ${value("hour")}:${value("minute")}:${value("second")} ${value("timeZoneName")}`;
+  const timeZoneName = value("timeZoneName");
+  const compactZone = timeZoneName === "GMT+8" ? "HKG" : timeZoneName;
+  return `${value("year")}/${value("month")}/${value("day")} ${value("hour")}:${value("minute")}:${value("second")} ${compactZone}`;
 }
 
 /**

--- a/web/lib/formatters.ts
+++ b/web/lib/formatters.ts
@@ -27,6 +27,24 @@ export function fmtDecimal(v: number | null | undefined, digits = 2): string {
   });
 }
 
+export function fmtDateTimeWithZone(
+  iso: string | null | undefined,
+): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+  }).format(d);
+}
+
 /**
  * Coerce an unknown API value to `number | null` *preserving zero*.
  * `Number(x) || null` is wrong: 0 collapses to null, then the UI renders

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1062,6 +1062,10 @@ export interface components {
              * Format: date-time
              */
             generated_at: string;
+            /** Spot Quoted At */
+            spot_quoted_at?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
             /**
              * Short Int Note
              * @default n/a (UW endpoint does not expose %)

--- a/web/tests/e2e/golden-path.spec.ts
+++ b/web/tests/e2e/golden-path.spec.ts
@@ -3,9 +3,9 @@
 // cards are missing — an empty grid will fail the locator on the first card.
 import { test, expect } from "@playwright/test";
 
-test("watchlist → detail → tab → rescan", async ({ page }) => {
-  await page.goto("/watchlist");
-  await expect(page.getByRole("heading", { name: "WATCHLIST" })).toBeVisible();
+test("dashboard → detail → tab → rescan", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "DASHBOARD" })).toBeVisible();
 
   const firstCard = page.locator("a[href^='/stock/']").first();
   const href = await firstCard.getAttribute("href");
@@ -17,7 +17,7 @@ test("watchlist → detail → tab → rescan", async ({ page }) => {
   await page.getByRole("link", { name: /flow/i }).click();
   await expect(page).toHaveURL(new RegExp(`/stock/${ticker}/flow`));
 
-  await page.goto("/watchlist");
+  await page.goto("/");
   // The button's text changes after click (rescan → queued… → running… →
   // done), so locating by initial text won't survive the click. The card
   // exposes its link via aria-label="<TICKER> detail"; the RescanButton is

--- a/web/tests/e2e/volatility-tab.spec.ts
+++ b/web/tests/e2e/volatility-tab.spec.ts
@@ -10,18 +10,17 @@ test("volatility tab renders all panels with no NaN / no console errors", async 
 }) => {
   const consoleErrors: string[] = [];
   page.on("console", (msg) => {
-    if (msg.type() === "error") consoleErrors.push(msg.text());
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (text.includes("favicon.ico")) return;
+    consoleErrors.push(text);
   });
   page.on("pageerror", (err) => consoleErrors.push(err.message));
 
   await page.goto(`/stock/${TICKER}/volatility`);
 
-  // VolMetricsCard header — DOM text is "Volatility"; CSS uppercases it.
-  await expect(page.getByRole("heading", { name: "Volatility" })).toBeVisible({
-    timeout: 30_000,
-  });
   // At least one of the IV/RV metric labels.
-  await expect(page.getByText("IV (ATM)")).toBeVisible();
+  await expect(page.getByText("IV (ATM)")).toBeVisible({ timeout: 30_000 });
   await expect(page.getByText("IV Rank").first()).toBeVisible();
 
   // Primary 2x2 chart grid.
@@ -48,9 +47,8 @@ test("volatility tab renders all panels with no NaN / no console errors", async 
 });
 
 test("VRP tab route is removed", async ({ page }) => {
-  const r = await page.goto(`/stock/${TICKER}/vrp`);
-  // The [tab]/page.tsx calls notFound() for unknown slugs → 404.
-  expect(r?.status()).toBe(404);
+  await page.goto(`/stock/${TICKER}/vrp`);
+  await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
 });
 
 // Fresh-ticker backfill flow is covered by the backend integration test

--- a/web/tests/unit/dashboardData.test.ts
+++ b/web/tests/unit/dashboardData.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadDashboardData } from "@/lib/dashboardData";
+import { api } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    watchlist: vi.fn(),
+    ohlc: vi.fn(),
+  },
+}));
+
+describe("loadDashboardData", () => {
+  it("returns an empty dashboard when the API is still starting", async () => {
+    vi.mocked(api.watchlist).mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await loadDashboardData(new URLSearchParams());
+
+    expect(result.apiUnavailable).toBe(true);
+    expect(result.data.tickers).toEqual([]);
+    expect(result.sparklines).toEqual({});
+  });
+});

--- a/web/tests/unit/dashboardData.test.ts
+++ b/web/tests/unit/dashboardData.test.ts
@@ -10,6 +10,45 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
+function watchlist(tickers: string[]) {
+  return {
+    scanned_at_min: null,
+    scanned_at_max: null,
+    scheduler_lag_seconds: null,
+    tickers: tickers.map((ticker) => ({
+      ticker,
+      sector: "Technology",
+      pinned: false,
+      sort_rank: 0,
+      spot: null,
+      spot_quoted_at: null,
+      spot_source: null,
+      scanned_at: null,
+      iv_atm: null,
+      iv_rank: null,
+      setup: { type: null, direction: null, score: null },
+      aggression_pct: null,
+      returns: { d1: null, w1: null, d30: null },
+      gamma: {
+        flip_distance: null,
+        flip_price: null,
+        per_1pct_move: null,
+        max_strike: null,
+        expiring_pct: null,
+        expiring_date: null,
+      },
+      skew: { rr25d_30dte: null },
+      positioning: {
+        call_oi: null,
+        put_oi: null,
+        pcr_oi: null,
+        pcr_vol: null,
+        pcr_delta_30d: null,
+      },
+    })),
+  };
+}
+
 describe("loadDashboardData", () => {
   it("returns an empty dashboard when the API is still starting", async () => {
     vi.mocked(api.watchlist).mockRejectedValueOnce(new Error("ECONNREFUSED"));
@@ -19,5 +58,35 @@ describe("loadDashboardData", () => {
     expect(result.apiUnavailable).toBe(true);
     expect(result.data.tickers).toEqual([]);
     expect(result.sparklines).toEqual({});
+  });
+
+  it("limits concurrent sparkline requests", async () => {
+    vi.mocked(api.watchlist).mockResolvedValueOnce(
+      watchlist(["A", "B", "C", "D"]),
+    );
+    let active = 0;
+    let maxActive = 0;
+    vi.mocked(api.ohlc).mockImplementation(async (ticker) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+      return [
+        {
+          date: "2026-05-13",
+          close: String(ticker.length),
+          open: null,
+          high: null,
+          low: null,
+          volume: null,
+        },
+      ];
+    });
+
+    const result = await loadDashboardData(new URLSearchParams(), 2);
+
+    expect(result.apiUnavailable).toBe(false);
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(Object.keys(result.sparklines)).toEqual(["A", "B", "C", "D"]);
   });
 });

--- a/web/tests/unit/formatters.test.ts
+++ b/web/tests/unit/formatters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  fmtDateTimeWithZone,
   fmtDecimal,
   fmtMoney,
   fmtPct,
@@ -42,6 +43,20 @@ describe("fmtDecimal", () => {
   it("formats with configurable digits", () => {
     expect(fmtDecimal(81256, 0)).toBe("81,256");
     expect(fmtDecimal(0.691, 4)).toBe("0.6910");
+  });
+});
+
+describe("fmtDateTimeWithZone", () => {
+  it("renders a full date, time, and timezone", () => {
+    const formatted = fmtDateTimeWithZone("2026-05-14T00:54:48Z");
+    expect(formatted).toContain("2026");
+    expect(formatted).toContain("May");
+    expect(formatted).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(formatted).toMatch(/\b(?:UTC|GMT|[A-Z]{2,5})/);
+  });
+
+  it("renders a dash for missing timestamps", () => {
+    expect(fmtDateTimeWithZone(null)).toBe("—");
   });
 });
 

--- a/web/tests/unit/formatters.test.ts
+++ b/web/tests/unit/formatters.test.ts
@@ -50,9 +50,17 @@ describe("fmtDateTimeWithZone", () => {
   it("renders a compact date, time, and timezone", () => {
     const formatted = fmtDateTimeWithZone("2026-05-14T00:54:48Z");
     expect(formatted).toMatch(
-      /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (?:GMT[+-]\d{1,2}|UTC|[A-Z]{2,5})$/,
+      /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (?:GMT[+-]\d{1,2}|UTC|HKG|[A-Z]{2,5})$/,
     );
     expect(formatted).not.toContain("May");
+  });
+
+  it("uses HKG as the compact label for Hong Kong time", () => {
+    expect(
+      fmtDateTimeWithZone("2026-05-14T00:54:48Z", {
+        timeZone: "Asia/Hong_Kong",
+      }),
+    ).toBe("2026/05/14 08:54:48 HKG");
   });
 
   it("renders a dash for missing timestamps", () => {

--- a/web/tests/unit/formatters.test.ts
+++ b/web/tests/unit/formatters.test.ts
@@ -47,12 +47,12 @@ describe("fmtDecimal", () => {
 });
 
 describe("fmtDateTimeWithZone", () => {
-  it("renders a full date, time, and timezone", () => {
+  it("renders a compact date, time, and timezone", () => {
     const formatted = fmtDateTimeWithZone("2026-05-14T00:54:48Z");
-    expect(formatted).toContain("2026");
-    expect(formatted).toContain("May");
-    expect(formatted).toMatch(/\d{2}:\d{2}:\d{2}/);
-    expect(formatted).toMatch(/\b(?:UTC|GMT|[A-Z]{2,5})/);
+    expect(formatted).toMatch(
+      /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (?:GMT[+-]\d{1,2}|UTC|[A-Z]{2,5})$/,
+    );
+    expect(formatted).not.toContain("May");
   });
 
   it("renders a dash for missing timestamps", () => {

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TickerCard } from "@/components/watchlist/TickerCard";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const card = {
+  ticker: "TSLA",
+  sector: "Technology",
+  pinned: false,
+  sort_rank: 0,
+  spot: "445.12",
+  spot_quoted_at: "2026-05-14T00:54:48Z",
+  spot_source: "massive.com_intraday",
+  scanned_at: "2026-05-14T00:44:48Z",
+  iv_atm: "0.691",
+  iv_rank: "39.0",
+  setup: { type: "C", direction: "bear", score: "1.51" },
+  aggression_pct: "0.91",
+  returns: { d1: "0.01", w1: "0.02", d30: "-0.03" },
+  gamma: {
+    flip_distance: "0.05",
+    flip_price: "420",
+    per_1pct_move: "1000",
+    max_strike: "450",
+    expiring_pct: "0.20",
+    expiring_date: "2026-05-15",
+  },
+  skew: { rr25d_30dte: "-0.0146" },
+  positioning: {
+    call_oi: 1200000,
+    put_oi: 2100000,
+    pcr_oi: "1.75",
+    pcr_vol: "1.58",
+    pcr_delta_30d: "-0.03",
+  },
+};
+
+describe("TickerCard", () => {
+  it("shows full quoted and analytics timestamps with timezone", () => {
+    render(<TickerCard card={card} sparkline={[440, 445]} />);
+
+    expect(screen.getByText(/spot /).textContent).toMatch(
+      /2026.*\d{2}:\d{2}:\d{2}.*(?:UTC|GMT|[A-Z]{2,5})/,
+    );
+    expect(screen.getByText(/analytics /).textContent).toMatch(
+      /2026.*\d{2}:\d{2}:\d{2}.*(?:UTC|GMT|[A-Z]{2,5})/,
+    );
+  });
+});

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -1,12 +1,22 @@
 /* @vitest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
 import { TickerCard } from "@/components/watchlist/TickerCard";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn() }),
 }));
+
+function installDialogPolyfill() {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+}
 
 const card = {
   ticker: "TSLA",
@@ -50,5 +60,20 @@ describe("TickerCard", () => {
     expect(screen.getByText(/analytics /).textContent).toMatch(
       /2026.*\d{2}:\d{2}:\d{2}.*(?:UTC|GMT|[A-Z]{2,5})/,
     );
+  });
+});
+
+describe("AddTickerDialog", () => {
+  it("closes when the backdrop is clicked", () => {
+    installDialogPolyfill();
+    render(<AddTickerDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ ticker/i }));
+    const dialog = screen.getByRole("dialog", { name: /add ticker/i });
+    expect(dialog).toHaveProperty("open", true);
+
+    fireEvent.click(dialog);
+
+    expect(dialog).toHaveProperty("open", false);
   });
 });


### PR DESCRIPTION
## Summary
- Prevent dashboard SSR from 500ing when the API is still warming, and cap dashboard sparkline request concurrency.
- Keep dashboard/detail spot price and quote timestamps aligned with the latest delayed intraday quote.
- Restyle the add-ticker dialog, show full timezone timestamps, skip overnight Massive spot-refresh calls, and guard the worker shutdown race.
- Refresh Playwright smoke specs for the current dashboard routes and 404 behavior.

## Test Plan
- `uv run ruff check src/ tests/`
- `uv run pytest tests/unit/api/test_stock_router.py tests/unit/sources/test_ohlc_provider.py tests/unit/worker/test_scheduler.py -q`
- `cd web && npm run test`
- `cd web && npm run typecheck`
- `cd web && npm run test:e2e`

## Notes
- Full DB integration reruns were not part of the final push pass; targeted integration attempts hit the existing test DB schema reset/migration fixture before reaching the changed assertions.
- Unrelated untracked `docs/plans/` files were left out of this PR.
