### PR TITLE
feat: prioritize and dedupe rescan queue

### DIFF
--- a/src/uw_scan/api/routers/jobs.py
+++ b/src/uw_scan/api/routers/jobs.py
@@ -30,7 +30,7 @@ def _to_status(job) -> JobStatus:
 
 @router.post("/watchlist/{ticker}/rescan", status_code=202, response_model=JobStatus)
 def enqueue_rescan(ticker: str, repo: Repository = Depends(get_repo)) -> JobStatus:
-    job_id = repo.enqueue_rescan_job(ticker.upper())
+    job_id = repo.enqueue_rescan_job(ticker.upper(), priority=10)
     job = repo.get_job(job_id)
     if job is None:
         raise HTTPException(status_code=500, detail="job not persisted")

--- a/src/uw_scan/api/routers/watchlist.py
+++ b/src/uw_scan/api/routers/watchlist.py
@@ -10,6 +10,8 @@ from uw_scan.api.deps import get_repo
 from uw_scan.api.schemas import (
     GammaBlock,
     PositioningBlock,
+    QueueStatus,
+    QueueSummary,
     ReturnsBlock,
     SetupBlock,
     SkewBlock,
@@ -25,6 +27,15 @@ router = APIRouter()
 
 def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
     """Map a joined watchlist_card + watchlist row to the API shape."""
+    queue = None
+    if row.active_job_id is not None:
+        queue = QueueStatus(
+            job_id=str(row.active_job_id),
+            status=row.active_job_status,
+            queue_position=row.active_job_queue_position,
+            requested_at=row.active_job_requested_at,
+            started_at=row.active_job_started_at,
+        )
     return WatchlistCard(
         ticker=row.ticker,
         sector=row.sector,
@@ -59,6 +70,7 @@ def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
             pcr_vol=row.pcr_vol,
             pcr_delta_30d=row.pcr_delta_30d,
         ),
+        queue=queue,
     )
 
 
@@ -110,10 +122,17 @@ def get_watchlist(
         out.append(_card_to_response(r))
 
     scanned_times = [c.scanned_at for c in out if c.scanned_at is not None]
+    queue = repo.get_rescan_queue_summary()
     return WatchlistResponse(
         scanned_at_min=min(scanned_times, default=None),
         scanned_at_max=max(scanned_times, default=None),
         scheduler_lag_seconds=None,
+        queue=QueueSummary(
+            total=queue.total,
+            queued=queue.queued,
+            running=queue.running,
+            oldest_requested_at=queue.oldest_requested_at,
+        ),
         tickers=out,
     )
 

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from decimal import Decimal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SetupBlock(BaseModel):
@@ -47,6 +47,14 @@ class PositioningBlock(BaseModel):
     pcr_delta_30d: Decimal | None = None
 
 
+class QueueStatus(BaseModel):
+    job_id: str
+    status: str
+    queue_position: int
+    requested_at: datetime
+    started_at: datetime | None = None
+
+
 class WatchlistCard(BaseModel):
     ticker: str
     sector: str
@@ -69,12 +77,21 @@ class WatchlistCard(BaseModel):
     gamma: GammaBlock
     skew: SkewBlock
     positioning: PositioningBlock
+    queue: QueueStatus | None = None
+
+
+class QueueSummary(BaseModel):
+    total: int = 0
+    queued: int = 0
+    running: int = 0
+    oldest_requested_at: datetime | None = None
 
 
 class WatchlistResponse(BaseModel):
     scanned_at_min: datetime | None = None
     scanned_at_max: datetime | None = None
     scheduler_lag_seconds: float | None = None
+    queue: QueueSummary = Field(default_factory=QueueSummary)
     tickers: list[WatchlistCard]
 
 

--- a/src/uw_scan/storage/migrations/024_rescan_queue_dedupe.sql
+++ b/src/uw_scan/storage/migrations/024_rescan_queue_dedupe.sql
@@ -1,0 +1,29 @@
+-- 024_rescan_queue_dedupe.sql — keep one active rescan job per ticker and allow priority ordering.
+
+SET search_path TO uw_scan, public;
+
+ALTER TABLE uw_scan.jobs
+  ADD COLUMN IF NOT EXISTS priority SMALLINT NOT NULL DEFAULT 0;
+
+WITH ranked AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY ticker
+      ORDER BY requested_at ASC, id ASC
+    ) AS rn
+  FROM uw_scan.jobs
+  WHERE status IN ('queued', 'running')
+)
+DELETE FROM uw_scan.jobs j
+USING ranked r
+WHERE j.id = r.id
+  AND r.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_active_ticker
+  ON uw_scan.jobs (ticker)
+  WHERE status IN ('queued', 'running');
+
+CREATE INDEX IF NOT EXISTS idx_jobs_queue_order
+  ON uw_scan.jobs (status, priority DESC, requested_at)
+  WHERE status IN ('queued', 'running');

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -76,6 +76,14 @@ class JobRow:
 
 
 @dataclass(frozen=True)
