### PR TITLE
Fix watchlist ticker readiness flow

### DIFF
--- a/web/app/stock/[ticker]/[tab]/page.tsx
+++ b/web/app/stock/[ticker]/[tab]/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
 import { api } from "@/lib/api";
+import { StockNotReadyDialog } from "@/components/stock/StockNotReadyDialog";
 import { MarketStructureTab } from "@/components/stock/tabs/MarketStructureTab";
 import { VolatilityTab } from "@/components/stock/tabs/VolatilityTab";
 import { FlowTab } from "@/components/stock/tabs/FlowTab";
 import { TradeInsightsTab } from "@/components/stock/tabs/TradeInsightsTab";
 import { TradePlanTab } from "@/components/stock/tabs/TradePlanTab";
+import { isStockReportNotReadyError } from "@/lib/stockNotReady";
 
 const REPORT_TABS = {
   "market-structure": MarketStructureTab,
@@ -25,6 +27,14 @@ export default async function TabPage({
   const Component = REPORT_TABS[tab as keyof typeof REPORT_TABS];
   if (!Component) notFound();
 
-  const report = await api.stock(ticker);
+  let report;
+  try {
+    report = await api.stock(ticker);
+  } catch (error) {
+    if (isStockReportNotReadyError(error, ticker)) {
+      return <StockNotReadyDialog ticker={ticker} />;
+    }
+    throw error;
+  }
   return <Component report={report} />;
 }

--- a/web/app/stock/[ticker]/layout.tsx
+++ b/web/app/stock/[ticker]/layout.tsx
@@ -1,7 +1,9 @@
 import { api } from "@/lib/api";
 import { DetailHeader } from "@/components/stock/DetailHeader";
+import { StockNotReadyDialog } from "@/components/stock/StockNotReadyDialog";
 import { TabBar } from "@/components/stock/TabBar";
 import { toNum } from "@/lib/formatters";
+import { isStockReportNotReadyError } from "@/lib/stockNotReady";
 
 export default async function StockLayout({
   children,
@@ -11,7 +13,15 @@ export default async function StockLayout({
   params: Promise<{ ticker: string }>;
 }) {
   const { ticker } = await params;
-  const report = await api.stock(ticker);
+  let report;
+  try {
+    report = await api.stock(ticker);
+  } catch (error) {
+    if (isStockReportNotReadyError(error, ticker)) {
+      return <StockNotReadyDialog ticker={ticker} />;
+    }
+    throw error;
+  }
 
   return (
     <div style={{ minHeight: "100%", background: "var(--bg-base)" }}>

--- a/web/components/stock/StockNotReadyDialog.tsx
+++ b/web/components/stock/StockNotReadyDialog.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+
+export function StockNotReadyDialog({
+  ticker,
+  onClose,
+}: {
+  ticker: string;
+  onClose?: () => void;
+}) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 80,
+        display: "grid",
+        placeItems: "center",
+        padding: 16,
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-labelledby="stock-not-ready-title"
+        style={{
+          width: "min(380px, calc(100vw - 32px))",
+          padding: 18,
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          boxShadow: "0 24px 64px rgba(0, 0, 0, 0.44)",
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-mono)",
+          pointerEvents: "auto",
+        }}
+      >
+        <div
+          id="stock-not-ready-title"
+          style={{
+            fontSize: 15,
+            fontWeight: 800,
+            letterSpacing: 0.8,
+            textTransform: "uppercase",
+            marginBottom: 8,
+          }}
+        >
+          {ticker.toUpperCase()} is not ready
+        </div>
+        <div
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: 12,
+            lineHeight: 1.45,
+            marginBottom: 14,
+          }}
+        >
+          Run a scan first, then open this ticker again.
+        </div>
+        {onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              minHeight: 34,
+              padding: "0 12px",
+              background: "var(--accent-bg)",
+              color: "var(--accent-text)",
+              border: 0,
+              borderRadius: 4,
+              fontFamily: "var(--font-mono)",
+              fontSize: 13,
+              cursor: "pointer",
+            }}
+          >
+            Close
+          </button>
+        ) : (
+          <Link
+            href="/"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              minHeight: 34,
+              padding: "0 12px",
+              background: "var(--accent-bg)",
+              color: "var(--accent-text)",
+              borderRadius: 4,
+              textDecoration: "none",
+              fontSize: 13,
+            }}
+          >
+            Back to dashboard
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/watchlist/AddTickerDialog.tsx
+++ b/web/components/watchlist/AddTickerDialog.tsx
@@ -1,25 +1,141 @@
 "use client";
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Check, ChevronDown } from "lucide-react";
 import { api } from "@/lib/api";
