### PR TITLE
Add adaptive query coverage health alert

### DIFF
--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Literal
 
 from apscheduler.triggers.cron import CronTrigger
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.config import Settings
@@ -47,6 +47,20 @@ class HealthResponse(BaseModel):
     http_5xx: int | None = None
     uw_today: int | None = None
     cache_hit_pct: float | None = None
+    record_health_ok: bool | None = None
+    record_health: list["RecordHealthCheck"] = Field(default_factory=list)
+
+
+class RecordHealthCheck(BaseModel):
+    table: str
+    window_start: datetime
+    expected_tickers: int
+    expected_min_tickers: int
+    actual_tickers: int
+    expected_min_rows: int
+    actual_rows: int
+    latest_at: datetime | None = None
+    ok: bool
 
 
 def _full_scan_interval_seconds(cron_expr: str, tz: str) -> float:
@@ -65,9 +79,19 @@ def _full_scan_interval_seconds(cron_expr: str, tz: str) -> float:
     return (b - a).total_seconds() if b else 3600.0
 
 
+def _parse_record_tables(record_tables: str | None) -> list[str] | None:
+    if record_tables is None:
+        return None
+    selected = [item.strip() for item in record_tables.split(",") if item.strip()]
+    return selected or None
+
+
 @router.get("/health", response_model=HealthResponse)
 def health(
     source: Annotated[HealthSource, Query()] = "uw",
+    record_window_hours: Annotated[float | None, Query(ge=0.1, le=168)] = None,
+    record_min_coverage: Annotated[float, Query(ge=0.0, le=1.0)] = 0.9,
+    record_tables: Annotated[str | None, Query()] = None,
     repo: Repository = Depends(get_repo),
     settings: Settings = Depends(get_settings),
 ) -> HealthResponse:
@@ -135,6 +159,40 @@ def health(
         "latest_spot_quote_at": latest_spot_quote_at,
         "latest_spot_quote_fetched_at": latest_spot_quote_fetched_at,
     }