+class RescanQueueSummaryRow:
+    total: int
+    queued: int
+    running: int
+    oldest_requested_at: datetime | None
+
+
+@dataclass(frozen=True)
 class ExternalApiUsageSummary:
     total_requests: int
     http_2xx: int
@@ -2464,6 +2472,15 @@ class Repository:
         with self._conn.cursor() as cur:
             cur.execute(
                 f"""
+                WITH active_jobs AS (
+                  SELECT
+                    id, ticker, status, requested_at, started_at,
+                    row_number() OVER (
+                      ORDER BY priority DESC, requested_at ASC, id ASC
+                    ) AS queue_position
+                  FROM {self._schema}.jobs
+                  WHERE status IN ('queued', 'running')
+                )
                 SELECT
                   w.ticker, w.sector, w.pinned, w.sort_rank,
                   c.run_id, c.scanned_at,
@@ -2493,10 +2510,16 @@ class Repository:
                   c.max_gex_strike, c.gex_expiring_pct, c.gex_expiring_date,
                   c.skew_25d_30dte,
                   c.call_oi_total, c.put_oi_total, c.pcr_oi, c.pcr_vol,
-                  c.pcr_delta_30d
+                  c.pcr_delta_30d,
+                  j.id AS active_job_id,
+                  j.status AS active_job_status,
+                  j.queue_position AS active_job_queue_position,
+                  j.requested_at AS active_job_requested_at,
+                  j.started_at AS active_job_started_at
                 FROM {self._schema}.watchlist w
                 LEFT JOIN {self._schema}.watchlist_card c ON w.ticker = c.ticker
                 LEFT JOIN {self._schema}.intraday_quote q ON w.ticker = q.ticker
+                LEFT JOIN active_jobs j ON w.ticker = j.ticker
                 WHERE w.removed_at IS NULL
                 ORDER BY w.pinned DESC, w.sort_rank, w.ticker
                 """
@@ -2626,14 +2649,20 @@ class Repository:
             return PcrHistoryRow(*row) if row else None
 
     # ---- jobs ----
-    def enqueue_rescan_job(self, ticker: str) -> str:
+    def enqueue_rescan_job(self, ticker: str, *, priority: int = 0) -> str:
         with self._conn.cursor() as cur:
             cur.execute(
                 f"""
-                INSERT INTO {self._schema}.jobs (ticker, status)
-                VALUES (%s, 'queued') RETURNING id
+                INSERT INTO {self._schema}.jobs (ticker, status, priority)
+                VALUES (%s, 'queued', %s)
+                ON CONFLICT (ticker) WHERE status IN ('queued', 'running')
+                DO UPDATE SET priority = GREATEST(
+                    {self._schema}.jobs.priority,
+                    EXCLUDED.priority
+                )
+                RETURNING id
                 """,
-                (ticker,),
+                (ticker, priority),
             )
             row = cur.fetchone()
             assert row is not None
@@ -2650,7 +2679,7 @@ class Repository:
                 WHERE id = (
                   SELECT id FROM {self._schema}.jobs
                   WHERE status='queued'
-                  ORDER BY requested_at
+                  ORDER BY priority DESC, requested_at ASC, id ASC
                   FOR UPDATE SKIP LOCKED
                   LIMIT 1
                 )
@@ -2682,6 +2711,29 @@ class Repository:
                 (error[:2000], job_id),
             )
         self._conn.commit()
