### PR TITLE
feat: refine setup classifier and explain formula

### DIFF
--- a/docs/superpowers/research/2026-05-15-setup-classifier-evidence.md
+++ b/docs/superpowers/research/2026-05-15-setup-classifier-evidence.md
@@ -1,0 +1,71 @@
+# Setup Classifier Evidence Note
+
+Date: 2026-05-15
+
+## Summary
+
+The old `C-BULL` / `C-BEAR` classifier used option-flow direction and then gated that direction with IV rank:
+
+- bull required `iv_rank >= 70`
+- bear required `iv_rank <= 30`
+
+That IV-rank direction gate is not well supported by the research reviewed. The stronger evidence supports using signed option demand as the directional input, while treating IV rank as volatility/structure context.
+
+## Evidence
+
+| Signal | Evidence read | Implementation implication |
+|---|---|---|
+| Buyer-initiated option flow | Pan and Poteshman find option volume initiated by buyers to open positions contains information about future stock returns; low put-call option-volume signals outperform high put-call signals over next-day and next-week horizons. | Keep signed option flow as the primary direction input. |
+| Options as informed-trading venue | Easley, O'Hara, and Srinivas model and test conditions where informed traders choose the options market. | It is reasonable to screen for unusual directional option demand, but still treat it as a hypothesis. |
+| Call-vs-put expensiveness | Cremers and Weinbaum find deviations from put-call parity contain information about future stock returns; relatively expensive calls outperform relatively expensive puts. | Direction should come from call/put demand or relative option richness, not from overall IV rank. |
+| Net buying pressure and IV | Bollen and Whaley find net buying pressure affects implied-volatility surfaces; for single-stock options, call demand is especially important for stock option IV changes. | IV response is useful context, but it should not be a hard directional veto. |
+| VRP | Bollerslev, Tauchen, and Zhou support variance-risk-premium return predictability at aggregate horizons, with important measurement constraints. | VRP is useful as a confluence/volatility feature, not a standalone bull/bear label. |
+| GEX / dealer hedging | Ni, Pearson, Poteshman, and White support a non-informational dealer-hedging channel affecting return volatility and large-move probability. | GEX belongs in confluence/regime context; simple thresholds need local validation. |
+
+## Formula Update
+
+Direction remains signed option premium:
+
+```text
+net_premium = net_call_premium - net_put_premium
+direction = bull if net_premium >= 0 else bear
+```
+
+For single-stock reports, the equivalent is:
+
+```text
+net_premium = bull_premium - bear_premium
+direction = bull if net_premium >= 0 else bear
+```
+
+The classifier now requires material and clean flow:
+
+```text
+abs(net_premium) >= 5,000,000
+flow_imbalance = abs(net_premium) / total_directional_premium
+flow_imbalance >= 20%
+```
+
+IV rank is retained as confirmation text or warning context, but it no longer blocks a setup. This is intentional: IV rank describes whether the option surface is rich or cheap relative to history, which should guide structure selection, not decide directional sign.
+
+## Current Limits
+
+The features are evidence-backed, but the exact production thresholds are still hypotheses:
+
+- `$5M` absolute premium
+- `20%` flow imbalance
+- `GEX/OI > 0.01`
+- `abs(VRP) > 0.05`
+- `relative_volume > 1.5`
+- `abs(flow polarization) > $50M`
+
+These should be validated against persisted scan snapshots with forward 1d / 5d / 20d returns, max adverse excursion, realized volatility change, IV/RV spread change, and candidate option P/L where legs are available.
+
+## References
+
+- Pan, J. and Poteshman, A. M. (2004), "The Information in Option Volume for Future Stock Prices", NBER Working Paper 10925: https://www.nber.org/system/files/working_papers/w10925/w10925.pdf
+- Easley, D., O'Hara, M., and Srinivas, P. S. (1998), "Option Volume and Stock Prices: Evidence on Where Informed Traders Trade", Journal of Finance: https://doi.org/10.1111/0022-1082.194060
+- Cremers, M. and Weinbaum, D. (2010), "Deviations from Put-Call Parity and Stock Return Predictability", JFQA: https://doi.org/10.1017/S002210901000013X
+- Bollen, N. P. B. and Whaley, R. E. (2004), "Does Net Buying Pressure Affect the Shape of Implied Volatility Functions?", Journal of Finance: https://www.whaley.info/_files/ugd/1362e1_81f94ba850fb4ec4aea173770b355408.pdf
+- Bollerslev, T., Tauchen, G., and Zhou, H. (2009), "Expected Stock Returns and Variance Risk Premia", Review of Financial Studies: https://academic.oup.com/rfs/article-pdf/22/11/4463/24429122/hhp008.pdf
+- Ni, S. X., Pearson, N. D., Poteshman, A. M., and White, J. S. (2021), "Does Option Trading Have a Pervasive Impact on Underlying Stock Prices?", Review of Financial Studies: https://academic.oup.com/rfs/article-pdf/34/4/1952/36683417/hhaa082.pdf

