### PR TITLE
Add flow alert baseline summary

### DIFF
--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -363,6 +363,10 @@ class VolatilityProfile(_UwBase):
 class FlowSnapshot(_UwBase):
     ticker: str
     flow_count: int
+    flow_count_is_limited: bool = False
+    flow_count_30d_avg: Decimal | None = None
+    flow_count_vs_30d_avg: Decimal | None = None
+    flow_count_30d_days: int = 0
     net_premium: Decimal
     bull_premium: Decimal
     bear_premium: Decimal

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -367,6 +367,7 @@ class FlowSnapshot(_UwBase):
     flow_count_30d_avg: Decimal | None = None
     flow_count_vs_30d_avg: Decimal | None = None
     flow_count_30d_days: int = 0
+    top_alert_rule: str | None = None
     net_premium: Decimal
     bull_premium: Decimal
     bear_premium: Decimal

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -33,6 +33,8 @@ from .storage.provider_usage import ExternalApiRequestRecorder
 
 logger = logging.getLogger(__name__)
 
+FLOW_ALERT_LIMIT = 100
+
 
 def _next_friday(today: _date) -> _date:
     """Pick the next Friday (today + 1..7 days)."""
@@ -79,10 +81,18 @@ def run_single_stock(
 
     try:
         # 1. Flow alerts (filtered to this ticker via param)
-        flow_alerts = uw_sources.fetch_flow_alerts(client, repo, run_id, ticker)
+        flow_alerts = uw_sources.fetch_flow_alerts(
+            client, repo, run_id, ticker, limit=FLOW_ALERT_LIMIT
+        )
         # Defensive: keep only this ticker
         ticker_alerts = [a for a in flow_alerts if a.ticker == ticker]
         repo.insert_flow_events(run_id, ticker, ticker_alerts)
+        repo.upsert_flow_alerts_daily_rollup(
+            run_id=run_id,
+            ticker=ticker,
+            alerts=ticker_alerts,
+            alert_limit=FLOW_ALERT_LIMIT,
+        )
 
         # 2. IV rank (time series)
         iv_rank_rows = uw_sources.fetch_iv_rank(client, repo, run_id, ticker)

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -27,6 +27,8 @@ from ..models import (
 )
 from ..storage.repository import Repository
 
+FLOW_ALERT_FETCH_LIMIT = 100
+
 
 def _to_decimal(value: object) -> Decimal | None:
     if value is None:
@@ -42,7 +44,9 @@ def _safe_get(d: dict | None, key: str):
     return d.get(key)
 
 
-def _build_flow_snapshot(ticker: str, flow_rows: list[dict]) -> FlowSnapshot:
+def _build_flow_snapshot(
+    ticker: str, flow_rows: list[dict], baseline: dict | None = None
+) -> FlowSnapshot:
     bull_premium = Decimal("0")
     bear_premium = Decimal("0")
     ask_side = Decimal("0")
@@ -95,6 +99,13 @@ def _build_flow_snapshot(ticker: str, flow_rows: list[dict]) -> FlowSnapshot:
     return FlowSnapshot(
         ticker=ticker,
         flow_count=len(flow_rows),
+        flow_count_is_limited=bool(_safe_get(baseline, "alert_count_is_limited"))
+        or len(flow_rows) >= FLOW_ALERT_FETCH_LIMIT,
+        flow_count_30d_avg=_to_decimal(_safe_get(baseline, "avg_30d_alert_count")),
+        flow_count_vs_30d_avg=_to_decimal(
+            _safe_get(baseline, "flow_count_vs_30d_avg")
+        ),
+        flow_count_30d_days=int(_safe_get(baseline, "baseline_days") or 0),
         net_premium=net_premium,
         bull_premium=bull_premium,
         bear_premium=bear_premium,
@@ -373,7 +384,8 @@ def assemble_single_stock_report(
     """Build a SingleStockReport from persisted run data."""
     ticker = ticker.upper()
     flow_rows = repo.fetch_flow_alerts_for_ticker(run_id, ticker)
-    flow = _build_flow_snapshot(ticker, flow_rows)
+    baseline = repo.fetch_flow_alerts_daily_baseline(run_id, ticker)
+    flow = _build_flow_snapshot(ticker, flow_rows, baseline)
 
     max_pain_rows_raw = repo.fetch_max_pain_rows(run_id, ticker)
     max_pain_rows: list[MaxPainRow] = []

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -106,6 +106,7 @@ def _build_flow_snapshot(
             _safe_get(baseline, "flow_count_vs_30d_avg")
         ),
         flow_count_30d_days=int(_safe_get(baseline, "baseline_days") or 0),
+        top_alert_rule=_safe_get(baseline, "top_alert_rule"),
         net_premium=net_premium,
         bull_premium=bull_premium,
         bear_premium=bear_premium,

--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -914,6 +914,22 @@ def _known_idea_id(idea_id: str, candidates: dict[str, dict[str, Any]]) -> bool:
 
 
 _PATH_PART_INDEX_RE = re.compile(r"\[-?\d*\]")
+_SOURCE_PATH_ALIASES = (
+    (
+        "tabs.market_structure.market_structure.stock_history.",
+        "tabs.market_structure.stock_history.",
+    ),
+)
+
+
+def _canonical_source_path(path: str, deterministic_payload: dict[str, Any]) -> str:
+    for invalid_prefix, canonical_prefix in _SOURCE_PATH_ALIASES:
+        if not path.startswith(invalid_prefix):
+            continue
+        candidate = f"{canonical_prefix}{path.removeprefix(invalid_prefix)}"
+        if _path_family_exists(candidate, deterministic_payload):
+            return candidate
+    return path
 
 
 def _path_family_exists(path: str, deterministic_payload: dict[str, Any]) -> bool:
@@ -965,6 +981,10 @@ def _validate_source_path_item(
     for unavailable in ("charm", "vanna", "short_interest"):
         if unavailable in lowered and not _missing_data_mentions(outcome, unavailable):
             raise ValueError(f"unavailable source field referenced: {source_path}")
+    canonical_source_path = _canonical_source_path(source_path, deterministic_payload)
+    if canonical_source_path != source_path:
+        item.source_path = canonical_source_path
+        source_path = canonical_source_path
     if not _path_family_exists(source_path, deterministic_payload):
         raise ValueError(f"source_path prefix does not exist: {source_path}")
 

--- a/src/uw_scan/storage/migrations/022_flow_alerts_daily_rollup.sql
+++ b/src/uw_scan/storage/migrations/022_flow_alerts_daily_rollup.sql
@@ -1,0 +1,30 @@
+-- 022_flow_alerts_daily_rollup.sql
+-- Daily ticker-level summary for alert-count baselines in the Flow tab.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.flow_alerts_daily_rollup (
+    ticker                 TEXT        NOT NULL,
+    trade_date             DATE        NOT NULL,
+    run_id                 BIGINT      REFERENCES uw_scan.scan_runs(run_id) ON DELETE SET NULL,
+    alert_count            INTEGER     NOT NULL DEFAULT 0,
+    alert_count_is_limited BOOLEAN     NOT NULL DEFAULT false,
+    total_premium          NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    bull_premium           NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    bear_premium           NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    ask_side_premium       NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    bid_side_premium       NUMERIC(20, 4) NOT NULL DEFAULT 0,
+    top_alert_rule         TEXT,
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (ticker, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_flow_alerts_daily_rollup_ticker_date
+    ON uw_scan.flow_alerts_daily_rollup(ticker, trade_date DESC);
+
+COMMENT ON COLUMN uw_scan.flow_alerts_daily_rollup.trade_date
+    IS 'US/Eastern market date used for daily alert-count baselines.';
+COMMENT ON COLUMN uw_scan.flow_alerts_daily_rollup.alert_count_is_limited
+    IS 'True when the count hit the fetch page limit and should be interpreted as count-or-more.';
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/023_backfill_flow_alerts_daily_rollup.sql
+++ b/src/uw_scan/storage/migrations/023_backfill_flow_alerts_daily_rollup.sql
@@ -1,0 +1,112 @@
+-- 023_backfill_flow_alerts_daily_rollup.sql
+-- Populate flow_alerts_daily_rollup from existing per-run flow_events.
+--
+-- If multiple scans exist for the same ticker + market date, keep the latest
+-- run_id. This matches the stock report's latest-run behavior and avoids
+-- double-counting same-day rescans.
+
+BEGIN;
+
+WITH event_rows AS (
+    SELECT
+        f.run_id,
+        UPPER(f.ticker) AS ticker,
+        COALESCE(
+            (f.created_at AT TIME ZONE 'America/New_York')::date,
+            (s.started_at AT TIME ZONE 'America/New_York')::date
+        ) AS trade_date,
+        LOWER(COALESCE(f.option_type, '')) AS option_type,
+        COALESCE(f.total_premium, 0)::numeric AS total_premium,
+        COALESCE(f.total_ask_side_prem, 0)::numeric AS total_ask_side_prem,
+        COALESCE(f.total_bid_side_prem, 0)::numeric AS total_bid_side_prem,
+        f.alert_rule
+    FROM uw_scan.flow_events f
+    JOIN uw_scan.scan_runs s ON s.run_id = f.run_id
+), per_run AS (
+    SELECT
+        run_id,
+        ticker,
+        trade_date,
+        COUNT(*)::integer AS alert_count,
+        (COUNT(*) >= 100) AS alert_count_is_limited,
+        SUM(total_premium)::numeric(20, 4) AS total_premium,
+        SUM(CASE WHEN option_type = 'call' THEN total_premium ELSE 0 END)::numeric(20, 4)
+            AS bull_premium,
+        SUM(CASE WHEN option_type = 'put' THEN total_premium ELSE 0 END)::numeric(20, 4)
+            AS bear_premium,
+        SUM(total_ask_side_prem)::numeric(20, 4) AS ask_side_premium,
+        SUM(total_bid_side_prem)::numeric(20, 4) AS bid_side_premium
+    FROM event_rows
+    GROUP BY run_id, ticker, trade_date
+), per_rule AS (
+    SELECT
+        run_id,
+        ticker,
+        trade_date,
+        alert_rule,
+        COUNT(*) AS rule_count
+    FROM event_rows
+    WHERE alert_rule IS NOT NULL
+    GROUP BY run_id, ticker, trade_date, alert_rule
+), top_rule AS (
+    SELECT DISTINCT ON (run_id, ticker, trade_date)
+        run_id,
+        ticker,
+        trade_date,
+        alert_rule AS top_alert_rule
+    FROM per_rule
+    ORDER BY run_id, ticker, trade_date, rule_count DESC, alert_rule ASC
+), ranked AS (
+    SELECT
+        p.*,
+        t.top_alert_rule,
+        ROW_NUMBER() OVER (
+            PARTITION BY p.ticker, p.trade_date
+            ORDER BY p.run_id DESC
+        ) AS rn
+    FROM per_run p
+    LEFT JOIN top_rule t
+      ON t.run_id = p.run_id
+     AND t.ticker = p.ticker
+     AND t.trade_date = p.trade_date
+)
+INSERT INTO uw_scan.flow_alerts_daily_rollup (
+    ticker,
+    trade_date,
+    run_id,
+    alert_count,
+    alert_count_is_limited,
+    total_premium,
+    bull_premium,
+    bear_premium,
+    ask_side_premium,
+    bid_side_premium,
+    top_alert_rule
+)
+SELECT
+    ticker,
+    trade_date,
+    run_id,
+    alert_count,
+    alert_count_is_limited,
+    total_premium,
+    bull_premium,
+    bear_premium,
+    ask_side_premium,
+    bid_side_premium,
+    top_alert_rule
+FROM ranked
+WHERE rn = 1
+ON CONFLICT (ticker, trade_date) DO UPDATE SET
+    run_id = EXCLUDED.run_id,
+    alert_count = EXCLUDED.alert_count,
+    alert_count_is_limited = EXCLUDED.alert_count_is_limited,
+    total_premium = EXCLUDED.total_premium,
+    bull_premium = EXCLUDED.bull_premium,
+    bear_premium = EXCLUDED.bear_premium,
+    ask_side_premium = EXCLUDED.ask_side_premium,
+    bid_side_premium = EXCLUDED.bid_side_premium,
+    top_alert_rule = EXCLUDED.top_alert_rule,
+    updated_at = now();
+
+COMMIT;

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date as _date
@@ -671,6 +672,86 @@ class Repository:
                     ),
                 )
         return len(rows)
+
+    def upsert_flow_alerts_daily_rollup(
+        self,
+        *,
+        run_id: int,
+        ticker: str,
+        alerts: Iterable[models.FlowAlert],
+        alert_limit: int,
+        trade_date: _date | None = None,
+    ) -> None:
+        rows = list(alerts)
+        if trade_date is None:
+            trade_date = self._flow_alert_trade_date(rows)
+
+        bull_premium = Decimal("0")
+        bear_premium = Decimal("0")
+        ask_side_premium = Decimal("0")
+        bid_side_premium = Decimal("0")
+        total_premium = Decimal("0")
+        rules: Counter[str] = Counter()
+
+        for row in rows:
+            premium = row.total_premium or Decimal("0")
+            total_premium += premium
+            opt_type = (row.type or "").lower()
+            if opt_type == "call":
+                bull_premium += premium
+            elif opt_type == "put":
+                bear_premium += premium
+            ask_side_premium += row.total_ask_side_prem or Decimal("0")
+            bid_side_premium += row.total_bid_side_prem or Decimal("0")
+            if row.alert_rule:
+                rules[row.alert_rule] += 1
+
+        top_alert_rule = rules.most_common(1)[0][0] if rules else None
+
+        sql = (
+            f"INSERT INTO {self._schema}.flow_alerts_daily_rollup ("
+            "ticker, trade_date, run_id, alert_count, alert_count_is_limited, "
+            "total_premium, bull_premium, bear_premium, ask_side_premium, "
+            "bid_side_premium, top_alert_rule) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (ticker, trade_date) DO UPDATE SET "
+            "run_id=EXCLUDED.run_id, alert_count=EXCLUDED.alert_count, "
+            "alert_count_is_limited=EXCLUDED.alert_count_is_limited, "
+            "total_premium=EXCLUDED.total_premium, "
+            "bull_premium=EXCLUDED.bull_premium, "
+            "bear_premium=EXCLUDED.bear_premium, "
+            "ask_side_premium=EXCLUDED.ask_side_premium, "
+            "bid_side_premium=EXCLUDED.bid_side_premium, "
+            "top_alert_rule=EXCLUDED.top_alert_rule, updated_at=now()"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    ticker.upper(),
+                    trade_date,
+                    run_id,
+                    len(rows),
+                    len(rows) >= alert_limit,
+                    total_premium,
+                    bull_premium,
+                    bear_premium,
+                    ask_side_premium,
+                    bid_side_premium,
+                    top_alert_rule,
+                ),
+            )
+
+    def _flow_alert_trade_date(self, rows: list[models.FlowAlert]) -> _date:
+        market_tz = ZoneInfo("America/New_York")
+        for row in rows:
+            if row.created_at is None:
+                continue
+            created_at = row.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=market_tz)
+            return created_at.astimezone(market_tz).date()
+        return datetime.now(market_tz).date()
 
     # ------------------------------------------------------------------
     # Time-series history (UPSERT by (ticker, market_date))
@@ -1398,6 +1479,40 @@ class Repository:
             cur.execute(sql, (run_id, ticker.upper()))
             cols = [d.name for d in cur.description or []]
             return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
+    def fetch_flow_alerts_daily_baseline(
+        self, run_id: int, ticker: str, lookback_days: int = 30
+    ) -> dict[str, Any] | None:
+        sql = (
+            "WITH current_rollup AS ("
+            f"SELECT ticker, trade_date, alert_count, alert_count_is_limited "
+            f"FROM {self._schema}.flow_alerts_daily_rollup "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY trade_date DESC LIMIT 1"
+            "), history AS ("
+            f"SELECT h.alert_count "
+            f"FROM {self._schema}.flow_alerts_daily_rollup h "
+            "JOIN current_rollup c ON c.ticker = h.ticker "
+            "WHERE h.trade_date < c.trade_date "
+            "AND h.trade_date >= c.trade_date - (%s::int * INTERVAL '1 day')"
+            ") "
+            "SELECT c.alert_count, c.alert_count_is_limited, "
+            "AVG(h.alert_count)::numeric AS avg_30d_alert_count, "
+            "CASE WHEN AVG(h.alert_count) > 0 "
+            "THEN ROUND(c.alert_count::numeric / AVG(h.alert_count)::numeric, 16) "
+            "ELSE NULL END AS flow_count_vs_30d_avg, "
+            "COUNT(h.alert_count)::int AS baseline_days "
+            "FROM current_rollup c "
+            "LEFT JOIN history h ON true "
+            "GROUP BY c.alert_count, c.alert_count_is_limited"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker.upper(), lookback_days))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [d.name for d in cur.description or []]
+            return dict(zip(cols, row, strict=False))
 
     def fetch_iv_rank_latest(self, ticker: str) -> dict[str, Any] | None:
         sql = (

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -1485,7 +1485,8 @@ class Repository:
     ) -> dict[str, Any] | None:
         sql = (
             "WITH current_rollup AS ("
-            f"SELECT ticker, trade_date, alert_count, alert_count_is_limited "
+            f"SELECT ticker, trade_date, alert_count, alert_count_is_limited, "
+            "top_alert_rule "
             f"FROM {self._schema}.flow_alerts_daily_rollup "
             "WHERE run_id = %s AND ticker = %s "
             "ORDER BY trade_date DESC LIMIT 1"
@@ -1496,7 +1497,7 @@ class Repository:
             "WHERE h.trade_date < c.trade_date "
             "AND h.trade_date >= c.trade_date - (%s::int * INTERVAL '1 day')"
             ") "
-            "SELECT c.alert_count, c.alert_count_is_limited, "
+            "SELECT c.alert_count, c.alert_count_is_limited, c.top_alert_rule, "
             "AVG(h.alert_count)::numeric AS avg_30d_alert_count, "
             "CASE WHEN AVG(h.alert_count) > 0 "
             "THEN ROUND(c.alert_count::numeric / AVG(h.alert_count)::numeric, 16) "
@@ -1504,7 +1505,7 @@ class Repository:
             "COUNT(h.alert_count)::int AS baseline_days "
             "FROM current_rollup c "
             "LEFT JOIN history h ON true "
-            "GROUP BY c.alert_count, c.alert_count_is_limited"
+            "GROUP BY c.alert_count, c.alert_count_is_limited, c.top_alert_rule"
         )
         with self._conn.cursor() as cur:
             cur.execute(sql, (run_id, ticker.upper(), lookback_days))

--- a/tests/integration/api/test_provider_usage.py
+++ b/tests/integration/api/test_provider_usage.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC
+
+from uw_scan.storage.repository import provider_day_bounds
 
 
 def _seed_provider_usage(repo):
+    provider_day_start, _ = provider_day_bounds()
+    request_at = provider_day_start.astimezone(UTC)
     for endpoint, ticker, status_code, status_family, latency in [
         ("iv_rank", "TSLA", 200, "2xx", 20),
         ("greek_exposure", "TSLA", 429, "4xx", 30),
@@ -19,8 +23,8 @@ def _seed_provider_usage(repo):
             params={"ticker": ticker},
             status_code=status_code,
             status_family=status_family,
-            started_at=datetime(2026, 5, 14, 14, 0, tzinfo=UTC),
-            finished_at=datetime(2026, 5, 14, 14, 0, tzinfo=UTC),
+            started_at=request_at,
+            finished_at=request_at,
             latency_ms=latency,
             official_daily_count=7 if provider == "uw" else None,
             official_daily_limit=1000 if provider == "uw" else None,

--- a/tests/integration/storage/test_flow_alerts_daily_rollup.py
+++ b/tests/integration/storage/test_flow_alerts_daily_rollup.py
@@ -62,6 +62,7 @@ def test_flow_alerts_daily_rollup_computes_30d_baseline(seeded_db_empty_cards):
 
     assert baseline["alert_count"] == 100
     assert baseline["alert_count_is_limited"] is True
+    assert baseline["top_alert_rule"] == "RepeatedHits"
     assert baseline["avg_30d_alert_count"] == Decimal("30.0000000000000000")
     assert baseline["flow_count_vs_30d_avg"] == Decimal("3.3333333333333333")
     assert baseline["baseline_days"] == 3

--- a/tests/integration/storage/test_flow_alerts_daily_rollup.py
+++ b/tests/integration/storage/test_flow_alerts_daily_rollup.py
@@ -1,0 +1,174 @@
+"""Flow-alert daily rollup persistence."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from uw_scan.config import Settings
+from uw_scan.models import FlowAlert
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _alert(
+    alert_id: str,
+    ticker: str = "GOOGL",
+    *,
+    option_type: str = "call",
+    premium: Decimal = Decimal("1000"),
+    rule: str = "RepeatedHits",
+    created_at: datetime = datetime(2026, 5, 14, 14, 30, tzinfo=timezone.utc),
+) -> FlowAlert:
+    return FlowAlert(
+        id=alert_id,
+        ticker=ticker,
+        type=option_type,
+        total_premium=premium,
+        total_ask_side_prem=premium * Decimal("0.7"),
+        total_bid_side_prem=premium * Decimal("0.3"),
+        alert_rule=rule,
+        created_at=created_at,
+    )
+
+
+def test_flow_alerts_daily_rollup_computes_30d_baseline(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+
+    for idx, count in enumerate([20, 30, 40], start=1):
+        run_id = repo.insert_scan_run("GOOGL")
+        repo.upsert_flow_alerts_daily_rollup(
+            run_id=run_id,
+            ticker="GOOGL",
+            alerts=[_alert(f"hist-{idx}-{n}") for n in range(count)],
+            alert_limit=100,
+            trade_date=date(2026, 5, 10 + idx),
+        )
+
+    current_run_id = repo.insert_scan_run("GOOGL")
+    repo.upsert_flow_alerts_daily_rollup(
+        run_id=current_run_id,
+        ticker="GOOGL",
+        alerts=[_alert(f"current-{n}") for n in range(100)],
+        alert_limit=100,
+        trade_date=date(2026, 5, 15),
+    )
+    repo.conn.commit()
+
+    baseline = repo.fetch_flow_alerts_daily_baseline(current_run_id, "GOOGL")
+
+    assert baseline["alert_count"] == 100
+    assert baseline["alert_count_is_limited"] is True
+    assert baseline["avg_30d_alert_count"] == Decimal("30.0000000000000000")
+    assert baseline["flow_count_vs_30d_avg"] == Decimal("3.3333333333333333")
+    assert baseline["baseline_days"] == 3
+
+
+def test_backfill_migration_rolls_up_existing_flow_events(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    old_run = repo.insert_scan_run("GOOGL")
+    repo.insert_flow_events(
+        old_run,
+        "GOOGL",
+        [_alert("old-1", premium=Decimal("10"))],
+    )
+    latest_run = repo.insert_scan_run("GOOGL")
+    repo.insert_flow_events(
+        latest_run,
+        "GOOGL",
+        [
+            _alert("new-1", option_type="call", premium=Decimal("100")),
+            _alert("new-2", option_type="put", premium=Decimal("50")),
+        ],
+    )
+    prior_run = repo.insert_scan_run("GOOGL")
+    repo.insert_flow_events(
+        prior_run,
+        "GOOGL",
+        [
+            _alert(
+                "prior-1",
+                premium=Decimal("20"),
+                created_at=datetime(2026, 5, 13, 14, 30, tzinfo=timezone.utc),
+            ),
+            _alert(
+                "prior-2",
+                premium=Decimal("20"),
+                created_at=datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc),
+            ),
+        ],
+    )
+    repo.conn.commit()
+
+    settings = Settings.from_env().model_copy(
+        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
+    )
+    subprocess.run(
+        [
+            "psql",
+            settings.db_dsn(),
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-f",
+            str(
+                REPO_ROOT
+                / "src/uw_scan/storage/migrations/023_backfill_flow_alerts_daily_rollup.sql"
+            ),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT run_id, alert_count, total_premium, bull_premium, bear_premium
+            FROM uw_scan.flow_alerts_daily_rollup
+            WHERE ticker = 'GOOGL' AND trade_date = '2026-05-14'
+            """
+        )
+        current = cur.fetchone()
+        cur.execute(
+            """
+            SELECT alert_count, avg_30d_alert_count, flow_count_vs_30d_avg
+            FROM (
+                WITH current_rollup AS (
+                    SELECT ticker, trade_date, alert_count
+                    FROM uw_scan.flow_alerts_daily_rollup
+                    WHERE run_id = %s
+                ), history AS (
+                    SELECT h.alert_count
+                    FROM uw_scan.flow_alerts_daily_rollup h
+                    JOIN current_rollup c ON c.ticker = h.ticker
+                    WHERE h.trade_date < c.trade_date
+                      AND h.trade_date >= c.trade_date - (30 * INTERVAL '1 day')
+                )
+                SELECT
+                    c.alert_count,
+                    AVG(h.alert_count)::numeric AS avg_30d_alert_count,
+                    ROUND(c.alert_count::numeric / AVG(h.alert_count)::numeric, 16)
+                        AS flow_count_vs_30d_avg
+                FROM current_rollup c
+                LEFT JOIN history h ON true
+                GROUP BY c.alert_count
+            ) s
+            """,
+            (latest_run,),
+        )
+        baseline = cur.fetchone()
+
+    assert current == (
+        latest_run,
+        2,
+        Decimal("150.0000"),
+        Decimal("100.0000"),
+        Decimal("50.0000"),
+    )
+    assert baseline == (
+        2,
+        Decimal("2.0000000000000000"),
+        Decimal("1.0000000000000000"),
+    )

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -751,6 +751,26 @@ def test_validate_trade_insights_ai_outcome_accepts_array_family_source_paths():
     assert parsed.metric_cards[0].source_path.endswith("rows[].net_dex")
 
 
+def test_validate_trade_insights_ai_outcome_canonicalizes_nested_stock_history_path():
+    deterministic = _analysis_input()
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+    nested_path = _sample_outcome_for(deterministic)
+    nested_path["metric_cards"][0]["source_path"] = (
+        "tabs.market_structure.market_structure.stock_history.rows[0].net_dex"
+    )
+
+    parsed = validate_trade_insights_ai_outcome(
+        nested_path,
+        deterministic,
+        produced_at=produced_at,
+    )
+
+    assert (
+        parsed.metric_cards[0].source_path
+        == "tabs.market_structure.stock_history.rows[0].net_dex"
+    )
+
+
 def test_validate_trade_insights_ai_outcome_accepts_negative_array_source_paths():
     deterministic = _analysis_input()
     produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)

