### PR TITLE
Fix Trade Insights AI source path index validation

### DIFF
--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -913,7 +913,7 @@ def _known_idea_id(idea_id: str, candidates: dict[str, dict[str, Any]]) -> bool:
     return idea_id in candidates or idea_id in STRATEGY_FAMILY_IDS
 
 
-_PATH_PART_INDEX_RE = re.compile(r"\[(?:\d+)?\]")
+_PATH_PART_INDEX_RE = re.compile(r"\[-?\d*\]")
 
 
 def _path_family_exists(path: str, deterministic_payload: dict[str, Any]) -> bool:

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -751,6 +751,23 @@ def test_validate_trade_insights_ai_outcome_accepts_array_family_source_paths():
     assert parsed.metric_cards[0].source_path.endswith("rows[].net_dex")
 
 
+def test_validate_trade_insights_ai_outcome_accepts_negative_array_source_paths():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+    latest_path = _sample_outcome_for(deterministic)
+    latest_path["metric_cards"][0]["source_path"] = (
+        "tabs.volatility.hv_iv_history[-1].rv"
+    )
+
+    parsed = validate_trade_insights_ai_outcome(
+        latest_path,
+        deterministic,
+        produced_at=produced_at,
+    )
+
+    assert parsed.metric_cards[0].source_path.endswith("hv_iv_history[-1].rv")
+
+
 def test_validate_trade_insights_ai_outcome_accepts_sparse_array_source_paths():
     deterministic = _analysis_input()
     produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- Accept negative array indexes in Trade Insights AI source_path validation.
- Add a regression test for paths like tabs.volatility.hv_iv_history[-1].rv.

## Test Plan
- uv run pytest tests/test_trade_insights_ai.py -q