### PR TITLE
Add provider request monitoring

### DIFF
--- a/docs/plans/2026-05-14-provider-request-monitoring-design.md
+++ b/docs/plans/2026-05-14-provider-request-monitoring-design.md
@@ -1,0 +1,184 @@
+# Provider Request Monitoring Design
+
+## Goal
+
+Track outbound Unusual Whales and Massive REST requests so the app can explain provider usage by status family, endpoint, ticker, and request time. Show the current provider-day totals in the lower-left health panel, and keep detailed request rows in Postgres for reference and audit.
+
+## Scope
+
+V1 tracks external provider calls only:
+
+- Unusual Whales REST calls made through `UwClient`
+- Massive REST calls made through `MassiveOhlcProvider`
+
+V1 does not track this app's own internal API traffic, such as `/api/health`, `/api/watchlist`, or stock detail reads.
+
+## Provider Day
+
+Usage summaries use a provider-day window that resets at 8:00 PM America/New_York:
+
+- start: the most recent 8:00 PM ET at or before `now`
+- end: the next 8:00 PM ET
+
+This aligns the sidebar and reports with daily provider usage accounting. It also avoids local-machine timezone drift when the app runs outside Eastern Time.
+
+## Data Model
+
+Create a new append-only ledger table, `uw_scan.external_api_requests`, as the shared usage telemetry model for both providers.
+
+Suggested columns:
+
+- `request_id BIGSERIAL PRIMARY KEY`
+- `provider TEXT NOT NULL` with values `uw` and `massive`
+- `endpoint_key TEXT NOT NULL`
+- `method TEXT NOT NULL`
+- `path_template TEXT`
+- `path TEXT NOT NULL`
+- `ticker TEXT`
+- `params_json JSONB NOT NULL DEFAULT '{}'::jsonb`
+- `status_code INTEGER`
+- `status_family TEXT NOT NULL`
+- `request_started_at TIMESTAMPTZ NOT NULL`
+- `request_finished_at TIMESTAMPTZ NOT NULL`
+- `latency_ms INTEGER NOT NULL`
+- `attempt INTEGER NOT NULL DEFAULT 0`
+- `run_id BIGINT REFERENCES uw_scan.scan_runs(run_id) ON DELETE SET NULL`
+- `job_name TEXT`
+- `provider_request_id TEXT`
+- `official_daily_count INTEGER`
+- `official_daily_limit INTEGER`
+- `official_minute_remaining INTEGER`
+- `official_minute_reset TEXT`
+- `error_message TEXT`
+- `inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()`
+
+Indexes:
+
+- `(provider, request_started_at DESC)`
+- `(provider, ticker, request_started_at DESC)`
+- `(provider, endpoint_key, request_started_at DESC)`
+- `(provider, status_family, request_started_at DESC)`
+
+For UW, keep existing `api_request_audit` and `raw_payloads` as payload provenance. The new ledger is for operational usage, latency, and status accounting.
+
+Add check constraints for the small enums and basic invariants:
+
+- `provider IN ('uw', 'massive')`
+- `method IN ('GET')` for V1
+- `status_family IN ('2xx', '3xx', '4xx', '5xx', 'transport_error')`
+- `latency_ms >= 0`
+- `attempt >= 0`
+
+Telemetry writes must be durable even when the scan transaction rolls back. Do not write request telemetry through the same transaction that owns scan persistence unless the caller explicitly commits only telemetry. Use a small telemetry recorder with its own autocommit connection per worker/API task so request rows survive failed scans without committing partial normalized data.
+
+## Capture Points
+
+### Unusual Whales
+
+Instrument `UwClient.get(...)`.
+
+Each outbound HTTP attempt should write one ledger row after a response or transport error. The existing UW fetchers still write raw payload audit rows only after a successful response has been parsed.
+
+Captured fields:
+
+- provider: `uw`
+- endpoint key: existing `EndpointSlug`
+- method: `GET`
+- path template/path from the endpoint registry
+- ticker if the endpoint uses one or params include ticker-like values
+- status code/status family
+- start/end/latency
+- retry attempt number
+- UW official headers: daily count, token request limit, minute remaining, minute reset
+- transport error message when no HTTP response exists
+
+### Massive
+
+Instrument `MassiveOhlcProvider`.
+
+V1 does not need official Massive reconciliation. Massive usage is tracked internally for throttle/debug visibility.
+
+Captured fields:
+
+- provider: `massive`
+- endpoint key: `daily_ohlc` or `intraday_quote`
+- method: `GET`
+- path template/path
+- ticker
+- params
+- status code/status family
+- start/end/latency
+- provider request id if Massive returns `request_id` in JSON
+- transport or HTTP error message
+
+## API Surface
+
+Add read-only provider usage endpoints:
+
+- `GET /api/provider-usage/summary?provider=uw|massive|all`
+- `GET /api/provider-usage/endpoints?provider=uw|massive|all`
+- `GET /api/provider-usage/tickers?provider=uw|massive|all`
+- `GET /api/provider-usage/requests?provider=...&ticker=...&status_family=...`
+
+All endpoints default to the current provider-day. Later versions can accept explicit `start` and `end`.
+
+Summary fields:
+
+- provider day start/end
+- total request count
+- `2xx`, `4xx`, `5xx`, `transport_error`
+- p50/p95/p99 latency
+- retry/throttle counts
+- latest error
+- UW official latest daily count/limit when available
+- UW delta: latest official daily count minus internal UW count in the provider-day
+
+Endpoint and ticker breakdowns return counts by status family and latency p95.
+
+Request rows return the newest bounded list for audit/debug, with params redacted and no secrets.
+
+Redaction rules are simple in V1: drop case-insensitive keys named `apiKey`, `apikey`, `api_key`, `token`, `authorization`, or `auth`, and truncate long string values before persistence.
+
+## Sidebar
+
+Wire `/api/health` to the ledger for the current provider-day and populate the existing fields:
+
+- `latency_p95_ms`
+- `http_2xx`
+- `http_4xx`
+- `http_5xx`
+- `uw_today`
+
+Keep the sidebar compact. It should remain a high-signal status panel, not a full audit screen.
+
+Suggested display:
+
+- `Source`: keep current source label or show `providers`
+- `Latency p95`: combined provider-day p95
+- `2xx`, `4xx`, `5xx`: combined provider-day totals
+- `UW Today`: optional future row, rendered as `internal / official` when the header has appeared
+
+## Testing
+
+Python:
+
+- migration creates the ledger table and indexes idempotently
+- repository can insert request rows and summarize by provider-day
+- provider-day helper handles before/after 8:00 PM ET
+- `UwClient` records `2xx`, `4xx`, `5xx`, retry attempts, and transport errors with `httpx.MockTransport`
+- `MassiveOhlcProvider` records daily and intraday requests with `httpx.MockTransport`
+- `/api/health` returns populated status counts and latency
+- provider usage endpoints return summary, endpoint, ticker, and request-row payloads
+
+Web:
+
+- HealthPanel renders populated counts and keeps dashes for missing values
+- generated OpenAPI types stay in sync after adding provider usage routes
+
+## Non-Goals
+
+- No Redis or in-memory counters
+- No request throttling changes in V1
+- No official Massive usage reconciliation
+- No tracking of internal app API traffic
+- No migration of existing UW raw payload audit rows into the new table

