### PR TITLE
fix(web): address deferred web-review follow-ups

### DIFF
--- a/src/uw_scan/api/routers/watchlist.py
+++ b/src/uw_scan/api/routers/watchlist.py
@@ -139,6 +139,23 @@ def get_watchlist(
     )
 
 
+@router.get("/watchlist/queue", response_model=QueueSummary)
+def get_watchlist_queue(repo: Repository = Depends(get_repo)) -> QueueSummary:
+    """Lightweight queue snapshot for the dashboard's QueueProgress widget.
+
+    Returns only the rescan-queue summary — no card joins, no meta. Designed
+    for the 2.5s polling loop in QueueProgress so the dashboard doesn't
+    refetch the full watchlist payload every tick.
+    """
+    q = repo.get_rescan_queue_summary()
+    return QueueSummary(
+        total=q.total,
+        queued=q.queued,
+        running=q.running,
+        oldest_requested_at=q.oldest_requested_at,
+    )
+
+
 @router.post("/watchlist", status_code=201)
 def post_watchlist(
     body: WatchlistMutation,

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -7,8 +7,13 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+# Rescan-jobs lifecycle vocabulary, shared by QueueStatus + JobStatus.
+# Source of truth is the worker / repository (see repository.py mark_job_*).
+QueueStatusValue = Literal["queued", "running", "done", "failed"]
 
 
 class SetupBlock(BaseModel):
@@ -49,7 +54,7 @@ class PositioningBlock(BaseModel):
 
 class QueueStatus(BaseModel):
     job_id: str
-    status: str
+    status: QueueStatusValue
     queue_position: int
     requested_at: datetime
     started_at: datetime | None = None
@@ -114,7 +119,7 @@ class WatchlistPatch(BaseModel):
 
 class JobStatus(BaseModel):
     job_id: str
-    status: str
+    status: QueueStatusValue
     run_id: int | None = None
     error: str | None = None
     requested_at: datetime

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -9127,6 +9127,28 @@
         ]
       }
     },
+    "/api/watchlist/queue": {
+      "get": {
+        "description": "Lightweight queue snapshot for the dashboard's QueueProgress widget.\n\nReturns only the rescan-queue summary \u2014 no card joins, no meta. Designed\nfor the 2.5s polling loop in QueueProgress so the dashboard doesn't\nrefetch the full watchlist payload every tick.",
+        "operationId": "get_watchlist_queue_api_watchlist_queue_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueSummary"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Watchlist Queue",
+        "tags": [
+          "watchlist"
+        ]
+      }
+    },
     "/api/watchlist/rescan-all": {
       "post": {
         "description": "Enqueue a rescan job for every active watchlist ticker.",

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -2412,6 +2412,12 @@
             "title": "Started At"
           },
           "status": {
+            "enum": [
+              "queued",
+              "running",
+              "done",
+              "failed"
+            ],
             "title": "Status",
             "type": "string"
           }
@@ -2427,6 +2433,18 @@
       "MarketAggregates": {
         "description": "Per-ticker aggregate fields sourced from the bulk-screener endpoint.\n\nPopulated by pipeline.run_single_stock alongside the existing per-section\nsub-models. Feeds the watchlist card POSITIONING and SKEW blocks.",
         "properties": {
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
           "call_oi_total": {
             "anyOf": [
               {
@@ -2494,18 +2512,6 @@
               }
             ],
             "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
           },
           "pcr_oi": {
             "anyOf": [
@@ -4573,6 +4579,12 @@
             "title": "Started At"
           },
           "status": {
+            "enum": [
+              "queued",
+              "running",
+              "done",
+              "failed"
+            ],
             "title": "Status",
             "type": "string"
           }
@@ -7475,6 +7487,18 @@
             ],
             "title": "Aggression Pct"
           },
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
           "gamma": {
             "$ref": "#/components/schemas/GammaBlock"
           },
@@ -7513,18 +7537,6 @@
               }
             ],
             "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
           },
           "pinned": {
             "title": "Pinned",

--- a/tests/integration/api/test_watchlist_queue_endpoint.py
+++ b/tests/integration/api/test_watchlist_queue_endpoint.py
@@ -1,0 +1,37 @@
+"""GET /api/watchlist/queue — thin queue-summary endpoint for QueueProgress polling."""
+
+from __future__ import annotations
+
+
+def test_queue_endpoint_returns_summary_shape_empty_db(client, seeded_db_empty_cards):
+    """Empty DB returns the QueueSummary shape with all-zero counts."""
+    r = client.get("/api/watchlist/queue")
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body.keys()) == {"total", "queued", "running", "oldest_requested_at"}
+    assert body["total"] == 0
+    assert body["queued"] == 0
+    assert body["running"] == 0
+    assert body["oldest_requested_at"] is None
+
+
+def test_queue_endpoint_does_not_return_tickers_or_meta(client, seeded_db_with_cards):
+    """The endpoint must not include any of the heavy watchlist fields —
+    this is the whole point: cheap polling."""
+    r = client.get("/api/watchlist/queue")
+    body = r.json()
+    assert "tickers" not in body
+    assert "scanned_at_min" not in body
+    assert "scanned_at_max" not in body
+    assert "scheduler_lag_seconds" not in body
+
+
+def test_queue_endpoint_counts_active_rescan(client, seeded_db_with_cards):
+    """After POSTing a rescan, the queue summary reflects it."""
+    client.post("/api/watchlist/TSLA/rescan")
+    r = client.get("/api/watchlist/queue")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["queued"] == 1
+    assert body["oldest_requested_at"] is not None

