### PR TITLE
Improve Trade Insights AI analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Environment:
 
 - `TRADE_INSIGHTS_AI_ENABLED` — enable the worker/API path when true
 - `TRADE_INSIGHTS_AI_MODEL` — optional Codex model; blank means local Codex default and rows store `codex-default`
-- `TRADE_INSIGHTS_AI_TIMEOUT_SECONDS` — subprocess timeout, default 90
+- `TRADE_INSIGHTS_AI_TIMEOUT_SECONDS` — subprocess timeout, default 300
 - `TRADE_INSIGHTS_AI_MAX_OUTPUT_BYTES` — structured output cap, default 262144
 - `TRADE_INSIGHTS_AI_POLL_SECONDS` — worker polling interval, default 3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Environment:
 
 - `TRADE_INSIGHTS_AI_ENABLED` — enable the worker/API path when true
 - `TRADE_INSIGHTS_AI_MODEL` — optional Codex model; blank means local Codex default and rows store `codex-default`
-- `TRADE_INSIGHTS_AI_TIMEOUT_SECONDS` — subprocess timeout, default 90
+- `TRADE_INSIGHTS_AI_TIMEOUT_SECONDS` — subprocess timeout, default 300
 - `TRADE_INSIGHTS_AI_MAX_OUTPUT_BYTES` — structured output cap, default 262144
 - `TRADE_INSIGHTS_AI_POLL_SECONDS` — worker polling interval, default 3
 

--- a/src/uw_scan/api/routers/trade_insights.py
+++ b/src/uw_scan/api/routers/trade_insights.py
@@ -235,9 +235,15 @@ def post_trade_insights_ai_analysis(
 )
 def get_latest_trade_insights_ai_analysis(
     ticker: str,
+    settings: Settings = Depends(get_settings),
     repo: Repository = Depends(get_repo),
 ) -> TradeInsightAiAnalysisResponse | None:
-    row = repo.find_latest_succeeded_trade_insight_ai_analysis(ticker=ticker.upper())
+    model_label = settings.trade_insights_ai_model.strip() or "codex-default"
+    row = repo.find_latest_trade_insight_ai_analysis(
+        ticker=ticker.upper(),
+        prompt_version=PROMPT_VERSION,
+        model=model_label,
+    )
     if row is None:
         return None
     return _row_to_ai_response(row)

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -65,7 +65,7 @@ class Settings(BaseModel):
     # Trade Insights V1.5 local Codex analysis
     trade_insights_ai_enabled: bool = False
     trade_insights_ai_model: str = ""
-    trade_insights_ai_timeout_seconds: float = 90.0
+    trade_insights_ai_timeout_seconds: float = 300.0
     trade_insights_ai_max_output_bytes: int = 262144
     trade_insights_ai_poll_seconds: int = 3
 