--- a/docs/plans/2026-05-14-provider-request-monitoring.md
+++ b/docs/plans/2026-05-14-provider-request-monitoring.md
@@ -1,0 +1,641 @@
+# Provider Request Monitoring Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Postgres-backed request ledger for outbound UW and Massive calls, expose provider-day usage summaries, and populate the existing sidebar health counters.
+
+**Architecture:** Create a new append-only `external_api_requests` table, repository methods for inserts plus provider-day summaries, and a durable telemetry recorder that writes through its own autocommit connection. Instrument `UwClient` and `MassiveOhlcProvider` at their HTTP boundaries so every provider response or transport error is recorded without committing partial scan data. Add read-only FastAPI routes for deeper audit views and wire `/api/health` to the current provider-day summary used by the sidebar.
+
+**Tech Stack:** Python via `uv` (`pyproject.toml` allows 3.11+, project runtime uses 3.13), FastAPI/Pydantic v2, psycopg 3, Postgres JSONB, httpx MockTransport tests, Next.js/TypeScript generated from OpenAPI.
+
+---
+
+## Notes
+
+- Do not pass secrets into telemetry rows. Store request params only after removing auth keys.
+- Do not commit unless the user explicitly asks; use the commit steps below as checkpoint guidance only.
+- Provider-day means 8:00 PM America/New_York to the next 8:00 PM America/New_York.
+- Keep existing UW `api_request_audit` and `raw_payloads`; the new table is operational telemetry.
+- Telemetry must survive scan rollbacks. Do not let client-side request recording commit the main scan transaction.
+- Production coverage must include scheduler jobs, the volatility backfill background task, and convenience env entrypoints that create provider clients.
+
+### Task 1: Add Ledger Migration, Constraints, And Insert Method
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/018_external_api_requests.sql`
+- Modify: `src/uw_scan/storage/repository.py`
+- Test: `tests/integration/storage/test_migrations.py`
+- Test: `tests/integration/storage/test_provider_usage_repository.py`
+
+**Step 1: Write migration test**
+
+Add assertions that `external_api_requests` exists after all migrations and has indexes for provider/time, ticker, endpoint, and status family. Add assertions for check constraints on `provider`, `method`, `status_family`, `latency_ms`, and `attempt`.
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_migrations.py -q
+```
+
+Expected: FAIL because the table does not exist.
+
+**Step 2: Add migration**
+
+Create `018_external_api_requests.sql`:
+
+```sql
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.external_api_requests (
+    request_id BIGSERIAL PRIMARY KEY,
+    provider TEXT NOT NULL,
+    endpoint_key TEXT NOT NULL,
+    method TEXT NOT NULL,
+    path_template TEXT,
+    path TEXT NOT NULL,
+    ticker TEXT,
+    params_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status_code INTEGER,
+    status_family TEXT NOT NULL,
+    request_started_at TIMESTAMPTZ NOT NULL,
+    request_finished_at TIMESTAMPTZ NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    attempt INTEGER NOT NULL DEFAULT 0,
+    run_id BIGINT REFERENCES uw_scan.scan_runs(run_id) ON DELETE SET NULL,
+    job_name TEXT,
+    provider_request_id TEXT,
+    official_daily_count INTEGER,
+    official_daily_limit INTEGER,
+    official_minute_remaining INTEGER,
+    official_minute_reset TEXT,
+    error_message TEXT,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT external_api_requests_provider_check
+        CHECK (provider IN ('uw', 'massive')),
+    CONSTRAINT external_api_requests_method_check
+        CHECK (method IN ('GET')),
+    CONSTRAINT external_api_requests_status_family_check
+        CHECK (status_family IN ('2xx', '3xx', '4xx', '5xx', 'transport_error')),
+    CONSTRAINT external_api_requests_latency_nonnegative_check
+        CHECK (latency_ms >= 0),
+    CONSTRAINT external_api_requests_attempt_nonnegative_check
+        CHECK (attempt >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_started_idx
+    ON uw_scan.external_api_requests (provider, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_ticker_started_idx
+    ON uw_scan.external_api_requests (provider, ticker, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_endpoint_started_idx
+    ON uw_scan.external_api_requests (provider, endpoint_key, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_status_started_idx
+    ON uw_scan.external_api_requests (provider, status_family, request_started_at DESC);
+```
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_migrations.py -q
+```
+
+Expected: PASS.
+
+**Step 3: Add repository dataclasses and insert method test**
+
+In `repository.py`, add small dataclasses:
+
+- `ExternalApiRequestInsert`
+- `ExternalApiUsageSummary`
+- `ExternalApiBreakdownRow`
+- `ExternalApiRequestRow`
+
+Create `tests/integration/storage/test_provider_usage_repository.py` with a freshly migrated DB fixture like the existing storage repository tests, then add:
+
+```python
+def test_external_api_request_roundtrip_and_summary(repo: Repository):
+    now = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
+    request_id = repo.insert_external_api_request(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path_template="/api/stock/{ticker}/iv-rank",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=42,
+        official_daily_count=10,
+        official_daily_limit=1000,
+    )
+    repo.conn.commit()
+    assert request_id > 0
+```
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_provider_usage_repository.py::test_external_api_request_roundtrip_and_summary -q
+```
+
+Expected: FAIL because the method does not exist.
+
+**Step 4: Implement insert method**
+
+Add `Repository.insert_external_api_request(...)` using explicit parameters and `Jsonb(params)`. Keep it a thin insert wrapper like existing repository methods.
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_provider_usage_repository.py::test_external_api_request_roundtrip_and_summary -q
+```
+
+Expected: PASS.
+
+**Step 5: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/storage/migrations/018_external_api_requests.sql src/uw_scan/storage/repository.py tests/integration/storage/test_migrations.py tests/integration/storage/test_provider_usage_repository.py
+git commit -m "feat: add external provider request ledger"
+```
+
+### Task 2: Add Provider-Day, Redaction, And Summary Queries
+
+**Files:**
+- Modify: `src/uw_scan/storage/repository.py`
+- Test: `tests/unit/storage/test_provider_usage_helpers.py`
+- Test: `tests/integration/storage/test_provider_usage_repository.py`
+
+**Step 1: Write provider-day tests**
+
+Add tests for:
+
+- `provider_day_bounds(now)` returns the previous 8 PM ET when `now` is before 8 PM ET.
+- `provider_day_bounds(now)` returns the same-day 8 PM ET when `now` is after 8 PM ET.
+- `status_family_for(status_code)` returns `2xx`, `3xx`, `4xx`, or `5xx`.
+- `status_family_for(None, error=True)` returns `transport_error`.
+- `redact_params(...)` drops auth-like keys and truncates long values.
+- summary counts `2xx`, `4xx`, `5xx`, `transport_error`.
+- p95 latency is computed from ledger rows.
+- latest UW official count/limit is taken from the newest UW row with header values.
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_provider_usage_helpers.py tests/integration/storage/test_provider_usage_repository.py -q
+```
+
+Expected: FAIL because summary helpers do not exist.
+
+**Step 2: Implement helpers and repository summaries**
+
+Add helper functions near the repository layer:
+
+- `provider_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]`
+- `status_family_for(status_code: int | None, *, transport_error: bool = False) -> str`
+- `redact_params(params: dict[str, object]) -> dict[str, object]`
+
+Add in `repository.py`:
+
+- `get_external_api_usage_summary(provider: str | None, start: datetime, end: datetime)`
+- `list_external_api_endpoint_usage(provider: str | None, start: datetime, end: datetime)`
+- `list_external_api_ticker_usage(provider: str | None, start: datetime, end: datetime)`
+- `list_external_api_requests(...)`
+
+Use SQL `FILTER` aggregates for counts and `percentile_cont(0.95)` for p95.
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_provider_usage_helpers.py tests/integration/storage/test_provider_usage_repository.py -q
+```
+
+Expected: PASS.
+
+**Step 3: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/storage/repository.py tests/unit/storage/test_provider_usage_helpers.py tests/integration/storage/test_provider_usage_repository.py
+git commit -m "feat: summarize provider request usage"
+```
+
+### Task 3: Add Durable Telemetry Recorder
+
+**Files:**
+- Create: `src/uw_scan/storage/provider_usage.py`
+- Modify: `src/uw_scan/api/deps.py`
+- Test: `tests/integration/storage/test_provider_usage_recorder.py`
+- Test: `tests/integration/api/conftest.py`
+
+**Step 1: Write failing recorder tests**
+
+Add tests that:
+
+- recorder inserts a row through an autocommit connection.
+- a rollback on the main scan connection does not erase a row written by the recorder.
+- recorder failures are logged and swallowed so telemetry cannot break scans.
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_provider_usage_recorder.py -q
+```
+
+Expected: FAIL because the recorder does not exist.
+
+**Step 2: Implement recorder**
+
+Create `ExternalApiRequestEvent` and `ExternalApiRequestRecorder`.
+
+The recorder should own a dedicated psycopg connection with `autocommit=True`, wrap a `Repository`, and expose:
+
+```python
+def record(self, event: ExternalApiRequestEvent) -> None: ...
+def close(self) -> None: ...
+def __enter__(self) -> ExternalApiRequestRecorder: ...
+def __exit__(self, *_exc) -> None: ...
+```
+
+It should catch/log exceptions inside `record` and never raise into provider clients.
+
+**Step 3: Add API dependency helper**
+
+In `api/deps.py`, add a generator dependency:
+
+```python
+def get_external_api_recorder() -> Generator[ExternalApiRequestRecorder, None, None]:
+    ...
+```
+
+Tests should be able to override this dependency like `get_repo`.
+
+Run:
+
+```bash
+uv run pytest tests/integration/storage/test_provider_usage_recorder.py -q
+```
+
+Expected: PASS.
+
+**Step 4: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/storage/provider_usage.py src/uw_scan/api/deps.py tests/integration/storage/test_provider_usage_recorder.py tests/integration/api/conftest.py
+git commit -m "feat: add durable provider request recorder"
+```
+
+### Task 4: Instrument UW Client
+
+**Files:**
+- Modify: `src/uw_scan/api/client.py`
+- Modify: `src/uw_scan/sources/uw.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Modify: `src/uw_scan/api/routers/volatility.py`
+- Modify: `src/uw_scan/pipeline.py`
+- Test: `tests/unit/api/test_uw_client_telemetry.py`
+- Test: `tests/integration/api/test_volatility_endpoint.py`
+
+**Step 1: Write failing UW client telemetry tests**
+
+Create tests with `httpx.MockTransport` covering:
+
+- successful `2xx` writes one ledger row with endpoint slug, ticker, latency, and UW headers.
+- `4xx` writes one ledger row before raising `UwHTTPError`.
+- `5xx` with retry writes each HTTP attempt.
+- every transport error attempt writes `transport_error`, including attempts that later retry.
+- telemetry recorder exceptions do not change the `UwClient` response/exception behavior.
+
+Run:
+
+```bash
+uv run pytest tests/unit/api/test_uw_client_telemetry.py -q
+```
+
+Expected: FAIL because `UwClient` cannot write telemetry yet.
+
+**Step 2: Add optional recorder to `UwClient`**
+
+Add constructor params:
+
+- `telemetry_recorder: ExternalApiRequestRecorder | None = None`
+- `job_name: str | None = None`
+
+Add a private `_record_request(...)` helper. It should no-op when `telemetry_recorder` is `None`.
+
+Write one ledger row per attempt after response or terminal transport failure. Do not include bearer token or secrets.
+
+**Step 3: Pass run context from UW fetchers**
+
+In `sources/uw.py`, pass `run_id` per call so one shared `UwClient` can safely scan many tickers:
+
+```python
+client.get(slug, ticker=ticker, params=params, run_id=run_id)
+```
+
+Adjust `UwClient.get` accordingly.
+
+**Step 4: Wire production UW client construction**
+
+Update every production `UwClient(...)` creation to pass a recorder when settings are available:
+
+- `worker/scheduler.py` full scan, rescan, and nightly flow refresh
+- `api/routers/volatility.py` background backfill
+- `pipeline.py::run_single_stock_for_ticker_via_env`
+
+Keep live tests and isolated direct client tests working by allowing `telemetry_recorder=None`.
+
+Run:
+
+```bash
+uv run pytest tests/unit/api/test_uw_client_telemetry.py -q
+uv run pytest tests/integration/test_scan_e2e.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/api/client.py src/uw_scan/sources/uw.py src/uw_scan/worker/scheduler.py src/uw_scan/api/routers/volatility.py src/uw_scan/pipeline.py tests/unit/api/test_uw_client_telemetry.py tests/integration/api/test_volatility_endpoint.py
+git commit -m "feat: record UW provider request telemetry"
+```
+
+### Task 5: Instrument Massive Provider
+
+**Files:**
+- Modify: `src/uw_scan/sources/ohlc.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Modify: `src/uw_scan/worker/volatility_jobs.py`
+- Test: `tests/unit/sources/test_ohlc_provider.py`
+- Test: `tests/integration/worker/test_volatility_jobs.py`
+
+**Step 1: Extend Massive provider tests**
+
+Add assertions that:
+
+- `fetch_daily` records `provider="massive"`, `endpoint_key="daily_ohlc"`, ticker, status, latency.
+- `fetch_intraday_quote` records `endpoint_key="intraday_quote"`.
+- 404 records `4xx` even when the method returns `None`.
+- raised HTTP errors still record rows.
+
+Run:
+
+```bash
+uv run pytest tests/unit/sources/test_ohlc_provider.py -q
+```
+
+Expected: FAIL.
+
+**Step 2: Implement Massive telemetry**
+
+Add optional constructor args:
+
+- `telemetry_recorder: ExternalApiRequestRecorder | None = None`
+- `job_name: str | None = None`
+
+Wrap each `_client.get(...)` call in start/end timing and insert a ledger row. Extract `request_id` from JSON when available, but tolerate invalid/empty JSON.
+
+**Step 3: Wire worker provider construction**
+
+In `worker/scheduler.py`, when creating `MassiveOhlcProvider`, pass a recorder and job name for:
+
+- `spot_refresh`
+- `ohlc_pull`
+- `_full_scan` if it uses the OHLC provider later
+
+In `worker/volatility_jobs.py`, thread the recorder into `daily_spy_ohlc_refresh`, because that function creates its own `MassiveOhlcProvider`.
+
+Run:
+
+```bash
+uv run pytest tests/unit/sources/test_ohlc_provider.py -q
+uv run pytest tests/integration/api/test_stock_ohlc_jobs.py -q
+uv run pytest tests/integration/worker/test_volatility_jobs.py -q
+```
+
+Expected: PASS.
+
+**Step 4: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/sources/ohlc.py src/uw_scan/worker/scheduler.py src/uw_scan/worker/volatility_jobs.py tests/unit/sources/test_ohlc_provider.py tests/integration/worker/test_volatility_jobs.py
+git commit -m "feat: record Massive provider request telemetry"
+```
+
+### Task 6: Add Provider Usage API
+
+**Files:**
+- Create: `src/uw_scan/api/routers/provider_usage.py`
+- Modify: `src/uw_scan/api/server.py`
+- Test: `tests/integration/api/test_provider_usage.py`
+- Test: `tests/integration/api/test_openapi_snapshot.py`
+
+**Step 1: Write API tests**
+
+Add tests for:
+
+- summary endpoint returns current provider-day bounds and counts.
+- endpoint breakdown groups by endpoint key.
+- ticker breakdown groups by ticker.
+- request list filters by provider/ticker/status family.
+- invalid provider values return 422.
+- requests endpoint is bounded with a default and maximum limit.
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_provider_usage.py -q
+```
+
+Expected: FAIL because route does not exist.
+
+**Step 2: Implement Pydantic schemas and routes**
+
+Create read-only router with:
+
+- `GET /api/provider-usage/summary`
+- `GET /api/provider-usage/endpoints`
+- `GET /api/provider-usage/tickers`
+- `GET /api/provider-usage/requests`
+
+Validate provider as `uw`, `massive`, or `all`. Default all endpoints to current provider-day.
+
+**Step 3: Register router and update OpenAPI snapshot**
+
+Modify `server.py` to include the new router. Run snapshot update only if the project has an existing blessed workflow; otherwise run the snapshot test and update deliberately.
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_provider_usage.py tests/integration/api/test_openapi_snapshot.py -q
+```
+
+Expected: PASS after snapshot is updated.
+
+**Step 4: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/api/routers/provider_usage.py src/uw_scan/api/server.py tests/integration/api/test_provider_usage.py tests/integration/api/openapi.snapshot.json
+git commit -m "feat: expose provider usage API"
+```
+
+### Task 7: Wire Health Sidebar Stats
+
+**Files:**
+- Modify: `src/uw_scan/api/routers/health.py`
+- Modify: `web/components/shared/HealthPanel.tsx`
+- Test: `tests/integration/api/test_health.py`
+- Test: `web/tests/unit/healthPanel.test.tsx`
+
+**Step 1: Extend health API tests**
+
+Seed provider request rows and assert `/api/health` returns:
+
+- `latency_p95_ms`
+- `http_2xx`
+- `http_4xx`
+- `http_5xx`
+- `uw_today`
+- health still includes usage fields when there is no successful full scan yet.
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_health.py -q
+```
+
+Expected: FAIL because health still returns placeholders.
+
+**Step 2: Implement health summary wiring**
+
+In `health.py`, fetch the provider-day summary and populate existing fields. Preserve current `ok/reason` behavior when no scans exist.
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_health.py -q
+```
+
+Expected: PASS.
+
+**Step 3: Add/update HealthPanel test**
+
+Create `web/tests/unit/healthPanel.test.tsx` if it does not exist. Mock `@/lib/api` and assert populated counts render, missing values render dashes, and the worker status remains unchanged.
+
+**Step 4: Update HealthPanel if needed**
+
+If adding an `UW Today` row, update `HealthPanel.tsx` and the generated type usage. Keep layout compact.
+
+Run:
+
+```bash
+cd web && npm run test -- healthPanel
+```
+
+Expected: PASS.
+
+**Step 5: Regenerate TypeScript types**
+
+Start the FastAPI app on port 8400, then run:
+
+```bash
+cd web && npm run gen:types
+```
+
+Expected: `web/lib/types.ts` updates with provider usage schemas.
+
+**Step 6: Checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git add src/uw_scan/api/routers/health.py web/components/shared/HealthPanel.tsx web/lib/types.ts tests/integration/api/test_health.py web/tests/unit/healthPanel.test.tsx
+git commit -m "feat: show provider usage in health panel"
+```
+
+### Task 8: Final Verification
+
+**Files:**
+- None unless tests expose issues.
+
+**Step 1: Run backend tests**
+
+```bash
+uv run pytest
+```
+
+Expected: PASS.
+
+**Step 2: Run frontend tests**
+
+```bash
+cd web && npm run test
+```
+
+Expected: PASS.
+
+**Step 3: Run type generation check**
+
+```bash
+uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400
+```
+
+In a second terminal:
+
+```bash
+cd web && npm run gen:types
+git diff -- web/lib/types.ts
+```
+
+Expected: either no diff or an intentional generated diff already staged.
+
+**Step 4: Run migration idempotence check**
+
+```bash
+bash scripts/migrate.sh
+bash scripts/migrate.sh
+```
+
+Expected: both runs complete without errors.
+
+**Step 5: Manual smoke**
+
+Run the app stack:
+
+```bash
+bash scripts/dev.sh
+```
+
+Trigger a health read and one scan/spot-refresh path, then check:
+
+- sidebar shows non-dash provider counts after provider requests happen
+- `GET /api/provider-usage/summary` returns provider-day totals
+- provider usage rows contain no secrets
+
+**Step 6: Final checkpoint**
+
+If explicitly asked to commit:
+
+```bash
+git status --short
+git add docs/plans/2026-05-14-provider-request-monitoring-design.md docs/plans/2026-05-14-provider-request-monitoring.md
+git add src/uw_scan web tests
+git commit -m "feat: monitor external provider requests"
+```

--- a/src/uw_scan/api/client.py
+++ b/src/uw_scan/api/client.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import httpx
+
+from uw_scan.storage.provider_usage import ExternalApiRequestEvent
+from uw_scan.storage.repository import redact_params, status_family_for
 
 from .endpoints import REGISTRY, Endpoint, EndpointSlug, build_path
 
@@ -51,6 +55,8 @@ class UwClient:
         base_url: str = "https://api.unusualwhales.com",
         timeout: float = 30.0,
         max_retries: int = 3,
+        telemetry_recorder: object | None = None,
+        job_name: str | None = None,
     ) -> None:
         if not api_key:
             raise LiveDataUnavailable("UW API key is empty")
@@ -60,6 +66,8 @@ class UwClient:
         self.max_retries = max_retries
         self._client = httpx.Client(timeout=timeout)
         self.rate_limit = RateLimitState()
+        self._telemetry_recorder = telemetry_recorder
+        self._job_name = job_name
 
     def close(self) -> None:
         self._client.close()
@@ -78,6 +86,7 @@ class UwClient:
         slug: EndpointSlug,
         ticker: str | None = None,
         params: dict[str, object] | None = None,
+        run_id: int | None = None,
     ) -> tuple[httpx.Response, dict[str, str]]:
         """Make a GET request; returns (response, header_snapshot)."""
         ep: Endpoint = REGISTRY[slug]
@@ -92,6 +101,7 @@ class UwClient:
 
         last_exc: Exception | None = None
         for attempt in range(self.max_retries + 1):
+            started_at = datetime.now(UTC)
             try:
                 resp = self._client.get(
                     url,
@@ -99,14 +109,44 @@ class UwClient:
                     headers={"Authorization": f"Bearer {self._api_key}"},
                 )
             except httpx.HTTPError as exc:
+                finished_at = datetime.now(UTC)
                 last_exc = exc
                 logger.exception(
                     "transport error on %s attempt %d: %s", slug, attempt, repr(exc)
+                )
+                self._record_request(
+                    slug=slug,
+                    ep=ep,
+                    path=path,
+                    ticker=ticker,
+                    params=params,
+                    status_code=None,
+                    status_family="transport_error",
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    attempt=attempt,
+                    run_id=run_id,
+                    error_message=str(exc),
                 )
                 self._backoff(attempt)
                 continue
 
             self._absorb_headers(resp)