--- a/web/components/shared/QueueProgress.tsx
+++ b/web/components/shared/QueueProgress.tsx
@@ -20,10 +20,11 @@ export function QueueProgress({ queue }: { queue?: QueueSummary }) {
     const delay = current.total > 0 ? 2500 : 5000;
     const t = setInterval(async () => {
       try {
-        const next = await api.watchlist();
-        const nextQueue = next.queue ?? EMPTY_QUEUE;
+        const nextQueue = await api.queueSummary();
         setCurrent(nextQueue);
-        if (nextQueue.total === 0) router.refresh();
+        // Trigger an RSC refresh only on the active→drained transition so we
+        // pull updated cards once; idle ticks should not refresh the page.
+        if (nextQueue.total === 0 && current.total > 0) router.refresh();
       } catch (e) {
         console.error(e);
       }

--- a/web/components/shared/RescanButton.tsx
+++ b/web/components/shared/RescanButton.tsx
@@ -4,8 +4,9 @@ import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import type { components } from "@/lib/types";
 
-type Status = "idle" | "queued" | "running" | "done" | "failed";
 type QueueStatus = components["schemas"]["QueueStatus"];
+type BackendStatus = QueueStatus["status"];
+type UiStatus = BackendStatus | "idle";
 
 export function RescanButton({
   ticker,
@@ -16,9 +17,7 @@ export function RescanButton({
 }) {
   const router = useRouter();
   const [jobId, setJobId] = useState<string | null>(initialJob?.job_id ?? null);
-  const [status, setStatus] = useState<Status>(
-    (initialJob?.status as Status | undefined) ?? "idle",
-  );
+  const [status, setStatus] = useState<UiStatus>(initialJob?.status ?? "idle");
 
   useEffect(() => {
     if (!jobId) return;
@@ -33,7 +32,7 @@ export function RescanButton({
       }
       try {
         const r = await api.job(jobId);
-        setStatus(r.status as Status);
+        setStatus(r.status);
         if (r.status === "done" || r.status === "failed") {
           clearInterval(t);
           if (r.status === "done") router.refresh();
@@ -53,7 +52,7 @@ export function RescanButton({
         setStatus("queued");
         try {
           const r = await api.rescan(ticker);
-          setStatus(r.status as Status);
+          setStatus(r.status);
           setJobId(r.job_id);
         } catch (err) {
           console.error(err);

--- a/web/components/shared/RescanButton.tsx
+++ b/web/components/shared/RescanButton.tsx
@@ -46,6 +46,7 @@ export function RescanButton({
 
   return (
     <button
+      aria-label={`rescan ${ticker}`}
       onClick={async (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -11,10 +11,29 @@ function sectorRank(sector: string, tickers: WatchlistCard[]) {
     sector as (typeof PRIORITY_SECTORS)[number],
   );
   if (priority >= 0) return priority;
-  return (
-    PRIORITY_SECTORS.length +
-    Math.min(...tickers.map((t) => t.sort_rank), Number.MAX_SAFE_INTEGER)
+
+  // Non-priority sectors: rank by max size of their members, so the sector
+  // that floats up is the one whose top card on display is biggest. Aligns
+  // sector ordering with `compareCards`'s within-section size ordering.
+  const maxSize = tickers.reduce<number>(
+    (m, t) => Math.max(m, sizeValue(t) ?? -Infinity),
+    -Infinity,
   );
+  if (maxSize === -Infinity) {
+    // All members unpriced — push past priced sectors but keep server-curated
+    // sort_rank as a stable fallback so unpriced sectors keep a deterministic
+    // relative order.
+    return (
+      PRIORITY_SECTORS.length +
+      Number.MAX_SAFE_INTEGER / 2 +
+      tickers.reduce<number>(
+        (m, t) => Math.min(m, t.sort_rank),
+        Number.MAX_SAFE_INTEGER,
+      )
+    );
+  }
+  // Subtract from a large constant so larger maxSize ⇒ smaller rank ⇒ earlier.
+  return PRIORITY_SECTORS.length + (Number.MAX_SAFE_INTEGER / 2 - maxSize);
 }
 
 function sizeValue(card: WatchlistCard) {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -16,6 +16,7 @@ type Json<
     : never;
 
 type WatchlistResponse = Json<"/api/watchlist", "get">;
+type QueueSummaryResponse = Json<"/api/watchlist/queue", "get">;
 type SingleStockReport = Json<"/api/stock/{ticker}", "get">;
 type StockHistoryResponse = Json<"/api/stock/{ticker}/history", "get">;
 type JobStatus = Json<"/api/jobs/{job_id}", "get">;
@@ -72,6 +73,8 @@ export const api = {
     const q = params.toString();
     return _fetch<WatchlistResponse>(`/api/watchlist${q ? `?${q}` : ""}`);
   },
+  queueSummary: (): Promise<QueueSummaryResponse> =>
+    _fetch<QueueSummaryResponse>(`/api/watchlist/queue`),
   stock: (ticker: string): Promise<SingleStockReport> =>
     _fetch<SingleStockReport>(`/api/stock/${ticker}`),
   stockHistory: (ticker: string): Promise<StockHistoryResponse> =>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -39,6 +39,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/watchlist/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Watchlist Queue
+         * @description Lightweight queue snapshot for the dashboard's QueueProgress widget.
+         *
+         *     Returns only the rescan-queue summary — no card joins, no meta. Designed
+         *     for the 2.5s polling loop in QueueProgress so the dashboard doesn't
+         *     refetch the full watchlist payload every tick.
+         */
+        get: operations["get_watchlist_queue_api_watchlist_queue_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/watchlist/{ticker}": {
         parameters: {
             query?: never;
@@ -2961,6 +2985,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_watchlist_queue_api_watchlist_queue_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueueSummary"];
                 };
             };
         };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1082,8 +1082,11 @@ export interface components {
         JobStatus: {
             /** Job Id */
             job_id: string;
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
             /** Run Id */
             run_id?: number | null;
             /** Error */
@@ -1645,8 +1648,11 @@ export interface components {
         QueueStatus: {
             /** Job Id */
             job_id: string;
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
             /** Queue Position */
             queue_position: number;
             /**

--- a/web/tests/e2e/golden-path.spec.ts
+++ b/web/tests/e2e/golden-path.spec.ts
@@ -16,12 +16,9 @@ test("dashboard → detail → tab → rescan", async ({ page }) => {
   await expect(page).toHaveURL(new RegExp(`/stock/${ticker}/flow`));
 
   await page.goto("/");
-  // The button's text changes after click (rescan → queued… → running… →
-  // done), so locating by initial text won't survive the click. The card
-  // exposes its link via aria-label="<TICKER> detail"; the RescanButton is
-  // a sibling of the link inside the same card wrapper.
-  const card = page.getByLabel(`${ticker} detail`).locator("xpath=..");
-  const rescan = card.locator("button").first();
+  // The button's visible text changes after click (rescan → queued… → running…
+  // → done), so we locate by aria-label which is stable across status changes.
+  const rescan = page.getByRole("button", { name: `rescan ${ticker}` });
   await expect(rescan).toHaveText("rescan");
   await rescan.click();
   await expect(rescan).toHaveText(/queued|running|done/, { timeout: 5000 });

--- a/web/tests/unit/cardGrid.test.tsx
+++ b/web/tests/unit/cardGrid.test.tsx
@@ -133,6 +133,34 @@ describe("CardGrid", () => {
     expect(order).toEqual(["TSLA", "AAPL"]);
   });
 
+  it("orders non-priority sectors by their members' max market cap (descending)", () => {
+    render(
+      <CardGrid
+        data={{
+          scanned_at_min: null,
+          scanned_at_max: null,
+          scheduler_lag_seconds: null,
+          queue: { total: 0, queued: 0, running: 0, oldest_requested_at: null },
+          tickers: [
+            // sort_rank says Banks first (400 < 420), but Healthcare has the
+            // bigger member by size (500B vs 1B) so the new ordering puts it
+            // ahead. Priority prefix (ETF) stays first either way.
+            card("XLF", "Banks", 400, "1000000000"),
+            card("JNJ", "Healthcare", 420, "500000000000"),
+            card("SPY", "ETF", 101, "300000000000"),
+          ],
+        }}
+        sparklines={{}}
+      />,
+    );
+
+    expect(screen.getAllByRole("heading").map((h) => h.textContent)).toEqual([
+      "ETF · 1",
+      "Healthcare · 1",
+      "Banks · 1",
+    ]);
+  });
+
   it("breaks final ties alphabetically by ticker when nothing else differs", () => {
     render(
       <CardGrid

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -21,6 +21,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/api", () => ({
   api: {
     watchlist: vi.fn(),
+    queueSummary: vi.fn(),
     rescan: vi.fn(),
     rescanAll: vi.fn(),
     job: vi.fn(),
@@ -32,6 +33,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.mocked(api.watchlist).mockReset();
+  vi.mocked(api.queueSummary).mockReset();
   vi.mocked(api.rescan).mockReset();
   vi.mocked(api.rescanAll).mockReset();
   vi.mocked(api.job).mockReset();
@@ -158,17 +160,11 @@ describe("QueueProgress", () => {
 
   it("discovers queue work that starts after the dashboard loaded idle", async () => {
     vi.useFakeTimers();
-    vi.mocked(api.watchlist).mockResolvedValueOnce({
-      scanned_at_min: null,
-      scanned_at_max: null,
-      scheduler_lag_seconds: null,
-      queue: {
-        total: 1,
-        queued: 1,
-        running: 0,
-        oldest_requested_at: "2026-05-16T00:13:17Z",
-      },
-      tickers: [],
+    vi.mocked(api.queueSummary).mockResolvedValueOnce({
+      total: 1,
+      queued: 1,
+      running: 0,
+      oldest_requested_at: "2026-05-16T00:13:17Z",
     });
 
     render(
@@ -188,7 +184,8 @@ describe("QueueProgress", () => {
       await vi.advanceTimersByTimeAsync(5000);
     });
 
-    expect(api.watchlist).toHaveBeenCalledOnce();
+    expect(api.queueSummary).toHaveBeenCalledOnce();
+    expect(api.watchlist).not.toHaveBeenCalled();
     expect(screen.getByText("0 running · 1 queued")).not.toBeNull();
 
     vi.useRealTimers();


### PR DESCRIPTION
## Summary

Addresses the three deferred items from the 2026-05-16 web code review that were explicitly out of scope for PR #33 (CardGrid landing). Plus a small drive-by to unbreak the `golden-path` Playwright spec broken by PR #33's pin button.

- **perf:** new `/api/watchlist/queue` endpoint; `QueueProgress` no longer refetches the full watchlist payload every 2.5s. Payload drops from full watchlist response (~N cards × all fields) to `{total, queued, running, oldest_requested_at}`. `router.refresh()` now fires only on the active→drained transition, not every idle tick.
- **types:** `QueueStatus.status` and `JobStatus.status` are now Pydantic `Literal["queued", "running", "done", "failed"]`. Regenerated `web/lib/types.ts` carries the union; unsafe `as Status` casts dropped in `RescanButton.tsx`. TypeScript now enforces the contract end-to-end.
- **fix:** `CardGrid.sectorRank` now ranks non-priority sectors by max member `sizeValue` (market_cap / AUM), matching the within-section card ordering in `compareCards`. Priority prefix (ETF / M7 / Semiconductor) unchanged.
- **e2e:** `RescanButton` now carries `aria-label="rescan {ticker}"` (accessibility win); `golden-path.spec.ts` locates the rescan button via `getByRole` instead of the fragile `.locator("button").first()` that PR #33's pin button had taken over.

## Commits

- `7776f01` fix(watchlist): rank non-priority sectors by max member size
- `a4f14cf` fix(api): type queue.status as Literal[queued|running|done|failed]
- `3a40c0e` perf(web): thin /api/watchlist/queue endpoint for QueueProgress
- `278cc04` fix(e2e): aria-label rescan button + use it in golden-path

## Test plan

- [x] `uv run pytest -x -q` — 369 passed / 5 skipped (3 new tests in `test_watchlist_queue_endpoint.py`)
- [x] `npm --prefix web run typecheck` — clean
- [x] `npm --prefix web run lint` — clean
- [x] `npm --prefix web run test -- --run` — 23 files / 138 tests (cardGrid +1, watchlistUi mock updated)
- [x] `npm --prefix web run build` — succeeds (1054ms)
- [x] `npx playwright test` (web/) — 4/4 passed (golden-path, pin-toggle, volatility-tab x2)
- [x] Manual: `curl /api/watchlist/queue` returns only `{total, queued, running, oldest_requested_at}`

## Deliberately deferred

Richer watchlist UI (drag/move/notes/bulk/keyboard) — sized at 3–5× a normal PR; needs a design pass before implementation.