+
+    def get_rescan_queue_summary(self) -> RescanQueueSummaryRow:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                  count(*) FILTER (WHERE status IN ('queued', 'running')) AS total,
+                  count(*) FILTER (WHERE status = 'queued') AS queued,
+                  count(*) FILTER (WHERE status = 'running') AS running,
+                  min(requested_at) FILTER (
+                    WHERE status IN ('queued', 'running')
+                  ) AS oldest_requested_at
+                FROM {self._schema}.jobs
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return RescanQueueSummaryRow(
+            total=row[0],
+            queued=row[1],
+            running=row[2],
+            oldest_requested_at=row[3],
+        )
 
     # ---- aggregates (JSONB on scan_runs) ----
     def set_aggregates(self, run_id: int, agg: "models.MarketAggregates") -> None:
@@ -3223,4 +3275,5 @@ __all__ = [
     "IntradayQuoteRow",
     "PcrHistoryRow",
     "JobRow",
+    "RescanQueueSummaryRow",
 ]

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -37,6 +37,7 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger("uw_scan.worker")
+RESCAN_WORKER_CONCURRENCY = 2
 
 
 def _spot_refresh_market_date(now: datetime) -> date | None:
@@ -274,6 +275,7 @@ def main() -> int:
         IntervalTrigger(seconds=1),
         id="rescan_tick",
         name="Ad-hoc rescan poll",
+        max_instances=RESCAN_WORKER_CONCURRENCY,
     )
     # Volatility tab v2 jobs — ET-anchored via from_crontab (review I9).
     sched.add_job(

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -564,6 +564,40 @@
             "title": "Flow Count",
             "type": "integer"
           },
+          "flow_count_30d_avg": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow Count 30D Avg"
+          },
+          "flow_count_30d_days": {
+            "default": 0,
+            "title": "Flow Count 30D Days",
+            "type": "integer"
+          },
+          "flow_count_is_limited": {
+            "default": false,
+            "title": "Flow Count Is Limited",
+            "type": "boolean"
+          },
+          "flow_count_vs_30d_avg": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow Count Vs 30D Avg"
+          },
           "net_premium": {
             "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
             "title": "Net Premium",
@@ -572,6 +606,17 @@
           "ticker": {
             "title": "Ticker",
             "type": "string"
+          },
+          "top_alert_rule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Alert Rule"
           },
           "top_alerts": {
             "default": [],
@@ -809,6 +854,30 @@
             ],
             "title": "Latency P95 Ms"
           },
+          "latest_spot_quote_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Spot Quote At"
+          },
+          "latest_spot_quote_fetched_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Spot Quote Fetched At"
+          },
           "ok": {
             "title": "Ok",
             "type": "boolean"
@@ -824,6 +893,57 @@
             ],
             "title": "Reason"
           },