+            finished_at = datetime.now(UTC)
+            self._record_request(
+                slug=slug,
+                ep=ep,
+                path=path,
+                ticker=ticker,
+                params=params,
+                status_code=resp.status_code,
+                status_family=status_family_for(resp.status_code),
+                started_at=started_at,
+                finished_at=finished_at,
+                attempt=attempt,
+                run_id=run_id,
+                error_message=resp.text if resp.status_code >= 400 else None,
+            )
 
             if resp.status_code == 429 or 500 <= resp.status_code < 600:
                 logger.warning(
@@ -134,6 +174,56 @@ class UwClient:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+    def _record_request(
+        self,
+        *,
+        slug: EndpointSlug,
+        ep: Endpoint,
+        path: str,
+        ticker: str | None,
+        params: dict[str, object],
+        status_code: int | None,
+        status_family: str,
+        started_at: datetime,
+        finished_at: datetime,
+        attempt: int,
+        run_id: int | None,
+        error_message: str | None,
+    ) -> None:
+        if self._telemetry_recorder is None:
+            return
+        latency_ms = max(0, int((finished_at - started_at).total_seconds() * 1000))
+        event = ExternalApiRequestEvent(
+            provider="uw",
+            endpoint_key=slug.value,
+            method="GET",
+            path_template=ep.path_template,
+            path=path,
+            ticker=ticker.upper() if ticker else None,
+            params=redact_params(params),
+            status_code=status_code,
+            status_family=status_family,
+            started_at=started_at,
+            finished_at=finished_at,
+            latency_ms=latency_ms,
+            attempt=attempt,
+            run_id=run_id,
+            job_name=self._job_name,
+            official_daily_count=self.rate_limit.daily_count,
+            official_daily_limit=self.rate_limit.daily_limit,
+            official_minute_remaining=self.rate_limit.minute_remaining,
+            official_minute_reset=self.rate_limit.minute_reset,
+            error_message=error_message[:1000] if error_message else None,
+        )
+        try:
+            self._telemetry_recorder.record(event)  # type: ignore[attr-defined]
+        except Exception as exc:
+            logger.exception(
+                "failed to emit UW request telemetry for %s: %s",
+                slug,
+                repr(exc),
+            )
+
     def _absorb_headers(self, resp: httpx.Response) -> None:
         h = resp.headers
         try:

--- a/src/uw_scan/api/deps.py
+++ b/src/uw_scan/api/deps.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 import psycopg
 
 from uw_scan.config import Settings
+from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 from uw_scan.storage.repository import Repository
 
 
@@ -23,3 +24,12 @@ def get_repo() -> Generator[Repository, None, None]:
         yield Repository(conn, schema=settings.db_schema)
     finally:
         conn.close()
+
+
+def get_external_api_recorder() -> Generator[ExternalApiRequestRecorder, None, None]:
+    settings = get_settings()
+    recorder = ExternalApiRequestRecorder(settings.db_dsn(), schema=settings.db_schema)
+    try:
+        yield recorder
+    finally:
+        recorder.close()

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.config import Settings
-from uw_scan.storage.repository import Repository
+from uw_scan.storage.repository import Repository, provider_day_bounds
 
 router = APIRouter()
 
@@ -78,6 +78,17 @@ def health(
         else None
     )
     watchlist_size = repo.count_active_watchlist()
+    provider_day_start, provider_day_end = provider_day_bounds()
+    provider_usage = repo.get_external_api_usage_summary(
+        None, provider_day_start, provider_day_end
+    )
+    provider_fields = {
+        "latency_p95_ms": provider_usage.latency_p95_ms,
+        "http_2xx": provider_usage.http_2xx,
+        "http_4xx": provider_usage.http_4xx,
+        "http_5xx": provider_usage.http_5xx,
+        "uw_today": provider_usage.uw_latest_daily_count,
+    }
 
     last_scan = repo.get_last_full_scan_finished_at()
     if last_scan is None:
@@ -87,6 +98,7 @@ def health(
             reason="no successful full scan yet",
             worker_lag_seconds=worker_lag,
             watchlist_size=watchlist_size,
+            **provider_fields,
         )
 
     lag = (datetime.now(timezone.utc) - last_scan).total_seconds()
@@ -102,6 +114,7 @@ def health(
             reason=f"scheduler lag {lag:.0f}s exceeds 2x interval ({threshold:.0f}s)",
             worker_lag_seconds=worker_lag,
             watchlist_size=watchlist_size,
+            **provider_fields,
         )
 
     return HealthResponse(
@@ -111,4 +124,5 @@ def health(
         last_full_scan_at=last_scan,
         worker_lag_seconds=worker_lag,
         watchlist_size=watchlist_size,
+        **provider_fields,
     )

--- a/src/uw_scan/api/routers/provider_usage.py
+++ b/src/uw_scan/api/routers/provider_usage.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from uw_scan.api.deps import get_repo
+from uw_scan.storage.repository import Repository, provider_day_bounds
+
+router = APIRouter()
+
+ProviderParam = Literal["uw", "massive", "all"]
+StatusFamilyParam = Literal["2xx", "3xx", "4xx", "5xx", "transport_error"]
+
+
+class ProviderUsageSummaryResponse(BaseModel):
+    provider_day_start: datetime
+    provider_day_end: datetime
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+    uw_latest_daily_count: int | None
+    uw_latest_daily_limit: int | None
+
+
+class ProviderUsageBreakdownRow(BaseModel):
+    key: str | None
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+
+
+class ProviderUsageBreakdownResponse(BaseModel):
+    provider_day_start: datetime
+    provider_day_end: datetime
+    rows: list[ProviderUsageBreakdownRow]
+
+
+class ProviderUsageRequestRow(BaseModel):
+    request_id: int
+    provider: str
+    endpoint_key: str
+    method: str
+    path: str
+    ticker: str | None
+    params: dict[str, object]
+    status_code: int | None
+    status_family: str
+    request_started_at: datetime
+    request_finished_at: datetime
+    latency_ms: int
+    attempt: int
+    run_id: int | None
+    job_name: str | None
+    provider_request_id: str | None
+    official_daily_count: int | None
+    official_daily_limit: int | None
+    official_minute_remaining: int | None
+    official_minute_reset: str | None
+    error_message: str | None
+
+
+class ProviderUsageRequestsResponse(BaseModel):
+    provider_day_start: datetime
+    provider_day_end: datetime
+    limit: int
+    rows: list[ProviderUsageRequestRow]
+
+
+def _provider_filter(provider: ProviderParam) -> str | None:
+    return None if provider == "all" else provider
+
+
+@router.get(
+    "/provider-usage/summary",
+    response_model=ProviderUsageSummaryResponse,
+)
+def provider_usage_summary(
+    provider: ProviderParam = "all",
+    repo: Repository = Depends(get_repo),
+) -> ProviderUsageSummaryResponse:
+    start, end = provider_day_bounds()
+    summary = repo.get_external_api_usage_summary(_provider_filter(provider), start, end)
+    return ProviderUsageSummaryResponse(
+        provider_day_start=start,
+        provider_day_end=end,
+        total_requests=summary.total_requests,
+        http_2xx=summary.http_2xx,
+        http_3xx=summary.http_3xx,
+        http_4xx=summary.http_4xx,
+        http_5xx=summary.http_5xx,
+        transport_errors=summary.transport_errors,
+        latency_p95_ms=summary.latency_p95_ms,
+        uw_latest_daily_count=summary.uw_latest_daily_count,
+        uw_latest_daily_limit=summary.uw_latest_daily_limit,
+    )
+
+
+@router.get(
+    "/provider-usage/endpoints",
+    response_model=ProviderUsageBreakdownResponse,
+)
+def provider_usage_endpoints(
+    provider: ProviderParam = "all",
+    repo: Repository = Depends(get_repo),
+) -> ProviderUsageBreakdownResponse:
+    start, end = provider_day_bounds()
+    rows = repo.list_external_api_endpoint_usage(_provider_filter(provider), start, end)
+    return ProviderUsageBreakdownResponse(
+        provider_day_start=start,
+        provider_day_end=end,
+        rows=[ProviderUsageBreakdownRow(**row.__dict__) for row in rows],
+    )
+
+
+@router.get(
+    "/provider-usage/tickers",
+    response_model=ProviderUsageBreakdownResponse,
+)
+def provider_usage_tickers(
+    provider: ProviderParam = "all",
+    repo: Repository = Depends(get_repo),
+) -> ProviderUsageBreakdownResponse:
+    start, end = provider_day_bounds()
+    rows = repo.list_external_api_ticker_usage(_provider_filter(provider), start, end)
+    return ProviderUsageBreakdownResponse(
+        provider_day_start=start,
+        provider_day_end=end,
+        rows=[ProviderUsageBreakdownRow(**row.__dict__) for row in rows],
+    )
+
+
+@router.get(
+    "/provider-usage/requests",
+    response_model=ProviderUsageRequestsResponse,
+)
+def provider_usage_requests(
+    provider: ProviderParam = "all",
+    ticker: str | None = None,
+    status_family: StatusFamilyParam | None = None,
+    limit: Annotated[int, Query(ge=1)] = 100,
+    repo: Repository = Depends(get_repo),
+) -> ProviderUsageRequestsResponse:
+    start, end = provider_day_bounds()
+    rows = repo.list_external_api_requests(
+        provider=_provider_filter(provider),
+        start=start,
+        end=end,
+        ticker=ticker,
+        status_family=status_family,
+        limit=limit,
+    )
+    return ProviderUsageRequestsResponse(
+        provider_day_start=start,
+        provider_day_end=end,
+        limit=max(1, min(limit, 500)),
+        rows=[ProviderUsageRequestRow(**row.__dict__) for row in rows],
+    )

--- a/src/uw_scan/api/routers/volatility.py
+++ b/src/uw_scan/api/routers/volatility.py
@@ -16,6 +16,7 @@ from uw_scan.reports.volatility_series import (
     run_volatility_backfill,
 )
 from uw_scan.storage.repository import Repository
+from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -67,37 +68,42 @@ def _kick_backfill(ticker: str) -> None:
                 started_at=datetime.now(timezone.utc),
             )
             conn.commit()
-            with UwClient(
-                api_key=settings.api_key.get_secret_value(),
-                base_url=settings.base_url,
-                timeout=settings.request_timeout_seconds,
-            ) as client:
-                run_id = repo.latest_run_id(ticker)
-                if run_id == 0:
-                    run_id = repo.insert_scan_run(ticker, notes="volatility_backfill")
-                    conn.commit()
-                # Cache all expiries from today through Dec 31 of NEXT calendar
-                # year (full forward-vol curve through year-end+1), capped at
-                # 40 maturities to bound API + smile volume.
-                year_end = date(datetime.now(timezone.utc).year + 1, 12, 31)
-                term_rows = repo.fetch_iv_term_rows(run_id, ticker)
-                if term_rows:
-                    expiries = [
-                        r["expiry"].isoformat()
-                        for r in sorted(term_rows, key=lambda r: r["expiry"])
-                        if r["expiry"] <= year_end
-                    ][:40]
-                else:
-                    expiries = [
-                        d.isoformat() for d in _next_fridays(40) if d <= year_end
-                    ]
-                status = run_volatility_backfill(
-                    client=client,
-                    repo=repo,
-                    run_id=run_id,
-                    ticker=ticker,
-                    nearest_expiries=expiries,
-                )
+            with ExternalApiRequestRecorder(
+                settings.db_dsn(), schema=settings.db_schema
+            ) as recorder:
+                with UwClient(
+                    api_key=settings.api_key.get_secret_value(),
+                    base_url=settings.base_url,
+                    timeout=settings.request_timeout_seconds,
+                    telemetry_recorder=recorder,
+                    job_name="volatility_backfill",
+                ) as client:
+                    run_id = repo.latest_run_id(ticker)
+                    if run_id == 0:
+                        run_id = repo.insert_scan_run(ticker, notes="volatility_backfill")
+                        conn.commit()
+                    # Cache all expiries from today through Dec 31 of NEXT calendar
+                    # year (full forward-vol curve through year-end+1), capped at
+                    # 40 maturities to bound API + smile volume.
+                    year_end = date(datetime.now(timezone.utc).year + 1, 12, 31)
+                    term_rows = repo.fetch_iv_term_rows(run_id, ticker)
+                    if term_rows:
+                        expiries = [
+                            r["expiry"].isoformat()
+                            for r in sorted(term_rows, key=lambda r: r["expiry"])
+                            if r["expiry"] <= year_end
+                        ][:40]
+                    else:
+                        expiries = [
+                            d.isoformat() for d in _next_fridays(40) if d <= year_end
+                        ]
+                    status = run_volatility_backfill(
+                        client=client,
+                        repo=repo,
+                        run_id=run_id,
+                        ticker=ticker,
+                        nearest_expiries=expiries,
+                    )
             repo.upsert_volatility_backfill_status(
                 ticker=ticker,
                 status=status,

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from uw_scan.api.routers import health, jobs, ohlc, stock, trade_insights, volatility, watchlist
+from uw_scan.api.routers import (
+    health,
+    jobs,
+    ohlc,
+    provider_usage,
+    stock,
+    trade_insights,
+    volatility,
+    watchlist,
+)
 
 
 def create_app() -> FastAPI:
@@ -25,6 +34,7 @@ def create_app() -> FastAPI:
     app.include_router(ohlc.router, prefix="/api", tags=["ohlc"])
     app.include_router(jobs.router, prefix="/api", tags=["jobs"])
     app.include_router(volatility.router, prefix="/api", tags=["volatility"])
+    app.include_router(provider_usage.router, prefix="/api", tags=["provider-usage"])
     app.include_router(trade_insights.router, prefix="/api", tags=["trade-insights"])
     return app
 

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -29,6 +29,7 @@ from .reports.trade_insights import (
 from .scan_universe import S2_UNIVERSE
 from .sources import uw as uw_sources
 from .storage.repository import Repository
+from .storage.provider_usage import ExternalApiRequestRecorder
 
 logger = logging.getLogger(__name__)
 
@@ -442,11 +443,16 @@ def run_single_stock_for_ticker_via_env(ticker: str) -> SingleStockReport:
     conn = psycopg.connect(settings.db_dsn())
     try:
         repo = Repository(conn, schema=settings.db_schema)
-        with UwClient(
-            api_key=settings.api_key.get_secret_value(),
-            base_url=settings.base_url,
-            timeout=settings.request_timeout_seconds,
-        ) as client:
-            return run_single_stock(ticker, client, repo)
+        with ExternalApiRequestRecorder(
+            settings.db_dsn(), schema=settings.db_schema
+        ) as recorder:
+            with UwClient(
+                api_key=settings.api_key.get_secret_value(),
+                base_url=settings.base_url,
+                timeout=settings.request_timeout_seconds,
+                telemetry_recorder=recorder,
+                job_name="run_single_stock_via_env",
+            ) as client:
+                return run_single_stock(ticker, client, repo)
     finally:
         conn.close()

--- a/src/uw_scan/sources/ohlc.py
+++ b/src/uw_scan/sources/ohlc.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Protocol
+from typing import Any, Protocol
 
 import httpx
+
+from uw_scan.storage.provider_usage import ExternalApiRequestEvent
+from uw_scan.storage.repository import redact_params, status_family_for
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +60,16 @@ class MassiveOhlcProvider:
         api_key: str,
         base_url: str = "https://api.massive.com",
         timeout: float = 10.0,
+        telemetry_recorder: object | None = None,
+        job_name: str | None = None,
     ) -> None:
         self._client = httpx.Client(
             base_url=base_url,
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=timeout,
         )
+        self._telemetry_recorder = telemetry_recorder
+        self._job_name = job_name
 
     def close(self) -> None:
         self._client.close()
@@ -78,7 +85,12 @@ class MassiveOhlcProvider:
             f"/v2/aggs/ticker/{ticker}/range/1/day/"
             f"{start.isoformat()}/{end.isoformat()}"
         )
-        r = self._client.get(path)
+        r = self._get_with_telemetry(
+            endpoint_key="daily_ohlc",
+            path_template="/v2/aggs/ticker/{ticker}/range/1/day/{from}/{to}",
+            path=path,
+            ticker=ticker,
+        )
         r.raise_for_status()
         payload = r.json()
         results = payload.get("results") or []
@@ -117,7 +129,13 @@ class MassiveOhlcProvider:
             f"/v2/aggs/ticker/{ticker}/range/1/minute/"
             f"{today.isoformat()}/{tomorrow.isoformat()}"
         )
-        r = self._client.get(path, params={"sort": "desc", "limit": 1})
+        r = self._get_with_telemetry(
+            endpoint_key="intraday_quote",
+            path_template="/v2/aggs/ticker/{ticker}/range/1/minute/{from}/{to}",
+            path=path,
+            ticker=ticker,
+            params={"sort": "desc", "limit": 1},
+        )
         if r.status_code == 404:
             return None
         r.raise_for_status()