--- a/tests/unit/test_report_assembly.py
+++ b/tests/unit/test_report_assembly.py
@@ -54,6 +54,18 @@ class _StubRepo:
             },
         ]
 
+    def fetch_flow_alerts_daily_baseline(
+        self, run_id: int, ticker: str, lookback_days: int = 30
+    ) -> dict:
+        self.fetched.append("flow_baseline")
+        return {
+            "alert_count": 100,
+            "alert_count_is_limited": True,
+            "avg_30d_alert_count": Decimal("35.50"),
+            "flow_count_vs_30d_avg": Decimal("2.8169"),
+            "baseline_days": 20,
+        }
+
     def fetch_max_pain_rows(self, run_id: int, ticker: str) -> list[dict]:
         self.fetched.append("max_pain")
         return [
@@ -227,6 +239,10 @@ def test_assemble_single_stock_report_populates_sections():
 
     # Flow section
     assert report.flow.flow_count == 1
+    assert report.flow.flow_count_is_limited is True
+    assert report.flow.flow_count_30d_avg == Decimal("35.50")
+    assert report.flow.flow_count_vs_30d_avg == Decimal("2.8169")
+    assert report.flow.flow_count_30d_days == 20
     assert report.flow.bull_premium == Decimal("22000")
     assert report.flow.bear_premium == Decimal("0")
     assert report.flow.net_premium == Decimal("22000")

--- a/tests/unit/test_report_assembly.py
+++ b/tests/unit/test_report_assembly.py
@@ -61,6 +61,7 @@ class _StubRepo:
         return {
             "alert_count": 100,
             "alert_count_is_limited": True,
+            "top_alert_rule": "RepeatedHits",
             "avg_30d_alert_count": Decimal("35.50"),
             "flow_count_vs_30d_avg": Decimal("2.8169"),
             "baseline_days": 20,
@@ -243,6 +244,7 @@ def test_assemble_single_stock_report_populates_sections():
     assert report.flow.flow_count_30d_avg == Decimal("35.50")
     assert report.flow.flow_count_vs_30d_avg == Decimal("2.8169")
     assert report.flow.flow_count_30d_days == 20
+    assert report.flow.top_alert_rule == "RepeatedHits"
     assert report.flow.bull_premium == Decimal("22000")
     assert report.flow.bear_premium == Decimal("0")
     assert report.flow.net_premium == Decimal("22000")

--- a/web/components/stock/panels/FlowAlertSummary.tsx
+++ b/web/components/stock/panels/FlowAlertSummary.tsx
@@ -1,0 +1,92 @@
+import type { components } from "@/lib/types";
+import { fmtDecimal, fmtMoney, toNum } from "@/lib/formatters";
+
+type Flow = components["schemas"]["FlowSnapshot"];
+type Alert = components["schemas"]["FlowAlert"];
+
+function alertCountLabel(flow: Flow): string {
+  const suffix = flow.flow_count_is_limited ? "+" : "";
+  return `${fmtDecimal(flow.flow_count, 0)}${suffix} alerts fetched`;
+}
+
+function topRule(alerts: Alert[]): string {
+  const top = [...alerts].sort(
+    (a, b) => (toNum(b.total_premium) ?? 0) - (toNum(a.total_premium) ?? 0),
+  )[0];
+  return top?.alert_rule ?? "—";
+}
+
+function baselineLabel(flow: Flow): string {
+  const ratio = toNum(flow.flow_count_vs_30d_avg);
+  if (ratio == null || !flow.flow_count_30d_days) {
+    return "30d baseline building";
+  }
+  const prefix = flow.flow_count_is_limited ? ">=" : "";
+  return `Alerts ${prefix}${ratio.toFixed(1)}x 30d avg`;
+}
+
+function hasBaseline(flow: Flow): boolean {
+  return toNum(flow.flow_count_vs_30d_avg) != null && Boolean(flow.flow_count_30d_days);
+}
+
+function askBidLabel(flow: Flow): string {
+  const ask = toNum(flow.ask_side_premium);
+  const bid = toNum(flow.bid_side_premium);
+  if (ask == null || bid == null || bid === 0) return "Ask/Bid —";
+  return `Ask/Bid ${(ask / bid).toFixed(1)}x`;
+}
+
+export function FlowAlertSummary({ flow }: { flow: Flow }) {
+  const alertPremium =
+    (toNum(flow.bull_premium) ?? 0) + (toNum(flow.bear_premium) ?? 0);
+  const items = [
+    { label: alertCountLabel(flow), highlight: false },
+    { label: `Top rule ${topRule(flow.top_alerts ?? [])}`, highlight: false },
+    { label: `Premium ${fmtMoney(alertPremium)}`, highlight: false },
+    { label: askBidLabel(flow), highlight: false },
+    { label: baselineLabel(flow), highlight: true },
+  ];
+  const baselineReady = hasBaseline(flow);
+
+  return (
+    <div
+      aria-label="Flow alert summary"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "8px 14px",
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color: "var(--text-muted)",
+      }}
+    >
+      {items.map((item) => (
+        <span
+          key={item.label}
+          data-highlight={item.highlight ? "baseline" : undefined}
+          style={
+            item.highlight
+              ? {
+                  color: baselineReady ? "var(--accent-warm)" : "var(--text-primary)",
+                  border: `1px solid ${
+                    baselineReady
+                      ? "color-mix(in srgb, var(--accent-warm) 55%, transparent)"
+                      : "var(--border-dim)"
+                  }`,
+                  background: baselineReady
+                    ? "color-mix(in srgb, var(--accent-warm) 16%, transparent)"
+                    : "var(--bg-panel)",
+                  padding: "3px 7px",
+                  borderRadius: 4,
+                  fontWeight: 800,
+                  lineHeight: 1,
+                }
+              : undefined
+          }
+        >
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/components/stock/panels/FlowAlertSummary.tsx
+++ b/web/components/stock/panels/FlowAlertSummary.tsx
@@ -41,7 +41,10 @@ export function FlowAlertSummary({ flow }: { flow: Flow }) {
     (toNum(flow.bull_premium) ?? 0) + (toNum(flow.bear_premium) ?? 0);
   const items = [
     { label: alertCountLabel(flow), highlight: false },
-    { label: `Top rule ${topRule(flow.top_alerts ?? [])}`, highlight: false },
+    {
+      label: `Top rule ${flow.top_alert_rule ?? topRule(flow.top_alerts ?? [])}`,
+      highlight: false,
+    },
     { label: `Premium ${fmtMoney(alertPremium)}`, highlight: false },
     { label: askBidLabel(flow), highlight: false },
     { label: baselineLabel(flow), highlight: true },

--- a/web/components/stock/panels/FlowSnapshotGrid.tsx
+++ b/web/components/stock/panels/FlowSnapshotGrid.tsx
@@ -77,15 +77,10 @@ export function FlowSnapshotGrid({ flow, darkPool, shortData }: Props) {
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+            gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
             gap: 12,
           }}
         >
-          <Tile
-            label="Alerts"
-            tip="alerts"
-            value={fmtDecimal(flow.flow_count, 0)}
-          />
           <Tile
             label="Net Premium"
             tip="netPremium"

--- a/web/components/stock/tabs/FlowTab.tsx
+++ b/web/components/stock/tabs/FlowTab.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { components } from "@/lib/types";
 import { FlowSnapshotGrid } from "../panels/FlowSnapshotGrid";
+import { FlowAlertSummary } from "../panels/FlowAlertSummary";
 import { FlowTimelinePanel } from "../panels/FlowTimelinePanel";
 import { OiMoversTable } from "../panels/OiMoversTable";
 import { StrikeProfilePanel } from "../panels/StrikeProfilePanel";
@@ -135,7 +136,18 @@ export function FlowTab({ report }: { report: Report }) {
       )}
 
       <section>
-        <h3 style={SECTION_HEADING}>Top Alerts</h3>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: 16,
+            margin: "8px 0",
+          }}
+        >
+          <h3 style={{ ...SECTION_HEADING, margin: 0 }}>Top Alerts</h3>
+          <FlowAlertSummary flow={report.flow} />
+        </div>
         <TopAlertsTable alerts={alerts} oiMoverIndex={oiDiffBySymbol} />
       </section>
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -513,6 +513,20 @@ export interface components {
             ticker: string;
             /** Flow Count */
             flow_count: number;
+            /**
+             * Flow Count Is Limited
+             * @default false
+             */
+            flow_count_is_limited: boolean;
+            /** Flow Count 30D Avg */
+            flow_count_30d_avg?: string | null;
+            /** Flow Count Vs 30D Avg */
+            flow_count_vs_30d_avg?: string | null;
+            /**
+             * Flow Count 30D Days
+             * @default 0
+             */
+            flow_count_30d_days: number;
             /** Net Premium */
             net_premium: string;
             /** Bull Premium */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -527,6 +527,8 @@ export interface components {
              * @default 0
              */
             flow_count_30d_days: number;
+            /** Top Alert Rule */
+            top_alert_rule?: string | null;
             /** Net Premium */
             net_premium: string;
             /** Bull Premium */

--- a/web/tests/unit/FlowAlertSummary.test.tsx
+++ b/web/tests/unit/FlowAlertSummary.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FlowAlertSummary } from "@/components/stock/panels/FlowAlertSummary";
+
+const FLOW = {
+  ticker: "GOOGL",
+  flow_count: 100,
+  flow_count_is_limited: true,
+  flow_count_30d_avg: "35.5",
+  flow_count_vs_30d_avg: "2.8169",
+  flow_count_30d_days: 20,
+  net_premium: "62000000",
+  bull_premium: "66000000",
+  bear_premium: "4000000",
+  ask_side_premium: "30000000",
+  bid_side_premium: "15000000",
+  top_alerts: [
+    { id: "1", alert_rule: "RepeatedHits", total_premium: "4455000" },
+    { id: "2", alert_rule: "FloorTradeLargeCap", total_premium: "100000" },
+  ],
+};
+
+describe("FlowAlertSummary", () => {
+  it("renders capped alert count, top rule, premium, ask/bid ratio, and baseline", () => {
+    render(<FlowAlertSummary flow={FLOW as never} />);
+
+    expect(screen.getByText("100+ alerts fetched")).toBeTruthy();
+    expect(screen.getByText("Top rule RepeatedHits")).toBeTruthy();
+    expect(screen.getByText("Premium $70,000,000")).toBeTruthy();
+    expect(screen.getByText("Ask/Bid 2.0x")).toBeTruthy();
+    const baseline = screen.getByText("Alerts >=2.8x 30d avg");
+    expect(baseline).toBeTruthy();
+    expect(baseline.getAttribute("data-highlight")).toBe("baseline");
+  });
+});

--- a/web/tests/unit/FlowAlertSummary.test.tsx
+++ b/web/tests/unit/FlowAlertSummary.test.tsx
@@ -9,6 +9,7 @@ const FLOW = {
   flow_count_30d_avg: "35.5",
   flow_count_vs_30d_avg: "2.8169",
   flow_count_30d_days: 20,
+  top_alert_rule: "RepeatedHits",
   net_premium: "62000000",
   bull_premium: "66000000",
   bear_premium: "4000000",

--- a/web/tests/unit/FlowSnapshotGrid.test.tsx
+++ b/web/tests/unit/FlowSnapshotGrid.test.tsx
@@ -14,7 +14,7 @@ const FIXTURE_FLOW = {
 } as unknown as Parameters<typeof FlowSnapshotGrid>[0]["flow"];
 
 describe("FlowSnapshotGrid", () => {
-  it("renders all 11 snapshot tile labels", () => {
+  it("renders premium, dark-pool, and short-interest labels without the capped alert card", () => {
     render(
       <FlowSnapshotGrid
         flow={FIXTURE_FLOW}
@@ -34,7 +34,6 @@ describe("FlowSnapshotGrid", () => {
     // Labels are stored Title Case in the DOM; CSS text-transform uppercases
     // them visually.
     for (const label of [
-      "Alerts",
       "Net Premium",
       "Bull Premium",
       "Bear Premium",
@@ -48,6 +47,7 @@ describe("FlowSnapshotGrid", () => {
     ]) {
       expect(screen.getByText(label)).toBeTruthy();
     }
+    expect(screen.queryByText("Alerts")).toBeNull();
   });
 
   it("reveals tooltip definition + benchmark on hover, hides on mouseleave", () => {
@@ -59,15 +59,15 @@ describe("FlowSnapshotGrid", () => {
       />,
     );
     // Closed by default — hover-gated.
-    expect(screen.queryByText(/UW flow alerts/)).toBeNull();
+    expect(screen.queryByText(/aggregate alert flow/)).toBeNull();
 
-    const trigger = screen.getByLabelText("Alerts explanation")
+    const trigger = screen.getByLabelText("Net Premium explanation")
       .parentElement as HTMLElement;
     fireEvent.mouseEnter(trigger);
-    expect(screen.getByText(/UW flow alerts/)).toBeTruthy();
-    expect(screen.getByText(/Median active ticker/)).toBeTruthy();
+    expect(screen.getByText(/aggregate alert flow/)).toBeTruthy();
+    expect(screen.getByText(/bull\/bear ratio/)).toBeTruthy();
 
     fireEvent.mouseLeave(trigger);
-    expect(screen.queryByText(/UW flow alerts/)).toBeNull();
+    expect(screen.queryByText(/aggregate alert flow/)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- persist `flow_alerts_daily_rollup` rows and backfill existing flow events for 30-day alert baselines
- replace the misleading Options Flow alert-count card with a compact Top Alerts header summary, including premium, ask/bid, top rule, and highlighted baseline ratio
- canonicalize the known AI Analysis source-path alias for nested market-structure stock history paths

## Tests
- `uv run pytest tests/integration/storage/test_flow_alerts_daily_rollup.py tests/unit/test_report_assembly.py tests/test_trade_insights_ai.py tests/integration/worker/test_trade_insights_ai_jobs.py tests/integration/api/test_trade_insights_ai_endpoint.py`
- `cd web && npm run test -- tests/unit/FlowSnapshotGrid.test.tsx tests/unit/FlowAlertSummary.test.tsx && npm run typecheck`
