### PR TITLE
Order watchlist cards by size

### DIFF
--- a/src/uw_scan/api/endpoints.py
+++ b/src/uw_scan/api/endpoints.py
@@ -30,6 +30,7 @@ class EndpointSlug(StrEnum):
     DARKPOOL_TICKER = "darkpool_ticker"
     SHORT_DATA = "short_data"
     BULK_SCREENER_STOCKS = "bulk_screener_stocks"
+    ETF_INFO = "etf_info"
     OPTIONS_VOLUME_DAILY = "options_volume_daily"
 
 
@@ -102,6 +103,9 @@ REGISTRY: dict[EndpointSlug, Endpoint] = {
     ),
     EndpointSlug.BULK_SCREENER_STOCKS: Endpoint(
         EndpointSlug.BULK_SCREENER_STOCKS, "/api/screener/stocks", ()
+    ),
+    EndpointSlug.ETF_INFO: Endpoint(
+        EndpointSlug.ETF_INFO, "/api/etfs/{ticker}/info", ()
     ),
     EndpointSlug.OPTIONS_VOLUME_DAILY: Endpoint(
         EndpointSlug.OPTIONS_VOLUME_DAILY,

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -16,7 +16,6 @@ from uw_scan.storage.repository import Repository, provider_day_bounds
 router = APIRouter()
 
 HealthSource = Literal["uw", "massive"]
-THROUGHPUT_WINDOW_MINUTES = 15
 
 
 def _source_label(source: HealthSource) -> str:
@@ -48,7 +47,7 @@ class HealthResponse(BaseModel):
     http_5xx: int | None = None
     uw_today: int | None = None
     cache_hit_pct: float | None = None
-    throughput_window_minutes: int = THROUGHPUT_WINDOW_MINUTES
+    throughput_window_minutes: float = 0.0
     requests_per_minute: float | None = None
     http_429: int | None = None
     avg_scan_duration_seconds: float | None = None
@@ -197,7 +196,7 @@ def health(
     )
     throughput = repo.get_throughput_summary(
         source,
-        now_utc - timedelta(minutes=THROUGHPUT_WINDOW_MINUTES),
+        provider_day_start,
         now_utc,
     )
     provider_fields = {
@@ -207,7 +206,7 @@ def health(
         "http_4xx": provider_usage.http_4xx,
         "http_5xx": provider_usage.http_5xx,
         "uw_today": provider_usage.uw_latest_daily_count,
-        "throughput_window_minutes": THROUGHPUT_WINDOW_MINUTES,
+        "throughput_window_minutes": throughput.window_minutes,
         "requests_per_minute": throughput.requests_per_minute,
         "http_429": throughput.http_429,
         "avg_scan_duration_seconds": throughput.avg_scan_duration_seconds,

--- a/src/uw_scan/api/routers/watchlist.py
+++ b/src/uw_scan/api/routers/watchlist.py
@@ -47,6 +47,8 @@ def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
         scanned_at=row.scanned_at,
         iv_atm=row.iv_atm,
         iv_rank=row.iv_rank,
+        market_cap=row.market_cap,
+        aum=row.aum,
         setup=SetupBlock(
             type=row.setup_type,
             direction=row.setup_direction,

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -70,6 +70,8 @@ class WatchlistCard(BaseModel):
 
     iv_atm: Decimal | None = None
     iv_rank: Decimal | None = None
+    market_cap: Decimal | None = None
+    aum: Decimal | None = None
 
     setup: SetupBlock
     aggression_pct: Decimal | None = None

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -481,6 +481,13 @@ class BulkScreenerRow(_UwBase):
     cum_dir_vega: int | None = None
 
 
+class EtfInfo(_UwBase):
+    aum: Decimal | None = None
+    name: str | None = None
+    avg30_volume: Decimal | None = None
+    has_options: bool | None = None
+
+
 class ScanTickerResult(_UwBase):
     """One row in the Full Scan output. Ranked by `score` desc."""
 
@@ -535,6 +542,8 @@ class MarketAggregates(_UwBase):
     pcr_oi: Decimal | None = None
     pcr_vol: Decimal | None = None
     iv30d: Decimal | None = None
+    market_cap: Decimal | None = None
+    aum: Decimal | None = None
 
 
 class StrikeGexBucket(_UwBase):

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from .models import (
     BulkScreenerRow,
     DarkPoolPrint,
+    EtfInfo,
     FlowAlert,
     GreekExposureRow,
     GreeksRow,
@@ -181,6 +182,19 @@ def normalize_bulk_screener(payload: dict) -> list[BulkScreenerRow]:
             f"bulk_screener payload['data'] expected list, got {type(raw).__name__}"
         )
     return [BulkScreenerRow(**r) for r in raw]
+
+
+def normalize_etf_info(payload: dict) -> EtfInfo:
+    if "data" not in payload:
+        raise NormalizationError(
+            f"etf_info payload missing 'data' key; got {list(payload.keys())}"
+        )
+    raw = payload["data"]
+    if not isinstance(raw, dict):
+        raise NormalizationError(
+            f"etf_info payload['data'] expected object, got {type(raw).__name__}"
+        )
+    return EtfInfo(**raw)
 
 
 # ---------------------------------------------------------------------------

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -258,6 +258,13 @@ def run_single_stock(
             client, repo, run_id, ticker
         )
         if screener_row is not None:
+            etf_aum = None
+            if (screener_row.issue_type or "").upper() == "ETF":
+                try:
+                    etf_info = uw_sources.fetch_etf_info(client, repo, run_id, ticker)
+                    etf_aum = etf_info.aum
+                except Exception as exc:  # noqa: BLE001 — card sort hint only
+                    logger.warning("ETF info fetch failed for %s: %s", ticker, repr(exc))
             pcr_vol = None
             if screener_row.put_volume and screener_row.call_volume:
                 pcr_vol = Decimal(screener_row.put_volume) / Decimal(
@@ -275,6 +282,8 @@ def run_single_stock(
                 pcr_oi=screener_row.put_call_ratio,
                 pcr_vol=pcr_vol,
                 iv30d=screener_row.iv30d,
+                market_cap=screener_row.marketcap,
+                aum=etf_aum,
             )
             report.aggregates = aggregates
             repo.set_aggregates(run_id, aggregates)

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -16,6 +16,7 @@ from ..api.endpoints import EndpointSlug, build_path
 from ..models import (
     BulkScreenerRow,
     DarkPoolPrint,
+    EtfInfo,
     FlowAlert,
     GreekExposureRow,
     GreeksRow,
@@ -363,3 +364,13 @@ def fetch_bulk_screener_ticker(
     )
     rows = normalize.normalize_bulk_screener(body)
     return rows[0] if rows else None
+
+
+def fetch_etf_info(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> EtfInfo:
+    body = _fetch_json(client, repo, run_id, EndpointSlug.ETF_INFO, ticker)
+    return normalize.normalize_etf_info(body)

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -2554,6 +2554,38 @@ class Repository:
                     ) AS queue_position
                   FROM {self._schema}.jobs
                   WHERE status IN ('queued', 'running')
+                ),
+                latest_market_caps AS (
+                  SELECT DISTINCT ON (ticker)
+                    ticker,
+                    marketcap
+                  FROM {self._schema}.scan_results
+                  WHERE marketcap IS NOT NULL
+                  ORDER BY ticker, run_id DESC
+                ),
+                latest_screener_sizes AS (
+                  SELECT DISTINCT ON (r.ticker)
+                    r.ticker,
+                    p.payload_jsonb->'data'->0->>'marketcap' AS market_cap
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE a.endpoint_slug = 'bulk_screener_stocks'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'array'
+                    AND p.payload_jsonb->'data'->0->>'marketcap' IS NOT NULL
+                  ORDER BY r.ticker, r.run_id DESC
+                ),
+                latest_etf_aum AS (
+                  SELECT DISTINCT ON (r.ticker)
+                    r.ticker,
+                    p.payload_jsonb->'data'->>'aum' AS aum
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE a.endpoint_slug = 'etf_info'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'object'
+                    AND p.payload_jsonb->'data'->>'aum' IS NOT NULL
+                  ORDER BY r.ticker, r.run_id DESC
                 )
                 SELECT
                   w.ticker, w.sector, w.pinned, w.sort_rank,
@@ -2580,6 +2612,12 @@ class Repository:
                   c.setup_type, c.setup_direction, c.setup_score,
                   c.aggression_pct,
                   c.ret_1d, c.ret_1w, c.ret_30d,
+                  COALESCE(
+                    sr.aggregates->>'market_cap',
+                    lmc.marketcap::text,
+                    lss.market_cap
+                  ) AS market_cap,
+                  COALESCE(sr.aggregates->>'aum', lea.aum) AS aum,
                   c.gex_flip_distance, c.gex_flip_price, c.gex_per_1pct_move,
                   c.max_gex_strike, c.gex_expiring_pct, c.gex_expiring_date,
                   c.skew_25d_30dte,
@@ -2592,6 +2630,10 @@ class Repository:
                   j.started_at AS active_job_started_at
                 FROM {self._schema}.watchlist w
                 LEFT JOIN {self._schema}.watchlist_card c ON w.ticker = c.ticker
+                LEFT JOIN {self._schema}.scan_runs sr ON c.run_id = sr.run_id
+                LEFT JOIN latest_market_caps lmc ON w.ticker = lmc.ticker
+                LEFT JOIN latest_screener_sizes lss ON w.ticker = lss.ticker
+                LEFT JOIN latest_etf_aum lea ON w.ticker = lea.ticker
                 LEFT JOIN {self._schema}.intraday_quote q ON w.ticker = q.ticker
                 LEFT JOIN active_jobs j ON w.ticker = j.ticker
                 WHERE w.removed_at IS NULL

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -516,13 +516,13 @@ class Repository:
         self, provider: str | None, start: datetime, end: datetime
     ) -> ThroughputSummaryRow:
         provider_filter = None if provider in (None, "all") else provider
-        window_minutes = max((end - start).total_seconds() / 60.0, 1 / 60)
         with self._conn.cursor() as cur:
             cur.execute(
                 f"""
                 SELECT
                   count(*)::int AS total_requests,
-                  count(*) FILTER (WHERE status_code = 429)::int AS http_429
+                  count(*) FILTER (WHERE status_code = 429)::int AS http_429,
+                  min(request_started_at) AS first_request_at
                 FROM {self._schema}.external_api_requests
                 WHERE request_started_at >= %s
                   AND request_started_at < %s
@@ -536,6 +536,7 @@ class Repository:
             cur.execute(
                 f"""
                 SELECT avg(extract(epoch FROM finished_at - started_at))
+                     , min(started_at)
                 FROM {self._schema}.scan_runs
                 WHERE finished_at >= %s
                   AND finished_at < %s
@@ -550,7 +551,7 @@ class Repository:
 
             cur.execute(
                 f"""
-                SELECT count(*)::int
+                SELECT count(*)::int, min(requested_at)
                 FROM {self._schema}.jobs
                 WHERE finished_at >= %s
                   AND finished_at < %s
@@ -563,12 +564,16 @@ class Repository:
 
         total_requests = int(request_row[0])
         drained_jobs = int(queue_row[0])
+        active_starts = [request_row[2], scan_row[1], queue_row[1]]
+        first_activity = min((ts for ts in active_starts if ts is not None), default=start)
+        active_start = max(start, first_activity)
+        active_window_minutes = max((end - active_start).total_seconds() / 60.0, 1 / 60)
         return ThroughputSummaryRow(
-            window_minutes=window_minutes,
-            requests_per_minute=total_requests / window_minutes,
+            window_minutes=active_window_minutes,
+            requests_per_minute=total_requests / active_window_minutes,
             http_429=int(request_row[1]),
             avg_scan_duration_seconds=_nullable_float(scan_row[0]),
-            queue_drain_rate_per_minute=drained_jobs / window_minutes,
+            queue_drain_rate_per_minute=drained_jobs / active_window_minutes,
         )
 
     def list_external_api_endpoint_usage(

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1027,9 +1027,9 @@
             "title": "Spot Refresh Heartbeat Lag Seconds"
           },
           "throughput_window_minutes": {
-            "default": 15,
+            "default": 0.0,
             "title": "Throughput Window Minutes",
-            "type": "integer"
+            "type": "number"
           },
           "uw_today": {
             "anyOf": [

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1500,6 +1500,30 @@
             ],
             "title": "Iv30D"
           },
+          "market_cap": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Cap"
+          },
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
           "pcr_oi": {
             "anyOf": [
               {
@@ -5951,6 +5975,30 @@
               }
             ],
             "title": "Iv Rank"
+          },
+          "market_cap": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Cap"
+          },
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
           },
           "pinned": {
             "title": "Pinned",

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -171,7 +171,7 @@ def test_health_includes_throughput_metrics(client, seeded_db_with_cards):
 
     assert r.status_code == 200
     body = r.json()
-    assert body["throughput_window_minutes"] == 15
+    assert body["throughput_window_minutes"] > 0
     assert body["requests_per_minute"] > 0
     assert body["http_429"] == 1
     assert body["avg_scan_duration_seconds"] is not None

--- a/tests/unit/test_models_aggregates.py
+++ b/tests/unit/test_models_aggregates.py
@@ -14,6 +14,8 @@ def test_market_aggregates_defaults_to_none():
     assert agg.put_oi_total is None
     assert agg.pcr_oi is None
     assert agg.pcr_vol is None
+    assert agg.market_cap is None
+    assert agg.aum is None
 
 
 def test_market_aggregates_construct_from_screener_fields():
@@ -29,9 +31,13 @@ def test_market_aggregates_construct_from_screener_fields():
         pcr_oi=Decimal("2.00"),
         pcr_vol=Decimal("1.60"),
         iv30d=Decimal("0.42"),
+        market_cap=Decimal("1500000000000"),
+        aum=Decimal("428887833900"),
     )
     assert agg.pcr_oi == Decimal("2.00")
     assert agg.iv30d == Decimal("0.42")
+    assert agg.market_cap == Decimal("1500000000000")
+    assert agg.aum == Decimal("428887833900")
 
 
 def test_strike_gex_bucket_round_trip():

--- a/tests/unit/test_uw_sources_bulk_screener_ticker.py
+++ b/tests/unit/test_uw_sources_bulk_screener_ticker.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from uw_scan.models import BulkScreenerRow
+from uw_scan.models import BulkScreenerRow, EtfInfo
 from uw_scan.sources import uw as uw_sources
 
 
@@ -58,3 +58,18 @@ def test_fetch_bulk_screener_ticker_returns_none_when_empty():
             client, repo, run_id=42, ticker="ZZZZ"
         )
     assert row is None
+
+
+def test_fetch_etf_info_returns_aum():
+    client = MagicMock()
+    repo = MagicMock()
+    with patch.object(
+        uw_sources,
+        "_fetch_json",
+        return_value={"data": {"aum": "428887833900", "name": "SPDR S&P 500 ETF"}},
+    ) as mock_fetch:
+        row = uw_sources.fetch_etf_info(client, repo, run_id=42, ticker="SPY")
+
+    assert isinstance(row, EtfInfo)
+    assert row.aum == Decimal("428887833900")
+    assert mock_fetch.call_args.args[3] == uw_sources.EndpointSlug.ETF_INFO

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -234,15 +234,11 @@ export function HealthPanel() {
         <span style={valStyle}>{dash(h?.watchlist_size)}</span>
       </div>
       <div style={rowStyle}>
-        <span style={labelStyle}>Cache Hit</span>
-        <span style={valStyle}>{dash(h?.cache_hit_pct, "%")}</span>
-      </div>
-      <div style={rowStyle}>
         <span style={labelStyle}>Latency p95</span>
         <span style={valStyle}>{dash(h?.latency_p95_ms, "ms")}</span>
       </div>
       <div style={rowStyle}>
-        <span style={labelStyle}>Req/min</span>
+        <span style={labelStyle}>Req avg/min</span>
         <span style={valStyle}>{fmtRate(h?.requests_per_minute)}</span>
       </div>
       <div style={rowStyle}>
@@ -254,7 +250,7 @@ export function HealthPanel() {
         <span style={valStyle}>{fmtDuration(h?.avg_scan_duration_seconds)}</span>
       </div>
       <div style={rowStyle}>
-        <span style={labelStyle}>Queue/min</span>
+        <span style={labelStyle}>Queue avg/min</span>
         <span style={valStyle}>{fmtRate(h?.queue_drain_rate_per_minute)}</span>
       </div>
       <div style={rowStyle}>

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -5,6 +5,44 @@ import { TickerCard } from "./TickerCard";
 type WatchlistCard = components["schemas"]["WatchlistCard"];
 type WatchlistResponse = components["schemas"]["WatchlistResponse"];
 
+const PRIORITY_SECTORS = ["ETF", "M7", "Semiconductor"] as const;
+
+function sectorRank(sector: string, tickers: WatchlistCard[]) {
+  const priority = PRIORITY_SECTORS.indexOf(
+    sector as (typeof PRIORITY_SECTORS)[number],
+  );
+  if (priority >= 0) return priority;
+  return (
+    PRIORITY_SECTORS.length +
+    Math.min(...tickers.map((t) => t.sort_rank), Number.MAX_SAFE_INTEGER)
+  );
+}
+
+function sizeValue(card: WatchlistCard) {
+  const raw =
+    card.sector === "ETF"
+      ? (card.aum ?? card.market_cap)
+      : (card.market_cap ?? card.aum);
+  if (raw == null) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function compareCards(a: WatchlistCard, b: WatchlistCard) {
+  const aSize = sizeValue(a);
+  const bSize = sizeValue(b);
+  if (aSize !== null && bSize !== null && aSize !== bSize) {
+    return bSize - aSize;
+  }
+  if (aSize !== null) return -1;
+  if (bSize !== null) return 1;
+  return (
+    Number(b.pinned) - Number(a.pinned) ||
+    a.sort_rank - b.sort_rank ||
+    a.ticker.localeCompare(b.ticker)
+  );
+}
+
 export function CardGrid({
   data,
   sparklines,
@@ -19,12 +57,17 @@ export function CardGrid({
     grouped.set(t.sector, arr);
   }
   for (const arr of grouped.values()) {
-    arr.sort((a, b) => Number(b.pinned) - Number(a.pinned));
+    arr.sort(compareCards);
   }
+  const groupedEntries = [...grouped.entries()].sort(
+    ([sectorA, tickersA], [sectorB, tickersB]) =>
+      sectorRank(sectorA, tickersA) - sectorRank(sectorB, tickersB) ||
+      sectorA.localeCompare(sectorB),
+  );
 
   return (
     <div>
-      {[...grouped.entries()].map(([sector, tickers]) => (
+      {groupedEntries.map(([sector, tickers]) => (
         <section key={sector} style={{ marginBottom: 28 }}>
           <h2
             style={{

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -791,6 +791,8 @@ export interface components {
          *     sub-models. Feeds the watchlist card POSITIONING and SKEW blocks.
          */
         MarketAggregates: {
+            /** Aum */
+            aum?: string | null;
             /** Call Oi Total */
             call_oi_total?: number | null;
             /** Call Volume Ask Side */
@@ -801,6 +803,8 @@ export interface components {
             call_volume_total?: number | null;
             /** Iv30D */
             iv30d?: string | null;
+            /** Market Cap */
+            market_cap?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
@@ -2300,11 +2304,15 @@ export interface components {
         WatchlistCard: {
             /** Aggression Pct */
             aggression_pct?: string | null;
+            /** Aum */
+            aum?: string | null;
             gamma: components["schemas"]["GammaBlock"];
             /** Iv Atm */
             iv_atm?: string | null;
             /** Iv Rank */
             iv_rank?: string | null;
+            /** Market Cap */
+            market_cap?: string | null;
             /** Pinned */
             pinned: boolean;
             positioning: components["schemas"]["PositioningBlock"];

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -637,7 +637,7 @@ export interface components {
             spot_refresh_heartbeat_lag_seconds?: number | null;
             /**
              * Throughput Window Minutes
-             * @default 15
+             * @default 0
              */
             throughput_window_minutes: number;
             /** Uw Today */

--- a/web/tests/unit/cardGrid.test.tsx
+++ b/web/tests/unit/cardGrid.test.tsx
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CardGrid } from "@/components/watchlist/CardGrid";
+
+vi.mock("@/components/watchlist/TickerCard", () => ({
+  TickerCard: ({ card }: { card: { ticker: string } }) => (
+    <div data-testid="ticker-card">{card.ticker}</div>
+  ),
+}));
+
+const baseCard = {
+  pinned: false,
+  spot: null,
+  spot_quoted_at: null,
+  spot_source: null,
+  scanned_at: null,
+  iv_atm: null,
+  iv_rank: null,
+  setup: { type: null, direction: null, score: null },
+  aggression_pct: null,
+  returns: { d1: null, w1: null, d30: null },
+  gamma: {
+    flip_distance: null,
+    flip_price: null,
+    per_1pct_move: null,
+    max_strike: null,
+    expiring_pct: null,
+    expiring_date: null,
+  },
+  skew: { rr25d_30dte: null },
+  positioning: {
+    call_oi: null,
+    put_oi: null,
+    pcr_oi: null,
+    pcr_vol: null,
+    pcr_delta_30d: null,
+  },
+  queue: null,
+};
+
+function card(
+  ticker: string,
+  sector: string,
+  sortRank: number,
+  marketCap: string | null,
+  aum: string | null = null,
+) {
+  return {
+    ...baseCard,
+    ticker,
+    sector,
+    sort_rank: sortRank,
+    market_cap: marketCap,
+    aum,
+  };
+}
+
+describe("CardGrid", () => {
+  it("orders all-sector groups by dashboard priority and cards by market cap", () => {
+    render(
+      <CardGrid
+        data={{
+          scanned_at_min: null,
+          scanned_at_max: null,
+          scheduler_lag_seconds: null,
+          queue: { total: 0, queued: 0, running: 0, oldest_requested_at: null },
+          tickers: [
+            card("UNH", "Healthcare", 0, "500"),
+            card("HUT", "NeoCloud", 0, "4"),
+            card("AMD", "Semiconductor", 301, "300"),
+            card("TSLA", "M7", 206, "900"),
+            card("QQQ", "ETF", 102, "250", "600"),
+            card("AAPL", "M7", 201, "3000"),
+            card("SPY", "ETF", 101, "500", "400"),
+            card("AVGO", "Semiconductor", 302, "1200"),
+          ],
+        }}
+        sparklines={{}}
+      />,
+    );
+
+    expect(screen.getAllByRole("heading").map((h) => h.textContent)).toEqual([
+      "ETF · 2",
+      "M7 · 2",
+      "Semiconductor · 2",
+      "Healthcare · 1",
+      "NeoCloud · 1",
+    ]);
+
+    const sections = screen.getAllByRole("heading").map((heading) => {
+      const section = heading.closest("section");
+      expect(section).not.toBeNull();
+      return within(section as HTMLElement)
+        .getAllByTestId("ticker-card")
+        .map((item) => item.textContent);
+    });
+
+    expect(sections).toEqual([
+      ["QQQ", "SPY"],
+      ["AAPL", "TSLA"],
+      ["AVGO", "AMD"],
+      ["UNH"],
+      ["HUT"],
+    ]);
+  });
+});

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -101,6 +101,9 @@ describe("HealthPanel", () => {
     expect(screen.queryByText("2026/05/14 22:20:42 HKG")).toBeNull();
     expect(screen.getByDisplayValue("UnusualWhales")).toBeTruthy();
     expect(screen.getByText("UnusualWhales")).toBeTruthy();
+    expect(screen.queryByText("Cache Hit")).toBeNull();
+    expect(screen.getByText("Req avg/min")).toBeTruthy();
+    expect(screen.getByText("Queue avg/min")).toBeTruthy();
     expect(screen.getByText("88ms")).toBeTruthy();
     expect(screen.getByText("12.4/m")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();


### PR DESCRIPTION
## Summary
- order dashboard groups with ETF, M7, and Semiconductor first
- expose stock market cap and ETF AUM/size data to card payloads
- sort ETF cards by AUM first, falling back to screener size, and sort non-ETF groups by market cap
- average sidebar provider throughput stats over the active provider-day/runtime window and remove the unwired Cache Hit row

## Validation
- uv run pytest tests/unit/test_models_aggregates.py tests/unit/cards/test_derive.py tests/unit/test_uw_sources_bulk_screener_ticker.py tests/integration/api/test_openapi_snapshot.py -q
- uv run pytest tests/integration/api/test_health.py tests/integration/api/test_openapi_snapshot.py tests/integration/storage/test_provider_usage_repository.py -q
- npm run test -- cardGrid.test.tsx
- npm run test -- healthPanel.test.tsx
- npm run typecheck
- Playwright live DOM checks for dashboard ordering and sidebar health labels