--- a/src/uw_scan/scoring.py
+++ b/src/uw_scan/scoring.py
@@ -2,12 +2,12 @@
 
 Type C — Deep Conviction Directional (S1, single-stock context):
 - Net premium magnitude ≥ NET_PREMIUM_THRESHOLD ($5M default)
-- For bull: IV rank ≥ IV_RANK_HIGH (70) — vol mean-reversion + directional
-- For bear: IV rank ≤ IV_RANK_LOW (30)
+- Direction is determined by signed option flow, not IV rank
+- Flow imbalance must be material versus total observed option premium
 - ≥ 1 corroborating signal (dark pool size, OI build)
 
 Type F — Multi-Signal Confluence (S2, scan-row context):
-- Base: same flow + IV-rank gate as Type C
+- Base: same material flow + imbalance gate as Type C
 - PLUS ≥ 2 of: GEX-vs-OI shift, VRP magnitude, relative volume, flow polarization
 
 F takes precedence over C in the scan context.
@@ -20,8 +20,7 @@ from decimal import Decimal
 from .models import BulkScreenerRow, SetupClassification, SingleStockReport
 
 NET_PREMIUM_THRESHOLD = Decimal("5000000")  # $5M
-IV_RANK_HIGH = Decimal("70")
-IV_RANK_LOW = Decimal("30")
+FLOW_IMBALANCE_THRESHOLD = Decimal("0.20")
 DARK_POOL_NOTIONAL_THRESHOLD = Decimal("100000000")  # $100M
 MIN_OI_BUILD_COUNT = 1
 
@@ -35,6 +34,56 @@ F_MIN_SIGNALS = 2
 
 def _direction_from_flow(net_premium: Decimal) -> str:
     return "bull" if net_premium >= 0 else "bear"
+
+
+def _flow_imbalance(net_premium: Decimal, total_premium: Decimal | None) -> Decimal | None:
+    if total_premium is None:
+        return None
+    total = abs(total_premium)
+    if total <= 0:
+        return None
+    return abs(net_premium) / total
+
+
+def _row_total_premium(row: BulkScreenerRow) -> Decimal | None:
+    if row.call_premium is not None or row.put_premium is not None:
+        return abs(row.call_premium or Decimal("0")) + abs(
+            row.put_premium or Decimal("0")
+        )
+    if row.net_call_premium is not None or row.net_put_premium is not None:
+        return abs(row.net_call_premium or Decimal("0")) + abs(
+            row.net_put_premium or Decimal("0")
+        )
+    return None
+
+
+def _flow_context(
+    *,
+    net_premium: Decimal,
+    total_premium: Decimal | None,
+    iv_rank: Decimal | None,
+) -> tuple[bool, list[str], list[str], Decimal]:
+    confirmations = [
+        f"net premium = ${abs(net_premium):,.0f} "
+        f"({_direction_from_flow(net_premium)})"
+    ]
+    warnings: list[str] = []
+
+    imbalance = _flow_imbalance(net_premium, total_premium)
+    if imbalance is not None:
+        confirmations.append(f"flow imbalance = {imbalance:.2%}")
+        if imbalance < FLOW_IMBALANCE_THRESHOLD:
+            return False, confirmations, warnings, imbalance
+    else:
+        warnings.append("flow premium denominator unavailable; imbalance gate skipped")
+        imbalance = Decimal("0")
+
+    if iv_rank is None:
+        warnings.append("iv_rank unavailable; direction uses flow, not IV rank")
+    else:
+        confirmations.append(f"iv_rank = {iv_rank} (structure context only)")
+
+    return True, confirmations, warnings, imbalance
 
 
 def _row_net_premium(row: BulkScreenerRow) -> Decimal | None:
@@ -53,58 +102,46 @@ def _row_net_premium(row: BulkScreenerRow) -> Decimal | None:
     return ncp - npp
 
 
-def _check_c_base(row: BulkScreenerRow) -> tuple[bool, str | None, list[str]]:
+def _check_c_base(
+    row: BulkScreenerRow,
+) -> tuple[bool, str | None, list[str], list[str], Decimal]:
     """Check whether a screener row meets Type C base criteria.
 
-    Returns (ok, direction, confirmations). When ok is False, direction may still
-    be set but confirmations is empty.
+    When ok is False, direction may still be set if signed flow was available.
     """
     net_premium = _row_net_premium(row)
     if net_premium is None:
-        return False, None, []
+        return False, None, [], [], Decimal("0")
     abs_net = abs(net_premium)
     if abs_net < NET_PREMIUM_THRESHOLD:
-        return False, None, []
+        return False, None, [], [], Decimal("0")
     direction = _direction_from_flow(net_premium)
-    iv_rank = row.iv_rank
-    if iv_rank is None:
-        return False, direction, []
-    if direction == "bull" and iv_rank < IV_RANK_HIGH:
-        return False, direction, []
-    if direction == "bear" and iv_rank > IV_RANK_LOW:
-        return False, direction, []
-    confirmations = [
-        f"net premium = ${abs_net:,.0f} ({direction})",
-        f"iv_rank = {iv_rank}",
-    ]
-    return True, direction, confirmations
+    ok, confirmations, warnings, imbalance = _flow_context(
+        net_premium=net_premium,
+        total_premium=_row_total_premium(row),
+        iv_rank=row.iv_rank,
+    )
+    if not ok:
+        return False, direction, confirmations, warnings, imbalance
+    return True, direction, confirmations, warnings, imbalance
 
 
 def classify_setup_c(report: SingleStockReport) -> SetupClassification | None:
     """Classify the report as Type C (Deep Conviction) if criteria met. Else None."""
     net_premium = report.flow.net_premium
     abs_net = abs(net_premium)
-    iv_rank = report.volatility.iv_rank
-    confirmations: list[str] = []
-    warnings: list[str] = []
 
     if abs_net < NET_PREMIUM_THRESHOLD:
         return None
 
     direction = _direction_from_flow(net_premium)
-
-    if iv_rank is None:
-        warnings.append("iv_rank unavailable")
-        # Don't classify without IV rank
+    ok, confirmations, warnings, imbalance = _flow_context(
+        net_premium=net_premium,
+        total_premium=report.flow.bull_premium + report.flow.bear_premium,
+        iv_rank=report.volatility.iv_rank,
+    )
+    if not ok:
         return None
-
-    if direction == "bull" and iv_rank < IV_RANK_HIGH:
-        return None
-    if direction == "bear" and iv_rank > IV_RANK_LOW:
-        return None
-
-    confirmations.append(f"net premium = ${abs_net:,.0f} ({direction})")
-    confirmations.append(f"iv_rank = {iv_rank}")
 
     # At least one corroborating signal
     corroborated = False
@@ -129,15 +166,10 @@ def classify_setup_c(report: SingleStockReport) -> SetupClassification | None:
 
     # Score: weighted blend, capped at 5.0
     premium_score = min(Decimal("3"), abs_net / Decimal("100000000") * Decimal("3"))
-    ivr_score = Decimal("0")
-    if direction == "bull":
-        ivr_score = (iv_rank - IV_RANK_HIGH) / Decimal("30") * Decimal("1")
-    else:
-        ivr_score = (IV_RANK_LOW - iv_rank) / Decimal("30") * Decimal("1")
-    ivr_score = max(Decimal("0"), min(Decimal("1"), ivr_score))
+    flow_score = max(Decimal("0"), min(Decimal("1"), imbalance))
     corr_score = Decimal("1") if corroborated else Decimal("0")
 