+import { SECTOR_ROWS, WATCHLIST_SECTORS } from "./sectorGroups";
 
-const SECTORS = [
-  "Technology",
-  "Financials",
-  "Healthcare",
-  "Consumer Discretionary",
-  "Communication Services",
-  "Energy",
-  "Industrials",
-  "Consumer Staples",
-  "ETF",
-];
+function SectorMenu({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (sector: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) setOpen(false);
+      }}
+      style={{ position: "relative" }}
+    >
+      <button
+        type="button"
+        aria-label={`Sector ${value}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((next) => !next)}
+        className="uw-dialog-field"
+        style={{
+          width: "100%",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          textAlign: "left",
+          cursor: "pointer",
+        }}
+      >
+        <span>{value}</span>
+        <ChevronDown
+          size={14}
+          aria-hidden="true"
+          style={{
+            color: "var(--text-secondary)",
+            transform: open ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 120ms ease",
+          }}
+        />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Sector"
+          tabIndex={-1}
+          style={{
+            marginTop: 6,
+            maxHeight: 320,
+            overflowY: "auto",
+            padding: 6,
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border-dim)",
+            borderRadius: 4,
+            boxShadow: "0 18px 40px rgba(0, 0, 0, 0.45)",
+          }}
+        >
+          {SECTOR_ROWS.map((row) => {
+            const sectors = row.items.filter((item) => item !== "All");
+            if (sectors.length === 0) return null;
+
+            return (
+              <div key={row.label}>
+                <div
+                  style={{
+                    padding: "8px 8px 5px",
+                    color: "var(--text-muted)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    letterSpacing: 1,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {row.label}
+                </div>
+                {sectors.map((sector) => {
+                  const selected = sector === value;
+                  return (
+                    <button
+                      key={sector}
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => {
+                        onChange(sector);
+                        setOpen(false);
+                      }}
+                      style={{
+                        width: "100%",
+                        display: "grid",
+                        gridTemplateColumns: "18px 1fr",
+                        gap: 6,
+                        alignItems: "center",
+                        padding: "7px 8px",
+                        background: selected ? "var(--accent-bg)" : "transparent",
+                        color: selected
+                          ? "var(--accent-text)"
+                          : "var(--text-primary)",
+                        border: 0,
+                        borderRadius: 3,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 12,
+                        textAlign: "left",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <span>
+                        {selected && <Check size={13} aria-hidden="true" />}
+                      </span>
+                      <span>{sector}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function AddTickerDialog() {
   const ref = useRef<HTMLDialogElement>(null);
   const router = useRouter();
   const [ticker, setTicker] = useState("");
-  const [sector, setSector] = useState(SECTORS[0]);
+  const [sector, setSector] = useState(WATCHLIST_SECTORS[0]);
   const [notes, setNotes] = useState("");
 
   const submit = async (e: React.FormEvent) => {
@@ -71,17 +187,7 @@ export function AddTickerDialog() {
             onChange={(e) => setTicker(e.target.value)}
             className="uw-dialog-field"
           />
-          <select
-            value={sector}
-            onChange={(e) => setSector(e.target.value)}
-            className="uw-dialog-field"
-          >
-            {SECTORS.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
+          <SectorMenu value={sector} onChange={setSector} />
           <input
             placeholder="notes (optional)"
             value={notes}

--- a/web/components/watchlist/FilterBar.tsx
+++ b/web/components/watchlist/FilterBar.tsx
@@ -1,37 +1,7 @@
 "use client";
 import { useState, type CSSProperties } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-
-// Sector chips arranged in labeled sub-rows by relevance.
-// "All" lives on the Index row as the universal reset.
-const SECTOR_ROWS: { label: string; items: string[] }[] = [
-  { label: "Index", items: ["All", "ETF"] },
-  {
-    label: "AI/Tech",
-    items: [
-      "M7",
-      "Semiconductor",
-      "Memory",
-      "Optical",
-      "NeoCloud",
-      "Power",
-      "SaaS",
-      "Networking",
-    ],
-  },
-  { label: "Thematic", items: ["Crypto", "Fintech", "Space", "Defense"] },
-  {
-    label: "Defensive",
-    items: [
-      "Healthcare",
-      "Energy",
-      "Banks",
-      "Consumer",
-      "Telecom-Media",
-      "Airlines",
-    ],
-  },
-];
+import { SECTOR_ROWS } from "./sectorGroups";
 
 const SETUPS = ["All", "C-bull", "C-bear", "F-MULTI", "NEUTRAL"];
 

--- a/web/components/watchlist/TickerCard.tsx
+++ b/web/components/watchlist/TickerCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 import Link from "next/link";
+import { useState } from "react";
 import type { components } from "@/lib/types";
+import { StockNotReadyDialog } from "@/components/stock/StockNotReadyDialog";
 import { SetupBadge } from "./SetupBadge";
 import { SparklineRow } from "./SparklineRow";
 import { AggressionGauge } from "./AggressionGauge";
@@ -25,6 +27,7 @@ const linkReset = {
 };
 
 export function TickerCard({ card, sparkline }: Props) {
+  const [showNotReady, setShowNotReady] = useState(false);
   const fresh = bucketFreshness(card.scanned_at);
   const dot =
     fresh === "fresh"
@@ -32,6 +35,94 @@ export function TickerCard({ card, sparkline }: Props) {
       : fresh === "stale"
         ? "var(--warning)"
         : "var(--negative)";
+  const isReady = card.scanned_at != null;
+
+  const detailContent = (
+    <>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 6,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: dot,
+              display: "inline-block",
+            }}
+          />
+          <span style={{ fontSize: 16, fontWeight: 700 }}>{card.ticker}</span>
+          <span
+            style={{
+              fontSize: 13,
+              color: "var(--text-secondary)",
+              fontWeight: 500,
+            }}
+          >
+            {toNum(card.spot) != null
+              ? `$${fmtDecimal(toNum(card.spot), 2)}`
+              : "—"}
+          </span>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <div style={{ fontSize: 16, fontWeight: 700 }}>
+            {fmtPct(toNum(card.iv_atm), 1)}
+          </div>
+          <div style={{ fontSize: 9, color: "var(--text-muted)" }}>
+            IVR {fmtDecimal(toNum(card.iv_rank), 0)}
+          </div>
+        </div>
+      </div>
+
+      <SetupBadge
+        type={card.setup?.type ?? null}
+        direction={card.setup?.direction ?? null}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 8,
+          alignItems: "center",
+          margin: "8px 0",
+        }}
+      >
+        <SparklineRow
+          closes={sparkline}
+          ret_1d={toNum(card.returns?.d1)}
+          ret_1w={toNum(card.returns?.w1)}
+          ret_30d={toNum(card.returns?.d30)}
+        />
+        <AggressionGauge value={toNum(card.aggression_pct)} />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
+        <GammaBlock
+          flip_distance={toNum(card.gamma.flip_distance)}
+          flip_price={toNum(card.gamma.flip_price)}
+          per_1pct_move={toNum(card.gamma.per_1pct_move)}
+          max_strike={toNum(card.gamma.max_strike)}
+          expiring_pct={toNum(card.gamma.expiring_pct)}
+          expiring_date={card.gamma.expiring_date ?? null}
+        />
+        <SkewBlock rr25d_30dte={toNum(card.skew.rr25d_30dte)} />
+        <PositioningBlock
+          call_oi={card.positioning.call_oi ?? null}
+          put_oi={card.positioning.put_oi ?? null}
+          pcr_oi={toNum(card.positioning.pcr_oi)}
+          pcr_vol={toNum(card.positioning.pcr_vol)}
+          pcr_delta_30d={toNum(card.positioning.pcr_delta_30d)}
+        />
+      </div>
+    </>
+  );
 
   return (
     <div
@@ -44,94 +135,34 @@ export function TickerCard({ card, sparkline }: Props) {
         fontFamily: "var(--font-mono)",
       }}
     >
-      <Link
-        href={`/stock/${card.ticker}/market-structure`}
-        aria-label={`${card.ticker} detail`}
-        style={{ ...linkReset, display: "block" }}
-      >
-        <div
+      {isReady ? (
+        <Link
+          href={`/stock/${card.ticker}/market-structure`}
+          aria-label={`${card.ticker} detail`}
+          style={{ ...linkReset, display: "block" }}
+        >
+          {detailContent}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          aria-label={`${card.ticker} detail`}
+          onClick={() => setShowNotReady(true)}
           style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: 6,
+            ...linkReset,
+            display: "block",
+            width: "100%",
+            padding: 0,
+            background: "transparent",
+            border: 0,
+            textAlign: "left",
+            font: "inherit",
+            cursor: "pointer",
           }}
         >
-          <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
-            <span
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: dot,
-                display: "inline-block",
-              }}
-            />
-            <span style={{ fontSize: 16, fontWeight: 700 }}>{card.ticker}</span>
-            <span
-              style={{
-                fontSize: 13,
-                color: "var(--text-secondary)",
-                fontWeight: 500,
-              }}
-            >
-              {toNum(card.spot) != null
-                ? `$${fmtDecimal(toNum(card.spot), 2)}`
-                : "—"}
-            </span>
-          </div>
-          <div style={{ textAlign: "right" }}>
-            <div style={{ fontSize: 16, fontWeight: 700 }}>
-              {fmtPct(toNum(card.iv_atm), 1)}
-            </div>
-            <div style={{ fontSize: 9, color: "var(--text-muted)" }}>
-              IVR {fmtDecimal(toNum(card.iv_rank), 0)}
-            </div>
-          </div>
-        </div>
-
-        <SetupBadge
-          type={card.setup?.type ?? null}
-          direction={card.setup?.direction ?? null}
-        />
-
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "1fr auto",
-            gap: 8,
-            alignItems: "center",
-            margin: "8px 0",
-          }}
-        >
-          <SparklineRow
-            closes={sparkline}
-            ret_1d={toNum(card.returns?.d1)}
-            ret_1w={toNum(card.returns?.w1)}
-            ret_30d={toNum(card.returns?.d30)}
-          />
-          <AggressionGauge value={toNum(card.aggression_pct)} />
-        </div>
-
-        <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
-          <GammaBlock
-            flip_distance={toNum(card.gamma.flip_distance)}
-            flip_price={toNum(card.gamma.flip_price)}
-            per_1pct_move={toNum(card.gamma.per_1pct_move)}
-            max_strike={toNum(card.gamma.max_strike)}
-            expiring_pct={toNum(card.gamma.expiring_pct)}
-            expiring_date={card.gamma.expiring_date ?? null}
-          />
-          <SkewBlock rr25d_30dte={toNum(card.skew.rr25d_30dte)} />
-          <PositioningBlock
-            call_oi={card.positioning.call_oi ?? null}
-            put_oi={card.positioning.put_oi ?? null}
-            pcr_oi={toNum(card.positioning.pcr_oi)}
-            pcr_vol={toNum(card.positioning.pcr_vol)}
-            pcr_delta_30d={toNum(card.positioning.pcr_delta_30d)}
-          />
-        </div>
-      </Link>
+          {detailContent}
+        </button>
+      )}
 
       <div
         style={{
@@ -158,6 +189,12 @@ export function TickerCard({ card, sparkline }: Props) {
         </div>
         <RescanButton ticker={card.ticker} />
       </div>
+      {showNotReady && (
+        <StockNotReadyDialog
+          ticker={card.ticker}
+          onClose={() => setShowNotReady(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/components/watchlist/sectorGroups.ts
+++ b/web/components/watchlist/sectorGroups.ts
@@ -1,0 +1,32 @@
+export const SECTOR_ROWS: { label: string; items: string[] }[] = [
+  { label: "Index", items: ["All", "ETF"] },
+  {
+    label: "AI/Tech",
+    items: [
+      "M7",
+      "Semiconductor",
+      "Memory",
+      "Optical",
+      "NeoCloud",
+      "Power",
+      "SaaS",
+      "Networking",
+    ],
+  },
+  { label: "Thematic", items: ["Crypto", "Fintech", "Space", "Defense"] },
+  {
+    label: "Defensive",
+    items: [
+      "Healthcare",
+      "Energy",
+      "Banks",
+      "Consumer",
+      "Telecom-Media",
+      "Airlines",
+    ],
+  },
+];
+
+export const WATCHLIST_SECTORS = SECTOR_ROWS.flatMap((row) =>
+  row.items.filter((item) => item !== "All"),
+);

--- a/web/lib/stockNotReady.ts
+++ b/web/lib/stockNotReady.ts
@@ -1,0 +1,9 @@
+export function isStockReportNotReadyError(error: unknown, ticker: string) {
+  if (!(error instanceof Error)) return false;
+
+  const escapedTicker = ticker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `API 404 for /api/stock/${escapedTicker}: .*"detail"\\s*:\\s*"no runs for ${escapedTicker}"`,
+    "i",
+  ).test(error.message);
+}

--- a/web/tests/unit/stockNotReady.test.tsx
+++ b/web/tests/unit/stockNotReady.test.tsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import StockLayout from "@/app/stock/[ticker]/layout";
+import TabPage from "@/app/stock/[ticker]/[tab]/page";
+import { api } from "@/lib/api";
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("not found");
+  }),
+  usePathname: () => "/stock/SOXX/market-structure",
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    stock: vi.fn(),
+  },
+}));
+
+function noRunsError(ticker: string) {
+  return new Error(
+    `API 404 for /api/stock/${ticker}: {"detail":"no runs for ${ticker}"}`,
+  );
+}
+
+describe("stock not-ready state", () => {
+  it("renders a not-ready popup from the stock layout when a ticker has no scan run", async () => {
+    vi.mocked(api.stock).mockRejectedValueOnce(noRunsError("SOXX"));
+
+    render(
+      await StockLayout({
+        children: <div>stock child</div>,
+        params: Promise.resolve({ ticker: "SOXX" }),
+      }),
+    );
+
+    expect(screen.getByText("SOXX is not ready")).not.toBeNull();
+    expect(screen.queryByText("stock child")).toBeNull();
+  });
+
+  it("renders a not-ready popup from report tabs when a ticker has no scan run", async () => {
+    vi.mocked(api.stock).mockRejectedValueOnce(noRunsError("SOXX"));
+
+    render(
+      await TabPage({
+        params: Promise.resolve({ ticker: "SOXX", tab: "market-structure" }),
+      }),
+    );
+
+    expect(screen.getByText("SOXX is not ready")).not.toBeNull();
+  });
+});

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -84,9 +84,53 @@ describe("TickerCard", () => {
 
     expect(timestampBlock).toHaveProperty("style.fontSize", "8px");
   });
+
+  it("shows an in-place not-ready popup for an unscanned ticker", () => {
+    render(
+      <TickerCard
+        card={{ ...card, ticker: "SOXX", scanned_at: null }}
+        sparkline={[]}
+      />,
+    );
+
+    expect(screen.queryByRole("link", { name: /soxx detail/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /soxx detail/i }));
+
+    expect(screen.getByText("SOXX is not ready")).not.toBeNull();
+  });
 });
 
 describe("AddTickerDialog", () => {
+  it("uses the current dashboard sector grouping in the sector menu", () => {
+    installDialogPolyfill();
+    render(<AddTickerDialog />);
+
+    fireEvent.click(screen.getByRole("button", { name: /\+ ticker/i }));
+
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByRole("button", { name: /sector etf/i })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /sector etf/i }));
+
+    expect(screen.getByText("Index")).not.toBeNull();
+    expect(screen.getByText("AI/Tech")).not.toBeNull();
+    expect(screen.getByText("Thematic")).not.toBeNull();
+    expect(screen.getByText("Defensive")).not.toBeNull();
+    expect(screen.getByRole("option", { name: "ETF" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "M7" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "NeoCloud" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "Power" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "Airlines" })).not.toBeNull();
+    expect(screen.queryByRole("option", { name: "Technology" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "All" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("option", { name: "Power" }));
+
+    expect(screen.getByRole("button", { name: /sector power/i })).not.toBeNull();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
   it("closes when the backdrop is clicked", () => {
     installDialogPolyfill();
     render(<AddTickerDialog />);


### PR DESCRIPTION
## Summary
- Replace the add-ticker sector native select with a styled grouped menu using the current watchlist filter groups.
- Show a non-blocking not-ready popup for unscanned ticker detail pages and dashboard card clicks.
- Add regression coverage for the custom sector menu and not-ready behavior.

## Test Plan
- npm run test -- watchlistUi.test.tsx stockNotReady.test.tsx filterBar.test.tsx
- npm run typecheck
- npm run lint