### PR TITLE
fix(watchlist): pin cards first within sector + pin/unpin UI + CardGrid cleanup

### DIFF
--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -29,6 +29,9 @@ function sizeValue(card: WatchlistCard) {
 }
 
 function compareCards(a: WatchlistCard, b: WatchlistCard) {
+  const pinDiff = Number(b.pinned) - Number(a.pinned);
+  if (pinDiff !== 0) return pinDiff;
+
   const aSize = sizeValue(a);
   const bSize = sizeValue(b);
   if (aSize !== null && bSize !== null && aSize !== bSize) {
@@ -36,11 +39,8 @@ function compareCards(a: WatchlistCard, b: WatchlistCard) {
   }
   if (aSize !== null) return -1;
   if (bSize !== null) return 1;
-  return (
-    Number(b.pinned) - Number(a.pinned) ||
-    a.sort_rank - b.sort_rank ||
-    a.ticker.localeCompare(b.ticker)
-  );
+
+  return a.sort_rank - b.sort_rank || a.ticker.localeCompare(b.ticker);
 }
 
 export function CardGrid({

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -1,12 +1,11 @@
 "use client";
 import type { components } from "@/lib/types";
 import { toNum } from "@/lib/formatters";
+import { PRIORITY_SECTORS } from "./sectorGroups";
 import { TickerCard } from "./TickerCard";
 
 type WatchlistCard = components["schemas"]["WatchlistCard"];
 type WatchlistResponse = components["schemas"]["WatchlistResponse"];
-
-const PRIORITY_SECTORS = ["ETF", "M7", "Semiconductor"] as const;
 
 function sectorRank(sector: string, tickers: WatchlistCard[]) {
   const priority = PRIORITY_SECTORS.indexOf(

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -1,4 +1,3 @@
-"use client";
 import type { components } from "@/lib/types";
 import { toNum } from "@/lib/formatters";
 import { PRIORITY_SECTORS } from "./sectorGroups";

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
 import { TickerCard } from "./TickerCard";
 
 type WatchlistCard = components["schemas"]["WatchlistCard"];
@@ -23,9 +24,7 @@ function sizeValue(card: WatchlistCard) {
     card.sector === "ETF"
       ? (card.aum ?? card.market_cap)
       : (card.market_cap ?? card.aum);
-  if (raw == null) return null;
-  const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
+  return toNum(raw);
 }
 
 function compareCards(a: WatchlistCard, b: WatchlistCard) {

--- a/web/components/watchlist/PinButton.tsx
+++ b/web/components/watchlist/PinButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Pin } from "lucide-react";
+import { api } from "@/lib/api";
+
+export function PinButton({
+  ticker,
+  pinned,
+}: {
+  ticker: string;
+  pinned: boolean;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  const toggle = async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      await api.patchTicker(ticker, { pinned: !pinned });
+      router.refresh();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={pending}
+      aria-label={pinned ? `Unpin ${ticker}` : `Pin ${ticker}`}
+      aria-pressed={pinned}
+      title={pinned ? "Unpin" : "Pin to top of sector"}
+      style={{
+        background: "transparent",
+        border: 0,
+        cursor: pending ? "wait" : "pointer",
+        padding: 4,
+        marginRight: 4,
+        color: pinned ? "var(--warning)" : "var(--text-muted)",
+        opacity: pending ? 0.5 : 1,
+        display: "inline-flex",
+        alignItems: "center",
+      }}
+    >
+      <Pin size={14} fill={pinned ? "currentColor" : "none"} />
+    </button>
+  );
+}

--- a/web/components/watchlist/TickerCard.tsx
+++ b/web/components/watchlist/TickerCard.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/formatters";
 import { bucketFreshness } from "@/lib/freshness";
 import { RescanButton } from "@/components/shared/RescanButton";
+import { PinButton } from "./PinButton";
 
 type Card = components["schemas"]["WatchlistCard"];
 type Props = { card: Card; sparkline: number[] };
@@ -190,13 +191,18 @@ export function TickerCard({ card, sparkline }: Props) {
           <div>spot {fmtDateTimeWithZone(card.spot_quoted_at)}</div>
           <div>
             analytics{" "}
-            {card.scanned_at ? fmtDateTimeWithZone(card.scanned_at) : "not scanned"}
+            {card.scanned_at
+              ? fmtDateTimeWithZone(card.scanned_at)
+              : "not scanned"}
           </div>
           {queueLabel && (
             <div style={{ color: "var(--warning)" }}>{queueLabel}</div>
           )}
         </div>
-        <RescanButton ticker={card.ticker} initialJob={card.queue ?? null} />
+        <div style={{ display: "flex", alignItems: "center" }}>
+          <PinButton ticker={card.ticker} pinned={card.pinned} />
+          <RescanButton ticker={card.ticker} initialJob={card.queue ?? null} />
+        </div>
       </div>
       {showNotReady && (
         <StockNotReadyDialog

--- a/web/components/watchlist/sectorGroups.ts
+++ b/web/components/watchlist/sectorGroups.ts
@@ -30,3 +30,5 @@ export const SECTOR_ROWS: { label: string; items: string[] }[] = [
 export const WATCHLIST_SECTORS = SECTOR_ROWS.flatMap((row) =>
   row.items.filter((item) => item !== "All"),
 );
+
+export const PRIORITY_SECTORS = ["ETF", "M7", "Semiconductor"] as const;

--- a/web/tests/e2e/pin-toggle.spec.ts
+++ b/web/tests/e2e/pin-toggle.spec.ts
@@ -1,0 +1,47 @@
+// Prereq (same as golden-path.spec.ts): the watchlist must contain at least
+// one card for TICKER, and ideally its sector has 2+ tickers so the reorder
+// assertion below has something to prove.
+import { expect, test } from "@playwright/test";
+
+const TICKER = "TSLA";
+
+test("pin toggle persists via API and reorders card within sector", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "DASHBOARD" })).toBeVisible();
+
+  // PinButton renders aria-label="Pin <T>" when unpinned, "Unpin <T>" when pinned,
+  // and aria-pressed reflects the pinned prop. Match either form.
+  const pin = page.getByRole("button", {
+    name: new RegExp(`^(Pin|Unpin) ${TICKER}$`),
+  });
+  await expect(pin).toBeVisible();
+  const initiallyPinned = (await pin.getAttribute("aria-pressed")) === "true";
+
+  // Toggle once: click → patchTicker → router.refresh → new aria-pressed.
+  await pin.click();
+  await expect(pin).toHaveAttribute("aria-pressed", String(!initiallyPinned), {
+    timeout: 5000,
+  });
+
+  if (!initiallyPinned) {
+    // Newly pinned: card must now be first in its sector grid.
+    const sectorGrid = page
+      .locator("section")
+      .filter({ has: page.getByLabel(`${TICKER} detail`) })
+      .locator("div")
+      .first();
+    const firstAriaLabel = await sectorGrid
+      .locator("[aria-label$=' detail']")
+      .first()
+      .getAttribute("aria-label");
+    expect(firstAriaLabel).toBe(`${TICKER} detail`);
+  }
+
+  // Restore original state to keep the suite idempotent.
+  await pin.click();
+  await expect(pin).toHaveAttribute("aria-pressed", String(initiallyPinned), {
+    timeout: 5000,
+  });
+});

--- a/web/tests/unit/cardGrid.test.tsx
+++ b/web/tests/unit/cardGrid.test.tsx
@@ -105,4 +105,58 @@ describe("CardGrid", () => {
       ["HUT"],
     ]);
   });
+
+  it("places pinned cards first within their sector regardless of size", () => {
+    render(
+      <CardGrid
+        data={{
+          scanned_at_min: null,
+          scanned_at_max: null,
+          scheduler_lag_seconds: null,
+          queue: { total: 0, queued: 0, running: 0, oldest_requested_at: null },
+          tickers: [
+            { ...card("AAPL", "M7", 201, "3000"), pinned: false },
+            { ...card("TSLA", "M7", 206, "900"), pinned: true },
+          ],
+        }}
+        sparklines={{}}
+      />,
+    );
+
+    const section = screen
+      .getByRole("heading")
+      .closest("section") as HTMLElement;
+    const order = within(section)
+      .getAllByTestId("ticker-card")
+      .map((el) => el.textContent);
+
+    expect(order).toEqual(["TSLA", "AAPL"]);
+  });
+
+  it("breaks final ties alphabetically by ticker when nothing else differs", () => {
+    render(
+      <CardGrid
+        data={{
+          scanned_at_min: null,
+          scanned_at_max: null,
+          scheduler_lag_seconds: null,
+          queue: { total: 0, queued: 0, running: 0, oldest_requested_at: null },
+          tickers: [
+            card("ZZZ", "ETF", 100, null),
+            card("AAA", "ETF", 100, null),
+          ],
+        }}
+        sparklines={{}}
+      />,
+    );
+
+    const section = screen
+      .getByRole("heading")
+      .closest("section") as HTMLElement;
+    const order = within(section)
+      .getAllByTestId("ticker-card")
+      .map((el) => el.textContent);
+
+    expect(order).toEqual(["AAA", "ZZZ"]);
+  });
 });

--- a/web/tests/unit/pinButton.test.tsx
+++ b/web/tests/unit/pinButton.test.tsx
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PinButton } from "@/components/watchlist/PinButton";
+import { api } from "@/lib/api";
+
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    patchTicker: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.mocked(api.patchTicker).mockResolvedValue({ ok: true, ticker: "AAPL" });
+  refresh.mockReset();
+});
+
+afterEach(() => {
+  vi.mocked(api.patchTicker).mockReset();
+});
+
+describe("PinButton", () => {
+  it("renders 'Pin <ticker>' label and aria-pressed=false when unpinned", () => {
+    render(<PinButton ticker="AAPL" pinned={false} />);
+    const btn = screen.getByRole("button", { name: "Pin AAPL" });
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("renders 'Unpin <ticker>' label and aria-pressed=true when pinned", () => {
+    render(<PinButton ticker="AAPL" pinned={true} />);
+    const btn = screen.getByRole("button", { name: "Unpin AAPL" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("calls patchTicker with toggled value and refreshes router on click", async () => {
+    render(<PinButton ticker="AAPL" pinned={false} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(api.patchTicker).toHaveBeenCalledWith("AAPL", { pinned: true });
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles in the unpin direction when already pinned", async () => {
+    render(<PinButton ticker="AAPL" pinned={true} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(api.patchTicker).toHaveBeenCalledWith("AAPL", { pinned: false });
+    });
+  });
+
+  it("does not refresh when the request fails", async () => {
+    vi.mocked(api.patchTicker).mockRejectedValueOnce(new Error("boom"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<PinButton ticker="AAPL" pinned={false} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(api.patchTicker).toHaveBeenCalled();
+    });
+    expect(refresh).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -1,5 +1,11 @@
 /* @vitest-environment jsdom */
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ScanAllButton } from "@/components/shared/ScanAllButton";
@@ -18,6 +24,7 @@ vi.mock("@/lib/api", () => ({
     rescan: vi.fn(),
     rescanAll: vi.fn(),
     job: vi.fn(),
+    patchTicker: vi.fn(),
   },
 }));
 
@@ -28,6 +35,7 @@ afterEach(() => {
   vi.mocked(api.rescan).mockReset();
   vi.mocked(api.rescanAll).mockReset();
   vi.mocked(api.job).mockReset();
+  vi.mocked(api.patchTicker).mockReset();
 });
 
 function installDialogPolyfill() {
@@ -213,7 +221,9 @@ describe("AddTickerDialog", () => {
 
     fireEvent.click(screen.getByRole("option", { name: "Power" }));
 
-    expect(screen.getByRole("button", { name: /sector power/i })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /sector power/i }),
+    ).not.toBeNull();
     expect(screen.queryByRole("listbox")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- **Bug fix:** restore pinned-first ordering within each sector. The `compareCards` comparator had demoted `pinned` to a tertiary tiebreaker behind size, silently overriding the server-side `ORDER BY pinned DESC` semantic. A pinned ticker with a smaller market cap was being shown below an unpinned mega-cap. Pinning is now the primary key, with size (market_cap or AUM) ordering the unpinned remainder.
- **Feature:** minimal pin/unpin UI on every TickerCard. A small Pin icon in the card footer toggles the pinned flag via `PATCH /api/watchlist/{ticker}`, then `router.refresh()` re-fetches the watchlist so the now-pinned card floats to the top of its sector. Until this commit, pinning was wired all the way to the database but had no UI affordance — users could not pin a card without hitting the API directly.
- **Cleanup:** drop the unnecessary \`\"use client\"\` directive on `CardGrid` (component is pure render — no hooks, state, or browser APIs), use the codebase's `toNum` formatter instead of an inline reimplementation, and move `PRIORITY_SECTORS` to `sectorGroups.ts` as the single source of truth for sector taxonomy + dashboard priority.
- **Tests:** 7 new cases — pinned-primary comparator behavior, ticker alphabetical tiebreak, and full coverage of the new PinButton component (label states, click behavior, error handling).

## Background

Spotted during the code review at `docs/reviews/2026-05-16-web-code-review.md`. Server-side ordering in `src/uw_scan/storage/repository.py:list_watchlist_cards` is `ORDER BY w.pinned DESC, w.sort_rank, w.ticker`. The client-side comparator was overriding "pinned DESC" without intent — a real regression introduced when market_cap sorting was added. The accompanying UI work closes the gap between "backend supports pinning" and "users can pin."

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test -- --run\` passes (133/133, up from 126 — 7 new tests across 2 new files)
- [x] \`npm run build\` succeeds (verifies RSC boundary holds after dropping \`\"use client\"\` from CardGrid)
- [x] Independent review via 3-way tribunal (Codex + Gemini + Claude) on the comparator fix: no must-fix items
- [ ] Visual smoke test on the dashboard: pin a small-cap ticker in a sector with bigger names, confirm pinned card renders first

## Follow-ups not in this PR

- **Sector ranking vs card ranking alignment** — `sectorRank` uses min `sort_rank` for non-priority sectors while `compareCards` uses size. A sector promoted by ticker X's low `sort_rank` may render ticker Y first if Y is bigger. Pre-existing, predates this branch. Worth a separate small PR.
- **Richer watchlist UI** — drag-to-reorder (`sort_rank` mutation), move-between-sectors, inline notes, bulk operations, keyboard navigation. Details in `docs/reviews/2026-05-16-web-code-review.md` under "Follow-up: richer watchlist UI improvements." Worth a design pass before implementation.
- **QueueProgress polling** — currently polls a full `api.watchlist()` every 2.5s. A thinner queue-only endpoint would cut payload size considerably.