-    raw = premium_score + ivr_score + corr_score
+    raw = premium_score + flow_score + corr_score
     score = min(Decimal("5"), max(Decimal("0"), raw))
 
     return SetupClassification(
@@ -148,8 +180,9 @@ def classify_setup_c(report: SingleStockReport) -> SetupClassification | None:
         confirmations=confirmations,
         warnings=warnings,
         notes=(
-            f"Type C: |net premium| ≥ ${NET_PREMIUM_THRESHOLD:,.0f}, IV rank "
-            f"thresholds met for {direction}, corroborated by "
+            f"Type C: |net premium| ≥ ${NET_PREMIUM_THRESHOLD:,.0f}, "
+            f"flow imbalance ≥ {FLOW_IMBALANCE_THRESHOLD:.0%} for {direction}, "
+            f"corroborated by "
             f"{'dark pool' if report.dark_pool_notional and report.dark_pool_notional >= DARK_POOL_NOTIONAL_THRESHOLD else 'OI build'}."
         ),
     )
@@ -201,7 +234,7 @@ def classify_setup_f(row: BulkScreenerRow) -> SetupClassification | None:
     over C in the scan context — callers should call this BEFORE the C-only
     fallback when ranking screener rows.
     """
-    ok, direction, confirmations = _check_c_base(row)
+    ok, direction, confirmations, warnings, imbalance = _check_c_base(row)
     if not ok or direction is None:
         return None
 
@@ -209,20 +242,15 @@ def classify_setup_f(row: BulkScreenerRow) -> SetupClassification | None:
     if len(signals) < F_MIN_SIGNALS:
         return None
 
-    # Score: blend net-premium magnitude, IV-rank distance, and signal count.
+    # Score: blend net-premium magnitude, flow quality, and signal count.
     net_premium = _row_net_premium(row) or Decimal("0")
     abs_net = abs(net_premium)
-    iv_rank = row.iv_rank or Decimal("0")
 
     premium_score = min(Decimal("2"), abs_net / Decimal("100000000") * Decimal("2"))
-    if direction == "bull":
-        ivr_score = (iv_rank - IV_RANK_HIGH) / Decimal("30") * Decimal("1")
-    else:
-        ivr_score = (IV_RANK_LOW - iv_rank) / Decimal("30") * Decimal("1")
-    ivr_score = max(Decimal("0"), min(Decimal("1"), ivr_score))
+    flow_score = max(Decimal("0"), min(Decimal("1"), imbalance))
     signal_score = min(Decimal("2"), Decimal(len(signals)) * Decimal("0.5"))
 
-    raw = premium_score + ivr_score + signal_score + Decimal("1")  # +1 base for F
+    raw = premium_score + flow_score + signal_score + Decimal("1")  # +1 base for F
     score = min(Decimal("6"), max(Decimal("0"), raw))
 
     confs = list(confirmations) + [f"{len(signals)} corroborating signals: {signals}"]
@@ -233,7 +261,7 @@ def classify_setup_f(row: BulkScreenerRow) -> SetupClassification | None:
         direction=direction,
         score=score,
         confirmations=confs,
-        warnings=[],
+        warnings=warnings,
         notes=(
             f"Type F: Type C base met ({direction}), plus {len(signals)} of 4 "
             f"corroborating signals (need ≥ {F_MIN_SIGNALS})."
@@ -246,24 +274,19 @@ def classify_setup_c_from_row(row: BulkScreenerRow) -> SetupClassification | Non
 
     Used in the Full Scan as the fallback when Type F doesn't qualify. Scan-row
     Type C does NOT check dark pool / OI build (those are S3 fanout); the C
-    base check (premium + IV rank) is sufficient at the scan level.
+    base check (premium magnitude + flow imbalance) is sufficient at scan level.
     """
-    ok, direction, confirmations = _check_c_base(row)
+    ok, direction, confirmations, warnings, imbalance = _check_c_base(row)
     if not ok or direction is None:
         return None
 
     net_premium = _row_net_premium(row) or Decimal("0")
     abs_net = abs(net_premium)
-    iv_rank = row.iv_rank or Decimal("0")
 
     premium_score = min(Decimal("3"), abs_net / Decimal("100000000") * Decimal("3"))