+          "record_health": {
+            "items": {
+              "$ref": "#/components/schemas/RecordHealthCheck"
+            },
+            "title": "Record Health",
+            "type": "array"
+          },
+          "record_health_ok": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Health Ok"
+          },
+          "rescan_heartbeat_lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rescan Heartbeat Lag Seconds"
+          },
+          "scheduler_heartbeat_lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduler Heartbeat Lag Seconds"
+          },
+          "scheduler_heartbeat_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduler Heartbeat Name"
+          },
           "scheduler_lag_seconds": {
             "anyOf": [
               {
@@ -836,9 +956,31 @@
             "title": "Scheduler Lag Seconds"
           },
           "source": {
-            "default": "massive.com",
+            "default": "UnusualWhales",
             "title": "Source",
             "type": "string"
+          },
+          "spot_quote_lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Quote Lag Seconds"
+          },
+          "spot_refresh_heartbeat_lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Refresh Heartbeat Lag Seconds"
           },
           "uw_today": {
             "anyOf": [
@@ -2797,6 +2939,141 @@
         "title": "ProviderUsageSummaryResponse",
         "type": "object"
       },
+      "QueueStatus": {
+        "properties": {
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "queue_position": {
+            "title": "Queue Position",
+            "type": "integer"
+          },
+          "requested_at": {
+            "format": "date-time",
+            "title": "Requested At",
+            "type": "string"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "status",
+          "queue_position",
+          "requested_at"
+        ],
+        "title": "QueueStatus",
+        "type": "object"
+      },
+      "QueueSummary": {
+        "properties": {
+          "oldest_requested_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oldest Requested At"
+          },
+          "queued": {
+            "default": 0,
+            "title": "Queued",
+            "type": "integer"
+          },
+          "running": {
+            "default": 0,
+            "title": "Running",
+            "type": "integer"
+          },
+          "total": {
+            "default": 0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "title": "QueueSummary",
+        "type": "object"
+      },
+      "RecordHealthCheck": {
+        "properties": {
+          "actual_rows": {
+            "title": "Actual Rows",
+            "type": "integer"
+          },
+          "actual_tickers": {
+            "title": "Actual Tickers",
+            "type": "integer"
+          },
+          "expected_min_rows": {
+            "title": "Expected Min Rows",
+            "type": "integer"
+          },
+          "expected_min_tickers": {
+            "title": "Expected Min Tickers",
+            "type": "integer"
+          },
+          "expected_tickers": {
+            "title": "Expected Tickers",
+            "type": "integer"
+          },
+          "latest_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest At"
+          },
+          "ok": {
+            "title": "Ok",
+            "type": "boolean"
+          },
+          "table": {
+            "title": "Table",
+            "type": "string"
+          },
+          "window_start": {
+            "format": "date-time",
+            "title": "Window Start",
+            "type": "string"
+          }
+        },
+        "required": [
+          "table",
+          "window_start",
+          "expected_tickers",
+          "expected_min_tickers",
+          "actual_tickers",
+          "expected_min_rows",
+          "actual_rows",
+          "ok"
+        ],
+        "title": "RecordHealthCheck",
+        "type": "object"
+      },
       "RegimeQuadrantBlock": {
         "properties": {
           "cutoff_corr": {
@@ -2912,6 +3189,17 @@
           "date"
         ],
         "title": "RegimeQuadrantPoint",
+        "type": "object"
+      },
+      "RescanAllRequest": {
+        "properties": {
+          "confirmed": {
+            "default": false,
+            "title": "Confirmed",
+            "type": "boolean"
+          }
+        },
+        "title": "RescanAllRequest",
         "type": "object"
       },
       "ReturnsBlock": {
@@ -3272,6 +3560,29 @@
             "default": "n/a (UW endpoint does not expose %)",
             "title": "Short Int Note",
             "type": "string"
+          },
+          "spot_quoted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Quoted At"
+          },
+          "spot_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Source"
           },
           "strike_gex_curve": {
             "default": [],
@@ -5592,6 +5903,16 @@
           "positioning": {
             "$ref": "#/components/schemas/PositioningBlock"
           },
+          "queue": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/QueueStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "returns": {
             "$ref": "#/components/schemas/ReturnsBlock"
           },
@@ -5766,6 +6087,9 @@
       },
       "WatchlistResponse": {
         "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/QueueSummary"
+          },
           "scanned_at_max": {
             "anyOf": [
               {
@@ -5826,6 +6150,68 @@
     "/api/health": {
       "get": {
         "operationId": "health_api_health_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "default": "uw",
+              "enum": [
+                "uw",
+                "massive"
+              ],
+              "title": "Source",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "record_window_hours",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 168,
+                  "minimum": 0.1,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Record Window Hours"
+            }
+          },
+          {
+            "in": "query",
+            "name": "record_min_coverage",
+            "required": false,
+            "schema": {
+              "default": 0.9,
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Record Min Coverage",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "record_tables",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Record Tables"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -5836,6 +6222,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Health",
@@ -6743,6 +7139,23 @@
       "post": {
         "description": "Enqueue a rescan job for every active watchlist ticker.",
         "operationId": "enqueue_rescan_all_api_watchlist_rescan_all_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RescanAllRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Payload"
+              }
+            }
+          }
+        },
         "responses": {
           "202": {
             "content": {
@@ -6757,6 +7170,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Enqueue Rescan All",

--- a/tests/integration/api/test_openapi_snapshot.py
+++ b/tests/integration/api/test_openapi_snapshot.py
@@ -20,3 +20,7 @@ def test_openapi_paths_match_snapshot(client):
             assert method in current["paths"][path], (
                 f"Method {method.upper()} {path} removed from OpenAPI"
             )
+    assert current["components"]["schemas"] == expected["components"]["schemas"], (
+        "OpenAPI schemas changed — regenerate tests/integration/api/openapi.snapshot.json "
+        "if the change is intentional."
+    )

--- a/tests/integration/api/test_stock_ohlc_jobs.py
+++ b/tests/integration/api/test_stock_ohlc_jobs.py
@@ -54,6 +54,14 @@ def test_post_rescan_enqueues_job(client, seeded_db_with_cards):
     assert body["status"] == "queued"
 
 
+def test_post_rescan_reuses_existing_active_job(client, seeded_db_with_cards):
+    first = client.post("/api/watchlist/TSLA/rescan").json()
+    second = client.post("/api/watchlist/TSLA/rescan").json()
+
+    assert second["job_id"] == first["job_id"]
+    assert second["status"] == "queued"
+
+
 def test_post_rescan_all_requires_explicit_confirmation(client, seeded_db_with_cards):
     r = client.post("/api/watchlist/rescan-all")
 

--- a/tests/integration/api/test_watchlist_endpoint.py
+++ b/tests/integration/api/test_watchlist_endpoint.py
@@ -32,6 +32,23 @@ def test_get_watchlist_returns_seeded_cards(client, seeded_db_with_cards):
         assert key in card
 
 
+def test_get_watchlist_includes_queue_summary_and_card_status(
+    client, seeded_db_with_cards
+):
+    job = client.post("/api/watchlist/TSLA/rescan").json()
+
+    r = client.get("/api/watchlist")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["queue"]["total"] == 1
+    assert body["queue"]["queued"] == 1
+    tsla = next(card for card in body["tickers"] if card["ticker"] == "TSLA")
+    assert tsla["queue"]["job_id"] == job["job_id"]
+    assert tsla["queue"]["status"] == "queued"
+    assert tsla["queue"]["queue_position"] == 1
+
+
 def test_get_watchlist_filters_by_sector(client, seeded_db_with_cards):
     r = client.get("/api/watchlist?sector=Technology")
     assert r.status_code == 200

--- a/tests/integration/storage/test_repository_watchlist.py
+++ b/tests/integration/storage/test_repository_watchlist.py
@@ -149,3 +149,47 @@ def test_enqueue_and_claim_job(repo):
     assert str(claimed.id) == job_id
     assert claimed.status == "running"
     assert repo.claim_next_queued_job() is None
+
+
+def test_enqueue_rescan_job_reuses_first_active_job(repo):
+    repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
+
+    first_id = repo.enqueue_rescan_job("ZZTEST")
+    second_id = repo.enqueue_rescan_job("ZZTEST")
+
+    assert second_id == first_id
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*)
+            FROM uw_scan.jobs
+            WHERE ticker='ZZTEST' AND status IN ('queued', 'running')
+            """
+        )
+        assert cur.fetchone()[0] == 1
+
+
+def test_card_list_includes_active_queue_status(repo):
+    repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
+    job_id = repo.enqueue_rescan_job("ZZTEST")
+
+    cards = {card.ticker: card for card in repo.list_watchlist_cards()}
+
+    queued = cards["ZZTEST"]
+    assert str(queued.active_job_id) == job_id
+    assert queued.active_job_status == "queued"
+    assert queued.active_job_queue_position == 1
+
+
+def test_queue_summary_counts_active_jobs(repo):
+    repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
+    repo.add_watchlist_ticker(ticker="ZZALT", sector="ETF", notes="t")
+    repo.enqueue_rescan_job("ZZTEST")
+    repo.enqueue_rescan_job("ZZALT")
+    repo.claim_next_queued_job()
+
+    summary = repo.get_rescan_queue_summary()
+
+    assert summary.total == 2
+    assert summary.running == 1
+    assert summary.queued == 1

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -8,6 +8,7 @@ from pydantic import SecretStr
 
 from uw_scan.config import Settings
 from uw_scan.worker.scheduler import (
+    RESCAN_WORKER_CONCURRENCY,
     _ohlc_provider,
     _record_worker_heartbeat,
     _spot_refresh_market_date,
@@ -92,3 +93,7 @@ def test_ohlc_provider_uses_configured_request_timeout(monkeypatch) -> None:
 
     assert provider is not None
     assert captured["timeout"] == 42.0
+
+
+def test_rescan_worker_concurrency_is_two() -> None:
+    assert RESCAN_WORKER_CONCURRENCY == 2

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 import { CardGrid } from "@/components/watchlist/CardGrid";
 import { FilterBar } from "@/components/watchlist/FilterBar";
 import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
+import { QueueProgress } from "@/components/shared/QueueProgress";
 import { ScanAllButton } from "@/components/shared/ScanAllButton";
 import { loadDashboardData } from "@/lib/dashboardData";
 
@@ -40,6 +41,7 @@ export default async function DashboardPage({
           DASHBOARD
         </h1>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <QueueProgress queue={data.queue} />
           <ScanAllButton />
           <AddTickerDialog />
         </div>

--- a/web/components/shared/QueueProgress.tsx
+++ b/web/components/shared/QueueProgress.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { components } from "@/lib/types";
+import { api } from "@/lib/api";
+
+type QueueSummary = components["schemas"]["QueueSummary"];
+
+export function QueueProgress({ queue }: { queue: QueueSummary }) {
+  const router = useRouter();
+  const [current, setCurrent] = useState(queue);
+
+  useEffect(() => {
+    setCurrent(queue);
+  }, [queue.oldest_requested_at, queue.queued, queue.running, queue.total]);
+
+  useEffect(() => {
+    const delay = current.total > 0 ? 2500 : 5000;
+    const t = setInterval(async () => {
+      try {
+        const next = await api.watchlist();
+        setCurrent(next.queue);
+        if (next.queue.total === 0) router.refresh();
+      } catch (e) {
+        console.error(e);
+      }
+    }, delay);
+    return () => clearInterval(t);
+  }, [current.total, router]);
+
+  const total = current.total;
+  const running = current.running;
+  const queued = current.queued;
+  const width = total > 0 ? Math.max(8, (running / total) * 100) : 0;
+
+  return (
+    <div
+      aria-label="Rescan queue"
+      style={{
+        minWidth: 190,
+        fontFamily: "var(--font-mono)",
+        color: "var(--text-secondary)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: 8,
+          marginBottom: 4,
+          fontSize: 10,
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span>queue</span>
+        <span>
+          {total > 0 ? `${running} running · ${queued} queued` : "idle"}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label="Rescan queue progress"
+        aria-valuemin={0}
+        aria-valuenow={running}
+        aria-valuemax={Math.max(total, 1)}
+        style={{
+          height: 4,
+          background: "var(--border-dim)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${width}%`,
+            background: total > 0 ? "var(--warning)" : "transparent",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/components/shared/RescanButton.tsx
+++ b/web/components/shared/RescanButton.tsx
@@ -2,13 +2,28 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
+import type { components } from "@/lib/types";
 
 type Status = "idle" | "queued" | "running" | "done" | "failed";
+type QueueStatus = components["schemas"]["QueueStatus"];
 
-export function RescanButton({ ticker }: { ticker: string }) {
+export function RescanButton({
+  ticker,
+  initialJob,
+}: {
+  ticker: string;
+  initialJob?: QueueStatus | null;
+}) {
   const router = useRouter();
-  const [jobId, setJobId] = useState<string | null>(null);
-  const [status, setStatus] = useState<Status>("idle");
+  const [jobId, setJobId] = useState<string | null>(initialJob?.job_id ?? null);
+  const [status, setStatus] = useState<Status>(
+    (initialJob?.status as Status | undefined) ?? "idle",
+  );
+
+  useEffect(() => {
+    setJobId(initialJob?.job_id ?? null);
+    setStatus((initialJob?.status as Status | undefined) ?? "idle");
+  }, [initialJob?.job_id, initialJob?.status]);
 
   useEffect(() => {
     if (!jobId) return;
@@ -41,8 +56,14 @@ export function RescanButton({ ticker }: { ticker: string }) {
         e.preventDefault();
         e.stopPropagation();
         setStatus("queued");
-        const r = await api.rescan(ticker);
-        setJobId(r.job_id);
+        try {
+          const r = await api.rescan(ticker);
+          setStatus(r.status as Status);
+          setJobId(r.job_id);
+        } catch (err) {
+          console.error(err);
+          setStatus("failed");
+        }
       }}
       disabled={status === "queued" || status === "running"}
       style={{

--- a/web/components/watchlist/TickerCard.tsx
+++ b/web/components/watchlist/TickerCard.tsx
@@ -36,6 +36,12 @@ export function TickerCard({ card, sparkline }: Props) {
         ? "var(--warning)"
         : "var(--negative)";
   const isReady = card.scanned_at != null;
+  const queueLabel =
+    card.queue == null
+      ? null
+      : card.queue.status === "running"
+        ? "running"
+        : `${card.queue.status} #${card.queue.queue_position}`;
 
   const detailContent = (
     <>
@@ -186,8 +192,11 @@ export function TickerCard({ card, sparkline }: Props) {
             analytics{" "}
             {card.scanned_at ? fmtDateTimeWithZone(card.scanned_at) : "not scanned"}
           </div>
+          {queueLabel && (
+            <div style={{ color: "var(--warning)" }}>{queueLabel}</div>
+          )}
         </div>
-        <RescanButton ticker={card.ticker} />
+        <RescanButton ticker={card.ticker} initialJob={card.queue ?? null} />
       </div>
       {showNotReady && (
         <StockNotReadyDialog

--- a/web/lib/dashboardData.ts
+++ b/web/lib/dashboardData.ts
@@ -6,6 +6,12 @@ const emptyWatchlist: WatchlistResponse = {
   scanned_at_min: null,
   scanned_at_max: null,
   scheduler_lag_seconds: null,
+  queue: {
+    total: 0,
+    queued: 0,
+    running: 0,
+    oldest_requested_at: null,
+  },
   tickers: [],
 };
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1170,6 +1170,42 @@ export interface components {
             /** Uw Latest Daily Limit */
             uw_latest_daily_limit: number | null;
         };
+        /** QueueStatus */
+        QueueStatus: {
+            /** Job Id */
+            job_id: string;
+            /** Status */
+            status: string;
+            /** Queue Position */
+            queue_position: number;
+            /**
+             * Requested At
+             * Format: date-time
+             */
+            requested_at: string;
+            /** Started At */
+            started_at?: string | null;
+        };
+        /** QueueSummary */
+        QueueSummary: {
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
+            /**
+             * Queued
+             * @default 0
+             */
+            queued: number;
+            /**
+             * Running
+             * @default 0
+             */
+            running: number;
+            /** Oldest Requested At */
+            oldest_requested_at?: string | null;
+        };
         /** RecordHealthCheck */
         RecordHealthCheck: {
             /** Table */
@@ -2274,6 +2310,7 @@ export interface components {
             gamma: components["schemas"]["GammaBlock"];
             skew: components["schemas"]["SkewBlock"];
             positioning: components["schemas"]["PositioningBlock"];
+            queue?: components["schemas"]["QueueStatus"] | null;
         };
         /** WatchlistMutation */
         WatchlistMutation: {
@@ -2313,6 +2350,14 @@ export interface components {
             scanned_at_max?: string | null;
             /** Scheduler Lag Seconds */
             scheduler_lag_seconds?: number | null;
+            /**
+             * @default {
+             *       "total": 0,
+             *       "queued": 0,
+             *       "running": 0
+             *     }
+             */
+            queue: components["schemas"]["QueueSummary"];
             /** Tickers */
             tickers: components["schemas"]["WatchlistCard"][];
         };

--- a/web/tests/unit/dashboardData.test.ts
+++ b/web/tests/unit/dashboardData.test.ts
@@ -15,6 +15,12 @@ function watchlist(tickers: string[]) {
     scanned_at_min: null,
     scanned_at_max: null,
     scheduler_lag_seconds: null,
+    queue: {
+      total: 0,
+      queued: 0,
+      running: 0,
+      oldest_requested_at: null,
+    },
     tickers: tickers.map((ticker) => ({
       ticker,
       sector: "Technology",

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ScanAllButton } from "@/components/shared/ScanAllButton";
+import { QueueProgress } from "@/components/shared/QueueProgress";
 import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
 import { TickerCard } from "@/components/watchlist/TickerCard";
 import { api } from "@/lib/api";
@@ -13,13 +14,18 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/api", () => ({
   api: {
+    watchlist: vi.fn(),
+    rescan: vi.fn(),
     rescanAll: vi.fn(),
     job: vi.fn(),
   },
 }));
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
+  vi.mocked(api.watchlist).mockReset();
+  vi.mocked(api.rescan).mockReset();
   vi.mocked(api.rescanAll).mockReset();
   vi.mocked(api.job).mockReset();
 });
@@ -98,6 +104,86 @@ describe("TickerCard", () => {
     fireEvent.click(screen.getByRole("button", { name: /soxx detail/i }));
 
     expect(screen.getByText("SOXX is not ready")).not.toBeNull();
+  });
+
+  it("shows active queue status on the card", () => {
+    render(
+      <TickerCard
+        card={{
+          ...card,
+          queue: {
+            job_id: "00000000-0000-0000-0000-000000000001",
+            status: "queued",
+            queue_position: 4,
+            requested_at: "2026-05-16T00:13:17Z",
+            started_at: null,
+          },
+        }}
+        sparkline={[440, 445]}
+      />,
+    );
+
+    expect(screen.getByText("queued #4")).not.toBeNull();
+  });
+});
+
+describe("QueueProgress", () => {
+  it("shows running and queued rescan progress", () => {
+    render(
+      <QueueProgress
+        queue={{
+          total: 8,
+          queued: 6,
+          running: 2,
+          oldest_requested_at: "2026-05-16T00:13:17Z",
+        }}
+      />,
+    );
+
+    const progress = screen.getByRole("progressbar", {
+      name: /rescan queue/i,
+    });
+    expect(progress.getAttribute("aria-valuenow")).toBe("2");
+    expect(progress.getAttribute("aria-valuemax")).toBe("8");
+    expect(screen.getByText("2 running · 6 queued")).not.toBeNull();
+  });
+
+  it("discovers queue work that starts after the dashboard loaded idle", async () => {
+    vi.useFakeTimers();
+    vi.mocked(api.watchlist).mockResolvedValueOnce({
+      scanned_at_min: null,
+      scanned_at_max: null,
+      scheduler_lag_seconds: null,
+      queue: {
+        total: 1,
+        queued: 1,
+        running: 0,
+        oldest_requested_at: "2026-05-16T00:13:17Z",
+      },
+      tickers: [],
+    });
+
+    render(
+      <QueueProgress
+        queue={{
+          total: 0,
+          queued: 0,
+          running: 0,
+          oldest_requested_at: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("idle")).not.toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(api.watchlist).toHaveBeenCalledOnce();
+    expect(screen.getByText("0 running · 1 queued")).not.toBeNull();
+
+    vi.useRealTimers();
   });
 });
 


### PR DESCRIPTION
## Summary
- add one-active-job-per-ticker rescan dedupe with priority ordering
- expose rescan queue summary and per-card queue status in the watchlist API
- show dashboard queue progress and card queue state in the web UI
- update OpenAPI snapshot coverage for schema changes

## Tests
- uv run pytest tests/integration/api/test_openapi_snapshot.py tests/integration/storage/test_repository_watchlist.py::test_enqueue_rescan_job_reuses_first_active_job tests/integration/storage/test_repository_watchlist.py::test_card_list_includes_active_queue_status tests/integration/storage/test_repository_watchlist.py::test_queue_summary_counts_active_jobs tests/integration/api/test_watchlist_endpoint.py::test_get_watchlist_includes_queue_summary_and_card_status tests/integration/api/test_stock_ohlc_jobs.py::test_post_rescan_reuses_existing_active_job tests/unit/worker/test_scheduler.py::test_rescan_worker_concurrency_is_two
- cd web && npm run test -- tests/unit/watchlistUi.test.tsx tests/unit/dashboardData.test.ts
- cd web && npm run typecheck