+    record_fields = {"record_health_ok": None, "record_health": []}
+    record_reason = None
+    if record_window_hours is not None:
+        try:
+            record_rows = repo.list_record_health(
+                since=now_utc - timedelta(hours=record_window_hours),
+                expected_tickers=watchlist_size,
+                min_coverage=record_min_coverage,
+                tables=_parse_record_tables(record_tables),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        record_health = [
+            RecordHealthCheck(
+                table=row.table,
+                window_start=row.window_start,
+                expected_tickers=row.expected_tickers,
+                expected_min_tickers=row.expected_min_tickers,
+                actual_tickers=row.actual_tickers,
+                expected_min_rows=row.expected_min_rows,
+                actual_rows=row.actual_rows,
+                latest_at=row.latest_at,
+                ok=row.ok,
+            )
+            for row in record_rows
+        ]
+        record_ok = all(check.ok for check in record_health)
+        record_fields = {
+            "record_health_ok": record_ok,
+            "record_health": record_health,
+        }
+        if not record_ok:
+            failing = ", ".join(check.table for check in record_health if not check.ok)
+            record_reason = f"record coverage below expected: {failing}"
 
     last_scan = repo.get_last_full_scan_finished_at()
     if last_scan is None:
@@ -145,6 +203,7 @@ def health(
             watchlist_size=watchlist_size,
             **provider_fields,
             **heartbeat_fields,
+            **record_fields,
         )
 
     lag = (now_utc - last_scan).total_seconds()
@@ -161,6 +220,20 @@ def health(
             watchlist_size=watchlist_size,
             **provider_fields,
             **heartbeat_fields,
+            **record_fields,
+        )
+
+    if record_reason is not None:
+        return HealthResponse(
+            ok=False,
+            db=db_status,
+            scheduler_lag_seconds=lag,
+            last_full_scan_at=last_scan,
+            reason=record_reason,
+            watchlist_size=watchlist_size,
+            **provider_fields,
+            **heartbeat_fields,
+            **record_fields,
         )
 
     return HealthResponse(
@@ -171,4 +244,5 @@ def health(
         watchlist_size=watchlist_size,
         **provider_fields,
         **heartbeat_fields,
+        **record_fields,
     )

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -6,6 +6,7 @@ One method per insert/select. No `**kwargs` splatting from arbitrary dicts.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date as _date
@@ -15,6 +16,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 import psycopg
+from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
 from .. import models
@@ -120,6 +122,40 @@ class ExternalApiRequestRow:
     official_minute_remaining: int | None
     official_minute_reset: str | None
     error_message: str | None
+
+
+@dataclass(frozen=True)
+class RecordHealthRow:
+    table: str
+    window_start: datetime
+    expected_tickers: int
+    expected_min_tickers: int
+    actual_tickers: int
+    expected_min_rows: int
+    actual_rows: int
+    latest_at: datetime | None
+    ok: bool
+
+
+_RECORD_HEALTH_TIMESTAMP_COLUMNS = ("updated_at", "inserted_at")
+_RECORD_HEALTH_TICKER_COLUMNS = ("ticker", "underlying_symbol")
+_RECORD_HEALTH_EXCLUDED_TABLES = {
+    # Request logs and orchestration tables are covered by provider usage /
+    # scheduler health, not per-ticker persisted data coverage.
+    "external_api_requests",
+    "scan_results",
+    "scan_universe",
+    # Not watchlist-scoped periodic UW source tables.
+    "index_ohlc_daily",
+    "opportunity_scores",
+    "structure_ideas",
+    # Derived/backfill tables that do not update for every ticker each RTH window.
+    "iv_smile_snapshots",
+    "oi_by_expiry",
+    "option_surface_snapshots",
+    "stock_analytics_daily",
+    "vrp_daily",
+}
 
 
 class WatchlistCardRow:
@@ -2620,6 +2656,104 @@ class Repository:
             )
             row = cur.fetchone()
         return int(row[0]) if row else 0
+
+    def _discover_record_health_rules(self) -> dict[str, tuple[str, str, int]]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT table_name, array_agg(column_name::text ORDER BY ordinal_position)
+                FROM information_schema.columns
+                WHERE table_schema = %s
+                GROUP BY table_name
+                ORDER BY table_name
+                """,
+                (self._schema,),
+            )
+            discovered: dict[str, tuple[str, str, int]] = {}
+            for table, column_list in cur.fetchall():
+                table_name = str(table)
+                if table_name in _RECORD_HEALTH_EXCLUDED_TABLES:
+                    continue
+                columns = set(column_list or [])
+                timestamp_col = next(
+                    (
+                        column
+                        for column in _RECORD_HEALTH_TIMESTAMP_COLUMNS
+                        if column in columns
+                    ),
+                    None,
+                )
+                ticker_col = next(
+                    (
+                        column
+                        for column in _RECORD_HEALTH_TICKER_COLUMNS
+                        if column in columns
+                    ),
+                    None,
+                )
+                if timestamp_col is not None and ticker_col is not None:
+                    discovered[table_name] = (timestamp_col, ticker_col, 1)
+            return discovered
+
+    def list_record_health(
+        self,
+        *,
+        since: datetime,
+        expected_tickers: int,
+        min_coverage: float = 0.9,
+        tables: Iterable[str] | None = None,
+    ) -> list[RecordHealthRow]:
+        rules = self._discover_record_health_rules()
+        selected = list(tables) if tables is not None else list(rules)
+        unknown = sorted(set(selected) - set(rules))
+        if unknown:
+            raise ValueError(f"unknown record health table(s): {', '.join(unknown)}")
+
+        expected_min_tickers = (
+            0 if expected_tickers <= 0 else math.ceil(expected_tickers * min_coverage)
+        )
+        rows: list[RecordHealthRow] = []
+        with self._conn.cursor() as cur:
+            for table in selected:
+                timestamp_col, ticker_col, min_rows_per_ticker = rules[table]
+                cur.execute(
+                    psql.SQL(
+                        """
+                        SELECT
+                            COUNT(*)::int AS actual_rows,
+                            COUNT(DISTINCT {ticker_col})::int AS actual_tickers,
+                            MAX({timestamp_col}) AS latest_at
+                        FROM {schema}.{table}
+                        WHERE {timestamp_col} >= %s
+                        """
+                    ).format(
+                        schema=psql.Identifier(self._schema),
+                        table=psql.Identifier(table),
+                        timestamp_col=psql.Identifier(timestamp_col),
+                        ticker_col=psql.Identifier(ticker_col),
+                    ),
+                    (since,),
+                )
+                actual_rows, actual_tickers, latest_at = cur.fetchone() or (0, 0, None)
+                expected_min_rows = expected_min_tickers * min_rows_per_ticker
+                ok = (
+                    int(actual_tickers or 0) >= expected_min_tickers
+                    and int(actual_rows or 0) >= expected_min_rows
+                )
+                rows.append(
+                    RecordHealthRow(
+                        table=table,
+                        window_start=since,
+                        expected_tickers=expected_tickers,
+                        expected_min_tickers=expected_min_tickers,
+                        actual_tickers=int(actual_tickers or 0),
+                        expected_min_rows=expected_min_rows,
+                        actual_rows=int(actual_rows or 0),
+                        latest_at=latest_at,
+                        ok=ok,
+                    )
+                )
+        return rows
 
     # ---- worker_heartbeat ----
     def upsert_heartbeat(self, job_name: str) -> None:

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -158,6 +158,89 @@ def test_health_includes_massive_provider_usage_stats_when_source_is_massive(
     assert body["uw_today"] is None
 
 
+def test_health_record_check_alerts_on_low_recent_ticker_coverage(
+    client, seeded_db_with_cards
+):
+    r = client.get(
+        "/api/health?record_window_hours=8&record_min_coverage=0.9"
+        "&record_tables=watchlist_card"
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert body["record_health_ok"] is False
+    assert "record coverage below expected" in body["reason"]
+    card_check = next(
+        check for check in body["record_health"] if check["table"] == "watchlist_card"
+    )
+    assert card_check["actual_tickers"] == 1
+    assert card_check["expected_tickers"] == seeded_db_with_cards.count_active_watchlist()
+    assert card_check["ok"] is False
+
+
+def test_health_record_check_passes_when_selected_table_covers_watchlist(
+    client, seeded_db_empty_cards
+):
+    repo = seeded_db_empty_cards
+    now = datetime.now(UTC)
+    for row in repo.list_watchlist_cards():
+        run_id = repo.insert_scan_run(ticker=row.ticker)
+        repo.finish_scan_run(run_id, status="ok")
+        repo.upsert_watchlist_card(
+            ticker=row.ticker,
+            run_id=run_id,
+            scanned_at=now,
+            spot=Decimal("100.00"),
+        )
+
+    r = client.get("/api/health?record_window_hours=8&record_tables=watchlist_card")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["record_health_ok"] is True
+    assert body["record_health"][0]["table"] == "watchlist_card"
+    assert body["record_health"][0]["actual_tickers"] == repo.count_active_watchlist()
+
+
+def test_health_record_check_discovers_new_ticker_timestamp_tables(
+    client, seeded_db_empty_cards
+):
+    repo = seeded_db_empty_cards
+    now = datetime.now(UTC)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            CREATE TABLE {repo._schema}.synthetic_endpoint_snapshots (
+                ticker text NOT NULL,
+                inserted_at timestamptz NOT NULL DEFAULT now()
+            )
+            """
+        )
+        cur.executemany(
+            f"""
+            INSERT INTO {repo._schema}.synthetic_endpoint_snapshots
+                (ticker, inserted_at)
+            VALUES (%s, %s)
+            """,
+            [(row.ticker, now) for row in repo.list_watchlist_cards()],
+        )
+    repo.conn.commit()
+
+    r = client.get(
+        "/api/health?record_window_hours=8"
+        "&record_tables=synthetic_endpoint_snapshots"
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    synthetic = body["record_health"][0]
+    assert synthetic["table"] == "synthetic_endpoint_snapshots"
+    assert synthetic["ok"] is True
+    assert synthetic["actual_tickers"] == repo.count_active_watchlist()
+
+
 def test_health_unhealthy_when_no_scans(client, seeded_db_empty_cards):
     r = client.get("/api/health")
     body = r.json()

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -9,6 +9,8 @@ type ProviderSource = "uw" | "massive";
 
 const HEARTBEAT_HEALTHY_LAG_S = 5;
 const SPOT_REFRESH_HEALTHY_LAG_S = 660;
+const RECORD_WINDOW_HOURS = 8;
+const RECORD_MIN_COVERAGE = 0.9;
 
 const rowStyle: React.CSSProperties = {
   display: "flex",
@@ -68,6 +70,14 @@ function heartbeatStatus(
   return { label: "STALE", color: "var(--warning)" };
 }
 
+function recordHealthStatus(
+  ok: boolean | null | undefined,
+): { label: "OK" | "ALERT" | "UNKNOWN"; color: string } {
+  if (ok == null) return { label: "UNKNOWN", color: "var(--warning)" };
+  if (ok) return { label: "OK", color: "var(--positive)" };
+  return { label: "ALERT", color: "var(--negative)" };
+}
+
 function fmtDuration(seconds: number | null | undefined): string {
   if (seconds == null) return "—";
   const s = Math.max(0, Math.round(seconds));
@@ -111,7 +121,10 @@ export function HealthPanel() {
     let cancelled = false;
     const fetchOnce = async () => {
       try {
-        const r = await api.health(source);
+        const r = await api.health(source, {
+          recordMinCoverage: RECORD_MIN_COVERAGE,
+          recordWindowHours: RECORD_WINDOW_HOURS,
+        });
         if (!cancelled) setH(r);
       } catch {
         if (!cancelled) setH(null);
@@ -135,6 +148,7 @@ export function HealthPanel() {
     h?.spot_refresh_heartbeat_lag_seconds,
     SPOT_REFRESH_HEALTHY_LAG_S,
   );
+  const recordsStatus = recordHealthStatus(h?.record_health_ok);
 
   return (
     <div
@@ -145,10 +159,11 @@ export function HealthPanel() {
     >
       <StatusRow label="API" status={apiStatus} />
       <StatusRow label="Scheduler" status={schedulerStatus} />
-      <StatusRow label="Rescan" status={rescanStatus} />
-      <StatusRow label="Spot Job" status={spotRefreshStatus} />
+      <StatusRow label="UW Worker" status={rescanStatus} />
+      <StatusRow label="Massive Worker" status={spotRefreshStatus} />
+      <StatusRow label="Query Coverage" status={recordsStatus} />
       <div style={rowStyle}>
-        <span style={labelStyle}>Spot Age</span>
+        <span style={labelStyle}>Last spot</span>
         <span
           style={valStyle}
           title={`Quote ${fmtDateTimeWithZone(h?.latest_spot_quote_at)} / fetched ${fmtDateTimeWithZone(h?.latest_spot_quote_fetched_at)}`}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -24,6 +24,10 @@ type HealthResponse = Json<"/api/health", "get">;
 type HealthSource = NonNullable<
   paths["/api/health"]["get"]["parameters"]["query"]
 >["source"];
+type HealthOptions = {
+  recordWindowHours?: number;
+  recordMinCoverage?: number;
+};
 type VolatilitySeriesResponse = Json<
   "/api/stock/{ticker}/volatility/series",
   "get"
@@ -98,8 +102,19 @@ export const api = {
     }),
   job: (jobId: string): Promise<JobStatus> =>
     _fetch<JobStatus>(`/api/jobs/${jobId}`),
-  health: (source: HealthSource = "uw"): Promise<HealthResponse> =>
-    _fetch<HealthResponse>(`/api/health?source=${source}`),
+  health: (
+    source: HealthSource = "uw",
+    options: HealthOptions = {},
+  ): Promise<HealthResponse> => {
+    const params = new URLSearchParams({ source: source ?? "uw" });
+    if (options.recordWindowHours != null) {
+      params.set("record_window_hours", String(options.recordWindowHours));
+    }
+    if (options.recordMinCoverage != null) {
+      params.set("record_min_coverage", String(options.recordMinCoverage));
+    }
+    return _fetch<HealthResponse>(`/api/health?${params.toString()}`);
+  },
   addTicker: (body: {
     ticker: string;
     sector: string;

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -613,6 +613,10 @@ export interface components {
             uw_today?: number | null;
             /** Cache Hit Pct */
             cache_hit_pct?: number | null;
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Record Health */
+            record_health?: components["schemas"]["RecordHealthCheck"][];
         };
         /** InsightBadge */
         InsightBadge: {
@@ -1149,6 +1153,30 @@ export interface components {
             uw_latest_daily_count: number | null;
             /** Uw Latest Daily Limit */
             uw_latest_daily_limit: number | null;
+        };
+        /** RecordHealthCheck */
+        RecordHealthCheck: {
+            /** Table */
+            table: string;
+            /**
+             * Window Start
+             * Format: date-time
+             */
+            window_start: string;
+            /** Expected Tickers */
+            expected_tickers: number;
+            /** Expected Min Tickers */
+            expected_min_tickers: number;
+            /** Actual Tickers */
+            actual_tickers: number;
+            /** Expected Min Rows */
+            expected_min_rows: number;
+            /** Actual Rows */
+            actual_rows: number;
+            /** Latest At */
+            latest_at?: string | null;
+            /** Ok */
+            ok: boolean;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
@@ -2285,6 +2313,9 @@ export interface operations {
         parameters: {
             query?: {
                 source?: "uw" | "massive";
+                record_window_hours?: number | null;
+                record_min_coverage?: number;
+                record_tables?: string | null;
             };
             header?: never;
             path?: never;

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -39,15 +39,19 @@ describe("HealthPanel", () => {
       http_5xx: 1,
       uw_today: 40,
       cache_hit_pct: null,
+      record_health_ok: true,
+      record_health: [],
     });
 
     render(<HealthPanel />);
 
     await waitFor(() => expect(screen.getByText("API")).toBeTruthy());
     expect(screen.getByText("Scheduler")).toBeTruthy();
-    expect(screen.getByText("Rescan")).toBeTruthy();
-    expect(screen.getByText("Spot Job")).toBeTruthy();
-    expect(screen.getByText("Spot Age")).toBeTruthy();
+    expect(screen.getByText("UW Worker")).toBeTruthy();
+    expect(screen.getByText("Massive Worker")).toBeTruthy();
+    expect(screen.getByText("Query Coverage")).toBeTruthy();
+    expect(screen.getByText("OK")).toBeTruthy();
+    expect(screen.getByText("Last spot")).toBeTruthy();
     expect(screen.getByText("1m")).toBeTruthy();
     expect(screen.getAllByText("ONLINE").length).toBeGreaterThanOrEqual(3);
     expect(screen.getByText("STALE")).toBeTruthy();
@@ -84,6 +88,8 @@ describe("HealthPanel", () => {
       http_5xx: null,
       uw_today: null,
       cache_hit_pct: null,
+      record_health_ok: null,
+      record_health: [],
     });
 
     render(<HealthPanel />);
@@ -116,6 +122,8 @@ describe("HealthPanel", () => {
         http_5xx: 1,
         uw_today: 40,
         cache_hit_pct: null,
+        record_health_ok: true,
+        record_health: [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -139,19 +147,76 @@ describe("HealthPanel", () => {
         http_5xx: 2,
         uw_today: null,
         cache_hit_pct: null,
+        record_health_ok: true,
+        record_health: [],
       });
 
     render(<HealthPanel />);
 
-    await waitFor(() => expect(api.health).toHaveBeenCalledWith("uw"));
+    await waitFor(() =>
+      expect(api.health).toHaveBeenCalledWith("uw", {
+        recordMinCoverage: 0.9,
+        recordWindowHours: 8,
+      }),
+    );
     fireEvent.change(screen.getByRole("combobox", { name: "Source" }), {
       target: { value: "massive" },
     });
 
-    await waitFor(() => expect(api.health).toHaveBeenCalledWith("massive"));
+    await waitFor(() =>
+      expect(api.health).toHaveBeenCalledWith("massive", {
+        recordMinCoverage: 0.9,
+        recordWindowHours: 8,
+      }),
+    );
     expect(screen.getByText("Massive.com")).toBeTruthy();
     expect(screen.getByText("55ms")).toBeTruthy();
     expect(screen.getByText("10")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("renders a compact query coverage alert when DB coverage is low", async () => {
+    vi.mocked(api.health).mockResolvedValue({
+      ok: false,
+      db: "up",
+      scheduler_lag_seconds: 12,
+      last_full_scan_at: "2026-05-14T14:20:42Z",
+      reason: "record coverage below expected: flow_events",
+      worker_lag_seconds: 1,
+      scheduler_heartbeat_lag_seconds: 1,
+      scheduler_heartbeat_name: "worker",
+      rescan_heartbeat_lag_seconds: 1,
+      spot_refresh_heartbeat_lag_seconds: 1,
+      spot_quote_lag_seconds: 60,
+      latest_spot_quote_at: "2026-05-14T14:19:42Z",
+      latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
+      watchlist_size: 97,
+      source: "UnusualWhales",
+      latency_p95_ms: 88,
+      http_2xx: 120,
+      http_4xx: 0,
+      http_5xx: 0,
+      uw_today: 40,
+      cache_hit_pct: null,
+      record_health_ok: false,
+      record_health: [
+        {
+          table: "flow_events",
+          window_start: "2026-05-14T06:20:42Z",
+          expected_tickers: 97,
+          expected_min_tickers: 88,
+          actual_tickers: 20,
+          expected_min_rows: 88,
+          actual_rows: 1234,
+          latest_at: "2026-05-14T14:20:42Z",
+          ok: false,
+        },
+      ],
+    });
+
+    render(<HealthPanel />);
+
+    await waitFor(() => expect(screen.getByText("Query Coverage")).toBeTruthy());
+    expect(screen.getByText("ALERT")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Add adaptive ticker/timestamp table discovery for query coverage checks in /api/health.
- Surface query coverage status in the sidebar HealthPanel.
- Regenerate web API types and cover backend/frontend behavior with tests.

## Test Plan
- uv run pytest tests/integration/api/test_health.py tests/integration/api/test_openapi_snapshot.py -q
- cd web && npm run test -- tests/unit/healthPanel.test.tsx
- cd web && npm run typecheck