-    if direction == "bull":
-        ivr_score = (iv_rank - IV_RANK_HIGH) / Decimal("30") * Decimal("1")
-    else:
-        ivr_score = (IV_RANK_LOW - iv_rank) / Decimal("30") * Decimal("1")
-    ivr_score = max(Decimal("0"), min(Decimal("1"), ivr_score))
+    flow_score = max(Decimal("0"), min(Decimal("1"), imbalance))
 
-    raw = premium_score + ivr_score
+    raw = premium_score + flow_score
     score = min(Decimal("4"), max(Decimal("0"), raw))
 
     return SetupClassification(
@@ -272,9 +295,9 @@ def classify_setup_c_from_row(row: BulkScreenerRow) -> SetupClassification | Non
         direction=direction,
         score=score,
         confirmations=confirmations,
-        warnings=[],
+        warnings=warnings,
         notes=(
             f"Type C (scan-row): |net premium| ≥ ${NET_PREMIUM_THRESHOLD:,.0f}, "
-            f"IV rank gate met for {direction}."
+            f"flow imbalance ≥ {FLOW_IMBALANCE_THRESHOLD:.0%} for {direction}."
         ),
     )

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -109,6 +109,7 @@ def _ohlc_provider(
     return MassiveOhlcProvider(
         api_key=settings.massive_api_key.get_secret_value(),
         base_url=settings.massive_base_url,
+        timeout=settings.request_timeout_seconds,
         telemetry_recorder=telemetry_recorder,
         job_name=job_name,
     )

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -37,6 +37,8 @@ def _mk_report(
     dark_pool_notional: Decimal | None = None,
     oi_change_top_count: int = 0,
 ) -> SingleStockReport:
+    bull_premium = max(net_premium, Decimal("0"))
+    bear_premium = abs(min(net_premium, Decimal("0")))
     return SingleStockReport(
         run_id=1,
         ticker="TSLA",
@@ -47,9 +49,9 @@ def _mk_report(
             ticker="TSLA",
             flow_count=10,
             net_premium=net_premium,
-            bull_premium=Decimal("10000000"),
-            bear_premium=Decimal("0"),
-            ask_side_premium=Decimal("0"),
+            bull_premium=bull_premium,
+            bear_premium=bear_premium,
+            ask_side_premium=abs(net_premium),
             bid_side_premium=Decimal("0"),
         ),
         vrp=VRPAssessment(vrp=None, signal="unknown", note=""),
@@ -92,23 +94,28 @@ def test_low_premium_returns_none():
     assert classify_setup_c(r) is None
 
 
-def test_wrong_direction_iv_rank_returns_none():
-    # Bull flow but low IV rank → no C
+def test_low_iv_rank_does_not_veto_bull_direction():
     r = _mk_report(
         net_premium=Decimal("20000000"),
         iv_rank=Decimal("20"),
         dark_pool_notional=Decimal("500000000"),
     )
-    assert classify_setup_c(r) is None
+    setup = classify_setup_c(r)
+    assert setup is not None
+    assert setup.direction == "bull"
+    assert any("iv_rank = 20" in c for c in setup.confirmations)
 
 
-def test_missing_iv_rank_returns_none():
+def test_missing_iv_rank_does_not_veto_strong_flow():
     r = _mk_report(
         net_premium=Decimal("20000000"),
         iv_rank=None,
         dark_pool_notional=Decimal("500000000"),
     )
-    assert classify_setup_c(r) is None
+    setup = classify_setup_c(r)
+    assert setup is not None
+    assert setup.direction == "bull"
+    assert "iv_rank unavailable; direction uses flow, not IV rank" in setup.warnings
 
 
 def test_no_corroborating_signal_returns_none():
@@ -148,11 +155,15 @@ def _mk_row(
     total_open_interest: int | None = 1_000_000,
     variance_risk_premium: Decimal | None = None,
     relative_volume: Decimal | None = None,
+    call_premium: Decimal | None = Decimal("100000000"),
+    put_premium: Decimal | None = Decimal("0"),
 ) -> BulkScreenerRow:
     return BulkScreenerRow(
         ticker=ticker,
         net_call_premium=net_call_premium,
         net_put_premium=net_put_premium,
+        call_premium=call_premium,
+        put_premium=put_premium,
         iv_rank=iv_rank,
         gex_net_change=gex_net_change,
         total_open_interest=total_open_interest,
@@ -211,8 +222,8 @@ def test_classify_setup_f_base_miss_returns_none():
     assert classify_setup_f(row) is None
 
 
-def test_classify_setup_f_iv_rank_gate_returns_none():
-    """Bull flow but low IV rank → no F."""
+def test_classify_setup_f_low_iv_rank_still_qualifies_on_flow_and_signals():
+    """Bull flow with low IV rank can still be F; IV rank is structure context."""
     row = _mk_row(
         net_call_premium=Decimal("100000000"),
         net_put_premium=Decimal("0"),
@@ -222,7 +233,10 @@ def test_classify_setup_f_iv_rank_gate_returns_none():
         variance_risk_premium=Decimal("-0.10"),
         relative_volume=Decimal("3.0"),
     )
-    assert classify_setup_f(row) is None
+    setup = classify_setup_f(row)
+    assert setup is not None
+    assert setup.setup_type == "F"
+    assert setup.direction == "bull"
 
 
 def test_classify_setup_f_bear_with_signals():
@@ -250,7 +264,10 @@ def test_classify_setup_f_missing_iv_rank_returns_none():
         total_open_interest=1_000_000,
         variance_risk_premium=Decimal("-0.10"),
     )
-    assert classify_setup_f(row) is None
+    setup = classify_setup_f(row)
+    assert setup is not None
+    assert setup.direction == "bull"
+    assert "iv_rank unavailable; direction uses flow, not IV rank" in setup.warnings
 
 
 def test_detect_f_signals_counts_correctly():
@@ -278,6 +295,17 @@ def test_classify_setup_c_from_row_qualifies():
     assert setup is not None
     assert setup.setup_type == "C"
     assert setup.direction == "bull"
+
+
+def test_classify_setup_c_from_row_rejects_weak_flow_imbalance():
+    row = _mk_row(
+        net_call_premium=Decimal("105000000"),
+        net_put_premium=Decimal("95000000"),
+        call_premium=Decimal("105000000"),
+        put_premium=Decimal("95000000"),
+        iv_rank=Decimal("90"),
+    )
+    assert classify_setup_c_from_row(row) is None
 
 
 def test_classify_setup_c_from_row_below_premium():

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from datetime import datetime
 from contextlib import contextmanager
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
 from uw_scan.worker.scheduler import (
+    _ohlc_provider,
     _record_worker_heartbeat,
     _spot_refresh_market_date,
     _uw_auto_request_allowed,
@@ -67,3 +71,24 @@ def test_record_worker_heartbeat_uses_dedicated_worker_key(monkeypatch) -> None:
     _record_worker_heartbeat(object())
 
     assert calls == ["worker"]
+
+
+def test_ohlc_provider_uses_configured_request_timeout(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeProvider:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("uw_scan.worker.scheduler.MassiveOhlcProvider", FakeProvider)
+
+    settings = Settings(
+        api_key="uw",
+        massive_api_key=SecretStr("massive"),
+        request_timeout_seconds=42.0,
+    )
+
+    provider = _ohlc_provider(settings)
+
+    assert provider is not None
+    assert captured["timeout"] == 42.0

--- a/web/components/watchlist/FilterBar.tsx
+++ b/web/components/watchlist/FilterBar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState, type CSSProperties } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 // Sector chips arranged in labeled sub-rows by relevance.
@@ -34,7 +35,7 @@ const SECTOR_ROWS: { label: string; items: string[] }[] = [
 
 const SETUPS = ["All", "C-bull", "C-bear", "F-MULTI", "NEUTRAL"];
 
-const rowLabelStyle: React.CSSProperties = {
+const rowLabelStyle: CSSProperties = {
   fontSize: 10,
   fontFamily: "var(--font-mono)",
   color: "var(--text-muted)",
@@ -43,6 +44,81 @@ const rowLabelStyle: React.CSSProperties = {
   alignSelf: "center",
   minWidth: 56,
 };
+
+function SetupFormulaPopover() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      style={{ position: "relative", display: "inline-flex" }}
+    >
+      <button
+        type="button"
+        aria-label="Setup formula explanation"
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        style={{
+          cursor: "help",
+          fontSize: 10,
+          fontFamily: "var(--font-mono)",
+          color: "var(--text-muted)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: "50%",
+          width: 14,
+          height: 14,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "transparent",
+          padding: 0,
+        }}
+      >
+        i
+      </button>
+      {open && (
+        <div
+          role="tooltip"
+          style={{
+            position: "absolute",
+            top: 20,
+            left: 0,
+            zIndex: 20,
+            width: 520,
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border-dim)",
+            borderRadius: 4,
+            padding: 10,
+            fontSize: 11,
+            lineHeight: 1.45,
+            color: "var(--text-primary)",
+            boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
+          }}
+        >
+          <p style={{ margin: 0 }}>
+            Flow direction = sign(net call premium - net put premium).
+          </p>
+          <p style={{ margin: "6px 0 0 0" }}>
+            net premium = net call premium - net put premium.
+          </p>
+          <p style={{ margin: "6px 0 0 0" }}>
+            Type C requires abs(net premium) &gt;= $5M and flow imbalance &gt;=
+            20%, where flow imbalance = abs(net premium) / (call premium + put
+            premium).
+          </p>
+          <p style={{ margin: "6px 0 0 0" }}>
+            F-MULTI = Type C base plus at least 2 of: GEX/OI shift, VRP anomaly,
+            relative volume &gt; 1.5, or flow polarization &gt; $50M.
+          </p>
+          <p style={{ margin: "6px 0 0 0", color: "var(--text-secondary)" }}>
+            IV rank is context for structure, not a directional veto.
+          </p>
+        </div>
+      )}
+    </span>
+  );
+}
 
 export function FilterBar({
   current,
@@ -111,7 +187,17 @@ export function FilterBar({
           marginTop: 4,
         }}
       >
-        <span style={rowLabelStyle}>Regime</span>
+        <span
+          style={{
+            ...rowLabelStyle,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+          }}
+        >
+          <span>Setup</span>
+          <SetupFormulaPopover />
+        </span>
         <div style={{ display: "flex", gap: 4, flexWrap: "wrap", flex: 1 }}>
           {SETUPS.map((s) =>
             chip(s, (current.setup ?? "All") === s, () =>

--- a/web/tests/unit/filterBar.test.tsx
+++ b/web/tests/unit/filterBar.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FilterBar } from "@/components/watchlist/FilterBar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("FilterBar", () => {
+  it("shows setup formula explanation in a compact popover", () => {
+    render(<FilterBar current={{}} />);
+
+    expect(screen.getByText("Setup")).toBeDefined();
+    expect(screen.queryByText(/Flow direction/)).toBeNull();
+
+    const trigger = screen.getByLabelText("Setup formula explanation");
+    const hoverRegion = trigger.parentElement!;
+    fireEvent.mouseEnter(hoverRegion);
+
+    expect(screen.getByText(/Flow direction/)).toBeDefined();
+    expect(screen.getByText(/net premium = net call premium/)).toBeDefined();
+    expect(screen.getByText(/abs\(net premium\) >= \$5M/)).toBeDefined();
+    expect(screen.getByText(/flow imbalance = abs\(net premium\)/)).toBeDefined();
+    expect(screen.getByText(/F-MULTI = Type C base/)).toBeDefined();
+    expect(screen.getByText(/IV rank is context/)).toBeDefined();
+
+    fireEvent.mouseLeave(hoverRegion);
+
+    expect(screen.queryByText(/Flow direction/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace IV-rank directional gates with signed-flow plus flow-imbalance setup classification
- add setup classifier evidence note
- add hover formula explainer to the watchlist setup filter
- pass configured request timeout into Massive OHLC provider

## Verification
- uv run ruff check src/uw_scan/scoring.py tests/unit/test_scoring.py src/uw_scan/worker/scheduler.py tests/unit/worker/test_scheduler.py
- uv run pytest tests/unit/worker/test_scheduler.py tests/integration/worker/test_worker_jobs.py -q
- uv run pytest tests/unit/test_scoring.py tests/unit/test_scan_assembly.py tests/integration/api/test_watchlist_endpoint.py -q
- cd web && npm run test -- --run filterBar
- cd web && npm run lint
- cd web && npm run typecheck