### PR TITLE
feat: split provider workers and surface throughput telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,12 @@ UW_SCAN_SPOT_REFRESH_SECONDS=300
 UW_SCAN_FULL_SCAN_CRON=0 5-16 * * 1-5
 UW_SCAN_OHLC_PULL_CRON=30 17 * * 1-5
 UW_SCAN_RTH_TZ=America/New_York
+
+# Worker sharding
+# all = legacy single scheduler; uw/massive = provider-specific worker role.
+# Run two uw workers and two massive workers with INDEX=0/1 and COUNT=2.
+UW_SCAN_WORKER_ROLE=all
+UW_SCAN_WORKER_INDEX=0
+UW_SCAN_WORKER_COUNT=1
+UW_SCAN_UW_WORKER_COUNT=0
+UW_SCAN_MASSIVE_WORKER_COUNT=0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Postgres `option_wizard` DB, schema `uw_scan`. UW (Unusual Whales) is the primar
 ```bash
 uv sync --extra postgres          # install
 bash scripts/migrate.sh           # apply SQL migrations (idempotent)
-bash scripts/dev.sh               # run all three processes
+bash scripts/dev.sh               # run web, API, 2 UW workers, and 2 massive workers
 uv run pytest                     # python tests
 cd web && npm run test            # vitest
 cd web && npm run gen:types       # regenerate types.ts after API change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Postgres `option_wizard` DB, schema `uw_scan`. UW (Unusual Whales) is the primar
 ```bash
 uv sync --extra postgres          # install
 bash scripts/migrate.sh           # apply SQL migrations (idempotent)
-bash scripts/dev.sh               # run all three processes
+bash scripts/dev.sh               # run web, API, 2 UW workers, and 2 massive workers
 uv run pytest                     # python tests
 cd web && npm run test            # vitest
 cd web && npm run gen:types       # regenerate types.ts after API change

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ uv sync --extra postgres
 cp .env.example .env       # fill UW_SCAN_API_KEY + MASSIVE_API_KEY
 
 bash scripts/migrate.sh    # idempotent SQL migrations against option_wizard.uw_scan
-bash scripts/dev.sh        # next (3001) + fastapi (8400) + worker, concurrent
+bash scripts/dev.sh        # next (3001) + fastapi (8400) + 2 UW workers + 2 massive workers
 ```
 
 - Web: <http://127.0.0.1:3001>
@@ -94,13 +94,13 @@ bash scripts/dev.sh        # next (3001) + fastapi (8400) + worker, concurrent
 ## Architecture in one breath
 
 ```