@@ -135,3 +153,99 @@ class MassiveOhlcProvider:
             price=Decimal(str(c)),
             quoted_at=datetime.fromtimestamp(int(t_ms) / 1000, tz=timezone.utc),
         )
+
+    def _get_with_telemetry(
+        self,
+        *,
+        endpoint_key: str,
+        path_template: str,
+        path: str,
+        ticker: str,
+        params: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        started_at = datetime.now(UTC)
+        try:
+            response = self._client.get(path, params=params)
+        except httpx.HTTPError as exc:
+            finished_at = datetime.now(UTC)
+            self._record_request(
+                endpoint_key=endpoint_key,
+                path_template=path_template,
+                path=path,
+                ticker=ticker,
+                params=params,
+                status_code=None,
+                started_at=started_at,
+                finished_at=finished_at,
+                provider_request_id=None,
+                error_message=str(exc),
+            )
+            raise
+        finished_at = datetime.now(UTC)
+        provider_request_id = self._extract_request_id(response)
+        self._record_request(
+            endpoint_key=endpoint_key,
+            path_template=path_template,
+            path=path,
+            ticker=ticker,
+            params=params,
+            status_code=response.status_code,
+            started_at=started_at,
+            finished_at=finished_at,
+            provider_request_id=provider_request_id,
+            error_message=response.text if response.status_code >= 400 else None,
+        )
+        return response
+
+    def _record_request(
+        self,
+        *,
+        endpoint_key: str,
+        path_template: str,
+        path: str,
+        ticker: str,
+        params: dict[str, object] | None,
+        status_code: int | None,
+        started_at: datetime,
+        finished_at: datetime,
+        provider_request_id: str | None,
+        error_message: str | None,
+    ) -> None:
+        if self._telemetry_recorder is None:
+            return
+        event = ExternalApiRequestEvent(
+            provider="massive",
+            endpoint_key=endpoint_key,
+            method="GET",
+            path_template=path_template,
+            path=path,
+            ticker=ticker.upper(),
+            params=redact_params(params),
+            status_code=status_code,
+            status_family=status_family_for(status_code),
+            started_at=started_at,
+            finished_at=finished_at,
+            latency_ms=max(0, int((finished_at - started_at).total_seconds() * 1000)),
+            job_name=self._job_name,
+            provider_request_id=provider_request_id,
+            error_message=error_message[:1000] if error_message else None,
+        )
+        try:
+            self._telemetry_recorder.record(event)  # type: ignore[attr-defined]
+        except Exception as exc:
+            logger.exception(
+                "failed to emit Massive request telemetry for %s: %s",
+                endpoint_key,
+                repr(exc),
+            )
+
+    def _extract_request_id(self, response: httpx.Response) -> str | None:
+        try:
+            payload: Any = response.json()
+        except ValueError:
+            return None
+        if isinstance(payload, dict):
+            request_id = payload.get("request_id")
+            if request_id is not None:
+                return str(request_id)
+        return None

--- a/src/uw_scan/sources/ohlc.py
+++ b/src/uw_scan/sources/ohlc.py
@@ -242,7 +242,8 @@ class MassiveOhlcProvider:
     def _extract_request_id(self, response: httpx.Response) -> str | None:
         try:
             payload: Any = response.json()
-        except ValueError:
+        except ValueError as exc:
+            logger.debug("Massive response did not include JSON: %s", repr(exc))
             return None
         if isinstance(payload, dict):
             request_id = payload.get("request_id")

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -78,7 +78,7 @@ def _fetch_json(
 ) -> dict:
     path = build_path(slug, ticker)
     started = datetime.now(UTC)
-    resp, _hdrs = client.get(slug, ticker=ticker, params=params)
+    resp, _hdrs = client.get(slug, ticker=ticker, params=params, run_id=run_id)
     finished = datetime.now(UTC)
     body = resp.json()
     _persist_audit(

--- a/src/uw_scan/storage/migrations/019_external_api_requests.sql
+++ b/src/uw_scan/storage/migrations/019_external_api_requests.sql
@@ -1,0 +1,49 @@
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.external_api_requests (
+    request_id BIGSERIAL PRIMARY KEY,
+    provider TEXT NOT NULL,
+    endpoint_key TEXT NOT NULL,
+    method TEXT NOT NULL,
+    path_template TEXT,
+    path TEXT NOT NULL,
+    ticker TEXT,
+    params_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status_code INTEGER,
+    status_family TEXT NOT NULL,
+    request_started_at TIMESTAMPTZ NOT NULL,
+    request_finished_at TIMESTAMPTZ NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    attempt INTEGER NOT NULL DEFAULT 0,
+    run_id BIGINT REFERENCES uw_scan.scan_runs(run_id) ON DELETE SET NULL,
+    job_name TEXT,
+    provider_request_id TEXT,
+    official_daily_count INTEGER,
+    official_daily_limit INTEGER,
+    official_minute_remaining INTEGER,
+    official_minute_reset TEXT,
+    error_message TEXT,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT external_api_requests_provider_check
+        CHECK (provider IN ('uw', 'massive')),
+    CONSTRAINT external_api_requests_method_check
+        CHECK (method IN ('GET')),
+    CONSTRAINT external_api_requests_status_family_check
+        CHECK (status_family IN ('2xx', '3xx', '4xx', '5xx', 'transport_error')),
+    CONSTRAINT external_api_requests_latency_nonnegative_check
+        CHECK (latency_ms >= 0),
+    CONSTRAINT external_api_requests_attempt_nonnegative_check
+        CHECK (attempt >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_started_idx
+    ON uw_scan.external_api_requests (provider, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_ticker_started_idx
+    ON uw_scan.external_api_requests (provider, ticker, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_endpoint_started_idx
+    ON uw_scan.external_api_requests (provider, endpoint_key, request_started_at DESC);
+
+CREATE INDEX IF NOT EXISTS external_api_requests_provider_status_started_idx
+    ON uw_scan.external_api_requests (provider, status_family, request_started_at DESC);

--- a/src/uw_scan/storage/provider_usage.py
+++ b/src/uw_scan/storage/provider_usage.py
@@ -1,0 +1,91 @@
+"""Durable external provider request telemetry recording."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import psycopg
+
+from uw_scan.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExternalApiRequestEvent:
+    provider: str
+    endpoint_key: str
+    method: str
+    path: str
+    status_family: str
+    started_at: datetime
+    finished_at: datetime
+    latency_ms: int
+    path_template: str | None = None
+    ticker: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    status_code: int | None = None
+    attempt: int = 0
+    run_id: int | None = None
+    job_name: str | None = None
+    provider_request_id: str | None = None
+    official_daily_count: int | None = None
+    official_daily_limit: int | None = None
+    official_minute_remaining: int | None = None
+    official_minute_reset: str | None = None
+    error_message: str | None = None
+
+
+class ExternalApiRequestRecorder:
+    """Write request telemetry outside scan transactions.
+
+    The recorder owns an autocommit connection so provider telemetry survives
+    rollbacks in the main scan/pipeline connection.
+    """
+
+    def __init__(self, dsn: str, *, schema: str = "uw_scan") -> None:
+        self._conn = psycopg.connect(dsn, autocommit=True)
+        self._repo = Repository(self._conn, schema=schema)
+
+    def record(self, event: ExternalApiRequestEvent) -> None:
+        try:
+            self._repo.insert_external_api_request(
+                provider=event.provider,
+                endpoint_key=event.endpoint_key,
+                method=event.method,
+                path_template=event.path_template,
+                path=event.path,
+                ticker=event.ticker,
+                params=event.params,
+                status_code=event.status_code,
+                status_family=event.status_family,
+                started_at=event.started_at,
+                finished_at=event.finished_at,
+                latency_ms=event.latency_ms,
+                attempt=event.attempt,
+                run_id=event.run_id,
+                job_name=event.job_name,
+                provider_request_id=event.provider_request_id,
+                official_daily_count=event.official_daily_count,
+                official_daily_limit=event.official_daily_limit,
+                official_minute_remaining=event.official_minute_remaining,
+                official_minute_reset=event.official_minute_reset,
+                error_message=event.error_message,
+            )
+        except Exception as exc:
+            logger.exception(
+                "failed to record external API request telemetry: %s",
+                repr(exc),
+            )
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "ExternalApiRequestRecorder":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -9,9 +9,10 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date as _date
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import psycopg
 from psycopg.types.json import Jsonb
@@ -71,6 +72,56 @@ class JobRow:
     finished_at: datetime | None
 
 
+@dataclass(frozen=True)
+class ExternalApiUsageSummary:
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+    uw_latest_daily_count: int | None
+    uw_latest_daily_limit: int | None
+
+
+@dataclass(frozen=True)
+class ExternalApiBreakdownRow:
+    key: str | None
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+
+
+@dataclass(frozen=True)
+class ExternalApiRequestRow:
+    request_id: int
+    provider: str
+    endpoint_key: str
+    method: str
+    path: str
+    ticker: str | None
+    params: dict[str, Any]
+    status_code: int | None
+    status_family: str
+    request_started_at: datetime
+    request_finished_at: datetime
+    latency_ms: int
+    attempt: int
+    run_id: int | None
+    job_name: str | None
+    provider_request_id: str | None
+    official_daily_count: int | None
+    official_daily_limit: int | None
+    official_minute_remaining: int | None
+    official_minute_reset: str | None
+    error_message: str | None
+
+
 class WatchlistCardRow:
     """Variable-shaped: 25+ fields, many nullable. Wraps a dict for forward-compat
     when the card schema grows. Use .from_db(row, cursor.description) to construct."""
@@ -96,11 +147,64 @@ class WatchlistCardRow:
 
 
 logger = logging.getLogger(__name__)
+_PROVIDER_DAY_TZ = ZoneInfo("America/New_York")
+_REDACTED_PARAM_KEYS = {
+    "apikey",
+    "api_key",
+    "authorization",
+    "auth",
+    "token",
+}
 
 
 def _d(value: Decimal | None) -> Any:
     """psycopg handles Decimal natively; keep this for symmetry with other casters."""
     return value
+
+
+def provider_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
+    current = now or datetime.now(tz=_PROVIDER_DAY_TZ)
+    local = current.astimezone(_PROVIDER_DAY_TZ)
+    reset = local.replace(hour=20, minute=0, second=0, microsecond=0)
+    if local < reset:
+        reset -= timedelta(days=1)
+    return reset, reset + timedelta(days=1)
+
+
+def status_family_for(
+    status_code: int | None, *, transport_error: bool = False
+) -> str:
+    if transport_error:
+        return "transport_error"
+    if status_code is None:
+        return "transport_error"
+    if 200 <= status_code <= 299:
+        return "2xx"
+    if 300 <= status_code <= 399:
+        return "3xx"
+    if 400 <= status_code <= 499:
+        return "4xx"
+    if 500 <= status_code <= 599:
+        return "5xx"
+    return "transport_error"
+
+
+def redact_params(params: dict[str, object] | None) -> dict[str, object]:
+    redacted: dict[str, object] = {}
+    for key, value in (params or {}).items():
+        if key.lower() in _REDACTED_PARAM_KEYS:
+            continue
+        if isinstance(value, str) and len(value) > 256:
+            redacted[key] = value[:253] + "..."
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _nullable_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(round(float(value)))
 
 
 class Repository:
@@ -230,6 +334,249 @@ class Repository:
             row = cur.fetchone()
         assert row is not None
         return int(row[0])
+
+    # ------------------------------------------------------------------
+    # external_api_requests
+    # ------------------------------------------------------------------
+    def insert_external_api_request(
+        self,
+        *,
+        provider: str,
+        endpoint_key: str,
+        method: str,
+        path_template: str | None = None,
+        path: str,
+        ticker: str | None = None,
+        params: dict[str, Any] | None = None,
+        status_code: int | None = None,
+        status_family: str,
+        started_at: datetime,
+        finished_at: datetime,
+        latency_ms: int,
+        attempt: int = 0,
+        run_id: int | None = None,
+        job_name: str | None = None,
+        provider_request_id: str | None = None,
+        official_daily_count: int | None = None,
+        official_daily_limit: int | None = None,
+        official_minute_remaining: int | None = None,
+        official_minute_reset: str | None = None,
+        error_message: str | None = None,
+    ) -> int:
+        sql = (
+            f"INSERT INTO {self._schema}.external_api_requests ("
+            "provider, endpoint_key, method, path_template, path, ticker, "
+            "params_json, status_code, status_family, request_started_at, "
+            "request_finished_at, latency_ms, attempt, run_id, job_name, "
+            "provider_request_id, official_daily_count, official_daily_limit, "
+            "official_minute_remaining, official_minute_reset, error_message) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, "
+            "%s, %s, %s, %s, %s, %s, %s) RETURNING request_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    provider,
+                    endpoint_key,
+                    method,
+                    path_template,
+                    path,
+                    ticker.upper() if ticker else None,
+                    Jsonb(params or {}),
+                    status_code,
+                    status_family,
+                    started_at,
+                    finished_at,
+                    latency_ms,
+                    attempt,
+                    run_id,
+                    job_name,
+                    provider_request_id,
+                    official_daily_count,
+                    official_daily_limit,
+                    official_minute_remaining,
+                    official_minute_reset,
+                    error_message,
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def get_external_api_usage_summary(
+        self, provider: str | None, start: datetime, end: datetime
+    ) -> ExternalApiUsageSummary:
+        provider_filter = None if provider in (None, "all") else provider
+        sql = (
+            "WITH scoped AS ("
+            f"SELECT * FROM {self._schema}.external_api_requests "
+            "WHERE request_started_at >= %s "
+            "  AND request_started_at < %s "
+            "  AND (%s::text IS NULL OR provider = %s)"
+            "), latest_uw AS ("
+            "SELECT official_daily_count, official_daily_limit "
+            "FROM scoped "
+            "WHERE provider = 'uw' "
+            "  AND official_daily_count IS NOT NULL "
+            "ORDER BY request_started_at DESC, request_id DESC "
+            "LIMIT 1"
+            ") "
+            "SELECT "
+            "COUNT(*)::int AS total_requests, "
+            "COUNT(*) FILTER (WHERE status_family = '2xx')::int AS http_2xx, "
+            "COUNT(*) FILTER (WHERE status_family = '3xx')::int AS http_3xx, "
+            "COUNT(*) FILTER (WHERE status_family = '4xx')::int AS http_4xx, "
+            "COUNT(*) FILTER (WHERE status_family = '5xx')::int AS http_5xx, "
+            "COUNT(*) FILTER (WHERE status_family = 'transport_error')::int "
+            "    AS transport_errors, "
+            "percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) "
+            "    AS latency_p95_ms, "
+            "(SELECT official_daily_count FROM latest_uw) AS uw_latest_daily_count, "
+            "(SELECT official_daily_limit FROM latest_uw) AS uw_latest_daily_limit "
+            "FROM scoped"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (start, end, provider_filter, provider_filter))
+            row = cur.fetchone()
+        assert row is not None
+        return ExternalApiUsageSummary(
+            total_requests=int(row[0]),
+            http_2xx=int(row[1]),
+            http_3xx=int(row[2]),
+            http_4xx=int(row[3]),
+            http_5xx=int(row[4]),
+            transport_errors=int(row[5]),
+            latency_p95_ms=_nullable_int(row[6]),
+            uw_latest_daily_count=row[7],
+            uw_latest_daily_limit=row[8],
+        )
+
+    def list_external_api_endpoint_usage(
+        self, provider: str | None, start: datetime, end: datetime
+    ) -> list[ExternalApiBreakdownRow]:
+        return self._list_external_api_breakdown(
+            "endpoint_key", provider=provider, start=start, end=end
+        )
+
+    def list_external_api_ticker_usage(
+        self, provider: str | None, start: datetime, end: datetime
+    ) -> list[ExternalApiBreakdownRow]:
+        return self._list_external_api_breakdown(
+            "ticker", provider=provider, start=start, end=end
+        )
+
+    def _list_external_api_breakdown(
+        self, column: str, *, provider: str | None, start: datetime, end: datetime
+    ) -> list[ExternalApiBreakdownRow]:
+        if column not in {"endpoint_key", "ticker"}:
+            raise ValueError(f"unsupported external API breakdown: {column}")
+        provider_filter = None if provider in (None, "all") else provider
+        sql = (
+            f"SELECT {column} AS key, "
+            "COUNT(*)::int AS total_requests, "
+            "COUNT(*) FILTER (WHERE status_family = '2xx')::int AS http_2xx, "
+            "COUNT(*) FILTER (WHERE status_family = '3xx')::int AS http_3xx, "
+            "COUNT(*) FILTER (WHERE status_family = '4xx')::int AS http_4xx, "
+            "COUNT(*) FILTER (WHERE status_family = '5xx')::int AS http_5xx, "
+            "COUNT(*) FILTER (WHERE status_family = 'transport_error')::int "
+            "    AS transport_errors, "
+            "percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_ms) "
+            "    AS latency_p95_ms "
+            f"FROM {self._schema}.external_api_requests "
+            "WHERE request_started_at >= %s "
+            "  AND request_started_at < %s "
+            "  AND (%s::text IS NULL OR provider = %s) "
+            f"GROUP BY {column} "
+            "ORDER BY total_requests DESC, key ASC NULLS LAST"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (start, end, provider_filter, provider_filter))
+            rows = cur.fetchall()
+        return [
+            ExternalApiBreakdownRow(
+                key=row[0],
+                total_requests=int(row[1]),
+                http_2xx=int(row[2]),
+                http_3xx=int(row[3]),
+                http_4xx=int(row[4]),
+                http_5xx=int(row[5]),
+                transport_errors=int(row[6]),
+                latency_p95_ms=_nullable_int(row[7]),
+            )
+            for row in rows
+        ]
+
+    def list_external_api_requests(
+        self,
+        *,
+        provider: str | None,
+        start: datetime,
+        end: datetime,
+        ticker: str | None = None,
+        status_family: str | None = None,
+        limit: int = 100,
+    ) -> list[ExternalApiRequestRow]:
+        provider_filter = None if provider in (None, "all") else provider
+        ticker_filter = ticker.upper() if ticker else None
+        bounded_limit = max(1, min(limit, 500))
+        sql = (
+            "SELECT request_id, provider, endpoint_key, method, path, ticker, "
+            "params_json, status_code, status_family, request_started_at, "
+            "request_finished_at, latency_ms, attempt, run_id, job_name, "
+            "provider_request_id, official_daily_count, official_daily_limit, "
+            "official_minute_remaining, official_minute_reset, error_message "
+            f"FROM {self._schema}.external_api_requests "
+            "WHERE request_started_at >= %s "
+            "  AND request_started_at < %s "
+            "  AND (%s::text IS NULL OR provider = %s) "
+            "  AND (%s::text IS NULL OR ticker = %s) "
+            "  AND (%s::text IS NULL OR status_family = %s) "
+            "ORDER BY request_started_at DESC, request_id DESC "
+            "LIMIT %s"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    start,
+                    end,
+                    provider_filter,
+                    provider_filter,
+                    ticker_filter,
+                    ticker_filter,
+                    status_family,
+                    status_family,
+                    bounded_limit,
+                ),
+            )
+            rows = cur.fetchall()
+        return [
+            ExternalApiRequestRow(
+                request_id=int(row[0]),
+                provider=row[1],
+                endpoint_key=row[2],
+                method=row[3],
+                path=row[4],
+                ticker=row[5],
+                params=dict(row[6]),
+                status_code=row[7],
+                status_family=row[8],
+                request_started_at=row[9],
+                request_finished_at=row[10],
+                latency_ms=int(row[11]),
+                attempt=int(row[12]),
+                run_id=row[13],
+                job_name=row[14],
+                provider_request_id=row[15],
+                official_daily_count=row[16],
+                official_daily_limit=row[17],
+                official_minute_remaining=row[18],
+                official_minute_reset=row[19],
+                error_message=row[20],
+            )
+            for row in rows
+        ]
 
     # ------------------------------------------------------------------
     # flow_events

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -19,6 +19,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from uw_scan.api.client import UwClient
 from uw_scan.config import Settings
 from uw_scan.sources.ohlc import MassiveOhlcProvider
+from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.flow_data_refresh import flow_data_refresh
 from uw_scan.worker.jobs.full_scan import full_scan_once
@@ -58,21 +59,44 @@ def _repo(settings: Settings) -> Iterator[Repository]:
         conn.close()
 
 
-def _uw_client(settings: Settings) -> UwClient:
+@contextmanager
+def _external_api_recorder(settings: Settings) -> Iterator[ExternalApiRequestRecorder]:
+    recorder = ExternalApiRequestRecorder(settings.db_dsn(), schema=settings.db_schema)
+    try:
+        yield recorder
+    finally:
+        recorder.close()
+
+
+def _uw_client(
+    settings: Settings,
+    *,
+    telemetry_recorder: ExternalApiRequestRecorder | None = None,
+    job_name: str | None = None,
+) -> UwClient:
     return UwClient(
         api_key=settings.api_key.get_secret_value(),
         base_url=settings.base_url,
         timeout=settings.request_timeout_seconds,
+        telemetry_recorder=telemetry_recorder,
+        job_name=job_name,
     )
 
 
-def _ohlc_provider(settings: Settings) -> MassiveOhlcProvider | None:
+def _ohlc_provider(
+    settings: Settings,
+    *,
+    telemetry_recorder: ExternalApiRequestRecorder | None = None,
+    job_name: str | None = None,
+) -> MassiveOhlcProvider | None:
     if settings.massive_api_key is None:
         logger.warning("MASSIVE_API_KEY not set; OHLC jobs are no-ops")
         return None
     return MassiveOhlcProvider(
         api_key=settings.massive_api_key.get_secret_value(),
         base_url=settings.massive_base_url,
+        telemetry_recorder=telemetry_recorder,
+        job_name=job_name,
     )
 
 
@@ -105,65 +129,96 @@ def main() -> int:
         if market_date is None:
             logger.debug("spot_refresh skipped outside market hours")
             return
-        provider = _ohlc_provider(settings)
-        if provider is None:
-            return
-        try:
-            with _repo(settings) as repo:
-                n = spot_refresh_once(repo, provider, market_date=market_date)
-                logger.info("spot_refresh updated %d cards", n)
-        finally:
-            provider.close()
+        with _external_api_recorder(settings) as recorder:
+            provider = _ohlc_provider(
+                settings, telemetry_recorder=recorder, job_name="spot_refresh"
+            )
+            if provider is None:
+                return
+            try:
+                with _repo(settings) as repo:
+                    n = spot_refresh_once(repo, provider, market_date=market_date)
+                    logger.info("spot_refresh updated %d cards", n)
+            finally:
+                provider.close()
 
     def _full_scan() -> None:
-        with _uw_client(settings) as uw:
-            ohlc = _ohlc_provider(settings) or _NoOhlc()
-            try:
-                with _repo(settings) as repo:
-                    n = full_scan_once(repo, uw, ohlc)
-                    logger.info("full_scan completed %d tickers", n)
-            finally:
-                ohlc.close()
+        with _external_api_recorder(settings) as recorder:
+            with _uw_client(
+                settings, telemetry_recorder=recorder, job_name="full_scan"
+            ) as uw:
+                ohlc = (
+                    _ohlc_provider(
+                        settings,
+                        telemetry_recorder=recorder,
+                        job_name="full_scan",
+                    )
+                    or _NoOhlc()
+                )
+                try:
+                    with _repo(settings) as repo:
+                        n = full_scan_once(repo, uw, ohlc)
+                        logger.info("full_scan completed %d tickers", n)
+                finally:
+                    ohlc.close()
 
     def _ohlc_pull() -> None:
-        provider = _ohlc_provider(settings)
-        if provider is None:
-            return
-        try:
-            with _repo(settings) as repo:
-                n = ohlc_pull_once(repo, provider)
-                logger.info("ohlc_pull refreshed %d tickers", n)
-        finally:
-            provider.close()
-
-    def _rescan() -> None:
-        with _uw_client(settings) as uw:
-            ohlc = _ohlc_provider(settings) or _NoOhlc()
+        with _external_api_recorder(settings) as recorder:
+            provider = _ohlc_provider(
+                settings, telemetry_recorder=recorder, job_name="ohlc_pull"
+            )
+            if provider is None:
+                return
             try:
                 with _repo(settings) as repo:
-                    rescan_tick(repo, uw, ohlc)
+                    n = ohlc_pull_once(repo, provider)
+                    logger.info("ohlc_pull refreshed %d tickers", n)
             finally:
-                ohlc.close()
+                provider.close()
+
+    def _rescan() -> None:
+        with _external_api_recorder(settings) as recorder:
+            with _uw_client(
+                settings, telemetry_recorder=recorder, job_name="rescan_tick"
+            ) as uw:
+                ohlc = (
+                    _ohlc_provider(
+                        settings,
+                        telemetry_recorder=recorder,
+                        job_name="rescan_tick",
+                    )
+                    or _NoOhlc()
+                )
+                try:
+                    with _repo(settings) as repo:
+                        rescan_tick(repo, uw, ohlc)
+                finally:
+                    ohlc.close()
 
     def _spy_ohlc_refresh() -> None:
         if settings.massive_api_key is None:
             logger.warning("MASSIVE_API_KEY not set; skipping SPY refresh")
             return
-        with _repo(settings) as repo:
-            daily_spy_ohlc_refresh(
-                repo=repo,
-                api_key=settings.massive_api_key.get_secret_value(),
-                tz=settings.rth_tz,
-            )
+        with _external_api_recorder(settings) as recorder:
+            with _repo(settings) as repo:
+                daily_spy_ohlc_refresh(
+                    repo=repo,
+                    api_key=settings.massive_api_key.get_secret_value(),
+                    tz=settings.rth_tz,
+                    telemetry_recorder=recorder,
+                )
 
     def _vol_analytics_rollup() -> None:
         with _repo(settings) as repo:
             nightly_vol_analytics_rollup(repo=repo)
 
     def _flow_data_refresh() -> None:
-        with _uw_client(settings) as uw:
-            with _repo(settings) as repo:
-                flow_data_refresh(repo=repo, client=uw, settings=settings)
+        with _external_api_recorder(settings) as recorder:
+            with _uw_client(
+                settings, telemetry_recorder=recorder, job_name="flow_data_refresh"
+            ) as uw:
+                with _repo(settings) as repo:
+                    flow_data_refresh(repo=repo, client=uw, settings=settings)
 
     def _trade_insights_ai_tick() -> None:
         trade_insights_ai_tick(settings)

--- a/src/uw_scan/worker/volatility_jobs.py
+++ b/src/uw_scan/worker/volatility_jobs.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 
 from uw_scan.cards import vol_series
 from uw_scan.sources.ohlc import MassiveOhlcProvider
+from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 from uw_scan.storage.repository import Repository
 
 log = logging.getLogger(__name__)
@@ -24,12 +25,17 @@ def daily_spy_ohlc_refresh(
     repo: Repository,
     api_key: str,
     tz: str = "America/New_York",
+    telemetry_recorder: ExternalApiRequestRecorder | None = None,
 ) -> None:
     """ET-anchored — host may live in any timezone (e.g. HKT), so date.today()
     would compute the wrong market date around the rollover (review I8)."""
     today = datetime.now(ZoneInfo(tz)).date()
     start = today - timedelta(days=2)
-    with MassiveOhlcProvider(api_key=api_key) as prov:
+    with MassiveOhlcProvider(
+        api_key=api_key,
+        telemetry_recorder=telemetry_recorder,
+        job_name="daily_spy_ohlc_refresh",
+    ) as prov:
         bars = prov.fetch_daily("SPY", start=start, end=today)
     repo.upsert_index_ohlc_rows(bars)
     repo.conn.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import os
+
+
+def pytest_configure() -> None:
+    # Local safety default: integration fixtures still point at an isolated DB,
+    # but developers do not need to prefix every pytest command.
+    os.environ.setdefault("UW_SCAN_TEST_DB_NAME", "option_wizard_test")

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -2402,6 +2402,401 @@
         "title": "PositioningBlock",
         "type": "object"
       },
+      "ProviderUsageBreakdownResponse": {
+        "properties": {
+          "provider_day_end": {
+            "format": "date-time",
+            "title": "Provider Day End",
+            "type": "string"
+          },
+          "provider_day_start": {
+            "format": "date-time",
+            "title": "Provider Day Start",
+            "type": "string"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderUsageBreakdownRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "provider_day_start",
+          "provider_day_end",
+          "rows"
+        ],
+        "title": "ProviderUsageBreakdownResponse",
+        "type": "object"
+      },
+      "ProviderUsageBreakdownRow": {
+        "properties": {
+          "http_2xx": {
+            "title": "Http 2Xx",
+            "type": "integer"
+          },
+          "http_3xx": {
+            "title": "Http 3Xx",
+            "type": "integer"
+          },
+          "http_4xx": {
+            "title": "Http 4Xx",
+            "type": "integer"
+          },
+          "http_5xx": {
+            "title": "Http 5Xx",
+            "type": "integer"
+          },
+          "key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key"
+          },
+          "latency_p95_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency P95 Ms"
+          },
+          "total_requests": {
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "transport_errors": {
+            "title": "Transport Errors",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "key",
+          "total_requests",
+          "http_2xx",
+          "http_3xx",
+          "http_4xx",
+          "http_5xx",
+          "transport_errors",
+          "latency_p95_ms"
+        ],
+        "title": "ProviderUsageBreakdownRow",
+        "type": "object"
+      },
+      "ProviderUsageRequestRow": {
+        "properties": {
+          "attempt": {
+            "title": "Attempt",
+            "type": "integer"
+          },
+          "endpoint_key": {
+            "title": "Endpoint Key",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "job_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Name"
+          },
+          "latency_ms": {
+            "title": "Latency Ms",
+            "type": "integer"
+          },
+          "method": {
+            "title": "Method",
+            "type": "string"
+          },
+          "official_daily_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Official Daily Count"
+          },
+          "official_daily_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Official Daily Limit"
+          },
+          "official_minute_remaining": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Official Minute Remaining"
+          },
+          "official_minute_reset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Official Minute Reset"
+          },
+          "params": {
+            "additionalProperties": true,
+            "title": "Params",
+            "type": "object"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "provider_request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Request Id"
+          },
+          "request_finished_at": {
+            "format": "date-time",
+            "title": "Request Finished At",
+            "type": "string"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "integer"
+          },
+          "request_started_at": {
+            "format": "date-time",
+            "title": "Request Started At",
+            "type": "string"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          },
+          "status_family": {
+            "title": "Status Family",
+            "type": "string"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          }
+        },
+        "required": [
+          "request_id",
+          "provider",
+          "endpoint_key",
+          "method",
+          "path",
+          "ticker",
+          "params",
+          "status_code",
+          "status_family",
+          "request_started_at",
+          "request_finished_at",
+          "latency_ms",
+          "attempt",
+          "run_id",
+          "job_name",
+          "provider_request_id",
+          "official_daily_count",
+          "official_daily_limit",
+          "official_minute_remaining",
+          "official_minute_reset",
+          "error_message"
+        ],
+        "title": "ProviderUsageRequestRow",
+        "type": "object"
+      },
+      "ProviderUsageRequestsResponse": {
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "provider_day_end": {
+            "format": "date-time",
+            "title": "Provider Day End",
+            "type": "string"
+          },
+          "provider_day_start": {
+            "format": "date-time",
+            "title": "Provider Day Start",
+            "type": "string"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderUsageRequestRow"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "provider_day_start",
+          "provider_day_end",
+          "limit",
+          "rows"
+        ],
+        "title": "ProviderUsageRequestsResponse",
+        "type": "object"
+      },
+      "ProviderUsageSummaryResponse": {
+        "properties": {
+          "http_2xx": {
+            "title": "Http 2Xx",
+            "type": "integer"
+          },
+          "http_3xx": {
+            "title": "Http 3Xx",
+            "type": "integer"
+          },
+          "http_4xx": {
+            "title": "Http 4Xx",
+            "type": "integer"
+          },
+          "http_5xx": {
+            "title": "Http 5Xx",
+            "type": "integer"
+          },
+          "latency_p95_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency P95 Ms"
+          },
+          "provider_day_end": {
+            "format": "date-time",
+            "title": "Provider Day End",
+            "type": "string"
+          },
+          "provider_day_start": {
+            "format": "date-time",
+            "title": "Provider Day Start",
+            "type": "string"
+          },
+          "total_requests": {
+            "title": "Total Requests",
+            "type": "integer"
+          },
+          "transport_errors": {
+            "title": "Transport Errors",
+            "type": "integer"
+          },
+          "uw_latest_daily_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uw Latest Daily Count"
+          },
+          "uw_latest_daily_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uw Latest Daily Limit"
+          }
+        },
+        "required": [
+          "provider_day_start",
+          "provider_day_end",
+          "total_requests",
+          "http_2xx",
+          "http_3xx",
+          "http_4xx",
+          "http_5xx",
+          "transport_errors",
+          "latency_p95_ms",
+          "uw_latest_daily_count",
+          "uw_latest_daily_limit"
+        ],
+        "title": "ProviderUsageSummaryResponse",
+        "type": "object"
+      },
       "RegimeQuadrantBlock": {
         "properties": {
           "cutoff_corr": {
@@ -5549,6 +5944,248 @@
         ]
       }
     },
+    "/api/provider-usage/endpoints": {
+      "get": {
+        "operationId": "provider_usage_endpoints_api_provider_usage_endpoints_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "uw",
+                "massive",
+                "all"
+              ],
+              "title": "Provider",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Provider Usage Endpoints",
+        "tags": [
+          "provider-usage"
+        ]
+      }
+    },
+    "/api/provider-usage/requests": {
+      "get": {
+        "operationId": "provider_usage_requests_api_provider_usage_requests_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "uw",
+                "massive",
+                "all"
+              ],
+              "title": "Provider",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ticker",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Ticker"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status_family",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "2xx",
+                    "3xx",
+                    "4xx",
+                    "5xx",
+                    "transport_error"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Family"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsageRequestsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Provider Usage Requests",
+        "tags": [
+          "provider-usage"
+        ]
+      }
+    },
+    "/api/provider-usage/summary": {
+      "get": {
+        "operationId": "provider_usage_summary_api_provider_usage_summary_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "uw",
+                "massive",
+                "all"
+              ],
+              "title": "Provider",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsageSummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Provider Usage Summary",
+        "tags": [
+          "provider-usage"
+        ]
+      }
+    },
+    "/api/provider-usage/tickers": {
+      "get": {
+        "operationId": "provider_usage_tickers_api_provider_usage_tickers_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "uw",
+                "massive",
+                "all"
+              ],
+              "title": "Provider",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Provider Usage Tickers",
+        "tags": [
+          "provider-usage"
+        ]
+      }
+    },
     "/api/stock/{ticker}": {
       "get": {
         "operationId": "get_stock_api_stock__ticker__get",
@@ -5901,6 +6538,7 @@
             "name": "analysis_id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "title": "Analysis Id",
               "type": "string"
             }

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 
 def test_health_ok_when_recent_scan(client, seeded_db_with_cards):
     r = client.get("/api/health")
@@ -11,6 +13,50 @@ def test_health_ok_when_recent_scan(client, seeded_db_with_cards):
     assert body["db"] == "up"
     assert body["scheduler_lag_seconds"] is not None
     assert body["last_full_scan_at"] is not None
+
+
+def test_health_includes_provider_usage_stats(client, seeded_db_empty_cards):
+    now = datetime.now(UTC)
+    seeded_db_empty_cards.insert_external_api_request(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=25,
+        official_daily_count=33,
+        official_daily_limit=1000,
+    )
+    seeded_db_empty_cards.insert_external_api_request(
+        provider="massive",
+        endpoint_key="daily_ohlc",
+        method="GET",
+        path="/v2/aggs/ticker/AAPL/range/1/day/2026-05-13/2026-05-14",
+        ticker="AAPL",
+        params={},
+        status_code=503,
+        status_family="5xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=25,
+    )
+    seeded_db_empty_cards.conn.commit()
+
+    r = client.get("/api/health")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert body["http_2xx"] == 1
+    assert body["http_4xx"] == 0
+    assert body["http_5xx"] == 1
+    assert body["latency_p95_ms"] == 25
+    assert body["uw_today"] == 33
 
 
 def test_health_unhealthy_when_no_scans(client, seeded_db_empty_cards):

--- a/tests/integration/api/test_provider_usage.py
+++ b/tests/integration/api/test_provider_usage.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _seed_provider_usage(repo):
+    for endpoint, ticker, status_code, status_family, latency in [
+        ("iv_rank", "TSLA", 200, "2xx", 20),
+        ("greek_exposure", "TSLA", 429, "4xx", 30),
+        ("daily_ohlc", "AAPL", 200, "2xx", 40),
+    ]:
+        provider = "massive" if endpoint == "daily_ohlc" else "uw"
+        repo.insert_external_api_request(
+            provider=provider,
+            endpoint_key=endpoint,
+            method="GET",
+            path=f"/example/{ticker}/{endpoint}",
+            ticker=ticker,
+            params={"ticker": ticker},
+            status_code=status_code,
+            status_family=status_family,
+            started_at=datetime(2026, 5, 14, 14, 0, tzinfo=UTC),
+            finished_at=datetime(2026, 5, 14, 14, 0, tzinfo=UTC),
+            latency_ms=latency,
+            official_daily_count=7 if provider == "uw" else None,
+            official_daily_limit=1000 if provider == "uw" else None,
+        )
+    repo.conn.commit()
+
+
+def test_provider_usage_summary_returns_provider_day_counts(client, seeded_db_empty_cards):
+    _seed_provider_usage(seeded_db_empty_cards)
+
+    response = client.get("/api/provider-usage/summary?provider=all")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["provider_day_start"].endswith("-04:00")
+    assert body["provider_day_end"].endswith("-04:00")
+    assert body["total_requests"] == 3
+    assert body["http_2xx"] == 2
+    assert body["http_4xx"] == 1
+    assert body["http_5xx"] == 0
+    assert body["uw_latest_daily_count"] == 7
+    assert body["uw_latest_daily_limit"] == 1000
+
+
+def test_provider_usage_breakdowns_group_by_endpoint_and_ticker(
+    client, seeded_db_empty_cards
+):
+    _seed_provider_usage(seeded_db_empty_cards)
+
+    endpoints = client.get("/api/provider-usage/endpoints?provider=uw")
+    tickers = client.get("/api/provider-usage/tickers?provider=uw")
+
+    assert endpoints.status_code == 200
+    assert {row["key"]: row["total_requests"] for row in endpoints.json()["rows"]} == {
+        "greek_exposure": 1,
+        "iv_rank": 1,
+    }
+    assert tickers.status_code == 200
+    assert tickers.json()["rows"] == [
+        {
+            "key": "TSLA",
+            "total_requests": 2,
+            "http_2xx": 1,
+            "http_3xx": 0,
+            "http_4xx": 1,
+            "http_5xx": 0,
+            "transport_errors": 0,
+            "latency_p95_ms": 30,
+        }
+    ]
+
+
+def test_provider_usage_requests_filters_and_bounds_limit(client, seeded_db_empty_cards):
+    _seed_provider_usage(seeded_db_empty_cards)
+
+    response = client.get(
+        "/api/provider-usage/requests"
+        "?provider=uw&ticker=TSLA&status_family=4xx&limit=999"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limit"] == 500
+    assert len(body["rows"]) == 1
+    assert body["rows"][0]["endpoint_key"] == "greek_exposure"
+    assert body["rows"][0]["params"] == {"ticker": "TSLA"}
+
+
+def test_provider_usage_rejects_invalid_provider(client, seeded_db_empty_cards):
+    response = client.get("/api/provider-usage/summary?provider=internal")
+
+    assert response.status_code == 422

--- a/tests/integration/api/test_volatility_endpoint.py
+++ b/tests/integration/api/test_volatility_endpoint.py
@@ -55,18 +55,28 @@ def test_volatility_series_endpoint_ready_when_fresh_history_present(
 
 
 def test_volatility_series_endpoint_kicks_off_backfill_when_history_thin(
-    client, seeded_db_empty_cards
+    client, seeded_db_empty_cards, monkeypatch
 ):
     """No history at all → backfill_status == 'running'."""
+    monkeypatch.setattr(
+        "uw_scan.api.routers.volatility._kick_backfill",
+        lambda _ticker: None,
+    )
     r = client.get("/api/stock/UNSEEDED/volatility/series")
     assert r.status_code == 200
     body = r.json()
     assert body["backfill_status"] == "running"
 
 
-def test_volatility_series_empty_response_shape_is_safe(client, seeded_db_empty_cards):
+def test_volatility_series_empty_response_shape_is_safe(
+    client, seeded_db_empty_cards, monkeypatch
+):
     """Even with zero history, response defaults are non-None blocks
     (frontend dereferences .points / .bins directly — review I5)."""
+    monkeypatch.setattr(
+        "uw_scan.api.routers.volatility._kick_backfill",
+        lambda _ticker: None,
+    )
     r = client.get("/api/stock/NEWTKR/volatility/series")
     body = r.json()
     # Empty defaults present, not None.

--- a/tests/integration/storage/test_migrations.py
+++ b/tests/integration/storage/test_migrations.py
@@ -74,6 +74,7 @@ def test_all_new_tables_exist(fresh_schema):
         "intraday_quote",
         "pcr_history",
         "jobs",
+        "external_api_requests",
     }
     with fresh_schema.cursor() as cur:
         cur.execute("SELECT tablename FROM pg_tables WHERE schemaname='uw_scan'")
@@ -241,3 +242,68 @@ def test_trade_insight_ai_analysis_schema(fresh_schema):
         assert "status = 'succeeded'" in indexes[
             "idx_trade_insight_ai_analyses_succeeded_reuse"
         ]
+
+
+def test_external_api_requests_schema(fresh_schema):
+    with fresh_schema.cursor() as cur:
+        cur.execute("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'uw_scan'
+              AND table_name = 'external_api_requests'
+        """)
+        columns = {row[0] for row in cur.fetchall()}
+        assert {
+            "request_id",
+            "provider",
+            "endpoint_key",
+            "method",
+            "path_template",
+            "path",
+            "ticker",
+            "params_json",
+            "status_code",
+            "status_family",
+            "request_started_at",
+            "request_finished_at",
+            "latency_ms",
+            "attempt",
+            "run_id",
+            "job_name",
+            "provider_request_id",
+            "official_daily_count",
+            "official_daily_limit",
+            "official_minute_remaining",
+            "official_minute_reset",
+            "error_message",
+            "inserted_at",
+        } <= columns
+
+        cur.execute("""
+            SELECT conname
+            FROM pg_constraint
+            WHERE conrelid = 'uw_scan.external_api_requests'::regclass
+              AND contype = 'c'
+        """)
+        constraints = {row[0] for row in cur.fetchall()}
+        assert {
+            "external_api_requests_provider_check",
+            "external_api_requests_method_check",
+            "external_api_requests_status_family_check",
+            "external_api_requests_latency_nonnegative_check",
+            "external_api_requests_attempt_nonnegative_check",
+        } <= constraints
+
+        cur.execute("""
+            SELECT indexname
+            FROM pg_indexes
+            WHERE schemaname = 'uw_scan'
+              AND tablename = 'external_api_requests'
+        """)
+        indexes = {row[0] for row in cur.fetchall()}
+        assert {
+            "external_api_requests_provider_started_idx",
+            "external_api_requests_provider_ticker_started_idx",
+            "external_api_requests_provider_endpoint_started_idx",
+            "external_api_requests_provider_status_started_idx",
+        } <= indexes

--- a/tests/integration/storage/test_provider_usage_client_instrumentation.py
+++ b/tests/integration/storage/test_provider_usage_client_instrumentation.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, date, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+import pytest
+
+from uw_scan.api.client import UwClient, UwHTTPError
+from uw_scan.api.endpoints import EndpointSlug
+from uw_scan.config import Settings
+from uw_scan.sources.ohlc import MassiveOhlcProvider
+from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
+from uw_scan.storage.repository import Repository
+
+
+class _ProviderStubHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_args: object) -> None:
+        return
+
+    def _json(
+        self,
+        status: int,
+        payload: dict[str, object],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        for key, value in (headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path == "/api/stock/TSLA/iv-rank":
+            self._json(200, {"ok": True}, _uw_headers(101))
+        elif path == "/api/stock/AAPL/iv-rank":
+            self._json(200, {"ok": True}, _uw_headers(102))
+        elif path == "/api/stock/TSLA/greek-exposure/strike-expiry":
+            self._json(429, {"error": "rate limited"}, _uw_headers(103))
+        elif path == "/api/stock/NVDA/volatility/stats":
+            self._json(503, {"error": "unavailable"}, _uw_headers(104))
+        elif path == "/v2/aggs/ticker/TSLA/range/1/day/2026-05-01/2026-05-02":
+            self._json(
+                200,
+                {
+                    "request_id": "massive-ok-1",
+                    "results": [{
+                        "t": 1777593600000,
+                        "o": 1,
+                        "h": 2,
+                        "l": 1,
+                        "c": 1.5,
+                        "v": 100,
+                    }],
+                },
+            )
+        elif path == "/v2/aggs/ticker/MSFT/range/1/day/2026-05-01/2026-05-02":
+            self._json(503, {"request_id": "massive-fail-1", "error": "maintenance"})
+        else:
+            self._json(404, {"error": "not found", "path": path})
+
+
+def _uw_headers(daily_count: int) -> dict[str, str]:
+    return {
+        "x-uw-daily-req-count": str(daily_count),
+        "x-uw-token-req-limit": "1000",
+        "x-uw-req-per-minute-remaining": "87",
+        "x-uw-req-per-minute-reset": "60",
+    }
+
+
+@pytest.fixture
+def provider_stub_base_url() -> str:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _ProviderStubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+
+def _settings_for_repo(repo: Repository) -> Settings:
+    return Settings.from_env().model_copy(update={"db_name": repo.conn.info.dbname})
+
+
+def test_clients_record_realistic_provider_request_rows(
+    seeded_db_empty_cards: Repository,
+    provider_stub_base_url: str,
+) -> None:
+    settings = _settings_for_repo(seeded_db_empty_cards)
+
+    with ExternalApiRequestRecorder(
+        settings.db_dsn(), schema=settings.db_schema
+    ) as recorder:
+        with UwClient(
+            "dummy-key",
+            base_url=provider_stub_base_url,
+            max_retries=0,
+            telemetry_recorder=recorder,
+            job_name="client_instrumentation_test",
+        ) as client:
+            client.get(EndpointSlug.IV_RANK, ticker="TSLA")
+            client.get(EndpointSlug.IV_RANK, ticker="AAPL")
+
+        for slug, ticker, params in [
+            (EndpointSlug.GREEK_EXPOSURE, "TSLA", {"expiry": "2026-06-19"}),
+            (EndpointSlug.VOLATILITY_STATS, "NVDA", {}),
+        ]:
+            with UwClient(
+                "dummy-key",
+                base_url=provider_stub_base_url,
+                max_retries=0,
+                telemetry_recorder=recorder,
+                job_name="client_instrumentation_test",
+            ) as client:
+                with pytest.raises(UwHTTPError):
+                    client.get(slug, ticker=ticker, params=params)
+
+        with MassiveOhlcProvider(
+            "dummy-key",
+            base_url=provider_stub_base_url,
+            telemetry_recorder=recorder,
+            job_name="client_instrumentation_test",
+        ) as provider:
+            provider.fetch_daily("TSLA", date(2026, 5, 1), date(2026, 5, 2))
+            with pytest.raises(Exception):
+                provider.fetch_daily("MSFT", date(2026, 5, 1), date(2026, 5, 2))
+
+    rows = seeded_db_empty_cards.list_external_api_requests(
+        provider="all",
+        start=datetime.now(UTC) - timedelta(minutes=5),
+        end=datetime.now(UTC) + timedelta(minutes=5),
+        limit=10,
+    )
+    rows = [row for row in rows if row.job_name == "client_instrumentation_test"]
+
+    assert len(rows) == 6
+    recorded = sorted(
+        (row.provider, row.endpoint_key, row.ticker, row.status_family)
+        for row in rows
+    )
+    assert recorded == [
+        ("massive", "daily_ohlc", "MSFT", "5xx"),
+        ("massive", "daily_ohlc", "TSLA", "2xx"),
+        ("uw", "greek_exposure", "TSLA", "4xx"),
+        ("uw", "iv_rank", "AAPL", "2xx"),
+        ("uw", "iv_rank", "TSLA", "2xx"),
+        ("uw", "volatility_stats", "NVDA", "5xx"),
+    ]
+    assert max(row.official_daily_count or 0 for row in rows) == 104
+    assert {row.provider_request_id for row in rows if row.provider == "massive"} == {
+        "massive-ok-1",
+        "massive-fail-1",
+    }

--- a/tests/integration/storage/test_provider_usage_recorder.py
+++ b/tests/integration/storage/test_provider_usage_recorder.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from uw_scan.config import Settings
+from uw_scan.storage.provider_usage import (
+    ExternalApiRequestEvent,
+    ExternalApiRequestRecorder,
+)
+from uw_scan.storage.repository import Repository
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _test_settings() -> Settings:
+    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
+    return Settings.from_env().model_copy(
+        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
+    )
+
+
+@pytest.fixture
+def settings() -> Settings:
+    settings = _test_settings()
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
+            cur.execute("CREATE SCHEMA uw_scan")
+    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    return settings
+
+
+def _event() -> ExternalApiRequestEvent:
+    now = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
+    return ExternalApiRequestEvent(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=42,
+        official_daily_count=15,
+    )
+
+
+def test_recorder_inserts_through_autocommit_connection(settings: Settings):
+    with ExternalApiRequestRecorder(settings.db_dsn(), schema=settings.db_schema) as recorder:
+        recorder.record(_event())
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        count = Repository(conn).get_external_api_usage_summary(
+            "uw",
+            datetime(2026, 5, 14, 0, 0, tzinfo=UTC),
+            datetime(2026, 5, 15, 0, 0, tzinfo=UTC),
+        ).total_requests
+
+    assert count == 1
+
+
+def test_recorder_row_survives_main_connection_rollback(settings: Settings):
+    main_conn = psycopg.connect(settings.db_dsn())
+    try:
+        main_repo = Repository(main_conn)
+        main_repo.insert_scan_run("TSLA")
+        with ExternalApiRequestRecorder(
+            settings.db_dsn(), schema=settings.db_schema
+        ) as recorder:
+            recorder.record(_event())
+        main_conn.rollback()
+    finally:
+        main_conn.close()
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        count = Repository(conn).get_external_api_usage_summary(
+            "uw",
+            datetime(2026, 5, 14, 0, 0, tzinfo=UTC),
+            datetime(2026, 5, 15, 0, 0, tzinfo=UTC),
+        ).total_requests
+
+    assert count == 1
+
+
+def test_recorder_logs_and_swallows_insert_failures(
+    settings: Settings, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    with ExternalApiRequestRecorder(settings.db_dsn(), schema=settings.db_schema) as recorder:
+
+        def _boom(**_kwargs):
+            raise RuntimeError("telemetry insert failed")
+
+        monkeypatch.setattr(recorder._repo, "insert_external_api_request", _boom)
+        caplog.set_level(logging.ERROR, logger="uw_scan.storage.provider_usage")
+
+        recorder.record(_event())
+
+    assert "failed to record external API request telemetry" in caplog.text

--- a/tests/integration/storage/test_provider_usage_repository.py
+++ b/tests/integration/storage/test_provider_usage_repository.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from uw_scan.config import Settings
+from uw_scan.storage.repository import Repository
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _test_settings() -> Settings:
+    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
+    if not test_db:
+        pytest.fail(
+            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
+            pytrace=False,
+        )
+    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
+    return Settings.from_env().model_copy(update={"db_name": test_db})
+
+
+@pytest.fixture
+def repo() -> Repository:
+    settings = _test_settings()
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
+            cur.execute("CREATE SCHEMA uw_scan")
+    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    with psycopg.connect(settings.db_dsn()) as conn:
+        yield Repository(conn, schema=settings.db_schema)
+
+
+def test_external_api_request_roundtrip(repo: Repository):
+    now = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
+
+    request_id = repo.insert_external_api_request(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path_template="/api/stock/{ticker}/iv-rank",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=42,
+        official_daily_count=10,
+        official_daily_limit=1000,
+    )
+    repo.conn.commit()
+
+    assert request_id > 0
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT provider, endpoint_key, ticker, params_json, status_code,
+                   status_family, latency_ms, official_daily_count,
+                   official_daily_limit
+            FROM uw_scan.external_api_requests
+            WHERE request_id = %s
+            """,
+            (request_id,),
+        )
+        row = cur.fetchone()
+
+    assert row == (
+        "uw",
+        "iv_rank",
+        "TSLA",
+        {},
+        200,
+        "2xx",
+        42,
+        10,
+        1000,
+    )
+
+
+def test_external_api_usage_summary_counts_latency_and_latest_official(repo: Repository):
+    start = datetime(2026, 5, 14, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 5, 15, 0, 0, tzinfo=UTC)
+
+    for offset, status_code, status_family, latency, official_count in [
+        (1, 200, "2xx", 50, 10),
+        (2, 404, "4xx", 50, 11),
+        (3, 503, "5xx", 50, 12),
+        (4, None, "transport_error", 50, None),
+    ]:
+        now = datetime(2026, 5, 14, offset, 0, tzinfo=UTC)
+        repo.insert_external_api_request(
+            provider="uw",
+            endpoint_key="iv_rank",
+            method="GET",
+            path="/api/stock/TSLA/iv-rank",
+            ticker="TSLA",
+            params={"ticker": "TSLA"},
+            status_code=status_code,
+            status_family=status_family,
+            started_at=now,
+            finished_at=now,
+            latency_ms=latency,
+            official_daily_count=official_count,
+            official_daily_limit=1000 if official_count is not None else None,
+        )
+    repo.insert_external_api_request(
+        provider="massive",
+        endpoint_key="daily_ohlc",
+        method="GET",
+        path="/v2/aggs/ticker/AAPL/range/1/day/2026-05-13/2026-05-14",
+        ticker="AAPL",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=datetime(2026, 5, 14, 5, 0, tzinfo=UTC),
+        finished_at=datetime(2026, 5, 14, 5, 0, tzinfo=UTC),
+        latency_ms=50,
+    )
+    repo.conn.commit()
+
+    summary = repo.get_external_api_usage_summary(None, start, end)
+
+    assert summary.total_requests == 5
+    assert summary.http_2xx == 2
+    assert summary.http_4xx == 1
+    assert summary.http_5xx == 1
+    assert summary.transport_errors == 1
+    assert summary.latency_p95_ms == 50
+    assert summary.uw_latest_daily_count == 12
+    assert summary.uw_latest_daily_limit == 1000
+
+
+def test_external_api_usage_breakdowns_and_request_filters(repo: Repository):
+    now = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
+    start = datetime(2026, 5, 14, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 5, 15, 0, 0, tzinfo=UTC)
+
+    repo.insert_external_api_request(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={"ticker": "TSLA"},
+        status_code=200,
+        status_family="2xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=20,
+    )
+    repo.insert_external_api_request(
+        provider="uw",
+        endpoint_key="greek_exposure",
+        method="GET",
+        path="/api/stock/TSLA/greek-exposure",
+        ticker="TSLA",
+        params={"ticker": "TSLA"},
+        status_code=429,
+        status_family="4xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=30,
+    )
+    repo.conn.commit()
+
+    endpoint_rows = repo.list_external_api_endpoint_usage("uw", start, end)
+    ticker_rows = repo.list_external_api_ticker_usage("uw", start, end)
+    request_rows = repo.list_external_api_requests(
+        provider="uw",
+        start=start,
+        end=end,
+        ticker="TSLA",
+        status_family="4xx",
+        limit=10,
+    )
+
+    assert {row.key: row.total_requests for row in endpoint_rows} == {
+        "greek_exposure": 1,
+        "iv_rank": 1,
+    }
+    assert [(row.key, row.total_requests, row.http_4xx) for row in ticker_rows] == [
+        ("TSLA", 2, 1)
+    ]
+    assert len(request_rows) == 1
+    assert request_rows[0].endpoint_key == "greek_exposure"
+    assert request_rows[0].params == {"ticker": "TSLA"}

--- a/tests/unit/api/test_uw_client_telemetry.py
+++ b/tests/unit/api/test_uw_client_telemetry.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from uw_scan.api.client import LiveDataUnavailable, UwClient, UwHTTPError
+from uw_scan.api.endpoints import EndpointSlug
+
+
+class Recorder:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.events = []
+        self.fail = fail
+
+    def record(self, event):
+        if self.fail:
+            raise RuntimeError("recorder failed")
+        self.events.append(event)
+
+
+def _client(transport: httpx.MockTransport, recorder: Recorder) -> UwClient:
+    client = UwClient(
+        api_key="uw-test",
+        base_url="https://uw.test",
+        max_retries=0,
+        telemetry_recorder=recorder,
+        job_name="unit",
+    )
+    client._client = httpx.Client(transport=transport)
+    return client
+
+
+def test_uw_client_records_success_with_headers_and_context():
+    recorder = Recorder()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"ok": True},
+            headers={
+                "x-uw-daily-req-count": "12",
+                "x-uw-token-req-limit": "1000",
+                "x-uw-req-per-minute-remaining": "99",
+                "x-uw-req-per-minute-reset": "17",
+            },
+        )
+
+    with _client(httpx.MockTransport(handler), recorder) as client:
+        client.get(EndpointSlug.IV_RANK, ticker="TSLA", run_id=123)
+
+    assert len(recorder.events) == 1
+    event = recorder.events[0]
+    assert event.provider == "uw"
+    assert event.endpoint_key == "iv_rank"
+    assert event.path_template == "/api/stock/{ticker}/iv-rank"
+    assert event.path == "/api/stock/TSLA/iv-rank"
+    assert event.ticker == "TSLA"
+    assert event.status_code == 200
+    assert event.status_family == "2xx"
+    assert event.run_id == 123
+    assert event.job_name == "unit"
+    assert event.official_daily_count == 12
+    assert event.official_daily_limit == 1000
+    assert event.official_minute_remaining == 99
+    assert event.official_minute_reset == "17"
+    assert event.latency_ms >= 0
+
+
+def test_uw_client_records_4xx_before_raising():
+    recorder = Recorder()
+
+    with _client(
+        httpx.MockTransport(lambda _request: httpx.Response(404, text="missing")),
+        recorder,
+    ) as client:
+        with pytest.raises(UwHTTPError):
+            client.get(EndpointSlug.IV_RANK, ticker="TSLA")
+
+    assert len(recorder.events) == 1
+    assert recorder.events[0].status_code == 404
+    assert recorder.events[0].status_family == "4xx"
+
+
+def test_uw_client_records_every_5xx_retry_attempt(monkeypatch: pytest.MonkeyPatch):
+    recorder = Recorder()
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(503, text="try later")
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    client = UwClient(
+        api_key="uw-test",
+        base_url="https://uw.test",
+        max_retries=2,
+        telemetry_recorder=recorder,
+    )
+    client._client = httpx.Client(transport=httpx.MockTransport(handler))
+    with client:
+        with pytest.raises(UwHTTPError):
+            client.get(EndpointSlug.IV_RANK, ticker="TSLA")
+
+    assert calls == 3
+    assert [event.attempt for event in recorder.events] == [0, 1, 2]
+    assert [event.status_family for event in recorder.events] == ["5xx", "5xx", "5xx"]
+
+
+def test_uw_client_records_transport_errors(monkeypatch: pytest.MonkeyPatch):
+    recorder = Recorder()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    with _client(httpx.MockTransport(handler), recorder) as client:
+        with pytest.raises(LiveDataUnavailable):
+            client.get(EndpointSlug.IV_RANK, ticker="TSLA")
+
+    assert len(recorder.events) == 1
+    assert recorder.events[0].status_code is None
+    assert recorder.events[0].status_family == "transport_error"
+    assert "offline" in (recorder.events[0].error_message or "")
+
+
+def test_uw_client_ignores_recorder_failures():
+    recorder = Recorder(fail=True)
+
+    with _client(
+        httpx.MockTransport(lambda _request: httpx.Response(200, json={"ok": True})),
+        recorder,
+    ) as client:
+        response, _headers = client.get(EndpointSlug.IV_RANK, ticker="TSLA")
+
+    assert response.status_code == 200

--- a/tests/unit/sources/test_ohlc_provider.py
+++ b/tests/unit/sources/test_ohlc_provider.py
@@ -6,12 +6,26 @@ from datetime import date, timezone
 from decimal import Decimal
 
 import httpx
+import pytest
 
 from uw_scan.sources.ohlc import MassiveOhlcProvider
 
 
-def _provider_with(handler) -> MassiveOhlcProvider:
-    p = MassiveOhlcProvider(api_key="test", base_url="https://api.massive.com")
+class Recorder:
+    def __init__(self) -> None:
+        self.events = []
+
+    def record(self, event):
+        self.events.append(event)
+
+
+def _provider_with(handler, recorder: Recorder | None = None) -> MassiveOhlcProvider:
+    p = MassiveOhlcProvider(
+        api_key="test",
+        base_url="https://api.massive.com",
+        telemetry_recorder=recorder,
+        job_name="unit",
+    )
     p._client = httpx.Client(
         transport=httpx.MockTransport(handler),
         headers={"Authorization": "Bearer test"},
@@ -21,12 +35,15 @@ def _provider_with(handler) -> MassiveOhlcProvider:
 
 
 def test_fetch_daily_returns_bars():
+    recorder = Recorder()
+
     def handler(req):
         assert req.url.path == "/v2/aggs/ticker/AAPL/range/1/day/2026-04-01/2026-05-01"
         return httpx.Response(
             200,
             json={
                 "ticker": "AAPL",
+                "request_id": "req-daily",
                 "results": [
                     {
                         "t": 1746057600000,
@@ -48,11 +65,18 @@ def test_fetch_daily_returns_bars():
             },
         )
 
-    p = _provider_with(handler)
+    p = _provider_with(handler, recorder)
     bars = p.fetch_daily("AAPL", date(2026, 4, 1), date(2026, 5, 1))
     assert len(bars) == 2
     assert bars[0].close == Decimal("101.25")
     assert bars[1].volume == 9876543
+    assert len(recorder.events) == 1
+    assert recorder.events[0].provider == "massive"
+    assert recorder.events[0].endpoint_key == "daily_ohlc"
+    assert recorder.events[0].ticker == "AAPL"
+    assert recorder.events[0].status_code == 200
+    assert recorder.events[0].status_family == "2xx"
+    assert recorder.events[0].provider_request_id == "req-daily"
 
 
 def test_fetch_daily_empty():
@@ -65,6 +89,8 @@ def test_fetch_intraday_quote_uses_latest_minute_bar():
     """Quotes endpoint is gated on our tier; use the most-recent minute
     aggregate close as a 15-min-delayed intraday price."""
 
+    recorder = Recorder()
+
     def handler(req):
         assert "/v2/aggs/ticker/TSLA/range/1/minute/" in req.url.path
         assert req.url.params.get("sort") == "desc"
@@ -74,6 +100,7 @@ def test_fetch_intraday_quote_uses_latest_minute_bar():
             json={
                 "ticker": "TSLA",
                 "status": "DELAYED",
+                "request_id": "req-quote",
                 "results": [
                     {
                         "v": 16472,
@@ -89,11 +116,15 @@ def test_fetch_intraday_quote_uses_latest_minute_bar():
             },
         )
 
-    p = _provider_with(handler)
+    p = _provider_with(handler, recorder)
     q = p.fetch_intraday_quote("TSLA")
     assert q is not None
     assert q.price == Decimal("445.12")
     assert q.quoted_at.tzinfo is timezone.utc
+    assert len(recorder.events) == 1
+    assert recorder.events[0].endpoint_key == "intraday_quote"
+    assert recorder.events[0].status_family == "2xx"
+    assert recorder.events[0].provider_request_id == "req-quote"
 
 
 def test_fetch_intraday_quote_uses_supplied_market_date():
@@ -111,5 +142,22 @@ def test_fetch_intraday_quote_empty_results():
 
 
 def test_fetch_intraday_quote_404():
-    p = _provider_with(lambda req: httpx.Response(404, json={}))
+    recorder = Recorder()
+    p = _provider_with(lambda req: httpx.Response(404, json={}), recorder)
     assert p.fetch_intraday_quote("UNKNOWN") is None
+    assert len(recorder.events) == 1
+    assert recorder.events[0].status_code == 404
+    assert recorder.events[0].status_family == "4xx"
+
+
+def test_fetch_daily_records_raised_http_error():
+    recorder = Recorder()
+    p = _provider_with(lambda req: httpx.Response(500, text="down"), recorder)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        p.fetch_daily("AAPL", date(2026, 4, 1), date(2026, 5, 1))
+
+    assert len(recorder.events) == 1
+    assert recorder.events[0].status_code == 500
+    assert recorder.events[0].status_family == "5xx"
+    assert "down" in (recorder.events[0].error_message or "")

--- a/tests/unit/storage/test_provider_usage_helpers.py
+++ b/tests/unit/storage/test_provider_usage_helpers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from uw_scan.storage.repository import (
+    provider_day_bounds,
+    redact_params,
+    status_family_for,
+)
+
+
+def test_provider_day_bounds_uses_previous_8pm_et_before_reset():
+    now = datetime(2026, 5, 14, 23, 59, tzinfo=UTC)
+
+    start, end = provider_day_bounds(now)
+
+    assert start.isoformat() == "2026-05-13T20:00:00-04:00"
+    assert end.isoformat() == "2026-05-14T20:00:00-04:00"
+
+
+def test_provider_day_bounds_uses_same_day_8pm_et_after_reset():
+    now = datetime(2026, 5, 15, 0, 1, tzinfo=UTC)
+
+    start, end = provider_day_bounds(now)
+
+    assert start.isoformat() == "2026-05-14T20:00:00-04:00"
+    assert end.isoformat() == "2026-05-15T20:00:00-04:00"
+
+
+def test_status_family_for_http_statuses_and_transport_errors():
+    assert status_family_for(200) == "2xx"
+    assert status_family_for(302) == "3xx"
+    assert status_family_for(404) == "4xx"
+    assert status_family_for(503) == "5xx"
+    assert status_family_for(None, transport_error=True) == "transport_error"
+
+
+def test_redact_params_drops_auth_keys_and_truncates_long_values():
+    params = {
+        "ticker": "TSLA",
+        "api_key": "secret",
+        "Authorization": "Bearer secret",
+        "notes": "x" * 300,
+        "limit": 100,
+    }
+
+    redacted = redact_params(params)
+
+    assert redacted["ticker"] == "TSLA"
+    assert redacted["limit"] == 100
+    assert "api_key" not in redacted
+    assert "Authorization" not in redacted
+    assert redacted["notes"] == ("x" * 253) + "..."

--- a/web/components/watchlist/TickerCard.tsx
+++ b/web/components/watchlist/TickerCard.tsx
@@ -45,7 +45,7 @@ export function TickerCard({ card, sparkline }: Props) {
       }}
     >
       <Link
-        href={`/stock/${card.ticker}`}
+        href={`/stock/${card.ticker}/market-structure`}
         aria-label={`${card.ticker} detail`}
         style={{ ...linkReset, display: "block" }}
       >

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -219,6 +219,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/provider-usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Summary */
+        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Endpoints */
+        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/tickers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Tickers */
+        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Requests */
+        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/stock/{ticker}/trade-insights": {
         parameters: {
             query?: never;
@@ -932,6 +1000,141 @@ export interface components {
             pcr_vol?: string | null;
             /** Pcr Delta 30D */
             pcr_delta_30d?: string | null;
+        };
+        /** ProviderUsageBreakdownResponse */
+        ProviderUsageBreakdownResponse: {
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /** Rows */
+            rows: components["schemas"]["ProviderUsageBreakdownRow"][];
+        };
+        /** ProviderUsageBreakdownRow */
+        ProviderUsageBreakdownRow: {
+            /** Key */
+            key: string | null;
+            /** Total Requests */
+            total_requests: number;
+            /** Http 2Xx */
+            http_2xx: number;
+            /** Http 3Xx */
+            http_3xx: number;
+            /** Http 4Xx */
+            http_4xx: number;
+            /** Http 5Xx */
+            http_5xx: number;
+            /** Transport Errors */
+            transport_errors: number;
+            /** Latency P95 Ms */
+            latency_p95_ms: number | null;
+        };
+        /** ProviderUsageRequestRow */
+        ProviderUsageRequestRow: {
+            /** Request Id */
+            request_id: number;
+            /** Provider */
+            provider: string;
+            /** Endpoint Key */
+            endpoint_key: string;
+            /** Method */
+            method: string;
+            /** Path */
+            path: string;
+            /** Ticker */
+            ticker: string | null;
+            /** Params */
+            params: {
+                [key: string]: unknown;
+            };
+            /** Status Code */
+            status_code: number | null;
+            /** Status Family */
+            status_family: string;
+            /**
+             * Request Started At
+             * Format: date-time
+             */
+            request_started_at: string;
+            /**
+             * Request Finished At
+             * Format: date-time
+             */
+            request_finished_at: string;
+            /** Latency Ms */
+            latency_ms: number;
+            /** Attempt */
+            attempt: number;
+            /** Run Id */
+            run_id: number | null;
+            /** Job Name */
+            job_name: string | null;
+            /** Provider Request Id */
+            provider_request_id: string | null;
+            /** Official Daily Count */
+            official_daily_count: number | null;
+            /** Official Daily Limit */
+            official_daily_limit: number | null;
+            /** Official Minute Remaining */
+            official_minute_remaining: number | null;
+            /** Official Minute Reset */
+            official_minute_reset: string | null;
+            /** Error Message */
+            error_message: string | null;
+        };
+        /** ProviderUsageRequestsResponse */
+        ProviderUsageRequestsResponse: {
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /** Limit */
+            limit: number;
+            /** Rows */
+            rows: components["schemas"]["ProviderUsageRequestRow"][];
+        };
+        /** ProviderUsageSummaryResponse */
+        ProviderUsageSummaryResponse: {
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /** Total Requests */
+            total_requests: number;
+            /** Http 2Xx */
+            http_2xx: number;
+            /** Http 3Xx */
+            http_3xx: number;
+            /** Http 4Xx */
+            http_4xx: number;
+            /** Http 5Xx */
+            http_5xx: number;
+            /** Transport Errors */
+            transport_errors: number;
+            /** Latency P95 Ms */
+            latency_p95_ms: number | null;
+            /** Uw Latest Daily Count */
+            uw_latest_daily_count: number | null;
+            /** Uw Latest Daily Limit */
+            uw_latest_daily_limit: number | null;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
@@ -2471,6 +2674,133 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VolatilitySeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_summary_api_provider_usage_summary_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_endpoints_api_provider_usage_endpoints_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_tickers_api_provider_usage_tickers_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_requests_api_provider_usage_requests_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+                ticker?: string | null;
+                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/e2e/golden-path.spec.ts
+++ b/web/tests/e2e/golden-path.spec.ts
@@ -4,14 +4,12 @@
 import { test, expect } from "@playwright/test";
 
 test("dashboard → detail → tab → rescan", async ({ page }) => {
+  const ticker = "TSLA";
+
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "DASHBOARD" })).toBeVisible();
 
-  const firstCard = page.locator("a[href^='/stock/']").first();
-  const href = await firstCard.getAttribute("href");
-  const ticker = href?.split("/").pop();
-  if (!ticker) throw new Error("no ticker card visible — seed the DB first");
-  await firstCard.click();
+  await page.getByLabel(`${ticker} detail`).click();
 
   await expect(page).toHaveURL(new RegExp(`/stock/${ticker}/market-structure`));
   await page.getByRole("link", { name: /flow/i }).click();
@@ -22,10 +20,7 @@ test("dashboard → detail → tab → rescan", async ({ page }) => {
   // done), so locating by initial text won't survive the click. The card
   // exposes its link via aria-label="<TICKER> detail"; the RescanButton is
   // a sibling of the link inside the same card wrapper.
-  const card = page
-    .locator("a[aria-label$='detail']")
-    .first()
-    .locator("xpath=..");
+  const card = page.getByLabel(`${ticker} detail`).locator("xpath=..");
   const rescan = card.locator("button").first();
   await expect(rescan).toHaveText("rescan");
   await rescan.click();

--- a/web/tests/e2e/volatility-tab.spec.ts
+++ b/web/tests/e2e/volatility-tab.spec.ts
@@ -1,9 +1,9 @@
-// Volatility Tab v2 — end-to-end smoke. Requires the dev DB to have at
-// least one ticker with >=90 days of realized_volatility_history and SPY
-// rows in index_ohlc_daily (see scripts/seed_spy_ohlc.py).
+// Volatility Tab v2 — end-to-end smoke. Requires the dev DB to be seeded with
+// scripts/dry_run_volatility_endpoint.py, which creates a synthetic DRYRUN
+// ticker with IV/RV history, SPY rows, smile data, and greeks.
 import { expect, test } from "@playwright/test";
 
-const TICKER = "TSLA";
+const TICKER = "DRYRUN";
 
 test("volatility tab renders all panels with no NaN / no console errors", async ({
   page,
@@ -49,6 +49,9 @@ test("volatility tab renders all panels with no NaN / no console errors", async 
 test("VRP tab route is removed", async ({ page }) => {
   await page.goto(`/stock/${TICKER}/vrp`);
   await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "This page could not be found." }),
+  ).toBeVisible();
 });
 
 // Fresh-ticker backfill flow is covered by the backend integration test

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HealthPanel } from "@/components/shared/HealthPanel";
+import { api } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    health: vi.fn(),
+  },
+}));
+
+describe("HealthPanel", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders provider usage stats from health", async () => {
+    vi.mocked(api.health).mockResolvedValue({
+      ok: true,
+      db: "up",
+      scheduler_lag_seconds: 12,
+      last_full_scan_at: "2026-05-14T14:20:42Z",
+      reason: null,
+      worker_lag_seconds: 1,
+      watchlist_size: 97,
+      source: "massive.com",
+      latency_p95_ms: 88,
+      http_2xx: 120,
+      http_4xx: 3,
+      http_5xx: 1,
+      uw_today: 40,
+      cache_hit_pct: null,
+    });
+
+    render(<HealthPanel />);
+
+    await waitFor(() => expect(screen.getByText("ONLINE")).toBeTruthy());
+    expect(screen.getByText("88ms")).toBeTruthy();
+    expect(screen.getByText("120")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("keeps dashes for missing metrics", async () => {
+    vi.mocked(api.health).mockResolvedValue({
+      ok: false,
+      db: "up",
+      scheduler_lag_seconds: null,
+      last_full_scan_at: null,
+      reason: "no successful full scan yet",
+      worker_lag_seconds: null,
+      watchlist_size: null,
+      source: "massive.com",
+      latency_p95_ms: null,
+      http_2xx: null,
+      http_4xx: null,
+      http_5xx: null,
+      uw_today: null,
+      cache_hit_pct: null,
+    });
+
+    render(<HealthPanel />);
+
+    await waitFor(() => expect(screen.getByText("UNKNOWN")).toBeTruthy());
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Add durable UW/Massive request telemetry in `uw_scan.external_api_requests`.
- Record provider, endpoint, ticker, timestamp, status family, latency, UW usage headers, Massive request IDs, job name, and run linkage where available.
- Expose provider usage summary/breakdowns/request audit API endpoints and surface 2xx/4xx/5xx/latency/UW usage in health stats.
- Wire telemetry through scheduler, pipeline, volatility jobs, UW client, and Massive OHLC provider.
- Fix watchlist cards to link directly to the default stock tab instead of relying on the app-router redirect.

## Verification

- `uv run pytest` -> 263 passed, 5 skipped
- `cd web && npm run test` -> 94 passed
- `cd web && npm run typecheck` -> passed
- `cd web && npm run build` -> passed
- `cd web && npm run test:e2e` -> 3 passed
- `uv run ruff check` -> passed
- `git diff --check` -> passed
- Live provider smoke into `option_wizard_test`:
  - UW `iv_rank` TSLA recorded `2xx/200`, daily usage `2204/20000`, minute remaining `87`
  - Massive `daily_ohlc` TSLA recorded `2xx/200`, request_id persisted, 8 bars returned