@@ -119,7 +119,7 @@ class Settings(BaseModel):
             trade_insights_ai_enabled=_env_bool("TRADE_INSIGHTS_AI_ENABLED", False),
             trade_insights_ai_model=os.environ.get("TRADE_INSIGHTS_AI_MODEL", ""),
             trade_insights_ai_timeout_seconds=float(
-                os.environ.get("TRADE_INSIGHTS_AI_TIMEOUT_SECONDS", "90.0")
+                os.environ.get("TRADE_INSIGHTS_AI_TIMEOUT_SECONDS", "300.0")
             ),
             trade_insights_ai_max_output_bytes=int(
                 os.environ.get("TRADE_INSIGHTS_AI_MAX_OUTPUT_BYTES", "262144")

--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -420,12 +420,9 @@ def assemble_trade_insights(
     flow_rows = _build_flow_table(contracts)
     term_rows = _build_term_rows(repo.fetch_iv_term_rows(run_id, ticker), contracts, spot)
     candidates = _build_candidates(contracts, spot)
-    # V1 intentionally hardcodes event_data_known=False so every candidate ends
-    # as `needs_check` and `preferred_idea_id` stays None. The earnings/dividend
-    # plumbing exists upstream (flow_events.next_earnings_date,
-    # SingleStockReport.next_earnings_date) but is not wired through to this
-    # assembler in V1. A follow-up patch should read those fields and flip the
-    # gate when both are present and outside all candidate expiries.
+    # Event data is still not wired through this assembler, so it stays visible
+    # as a required pre-sizing check. It should not suppress the research read
+    # or erase the best defined-risk candidate.
     event_data_known = False
     liquidity_ready = bool(contracts) and all(c.max_loss is not None for c in candidates)
 
@@ -475,16 +472,10 @@ def assemble_trade_insights(
         ),
     ]
 
-    can_prefer = (
-        bool(candidates)
-        and event_data_known
-        and liquidity_ready
-        and source_reconciliation.status != "UNKNOWN"
-    )
-    if not can_prefer:
-        for candidate in candidates:
-            candidate.status = "needs_check"
+    can_prefer = bool(candidates) and liquidity_ready
     preferred = candidates[0].idea_id if can_prefer else None
+    for candidate in candidates:
+        candidate.status = "preferred" if candidate.idea_id == preferred else "candidate"
     return TradeInsightsResponse(
         ticker=ticker,
         as_of=as_of,
@@ -503,12 +494,17 @@ def assemble_trade_insights(
         term_structure_table=term_rows,
         candidate_structures=candidates,
         synthesis=InsightsSynthesis(
-            dominant_story="Deterministic research-grade ideas built from current chain, flow, and term data."
+            dominant_story=(
+                f"Research-grade setup favors candidate {preferred}; event, source, and "
+                "liquidity checks remain pre-sizing controls."
+            )
+            if preferred
+            else "Deterministic research-grade ideas built from current chain, flow, and term data."
             if candidates
             else "Insufficient option-chain data for structure generation.",
             preferred_idea_id=preferred,
             best_risk_reward_idea_id=preferred,
-            avoid=["Naked short options", "Executable recommendation language"],
+            avoid=["Naked short options", "Undefined-risk short-vol structures"],
             required_before_sizing=[
                 "Confirm event calendar through all expiries",
                 "Confirm bid/ask width and open interest",

--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -15,7 +15,414 @@ from typing import Any
 
 from uw_scan.models import TradeInsightAiOutcome
 
-PROMPT_VERSION = "trade-insights-ai-v1"
+PROMPT_VERSION = "trade-insights-ai-v2"
+STRATEGY_FAMILY_IDS = frozenset(
+    {
+        "long_stock",
+        "long_call",
+        "call_debit_spread",
+        "put_credit_spread",
+        "covered_call",
+        "cash_secured_put",
+        "iron_condor",
+        "short_strangle",
+        "long_put",
+        "put_debit_spread",
+        "calendar_spread",
+        "no_trade",
+    }
+)
+FINAL_RATING_VALUES = ("A", "B", "C", "D", "F")
+
+MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist, market-structure analyst, and risk manager.
+
+Your job is to analyze one stock using three evidence pillars:
+
+1. Market Structure
+   - Spot price
+   - GEX flip
+   - Net GEX
+   - Net DEX
+   - Gamma magnets / max pain / put wall / call wall
+   - GEX profile by strike
+   - Expected range
+   - Dealer gamma regime
+   - Support / resistance from options positioning
+
+2. Volatility
+   - IV ATM
+   - Realized volatility
+   - IV/RV ratio
+   - VRP
+   - IV rank / IV percentile
+   - Term structure
+   - Skew
+   - IV distribution
+   - IV vs RV time series
+   - Regime quadrant: Goldilocks / Fragile Calm / Stock Picker / Systemic Panic
+
+3. Flow and Positioning
+   - Options premium
+   - Bull vs bear premium
+   - Call / put volume
+   - Call / put OI
+   - Top alerts
+   - OI change movers
+   - Dark pool prints
+   - Short availability / borrow fee / rebate
+   - Sweep / repeated hit / churn flags
+   - Large notional strikes and expiries
+
+The objective is to produce a high-quality trading interpretation, not a dashboard summary.
+
+Important rules:
+
+- Do not invent data.
+- Only use the input provided.
+- If a required field is missing, say “Missing / not provided.”
+- Do not overfit to one metric.
+- Do not blindly say bullish just because call premium is high.
+- Do not blindly say bearish just because puts are active.
+- Resolve conflicts explicitly.
+- Distinguish between:
+  - directional signal
+  - volatility signal
+  - positioning signal
+  - execution readiness
+- Explain whether the setup favors:
+  - long stock
+  - long calls
+  - call debit spread
+  - put credit spread
+  - covered call
+  - short strangle / iron condor
+  - long put / put debit spread
+  - no trade
+- If the data is contradictory or incomplete, recommend “watch / wait” and specify exactly what would make it actionable.
+- Trade recommendations must include entry trigger, invalidation level, target zone, time horizon, preferred option structure, and risk notes.
+- All recommendations are research-only and not financial advice.
+
+Input:
+
+Ticker: {{ticker}}
+As-of date: {{as_of_date}}
+Spot: {{spot}}
+
+Market Structure Data:
+{{market_structure_data}}
+
+Volatility Data:
+{{volatility_data}}
+
+Flow and Positioning Data:
+{{flow_positioning_data}}
+
+Optional User Context:
+- Current position: {{current_position_or_none}}
+- Trading horizon: {{trading_horizon}}
+- Risk tolerance: {{risk_tolerance}}
+- Preferred strategy type: {{preferred_strategy_type}}
+- Earnings / event calendar known? {{event_calendar_status}}
+
+Now produce the analysis using the following structure.
+
+# {{ticker}} Options Market Intelligence Report
+
+## 1. Executive Decision
+
+Give one clear headline:
+
+- Bullish directional
+- Bearish directional
+- Range-bound / pinned
+- Volatility-selling setup
+- Volatility-buying setup
+- Conflicted / no-trade
+
+Then provide:
+
+| Field | Answer |
+|---|---|
+| Primary Setup | One sentence |
+| Trade Bias | Bullish / Bearish / Range / Volatility |
+| Confidence | High / Medium / Low |
+| Actionability | Ready / Watchlist / No Trade |
+| Best Structure | Specific option or stock structure |
+| Main Risk | One sentence |
+| Key Trigger | One sentence |
+
+Do not write generic language. Make a decision.
+
+## 2. Market Structure Interpretation
+
+Analyze the market structure in plain English.
+
+Must cover:
+
+- Where spot is relative to GEX flip.
+- Whether spot is above or below the dealer regime boundary.
+- Whether net GEX is stabilizing or destabilizing.
+- Whether net DEX supports directional acceleration or mean reversion.
+- Where the nearest magnets are.
+- Whether price is likely pinned, pulled upward, pulled downward, or exposed to acceleration.
+- Which strikes are likely support and resistance.
+- Whether the expected range is narrow, wide, useful, or unreliable.
+
+Output:
+
+### Market Structure Read
+
+State the core read in 3-5 sentences.
+
+### Key Levels
+
+| Level | Price | Meaning | Trading Use |
+|---|---:|---|---|
+| Spot | | Current reference | |
+| GEX Flip | | Regime boundary | |
+| Max Magnet | | Attraction / pin risk | |
+| Put Wall | | Downside support / risk level | |
+| Call Wall / Resistance | | Upside resistance | |
+| Max Accel | | Acceleration risk | |
+
+### Market Structure Verdict
+
+Choose one:
+
+- Bullish with positive gamma support
+- Bullish but pinned
+- Bearish below flip
+- Range-bound / magnet-dominated
+- Fragile because positive gamma conflicts with aggressive flow
+- Unclear due to missing data
+
+Explain why.
+
+## 3. Volatility Interpretation
+
+Analyze whether volatility is cheap, fair, or rich.
+
+Must cover:
+
+- IV vs RV
+- VRP
+- IV rank / percentile
+- term structure
+- skew
+- whether volatility selling or buying is favored
+- whether high IV is justified by event risk
+- whether the setup favors defined-risk or undefined-risk structures
+
+Output:
+
+### Volatility Read
+
+3-5 sentences.
+
+### Volatility Evidence
+
+| Metric | Value | Interpretation |
+|---|---:|---|
+| IV ATM | | |
+| RV | | |
+| IV/RV | | |
+| VRP | | |
+| IV Rank | | |
+| IV Percentile | | |
+| Skew | | |
+| Term Structure | | |
+
+### Volatility Verdict
+
+Choose one:
+
+- IV rich, short-vol favored
+- IV cheap, long-vol favored
+- IV rich but dangerous to sell due to flow/event risk
+- IV fair, no edge
+- Data insufficient
+
+Then explain which option structures fit the volatility regime.
+
+## 4. Flow and Positioning Interpretation
+
+Analyze whether flow confirms or contradicts market structure.
+
+Must cover:
+
+- Bull premium vs bear premium
+- Call demand vs put demand
+- Ask-side vs bid-side premium
+- Volume/OI quality
+- Whether alerts are opening, closing, churn, or ambiguous
+- Whether large call flow is bullish speculation, call overwriting, closing, or mixed
+- Whether large put flow is protection, bearish bet, or premium sale
+- Dark pool / short interest context if available
+
+Output:
+
+### Flow Read
+
+3-5 sentences.
+
+### Flow Quality Check
+
+| Signal | Read | Quality |
+|---|---|---|
+| Bull premium vs bear premium | | Strong / Medium / Weak |
+| Ask vs bid premium | | |
+| Call volume / OI | | |
+| Put volume / OI | | |
+| Top alerts | | |
+| OI change | | |
+| Dark pool / short data | | |
+
+### Flow Verdict
+
+Choose one:
+
+- Clean bullish accumulation
+- Bullish but crowded
+- Bearish protection building
+- Bearish speculation
+- Short-vol / overwrite activity
+- Churn / noisy / low signal
+- Mixed and not actionable
+
+Explain why.
+
+## 5. Cross-Pillar Conflict Resolution
+
+This is the most important section.
+
+Create a table:
+
+| Pillar | Bias | Strength | Evidence | Conflict |
+|---|---|---:|---|---|
+| Market Structure | Bull / Bear / Range | 1-5 | | |
+| Volatility | Long vol / Short vol / Neutral | 1-5 | | |
+| Flow | Bull / Bear / Mixed | 1-5 | | |
+
+Then answer:
+
+1. What is the dominant signal?
+2. What is the biggest contradiction?
+3. Which data should be trusted more for the next 1-5 trading days?
+4. Which data should be trusted more for the next 2-6 weeks?
+5. What would invalidate the current interpretation?
+
+Do not skip this. Do not say “mixed” without explaining what wins.
+
+## 6. Scenario Map
+
+Produce three scenarios.
+
+| Scenario | Probability | Trigger | Expected Move | Best Trade |
+|---|---:|---|---|---|
+| Bullish Breakout | % | | | |
+| Range / Pin | % | | | |
+| Bearish Breakdown | % | | | |
+
+Probabilities must sum to 100%.
+
+Use the options levels to define triggers.
+
+Example style:
+
+- Bullish breakout if spot holds above GEX flip and breaks above max magnet / call wall with confirming call OI expansion.
+- Range if spot remains between flip and magnet with positive GEX.
+- Bearish breakdown if spot loses flip and put wall fails.
+
+## 7. Trade Recommendation
+
+Give a concrete recommendation, but only if actionability is sufficient.
+
+If actionable, provide:
+
+### Preferred Trade
+
+| Field | Recommendation |
+|---|---|
+| Structure | |
+| Direction | |
+| Entry Trigger | |
+| Entry Zone | |
+| Expiry | |
+| Strike Selection Logic | |
+| Target | |
+| Stop / Invalidation | |
+| Position Size | Conservative / Normal / Small only |
+| Why This Structure | |
+| Main Risk | |
+
+If not actionable, provide:
+
+### No-Trade / Watchlist Plan
+
+| Watch Item | Trigger Needed | Why It Matters |
+|---|---|---|
+| Price | | |
+| OI confirmation | | |
+| IV confirmation | | |
+| Flow confirmation | | |
+| Event check | | |
+
+## 8. Strategy Selection Logic
+
+Choose the best structure from the following, and explain why others are rejected.
+
+Possible structures:
+
+- Long stock
+- Long call
+- Call debit spread
+- Put credit spread
+- Covered call
+- Cash-secured put
+- Iron condor
+- Short strangle
+- Long put
+- Put debit spread
+- Calendar spread
+- No trade
+
+Output:
+
+| Strategy | Fit | Reason |
+|---|---|---|
+| Long stock | Good / Bad / Conditional | |
+| Long call | | |
+| Call debit spread | | |
+| Put credit spread | | |
+| Covered call | | |
+| Iron condor | | |
+| Long put / put spread | | |
+| No trade | | |
+
+## 9. Final Trading Plan
+
+End with a direct, practical summary:
+
+- Base case:
+- Best trade:
+- Avoid:
+- Add risk only if:
+- Reduce / hedge if:
+- Key level to watch:
+- Key options signal to watch:
+- Final rating:
+
+The final rating must be one of:
+
+- A: Actionable high-conviction
+- B: Actionable but size small
+- C: Watchlist only
+- D: No trade
+- F: Data insufficient
+
+Do not end with vague commentary.
+Do not simply repeat the dashboard.
+Do not use generic phrases like “monitor closely” unless you specify what to monitor and what action follows."""
 
 _VOLATILE_HASH_KEYS = {
     "analysis_input_hash",
@@ -394,19 +801,52 @@ def build_trade_insights_ai_prompt_payload(
 def build_trade_insights_ai_prompt(prompt_payload: dict[str, Any]) -> str:
     payload_json = json.dumps(prompt_payload, sort_keys=True, indent=2, default=str)
     return (
-        "You are producing a Trade Insights AI analysis for an options research UI.\n"
-        "Analyze only the supplied combined deterministic prompt payload.\n"
+        f"{MARKET_INTELLIGENCE_PROMPT}\n\n"
+        "Integration notes for this local JSON runner:\n"
+        "Analyze only the supplied combined deterministic prompt payload below.\n"
         "Do not fetch outside data. Do not use tools. Do not invent unavailable fields.\n"
+        "Map the prompt placeholders from the JSON payload: ticker from ticker, as_of date "
+        "from tabs.trade_insights.as_of or analysis_produced_at, spot from underlying_price "
+        "or tabs.market_structure.market_structure.spot, market structure data from "
+        "tabs.market_structure, volatility data from tabs.volatility, and flow/positioning "
+        "data from tabs.flow and tabs.positioning.\n"
+        "For optional user context, use Missing / not provided unless the payload explicitly "
+        "contains that field.\n"
         "Build the read from Market Structure, Volatility, Flow, and positioning before "
         "discussing candidate expressions.\n"
         "Use analysis_produced_at exactly as supplied; do not invent a different production time.\n"
+        f"schema_version must exactly equal {PROMPT_VERSION}.\n"
         "Preserve every candidate status, every risk_flags array, and every deterministic "
         "max_loss/max_profit value exactly as supplied.\n"
-        "Treat all needs_check candidates as not executable.\n"
+        "Do not defer solely because a deterministic candidate status is needs_check; give "
+        "a research-only recommendation when the supplied evidence supports one, and put "
+        "remaining checks into the trigger, risk, watchlist, or readiness language.\n"
+        "Project safety override: do not recommend naked short options or undefined-risk "
+        "short-vol structures; if the prompt's strategy list includes one, reject it unless "
+        "it is converted to a defined-risk alternative such as an iron condor.\n"
         "Avoid order placement, position sizing, personalized financial advice, and imperative "
         "trade instructions.\n"
-        "Keep the result compact card-oriented, suitable for a grouped dashboard rather than "
-        "long prose.\n"
+        "Map the full report into the existing TradeInsightAiOutcome JSON fields: use headline "
+        "and dominant_read for Executive Decision, section_cards for the three pillar reads, "
+        "conflicts for cross-pillar conflict resolution, scenario_cards for the scenario map, "
+        "preferred_expression and best_expressions for the preferred trade/readiness, "
+        "required_checks for precise triggers or confirmations, rejected_ideas for strategy "
+        "selection rejects, and rendering.disclaimer/final text for research-only framing.\n"
+        "For preferred_expression, best_expressions, and rejected_ideas idea_id fields, use "
+        "a supplied candidate_structures idea_id when referencing a deterministic candidate. "
+        "When referencing a strategy family from Strategy Selection Logic instead, use only "
+        f"one canonical strategy id from {sorted(STRATEGY_FAMILY_IDS)}. For strategy-family "
+        "preferred_expression or best_expressions entries, set status_observed to "
+        "strategy_review and risk_flags_observed to [].\n"
+        f"Put only one final rating letter from {list(FINAL_RATING_VALUES)} in "
+        "headline.conviction; put the explanatory rating text in "
+        "headline.conviction_label.\n"
+        "Set guardrails.no_executable_recommendations=true when recommendations remain "
+        "research-only, non-imperative, and not order-placement instructions; this field does "
+        "not prohibit research recommendations.\n"
+        "Keep the result compact enough for the AI Analysis card while preserving the "
+        "decision, conflict resolution, scenario map, preferred structure, and final rating "
+        "requested above.\n"
         "Emit only JSON conforming to the TradeInsightAiOutcome schema.\n\n"
         "Payload:\n"
         f"{payload_json}\n"
@@ -426,7 +866,12 @@ def _coerce_strict_schema(node: Any) -> Any:
 
 
 def trade_insights_ai_output_schema() -> dict[str, Any]:
-    return _coerce_strict_schema(TradeInsightAiOutcome.model_json_schema())
+    schema = _coerce_strict_schema(TradeInsightAiOutcome.model_json_schema())
+    schema["properties"]["schema_version"]["const"] = PROMPT_VERSION
+    schema["$defs"]["TradeInsightAiHeadline"]["properties"]["conviction"]["enum"] = (
+        list(FINAL_RATING_VALUES)
+    )
+    return schema
 
 
 _IMPERATIVE_PHRASES = (
@@ -447,7 +892,11 @@ def _candidate_map(deterministic_payload: dict[str, Any]) -> dict[str, dict[str,
     }
 
 
-_PATH_PART_INDEX_RE = re.compile(r"\[\d+\]")
+def _known_idea_id(idea_id: str, candidates: dict[str, dict[str, Any]]) -> bool:
+    return idea_id in candidates or idea_id in STRATEGY_FAMILY_IDS
+
+
+_PATH_PART_INDEX_RE = re.compile(r"\[(?:\d+)?\]")
 
 
 def _path_family_exists(path: str, deterministic_payload: dict[str, Any]) -> bool:
@@ -536,6 +985,8 @@ def validate_trade_insights_ai_outcome(
         )
     if parsed.schema_version != PROMPT_VERSION:
         raise ValueError("schema_version does not match prompt version")
+    if parsed.headline.conviction not in FINAL_RATING_VALUES:
+        raise ValueError("final rating must be one of A, B, C, D, or F")
     if parsed.ticker != deterministic_payload.get("ticker"):
         raise ValueError("ticker does not match deterministic payload")
     if parsed.snapshot.run_id != deterministic_payload.get("run_id"):
@@ -552,11 +1003,11 @@ def validate_trade_insights_ai_outcome(
 
     candidates = _candidate_map(deterministic_payload)
     for item in [*parsed.best_expressions, *parsed.rejected_ideas]:
-        if item.idea_id not in candidates:
+        if not _known_idea_id(item.idea_id, candidates):
             raise ValueError(f"unknown idea_id referenced: {item.idea_id}")
     if (
         parsed.preferred_expression is not None
-        and parsed.preferred_expression.idea_id not in candidates
+        and not _known_idea_id(parsed.preferred_expression.idea_id, candidates)
     ):
         raise ValueError(
             f"unknown idea_id referenced: {parsed.preferred_expression.idea_id}"
@@ -566,6 +1017,16 @@ def validate_trade_insights_ai_outcome(
     if parsed.preferred_expression is not None:
         echo_items.append(parsed.preferred_expression)
     for item in echo_items:
+        if item.idea_id in STRATEGY_FAMILY_IDS:
+            if item.status_observed != "strategy_review":
+                raise ValueError(
+                    f"strategy status_observed must be strategy_review for {item.idea_id}"
+                )
+            if item.risk_flags_observed != []:
+                raise ValueError(
+                    f"strategy risk_flags_observed must be empty for {item.idea_id}"
+                )
+            continue
         candidate = candidates[item.idea_id]
         if item.status_observed != candidate.get("status"):
             raise ValueError(f"status_observed changed for idea_id {item.idea_id}")

--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -32,6 +32,7 @@ STRATEGY_FAMILY_IDS = frozenset(
         "no_trade",
     }
 )
+PREFERRED_STRATEGY_FAMILY_IDS = STRATEGY_FAMILY_IDS - {"short_strangle"}
 FINAL_RATING_VALUES = ("A", "B", "C", "D", "F")
 
 MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist, market-structure analyst, and risk manager.
@@ -605,6 +606,10 @@ def build_trade_insights_ai_analysis_input(
 
     trade_candidates = list(trade_insights_payload.get("candidate_structures") or [])
     synthesis = trade_insights_payload.get("synthesis") or {}
+    next_earnings_date = stock_report_payload.get("next_earnings_date")
+    event_data_known = next_earnings_date is not None
+    if not event_data_known:
+        missing_data.append("tabs.positioning.next_earnings_date is empty")
 
     analysis_input: dict[str, Any] = {
         "prompt_version": PROMPT_VERSION,
@@ -695,13 +700,13 @@ def build_trade_insights_ai_analysis_input(
                     :50
                 ],
                 "aggregates": stock_report_payload.get("aggregates") or {},
-                "next_earnings_date": stock_report_payload.get("next_earnings_date"),
+                "next_earnings_date": next_earnings_date,
             },
             "trade_insights": trade_insights_payload,
         },
         "candidate_structures": trade_candidates,
         "required_before_sizing": list(synthesis.get("required_before_sizing") or []),
-        "event_data_known": False,
+        "event_data_known": event_data_known,
         "data_freshness": _build_data_freshness(
             stock_history_rows=stock_history_rows,
             hv_iv_history=hv_iv_history,
@@ -834,10 +839,12 @@ def build_trade_insights_ai_prompt(prompt_payload: dict[str, Any]) -> str:
         "selection rejects, and rendering.disclaimer/final text for research-only framing.\n"
         "For preferred_expression, best_expressions, and rejected_ideas idea_id fields, use "
         "a supplied candidate_structures idea_id when referencing a deterministic candidate. "
-        "When referencing a strategy family from Strategy Selection Logic instead, use only "
-        f"one canonical strategy id from {sorted(STRATEGY_FAMILY_IDS)}. For strategy-family "
+        "When referencing a strategy family from Strategy Selection Logic in "
+        "preferred_expression or best_expressions, use only one canonical strategy id "
+        f"from {sorted(PREFERRED_STRATEGY_FAMILY_IDS)}. For strategy-family "
         "preferred_expression or best_expressions entries, set status_observed to "
-        "strategy_review and risk_flags_observed to [].\n"
+        "strategy_review and risk_flags_observed to []. rejected_ideas may reference "
+        f"any canonical strategy id from {sorted(STRATEGY_FAMILY_IDS)}.\n"
         f"Put only one final rating letter from {list(FINAL_RATING_VALUES)} in "
         "headline.conviction; put the explanatory rating text in "
         "headline.conviction_label.\n"
@@ -882,6 +889,16 @@ _IMPERATIVE_PHRASES = (
     "place this order",
     "size this position",
 )
+_IMPERATIVE_PATTERNS = tuple(
+    re.compile(pattern, re.I)
+    for pattern in (
+        r"\byou\s+should\s+(?:buy|sell|enter|open|execute)\b",
+        r"\bmust\s+(?:buy|sell|enter|open|execute)\b",
+        r"\b(?:take|open)\s+this\s+trade\b",
+        r"\b(?:place|send)\s+(?:this|the|an?)\s+order\b",
+        r"\bgo\s+(?:long|short)\s+now\b",
+    )
+)
 
 
 def _candidate_map(deterministic_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -903,16 +920,20 @@ def _path_family_exists(path: str, deterministic_payload: dict[str, Any]) -> boo
     parts = [_PATH_PART_INDEX_RE.sub("", p) for p in path.split(".") if p]
     if not parts:
         return False
-    node: Any = deterministic_payload
-    for part in parts:
-        while isinstance(node, list):
-            if not node or not isinstance(node[0], dict):
-                return False
-            node = node[0]
-        if not isinstance(node, dict) or part not in node:
+    return _path_parts_exist(deterministic_payload, parts)
+
+
+def _path_parts_exist(node: Any, parts: list[str]) -> bool:
+    if not parts:
+        return True
+    if isinstance(node, list):
+        if not node:
             return False
-        node = node[part]
-    return True
+        return any(_path_parts_exist(item, parts) for item in node)
+    part = parts[0]
+    if not isinstance(node, dict) or part not in node:
+        return False
+    return _path_parts_exist(node[part], parts[1:])
 
 
 def _mentions_missing_data(item: Any) -> bool:
@@ -963,6 +984,9 @@ def _reject_imperative_text(outcome: TradeInsightAiOutcome) -> None:
     for phrase in _IMPERATIVE_PHRASES:
         if re.search(rf"(^|[.!?]\s+){re.escape(phrase)}\b", free_text, re.I):
             raise ValueError(f"imperative trade instruction rejected: {phrase}")
+    for pattern in _IMPERATIVE_PATTERNS:
+        if pattern.search(free_text):
+            raise ValueError("imperative trade instruction rejected")
 
 
 def validate_trade_insights_ai_outcome(
@@ -1018,6 +1042,10 @@ def validate_trade_insights_ai_outcome(
         echo_items.append(parsed.preferred_expression)
     for item in echo_items:
         if item.idea_id in STRATEGY_FAMILY_IDS:
+            if item.idea_id not in PREFERRED_STRATEGY_FAMILY_IDS:
+                raise ValueError(
+                    f"undefined-risk strategy family cannot be preferred: {item.idea_id}"
+                )
             if item.status_observed != "strategy_review":
                 raise ValueError(
                     f"strategy status_observed must be strategy_review for {item.idea_id}"
@@ -1032,6 +1060,11 @@ def validate_trade_insights_ai_outcome(
             raise ValueError(f"status_observed changed for idea_id {item.idea_id}")
         if item.risk_flags_observed != list(candidate.get("risk_flags") or []):
             raise ValueError(f"risk_flags_observed changed for idea_id {item.idea_id}")
+
+    for conflict in parsed.conflicts:
+        for idea_id in conflict.affected_idea_ids:
+            if not _known_idea_id(idea_id, candidates):
+                raise ValueError(f"unknown idea_id referenced: {idea_id}")
 
     if not (
         parsed.guardrails.statuses_preserved

--- a/src/uw_scan/storage/migrations/021_trade_insights_ai_v2_prompt_rows.sql
+++ b/src/uw_scan/storage/migrations/021_trade_insights_ai_v2_prompt_rows.sql
@@ -1,0 +1,23 @@
+-- Keep active Trade Insights AI rows aligned with the v2 prompt contract.
+-- Old active rows were created with a v1 prompt version and can otherwise be
+-- claimed by a newer worker, producing schema_version mismatch failures.
+
+SET search_path TO uw_scan, public;
+
+UPDATE uw_scan.trade_insight_ai_analyses
+SET
+    status = 'failed',
+    error_message = 'Superseded by trade-insights-ai-v2 prompt version',
+    finished_at = COALESCE(finished_at, now())
+WHERE prompt_version <> 'trade-insights-ai-v2'
+  AND status IN ('queued', 'running');
+
+UPDATE uw_scan.trade_insight_ai_analyses
+SET analysis_input_jsonb = jsonb_set(
+    analysis_input_jsonb,
+    '{prompt_version}',
+    '"trade-insights-ai-v2"'::jsonb,
+    true
+)
+WHERE prompt_version = 'trade-insights-ai-v2'
+  AND COALESCE(analysis_input_jsonb->>'prompt_version', '') <> 'trade-insights-ai-v2';

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1768,6 +1768,34 @@ class Repository:
             cols = [d.name for d in cur.description or []]
             return dict(zip(cols, row, strict=False))
 
+    def find_latest_trade_insight_ai_analysis(
+        self,
+        *,
+        ticker: str,
+        prompt_version: str,
+        model: str,
+    ) -> dict[str, Any] | None:
+        sql = (
+            f"SELECT * FROM {self._schema}.trade_insight_ai_analyses "
+            "WHERE ticker = %s "
+            "AND prompt_version = %s "
+            "AND model = %s "
+            "AND status IN ('queued', 'running', 'succeeded') "
+            "ORDER BY "
+            "  CASE status WHEN 'running' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END, "
+            "  started_at DESC NULLS LAST, "
+            "  requested_at DESC, "
+            "  finished_at DESC NULLS LAST "
+            "LIMIT 1"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (ticker.upper(), prompt_version, model))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [d.name for d in cur.description or []]
+            return dict(zip(cols, row, strict=False))
+
     def enqueue_trade_insight_ai_analysis(
         self,
         *,

--- a/src/uw_scan/worker/jobs/trade_insights_ai.py
+++ b/src/uw_scan/worker/jobs/trade_insights_ai.py
@@ -14,6 +14,7 @@ import psycopg
 
 from uw_scan.config import Settings
 from uw_scan.reports.trade_insights_ai import (
+    PROMPT_VERSION,
     build_trade_insights_ai_prompt,
     build_trade_insights_ai_prompt_payload,
     render_trade_insights_ai_markdown,
@@ -155,6 +156,13 @@ def trade_insights_ai_tick(settings: Settings) -> bool:
             repo.conn.commit()
             return False
         analysis_id = str(row["analysis_id"])
+        if row["prompt_version"] != PROMPT_VERSION:
+            repo.fail_trade_insight_ai_analysis(
+                analysis_id,
+                f"obsolete prompt_version {row['prompt_version']} superseded by {PROMPT_VERSION}",
+            )
+            repo.conn.commit()
+            return True
         analysis_input = dict(row["analysis_input_jsonb"])
         produced_at = datetime.now(timezone.utc)
         prompt_payload = build_trade_insights_ai_prompt_payload(

--- a/tests/integration/api/test_trade_insights_ai_endpoint.py
+++ b/tests/integration/api/test_trade_insights_ai_endpoint.py
@@ -190,6 +190,41 @@ def test_trade_insights_ai_post_queues_and_get_fetches_status(
     assert client.get(f"/api/stock/AAPL/trade-insights/ai-analysis/{body['analysis_id']}").status_code == 404
 
 
+def test_trade_insights_ai_latest_resumes_active_progress(
+    seeded_db_empty_cards,
+    monkeypatch,
+):
+    repo = seeded_db_empty_cards
+    _seed_run(repo)
+    _patch_api_sources(monkeypatch)
+    client = _client_for_settings(_settings_for_repo(repo))
+
+    first = client.post("/api/stock/TSLA/trade-insights/ai-analysis", json={}).json()
+    latest = client.get("/api/stock/TSLA/trade-insights/ai-analysis/latest")
+
+    assert latest.status_code == 200
+    assert latest.json()["analysis_id"] == first["analysis_id"]
+    assert latest.json()["status"] == "queued"
+
+    row = repo.get_trade_insight_ai_analysis(first["analysis_id"], ticker="TSLA")
+    assert row is not None
+    repo.complete_trade_insight_ai_analysis(
+        first["analysis_id"],
+        outcome=_sample_outcome_for(row["analysis_input_jsonb"]),
+        markdown="done",
+    )
+    repo.conn.commit()
+    forced = client.post(
+        "/api/stock/TSLA/trade-insights/ai-analysis",
+        json={"force_rerun": True},
+    ).json()
+    latest_after_rerun = client.get("/api/stock/TSLA/trade-insights/ai-analysis/latest")
+
+    assert latest_after_rerun.status_code == 200
+    assert latest_after_rerun.json()["analysis_id"] == forced["analysis_id"]
+    assert latest_after_rerun.json()["status"] == "queued"
+
+
 def test_trade_insights_ai_post_reuses_active_analysis_for_same_input(
     seeded_db_empty_cards,
     monkeypatch,

--- a/tests/integration/storage/test_repository_trade_insights_ai.py
+++ b/tests/integration/storage/test_repository_trade_insights_ai.py
@@ -140,6 +140,35 @@ def test_find_completed_trade_insight_ai_analysis_reuses_most_recent_success(
     assert found["markdown"] == "new"
 
 
+def test_find_latest_trade_insight_ai_analysis_prefers_active_progress(
+    seeded_db_empty_cards,
+):
+    repo = seeded_db_empty_cards
+    run_id, snapshot_id = _create_snapshot(repo)
+    succeeded_id = _enqueue(repo, snapshot_id=snapshot_id, run_id=run_id)
+    repo.complete_trade_insight_ai_analysis(
+        succeeded_id,
+        outcome={"schema_version": "trade-insights-ai-v1"},
+        markdown="done",
+    )
+    queued_id = _enqueue(
+        repo,
+        snapshot_id=snapshot_id,
+        run_id=run_id,
+        analysis_input_hash="new-ai-hash",
+    )
+
+    found = repo.find_latest_trade_insight_ai_analysis(
+        ticker="TSLA",
+        prompt_version="trade-insights-ai-v1",
+        model="codex-default",
+    )
+
+    assert found is not None
+    assert str(found["analysis_id"]) == queued_id
+    assert found["status"] == "queued"
+
+
 def test_changed_analysis_input_hash_does_not_reuse_completed_row(
     seeded_db_empty_cards,
 ):

--- a/tests/integration/worker/test_trade_insights_ai_jobs.py
+++ b/tests/integration/worker/test_trade_insights_ai_jobs.py
@@ -6,6 +6,7 @@ import psycopg
 
 from tests.test_trade_insights_ai import _analysis_input, _sample_outcome_for
 from uw_scan.config import Settings
+from uw_scan.reports.trade_insights_ai import PROMPT_VERSION
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.trade_insights_ai import (
     TradeInsightsAiRunnerError,
@@ -46,7 +47,11 @@ def _create_snapshot(repo: Repository):
     return run_id, snapshot_id
 
 
-def _enqueue_analysis(repo: Repository) -> tuple[str, dict]:
+def _enqueue_analysis(
+    repo: Repository,
+    *,
+    prompt_version: str = PROMPT_VERSION,
+) -> tuple[str, dict]:
     run_id, snapshot_id = _create_snapshot(repo)
     analysis_input = _analysis_input()
     analysis_input["stored_marker"] = "queued-payload"
@@ -57,7 +62,7 @@ def _enqueue_analysis(repo: Repository) -> tuple[str, dict]:
         trade_insights_input_hash=analysis_input["trade_insights_input_hash"],
         analysis_input_hash=analysis_input["analysis_input_hash"],
         analysis_input=analysis_input,
-        prompt_version="trade-insights-ai-v1",
+        prompt_version=prompt_version,
         model="codex-default",
     )
     repo.conn.commit()
@@ -135,6 +140,35 @@ def test_trade_insights_ai_tick_marks_invalid_output_failed(
     row = repo.get_trade_insight_ai_analysis(analysis_id, ticker="TSLA")
     assert row["status"] == "failed"
     assert row["error_message"]
+
+
+def test_trade_insights_ai_tick_marks_obsolete_prompt_version_failed(
+    seeded_db_empty_cards,
+    monkeypatch,
+):
+    repo = seeded_db_empty_cards
+    settings = _settings_for_repo(repo)
+    analysis_id, _analysis_input_payload = _enqueue_analysis(
+        repo,
+        prompt_version="trade-insights-ai-v1",
+    )
+    runner_called = False
+
+    def fake_runner(*_args, **_kwargs):
+        nonlocal runner_called
+        runner_called = True
+        return {}
+
+    monkeypatch.setattr(
+        "uw_scan.worker.jobs.trade_insights_ai.run_codex_trade_insights_analysis",
+        fake_runner,
+    )
+
+    assert trade_insights_ai_tick(settings) is True
+    row = repo.get_trade_insight_ai_analysis(analysis_id, ticker="TSLA")
+    assert row["status"] == "failed"
+    assert "obsolete prompt_version" in row["error_message"]
+    assert runner_called is False
 
 
 def test_trade_insights_ai_tick_marks_mismatched_produced_at_failed(

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -169,9 +169,17 @@ def test_assemble_trade_insights_builds_research_response():
         "calendar_spread",
     }.issubset({c.structure for c in response.candidate_structures})
     assert response.source_reconciliation.status == "UNKNOWN"
-    assert response.header.preferred_idea_id is None
-    assert response.synthesis.preferred_idea_id is None
-    assert all(c.status == "needs_check" for c in response.candidate_structures)
+    assert response.header.preferred_idea_id == "A"
+    assert response.synthesis.preferred_idea_id == "A"
+    assert response.synthesis.best_risk_reward_idea_id == "A"
+    assert response.candidate_structures[0].status == "preferred"
+    assert all(
+        c.status in {"preferred", "candidate"}
+        for c in response.candidate_structures
+    )
+    assert not any(c.status == "needs_check" for c in response.candidate_structures)
+    assert "Executable recommendation language" not in response.synthesis.avoid
+    assert "Confirm event calendar through all expiries" in response.synthesis.required_before_sizing
 
 
 def test_iron_condor_max_loss_matches_width_minus_total_credit():

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -449,7 +449,7 @@ def test_build_trade_insights_ai_analysis_input_uses_real_tab_payload_fields():
     assert analysis_input["tabs"]["positioning"]["aggregates"]["pcr_volume"] == "0.9"
     assert analysis_input["tabs"]["trade_insights"]["synthesis"]["dominant_story"]
     assert analysis_input["candidate_structures"][0]["idea_id"] == "A"
-    assert analysis_input["event_data_known"] is False
+    assert analysis_input["event_data_known"] is True
 
 
 def test_trade_insights_ai_analysis_hash_is_stable_and_ignores_volatile_times():
@@ -517,6 +517,7 @@ def test_trade_insights_ai_prompt_prunes_long_arrays_and_allows_empty_history():
     payloads["volatility"]["hv_iv_history"] = []
     payloads["volatility"]["vrp_spread"] = []
     degraded = _analysis_input(
+        stock_report={**payloads["stock_report"], "next_earnings_date": None},
         stock_history=payloads["stock_history"],
         volatility=payloads["volatility"],
     )
@@ -524,6 +525,8 @@ def test_trade_insights_ai_prompt_prunes_long_arrays_and_allows_empty_history():
     assert degraded["tabs"]["volatility"]["hv_iv_history"] == []
     assert any("stock_history.rows" in note for note in degraded["missing_data"])
     assert any("volatility.hv_iv_history" in note for note in degraded["missing_data"])
+    assert any("next_earnings_date" in note for note in degraded["missing_data"])
+    assert degraded["event_data_known"] is False
 
 
 def test_trade_insights_ai_prompt_payload_and_prompt_are_recommendation_oriented_guarded():
@@ -613,6 +616,15 @@ def test_validate_trade_insights_ai_outcome_rejects_candidate_guardrail_drift():
     with pytest.raises(ValueError, match="final rating"):
         validate_trade_insights_ai_outcome(bad_rating, deterministic, produced_at=produced_at)
 
+    bad_conflict_ref = _sample_outcome_for(deterministic)
+    bad_conflict_ref["conflicts"][0]["affected_idea_ids"] = ["UNKNOWN"]
+    with pytest.raises(ValueError, match="unknown idea_id"):
+        validate_trade_insights_ai_outcome(
+            bad_conflict_ref,
+            deterministic,
+            produced_at=produced_at,
+        )
+
 
 def test_validate_trade_insights_ai_outcome_allows_strategy_family_ids():
     deterministic = _analysis_input()
@@ -639,6 +651,39 @@ def test_validate_trade_insights_ai_outcome_allows_strategy_family_ids():
     assert parsed.preferred_expression is not None
     assert parsed.preferred_expression.idea_id == "long_stock"
     assert parsed.best_expressions[0].status_observed == "strategy_review"
+
+
+def test_validate_trade_insights_ai_outcome_rejects_undefined_risk_preferred_strategy():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    preferred_short_strangle = _sample_outcome_for(deterministic)
+    preferred_short_strangle["preferred_expression"]["idea_id"] = "short_strangle"
+    preferred_short_strangle["preferred_expression"]["structure"] = "short_strangle"
+    preferred_short_strangle["preferred_expression"]["status_observed"] = (
+        "strategy_review"
+    )
+    preferred_short_strangle["preferred_expression"]["risk_flags_observed"] = []
+    with pytest.raises(ValueError, match="undefined-risk"):
+        validate_trade_insights_ai_outcome(
+            preferred_short_strangle,
+            deterministic,
+            produced_at=produced_at,
+        )
+
+    best_short_strangle = _sample_outcome_for(deterministic)
+    best_short_strangle["best_expressions"][0]["idea_id"] = "short_strangle"
+    best_short_strangle["best_expressions"][0]["structure"] = "short_strangle"
+    best_short_strangle["best_expressions"][0]["status_observed"] = (
+        "strategy_review"
+    )
+    best_short_strangle["best_expressions"][0]["risk_flags_observed"] = []
+    with pytest.raises(ValueError, match="undefined-risk"):
+        validate_trade_insights_ai_outcome(
+            best_short_strangle,
+            deterministic,
+            produced_at=produced_at,
+        )
 
 
 def test_validate_trade_insights_ai_outcome_rejects_time_and_section_mismatches():
@@ -706,6 +751,30 @@ def test_validate_trade_insights_ai_outcome_accepts_array_family_source_paths():
     assert parsed.metric_cards[0].source_path.endswith("rows[].net_dex")
 
 
+def test_validate_trade_insights_ai_outcome_accepts_sparse_array_source_paths():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+    sparse_path = _sample_outcome_for(deterministic)
+    sparse_path["metric_cards"][0]["source_path"] = (
+        "tabs.flow.option_chain_per_strike[].call_open_interest"
+    )
+    deterministic["tabs"]["flow"]["option_chain_per_strike"][0].pop(
+        "call_open_interest",
+        None,
+    )
+    sparse_path["snapshot"]["analysis_input_hash"] = hash_trade_insights_ai_analysis_input(
+        deterministic
+    )
+
+    parsed = validate_trade_insights_ai_outcome(
+        sparse_path,
+        deterministic,
+        produced_at=produced_at,
+    )
+
+    assert parsed.metric_cards[0].source_path.endswith("call_open_interest")
+
+
 def test_validate_trade_insights_ai_outcome_rejects_field_aware_imperatives():
     deterministic = _analysis_input()
     produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
@@ -718,6 +787,17 @@ def test_validate_trade_insights_ai_outcome_rejects_field_aware_imperatives():
     rejected["preferred_expression"]["title"] = "Buy now"
     with pytest.raises(ValueError, match="imperative"):
         validate_trade_insights_ai_outcome(rejected, deterministic, produced_at=produced_at)
+
+    advice_order = _sample_outcome_for(deterministic)
+    advice_order["preferred_expression"]["why"] = (
+        "You should buy this spread because flow is bullish."
+    )
+    with pytest.raises(ValueError, match="imperative"):
+        validate_trade_insights_ai_outcome(
+            advice_order,
+            deterministic,
+            produced_at=produced_at,
+        )
 
 
 def test_render_trade_insights_ai_markdown_uses_structured_sections():

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -25,7 +25,7 @@ from uw_scan.reports.trade_insights_ai import (
 def _sample_outcome() -> dict:
     produced_at = "2026-03-24T20:18:42Z"
     return {
-        "schema_version": "trade-insights-ai-v1",
+        "schema_version": PROMPT_VERSION,
         "analysis_produced_at": produced_at,
         "ticker": "TSLA",
         "underlying_price": "$380.88",
@@ -228,7 +228,7 @@ def test_trade_insight_ai_analysis_response_includes_queue_and_hash_fields():
         trade_insights_input_hash="sha256-trade-insights",
         analysis_input_hash="sha256-combined",
         model="codex-default",
-        prompt_version="trade-insights-ai-v1",
+        prompt_version=PROMPT_VERSION,
         status="queued",
         requested_at=datetime(2026, 3, 24, 20, 0, tzinfo=timezone.utc),
     )
@@ -526,7 +526,7 @@ def test_trade_insights_ai_prompt_prunes_long_arrays_and_allows_empty_history():
     assert any("volatility.hv_iv_history" in note for note in degraded["missing_data"])
 
 
-def test_trade_insights_ai_prompt_payload_and_prompt_are_card_oriented_guarded():
+def test_trade_insights_ai_prompt_payload_and_prompt_are_recommendation_oriented_guarded():
     analysis_input = _analysis_input()
     produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
 
@@ -538,11 +538,24 @@ def test_trade_insights_ai_prompt_payload_and_prompt_are_card_oriented_guarded()
 
     assert prompt_payload["analysis_produced_at"] == "2026-03-24T20:18:42Z"
     assert prompt_payload["analysis_input_hash"] == hash_trade_insights_ai_analysis_input(analysis_input)
+    assert "You are an institutional options strategist, market-structure analyst, and risk manager." in prompt
     assert "Analyze only the supplied combined deterministic prompt payload" in prompt
     assert "Do not fetch outside data" in prompt
-    assert "Market Structure, Volatility, Flow, and positioning" in prompt
-    assert "compact card-oriented" in prompt
+    assert "1. Market Structure" in prompt
+    assert "2. Volatility" in prompt
+    assert "3. Flow and Positioning" in prompt
+    assert "The objective is to produce a high-quality trading interpretation, not a dashboard summary." in prompt
+    assert "Trade recommendations must include entry trigger" in prompt
+    assert "Do not defer solely because a deterministic candidate status is needs_check" in prompt
+    assert "All recommendations are research-only and not financial advice." in prompt
+    assert f"schema_version must exactly equal {PROMPT_VERSION}" in prompt
+    assert "Map the full report into the existing TradeInsightAiOutcome JSON fields" in prompt
+    assert "does not prohibit research recommendations" in prompt
+    assert "# {{ticker}} Options Market Intelligence Report" in prompt
+    assert "## 5. Cross-Pillar Conflict Resolution" in prompt
+    assert "The final rating must be one of:" in prompt
     assert "Preserve every candidate status" in prompt
+    assert "Treat all needs_check candidates as not executable" not in prompt
     assert "Emit only JSON" in prompt
     assert '"tabs"' in prompt
 
@@ -551,6 +564,14 @@ def test_trade_insights_ai_output_schema_requires_structured_sections():
     schema = trade_insights_ai_output_schema()
 
     assert schema["title"] == "TradeInsightAiOutcome"
+    assert schema["properties"]["schema_version"]["const"] == PROMPT_VERSION
+    assert schema["$defs"]["TradeInsightAiHeadline"]["properties"]["conviction"]["enum"] == [
+        "A",
+        "B",
+        "C",
+        "D",
+        "F",
+    ]
     required = set(schema["required"])
     assert {
         "metric_cards",
@@ -586,6 +607,38 @@ def test_validate_trade_insights_ai_outcome_rejects_candidate_guardrail_drift():
     bad_guardrails["guardrails"]["statuses_preserved"] = False
     with pytest.raises(ValueError, match="guardrails"):
         validate_trade_insights_ai_outcome(bad_guardrails, deterministic, produced_at=produced_at)
+
+    bad_rating = _sample_outcome_for(deterministic)
+    bad_rating["headline"]["conviction"] = "Medium-low actionable conviction"
+    with pytest.raises(ValueError, match="final rating"):
+        validate_trade_insights_ai_outcome(bad_rating, deterministic, produced_at=produced_at)
+
+
+def test_validate_trade_insights_ai_outcome_allows_strategy_family_ids():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    strategy_read = _sample_outcome_for(deterministic)
+    strategy_read["preferred_expression"]["idea_id"] = "long_stock"
+    strategy_read["preferred_expression"]["structure"] = "long_stock"
+    strategy_read["preferred_expression"]["status_observed"] = "strategy_review"
+    strategy_read["preferred_expression"]["risk_flags_observed"] = []
+    strategy_read["best_expressions"][0]["idea_id"] = "long_stock"
+    strategy_read["best_expressions"][0]["structure"] = "long_stock"
+    strategy_read["best_expressions"][0]["status_observed"] = "strategy_review"
+    strategy_read["best_expressions"][0]["risk_flags_observed"] = []
+    strategy_read["rejected_ideas"][0]["idea_id"] = "short_strangle"
+    strategy_read["rejected_ideas"][0]["structure"] = "short_strangle"
+
+    parsed = validate_trade_insights_ai_outcome(
+        strategy_read,
+        deterministic,
+        produced_at=produced_at,
+    )
+
+    assert parsed.preferred_expression is not None
+    assert parsed.preferred_expression.idea_id == "long_stock"
+    assert parsed.best_expressions[0].status_observed == "strategy_review"
 
 
 def test_validate_trade_insights_ai_outcome_rejects_time_and_section_mismatches():
@@ -634,6 +687,23 @@ def test_validate_trade_insights_ai_outcome_rejects_source_path_problems():
     bad_leaf["metric_cards"][0]["source_path"] = "tabs.volatility.header.not_real"
     with pytest.raises(ValueError, match="source_path"):
         validate_trade_insights_ai_outcome(bad_leaf, deterministic, produced_at=produced_at)
+
+
+def test_validate_trade_insights_ai_outcome_accepts_array_family_source_paths():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+    wildcard_path = _sample_outcome_for(deterministic)
+    wildcard_path["metric_cards"][0]["source_path"] = (
+        "tabs.market_structure.stock_history.rows[].net_dex"
+    )
+
+    parsed = validate_trade_insights_ai_outcome(
+        wildcard_path,
+        deterministic,
+        produced_at=produced_at,
+    )
+
+    assert parsed.metric_cards[0].source_path.endswith("rows[].net_dex")
 
 
 def test_validate_trade_insights_ai_outcome_rejects_field_aware_imperatives():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,9 @@
+from uw_scan.config import Settings
+
+
+def test_trade_insights_ai_default_timeout_matches_deep_prompt_budget():
+    settings = Settings(
+        api_key="dummy",
+    )
+
+    assert settings.trade_insights_ai_timeout_seconds == 300.0

--- a/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
+++ b/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
 import { api, type TradeInsightsAiAnalysisResponse } from "@/lib/api";
 import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
 
 type Outcome = NonNullable<TradeInsightsAiAnalysisResponse["outcome"]>;
+export const AI_ANALYSIS_POLL_MAX_MS = 10 * 60 * 1000;
 
 const labelStyle = {
   fontFamily: "var(--font-mono)",
@@ -15,293 +17,494 @@ const labelStyle = {
   textTransform: "uppercase" as const,
 };
 
-function MiniCard({
-  label,
-  value,
-  note,
-}: {
-  label: string;
-  value: string;
-  note?: string | null;
-}) {
+type Tone = "positive" | "negative" | "warning" | "neutral";
+type SectionCardData = Outcome["section_cards"]["market_structure"];
+
+function toneColor(tone: Tone): string {
+  if (tone === "positive") return "var(--positive)";
+  if (tone === "negative") return "var(--negative)";
+  if (tone === "warning") return "var(--warning)";
+  return "var(--neutral)";
+}
+
+function toneFromText(value: string | null | undefined): Tone {
+  const text = (value ?? "").toLowerCase();
+  if (
+    text.includes("bull") ||
+    text.includes("buy") ||
+    text.includes("positive") ||
+    text.includes("break")
+  ) {
+    return "positive";
+  }
+  if (
+    text.includes("bear") ||
+    text.includes("sell") ||
+    text.includes("negative") ||
+    text.includes("blocked") ||
+    text.includes("failed")
+  ) {
+    return "negative";
+  }
+  if (
+    text.includes("wait") ||
+    text.includes("mixed") ||
+    text.includes("check") ||
+    text.includes("risk")
+  ) {
+    return "warning";
+  }
+  return "neutral";
+}
+
+function tidy(value: string | number | null | undefined): string {
+  if (value == null || value === "") return "None";
+  const text = String(value);
+  if (!/^-?\d+(\.\d+)?$/.test(text)) return text;
+  const n = Number(text);
+  if (!Number.isFinite(n)) return text;
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: Math.abs(n) < 1 ? 4 : 2,
+  }).format(n);
+}
+
+function shortDate(value: string | null | undefined): string {
+  if (!value) return "unknown";
+  return value.slice(0, 10);
+}
+
+function clipped(value: string, max = 120): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1).trim()}...`;
+}
+
+function plainText(value: string | null | undefined): string {
+  return (value ?? "")
+    .replaceAll("needs_check", "pending validation")
+    .replaceAll("do_not_sell", "do not sell premium")
+    .replaceAll("_", " ");
+}
+
+function scoreText(section: SectionCardData): string | null {
+  if (section.score == null || section.max_score == null) return null;
+  return `score ${section.score}/${section.max_score} · ${section.data_quality}`;
+}
+
+function isInFlight(analysis: TradeInsightsAiAnalysisResponse): boolean {
+  return analysis.status === "queued" || analysis.status === "running";
+}
+
+function SmallHeading({ children }: { children: ReactNode }) {
   return (
-    <div
-      style={{
-        border: "1px solid var(--border-dim)",
-        borderRadius: 4,
-        padding: 10,
-        minHeight: 76,
-      }}
-    >
-      <div style={labelStyle}>{label}</div>
-      <div
-        style={{
-          color: "var(--text-primary)",
-          fontFamily: "var(--font-mono)",
-          fontSize: 16,
-        }}
-      >
-        {value}
-      </div>
-      {note && (
-        <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
-          {note}
-        </div>
-      )}
+    <div style={{ color: "var(--text-primary)", fontSize: 12, fontWeight: 700 }}>
+      {children}
     </div>
   );
 }
 
-function SectionCard({
-  section,
+function CompactNote({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: 8,
+      }}
+    >
+      <SmallHeading>{label}</SmallHeading>
+      <div style={{ color: "var(--text-secondary)", fontSize: 12, lineHeight: 1.4 }}>
+        {plainText(clipped(value, 110))}
+      </div>
+    </div>
+  );
+}
+
+function AnalysisCard({
+  title,
+  subtitle,
+  tone,
+  children,
 }: {
-  section: Outcome["section_cards"]["market_structure"];
+  title: string;
+  subtitle?: string | null;
+  tone: Tone;
+  children: ReactNode;
 }) {
   return (
     <div
       style={{
         border: "1px solid var(--border-dim)",
         borderRadius: 4,
-        padding: 12,
+        borderLeft: `6px solid ${toneColor(tone)}`,
+        background: "var(--bg-panel)",
+        height: "100%",
+        minHeight: 0,
+        padding: "12px 14px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        overflowWrap: "anywhere",
       }}
     >
-      <div style={labelStyle}>{section.title}</div>
-      <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
-        {section.summary}
-      </div>
-      {section.score != null && section.max_score != null && (
+      <div>
         <div
           style={{
-            color: "var(--text-muted)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
+            color: "var(--text-primary)",
+            fontSize: 15,
+            fontWeight: 700,
+            lineHeight: 1.25,
           }}
         >
-          score {section.score}/{section.max_score} · {section.data_quality}
+          {title}
         </div>
-      )}
-      {[
-        ...(section.highlights ?? []),
-        ...(section.levels ?? []).map((level) => ({
-          label: level.kind,
-          value: `${level.price} ${level.value}`,
-          note: level.note,
-        })),
-      ].map((item) => (
-        <div
-          key={`${item.label}-${item.value}`}
-          style={{ marginTop: 8, fontSize: 12 }}
-        >
-          <span style={{ color: "var(--text-secondary)" }}>{item.label}: </span>
-          <span style={{ color: "var(--text-primary)" }}>{item.value}</span>
+        {subtitle && (
+          <div
+            style={{
+              color: "var(--text-muted)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              marginTop: 4,
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function KeyValueGrid({
+  items,
+}: {
+  items: { label: string; value: string | number | null | undefined }[];
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 120px), 1fr))",
+        gap: "8px 12px",
+      }}
+    >
+      {items.map((item) => (
+        <div key={item.label}>
+          <div
+            style={{
+              color: "var(--text-primary)",
+              fontSize: 12,
+              fontWeight: 700,
+            }}
+          >
+            {item.label}
+          </div>
+          <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
+            {plainText(tidy(item.value))}
+          </div>
         </div>
       ))}
     </div>
   );
 }
 
-function OutcomeGrid({ outcome }: { outcome: Outcome }) {
+function BulletList({
+  items,
+  limit = 4,
+}: {
+  items: (string | null | undefined)[];
+  limit?: number;
+}) {
+  const visible = items.filter(Boolean).slice(0, limit) as string[];
+  if (visible.length === 0) {
+    return <div style={{ color: "var(--text-muted)", fontSize: 12 }}>None</div>;
+  }
   return (
-    <div style={{ display: "grid", gap: 14 }}>
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "minmax(220px, 1.2fr) minmax(180px, 0.8fr)",
-          gap: 12,
-        }}
-      >
-        <div>
-          <div style={{ ...labelStyle, marginBottom: 4 }}>{outcome.ticker}</div>
-          <div
-            style={{
-              color: "var(--text-primary)",
-              fontSize: 18,
-              fontWeight: 700,
-            }}
-          >
-            {outcome.headline.title}
-          </div>
-          <div
-            style={{
-              color: "var(--text-secondary)",
-              fontSize: 12,
-              marginTop: 6,
-            }}
-          >
-            Generated analysis from local Codex. Deterministic risk checks
-            remain authoritative.
-          </div>
+    <div style={{ display: "grid", gap: 5 }}>
+      {visible.map((item) => (
+        <div key={item} style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+          {plainText(item)}
         </div>
-        <div
-          style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}
-        >
-          <MiniCard label="Stance" value={outcome.headline.stance_label} />
-          <MiniCard
-            label="Score"
-            value={`${outcome.headline.score}/${outcome.headline.score_scale}`}
-            note={`${outcome.headline.conviction} · ${outcome.headline.conviction_label}`}
-          />
-        </div>
-      </div>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-          gap: 8,
-        }}
-      >
-        <MiniCard
-          label="Produced"
-          value={outcome.analysis_produced_at.slice(0, 10)}
-        />
-        <MiniCard
-          label="Data"
-          value={outcome.snapshot.freshness_label}
-          note={outcome.snapshot.data_as_of}
-        />
-        <MiniCard label="Risk" value={outcome.headline.primary_risk} />
-        <MiniCard label="Watch" value={outcome.headline.watch_trigger} />
-        {outcome.metric_cards.map((card) => (
-          <MiniCard
-            key={`${card.label}-${card.value}`}
-            label={card.label}
-            value={card.value}
-            note={card.note}
-          />
-        ))}
-      </div>
-
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-          gap: 8,
-        }}
-      >
-        {outcome.scenario_cards.map((card) => (
-          <MiniCard
-            key={card.case}
-            label={card.case}
-            value={card.title}
-            note={card.description}
-          />
-        ))}
-      </div>
-
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-        <SectionCard section={outcome.section_cards.market_structure} />
-        <SectionCard section={outcome.section_cards.volatility} />
-        <SectionCard section={outcome.section_cards.flow_positioning} />
-        {outcome.vrp_assessment && (
-          <div
-            style={{
-              border: "1px solid var(--border-dim)",
-              borderRadius: 4,
-              padding: 12,
-            }}
-          >
-            <div style={labelStyle}>{outcome.vrp_assessment.title}</div>
-            <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
-              {outcome.vrp_assessment.summary}
-            </div>
-            <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
-              {outcome.vrp_assessment.reason}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {outcome.preferred_expression && (
-        <div
-          style={{
-            border: "1px solid var(--border-dim)",
-            borderRadius: 4,
-            padding: 12,
-          }}
-        >
-          <div style={labelStyle}>Preferred Expression</div>
-          <div style={{ color: "var(--text-primary)", fontSize: 15 }}>
-            {outcome.preferred_expression.title}
-          </div>
-          <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
-            {outcome.preferred_expression.why}
-          </div>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(4, 1fr)",
-              gap: 8,
-              marginTop: 8,
-            }}
-          >
-            <MiniCard
-              label="Entry"
-              value={outcome.preferred_expression.estimated_entry}
-            />
-            <MiniCard
-              label="Max Profit"
-              value={outcome.preferred_expression.max_profit_observed}
-            />
-            <MiniCard
-              label="Max Loss"
-              value={outcome.preferred_expression.max_loss_observed}
-            />
-            <MiniCard
-              label="Status"
-              value={outcome.preferred_expression.status_observed}
-            />
-          </div>
-        </div>
-      )}
-
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-        <List
-          title="Conflicts"
-          items={(outcome.conflicts ?? []).map((item) => item.description)}
-        />
-        <List
-          title="Required Checks"
-          items={(outcome.required_checks ?? []).map((item) => item.check)}
-        />
-        <List
-          title="Rejected Ideas"
-          items={(outcome.rejected_ideas ?? []).map(
-            (item) => `${item.idea_id}: ${item.reason}`,
-          )}
-        />
-        <List title="Missing Data" items={outcome.missing_data ?? []} />
-      </div>
+      ))}
     </div>
   );
 }
 
-function List({ title, items }: { title: string; items: string[] }) {
+function ScenarioList({ cards }: { cards: Outcome["scenario_cards"] }) {
+  const visible = cards.slice(0, 3);
+  if (visible.length === 0) {
+    return <div style={{ color: "var(--text-muted)", fontSize: 12 }}>None</div>;
+  }
   return (
-    <div
-      style={{
-        border: "1px solid var(--border-dim)",
-        borderRadius: 4,
-        padding: 12,
-      }}
-    >
-      <div style={labelStyle}>{title}</div>
-      {items.length === 0 ? (
-        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>None</div>
-      ) : (
-        items.map((item) => (
+    <div style={{ display: "grid", gap: 5 }}>
+      {visible.map((card) => (
+        <div key={card.case}>
           <div
-            key={item}
             style={{
-              color: "var(--text-secondary)",
+              color: "var(--text-primary)",
               fontSize: 12,
-              marginTop: 4,
+              fontWeight: 700,
             }}
           >
-            {item}
+            {card.title}
           </div>
-        ))
-      )}
+          <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+            {plainText(clipped(card.description, 96))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SectionSummaryCard({
+  section,
+  tone,
+}: {
+  section: SectionCardData;
+  tone: Tone;
+}) {
+  const highlights = [
+    ...(section.highlights ?? []).map(
+      (item) => `${item.label}: ${tidy(item.value)}${item.note ? ` · ${item.note}` : ""}`,
+    ),
+    ...(section.levels ?? []).map(
+      (level) =>
+        `${level.kind}: ${tidy(level.price)} ${tidy(level.value)}${
+          level.note ? ` · ${level.note}` : ""
+        }`,
+    ),
+  ];
+  return (
+    <AnalysisCard title={section.title} subtitle={scoreText(section)} tone={tone}>
+      <div
+        style={{
+          color: "var(--text-primary)",
+          fontSize: 13,
+          fontWeight: 600,
+          lineHeight: 1.45,
+        }}
+      >
+        {plainText(section.summary)}
+      </div>
+      <BulletList items={highlights} />
+    </AnalysisCard>
+  );
+}
+
+function OutcomeGrid({ outcome }: { outcome: Outcome }) {
+  const preferred = outcome.preferred_expression;
+  const topMetrics = outcome.metric_cards.slice(0, 6).map((card) => ({
+    label: card.label,
+    value: card.value,
+  }));
+  const requiredChecks = (outcome.required_checks ?? []).map((item) => item.check);
+  const conflicts = (outcome.conflicts ?? []).map((item) => item.description);
+  const missing = outcome.missing_data ?? [];
+
+  return (
+    <div style={{ display: "grid", gap: 14 }}>
+      <div
+        style={{
+          border: "1px solid var(--border-dim)",
+          borderLeft: `6px solid ${toneColor(toneFromText(outcome.headline.stance_label))}`,
+          borderRadius: 4,
+          padding: "12px 14px",
+          background: "var(--bg-panel)",
+        }}
+      >
+        <div style={labelStyle}>{outcome.ticker} AI Analysis</div>
+        <div
+          style={{
+            color: "var(--text-primary)",
+            fontSize: 16,
+            fontWeight: 700,
+            lineHeight: 1.25,
+            marginTop: 4,
+          }}
+        >
+          {outcome.headline.title}
+        </div>
+        <div
+          style={{
+            color: "var(--text-primary)",
+            fontSize: 13,
+            fontWeight: 600,
+            lineHeight: 1.45,
+            marginTop: 8,
+          }}
+        >
+          {plainText(outcome.dominant_read?.summary ?? outcome.headline.top_reason)}
+        </div>
+        <KeyValueGrid
+          items={[
+            { label: "Stance", value: outcome.headline.stance_label },
+            {
+              label: "Score",
+              value: `${outcome.headline.score}/${outcome.headline.score_scale}`,
+            },
+            {
+              label: "Conviction",
+              value: `${outcome.headline.conviction} · ${outcome.headline.conviction_label}`,
+            },
+            {
+              label: "Data",
+              value: `${outcome.snapshot.freshness_label} · ${shortDate(outcome.snapshot.data_as_of)}`,
+            },
+            ...topMetrics,
+          ]}
+        />
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+            gap: 8,
+            marginTop: 10,
+          }}
+        >
+          <CompactNote label="Primary Risk" value={outcome.headline.primary_risk} />
+          <CompactNote label="Trigger To Watch" value={outcome.headline.watch_trigger} />
+        </div>
+        <div
+          style={{
+            color: "var(--text-muted)",
+            fontSize: 12,
+            fontWeight: 700,
+            marginTop: 10,
+          }}
+        >
+          Generated analysis from local Codex · {outcome.analysis_produced_at.slice(0, 10)} · Not financial advice
+        </div>
+      </div>
+
+      <div
+        data-testid="ai-analysis-card-grid"
+        style={{
+          display: "grid",
+          gap: 12,
+        }}
+      >
+        <div
+          data-testid="ai-analysis-upper-card-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+            alignItems: "stretch",
+            gap: 12,
+          }}
+        >
+          <SectionSummaryCard
+            section={outcome.section_cards.market_structure}
+            tone="positive"
+          />
+          <SectionSummaryCard
+            section={outcome.section_cards.volatility}
+            tone={toneFromText(outcome.section_cards.volatility.summary)}
+          />
+          <SectionSummaryCard
+            section={outcome.section_cards.flow_positioning}
+            tone={toneFromText(outcome.section_cards.flow_positioning.summary)}
+          />
+        </div>
+        <div
+          data-testid="ai-analysis-lower-card-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(0, 0.95fr) minmax(0, 0.9fr) minmax(0, 1.15fr)",
+            alignItems: "stretch",
+            gap: 12,
+          }}
+        >
+          <AnalysisCard
+            title={outcome.vrp_assessment?.title ?? "VRP Assessment"}
+            subtitle="Vol premium edge and blockers"
+            tone={toneFromText(outcome.vrp_assessment?.signal)}
+          >
+            <div
+              style={{
+                color: "var(--text-primary)",
+                fontSize: 13,
+                fontWeight: 600,
+                lineHeight: 1.45,
+              }}
+            >
+              {plainText(
+                outcome.vrp_assessment?.summary ?? "No VRP assessment supplied.",
+              )}
+            </div>
+            {outcome.vrp_assessment?.metrics?.length ? (
+              <KeyValueGrid
+                items={outcome.vrp_assessment.metrics.slice(0, 6).map((metric) => ({
+                  label: metric.label,
+                  value: metric.value,
+                }))}
+              />
+            ) : null}
+            {requiredChecks.length > 0 && (
+              <div>
+                <SmallHeading>Checks blocking action</SmallHeading>
+                <BulletList items={requiredChecks} limit={3} />
+              </div>
+            )}
+            {outcome.vrp_assessment?.reason && (
+              <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+                {plainText(outcome.vrp_assessment.reason)}
+              </div>
+            )}
+          </AnalysisCard>
+          <AnalysisCard
+            title="Trade Setup Readiness"
+            subtitle={
+              preferred
+                ? preferred.title
+                : "No trade structure cleared validation"
+            }
+            tone={toneFromText(preferred?.status_observed)}
+          >
+            {preferred ? (
+              <>
+                <KeyValueGrid
+                  items={[
+                    { label: "Structure", value: preferred.structure },
+                    { label: "Entry", value: preferred.estimated_entry },
+                    { label: "Max Profit", value: preferred.max_profit_observed },
+                    { label: "Max Loss", value: preferred.max_loss_observed },
+                    { label: "R:R", value: preferred.reward_risk },
+                    { label: "Status", value: preferred.status_observed },
+                  ]}
+                />
+                <div style={{ color: "var(--text-primary)", fontSize: 13 }}>
+                  {plainText(preferred.why)}
+                </div>
+                <BulletList items={preferred.management_notes ?? []} limit={3} />
+              </>
+            ) : (
+              <div style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+                No entry candidate is ready yet. The generated structures stay
+                pending validation until the checklist passes.
+              </div>
+            )}
+          </AnalysisCard>
+          <AnalysisCard
+            title="Validation Checklist"
+            subtitle="What must be watched or confirmed"
+            tone="warning"
+          >
+            <div>
+              <SmallHeading>Price paths to watch</SmallHeading>
+              <ScenarioList cards={outcome.scenario_cards} />
+            </div>
+            <div>
+              <SmallHeading>Must confirm before sizing</SmallHeading>
+              <BulletList items={requiredChecks} limit={3} />
+            </div>
+            <div>
+              <SmallHeading>Why still blocked</SmallHeading>
+              <BulletList items={[...conflicts, ...missing]} limit={3} />
+            </div>
+          </AnalysisCard>
+        </div>
+      </div>
     </div>
   );
 }
@@ -311,13 +514,35 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
     useState<TradeInsightsAiAnalysisResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [unavailable, setUnavailable] = useState(false);
-  const hydratedRef = useRef<string | null>(null);
   const requestTokenRef = useRef(0);
+
+  async function pollAnalysis(
+    started: TradeInsightsAiAnalysisResponse,
+    token: number,
+  ) {
+    const isCurrentRequest = () => requestTokenRef.current === token;
+    let current = started;
+    let elapsedMs = 0;
+    const intervalMs = 3000;
+    const maxMs = AI_ANALYSIS_POLL_MAX_MS;
+    while (isInFlight(current)) {
+      if (elapsedMs >= maxMs) break;
+      current = await api.tradeInsightsAiAnalysisStatus(
+        ticker,
+        started.analysis_id,
+      );
+      if (!isCurrentRequest()) return;
+      setAnalysis(current);
+      if (isInFlight(current)) {
+        await new Promise((r) => setTimeout(r, intervalMs));
+        if (!isCurrentRequest()) return;
+        elapsedMs += intervalMs;
+      }
+    }
+  }
 
   useEffect(() => {
     const token = ++requestTokenRef.current;
-    if (hydratedRef.current === ticker) return;
-    hydratedRef.current = ticker;
     setAnalysis(null);
     setLoading(false);
     setUnavailable(false);
@@ -327,6 +552,13 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
         const latest = await api.tradeInsightsAiAnalysisLatest(ticker);
         if (!cancelled && requestTokenRef.current === token && latest) {
           setAnalysis(latest);
+          if (isInFlight(latest)) {
+            setLoading(true);
+            await pollAnalysis(latest, token);
+            if (!cancelled && requestTokenRef.current === token) {
+              setLoading(false);
+            }
+          }
         }
       } catch (err) {
         if (
@@ -356,24 +588,7 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
       );
       if (!isCurrentRequest()) return;
       setAnalysis(started);
-      let current = started;
-      let elapsedMs = 0;
-      const intervalMs = 3000;
-      const maxMs = 5 * 60 * 1000;
-      while (current.status === "queued" || current.status === "running") {
-        if (elapsedMs >= maxMs) break;
-        current = await api.tradeInsightsAiAnalysisStatus(
-          ticker,
-          started.analysis_id,
-        );
-        if (!isCurrentRequest()) return;
-        setAnalysis(current);
-        if (current.status === "queued" || current.status === "running") {
-          await new Promise((r) => setTimeout(r, intervalMs));
-          if (!isCurrentRequest()) return;
-          elapsedMs += intervalMs;
-        }
-      }
+      await pollAnalysis(started, token);
     } catch (err) {
       if (!isCurrentRequest()) return;
       if (String(err).includes("503")) {
@@ -410,7 +625,7 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
             {loading ? "Running..." : "Run AI Analysis"}
           </button>
         )}
-        {analysis?.status === "queued" || analysis?.status === "running" ? (
+        {analysis && isInFlight(analysis) ? (
           <InsightStatusBanner
             text={`AI analysis ${analysis.status}`}
             severity="info"

--- a/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
+++ b/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
@@ -395,7 +395,7 @@ function OutcomeGrid({ outcome }: { outcome: Outcome }) {
         >
           <SectionSummaryCard
             section={outcome.section_cards.market_structure}
-            tone="positive"
+            tone={toneFromText(outcome.section_cards.market_structure.summary)}
           />
           <SectionSummaryCard
             section={outcome.section_cards.volatility}
@@ -554,9 +554,24 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
           setAnalysis(latest);
           if (isInFlight(latest)) {
             setLoading(true);
-            await pollAnalysis(latest, token);
-            if (!cancelled && requestTokenRef.current === token) {
-              setLoading(false);
+            try {
+              await pollAnalysis(latest, token);
+            } catch (err) {
+              if (!cancelled && requestTokenRef.current === token) {
+                if (String(err).includes("503")) {
+                  setUnavailable(true);
+                } else {
+                  setAnalysis((currentAnalysis) => ({
+                    ...currentAnalysis,
+                    status: "failed",
+                    error_message: String(err),
+                  }) as TradeInsightsAiAnalysisResponse);
+                }
+              }
+            } finally {
+              if (!cancelled && requestTokenRef.current === token) {
+                setLoading(false);
+              }
             }
           }
         }

--- a/web/components/stock/tabs/TradeInsightsTab.tsx
+++ b/web/components/stock/tabs/TradeInsightsTab.tsx
@@ -8,22 +8,38 @@ import { TermMovePanel } from "../panels/TermMovePanel";
 import { TradeInsightsAiAnalysisPanel } from "../panels/TradeInsightsAiAnalysisPanel";
 import { TradeInsightsBiasBanner } from "../panels/TradeInsightsBiasBanner";
 
+const upperPairGridStyle = {
+  display: "grid",
+  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+  alignItems: "stretch",
+  gridAutoRows: "1fr",
+  gap: 12,
+};
+
+const lowerPairGridStyle = {
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 1.15fr) minmax(0, 0.85fr)",
+  alignItems: "stretch",
+  gridAutoRows: "1fr",
+  gap: 12,
+};
+
 export async function TradeInsightsTab({ ticker }: { ticker: string }) {
   const insights = await api.tradeInsights(ticker);
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <TradeInsightsBiasBanner header={insights.header} />
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+      <TradeInsightsAiAnalysisPanel ticker={ticker} />
+      <div data-testid="trade-insights-upper-pair" style={upperPairGridStyle}>
+        <ChainFlowReadPanel rows={insights.flow_table} />
+        <TermMovePanel rows={insights.term_structure_table} />
+      </div>
+      <InsightsSynthesisPanel synthesis={insights.synthesis} />
+      <div data-testid="trade-insights-lower-pair" style={lowerPairGridStyle}>
         <SourceReconciliationPanel reconciliation={insights.source_reconciliation} />
         <SignalStackPanel rows={insights.signal_stack} />
       </div>
       <CandidateStructuresPanel candidates={insights.candidate_structures} />
-      <InsightsSynthesisPanel synthesis={insights.synthesis} />
-      <TradeInsightsAiAnalysisPanel ticker={ticker} />
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-        <ChainFlowReadPanel rows={insights.flow_table} />
-        <TermMovePanel rows={insights.term_structure_table} />
-      </div>
     </div>
   );
 }

--- a/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
+++ b/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
@@ -284,6 +284,23 @@ describe("TradeInsightsAiAnalysisPanel", () => {
     expect(screen.getAllByText(/2026-03-24/).length).toBeGreaterThan(0);
   });
 
+  it("derives market structure card tone from the AI read", async () => {
+    const bearish = succeededResponse();
+    if (bearish.outcome) {
+      bearish.outcome.section_cards.market_structure.summary =
+        "Bearish below the GEX flip.";
+    }
+    vi.mocked(api.tradeInsightsAiAnalysis).mockResolvedValueOnce(baseResponse);
+    vi.mocked(api.tradeInsightsAiAnalysisStatus).mockResolvedValueOnce(bearish);
+    render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
+
+    fireEvent.click(screen.getByText("Run AI Analysis"));
+
+    const topGrid = await screen.findByTestId("ai-analysis-upper-card-grid");
+    const marketCard = topGrid.firstElementChild as HTMLElement;
+    expect(marketCard.style.borderLeft).toContain("var(--negative)");
+  });
+
   it("hydrates the latest saved analysis under StrictMode effect replay", async () => {
     vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(
       succeededResponse(),
@@ -323,6 +340,22 @@ describe("TradeInsightsAiAnalysisPanel", () => {
       await status.promise;
     });
     expect(await screen.findByText("BUY setup")).toBeDefined();
+    expect(api.tradeInsightsAiAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("surfaces resume polling failures with retry affordance", async () => {
+    vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValueOnce(baseResponse);
+    vi.mocked(api.tradeInsightsAiAnalysisStatus).mockRejectedValueOnce(
+      new Error("API 500 for /ai-analysis/status: worker unavailable"),
+    );
+
+    render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
+
+    expect(
+      await screen.findByText(/worker unavailable/i),
+    ).toBeDefined();
+    expect(screen.getByText("Retry")).toBeDefined();
+    expect(screen.queryByText(/AI analysis queued/i)).toBeNull();
     expect(api.tradeInsightsAiAnalysis).not.toHaveBeenCalled();
   });
 

--- a/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
+++ b/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
@@ -1,8 +1,12 @@
 /* @vitest-environment jsdom */
+import { StrictMode } from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { TradeInsightsAiAnalysisPanel } from "@/components/stock/panels/TradeInsightsAiAnalysisPanel";
+import {
+  AI_ANALYSIS_POLL_MAX_MS,
+  TradeInsightsAiAnalysisPanel,
+} from "@/components/stock/panels/TradeInsightsAiAnalysisPanel";
 import { api, type TradeInsightsAiAnalysisResponse } from "@/lib/api";
 
 vi.mock("@/lib/api", async () => {
@@ -214,6 +218,10 @@ describe("TradeInsightsAiAnalysisPanel", () => {
     expect(screen.getByText("Run AI Analysis")).toBeDefined();
   });
 
+  it("keeps polling long enough for the deeper local Codex prompt", () => {
+    expect(AI_ANALYSIS_POLL_MAX_MS).toBe(10 * 60 * 1000);
+  });
+
   it("shows unavailable state when POST returns disabled", async () => {
     vi.mocked(api.tradeInsightsAiAnalysis).mockRejectedValueOnce(
       new Error("API 503 for /ai-analysis: disabled"),
@@ -249,8 +257,24 @@ describe("TradeInsightsAiAnalysisPanel", () => {
     expect(screen.getByText("Volatility")).toBeDefined();
     expect(screen.getByText("Flow & Positioning")).toBeDefined();
     expect(screen.getByText("VRP Assessment")).toBeDefined();
+    const cardGrid = screen.getByTestId("ai-analysis-card-grid");
+    const topGrid = screen.getByTestId("ai-analysis-upper-card-grid");
+    const lowerGrid = screen.getByTestId("ai-analysis-lower-card-grid");
+    expect(topGrid.style.gridTemplateColumns).toBe(
+      "repeat(3, minmax(0, 1fr))",
+    );
+    expect(lowerGrid.style.gridTemplateColumns).toBe(
+      "minmax(0, 0.95fr) minmax(0, 0.9fr) minmax(0, 1.15fr)",
+    );
+    expect(cardGrid.style.gap).toBe("12px");
+    expect(topGrid.style.alignItems).toBe("stretch");
+    expect(lowerGrid.style.alignItems).toBe("stretch");
     expect(screen.getByText("Bull Call Spread - TSLA")).toBeDefined();
-    expect(screen.getByText("Confirm event calendar")).toBeDefined();
+    expect(screen.getByText("Trade Setup Readiness")).toBeDefined();
+    expect(screen.getByText("Validation Checklist")).toBeDefined();
+    expect(screen.getByText("Price paths to watch")).toBeDefined();
+    expect(screen.getByText("Must confirm before sizing")).toBeDefined();
+    expect(screen.getAllByText("Confirm event calendar").length).toBeGreaterThan(0);
     expect(
       screen.getByText("No event calendar data in deterministic payload."),
     ).toBeDefined();
@@ -258,6 +282,48 @@ describe("TradeInsightsAiAnalysisPanel", () => {
       screen.getByText(/Generated analysis from local Codex/i),
     ).toBeDefined();
     expect(screen.getAllByText(/2026-03-24/).length).toBeGreaterThan(0);
+  });
+
+  it("hydrates the latest saved analysis under StrictMode effect replay", async () => {
+    vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(
+      succeededResponse(),
+    );
+
+    render(
+      <StrictMode>
+        <TradeInsightsAiAnalysisPanel ticker="TSLA" />
+      </StrictMode>,
+    );
+
+    expect(
+      await screen.findByText(
+        "TSLA near gamma resistance with cheap vol and bullish flow",
+      ),
+    ).toBeDefined();
+  });
+
+  it("resumes polling the latest queued analysis after remount", async () => {
+    const status = deferred<TradeInsightsAiAnalysisResponse>();
+    vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValueOnce(baseResponse);
+    vi.mocked(api.tradeInsightsAiAnalysisStatus).mockReturnValueOnce(
+      status.promise,
+    );
+
+    render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
+
+    expect(await screen.findByText(/AI analysis queued/i)).toBeDefined();
+    await waitFor(() =>
+      expect(api.tradeInsightsAiAnalysisStatus).toHaveBeenCalledWith(
+        "TSLA",
+        baseResponse.analysis_id,
+      ),
+    );
+    await act(async () => {
+      status.resolve(succeededResponse());
+      await status.promise;
+    });
+    expect(await screen.findByText("BUY setup")).toBeDefined();
+    expect(api.tradeInsightsAiAnalysis).not.toHaveBeenCalled();
   });
 
   it("renders failed status with retry affordance", async () => {

--- a/web/tests/unit/tradeInsightsTab.test.tsx
+++ b/web/tests/unit/tradeInsightsTab.test.tsx
@@ -1,0 +1,111 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TradeInsightsTab } from "@/components/stock/tabs/TradeInsightsTab";
+import { api, type TradeInsightsResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  return {
+    api: {
+      tradeInsights: vi.fn(),
+      tradeInsightsAiAnalysisLatest: vi.fn(),
+    },
+  };
+});
+
+function mockInsights(): TradeInsightsResponse {
+  return {
+    ticker: "TSLA",
+    mode: "research",
+    header: {
+      dominant_bias: "NEUTRAL_SHORT_VOL",
+      primary_setup: "TRADE_INSIGHTS_RESEARCH",
+      confidence_label: "MEDIUM",
+      data_quality_label: "MIXED",
+      idea_count: 0,
+      preferred_idea_id: null,
+      badges: [],
+    },
+    source_reconciliation: {
+      status: "UNKNOWN",
+      headline: "No external IV source reconciliation stored for this run",
+      primary_iv_source: null,
+      relative_shape_source: null,
+      rows: [],
+      decision: "Use chain-derived values for contract math.",
+    },
+    signal_stack: [],
+    candidate_structures: [],
+    synthesis: {
+      dominant_story: "Research-grade ideas built from current chain.",
+      preferred_idea_id: null,
+      best_risk_reward_idea_id: null,
+      avoid: [],
+      required_before_sizing: ["Confirm event calendar"],
+    },
+    flow_table: [
+      {
+        strike: "430",
+        call_volume: 1500,
+        call_open_interest: 1000,
+        put_volume: 600,
+        put_open_interest: 700,
+        call_put_volume_ratio: "2.5",
+        volume_oi_note: "Volume > OI; confirm with next-day OI",
+        read: "Call demand concentrated",
+        requires_t1_oi_confirmation: true,
+      },
+    ],
+    term_structure_table: [
+      {
+        expiry: "2026-05-15",
+        dte: 4,
+        atm_straddle: null,
+        implied_move_perc: "0.048",
+        daily_implied_move_perc: "0.012",
+        read: "Front elevated",
+      },
+    ],
+  } as TradeInsightsResponse;
+}
+
+function comesBefore(a: HTMLElement, b: HTMLElement): boolean {
+  return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+describe("TradeInsightsTab", () => {
+  beforeEach(() => {
+    vi.mocked(api.tradeInsights).mockResolvedValue(mockInsights());
+    vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(null);
+  });
+
+  it("orders header, AI analysis, chain and term highlights, synthesis, then lower details", async () => {
+    render(await TradeInsightsTab({ ticker: "TSLA" }));
+
+    const header = screen.getByText("TRADE_INSIGHTS_RESEARCH");
+    const aiAnalysis = screen.getByText("AI ANALYSIS");
+    const flowHighlights = screen.getByText("CHAIN / FLOW HIGHLIGHTS");
+    const termHighlights = screen.getByText("TERM / MOVE HIGHLIGHTS");
+    const synthesis = screen.getByText("SYNTHESIS / NEXT CHECKS");
+    const sourceReconciliation = screen.getByText("SOURCE RECONCILIATION");
+    const signalStack = screen.getByText("SIGNAL STACK");
+    const candidates = screen.getByText("CANDIDATE STRUCTURES");
+    const upperPairedGrid = screen.getByTestId("trade-insights-upper-pair");
+    const lowerPairedGrid = screen.getByTestId("trade-insights-lower-pair");
+
+    expect(comesBefore(header, aiAnalysis)).toBe(true);
+    expect(comesBefore(aiAnalysis, flowHighlights)).toBe(true);
+    expect(comesBefore(flowHighlights, termHighlights)).toBe(true);
+    expect(comesBefore(termHighlights, synthesis)).toBe(true);
+    expect(comesBefore(synthesis, sourceReconciliation)).toBe(true);
+    expect(comesBefore(sourceReconciliation, signalStack)).toBe(true);
+    expect(comesBefore(signalStack, candidates)).toBe(true);
+    expect(upperPairedGrid.style.gridAutoRows).toBe("1fr");
+    expect(upperPairedGrid.style.alignItems).toBe("stretch");
+    expect(lowerPairedGrid.style.gridTemplateColumns).toBe(
+      "minmax(0, 1.15fr) minmax(0, 0.85fr)",
+    );
+    expect(lowerPairedGrid.style.gridAutoRows).toBe("1fr");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the Trade Insights AI prompt contract with the v2 institutional-options report prompt and stricter output validation.
- Rework the Trade Insights AI card layout and move it to the top of the Trade Insights tab.
- Persist and reload active queued/running AI analysis jobs so navigation does not hide in-flight work or duplicate the queue.
- Add migration 021 to retire stale active v1 prompt rows and normalize v2 payload metadata.

## Test Plan
- [x] uv run pytest
- [x] cd web && npm run test
- [x] cd web && npm run typecheck
- [x] cd web && npm run build
- [x] git diff --check
- [x] Manual real-prompt GOOGL run through prompt builder, Codex runner, output schema, and validator