-UW + massive.com  →  worker (APScheduler, src/uw_scan/worker)
+UW + massive.com  →  sharded workers (APScheduler, src/uw_scan/worker)
                   →  Postgres uw_scan.*
                   →  FastAPI (src/uw_scan/api, port 8400)
                   →  Next.js 16 + React 19 (web/, port 3001)
 ```
 
-Three processes, one database, one schema. The worker is the only writer; the API is read-only; mutations cross through `/api/jobs` and are drained by the worker's 1s rescan loop.
+Six dev processes, one database, one schema. UW workers own UW scan/rescan/flow jobs; massive workers own spot/OHLC jobs. Per-ticker loops use stable shard ownership and rescans use DB claiming, so parallel workers do not duplicate provider work. The workers are the only writers; the API is read-only; mutations cross through `/api/jobs` and are drained by the UW workers' 1s rescan loop.
 
 Details by layer live in the `CLAUDE.md` files under `src/uw_scan/`, `web/`, and `tests/`.
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/dev.sh — run Next.js, FastAPI, and the worker scheduler concurrently.
+# scripts/dev.sh — run Next.js, FastAPI, and sharded worker schedulers concurrently.
 # Uses npx concurrently from the web/ package so we don't add a top-level node dep.
 set -euo pipefail
 
@@ -10,10 +10,13 @@ if [ ! -d web/node_modules ]; then
   ( cd web && npm install )
 fi
 
-# Color-prefixed concurrent run. Press Ctrl-C to stop all three.
+# Color-prefixed concurrent run. Press Ctrl-C to stop all processes.
 exec npx --prefix web concurrently \
-  -n next,api,worker \
-  -c cyan,green,yellow \
+  -n next,api,uw-0,uw-1,massive-0,massive-1 \
+  -c cyan,green,yellow,magenta,blue,white \
   "cd web && npm run dev" \
-  "uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src" \
-  "uv run python -m uw_scan.worker.scheduler"
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src" \
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -49,6 +49,16 @@ class HealthResponse(BaseModel):
     cache_hit_pct: float | None = None
     record_health_ok: bool | None = None
     record_health: list["RecordHealthCheck"] = Field(default_factory=list)
+    workers: list["WorkerHealth"] = Field(default_factory=list)
+
+
+class WorkerHealth(BaseModel):
+    label: str
+    role: Literal["uw", "massive"]
+    index: int
+    heartbeat_name: str
+    lag_seconds: float | None = None
+    last_beat_at: datetime | None = None
 
 
 class RecordHealthCheck(BaseModel):
@@ -84,6 +94,38 @@ def _parse_record_tables(record_tables: str | None) -> list[str] | None:
         return None
     selected = [item.strip() for item in record_tables.split(",") if item.strip()]
     return selected or None
+
+
+def _worker_health_rows(
+    *,
+    repo: Repository,
+    now_utc: datetime,
+    uw_count: int,
+    massive_count: int,
+) -> list[WorkerHealth]:
+    rows: list[WorkerHealth] = []
+    for role, count, label_prefix in (
+        ("uw", uw_count, "UW"),
+        ("massive", massive_count, "Massive"),
+    ):
+        for index in range(max(0, count)):
+            heartbeat_name = f"worker:{role}:{index}"
+            last_beat_at = repo.get_heartbeat(heartbeat_name)
+            rows.append(
+                WorkerHealth(
+                    label=f"{label_prefix} {index + 1}",
+                    role=role,
+                    index=index,
+                    heartbeat_name=heartbeat_name,
+                    last_beat_at=last_beat_at,
+                    lag_seconds=(
+                        (now_utc - last_beat_at).total_seconds()
+                        if last_beat_at is not None
+                        else None
+                    ),
+                )
+            )
+    return rows
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -137,6 +179,12 @@ def health(
         latest_spot_quote_at, latest_spot_quote_fetched_at = latest_spot_quote_times
         spot_quote_lag = (now_utc - latest_spot_quote_fetched_at).total_seconds()
     watchlist_size = repo.count_active_watchlist()
+    worker_health = _worker_health_rows(
+        repo=repo,
+        now_utc=now_utc,
+        uw_count=settings.uw_worker_count,
+        massive_count=settings.massive_worker_count,
+    )
     provider_day_start, provider_day_end = provider_day_bounds()
     provider_usage = repo.get_external_api_usage_summary(
         source, provider_day_start, provider_day_end
@@ -158,6 +206,7 @@ def health(
         "spot_quote_lag_seconds": spot_quote_lag,
         "latest_spot_quote_at": latest_spot_quote_at,
         "latest_spot_quote_fetched_at": latest_spot_quote_fetched_at,
+        "workers": worker_health,
     }
     record_fields = {"record_health_ok": None, "record_health": []}
     record_reason = None

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -16,6 +16,7 @@ from uw_scan.storage.repository import Repository, provider_day_bounds
 router = APIRouter()
 
 HealthSource = Literal["uw", "massive"]
+THROUGHPUT_WINDOW_MINUTES = 15
 
 
 def _source_label(source: HealthSource) -> str:
@@ -47,6 +48,11 @@ class HealthResponse(BaseModel):
     http_5xx: int | None = None
     uw_today: int | None = None
     cache_hit_pct: float | None = None
+    throughput_window_minutes: int = THROUGHPUT_WINDOW_MINUTES
+    requests_per_minute: float | None = None
+    http_429: int | None = None
+    avg_scan_duration_seconds: float | None = None
+    queue_drain_rate_per_minute: float | None = None
     record_health_ok: bool | None = None
     record_health: list["RecordHealthCheck"] = Field(default_factory=list)
     workers: list["WorkerHealth"] = Field(default_factory=list)
@@ -189,6 +195,11 @@ def health(
     provider_usage = repo.get_external_api_usage_summary(
         source, provider_day_start, provider_day_end
     )
+    throughput = repo.get_throughput_summary(
+        source,
+        now_utc - timedelta(minutes=THROUGHPUT_WINDOW_MINUTES),
+        now_utc,
+    )
     provider_fields = {
         "source": _source_label(source),
         "latency_p95_ms": provider_usage.latency_p95_ms,
@@ -196,6 +207,11 @@ def health(
         "http_4xx": provider_usage.http_4xx,
         "http_5xx": provider_usage.http_5xx,
         "uw_today": provider_usage.uw_latest_daily_count,
+        "throughput_window_minutes": THROUGHPUT_WINDOW_MINUTES,
+        "requests_per_minute": throughput.requests_per_minute,
+        "http_429": throughput.http_429,
+        "avg_scan_duration_seconds": throughput.avg_scan_duration_seconds,
+        "queue_drain_rate_per_minute": throughput.queue_drain_rate_per_minute,
     }
     heartbeat_fields = {
         "worker_lag_seconds": scheduler_heartbeat_lag,

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -59,6 +59,11 @@ class Settings(BaseModel):
     full_scan_cron: str = "0 5-16 * * 1-5"
     ohlc_pull_cron: str = "30 17 * * 1-5"
     rth_tz: str = "America/New_York"
+    worker_role: str = "all"
+    worker_index: int = 0
+    worker_count: int = 1
+    uw_worker_count: int = 0
+    massive_worker_count: int = 0
     # OHLC provider (massive.com)
     massive_api_key: SecretStr | None = None
     massive_base_url: str = "https://api.massive.com"
@@ -105,6 +110,13 @@ class Settings(BaseModel):
             full_scan_cron=os.environ.get("UW_SCAN_FULL_SCAN_CRON", "0 5-16 * * 1-5"),
             ohlc_pull_cron=os.environ.get("UW_SCAN_OHLC_PULL_CRON", "30 17 * * 1-5"),
             rth_tz=os.environ.get("UW_SCAN_RTH_TZ", "America/New_York"),
+            worker_role=os.environ.get("UW_SCAN_WORKER_ROLE", "all"),
+            worker_index=int(os.environ.get("UW_SCAN_WORKER_INDEX", "0")),
+            worker_count=int(os.environ.get("UW_SCAN_WORKER_COUNT", "1")),
+            uw_worker_count=int(os.environ.get("UW_SCAN_UW_WORKER_COUNT", "0")),
+            massive_worker_count=int(
+                os.environ.get("UW_SCAN_MASSIVE_WORKER_COUNT", "0")
+            ),
             # SecretStr("") is truthy and not None — would silently allow the
             # scheduler to instantiate a Massive client with a blank bearer and
             # generate a stream of 401s. Coerce blank to None before wrapping.

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -109,6 +109,15 @@ class ExternalApiBreakdownRow:
 
 
 @dataclass(frozen=True)
+class ThroughputSummaryRow:
+    window_minutes: float
+    requests_per_minute: float
+    http_429: int
+    avg_scan_duration_seconds: float | None
+    queue_drain_rate_per_minute: float
+
+
+@dataclass(frozen=True)
 class ExternalApiRequestRow:
     request_id: int
     provider: str
@@ -250,6 +259,12 @@ def _nullable_int(value: Any) -> int | None:
     if value is None:
         return None
     return int(round(float(value)))
+
+
+def _nullable_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
 
 
 class Repository:
@@ -495,6 +510,65 @@ class Repository:
             latency_p95_ms=_nullable_int(row[6]),
             uw_latest_daily_count=row[7],
             uw_latest_daily_limit=row[8],
+        )
+
+    def get_throughput_summary(
+        self, provider: str | None, start: datetime, end: datetime
+    ) -> ThroughputSummaryRow:
+        provider_filter = None if provider in (None, "all") else provider
+        window_minutes = max((end - start).total_seconds() / 60.0, 1 / 60)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                  count(*)::int AS total_requests,
+                  count(*) FILTER (WHERE status_code = 429)::int AS http_429
+                FROM {self._schema}.external_api_requests
+                WHERE request_started_at >= %s
+                  AND request_started_at < %s
+                  AND (%s::text IS NULL OR provider = %s)
+                """,
+                (start, end, provider_filter, provider_filter),
+            )
+            request_row = cur.fetchone()
+            assert request_row is not None
+
+            cur.execute(
+                f"""
+                SELECT avg(extract(epoch FROM finished_at - started_at))
+                FROM {self._schema}.scan_runs
+                WHERE finished_at >= %s
+                  AND finished_at < %s
+                  AND finished_at IS NOT NULL
+                  AND started_at IS NOT NULL
+                  AND (notes IS DISTINCT FROM 'flow_data_refresh')
+                """,
+                (start, end),
+            )
+            scan_row = cur.fetchone()
+            assert scan_row is not None
+
+            cur.execute(
+                f"""
+                SELECT count(*)::int
+                FROM {self._schema}.jobs
+                WHERE finished_at >= %s
+                  AND finished_at < %s
+                  AND status IN ('done', 'failed')
+                """,
+                (start, end),
+            )
+            queue_row = cur.fetchone()
+            assert queue_row is not None
+
+        total_requests = int(request_row[0])
+        drained_jobs = int(queue_row[0])
+        return ThroughputSummaryRow(
+            window_minutes=window_minutes,
+            requests_per_minute=total_requests / window_minutes,
+            http_429=int(request_row[1]),
+            avg_scan_duration_seconds=_nullable_float(scan_row[0]),
+            queue_drain_rate_per_minute=drained_jobs / window_minutes,
         )
 
     def list_external_api_endpoint_usage(
@@ -3291,4 +3365,5 @@ __all__ = [
     "PcrHistoryRow",
     "JobRow",
     "RescanQueueSummaryRow",
+    "ThroughputSummaryRow",
 ]

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -2690,6 +2690,21 @@ class Repository:
         self._conn.commit()
         return JobRow(*row) if row else None
 
+    def requeue_stale_running_jobs(self, older_than: timedelta) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE {self._schema}.jobs
+                SET status='queued', started_at=NULL, error=NULL
+                WHERE status='running'
+                  AND started_at < NOW() - %s
+                """,
+                (older_than,),
+            )
+            count = cur.rowcount
+        self._conn.commit()
+        return count
+
     def mark_job_done(self, job_id: str, run_id: int) -> None:
         with self._conn.cursor() as cur:
             cur.execute(

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -9,6 +9,18 @@
 - `jobs/spot_refresh.py` — intraday spot price refresh
 - `volatility_jobs.py` — `daily_spy_ohlc_refresh`, `nightly_vol_analytics_rollup` (Volatility tab v2)
 
+## Worker roles
+
+Set `UW_SCAN_WORKER_ROLE=uw|massive|all`, `UW_SCAN_WORKER_INDEX`, and
+`UW_SCAN_WORKER_COUNT` to split provider work across processes.
+
+- `uw` workers run `full_scan`, `rescan_tick`, and `flow_data_refresh`.
+- `massive` workers run `spot_refresh`, `ohlc_pull`, and primary-worker-only
+  volatility OHLC/rollup jobs.
+- `all` preserves the legacy single scheduler shape.
+- Per-ticker scheduled jobs must use the scheduler-provided shard filter.
+  Rescans use DB claiming (`FOR UPDATE SKIP LOCKED`) and are not sharded.
+
 ## Schedule (all ET via `CronTrigger.from_crontab`)
 
 | Job | Trigger | Default |
@@ -24,6 +36,7 @@
 
 - **Every job opens its own conn** via `_repo(settings)` and closes it in `finally`. No long-lived connections — APScheduler runs jobs from a thread pool.
 - **MASSIVE_API_KEY can be unset.** Jobs that need it should no-op + warn (see `_spy_ohlc_refresh`). Never crash the scheduler.
+- **No duplicated provider work.** If a worker role can run in more than one process, loops over watchlist tickers must either use stable shard ownership or atomically claim queued work.
 - **ET timezone everywhere.** `CronTrigger.from_crontab(..., timezone=settings.rth_tz)`. Don't use UTC for trading-hour crons.
 - **Automatic UW scan freshness guard.** Full scan only queries tickers with no persisted card data or card data older than 8 hours. User-requested rescans always run.
 - **UW flow refresh window is weekdays 5:00am-7:59pm ET.** Flow-tab refresh skips outside that window.

--- a/src/uw_scan/worker/jobs/flow_data_refresh.py
+++ b/src/uw_scan/worker/jobs/flow_data_refresh.py
@@ -16,6 +16,7 @@ Per-ticker semantics:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
@@ -35,11 +36,16 @@ OPTIONS_VOLUME_LOOKBACK = 200
 
 
 def flow_data_refresh(
-    *, repo: Repository, client: UwClient, settings: Settings
+    *,
+    repo: Repository,
+    client: UwClient,
+    settings: Settings,
+    ticker_filter: Callable[[str], bool] | None = None,
+    lock_key: int = FLOW_REFRESH_LOCK,
 ) -> None:
     """Refresh Flow-tab tables for every watchlist ticker."""
 
-    if not repo.try_advisory_lock(FLOW_REFRESH_LOCK):
+    if not repo.try_advisory_lock(lock_key):
         logger.info("flow_data_refresh: lock held; skipping this tick")
         return
 
@@ -50,6 +56,11 @@ def flow_data_refresh(
         cards = repo.list_watchlist_cards()
         for card in cards:
             ticker = card.ticker
+            if ticker_filter is not None and not ticker_filter(ticker):
+                logger.debug(
+                    "flow_data_refresh: %s skipped outside this worker shard", ticker
+                )
+                continue
             run_id = repo.insert_scan_run(ticker, notes="flow_data_refresh")
             try:
                 vol_rows = fetch_options_volume_daily(
@@ -95,4 +106,4 @@ def flow_data_refresh(
                 repo.conn.rollback()
                 logger.exception("flow_data_refresh: %s failed: %r", ticker, exc)
     finally:
-        repo.release_advisory_lock(FLOW_REFRESH_LOCK)
+        repo.release_advisory_lock(lock_key)

--- a/src/uw_scan/worker/jobs/full_scan.py
+++ b/src/uw_scan/worker/jobs/full_scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 
 from uw_scan.cards.derive import compute_watchlist_card_row
@@ -34,12 +35,16 @@ def full_scan_once(
     *,
     now: datetime | None = None,
     stale_after: timedelta = DEFAULT_STALE_AFTER,
+    ticker_filter: Callable[[str], bool] | None = None,
 ) -> int:
     """Run UW deep scans only for active tickers missing data or older than max age."""
     _ = ohlc_provider  # currently OHLC is pulled separately; reserved for future
     current = now or datetime.now(timezone.utc)
     completed = 0
     for w in repo.list_watchlist_cards():
+        if ticker_filter is not None and not ticker_filter(w.ticker):
+            logger.debug("full_scan skipped %s outside this worker shard", w.ticker)
+            continue
         if not _is_missing_or_stale(
             w.scanned_at, now=current, stale_after=stale_after
         ):

--- a/src/uw_scan/worker/jobs/ohlc_pull.py
+++ b/src/uw_scan/worker/jobs/ohlc_pull.py
@@ -4,6 +4,7 @@ OHLC provider and upsert into uw_scan.daily_ohlc."""
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import date, timedelta
 
 from uw_scan.sources.ohlc import OhlcProvider
@@ -11,11 +12,20 @@ from uw_scan.sources.ohlc import OhlcProvider
 logger = logging.getLogger(__name__)
 
 
-def ohlc_pull_once(repo, provider: OhlcProvider, lookback_days: int = 40) -> int:
+def ohlc_pull_once(
+    repo,
+    provider: OhlcProvider,
+    lookback_days: int = 40,
+    *,
+    ticker_filter: Callable[[str], bool] | None = None,
+) -> int:
     completed = 0
     end = date.today()
     start = end - timedelta(days=lookback_days * 2)  # weekend/holiday buffer
     for w in repo.list_active_watchlist():
+        if ticker_filter is not None and not ticker_filter(w.ticker):
+            logger.debug("ohlc_pull skipped %s outside this worker shard", w.ticker)
+            continue
         try:
             bars = provider.fetch_daily(w.ticker, start, end)
             for bar in bars:

--- a/src/uw_scan/worker/jobs/rescan_loop.py
+++ b/src/uw_scan/worker/jobs/rescan_loop.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from uw_scan.cards.derive import compute_watchlist_card_row
 from uw_scan.pipeline import run_single_stock
 from uw_scan.sources.ohlc import OhlcProvider
 
 logger = logging.getLogger(__name__)
+STALE_RUNNING_AFTER = timedelta(minutes=30)
 
 
 def rescan_tick(repo, uw_client, ohlc_provider: OhlcProvider) -> bool:
@@ -18,6 +20,9 @@ def rescan_tick(repo, uw_client, ohlc_provider: OhlcProvider) -> bool:
     # is the closest signal we have to "worker is up." Sidebar HealthPanel
     # reads now() - last_beat_at to render the worker dot.
     repo.upsert_heartbeat("rescan_tick")
+    recovered = repo.requeue_stale_running_jobs(STALE_RUNNING_AFTER)
+    if recovered:
+        logger.warning("rescan_tick requeued %d stale running jobs", recovered)
     job = repo.claim_next_queued_job()
     if job is None:
         return False

--- a/src/uw_scan/worker/jobs/spot_refresh.py
+++ b/src/uw_scan/worker/jobs/spot_refresh.py
@@ -10,6 +10,7 @@ the card row. The next full scan resets them — acceptable per spec.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import date
 
 from uw_scan.cards.returns import compute_returns
@@ -23,10 +24,14 @@ def spot_refresh_once(
     provider: OhlcProvider,
     *,
     market_date: date | None = None,
+    ticker_filter: Callable[[str], bool] | None = None,
 ) -> int:
     """One pass over the active watchlist. Returns the number of cards updated."""
     updated = 0
     for w in repo.list_active_watchlist():
+        if ticker_filter is not None and not ticker_filter(w.ticker):
+            logger.debug("spot_refresh skipped %s outside this worker shard", w.ticker)
+            continue
         try:
             quote = provider.fetch_intraday_quote(w.ticker, market_date=market_date)
             if quote is None:

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 import signal
 import sys
-from collections.abc import Iterator
+import zlib
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, time
+from typing import Literal
 from zoneinfo import ZoneInfo
 
 import psycopg
@@ -38,6 +40,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger("uw_scan.worker")
 RESCAN_WORKER_CONCURRENCY = 2
+WorkerGroup = Literal["uw", "massive", "ai"]
+WORKER_ROLES: set[str] = {"all", "uw", "massive"}
 
 
 def _spot_refresh_market_date(now: datetime) -> date | None:
@@ -60,9 +64,77 @@ def _uw_auto_request_allowed(now: datetime) -> bool:
     return time(5, 0) <= current < time(20, 0)
 
 
+def _validate_worker_settings(settings: Settings) -> None:
+    role = settings.worker_role.lower()
+    if role not in WORKER_ROLES:
+        raise RuntimeError(
+            "UW_SCAN_WORKER_ROLE must be one of: all, uw, massive "
+            f"(got {settings.worker_role!r})"
+        )
+    if settings.worker_count < 1:
+        raise RuntimeError("UW_SCAN_WORKER_COUNT must be >= 1")
+    if settings.worker_index < 0 or settings.worker_index >= settings.worker_count:
+        raise RuntimeError(
+            "UW_SCAN_WORKER_INDEX must be between 0 and "
+            f"{settings.worker_count - 1} (got {settings.worker_index})"
+        )
+
+
+def _worker_groups(settings: Settings) -> set[WorkerGroup]:
+    role = settings.worker_role.lower()
+    if role == "all":
+        return {"uw", "massive", "ai"}
+    if role == "uw":
+        return {"uw"}
+    if role == "massive":
+        return {"massive"}
+    raise RuntimeError(
+        "UW_SCAN_WORKER_ROLE must be one of: all, uw, massive "
+        f"(got {settings.worker_role!r})"
+    )
+
+
+def _worker_owns_ticker(ticker: str, *, index: int, count: int) -> bool:
+    if count <= 1:
+        return True
+    normalized = ticker.strip().upper().encode("utf-8")
+    return zlib.crc32(normalized) % count == index
+
+
+def _ticker_shard_filter(settings: Settings) -> Callable[[str], bool]:
+    _validate_worker_settings(settings)
+    return lambda ticker: _worker_owns_ticker(
+        ticker, index=settings.worker_index, count=settings.worker_count
+    )
+
+
+def _rescan_worker_concurrency(settings: Settings) -> int:
+    if settings.worker_role.lower() == "uw" and settings.worker_count > 1:
+        return 1
+    return RESCAN_WORKER_CONCURRENCY
+
+
+def _is_primary_worker(settings: Settings) -> bool:
+    return settings.worker_role.lower() == "all" or settings.worker_index == 0
+
+
+def _worker_label(settings: Settings) -> str:
+    role = settings.worker_role.lower()
+    if role == "all":
+        return "all"
+    return f"{role}-{settings.worker_index}-of-{settings.worker_count}"
+
+
+def _worker_heartbeat_name(settings: Settings) -> str:
+    role = settings.worker_role.lower()
+    if role == "all":
+        return "worker"
+    return f"worker:{role}:{settings.worker_index}"
+
+
 def _record_worker_heartbeat(settings: Settings) -> None:
     with _repo(settings) as repo:
-        repo.upsert_heartbeat("worker")
+        repo.upsert_heartbeat(_worker_heartbeat_name(settings))
 
 
 @contextmanager
@@ -137,6 +209,9 @@ class _NoOhlc:
 
 def main() -> int:
     settings = Settings.from_env()
+    _validate_worker_settings(settings)
+    groups = _worker_groups(settings)
+    ticker_filter = _ticker_shard_filter(settings)
     sched = BlockingScheduler(timezone=settings.rth_tz)
 
     def _spot_refresh() -> None:
@@ -155,7 +230,12 @@ def main() -> int:
                 return
             try:
                 with _repo(settings) as repo:
-                    n = spot_refresh_once(repo, provider, market_date=market_date)
+                    n = spot_refresh_once(
+                        repo,
+                        provider,
+                        market_date=market_date,
+                        ticker_filter=ticker_filter,
+                    )
                     logger.info("spot_refresh updated %d cards", n)
             finally:
                 provider.close()
@@ -165,20 +245,11 @@ def main() -> int:
             with _uw_client(
                 settings, telemetry_recorder=recorder, job_name="full_scan"
             ) as uw:
-                ohlc = (
-                    _ohlc_provider(
-                        settings,
-                        telemetry_recorder=recorder,
-                        job_name="full_scan",
+                with _repo(settings) as repo:
+                    n = full_scan_once(
+                        repo, uw, _NoOhlc(), ticker_filter=ticker_filter
                     )
-                    or _NoOhlc()
-                )
-                try:
-                    with _repo(settings) as repo:
-                        n = full_scan_once(repo, uw, ohlc)
-                        logger.info("full_scan completed %d tickers", n)
-                finally:
-                    ohlc.close()
+                    logger.info("full_scan completed %d tickers", n)
 
     def _ohlc_pull() -> None:
         with _external_api_recorder(settings) as recorder:
@@ -189,7 +260,7 @@ def main() -> int:
                 return
             try:
                 with _repo(settings) as repo:
-                    n = ohlc_pull_once(repo, provider)
+                    n = ohlc_pull_once(repo, provider, ticker_filter=ticker_filter)
                     logger.info("ohlc_pull refreshed %d tickers", n)
             finally:
                 provider.close()
@@ -199,19 +270,8 @@ def main() -> int:
             with _uw_client(
                 settings, telemetry_recorder=recorder, job_name="rescan_tick"
             ) as uw:
-                ohlc = (
-                    _ohlc_provider(
-                        settings,
-                        telemetry_recorder=recorder,
-                        job_name="rescan_tick",
-                    )
-                    or _NoOhlc()
-                )
-                try:
-                    with _repo(settings) as repo:
-                        rescan_tick(repo, uw, ohlc)
-                finally:
-                    ohlc.close()
+                with _repo(settings) as repo:
+                    rescan_tick(repo, uw, _NoOhlc())
 
     def _spy_ohlc_refresh() -> None:
         if settings.massive_api_key is None:
@@ -239,7 +299,13 @@ def main() -> int:
                 settings, telemetry_recorder=recorder, job_name="flow_data_refresh"
             ) as uw:
                 with _repo(settings) as repo:
-                    flow_data_refresh(repo=repo, client=uw, settings=settings)
+                    flow_data_refresh(
+                        repo=repo,
+                        client=uw,
+                        settings=settings,
+                        ticker_filter=ticker_filter,
+                        lock_key=91501 + settings.worker_index,
+                    )
 
     def _trade_insights_ai_tick() -> None:
         trade_insights_ai_tick(settings)
@@ -252,51 +318,56 @@ def main() -> int:
         max_instances=1,
         coalesce=True,
     )
-    sched.add_job(
-        _spot_refresh,
-        IntervalTrigger(seconds=settings.spot_refresh_seconds),
-        id="spot_refresh",
-        name="Spot refresh",
-    )
-    sched.add_job(
-        _full_scan,
-        CronTrigger.from_crontab(settings.full_scan_cron, timezone=settings.rth_tz),
-        id="full_scan",
-        name="Full UW scan",
-    )
-    sched.add_job(
-        _ohlc_pull,
-        CronTrigger.from_crontab(settings.ohlc_pull_cron, timezone=settings.rth_tz),
-        id="ohlc_pull",
-        name="Daily OHLC pull",
-    )
-    sched.add_job(
-        _rescan,
-        IntervalTrigger(seconds=1),
-        id="rescan_tick",
-        name="Ad-hoc rescan poll",
-        max_instances=RESCAN_WORKER_CONCURRENCY,
-    )
-    # Volatility tab v2 jobs — ET-anchored via from_crontab (review I9).
-    sched.add_job(
-        _spy_ohlc_refresh,
-        CronTrigger.from_crontab("30 16 * * 1-5", timezone=settings.rth_tz),
-        id="daily_spy_ohlc_refresh",
-        name="Daily SPY OHLC refresh",
-    )
-    sched.add_job(
-        _vol_analytics_rollup,
-        CronTrigger.from_crontab("0 18 * * 1-5", timezone=settings.rth_tz),
-        id="nightly_vol_analytics_rollup",
-        name="Nightly vol analytics rollup",
-    )
-    sched.add_job(
-        _flow_data_refresh,
-        CronTrigger.from_crontab("15 18 * * 1-5", timezone=settings.rth_tz),
-        id="nightly_flow_data_refresh",
-        name="Nightly Flow tab data refresh",
-    )
-    if settings.trade_insights_ai_enabled:
+    if "massive" in groups:
+        sched.add_job(
+            _spot_refresh,
+            IntervalTrigger(seconds=settings.spot_refresh_seconds),
+            id="spot_refresh",
+            name="Spot refresh",
+        )
+        sched.add_job(
+            _ohlc_pull,
+            CronTrigger.from_crontab(settings.ohlc_pull_cron, timezone=settings.rth_tz),
+            id="ohlc_pull",
+            name="Daily OHLC pull",
+        )
+        if _is_primary_worker(settings):
+            # Volatility tab v2 jobs — ET-anchored via from_crontab (review I9).
+            sched.add_job(
+                _spy_ohlc_refresh,
+                CronTrigger.from_crontab("30 16 * * 1-5", timezone=settings.rth_tz),
+                id="daily_spy_ohlc_refresh",
+                name="Daily SPY OHLC refresh",
+            )
+            sched.add_job(
+                _vol_analytics_rollup,
+                CronTrigger.from_crontab("0 18 * * 1-5", timezone=settings.rth_tz),
+                id="nightly_vol_analytics_rollup",
+                name="Nightly vol analytics rollup",
+            )
+
+    if "uw" in groups:
+        sched.add_job(
+            _full_scan,
+            CronTrigger.from_crontab(settings.full_scan_cron, timezone=settings.rth_tz),
+            id="full_scan",
+            name="Full UW scan",
+        )
+        sched.add_job(
+            _rescan,
+            IntervalTrigger(seconds=1),
+            id="rescan_tick",
+            name="Ad-hoc rescan poll",
+            max_instances=_rescan_worker_concurrency(settings),
+        )
+        sched.add_job(
+            _flow_data_refresh,
+            CronTrigger.from_crontab("15 18 * * 1-5", timezone=settings.rth_tz),
+            id="nightly_flow_data_refresh",
+            name="Nightly Flow tab data refresh",
+        )
+
+    if "ai" in groups and settings.trade_insights_ai_enabled:
         sched.add_job(
             _trade_insights_ai_tick,
             IntervalTrigger(seconds=settings.trade_insights_ai_poll_seconds),
@@ -324,7 +395,7 @@ def main() -> int:
     signal.signal(signal.SIGTERM, _stop)
     signal.signal(signal.SIGINT, _stop)
 
-    logger.info("scheduler started")
+    logger.info("scheduler started role=%s groups=%s", _worker_label(settings), groups)
     sched.start()
     return 0
 

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -783,6 +783,17 @@
       },
       "HealthResponse": {
         "properties": {
+          "avg_scan_duration_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Scan Duration Seconds"
+          },
           "cache_hit_pct": {
             "anyOf": [
               {
@@ -808,6 +819,17 @@
               }
             ],
             "title": "Http 2Xx"
+          },
+          "http_429": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http 429"
           },
           "http_4xx": {
             "anyOf": [
@@ -882,6 +904,17 @@
             "title": "Ok",
             "type": "boolean"
           },
+          "queue_drain_rate_per_minute": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Queue Drain Rate Per Minute"
+          },
           "reason": {
             "anyOf": [
               {
@@ -910,6 +943,17 @@
               }
             ],
             "title": "Record Health Ok"
+          },
+          "requests_per_minute": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requests Per Minute"
           },
           "rescan_heartbeat_lag_seconds": {
             "anyOf": [
@@ -981,6 +1025,11 @@
               }
             ],
             "title": "Spot Refresh Heartbeat Lag Seconds"
+          },
+          "throughput_window_minutes": {
+            "default": 15,
+            "title": "Throughput Window Minutes",
+            "type": "integer"
           },
           "uw_today": {
             "anyOf": [

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1014,6 +1014,13 @@
               }
             ],
             "title": "Worker Lag Seconds"
+          },
+          "workers": {
+            "items": {
+              "$ref": "#/components/schemas/WorkerHealth"
+            },
+            "title": "Workers",
+            "type": "array"
           }
         },
         "required": [
@@ -6137,6 +6144,61 @@
           "tickers"
         ],
         "title": "WatchlistResponse",
+        "type": "object"
+      },
+      "WorkerHealth": {
+        "properties": {
+          "heartbeat_name": {
+            "title": "Heartbeat Name",
+            "type": "string"
+          },
+          "index": {
+            "title": "Index",
+            "type": "integer"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "lag_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lag Seconds"
+          },
+          "last_beat_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Beat At"
+          },
+          "role": {
+            "enum": [
+              "uw",
+              "massive"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "role",
+          "index",
+          "heartbeat_name"
+        ],
+        "title": "WorkerHealth",
         "type": "object"
       }
     }

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
+from uw_scan.api.routers.health import health
+from uw_scan.config import Settings
+
 
 def test_health_ok_when_recent_scan(client, seeded_db_with_cards):
     seeded_db_with_cards.upsert_heartbeat("worker")
@@ -65,6 +68,32 @@ def test_health_reports_spot_refresh_and_quote_freshness(client, seeded_db_empty
     assert body["spot_quote_lag_seconds"] < 5
     assert body["latest_spot_quote_at"] is not None
     assert body["latest_spot_quote_fetched_at"] is not None
+
+
+def test_health_reports_expected_provider_workers(seeded_db_with_cards):
+    seeded_db_with_cards.upsert_heartbeat("worker:uw:0")
+    seeded_db_with_cards.upsert_heartbeat("worker:massive:1")
+
+    response = health(
+        repo=seeded_db_with_cards,
+        settings=Settings(
+            api_key="test",
+            uw_worker_count=2,
+            massive_worker_count=2,
+        ),
+    )
+
+    workers = {worker.heartbeat_name: worker for worker in response.workers}
+    assert set(workers) == {
+        "worker:uw:0",
+        "worker:uw:1",
+        "worker:massive:0",
+        "worker:massive:1",
+    }
+    assert workers["worker:uw:0"].label == "UW 1"
+    assert workers["worker:uw:0"].lag_seconds is not None
+    assert workers["worker:uw:1"].lag_seconds is None
+    assert workers["worker:massive:1"].label == "Massive 2"
 
 
 def test_health_includes_uw_provider_usage_stats(client, seeded_db_empty_cards):

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -141,6 +141,43 @@ def test_health_includes_uw_provider_usage_stats(client, seeded_db_empty_cards):
     assert body["uw_today"] == 33
 
 
+def test_health_includes_throughput_metrics(client, seeded_db_with_cards):
+    now = datetime.now(UTC)
+    seeded_db_with_cards.insert_external_api_request(
+        provider="uw",
+        endpoint_key="iv_rank",
+        method="GET",
+        path="/api/stock/TSLA/iv-rank",
+        ticker="TSLA",
+        params={},
+        status_code=429,
+        status_family="4xx",
+        started_at=now,
+        finished_at=now,
+        latency_ms=25,
+    )
+    with seeded_db_with_cards.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {seeded_db_with_cards._schema}.jobs
+              (ticker, status, requested_at, started_at, finished_at)
+            VALUES ('TSLA', 'done', %s, %s, %s)
+            """,
+            (now, now, now),
+        )
+    seeded_db_with_cards.conn.commit()
+
+    r = client.get("/api/health")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["throughput_window_minutes"] == 15
+    assert body["requests_per_minute"] > 0
+    assert body["http_429"] == 1
+    assert body["avg_scan_duration_seconds"] is not None
+    assert body["queue_drain_rate_per_minute"] > 0
+
+
 def test_health_includes_massive_provider_usage_stats_when_source_is_massive(
     client, seeded_db_empty_cards
 ):

--- a/tests/integration/storage/test_provider_usage_repository.py
+++ b/tests/integration/storage/test_provider_usage_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import psycopg
@@ -142,6 +142,73 @@ def test_external_api_usage_summary_counts_latency_and_latest_official(repo: Rep
     assert summary.latency_p95_ms == 50
     assert summary.uw_latest_daily_count == 12
     assert summary.uw_latest_daily_limit == 1000
+
+
+def test_throughput_summary_counts_provider_and_queue_rates(repo: Repository):
+    start = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
+    end = datetime(2026, 5, 14, 14, 15, tzinfo=UTC)
+
+    for minute, status_code, status_family in [
+        (1, 200, "2xx"),
+        (2, 429, "4xx"),
+        (3, 200, "2xx"),
+    ]:
+        at = start + timedelta(minutes=minute)
+        repo.insert_external_api_request(
+            provider="uw",
+            endpoint_key="iv_rank",
+            method="GET",
+            path="/api/stock/TSLA/iv-rank",
+            ticker="TSLA",
+            params={},
+            status_code=status_code,
+            status_family=status_family,
+            started_at=at,
+            finished_at=at,
+            latency_ms=25,
+        )
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.scan_runs
+              (ticker, started_at, finished_at, status, notes)
+            VALUES
+              ('TSLA', %s, %s, 'ok', ''),
+              ('NVDA', %s, %s, 'ok', '')
+            """,
+            (
+                start,
+                start + timedelta(seconds=60),
+                start,
+                start + timedelta(seconds=180),
+            ),
+        )
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.jobs
+              (ticker, status, requested_at, started_at, finished_at)
+            VALUES
+              ('TSLA', 'done', %s, %s, %s),
+              ('NVDA', 'failed', %s, %s, %s)
+            """,
+            (
+                start,
+                start,
+                start + timedelta(minutes=2),
+                start,
+                start,
+                start + timedelta(minutes=3),
+            ),
+        )
+    repo.conn.commit()
+
+    summary = repo.get_throughput_summary("uw", start, end)
+
+    assert summary.requests_per_minute == 0.2
+    assert summary.http_429 == 1
+    assert summary.avg_scan_duration_seconds == 120.0
+    assert summary.queue_drain_rate_per_minute == pytest.approx(2 / 15)
 
 
 def test_external_api_usage_breakdowns_and_request_filters(repo: Repository):

--- a/tests/integration/storage/test_repository_watchlist.py
+++ b/tests/integration/storage/test_repository_watchlist.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 
@@ -193,3 +193,27 @@ def test_queue_summary_counts_active_jobs(repo):
     assert summary.total == 2
     assert summary.running == 1
     assert summary.queued == 1
+
+
+def test_requeue_stale_running_jobs(repo):
+    repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
+    job_id = repo.enqueue_rescan_job("ZZTEST")
+    claimed = repo.claim_next_queued_job()
+    assert claimed is not None
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE {repo._schema}.jobs
+            SET started_at=NOW() - INTERVAL '31 minutes'
+            WHERE id=%s
+            """,
+            (job_id,),
+        )
+    repo.conn.commit()
+
+    assert repo.requeue_stale_running_jobs(timedelta(minutes=30)) == 1
+    job = repo.get_job(job_id)
+    assert job is not None
+    assert job.status == "queued"
+    assert job.started_at is None

--- a/tests/integration/worker/test_worker_jobs.py
+++ b/tests/integration/worker/test_worker_jobs.py
@@ -226,6 +226,38 @@ def test_rescan_tick_claims_and_marks_done(seeded_db_with_cards):
     assert job.run_id == new_run_id
 
 
+def test_rescan_tick_recovers_stale_running_job(seeded_db_with_cards):
+    from uw_scan.worker.jobs.rescan_loop import rescan_tick
+
+    repo = seeded_db_with_cards
+    new_run_id = repo.insert_scan_run("TSLA")
+    repo.finish_scan_run(new_run_id, status="ok")
+    job_id = repo.enqueue_rescan_job("TSLA")
+    repo.claim_next_queued_job()
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE {repo._schema}.jobs
+            SET started_at=NOW() - INTERVAL '31 minutes'
+            WHERE id=%s
+            """,
+            (job_id,),
+        )
+    repo.conn.commit()
+
+    with patch(
+        "uw_scan.worker.jobs.rescan_loop.run_single_stock",
+        side_effect=lambda ticker, *_a, **_k: _stub_report(ticker, run_id=new_run_id),
+    ):
+        worked = rescan_tick(repo, MagicMock(), MagicMock())
+
+    assert worked is True
+    job = repo.get_job(job_id)
+    assert job is not None
+    assert job.status == "done"
+    assert job.run_id == new_run_id
+
+
 def test_rescan_tick_marks_failed_on_exception(seeded_db_with_cards):
     from uw_scan.worker.jobs.rescan_loop import rescan_tick
 

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -13,6 +13,7 @@ from uw_scan.worker.scheduler import (
     _record_worker_heartbeat,
     _spot_refresh_market_date,
     _uw_auto_request_allowed,
+    _worker_heartbeat_name,
 )
 
 
@@ -69,9 +70,32 @@ def test_record_worker_heartbeat_uses_dedicated_worker_key(monkeypatch) -> None:
 
     monkeypatch.setattr("uw_scan.worker.scheduler._repo", fake_repo)
 
-    _record_worker_heartbeat(object())
+    _record_worker_heartbeat(Settings(api_key="uw"))
 
     assert calls == ["worker"]
+
+
+def test_record_worker_heartbeat_uses_provider_worker_key(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class Repo:
+        def upsert_heartbeat(self, job_name: str) -> None:
+            calls.append(job_name)
+
+    @contextmanager
+    def fake_repo(_settings):
+        yield Repo()
+
+    monkeypatch.setattr("uw_scan.worker.scheduler._repo", fake_repo)
+
+    settings = Settings(api_key="uw", worker_role="massive", worker_index=1, worker_count=2)
+    _record_worker_heartbeat(settings)
+
+    assert calls == ["worker:massive:1"]
+
+
+def test_worker_heartbeat_name_keeps_legacy_all_worker() -> None:
+    assert _worker_heartbeat_name(Settings(api_key="uw")) == "worker"
 
 
 def test_ohlc_provider_uses_configured_request_timeout(monkeypatch) -> None:

--- a/tests/unit/worker/test_worker_sharding.py
+++ b/tests/unit/worker/test_worker_sharding.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+from uw_scan.worker.jobs.full_scan import full_scan_once
+from uw_scan.worker.jobs.ohlc_pull import ohlc_pull_once
+from uw_scan.worker.jobs.spot_refresh import spot_refresh_once
+from uw_scan.worker.scheduler import (
+    _rescan_worker_concurrency,
+    _ticker_shard_filter,
+    _worker_groups,
+    _worker_owns_ticker,
+)
+
+
+def _settings(**overrides):
+    values = {"api_key": SecretStr("uw"), **overrides}
+    return Settings(**values)
+
+
+def test_two_worker_shards_are_exclusive_and_exhaustive() -> None:
+    tickers = ["AAPL", "MSFT", "NVDA", "SOXX", "TSLA", "XOM"]
+    shard_0 = {t for t in tickers if _worker_owns_ticker(t, index=0, count=2)}
+    shard_1 = {t for t in tickers if _worker_owns_ticker(t, index=1, count=2)}
+
+    assert shard_0
+    assert shard_1
+    assert shard_0.isdisjoint(shard_1)
+    assert shard_0 | shard_1 == set(tickers)
+
+
+def test_ticker_shard_filter_is_disabled_for_single_worker() -> None:
+    ticker_filter = _ticker_shard_filter(_settings(worker_count=1))
+
+    assert ticker_filter("AAPL") is True
+    assert ticker_filter("MSFT") is True
+
+
+def test_worker_groups_split_provider_roles() -> None:
+    assert _worker_groups(_settings(worker_role="uw")) == {"uw"}
+    assert _worker_groups(_settings(worker_role="massive")) == {"massive"}
+    assert _worker_groups(_settings(worker_role="all")) == {"uw", "massive", "ai"}
+
+
+def test_split_uw_workers_run_one_rescan_instance_each() -> None:
+    assert (
+        _rescan_worker_concurrency(_settings(worker_role="uw", worker_count=2))
+        == 1
+    )
+    assert (
+        _rescan_worker_concurrency(_settings(worker_role="all", worker_count=1))
+        == 2
+    )
+
+
+def test_spot_refresh_respects_ticker_filter() -> None:
+    repo = MagicMock()
+    repo.list_active_watchlist.return_value = [
+        SimpleNamespace(ticker="AAPL"),
+        SimpleNamespace(ticker="MSFT"),
+    ]
+    provider = MagicMock()
+    provider.fetch_intraday_quote.return_value = None
+
+    spot_refresh_once(repo, provider, ticker_filter=lambda ticker: ticker == "AAPL")
+
+    provider.fetch_intraday_quote.assert_called_once_with("AAPL", market_date=None)
+
+
+def test_ohlc_pull_respects_ticker_filter() -> None:
+    repo = MagicMock()
+    repo.list_active_watchlist.return_value = [
+        SimpleNamespace(ticker="AAPL"),
+        SimpleNamespace(ticker="MSFT"),
+    ]
+    provider = MagicMock()
+    provider.fetch_daily.return_value = []
+
+    ohlc_pull_once(repo, provider, ticker_filter=lambda ticker: ticker == "MSFT")
+
+    assert provider.fetch_daily.call_count == 1
+    assert provider.fetch_daily.call_args.args[0] == "MSFT"
+
+
+def test_full_scan_respects_ticker_filter() -> None:
+    repo = MagicMock()
+    repo.list_watchlist_cards.return_value = [
+        SimpleNamespace(ticker="AAPL", scanned_at=None),
+        SimpleNamespace(ticker="MSFT", scanned_at=None),
+    ]
+
+    with patch(
+        "uw_scan.worker.jobs.full_scan.run_single_stock",
+        side_effect=RuntimeError("stop after ownership check"),
+    ) as run_single_stock:
+        completed = full_scan_once(
+            repo,
+            MagicMock(),
+            MagicMock(),
+            ticker_filter=lambda ticker: ticker == "MSFT",
+        )
+
+    assert completed == 0
+    run_single_stock.assert_called_once()
+    assert run_single_stock.call_args.args[0] == "MSFT"

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -5,6 +5,7 @@ import { fmtDateTimeWithZone } from "@/lib/formatters";
 import type { components } from "@/lib/types";
 
 type Health = components["schemas"]["HealthResponse"];
+type WorkerHealth = NonNullable<Health["workers"]>[number];
 type ProviderSource = "uw" | "massive";
 
 const HEARTBEAT_HEALTHY_LAG_S = 5;
@@ -78,6 +79,22 @@ function recordHealthStatus(
   return { label: "ALERT", color: "var(--negative)" };
 }
 
+function workerGroupStatus(workers: WorkerHealth[]): { label: string; color: string } {
+  if (workers.length === 0) return { label: "UNKNOWN", color: "var(--warning)" };
+  const online = workers.filter((worker) => {
+    const healthyLag =
+      worker.role === "massive" ? SPOT_REFRESH_HEALTHY_LAG_S : HEARTBEAT_HEALTHY_LAG_S;
+    return heartbeatStatus(worker.lag_seconds, healthyLag).label === "ONLINE";
+  }).length;
+  if (online === workers.length) {
+    return { label: `${online}/${workers.length}`, color: "var(--positive)" };
+  }
+  if (online === 0) {
+    return { label: `${online}/${workers.length}`, color: "var(--negative)" };
+  }
+  return { label: `${online}/${workers.length}`, color: "var(--warning)" };
+}
+
 function fmtDuration(seconds: number | null | undefined): string {
   if (seconds == null) return "—";
   const s = Math.max(0, Math.round(seconds));
@@ -148,6 +165,9 @@ export function HealthPanel() {
     h?.spot_refresh_heartbeat_lag_seconds,
     SPOT_REFRESH_HEALTHY_LAG_S,
   );
+  const workerRows = h?.workers ?? [];
+  const uwWorkers = workerRows.filter((worker) => worker.role === "uw");
+  const massiveWorkers = workerRows.filter((worker) => worker.role === "massive");
   const recordsStatus = recordHealthStatus(h?.record_health_ok);
 
   return (
@@ -159,8 +179,17 @@ export function HealthPanel() {
     >
       <StatusRow label="API" status={apiStatus} />
       <StatusRow label="Scheduler" status={schedulerStatus} />
-      <StatusRow label="UW Worker" status={rescanStatus} />
-      <StatusRow label="Massive Worker" status={spotRefreshStatus} />
+      {workerRows.length > 0 ? (
+        <>
+          <StatusRow label="UW Workers" status={workerGroupStatus(uwWorkers)} />
+          <StatusRow label="Massive Workers" status={workerGroupStatus(massiveWorkers)} />
+        </>
+      ) : (
+        <>
+          <StatusRow label="UW Worker" status={rescanStatus} />
+          <StatusRow label="Massive Worker" status={spotRefreshStatus} />
+        </>
+      )}
       <StatusRow label="Query Coverage" status={recordsStatus} />
       <div style={rowStyle}>
         <span style={labelStyle}>Last spot</span>

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -105,6 +105,11 @@ function fmtDuration(seconds: number | null | undefined): string {
   return `${hours}h`;
 }
 
+function fmtRate(value: number | null | undefined): string {
+  if (value == null) return "—";
+  return `${Number(value.toFixed(1))}/m`;
+}
+
 function StatusRow({
   label,
   status,
@@ -235,6 +240,22 @@ export function HealthPanel() {
       <div style={rowStyle}>
         <span style={labelStyle}>Latency p95</span>
         <span style={valStyle}>{dash(h?.latency_p95_ms, "ms")}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={labelStyle}>Req/min</span>
+        <span style={valStyle}>{fmtRate(h?.requests_per_minute)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={labelStyle}>429</span>
+        <span style={valStyle}>{dash(h?.http_429)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={labelStyle}>Scan avg</span>
+        <span style={valStyle}>{fmtDuration(h?.avg_scan_duration_seconds)}</span>
+      </div>
+      <div style={rowStyle}>
+        <span style={labelStyle}>Queue/min</span>
+        <span style={valStyle}>{fmtRate(h?.queue_drain_rate_per_minute)}</span>
       </div>
       <div style={rowStyle}>
         <span style={labelStyle}>2xx</span>

--- a/web/components/shared/QueueProgress.tsx
+++ b/web/components/shared/QueueProgress.tsx
@@ -5,22 +5,25 @@ import type { components } from "@/lib/types";
 import { api } from "@/lib/api";
 
 type QueueSummary = components["schemas"]["QueueSummary"];
+const EMPTY_QUEUE: QueueSummary = {
+  total: 0,
+  queued: 0,
+  running: 0,
+  oldest_requested_at: null,
+};
 
-export function QueueProgress({ queue }: { queue: QueueSummary }) {
+export function QueueProgress({ queue }: { queue?: QueueSummary }) {
   const router = useRouter();
-  const [current, setCurrent] = useState(queue);
-
-  useEffect(() => {
-    setCurrent(queue);
-  }, [queue.oldest_requested_at, queue.queued, queue.running, queue.total]);
+  const [current, setCurrent] = useState(queue ?? EMPTY_QUEUE);
 
   useEffect(() => {
     const delay = current.total > 0 ? 2500 : 5000;
     const t = setInterval(async () => {
       try {
         const next = await api.watchlist();
-        setCurrent(next.queue);
-        if (next.queue.total === 0) router.refresh();
+        const nextQueue = next.queue ?? EMPTY_QUEUE;
+        setCurrent(nextQueue);
+        if (nextQueue.total === 0) router.refresh();
       } catch (e) {
         console.error(e);
       }

--- a/web/components/shared/RescanButton.tsx
+++ b/web/components/shared/RescanButton.tsx
@@ -21,11 +21,6 @@ export function RescanButton({
   );
 
   useEffect(() => {
-    setJobId(initialJob?.job_id ?? null);
-    setStatus((initialJob?.status as Status | undefined) ?? "idle");
-  }, [initialJob?.job_id, initialJob?.status]);
-
-  useEffect(() => {
     if (!jobId) return;
     // Self-cancel after 60s so a zombie 'running' job (worker crashed mid-scan)
     // doesn't keep polling forever and refreshing the page.

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -584,12 +584,16 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
+            /** Avg Scan Duration Seconds */
+            avg_scan_duration_seconds?: number | null;
             /** Cache Hit Pct */
             cache_hit_pct?: number | null;
             /** Db */
             db: string;
             /** Http 2Xx */
             http_2xx?: number | null;
+            /** Http 429 */
+            http_429?: number | null;
             /** Http 4Xx */
             http_4xx?: number | null;
             /** Http 5Xx */
@@ -604,12 +608,16 @@ export interface components {
             latest_spot_quote_fetched_at?: string | null;
             /** Ok */
             ok: boolean;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
             /** Reason */
             reason?: string | null;
             /** Record Health */
             record_health?: components["schemas"]["RecordHealthCheck"][];
             /** Record Health Ok */
             record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
             /** Rescan Heartbeat Lag Seconds */
             rescan_heartbeat_lag_seconds?: number | null;
             /** Scheduler Heartbeat Lag Seconds */
@@ -627,6 +635,11 @@ export interface components {
             spot_quote_lag_seconds?: number | null;
             /** Spot Refresh Heartbeat Lag Seconds */
             spot_refresh_heartbeat_lag_seconds?: number | null;
+            /**
+             * Throughput Window Minutes
+             * @default 15
+             */
+            throughput_window_minutes: number;
             /** Uw Today */
             uw_today?: number | null;
             /** Watchlist Size */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -21,40 +21,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist": {
+    "/api/jobs/{job_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Watchlist */
-        get: operations["get_watchlist_api_watchlist_get"];
+        /** Get Job */
+        get: operations["get_job_api_jobs__job_id__get"];
         put?: never;
-        /** Post Watchlist */
-        post: operations["post_watchlist_api_watchlist_post"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist/{ticker}": {
+    "/api/ohlc/{ticker}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Get Ohlc */
+        get: operations["get_ohlc_api_ohlc__ticker__get"];
         put?: never;
         post?: never;
-        /** Delete Watchlist */
-        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
+        delete?: never;
         options?: never;
         head?: never;
-        /** Patch Watchlist */
-        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Endpoints */
+        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Requests */
+        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Summary */
+        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/tickers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Tickers */
+        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/stock/{ticker}": {
@@ -131,162 +197,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/ohlc/{ticker}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ohlc */
-        get: operations["get_ohlc_api_ohlc__ticker__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/{ticker}/rescan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Enqueue Rescan */
-        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/rescan-all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enqueue Rescan All
-         * @description Enqueue a rescan job for every active watchlist ticker.
-         */
-        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Job */
-        get: operations["get_job_api_jobs__job_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/stock/{ticker}/volatility/series": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Volatility Series */
-        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Summary */
-        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/endpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Endpoints */
-        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/tickers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Tickers */
-        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/requests": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Requests */
-        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/stock/{ticker}/trade-insights": {
         parameters: {
             query?: never;
@@ -355,78 +265,161 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/stock/{ticker}/volatility/series": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Volatility Series */
+        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Watchlist */
+        get: operations["get_watchlist_api_watchlist_get"];
+        put?: never;
+        /** Post Watchlist */
+        post: operations["post_watchlist_api_watchlist_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist/rescan-all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enqueue Rescan All
+         * @description Enqueue a rescan job for every active watchlist ticker.
+         */
+        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist/{ticker}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Watchlist */
+        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
+        options?: never;
+        head?: never;
+        /** Patch Watchlist */
+        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
+        trace?: never;
+    };
+    "/api/watchlist/{ticker}/rescan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Enqueue Rescan */
+        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         /** CandidateStructure */
         CandidateStructure: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Thesis */
-            thesis: string;
-            /** Expression Type */
-            expression_type: string;
-            /**
-             * Legs
-             * @default []
-             */
-            legs: components["schemas"]["InsightLeg"][];
-            /** Net Credit Debit */
-            net_credit_debit?: string | null;
-            /** Max Profit */
-            max_profit?: string | null;
-            /** Max Loss */
-            max_loss?: string | null;
             /**
              * Breakevens
              * @default []
              */
             breakevens: string[];
             /**
-             * Profit Zone
-             * @default
-             */
-            profit_zone: string;
-            /**
              * Edge Source
              * @default
              */
             edge_source: string;
+            /** Expression Type */
+            expression_type: string;
+            /** Idea Id */
+            idea_id: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["InsightLeg"][];
+            /** Max Loss */
+            max_loss?: string | null;
+            /** Max Profit */
+            max_profit?: string | null;
+            /** Net Credit Debit */
+            net_credit_debit?: string | null;
+            /**
+             * Profit Zone
+             * @default
+             */
+            profit_zone: string;
+            /** Rank */
+            rank: number;
             /**
              * Risk Flags
              * @default []
              */
             risk_flags: string[];
-            /** Rank */
-            rank: number;
             /**
              * Status
              * @default candidate
              */
             status: string;
+            /** Structure */
+            structure: string;
+            /** Thesis */
+            thesis: string;
         };
         /** ChainFlowReadRow */
         ChainFlowReadRow: {
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
             /** Call Open Interest */
             call_open_interest?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
             /** Call Put Volume Ratio */
             call_put_volume_ratio?: string | null;
-            /**
-             * Volume Oi Note
-             * @default
-             */
-            volume_oi_note: string;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
             /**
              * Read
              * @default
@@ -437,6 +430,13 @@ export interface components {
              * @default false
              */
             requires_t1_oi_confirmation: boolean;
+            /** Strike */
+            strike: string;
+            /**
+             * Volume Oi Note
+             * @default
+             */
+            volume_oi_note: string;
         };
         /** DivergencePoint */
         DivergencePoint: {
@@ -452,93 +452,93 @@ export interface components {
         };
         /** FlowAlert */
         FlowAlert: {
-            /** Id */
-            id: string;
-            /** Ticker */
-            ticker: string;
-            /** Option Chain */
-            option_chain?: string | null;
-            /** Type */
-            type?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Price */
-            price?: string | null;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            /** Total Size */
-            total_size?: number | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Volume Oi Ratio */
-            volume_oi_ratio?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Iv Start */
-            iv_start?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Id */
+            id: string;
+            /** Issue Type */
+            issue_type?: string | null;
             /** Iv End */
             iv_end?: string | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
+            /** Iv Start */
+            iv_start?: string | null;
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Price */
+            price?: string | null;
             /** Rule Id */
             rule_id?: string | null;
             /** Sector */
             sector?: string | null;
-            /** Issue Type */
-            issue_type?: string | null;
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Ticker */
+            ticker: string;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Total Size */
+            total_size?: number | null;
+            /** Type */
+            type?: string | null;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            /** Volume */
+            volume?: number | null;
+            /** Volume Oi Ratio */
+            volume_oi_ratio?: string | null;
         };
         /** FlowSnapshot */
         FlowSnapshot: {
-            /** Ticker */
-            ticker: string;
+            /** Ask Side Premium */
+            ask_side_premium: string;
+            /** Bear Premium */
+            bear_premium: string;
+            /** Bid Side Premium */
+            bid_side_premium: string;
+            /** Bull Premium */
+            bull_premium: string;
             /** Flow Count */
             flow_count: number;
-            /**
-             * Flow Count Is Limited
-             * @default false
-             */
-            flow_count_is_limited: boolean;
             /** Flow Count 30D Avg */
             flow_count_30d_avg?: string | null;
-            /** Flow Count Vs 30D Avg */
-            flow_count_vs_30d_avg?: string | null;
             /**
              * Flow Count 30D Days
              * @default 0
              */
             flow_count_30d_days: number;
-            /** Top Alert Rule */
-            top_alert_rule?: string | null;
+            /**
+             * Flow Count Is Limited
+             * @default false
+             */
+            flow_count_is_limited: boolean;
+            /** Flow Count Vs 30D Avg */
+            flow_count_vs_30d_avg?: string | null;
             /** Net Premium */
             net_premium: string;
-            /** Bull Premium */
-            bull_premium: string;
-            /** Bear Premium */
-            bear_premium: string;
-            /** Ask Side Premium */
-            ask_side_premium: string;
-            /** Bid Side Premium */
-            bid_side_premium: string;
+            /** Ticker */
+            ticker: string;
+            /** Top Alert Rule */
+            top_alert_rule?: string | null;
             /**
              * Top Alerts
              * @default []
@@ -547,18 +547,18 @@ export interface components {
         };
         /** GammaBlock */
         GammaBlock: {
+            /** Expiring Date */
+            expiring_date?: string | null;
+            /** Expiring Pct */
+            expiring_pct?: string | null;
             /** Flip Distance */
             flip_distance?: string | null;
             /** Flip Price */
             flip_price?: string | null;
-            /** Per 1Pct Move */
-            per_1pct_move?: string | null;
             /** Max Strike */
             max_strike?: string | null;
-            /** Expiring Pct */
-            expiring_pct?: string | null;
-            /** Expiring Date */
-            expiring_date?: string | null;
+            /** Per 1Pct Move */
+            per_1pct_move?: string | null;
         };
         /**
          * GexLevel
@@ -568,14 +568,14 @@ export interface components {
          *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
          */
         GexLevel: {
-            /** Strike */
-            strike: string;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
             /** Net Gex */
             net_gex?: string | null;
             /** Pct From Spot */
             pct_from_spot?: string | null;
-            /** Gamma Per Dollar */
-            gamma_per_dollar?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -584,55 +584,57 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
-            /** Ok */
-            ok: boolean;
+            /** Cache Hit Pct */
+            cache_hit_pct?: number | null;
             /** Db */
             db: string;
-            /** Scheduler Lag Seconds */
-            scheduler_lag_seconds?: number | null;
-            /** Last Full Scan At */
-            last_full_scan_at?: string | null;
-            /** Reason */
-            reason?: string | null;
-            /** Worker Lag Seconds */
-            worker_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Name */
-            scheduler_heartbeat_name?: string | null;
-            /** Rescan Heartbeat Lag Seconds */
-            rescan_heartbeat_lag_seconds?: number | null;
-            /** Spot Refresh Heartbeat Lag Seconds */
-            spot_refresh_heartbeat_lag_seconds?: number | null;
-            /** Spot Quote Lag Seconds */
-            spot_quote_lag_seconds?: number | null;
-            /** Latest Spot Quote At */
-            latest_spot_quote_at?: string | null;
-            /** Latest Spot Quote Fetched At */
-            latest_spot_quote_fetched_at?: string | null;
-            /** Watchlist Size */
-            watchlist_size?: number | null;
-            /**
-             * Source
-             * @default UnusualWhales
-             */
-            source: string;
-            /** Latency P95 Ms */
-            latency_p95_ms?: number | null;
             /** Http 2Xx */
             http_2xx?: number | null;
             /** Http 4Xx */
             http_4xx?: number | null;
             /** Http 5Xx */
             http_5xx?: number | null;
-            /** Uw Today */
-            uw_today?: number | null;
-            /** Cache Hit Pct */
-            cache_hit_pct?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
+            /** Last Full Scan At */
+            last_full_scan_at?: string | null;
+            /** Latency P95 Ms */
+            latency_p95_ms?: number | null;
+            /** Latest Spot Quote At */
+            latest_spot_quote_at?: string | null;
+            /** Latest Spot Quote Fetched At */
+            latest_spot_quote_fetched_at?: string | null;
+            /** Ok */
+            ok: boolean;
+            /** Reason */
+            reason?: string | null;
             /** Record Health */
             record_health?: components["schemas"]["RecordHealthCheck"][];
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Rescan Heartbeat Lag Seconds */
+            rescan_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Name */
+            scheduler_heartbeat_name?: string | null;
+            /** Scheduler Lag Seconds */
+            scheduler_lag_seconds?: number | null;
+            /**
+             * Source
+             * @default UnusualWhales
+             */
+            source: string;
+            /** Spot Quote Lag Seconds */
+            spot_quote_lag_seconds?: number | null;
+            /** Spot Refresh Heartbeat Lag Seconds */
+            spot_refresh_heartbeat_lag_seconds?: number | null;
+            /** Uw Today */
+            uw_today?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
+            /** Worker Lag Seconds */
+            worker_lag_seconds?: number | null;
+            /** Workers */
+            workers?: components["schemas"]["WorkerHealth"][];
         };
         /** InsightBadge */
         InsightBadge: {
@@ -648,41 +650,48 @@ export interface components {
         };
         /** InsightLeg */
         InsightLeg: {
-            /** Side */
-            side: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Option Right */
-            option_right: string;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
             /** Mid */
             mid?: string | null;
+            /** Option Right */
+            option_right: string;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** InsightSignalRow */
         InsightSignalRow: {
-            /** Lens */
-            lens: string;
-            /** Read */
-            read: string;
-            /**
-             * Evidence
-             * @default []
-             */
-            evidence: string[];
             /**
              * Conflicts
              * @default []
              */
             conflicts: string[];
+            /**
+             * Evidence
+             * @default []
+             */
+            evidence: string[];
+            /** Lens */
+            lens: string;
+            /** Read */
+            read: string;
         };
         /** InsightsSynthesis */
         InsightsSynthesis: {
+            /**
+             * Avoid
+             * @default []
+             */
+            avoid: string[];
+            /** Best Risk Reward Idea Id */
+            best_risk_reward_idea_id?: string | null;
             /**
              * Dominant Story
              * @default
@@ -690,13 +699,6 @@ export interface components {
             dominant_story: string;
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
-            /** Best Risk Reward Idea Id */
-            best_risk_reward_idea_id?: string | null;
-            /**
-             * Avoid
-             * @default []
-             */
-            avoid: string[];
             /**
              * Required Before Sizing
              * @default []
@@ -705,12 +707,12 @@ export interface components {
         };
         /** IvHistogramBin */
         IvHistogramBin: {
-            /** Lo */
-            lo: string;
-            /** Hi */
-            hi: string;
             /** Count */
             count: number;
+            /** Hi */
+            hi: string;
+            /** Lo */
+            lo: string;
         };
         /** IvHvPoint */
         IvHvPoint: {
@@ -750,23 +752,23 @@ export interface components {
         };
         /** JobStatus */
         JobStatus: {
-            /** Job Id */
-            job_id: string;
-            /** Status */
-            status: string;
-            /** Run Id */
-            run_id?: number | null;
             /** Error */
             error?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Job Id */
+            job_id: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
+            /** Run Id */
+            run_id?: number | null;
             /** Started At */
             started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
+            /** Status */
+            status: string;
         };
         /**
          * MarketAggregates
@@ -778,45 +780,37 @@ export interface components {
         MarketAggregates: {
             /** Call Oi Total */
             call_oi_total?: number | null;
-            /** Put Oi Total */
-            put_oi_total?: number | null;
-            /** Call Volume Total */
-            call_volume_total?: number | null;
-            /** Put Volume Total */
-            put_volume_total?: number | null;
             /** Call Volume Ask Side */
             call_volume_ask_side?: number | null;
             /** Call Volume Bid Side */
             call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
+            /** Call Volume Total */
+            call_volume_total?: number | null;
+            /** Iv30D */
+            iv30d?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
             pcr_vol?: string | null;
-            /** Iv30D */
-            iv30d?: string | null;
+            /** Put Oi Total */
+            put_oi_total?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
+            /** Put Volume Total */
+            put_volume_total?: number | null;
         };
         /** MarketStructure */
         MarketStructure: {
-            /** Spot */
-            spot?: string | null;
-            /** Nearest Expiry */
-            nearest_expiry?: string | null;
-            /** Total Call Gex */
-            total_call_gex?: string | null;
-            /** Total Put Gex */
-            total_put_gex?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Total Call Dex Oi */
-            total_call_dex_oi?: string | null;
-            /** Total Put Dex Oi */
-            total_put_dex_oi?: string | null;
             /** Max Pain */
             max_pain?: string | null;
+            /** Nearest Expiry */
+            nearest_expiry?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Spot */
+            spot?: string | null;
             /**
              * Top Call Oi Strikes
              * @default []
@@ -827,6 +821,14 @@ export interface components {
              * @default []
              */
             top_put_oi_strikes: string[];
+            /** Total Call Dex Oi */
+            total_call_dex_oi?: string | null;
+            /** Total Call Gex */
+            total_call_gex?: string | null;
+            /** Total Put Dex Oi */
+            total_put_dex_oi?: string | null;
+            /** Total Put Gex */
+            total_put_gex?: string | null;
         };
         /**
          * MarketStructureLevels
@@ -841,15 +843,17 @@ export interface components {
          *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
          */
         MarketStructureLevels: {
-            gex_flip?: components["schemas"]["GexLevel"] | null;
             call_wall?: components["schemas"]["GexLevel"] | null;
-            put_wall?: components["schemas"]["GexLevel"] | null;
-            max_magnet?: components["schemas"]["GexLevel"] | null;
-            second_magnet?: components["schemas"]["GexLevel"] | null;
+            gex_flip?: components["schemas"]["GexLevel"] | null;
             max_accel?: components["schemas"]["GexLevel"] | null;
+            max_magnet?: components["schemas"]["GexLevel"] | null;
+            put_wall?: components["schemas"]["GexLevel"] | null;
+            second_magnet?: components["schemas"]["GexLevel"] | null;
         };
         /** MaxPainRow */
         MaxPainRow: {
+            /** Close */
+            close?: string | null;
             /**
              * Expiry
              * Format: date
@@ -857,93 +861,91 @@ export interface components {
             expiry: string;
             /** Max Pain */
             max_pain?: string | null;
-            /** Close */
-            close?: string | null;
-            /** Open */
-            open?: string | null;
-            /** Next Upper Strike */
-            next_upper_strike?: string | null;
             /** Next Lower Strike */
             next_lower_strike?: string | null;
+            /** Next Upper Strike */
+            next_upper_strike?: string | null;
+            /** Open */
+            open?: string | null;
         };
         /** OhlcRow */
         OhlcRow: {
+            /** Close */
+            close: string;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Open */
-            open?: string | null;
             /** High */
             high?: string | null;
             /** Low */
             low?: string | null;
-            /** Close */
-            close: string;
+            /** Open */
+            open?: string | null;
             /** Volume */
             volume?: number | null;
         };
         /** OiChangeRow */
         OiChangeRow: {
-            /** Underlying Symbol */
-            underlying_symbol: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Curr Date */
-            curr_date?: string | null;
-            /** Last Date */
-            last_date?: string | null;
-            /** Curr Oi */
-            curr_oi?: number | null;
-            /** Last Oi */
-            last_oi?: number | null;
-            /** Oi Diff Plain */
-            oi_diff_plain?: number | null;
-            /** Oi Change */
-            oi_change?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Trades */
-            trades?: number | null;
+            /** Ask Volume */
+            ask_volume?: number | null;
             /** Avg Price */
             avg_price?: string | null;
-            /** Last Fill */
-            last_fill?: string | null;
+            /** Bid Volume */
+            bid_volume?: number | null;
+            /** Curr Date */
+            curr_date?: string | null;
+            /** Curr Oi */
+            curr_oi?: number | null;
             /** Days Of Oi Increases */
             days_of_oi_increases?: number | null;
             /** Days Of Vol Greater Than Oi */
             days_of_vol_greater_than_oi?: number | null;
+            /** Last Ask */
+            last_ask?: string | null;
+            /** Last Bid */
+            last_bid?: string | null;
+            /** Last Date */
+            last_date?: string | null;
+            /** Last Fill */
+            last_fill?: string | null;
+            /** Last Oi */
+            last_oi?: number | null;
+            /** Mid Volume */
+            mid_volume?: number | null;
+            /** No Side Volume */
+            no_side_volume?: number | null;
+            /** Oi Change */
+            oi_change?: string | null;
+            /** Oi Diff Plain */
+            oi_diff_plain?: number | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Percentage Of Total */
             percentage_of_total?: string | null;
-            /** Rnk */
-            rnk?: number | null;
             /** Prev Ask Volume */
             prev_ask_volume?: number | null;
             /** Prev Bid Volume */
             prev_bid_volume?: number | null;
             /** Prev Mid Volume */
             prev_mid_volume?: number | null;
-            /** Prev Neutral Volume */
-            prev_neutral_volume?: number | null;
             /** Prev Multi Leg Volume */
             prev_multi_leg_volume?: number | null;
+            /** Prev Neutral Volume */
+            prev_neutral_volume?: number | null;
             /** Prev Stock Multi Leg Volume */
             prev_stock_multi_leg_volume?: number | null;
             /** Prev Total Premium */
             prev_total_premium?: string | null;
-            /** Last Ask */
-            last_ask?: string | null;
-            /** Last Bid */
-            last_bid?: string | null;
-            /** Ask Volume */
-            ask_volume?: number | null;
-            /** Bid Volume */
-            bid_volume?: number | null;
-            /** Mid Volume */
-            mid_volume?: number | null;
-            /** No Side Volume */
-            no_side_volume?: number | null;
+            /** Rnk */
+            rnk?: number | null;
+            /** Trades */
+            trades?: number | null;
+            /** Underlying Symbol */
+            underlying_symbol: string;
+            /** Volume */
+            volume?: number | null;
         };
         /**
          * OptionChainPerStrikeRow
@@ -952,21 +954,21 @@ export interface components {
          *     Backs both strike-profile charts (Volume and OI variants).
          */
         OptionChainPerStrikeRow: {
+            /** Call Oi */
+            call_oi?: number | null;
+            /** Call Volume */
+            call_volume?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Oi */
-            call_oi?: number | null;
             /** Put Oi */
             put_oi?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * OptionsDailyRow
@@ -976,39 +978,10 @@ export interface components {
          *     alert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot.
          */
         OptionsDailyRow: {
-            /**
-             * Date
-             * Format: date
-             */
-            date: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Volume Ask Side */
-            call_volume_ask_side?: number | null;
-            /** Call Volume Bid Side */
-            call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Call Premium */
-            call_premium?: string | null;
-            /** Put Premium */
-            put_premium?: string | null;
-            /** Net Call Premium */
-            net_call_premium?: string | null;
-            /** Net Put Premium */
-            net_put_premium?: string | null;
-            /** Bullish Premium */
-            bullish_premium?: string | null;
-            /** Bearish Premium */
-            bearish_premium?: string | null;
-            /** Call Open Interest */
-            call_open_interest?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
+            /** Avg 30 Day Call Volume */
+            avg_30_day_call_volume?: string | null;
+            /** Avg 30 Day Put Volume */
+            avg_30_day_put_volume?: string | null;
             /** Avg 3 Day Call Volume */
             avg_3_day_call_volume?: string | null;
             /** Avg 3 Day Put Volume */
@@ -1017,45 +990,70 @@ export interface components {
             avg_7_day_call_volume?: string | null;
             /** Avg 7 Day Put Volume */
             avg_7_day_put_volume?: string | null;
-            /** Avg 30 Day Call Volume */
-            avg_30_day_call_volume?: string | null;
-            /** Avg 30 Day Put Volume */
-            avg_30_day_put_volume?: string | null;
+            /** Bearish Premium */
+            bearish_premium?: string | null;
+            /** Bullish Premium */
+            bullish_premium?: string | null;
+            /** Call Open Interest */
+            call_open_interest?: number | null;
+            /** Call Premium */
+            call_premium?: string | null;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Call Volume Ask Side */
+            call_volume_ask_side?: number | null;
+            /** Call Volume Bid Side */
+            call_volume_bid_side?: number | null;
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Net Call Premium */
+            net_call_premium?: string | null;
+            /** Net Put Premium */
+            net_put_premium?: string | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Premium */
+            put_premium?: string | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
         };
         /** PositioningBlock */
         PositioningBlock: {
             /** Call Oi */
             call_oi?: number | null;
-            /** Put Oi */
-            put_oi?: number | null;
+            /** Pcr Delta 30D */
+            pcr_delta_30d?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
             pcr_vol?: string | null;
-            /** Pcr Delta 30D */
-            pcr_delta_30d?: string | null;
+            /** Put Oi */
+            put_oi?: number | null;
         };
         /** ProviderUsageBreakdownResponse */
         ProviderUsageBreakdownResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageBreakdownRow"][];
         };
         /** ProviderUsageBreakdownRow */
         ProviderUsageBreakdownRow: {
-            /** Key */
-            key: string | null;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -1064,53 +1062,29 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
+            /** Key */
+            key: string | null;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
         };
         /** ProviderUsageRequestRow */
         ProviderUsageRequestRow: {
-            /** Request Id */
-            request_id: number;
-            /** Provider */
-            provider: string;
-            /** Endpoint Key */
-            endpoint_key: string;
-            /** Method */
-            method: string;
-            /** Path */
-            path: string;
-            /** Ticker */
-            ticker: string | null;
-            /** Params */
-            params: {
-                [key: string]: unknown;
-            };
-            /** Status Code */
-            status_code: number | null;
-            /** Status Family */
-            status_family: string;
-            /**
-             * Request Started At
-             * Format: date-time
-             */
-            request_started_at: string;
-            /**
-             * Request Finished At
-             * Format: date-time
-             */
-            request_finished_at: string;
-            /** Latency Ms */
-            latency_ms: number;
             /** Attempt */
             attempt: number;
-            /** Run Id */
-            run_id: number | null;
+            /** Endpoint Key */
+            endpoint_key: string;
+            /** Error Message */
+            error_message: string | null;
             /** Job Name */
             job_name: string | null;
-            /** Provider Request Id */
-            provider_request_id: string | null;
+            /** Latency Ms */
+            latency_ms: number;
+            /** Method */
+            method: string;
             /** Official Daily Count */
             official_daily_count: number | null;
             /** Official Daily Limit */
@@ -1119,40 +1093,56 @@ export interface components {
             official_minute_remaining: number | null;
             /** Official Minute Reset */
             official_minute_reset: string | null;
-            /** Error Message */
-            error_message: string | null;
+            /** Params */
+            params: {
+                [key: string]: unknown;
+            };
+            /** Path */
+            path: string;
+            /** Provider */
+            provider: string;
+            /** Provider Request Id */
+            provider_request_id: string | null;
+            /**
+             * Request Finished At
+             * Format: date-time
+             */
+            request_finished_at: string;
+            /** Request Id */
+            request_id: number;
+            /**
+             * Request Started At
+             * Format: date-time
+             */
+            request_started_at: string;
+            /** Run Id */
+            run_id: number | null;
+            /** Status Code */
+            status_code: number | null;
+            /** Status Family */
+            status_family: string;
+            /** Ticker */
+            ticker: string | null;
         };
         /** ProviderUsageRequestsResponse */
         ProviderUsageRequestsResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
+            /** Limit */
+            limit: number;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
-            /** Limit */
-            limit: number;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageRequestRow"][];
         };
         /** ProviderUsageSummaryResponse */
         ProviderUsageSummaryResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
-            /**
-             * Provider Day End
-             * Format: date-time
-             */
-            provider_day_end: string;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -1161,10 +1151,22 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
             /** Uw Latest Daily Count */
             uw_latest_daily_count: number | null;
             /** Uw Latest Daily Limit */
@@ -1174,8 +1176,6 @@ export interface components {
         QueueStatus: {
             /** Job Id */
             job_id: string;
-            /** Status */
-            status: string;
             /** Queue Position */
             queue_position: number;
             /**
@@ -1185,14 +1185,13 @@ export interface components {
             requested_at: string;
             /** Started At */
             started_at?: string | null;
+            /** Status */
+            status: string;
         };
         /** QueueSummary */
         QueueSummary: {
-            /**
-             * Total
-             * @default 0
-             */
-            total: number;
+            /** Oldest Requested At */
+            oldest_requested_at?: string | null;
             /**
              * Queued
              * @default 0
@@ -1203,11 +1202,28 @@ export interface components {
              * @default 0
              */
             running: number;
-            /** Oldest Requested At */
-            oldest_requested_at?: string | null;
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
         };
         /** RecordHealthCheck */
         RecordHealthCheck: {
+            /** Actual Rows */
+            actual_rows: number;
+            /** Actual Tickers */
+            actual_tickers: number;
+            /** Expected Min Rows */
+            expected_min_rows: number;
+            /** Expected Min Tickers */
+            expected_min_tickers: number;
+            /** Expected Tickers */
+            expected_tickers: number;
+            /** Latest At */
+            latest_at?: string | null;
+            /** Ok */
+            ok: boolean;
             /** Table */
             table: string;
             /**
@@ -1215,31 +1231,17 @@ export interface components {
              * Format: date-time
              */
             window_start: string;
-            /** Expected Tickers */
-            expected_tickers: number;
-            /** Expected Min Tickers */
-            expected_min_tickers: number;
-            /** Actual Tickers */
-            actual_tickers: number;
-            /** Expected Min Rows */
-            expected_min_rows: number;
-            /** Actual Rows */
-            actual_rows: number;
-            /** Latest At */
-            latest_at?: string | null;
-            /** Ok */
-            ok: boolean;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
+            /** Cutoff Corr */
+            cutoff_corr?: string | null;
+            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
             /**
              * Points
              * @default []
              */
             points: components["schemas"]["RegimeQuadrantPoint"][];
-            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
-            /** Cutoff Corr */
-            cutoff_corr?: string | null;
         };
         /** RegimeQuadrantLatest */
         RegimeQuadrantLatest: {
@@ -1286,10 +1288,10 @@ export interface components {
         ReturnsBlock: {
             /** D1 */
             d1?: string | null;
-            /** W1 */
-            w1?: string | null;
             /** D30 */
             d30?: string | null;
+            /** W1 */
+            w1?: string | null;
         };
         /** RvCorrPoint */
         RvCorrPoint: {
@@ -1305,41 +1307,49 @@ export interface components {
         };
         /** SetupBlock */
         SetupBlock: {
-            /** Type */
-            type?: string | null;
             /** Direction */
             direction?: string | null;
             /** Score */
             score?: string | null;
+            /** Type */
+            type?: string | null;
         };
         /** SetupClassification */
         SetupClassification: {
-            /** Setup Type */
-            setup_type: string;
-            /** Label */
-            label: string;
-            /** Direction */
-            direction: string;
-            /** Score */
-            score: string;
             /**
              * Confirmations
              * @default []
              */
             confirmations: string[];
-            /**
-             * Warnings
-             * @default []
-             */
-            warnings: string[];
+            /** Direction */
+            direction: string;
+            /** Label */
+            label: string;
             /**
              * Notes
              * @default
              */
             notes: string;
+            /** Score */
+            score: string;
+            /** Setup Type */
+            setup_type: string;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: string[];
         };
         /** ShortDataRow */
         ShortDataRow: {
+            /** Fee Rate */
+            fee_rate?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Rebate Rate */
+            rebate_rate?: string | null;
+            /** Short Shares Available */
+            short_shares_available?: number | null;
             /** Symbol */
             symbol: string;
             /**
@@ -1347,41 +1357,10 @@ export interface components {
              * Format: date-time
              */
             timestamp: string;
-            /** Name */
-            name?: string | null;
-            /** Short Shares Available */
-            short_shares_available?: number | null;
-            /** Fee Rate */
-            fee_rate?: string | null;
-            /** Rebate Rate */
-            rebate_rate?: string | null;
         };
         /** SingleStockReport */
         SingleStockReport: {
-            /** Run Id */
-            run_id: number;
-            /** Ticker */
-            ticker: string;
-            /**
-             * Generated At
-             * Format: date-time
-             */
-            generated_at: string;
-            /** Spot Quoted At */
-            spot_quoted_at?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /**
-             * Short Int Note
-             * @default n/a (UW endpoint does not expose %)
-             */
-            short_int_note: string;
-            market_structure: components["schemas"]["MarketStructure"];
-            volatility: components["schemas"]["VolatilityProfile"];
-            flow: components["schemas"]["FlowSnapshot"];
-            vrp: components["schemas"]["VRPAssessment"];
-            setup?: components["schemas"]["SetupClassification"] | null;
-            trade_plan?: components["schemas"]["TradePlan"] | null;
+            aggregates?: components["schemas"]["MarketAggregates"] | null;
             /** Dark Pool Notional */
             dark_pool_notional?: string | null;
             /**
@@ -1389,36 +1368,59 @@ export interface components {
              * @default 0
              */
             dark_pool_print_count: number;
-            short_data?: components["schemas"]["ShortDataRow"] | null;
+            flow: components["schemas"]["FlowSnapshot"];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            market_structure: components["schemas"]["MarketStructure"];
+            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
             /**
              * Max Pain Rows
              * @default []
              */
             max_pain_rows: components["schemas"]["MaxPainRow"][];
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
             /**
              * Oi Change Top
              * @default []
              */
             oi_change_top: components["schemas"]["OiChangeRow"][];
-            aggregates?: components["schemas"]["MarketAggregates"] | null;
-            /**
-             * Strike Gex Curve
-             * @default []
-             */
-            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
-            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
-            /**
-             * Options Timeline
-             * @default []
-             */
-            options_timeline: components["schemas"]["OptionsDailyRow"][];
             /**
              * Option Chain Per Strike
              * @default []
              */
             option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
+            /**
+             * Options Timeline
+             * @default []
+             */
+            options_timeline: components["schemas"]["OptionsDailyRow"][];
+            /** Run Id */
+            run_id: number;
+            setup?: components["schemas"]["SetupClassification"] | null;
+            short_data?: components["schemas"]["ShortDataRow"] | null;
+            /**
+             * Short Int Note
+             * @default n/a (UW endpoint does not expose %)
+             */
+            short_int_note: string;
+            /** Spot Quoted At */
+            spot_quoted_at?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
+            /**
+             * Strike Gex Curve
+             * @default []
+             */
+            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
+            /** Ticker */
+            ticker: string;
+            trade_plan?: components["schemas"]["TradePlan"] | null;
+            volatility: components["schemas"]["VolatilityProfile"];
+            vrp: components["schemas"]["VRPAssessment"];
         };
         /** SkewBlock */
         SkewBlock: {
@@ -1440,18 +1442,18 @@ export interface components {
         };
         /** SmilePoint */
         SmilePoint: {
-            /** Strike */
-            strike: string;
             /** Iv */
             iv?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** SourceReconciliation */
         SourceReconciliation: {
             /**
-             * Status
-             * @default UNKNOWN
+             * Decision
+             * @default Use deterministic data only where source agreement is understood.
              */
-            status: string;
+            decision: string;
             /**
              * Headline
              * @default Source reconciliation unavailable
@@ -1467,48 +1469,48 @@ export interface components {
              */
             rows: components["schemas"]["SourceReconciliationRow"][];
             /**
-             * Decision
-             * @default Use deterministic data only where source agreement is understood.
+             * Status
+             * @default UNKNOWN
              */
-            decision: string;
+            status: string;
         };
         /** SourceReconciliationRow */
         SourceReconciliationRow: {
-            /** Source Pair */
-            source_pair: string;
             /**
-             * Price Agreement
+             * Decision
              * @default
              */
-            price_agreement: string;
+            decision: string;
             /**
              * Iv Agreement
              * @default
              */
             iv_agreement: string;
+            /** Iv Diff */
+            iv_diff?: string | null;
             /**
-             * Decision
+             * Price Agreement
              * @default
              */
-            decision: string;
-            /** Strike */
-            strike?: string | null;
+            price_agreement: string;
             /** Source A Call Iv */
             source_a_call_iv?: string | null;
             /** Source B Call Iv */
             source_b_call_iv?: string | null;
-            /** Iv Diff */
-            iv_diff?: string | null;
+            /** Source Pair */
+            source_pair: string;
+            /** Strike */
+            strike?: string | null;
         };
         /** StockHistoryResponse */
         StockHistoryResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Rows
              * @default []
              */
             rows: components["schemas"]["StockHistoryRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /**
          * StockHistoryRow
@@ -1520,35 +1522,35 @@ export interface components {
          */
         StockHistoryRow: {
             /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /** Spot */
-            spot?: string | null;
-            /** Gex Flip */
-            gex_flip?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Net Dex */
-            net_dex?: string | null;
-            /** Iv30D */
-            iv30d?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
-            /**
              * Bias
              * @default NEUTRAL
              */
             bias: string;
+            /** Gex Flip */
+            gex_flip?: string | null;
+            /** Iv30D */
+            iv30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Net Dex */
+            net_dex?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Spot */
+            spot?: string | null;
         };
         /**
          * StrikeGexBucket
          * @description One row of the per-strike, per-expiry GEX curve persisted on each scan run.
          */
         StrikeGexBucket: {
-            /** Strike */
-            strike: string;
+            /** Call Gex */
+            call_gex?: string | null;
             /**
              * Expiry
              * Format: date
@@ -1556,26 +1558,26 @@ export interface components {
             expiry: string;
             /** Net Gex */
             net_gex?: string | null;
-            /** Call Gex */
-            call_gex?: string | null;
             /** Put Gex */
             put_gex?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** TermMoveRow */
         TermMoveRow: {
+            /** Atm Straddle */
+            atm_straddle?: string | null;
+            /** Daily Implied Move Perc */
+            daily_implied_move_perc?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Atm Straddle */
-            atm_straddle?: string | null;
             /** Implied Move Perc */
             implied_move_perc?: string | null;
-            /** Daily Implied Move Perc */
-            daily_implied_move_perc?: string | null;
             /**
              * Read
              * @default
@@ -1585,19 +1587,19 @@ export interface components {
         /** TermStructureExpiryRow */
         TermStructureExpiryRow: {
             /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /**
              * By Strike
              * @default {}
              */
             by_strike: {
                 [key: string]: string;
             };
+            /** Dte */
+            dte?: number | null;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
             /**
              * Strikes
              * @default {}
@@ -1621,104 +1623,101 @@ export interface components {
              * Format: uuid
              */
             analysis_id: string;
-            /** Ticker */
-            ticker: string;
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
-            /** Model */
-            model: string;
-            /** Prompt Version */
-            prompt_version: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "succeeded" | "failed";
-            /** Produced At */
-            produced_at?: string | null;
-            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
-            /** Markdown */
-            markdown?: string | null;
             /** Error Message */
             error_message?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Markdown */
+            markdown?: string | null;
+            /** Model */
+            model: string;
+            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
+            /** Produced At */
+            produced_at?: string | null;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
-            /** Started At */
-            started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
             /**
              * Reused
              * @default false
              */
             reused: boolean;
+            /** Run Id */
+            run_id: number;
+            /** Started At */
+            started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Ticker */
+            ticker: string;
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /** TradeInsightAiBestExpression */
         TradeInsightAiBestExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Role */
-            role: string;
-            /** Why */
-            why: string;
             /** Caveats */
             caveats?: string[];
-            /** Status Observed */
-            status_observed: string;
+            /** Idea Id */
+            idea_id: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Role */
+            role: string;
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiConflict */
         TradeInsightAiConflict: {
+            /** Affected Idea Ids */
+            affected_idea_ids?: string[];
+            /** Description */
+            description: string;
             /** Lens */
             lens: string;
             /** Severity */
             severity: string;
-            /** Description */
-            description: string;
-            /** Affected Idea Ids */
-            affected_idea_ids?: string[];
         };
         /** TradeInsightAiDominantRead */
         TradeInsightAiDominantRead: {
-            /** Headline */
-            headline: string;
-            /** Summary */
-            summary: string;
             /** Confidence Commentary */
             confidence_commentary: string;
             /** Data Quality Commentary */
             data_quality_commentary: string;
+            /** Headline */
+            headline: string;
+            /** Summary */
+            summary: string;
         };
         /** TradeInsightAiGuardrails */
         TradeInsightAiGuardrails: {
-            /** Statuses Preserved */
-            statuses_preserved: boolean;
-            /** Risk Flags Preserved */
-            risk_flags_preserved: boolean;
             /** No Executable Recommendations */
             no_executable_recommendations: boolean;
+            /** Risk Flags Preserved */
+            risk_flags_preserved: boolean;
+            /** Statuses Preserved */
+            statuses_preserved: boolean;
         };
         /** TradeInsightAiHeadline */
         TradeInsightAiHeadline: {
-            /** Title */
-            title: string;
-            /**
-             * Stance
-             * @enum {string}
-             */
-            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
-            /** Stance Label */
-            stance_label: string;
+            /** Conviction */
+            conviction: string;
+            /** Conviction Label */
+            conviction_label: string;
+            /** Primary Risk */
+            primary_risk: string;
             /** Score */
             score: number;
             /**
@@ -1726,14 +1725,17 @@ export interface components {
              * @default 100
              */
             score_scale: number;
-            /** Conviction */
-            conviction: string;
-            /** Conviction Label */
-            conviction_label: string;
+            /**
+             * Stance
+             * @enum {string}
+             */
+            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
+            /** Stance Label */
+            stance_label: string;
+            /** Title */
+            title: string;
             /** Top Reason */
             top_reason: string;
-            /** Primary Risk */
-            primary_risk: string;
             /** Watch Trigger */
             watch_trigger: string;
         };
@@ -1741,163 +1743,163 @@ export interface components {
         TradeInsightAiHighlight: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiLevel */
         TradeInsightAiLevel: {
-            /** Price */
-            price: string;
-            /** Kind */
-            kind: string;
-            /** Value */
-            value: string;
             /**
              * Importance
              * @default normal
              */
             importance: string;
-            /** Source Path */
-            source_path?: string | null;
+            /** Kind */
+            kind: string;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Price */
+            price: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiMetricCard */
         TradeInsightAiMetricCard: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /**
-             * Tone
-             * @default neutral
-             */
-            tone: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /**
+             * Tone
+             * @default neutral
+             */
+            tone: string;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiOutcome */
         TradeInsightAiOutcome: {
-            /** Schema Version */
-            schema_version: string;
             /**
              * Analysis Produced At
              * Format: date-time
              */
             analysis_produced_at: string;
-            /** Ticker */
-            ticker: string;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
-            headline: components["schemas"]["TradeInsightAiHeadline"];
-            /** Metric Cards */
-            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
-            /** Scenario Cards */
-            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
-            /** Score Breakdown */
-            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
-            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
-            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
-            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
-            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
             /** Best Expressions */
             best_expressions?: components["schemas"]["TradeInsightAiBestExpression"][];
             /** Conflicts */
             conflicts?: components["schemas"]["TradeInsightAiConflict"][];
-            /** Required Checks */
-            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
-            /** Rejected Ideas */
-            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
+            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
+            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            headline: components["schemas"]["TradeInsightAiHeadline"];
+            /** Metric Cards */
+            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Missing Data */
             missing_data?: string[];
+            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
+            /** Rejected Ideas */
+            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
             rendering: components["schemas"]["TradeInsightAiRendering"];
-            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            /** Required Checks */
+            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
+            /** Scenario Cards */
+            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
+            /** Schema Version */
+            schema_version: string;
+            /** Score Breakdown */
+            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
+            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
+            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
+            /** Ticker */
+            ticker: string;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
         };
         /** TradeInsightAiPreferredExpression */
         TradeInsightAiPreferredExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Title */
-            title: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
             /**
              * Estimated Entry
              * @default
              */
             estimated_entry: string;
-            /**
-             * Max Profit Observed
-             * @default
-             */
-            max_profit_observed: string;
+            /** Idea Id */
+            idea_id: string;
+            /** Management Notes */
+            management_notes?: string[];
             /**
              * Max Loss Observed
              * @default
              */
             max_loss_observed: string;
             /**
+             * Max Profit Observed
+             * @default
+             */
+            max_profit_observed: string;
+            /**
              * Reward Risk
              * @default
              */
             reward_risk: string;
-            /** Why */
-            why: string;
-            /** Management Notes */
-            management_notes?: string[];
-            /** Status Observed */
-            status_observed: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /** Title */
+            title: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiRejectedIdea */
         TradeInsightAiRejectedIdea: {
             /** Idea Id */
             idea_id: string;
-            /** Structure */
-            structure: string;
             /** Reason */
             reason: string;
+            /** Structure */
+            structure: string;
         };
         /** TradeInsightAiRendering */
         TradeInsightAiRendering: {
-            /** Disclaimer */
-            disclaimer: string;
             /** Card Order */
             card_order?: string[];
+            /** Disclaimer */
+            disclaimer: string;
         };
         /** TradeInsightAiRequiredCheck */
         TradeInsightAiRequiredCheck: {
-            /** Check */
-            check: string;
-            /** Reason */
-            reason: string;
             /**
              * Blocks Sizing
              * @default true
              */
             blocks_sizing: boolean;
+            /** Check */
+            check: string;
+            /** Reason */
+            reason: string;
             /**
              * Source
              * @default
@@ -1908,59 +1910,55 @@ export interface components {
         TradeInsightAiScenarioCard: {
             /** Case */
             case: ("upside" | "base" | "downside") | string;
+            /** Description */
+            description: string;
+            /** Title */
+            title: string;
             /**
              * Tone
              * @default neutral
              */
             tone: string;
-            /** Title */
-            title: string;
-            /** Description */
-            description: string;
         };
         /** TradeInsightAiScoreBreakdown */
         TradeInsightAiScoreBreakdown: {
-            /** Section */
-            section: string;
-            /** Score */
-            score: number;
             /** Max Score */
             max_score: number;
+            /** Score */
+            score: number;
+            /** Section */
+            section: string;
             /** Summary */
             summary: string;
         };
         /** TradeInsightAiSectionCard */
         TradeInsightAiSectionCard: {
-            /** Title */
-            title: string;
-            /** Score */
-            score?: number | null;
-            /** Max Score */
-            max_score?: number | null;
-            /** Summary */
-            summary: string;
-            /** Highlights */
-            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
-            /** Levels */
-            levels?: components["schemas"]["TradeInsightAiLevel"][];
             /**
              * Data Quality
              * @default unknown
              */
             data_quality: string;
+            /** Highlights */
+            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
+            /** Levels */
+            levels?: components["schemas"]["TradeInsightAiLevel"][];
+            /** Max Score */
+            max_score?: number | null;
+            /** Score */
+            score?: number | null;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightAiSectionCards */
         TradeInsightAiSectionCards: {
+            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
             market_structure: components["schemas"]["TradeInsightAiSectionCard"];
             volatility: components["schemas"]["TradeInsightAiSectionCard"];
-            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
         };
         /** TradeInsightAiSnapshotMeta */
         TradeInsightAiSnapshotMeta: {
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
             /** Data As Of */
@@ -1970,34 +1968,33 @@ export interface components {
              * @default unknown
              */
             freshness_label: string;
+            /** Run Id */
+            run_id: number;
             /** Source Notes */
             source_notes?: string[];
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /** TradeInsightAiVrpAssessment */
         TradeInsightAiVrpAssessment: {
-            /** Signal */
-            signal: string;
-            /** Title */
-            title: string;
-            /** Summary */
-            summary: string;
             /** Metrics */
             metrics?: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Reason */
             reason: string;
+            /** Signal */
+            signal: string;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightsHeader */
         TradeInsightsHeader: {
             /**
-             * Dominant Bias
-             * @default NEUTRAL
+             * Badges
+             * @default []
              */
-            dominant_bias: string;
-            /**
-             * Primary Setup
-             * @default NO_CLEAR_SETUP
-             */
-            primary_setup: string;
+            badges: components["schemas"]["InsightBadge"][];
             /**
              * Confidence Label
              * @default LOW
@@ -2009,6 +2006,11 @@ export interface components {
              */
             data_quality_label: string;
             /**
+             * Dominant Bias
+             * @default NEUTRAL
+             */
+            dominant_bias: string;
+            /**
              * Idea Count
              * @default 0
              */
@@ -2016,65 +2018,63 @@ export interface components {
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
             /**
-             * Badges
-             * @default []
+             * Primary Setup
+             * @default NO_CLEAR_SETUP
              */
-            badges: components["schemas"]["InsightBadge"][];
+            primary_setup: string;
         };
         /** TradeInsightsResponse */
         TradeInsightsResponse: {
-            /** Ticker */
-            ticker: string;
             /** As Of */
             as_of?: string | null;
-            /**
-             * Mode
-             * @default research
-             */
-            mode: string;
-            header: components["schemas"]["TradeInsightsHeader"];
-            /**
-             * @default {
-             *       "status": "UNKNOWN",
-             *       "headline": "Source reconciliation unavailable",
-             *       "rows": [],
-             *       "decision": "Use deterministic data only where source agreement is understood."
-             *     }
-             */
-            source_reconciliation: components["schemas"]["SourceReconciliation"];
-            /**
-             * Signal Stack
-             * @default []
-             */
-            signal_stack: components["schemas"]["InsightSignalRow"][];
-            /**
-             * Flow Table
-             * @default []
-             */
-            flow_table: components["schemas"]["ChainFlowReadRow"][];
-            /**
-             * Term Structure Table
-             * @default []
-             */
-            term_structure_table: components["schemas"]["TermMoveRow"][];
             /**
              * Candidate Structures
              * @default []
              */
             candidate_structures: components["schemas"]["CandidateStructure"][];
             /**
+             * Flow Table
+             * @default []
+             */
+            flow_table: components["schemas"]["ChainFlowReadRow"][];
+            header: components["schemas"]["TradeInsightsHeader"];
+            /**
+             * Mode
+             * @default research
+             */
+            mode: string;
+            /**
+             * Signal Stack
+             * @default []
+             */
+            signal_stack: components["schemas"]["InsightSignalRow"][];
+            /**
              * @default {
-             *       "dominant_story": "",
+             *       "decision": "Use deterministic data only where source agreement is understood.",
+             *       "headline": "Source reconciliation unavailable",
+             *       "rows": [],
+             *       "status": "UNKNOWN"
+             *     }
+             */
+            source_reconciliation: components["schemas"]["SourceReconciliation"];
+            /**
+             * @default {
              *       "avoid": [],
+             *       "dominant_story": "",
              *       "required_before_sizing": []
              *     }
              */
             synthesis: components["schemas"]["InsightsSynthesis"];
+            /**
+             * Term Structure Table
+             * @default []
+             */
+            term_structure_table: components["schemas"]["TermMoveRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /** TradePlan */
         TradePlan: {
-            /** Structure */
-            structure: string;
             /** Direction */
             direction: string;
             /**
@@ -2082,21 +2082,17 @@ export interface components {
              * @default []
              */
             legs: components["schemas"]["TradePlanLeg"][];
-            /** Rationale */
-            rationale: string;
             /** Max Loss */
             max_loss?: string | null;
             /** Max Profit */
             max_profit?: string | null;
+            /** Rationale */
+            rationale: string;
+            /** Structure */
+            structure: string;
         };
         /** TradePlanLeg */
         TradePlanLeg: {
-            /** Option Symbol */
-            option_symbol: string;
-            /** Side */
-            side: string;
-            /** Strike */
-            strike: string;
             /**
              * Expiry
              * Format: date
@@ -2104,88 +2100,94 @@ export interface components {
             expiry: string;
             /** Mid */
             mid?: string | null;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** VRPAssessment */
         VRPAssessment: {
-            /** Vrp */
-            vrp?: string | null;
-            /** Signal */
-            signal: string;
             /** Note */
             note: string;
+            /** Signal */
+            signal: string;
+            /** Vrp */
+            vrp?: string | null;
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
         };
         /** VolHeaderBlock */
         VolHeaderBlock: {
+            /** Implied Move 30D Perc */
+            implied_move_30d_perc?: string | null;
             /** Iv */
             iv?: string | null;
-            /** Rv */
-            rv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
             /** Iv Rank */
             iv_rank?: string | null;
             /** Iv Rank 1Y */
             iv_rank_1y?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
+            /** Rv */
+            rv?: string | null;
             /** Rv High 52W */
             rv_high_52w?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
-            /** Implied Move 30D Perc */
-            implied_move_30d_perc?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /** Vrp */
             vrp?: string | null;
             /**
-             * Vrp Signal
-             * @default
-             */
-            vrp_signal: string;
-            /**
              * Vrp Note
              * @default
              */
             vrp_note: string;
+            /**
+             * Vrp Signal
+             * @default
+             */
+            vrp_signal: string;
         };
         /** VolatilityProfile */
         VolatilityProfile: {
-            /** Iv */
-            iv?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv */
-            rv?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
-            /** Rv High 52W */
-            rv_high_52w?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
             /** Implied Move 30D Perc */
             implied_move_30d_perc?: string | null;
+            /** Iv */
+            iv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
+            /** Rv */
+            rv?: string | null;
+            /** Rv High 52W */
+            rv_high_52w?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /**
@@ -2199,8 +2201,6 @@ export interface components {
         };
         /** VolatilitySeriesResponse */
         VolatilitySeriesResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * As Of
              * Format: date
@@ -2208,44 +2208,6 @@ export interface components {
             as_of: string;
             /** Backfill Status */
             backfill_status: string;
-            header: components["schemas"]["VolHeaderBlock"];
-            /**
-             * Term Structure
-             * @default []
-             */
-            term_structure: components["schemas"]["TermStructureExpiryRow"][];
-            /**
-             * Smile
-             * @default []
-             */
-            smile: components["schemas"]["SmileExpiryCurve"][];
-            /**
-             * Hv Iv History
-             * @default []
-             */
-            hv_iv_history: components["schemas"]["IvHvPoint"][];
-            /**
-             * @default {
-             *       "bins": []
-             *     }
-             */
-            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
-            /**
-             * Iv Of Iv
-             * @default []
-             */
-            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
-            /**
-             * Rv Spy Corr
-             * @default []
-             */
-            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
-            /**
-             * @default {
-             *       "points": []
-             *     }
-             */
-            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
             /**
              * Divergence
              * @default []
@@ -2256,6 +2218,48 @@ export interface components {
              * @default
              */
             divergence_headline: string;
+            header: components["schemas"]["VolHeaderBlock"];
+            /**
+             * Hv Iv History
+             * @default []
+             */
+            hv_iv_history: components["schemas"]["IvHvPoint"][];
+            /**
+             * Iv Of Iv
+             * @default []
+             */
+            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
+            /**
+             * @default {
+             *       "bins": []
+             *     }
+             */
+            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
+            /**
+             * @default {
+             *       "points": []
+             *     }
+             */
+            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
+            /**
+             * Rv Spy Corr
+             * @default []
+             */
+            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
+            /**
+             * Smile
+             * @default []
+             */
+            smile: components["schemas"]["SmileExpiryCurve"][];
+            /** Spot */
+            spot?: string | null;
+            /**
+             * Term Structure
+             * @default []
+             */
+            term_structure: components["schemas"]["TermStructureExpiryRow"][];
+            /** Ticker */
+            ticker: string;
             /**
              * Vrp Spread
              * @default []
@@ -2266,8 +2270,6 @@ export interface components {
              * @default
              */
             vrp_spread_headline: string;
-            /** Spot */
-            spot?: string | null;
         };
         /** VrpDailyPoint */
         VrpDailyPoint: {
@@ -2283,12 +2285,24 @@ export interface components {
         };
         /** WatchlistCard */
         WatchlistCard: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
+            /** Aggression Pct */
+            aggression_pct?: string | null;
+            gamma: components["schemas"]["GammaBlock"];
+            /** Iv Atm */
+            iv_atm?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
             /** Pinned */
             pinned: boolean;
+            positioning: components["schemas"]["PositioningBlock"];
+            queue?: components["schemas"]["QueueStatus"] | null;
+            returns: components["schemas"]["ReturnsBlock"];
+            /** Scanned At */
+            scanned_at?: string | null;
+            /** Sector */
+            sector: string;
+            setup: components["schemas"]["SetupBlock"];
+            skew: components["schemas"]["SkewBlock"];
             /** Sort Rank */
             sort_rank: number;
             /** Spot */
@@ -2297,27 +2311,11 @@ export interface components {
             spot_quoted_at?: string | null;
             /** Spot Source */
             spot_source?: string | null;
-            /** Scanned At */
-            scanned_at?: string | null;
-            /** Iv Atm */
-            iv_atm?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            setup: components["schemas"]["SetupBlock"];
-            /** Aggression Pct */
-            aggression_pct?: string | null;
-            returns: components["schemas"]["ReturnsBlock"];
-            gamma: components["schemas"]["GammaBlock"];
-            skew: components["schemas"]["SkewBlock"];
-            positioning: components["schemas"]["PositioningBlock"];
-            queue?: components["schemas"]["QueueStatus"] | null;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistMutation */
         WatchlistMutation: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
             /** Notes */
             notes?: string | null;
             /**
@@ -2325,41 +2323,56 @@ export interface components {
              * @default false
              */
             pinned: boolean;
+            /** Sector */
+            sector: string;
             /**
              * Sort Rank
              * @default 0
              */
             sort_rank: number;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistPatch */
         WatchlistPatch: {
-            /** Sector */
-            sector?: string | null;
             /** Notes */
             notes?: string | null;
             /** Pinned */
             pinned?: boolean | null;
+            /** Sector */
+            sector?: string | null;
             /** Sort Rank */
             sort_rank?: number | null;
         };
         /** WatchlistResponse */
         WatchlistResponse: {
-            /** Scanned At Min */
-            scanned_at_min?: string | null;
+            queue?: components["schemas"]["QueueSummary"];
             /** Scanned At Max */
             scanned_at_max?: string | null;
+            /** Scanned At Min */
+            scanned_at_min?: string | null;
             /** Scheduler Lag Seconds */
             scheduler_lag_seconds?: number | null;
-            /**
-             * @default {
-             *       "total": 0,
-             *       "queued": 0,
-             *       "running": 0
-             *     }
-             */
-            queue: components["schemas"]["QueueSummary"];
             /** Tickers */
             tickers: components["schemas"]["WatchlistCard"][];
+        };
+        /** WorkerHealth */
+        WorkerHealth: {
+            /** Heartbeat Name */
+            heartbeat_name: string;
+            /** Index */
+            index: number;
+            /** Label */
+            label: string;
+            /** Lag Seconds */
+            lag_seconds?: number | null;
+            /** Last Beat At */
+            last_beat_at?: string | null;
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "uw" | "massive";
         };
     };
     responses: never;
@@ -2404,13 +2417,74 @@ export interface operations {
             };
         };
     };
-    get_watchlist_api_watchlist_get: {
+    get_job_api_jobs__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ohlc_api_ohlc__ticker__get: {
         parameters: {
             query?: {
-                sector?: string | null;
-                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
-                setup?: string | null;
-                fresh_within_minutes?: number | null;
+                days?: number;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OhlcRow"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_endpoints_api_provider_usage_endpoints_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
             };
             header?: never;
             path?: never;
@@ -2424,7 +2498,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WatchlistResponse"];
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2438,84 +2512,19 @@ export interface operations {
             };
         };
     };
-    post_watchlist_api_watchlist_post: {
+    provider_usage_requests_api_provider_usage_requests_get: {
         parameters: {
-            query?: never;
+            query?: {
+                provider?: "uw" | "massive" | "all";
+                ticker?: string | null;
+                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistMutation"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_watchlist_api_watchlist__ticker__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
         requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    patch_watchlist_api_watchlist__ticker__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistPatch"];
-            };
-        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -2523,9 +2532,69 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_summary_api_provider_usage_summary_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_tickers_api_provider_usage_tickers_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2666,292 +2735,6 @@ export interface operations {
             };
         };
     };
-    get_ohlc_api_ohlc__ticker__get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OhlcRow"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_api_watchlist__ticker__rescan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_all_api_watchlist_rescan_all_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RescanAllRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_job_api_jobs__job_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_volatility_series_api_stock__ticker__volatility_series_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_summary_api_provider_usage_summary_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_endpoints_api_provider_usage_endpoints_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_tickers_api_provider_usage_tickers_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_requests_api_provider_usage_requests_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-                ticker?: string | null;
-                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_trade_insights_api_stock__ticker__trade_insights_get: {
         parameters: {
             query?: never;
@@ -3068,6 +2851,236 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TradeInsightAiAnalysisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_volatility_series_api_stock__ticker__volatility_series_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_watchlist_api_watchlist_get: {
+        parameters: {
+            query?: {
+                sector?: string | null;
+                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
+                setup?: string | null;
+                fresh_within_minutes?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_watchlist_api_watchlist_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistMutation"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enqueue_rescan_all_api_watchlist_rescan_all_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RescanAllRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_watchlist_api_watchlist__ticker__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_watchlist_api_watchlist__ticker__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistPatch"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    enqueue_rescan_api_watchlist__ticker__rescan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -39,6 +39,11 @@ describe("HealthPanel", () => {
       http_5xx: 1,
       uw_today: 40,
       cache_hit_pct: null,
+      throughput_window_minutes: 15,
+      requests_per_minute: 12.4,
+      http_429: 2,
+      avg_scan_duration_seconds: 125,
+      queue_drain_rate_per_minute: 1.6,
       record_health_ok: true,
       record_health: [],
       workers: [
@@ -89,7 +94,7 @@ describe("HealthPanel", () => {
     expect(screen.getByText("Query Coverage")).toBeTruthy();
     expect(screen.getByText("OK")).toBeTruthy();
     expect(screen.getByText("Last spot")).toBeTruthy();
-    expect(screen.getByText("1m")).toBeTruthy();
+    expect(screen.getAllByText("1m").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("ONLINE").length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText("1/2")).toHaveLength(2);
     expect(screen.getByText("05/14 22:20 HKG")).toBeTruthy();
@@ -97,6 +102,10 @@ describe("HealthPanel", () => {
     expect(screen.getByDisplayValue("UnusualWhales")).toBeTruthy();
     expect(screen.getByText("UnusualWhales")).toBeTruthy();
     expect(screen.getByText("88ms")).toBeTruthy();
+    expect(screen.getByText("12.4/m")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("2m")).toBeTruthy();
+    expect(screen.getByText("1.6/m")).toBeTruthy();
     expect(screen.getByText("120")).toBeTruthy();
     expect(screen.getByText("3")).toBeTruthy();
     expect(screen.getByText("1")).toBeTruthy();
@@ -125,6 +134,7 @@ describe("HealthPanel", () => {
       http_5xx: null,
       uw_today: null,
       cache_hit_pct: null,
+      throughput_window_minutes: 15,
       record_health_ok: null,
       record_health: [],
       workers: [],
@@ -160,6 +170,7 @@ describe("HealthPanel", () => {
         http_5xx: 1,
         uw_today: 40,
         cache_hit_pct: null,
+        throughput_window_minutes: 15,
         record_health_ok: true,
         record_health: [],
       })
@@ -185,6 +196,7 @@ describe("HealthPanel", () => {
         http_5xx: 2,
         uw_today: null,
         cache_hit_pct: null,
+        throughput_window_minutes: 15,
         record_health_ok: true,
         record_health: [],
       });
@@ -236,6 +248,7 @@ describe("HealthPanel", () => {
       http_5xx: 0,
       uw_today: 40,
       cache_hit_pct: null,
+      throughput_window_minutes: 15,
       record_health_ok: false,
       record_health: [
         {

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -41,20 +41,57 @@ describe("HealthPanel", () => {
       cache_hit_pct: null,
       record_health_ok: true,
       record_health: [],
+      workers: [
+        {
+          label: "UW 1",
+          role: "uw",
+          index: 0,
+          heartbeat_name: "worker:uw:0",
+          lag_seconds: 1,
+          last_beat_at: "2026-05-14T14:20:41Z",
+        },
+        {
+          label: "UW 2",
+          role: "uw",
+          index: 1,
+          heartbeat_name: "worker:uw:1",
+          lag_seconds: null,
+          last_beat_at: null,
+        },
+        {
+          label: "Massive 1",
+          role: "massive",
+          index: 0,
+          heartbeat_name: "worker:massive:0",
+          lag_seconds: 240,
+          last_beat_at: "2026-05-14T14:16:42Z",
+        },
+        {
+          label: "Massive 2",
+          role: "massive",
+          index: 1,
+          heartbeat_name: "worker:massive:1",
+          lag_seconds: 700,
+          last_beat_at: "2026-05-14T14:09:02Z",
+        },
+      ],
     });
 
     render(<HealthPanel />);
 
     await waitFor(() => expect(screen.getByText("API")).toBeTruthy());
     expect(screen.getByText("Scheduler")).toBeTruthy();
-    expect(screen.getByText("UW Worker")).toBeTruthy();
-    expect(screen.getByText("Massive Worker")).toBeTruthy();
+    expect(screen.getByText("UW Workers")).toBeTruthy();
+    expect(screen.getByText("Massive Workers")).toBeTruthy();
+    expect(screen.queryByText("UW 1")).toBeNull();
+    expect(screen.queryByText("Massive 1")).toBeNull();
+    expect(screen.queryByText("UW Worker")).toBeNull();
     expect(screen.getByText("Query Coverage")).toBeTruthy();
     expect(screen.getByText("OK")).toBeTruthy();
     expect(screen.getByText("Last spot")).toBeTruthy();
     expect(screen.getByText("1m")).toBeTruthy();
-    expect(screen.getAllByText("ONLINE").length).toBeGreaterThanOrEqual(3);
-    expect(screen.getByText("STALE")).toBeTruthy();
+    expect(screen.getAllByText("ONLINE").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("1/2")).toHaveLength(2);
     expect(screen.getByText("05/14 22:20 HKG")).toBeTruthy();
     expect(screen.queryByText("2026/05/14 22:20:42 HKG")).toBeNull();
     expect(screen.getByDisplayValue("UnusualWhales")).toBeTruthy();
@@ -90,6 +127,7 @@ describe("HealthPanel", () => {
       cache_hit_pct: null,
       record_health_ok: null,
       record_health: [],
+      workers: [],
     });
 
     render(<HealthPanel />);


### PR DESCRIPTION
## Summary
- split UW and Massive workers into separate sharded worker pools
- fold worker pool status in the health panel
- add provider throughput telemetry for requests/min, 429s, average scan duration, and queue drain rate

## Verification
- uv run pytest tests/unit/worker/test_scheduler.py tests/unit/worker/test_worker_sharding.py tests/integration/worker/test_worker_jobs.py -q
- uv run pytest tests/integration/storage/test_repository_watchlist.py::test_requeue_stale_running_jobs tests/integration/worker/test_worker_jobs.py::test_rescan_tick_recovers_stale_running_job -q
- uv run pytest tests/integration/storage/test_provider_usage_repository.py::test_throughput_summary_counts_provider_and_queue_rates tests/integration/api/test_health.py::test_health_includes_throughput_metrics tests/integration/api/test_openapi_snapshot.py -q
- uv run ruff check src/ tests/ scripts/
- uv run python scripts/_lint_except.py src
- cd web && npm run test -- healthPanel.test.tsx
- cd web && npm run typecheck
- cd web && npm run lint