### PR TITLE
refactor(storage): split repository.py PR 1/3 (leaf modules)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Environment:
 - **Never add `Co-Authored-By: Claude` trailers** to commits
 - **Migrations are idempotent** (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`). No tracking table — re-running is a no-op
 - **Live API tests** are marked `live` and need `UW_SCAN_API_KEY`; default `pytest` excludes them
+- **Module size budget** — target <500 lines per Python file; at 1000+ lines stop adding methods and propose a split first. `repository.py` reached 5000+ lines because the line was never drawn — don't repeat. Split by domain seam (one module per cohesive set of methods), not by technical layer. Cite this rule in any PR that grows a file past 1000 lines without a split plan
 - **AGENTS.md** still lives at the root for Codex; keep both files in sync when policy changes
 
 ## Where to look first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Environment:
 - **Never add `Co-Authored-By: Claude` trailers** to commits
 - **Migrations are idempotent** (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`). No tracking table — re-running is a no-op
 - **Live API tests** are marked `live` and need `UW_SCAN_API_KEY`; default `pytest` excludes them
+- **Module size budget** — target <500 lines per Python file; at 1000+ lines stop adding methods and propose a split first. `repository.py` reached 5000+ lines because the line was never drawn — don't repeat. Split by domain seam (one module per cohesive set of methods), not by technical layer. Cite this rule in any PR that grows a file past 1000 lines without a split plan
 - **AGENTS.md** still lives at the root for Codex; keep both files in sync when policy changes
 
 ## Where to look first

--- a/docs/superpowers/plans/2026-05-16-repository-split-pr1.md
+++ b/docs/superpowers/plans/2026-05-16-repository-split-pr1.md
@@ -1,0 +1,860 @@
+# Repository.py Split — PR 1 of 3 (Leaf Modules)
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. Each task is independently shippable.
+
+**Goal:** Decompose the 5173-line `src/uw_scan/storage/repository.py` into focused per-domain mixin modules, starting with the 8 leaf domains. Pure code move + import update — no behavior changes.
+
+**Architecture:** Mixin pattern — `repository.py` stays as the assembled shell (`class Repository(_AuditMixin, _FlowMixin, …, _BaseMixin): pass` — `_BaseMixin` LAST owns `__init__`/`conn`) so all 30+ caller import paths (`from uw_scan.storage.repository import Repository`) keep working unchanged. Each domain mixin contains a cohesive method set; no mixin defines `__init__`. Dataclass row types move to `storage/rows.py` and are re-exported from `repository.py` for backward compat.
+
+**Tech Stack:** Python 3.13, no new dependencies. The split is purely structural; pytest is the verification gate (346+ tests must stay green).
+
+## Plan revisions from `/codex-review`
+
+Initial draft was reviewed by Codex + Claude before any code was written. 13 issues raised, all consensus or self-verified. Revisions applied:
+
+1. **CRITICAL — Task 1 line ranges wrong.** Originally claimed `WatchlistRow` occupied lines 26-264 (because the file dividers visually run that long). Reality: WatchlistRow is 26-35; 37-264 are cockpit-domain module helpers that must stay per Decision 2. Plan rewritten to move dataclasses by class name, not by line range.
+2. **CRITICAL — Task 2 missing `redact_params`/`status_family_for`.** Both are externally imported by `sources/ohlc.py`, `api/client.py`, `tests/unit/storage/test_provider_usage_helpers.py`. Added to `_helpers.py` move list with explicit re-export.
+3. **CRITICAL — Task 2 `provider_day_bounds` crash.** Needs `_PROVIDER_DAY_TZ` constant (line 515) moved too, plus `ZoneInfo` + `timedelta` imports. Template fixed.
+4. **CRITICAL — Task 6 hidden method.** `get_pcr_history_30d_ago` at line 4452 sits inside the `append_pcr_history` range. Added explicitly to the move table.
+5. **CRITICAL — Task 8 health constants/imports.** `_RECORD_HEALTH_TIMESTAMP_COLUMNS`, `_RECORD_HEALTH_TICKER_COLUMNS` (388-389) + `math.ceil` + `psql.SQL` + `Iterable` added to the move/imports list.
+6. **CRITICAL — Task 7 missing `logger`.** `mark_job_done`/`mark_job_failed` use `logger.warning`. Jobs mixin gets its own `logger = logging.getLogger(__name__)`.
+7. **CRITICAL — Task 9 script breakage.** `scripts/backfill_flow_footprint.py` imports `_flow_footprint_label` + `_aggressor_label_confidence` from `uw_scan.storage.repository`. Re-export from repository.py required (NOT just internal move).
+8. **CRITICAL — Task 9 flow.py imports.** Added `Iterable`, `Counter`, `Decimal`, `ZoneInfo`, `datetime`.
+9. **IMPORTANT — bare `pytest`** in Tasks 5-9 changed to `uv run pytest` per project standing rule.
+10. **IMPORTANT — Task 4 test path** changed from non-existent `tests/integration/sources/` to `tests/integration/test_repository_real_pg.py`.
+11. **IMPORTANT — MRO examples** reorganized: `_BaseMixin` always LAST in inheritance (matches the actual MRO requirement that domain mixins shadow base resolution).
+12. **MINOR — `_flow_alert_trade_date`** moved from `_FlowMixin` to module-level function in `flow.py` (doesn't use `self`).
+13. **MINOR — WatchlistCardRow line range** corrected from 409-523 to 409-513.
+
+## Why we're doing this now
+
+Per the new "Module size budget" standing rule (`CLAUDE.md`/`AGENTS.md`, just committed): repository.py reached 5173 lines because the line was never drawn. The 3-PR plan from `docs/reviews/2026-05-16-backend-modularization-and-reuse.md` decomposes by domain seam.
+
+**This PR (1 of 3):** extract the 8 leaf modules. ~32 methods + 12 row types + 2 utility functions moved. After PR-1 lands, `repository.py` shrinks from 5173 lines to ~4100 lines. PR-2 and PR-3 land the bigger domains (external_api, volatility, options, fetchers) in follow-up worktrees.
+
+## Mixin pattern primer
+
+Each domain module exports a single mixin class:
+
+```python
+# storage/audit.py
+from __future__ import annotations
+import psycopg
+from typing import Any
+from psycopg.types.json import Jsonb
+
+
+class _AuditMixin:
+    """Audit + raw payload writes. Mixed into Repository in repository.py."""
+
+    # Type hints for attributes the mixin uses (set by _BaseMixin.__init__):
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_audit_row(self, ...) -> int:
+        ...
+
+    def insert_raw_payload(self, audit_id: int, payload: dict | list) -> int:
+        ...
+```
+
+And the assembled shell:
+
+```python
+# storage/repository.py (post-split, ~100 lines)
+from .rows import (
+    WatchlistRow, DailyOhlcRow, IntradayQuoteRow, ...,  # re-export for callers
+)
+from ._base import _BaseMixin
+from ._helpers import (
+    _PROVIDER_DAY_TZ,
+    _REDACTED_PARAM_KEYS,
+    _d,
+    _nullable_float,
+    _nullable_int,
+    provider_day_bounds,
+    redact_params,
+    status_family_for,
+)
+# External callers may import provider_day_bounds, redact_params, status_family_for
+# from this module — they stay re-exported (see __all__ below).
+from .audit import _AuditMixin
+from .flow import _FlowMixin
+from .scan_outputs import _ScanOutputsMixin
+from .market_data import _MarketDataMixin
+from .jobs import _JobsMixin
+from .health import _HealthMixin
+
+
+class Repository(
+    _AuditMixin,
+    _FlowMixin,
+    _ScanOutputsMixin,
+    _MarketDataMixin,
+    _JobsMixin,
+    _HealthMixin,
+    _BaseMixin,  # MUST be last — owns __init__/conn; domain mixins shadow it
+    # PR-2 will add: _ExternalApiMixin, _VolatilityRawMixin, _OptionsMixin,
+    #                _ScanRunsMixin, _ScanResultsMixin, _WatchlistMixin
+    # PR-3 will add: _FetchersMixin, _TradeInsightsAiMixin, _VolatilityV2Mixin
+):
+    """Per-domain methods are defined on mixins; this class just assembles them.
+    See docs/superpowers/plans/2026-05-16-repository-split-pr1.md for the split
+    plan and storage/CLAUDE.md for module conventions."""
+    pass
+
+
+# PR-2/PR-3 will move the remaining ~125 methods out of repository.py.
+# Until then, the methods not yet extracted live directly on Repository above
+# (between the imports and the class definition — they'll move to dedicated
+# mixin files in subsequent PRs).
+```
+
+**MRO note:** `_BaseMixin` MUST be LAST in the inheritance order so domain mixins resolve their methods first via Python's left-to-right MRO. `_BaseMixin.__init__` is the ONLY `__init__` in the chain (domain mixins must not define their own); when `Repository(conn, schema=...)` is called, Python walks left-to-right past domain mixins (which have no `__init__`), reaches `_BaseMixin.__init__`, and calls it. Each mixin uses `self._conn` and `self._schema` set there. Domain mixins declare type hints (`_conn: psycopg.Connection`) for tooling but do not assign — assignment happens in `_BaseMixin.__init__`.
+
+## Task order (low → high blast radius)
+
+1. **rows.py** — no methods touched; pure dataclass relocation + re-exports
+2. **_helpers.py** — 2 functions; trivial
+3. **_base.py** — extract `__init__`, `conn` property; foundation for mixins
+4. **audit.py** — 2 methods; simplest mixin
+5. **scan_outputs.py** — 2 methods
+6. **market_data.py** — 9 methods (includes new etf_aum methods)
+7. **jobs.py** — 7 methods
+8. **health.py** — 7 methods
+9. **flow.py** — 3 methods + 2 module helpers
+
+## File-level invariants (apply to every task)
+
+- **One mixin class per file.** Name: `_<Domain>Mixin`.
+- **`from __future__ import annotations`** at top of every new file (consistent with existing convention).
+- **No business logic moves.** Methods are byte-identical except for `self` → leading whitespace adjustments.
+- **Re-exports preserved.** Dataclasses imported from `repository.py` by any caller must still be importable from there post-split.
+- **Run `uv run pytest tests/integration/storage/ tests/unit/storage/ -v` after each task.** Full green required before commit.
+- **No `git add -A`.** Stage specific files only — avoids accidentally including unrelated state.
+
+---
+
+## Task 1 — rows.py: extract 12 dataclass row types + WatchlistCardRow
+
+**Files:**
+- Create: `src/uw_scan/storage/rows.py`
+- Modify: `src/uw_scan/storage/repository.py` (delete moved classes, add import + re-export block)
+
+**Why first:** Zero method moves. Easiest to verify. All later tasks reference these row types.
+
+**Classes moved (current line ranges in repository.py — short, NOT contiguous):**
+
+| Class | Current lines |
+|---|---|
+| `WatchlistRow` | 26-35 |
+| `DailyOhlcRow` | 266-278 |
+| `IntradayQuoteRow` | 279-286 |
+| `PcrHistoryRow` | 287-294 |
+| `JobRow` | 295-307 |
+| `RescanQueueSummaryRow` | 308-315 |
+| `ExternalApiUsageSummary` | 316-328 |
+| `ExternalApiBreakdownRow` | 329-340 |
+| `ThroughputSummaryRow` | 341-349 |
+| `ExternalApiRequestRow` | 350-374 |
+| `RecordHealthRow` | 375-407 |
+| `WatchlistCardRow` | 409-513 (incl. `_LIST_FIELDS`, `from_db`, `from_list_row`, `__getattr__`, `to_dict`) |
+
+**CRITICAL: do NOT delete by line range.** Lines 37-264 (between `WatchlistRow` and `DailyOhlcRow`) contain cockpit-domain module helpers (`_row_for_date`, `_iv_delta_5d`, `_pin_candidate`, `_pin_distance_sigma`, `_median`, `_sum_optional`, `_sign_label`, `_vanna_conditional_reading`, `_charm_regime`, `_oi_change_bias`, `_flow_footprint_label`, `_aggressor_label_confidence`, `_vrp_sign_flip_status_for_db`, `_vrp_sign_flip_status_from_db`) that must STAY in repository.py per Decision 2 (they'll move with their domain modules in PR-2/PR-3, except `_flow_footprint_label` and `_aggressor_label_confidence` which move in Task 9). Delete by class definition — find each `@dataclass(frozen=True)` / `class WatchlistCardRow:` and delete from there to the next blank line before the next top-level definition.
+
+- [ ] **Step 1.1: Read current rows + their imports**
+
+```bash
+sed -n '1,25p' src/uw_scan/storage/repository.py  # see what imports the rows need
+```
+
+Capture the import list (`from __future__`, `from dataclasses import dataclass`, `from datetime import datetime`, `from decimal import Decimal`, `from typing import Any`, plus `models` if any row references it).
+
+- [ ] **Step 1.2: Create `src/uw_scan/storage/rows.py`**
+
+```python
+"""Frozen dataclasses + WatchlistCardRow used by the Repository methods.
+
+Moved from repository.py during the PR-1 split (see
+docs/superpowers/plans/2026-05-16-repository-split-pr1.md). All row types
+are re-exported from repository.py for backward compat with existing callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WatchlistRow:
+    # ... copied verbatim from repository.py ...
+
+
+# ... all 11 other dataclasses + WatchlistCardRow ...
+```
+
+- [ ] **Step 1.3: Replace classes in repository.py with imports + re-exports**
+
+In `repository.py`, delete each of the 12 class definitions individually (find each `@dataclass(frozen=True)` / `class WatchlistCardRow:` and remove that class only — DO NOT delete by line range, since the file has cockpit module helpers interleaved between dataclasses that must stay). At the top of the file (just after the existing imports), add:
+
+```python
+# All row types live in rows.py. Re-exported here so existing callers
+# (`from uw_scan.storage.repository import JobRow`) keep working.
+from .rows import (
+    DailyOhlcRow,
+    ExternalApiBreakdownRow,
+    ExternalApiRequestRow,
+    ExternalApiUsageSummary,
+    IntradayQuoteRow,
+    JobRow,
+    PcrHistoryRow,
+    RecordHealthRow,
+    RescanQueueSummaryRow,
+    ThroughputSummaryRow,
+    WatchlistCardRow,
+    WatchlistRow,
+)
+
+__all__ = [
+    "Repository",
+    "DailyOhlcRow",
+    "ExternalApiBreakdownRow",
+    "ExternalApiRequestRow",
+    "ExternalApiUsageSummary",
+    "IntradayQuoteRow",
+    "JobRow",
+    "PcrHistoryRow",
+    "RecordHealthRow",
+    "RescanQueueSummaryRow",
+    "ThroughputSummaryRow",
+    "WatchlistCardRow",
+    "WatchlistRow",
+]
+```
+
+- [ ] **Step 1.4: Run tests**
+
+```bash
+set -a; source ../../../.env; set +a
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ tests/unit/storage/ -v 2>&1 | tail -10
+```
+
+Expected: full green. Any `ImportError` or `AttributeError` on a row type means a caller used a different name than my re-export list — add to `__all__`.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/uw_scan/storage/rows.py src/uw_scan/storage/repository.py
+git commit -m "refactor(storage): extract row dataclasses to rows.py
+
+PR-1 of the 3-PR repository.py split (docs/reviews/2026-05-16-backend-
+modularization-and-reuse.md). Pure move + re-export. All 12 dataclass row
+types + WatchlistCardRow live in storage/rows.py; repository.py re-exports
+them so 'from uw_scan.storage.repository import JobRow' still works."
+```
+
+---
+
+## Task 2 — _helpers.py: extract pure utility helpers (REVISED per codex-review)
+
+**Files:**
+- Create: `src/uw_scan/storage/_helpers.py`
+- Modify: `src/uw_scan/storage/repository.py` (delete the helpers + module constants they depend on, import them back at the top)
+
+**Functions and constants moved:**
+
+| Symbol | Current lines | External-facing? |
+|---|---|---|
+| `_PROVIDER_DAY_TZ` constant | 515 | (used by `provider_day_bounds`) |
+| `_REDACTED_PARAM_KEYS` constant | 516-522 | (used by `redact_params`) |
+| `_d` function | 525-528 | internal |
+| `provider_day_bounds` function | 530-537 | YES — `api/routers/health.py`, `api/routers/provider_usage.py`, `tests/unit/storage/test_provider_usage_helpers.py` |
+| `status_family_for` function | 539-553 | YES — `sources/ohlc.py`, `api/client.py`, `tests/unit/storage/test_provider_usage_helpers.py` |
+| `redact_params` function | 555-565 | YES — `sources/ohlc.py`, `api/client.py`, `tests/unit/storage/test_provider_usage_helpers.py` |
+| `_nullable_int` function | 567-571 | internal |
+| `_nullable_float` function | 573-577 | internal |
+
+**External re-export critical.** All 3 external-facing functions (`provider_day_bounds`, `status_family_for`, `redact_params`) must remain importable from `uw_scan.storage.repository` — break this and 5+ callers fail.
+
+Cockpit-specific helpers (`_pin_candidate`, `_vanna_conditional_reading`, `_charm_regime`, `_oi_change_bias`, `_vrp_sign_flip_status_*`, etc., lines 37-264) stay in `repository.py`. They move with their domain modules in PR-2.
+
+- [ ] **Step 2.1: Create `src/uw_scan/storage/_helpers.py`**
+
+```python
+"""Pure-utility helpers used by Repository methods.
+
+Some of these are externally importable from `uw_scan.storage.repository`
+(provider_day_bounds, status_family_for, redact_params) and stay re-exported
+there for backward compat. Internal-only helpers (_d, _nullable_int,
+_nullable_float) are also here for cohesion.
+
+Moved from repository.py during the PR-1 split (docs/superpowers/plans/
+2026-05-16-repository-split-pr1.md). Cockpit-specific helpers
+(_pin_candidate, _vanna_conditional_reading, _charm_regime, etc.) stay in
+repository.py for PR-1 and will move with their domain modules in PR-2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from zoneinfo import ZoneInfo
+
+
+_PROVIDER_DAY_TZ = ZoneInfo("America/New_York")
+
+_REDACTED_PARAM_KEYS = {
+    "apikey",
+    "api_key",
+    "authorization",
+    "auth",
+    "token",
+}
+
+
+def _d(value: Decimal | None) -> Any:
+    """psycopg handles Decimal natively; keep this for symmetry with other casters."""
+    return value
+
+
+def provider_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
+    # ... copied verbatim from repository.py:530-537 ...
+
+
+def status_family_for(status_code: int | None, *, transport_error: bool = False) -> str:
+    # ... copied verbatim from repository.py:539-553 ...
+
+
+def redact_params(params: dict[str, object] | None) -> dict[str, object]:
+    # ... copied verbatim from repository.py:555-565 ...
+
+
+def _nullable_int(value: Any) -> int | None:
+    # ... copied verbatim from repository.py:567-571 ...
+
+
+def _nullable_float(value: Any) -> float | None:
+    # ... copied verbatim from repository.py:573-577 ...
+```
+
+- [ ] **Step 2.2: Replace in repository.py**
+
+Delete the 5 functions + 2 module constants (`_PROVIDER_DAY_TZ`, `_REDACTED_PARAM_KEYS`) listed above. Add to the imports block near the top:
+
+```python
+from ._helpers import (
+    _PROVIDER_DAY_TZ,    # cockpit code may still reference it; keep importable
+    _REDACTED_PARAM_KEYS,
+    _d,
+    _nullable_float,
+    _nullable_int,
+    provider_day_bounds,
+    redact_params,
+    status_family_for,
+)
+```
+
+Add `provider_day_bounds`, `redact_params`, `status_family_for` to the existing `__all__` from Task 1.
+
+**Verification grep:** `grep -rn "from uw_scan.storage.repository import" src/ tests/ | grep -E "redact_params|status_family_for|provider_day_bounds"` should show 5+ callers — they must continue to import successfully.
+
+- [ ] **Step 2.3: Run tests (includes test_provider_usage_helpers)**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ tests/unit/storage/test_provider_usage_helpers.py tests/unit/storage/test_watchlist_card_row.py -v 2>&1 | tail -10
+```
+
+`test_provider_usage_helpers.py` tests all three external helpers (`provider_day_bounds`, `status_family_for`, `redact_params`) — it's the smoke test for this task's re-export coverage.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add src/uw_scan/storage/_helpers.py src/uw_scan/storage/repository.py
+git commit -m "refactor(storage): extract pure helpers to _helpers.py
+
+Moves 5 functions (_d, provider_day_bounds, status_family_for,
+redact_params, _nullable_int, _nullable_float) and 2 module constants
+(_PROVIDER_DAY_TZ, _REDACTED_PARAM_KEYS) to storage/_helpers.py.
+
+External callers (sources/ohlc.py, api/client.py, api/routers/health.py,
+api/routers/provider_usage.py, tests/unit/storage/test_provider_usage_helpers.py)
+keep their 'from uw_scan.storage.repository import' paths working via
+explicit re-export from repository.py."
+```
+
+---
+
+## Task 3 — _base.py: extract the Repository base mixin
+
+**Files:**
+- Create: `src/uw_scan/storage/_base.py`
+- Modify: `src/uw_scan/storage/repository.py` (Repository now inherits `_BaseMixin`)
+
+**Why a base mixin:** each per-domain mixin will use `self._conn` and `self._schema`. Without a common base, every mixin would need to declare those attributes via type annotations alone, with no `__init__` to actually set them. `_BaseMixin` owns the constructor.
+
+- [ ] **Step 3.1: Create `src/uw_scan/storage/_base.py`**
+
+```python
+"""Repository base mixin: owns __init__, conn property, and the _schema /
+_conn attributes that every per-domain mixin reads.
+
+Mixed in LAST in the Repository inheritance order so domain mixins can
+shadow specific behavior if needed (none do today)."""
+
+from __future__ import annotations
+
+import psycopg
+
+
+class _BaseMixin:
+    """Owns the connection and schema. Other mixins reference self._conn
+    and self._schema; this class is what makes them concrete."""
+
+    def __init__(
+        self, conn: psycopg.Connection, schema: str = "uw_scan"
+    ) -> None:
+        self._conn = conn
+        self._schema = schema
+
+    @property
+    def conn(self) -> psycopg.Connection:
+        return self._conn
+```
+
+- [ ] **Step 3.2: Update repository.py**
+
+Delete the existing `__init__` (line 582) and `conn` property (line 587). Add `_BaseMixin` to the Repository inheritance list. At this point Repository looks like:
+
+```python
+class Repository(_BaseMixin):
+    """Per-domain methods live below; PR-1 will move them to mixins."""
+    # ... still ~5000 lines of methods until later tasks ...
+```
+
+- [ ] **Step 3.3: Run tests**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/ -v 2>&1 | tail -10
+```
+
+Note: this task tests broader scope because we're modifying the Repository constructor, which every test fixture uses.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/uw_scan/storage/_base.py src/uw_scan/storage/repository.py
+git commit -m "refactor(storage): extract _BaseMixin (Repository __init__ + conn)"
+```
+
+---
+
+## Task 4 — audit.py: extract 2 audit methods
+
+**Files:**
+- Create: `src/uw_scan/storage/audit.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods moved:**
+
+| Method | Current lines | Notes |
+|---|---|---|
+| `insert_audit_row` | 654-695 | |
+| `insert_raw_payload` | 696-705 | uses `Jsonb` import |
+
+- [ ] **Step 4.1: Create `src/uw_scan/storage/audit.py`**
+
+```python
+"""Audit + raw payload writes.
+
+API/worker fetchers call insert_audit_row immediately before any UW HTTP
+request (so even failures leave a row), then insert_raw_payload with the
+response body. The two-step shape lets us trace any UW call back to its
+HTTP request even when normalization fails."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+
+class _AuditMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_audit_row(
+        self,
+        # ... copied verbatim ...
+    ) -> int:
+        ...
+
+    def insert_raw_payload(self, audit_id: int, payload: dict | list) -> int:
+        ...
+```
+
+- [ ] **Step 4.2: Update repository.py**
+
+- Delete `insert_audit_row` + `insert_raw_payload` (lines 654-705)
+- Add `from .audit import _AuditMixin`
+- Update inheritance: `class Repository(_AuditMixin, _BaseMixin):`
+
+- [ ] **Step 4.3: Run tests**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ tests/integration/test_repository_real_pg.py -v 2>&1 | tail -10
+```
+
+(`tests/integration/test_repository_real_pg.py` exercises audit writes via the UW client codepath.)
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/uw_scan/storage/audit.py src/uw_scan/storage/repository.py
+git commit -m "refactor(storage): extract _AuditMixin (insert_audit_row + insert_raw_payload)"
+```
+
+---
+
+## Task 5 — scan_outputs.py: extract 2 scan-output methods
+
+**Files:**
+- Create: `src/uw_scan/storage/scan_outputs.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods moved:**
+
+| Method | Current lines |
+|---|---|
+| `insert_opportunity_score` | 3029-3063 |
+| `insert_structure_idea` | 3064-3088 |
+
+- [ ] **Step 5.1: Create file with `_ScanOutputsMixin`**
+- [ ] **Step 5.2: Delete from repository.py + add import + add to inheritance**
+- [ ] **Step 5.3: Run tests:** `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ -v`
+- [ ] **Step 5.4: Commit:** `refactor(storage): extract _ScanOutputsMixin`
+
+---
+
+## Task 6 — market_data.py: extract 9 market-data methods
+
+**Files:**
+- Create: `src/uw_scan/storage/market_data.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods moved (10 — REVISED per codex-review ISSUE-3 to add `get_pcr_history_30d_ago`):**
+
+| Method | Current lines |
+|---|---|
+| `upsert_daily_ohlc` | 4350-4376 |
+| `list_daily_ohlc` | 4377-4391 |
+| `upsert_intraday_quote` | 4392-4406 |
+| `get_intraday_quote` | 4407-4418 |
+| `get_latest_intraday_quote_times` | 4419-4432 |
+| `append_pcr_history` | 4433-4451 |
+| `get_pcr_history_30d_ago` | 4452-4469 |
+| `get_pcr_history_row` | 4650-4665 |
+| `get_recent_etf_aum` | 4601-4615 |
+| `upsert_etf_aum` | 4616-4630 |
+
+- [ ] **Step 6.1: Create file with `_MarketDataMixin`**
+
+Imports needed: `Iterable`, `_date`, `datetime`, `timedelta`, `Decimal`, `DailyOhlcRow`, `IntradayQuoteRow`, `PcrHistoryRow` (from `.rows`).
+
+- [ ] **Step 6.2: Delete from repository.py + add import + add to inheritance**
+- [ ] **Step 6.3: Run tests:** `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ tests/integration/test_pipeline_etf_caching.py tests/integration/test_pcr_history_append.py -v`
+- [ ] **Step 6.4: Commit:** `refactor(storage): extract _MarketDataMixin`
+
+---
+
+## Task 7 — jobs.py: extract 7 jobs queue methods
+
+**Files:**
+- Create: `src/uw_scan/storage/jobs.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods moved:**
+
+| Method | Current lines |
+|---|---|
+| `enqueue_rescan_job` | 4470-4492 |
+| `claim_next_queued_job` | 4493-4515 |
+| `requeue_stale_running_jobs` | 4516-4536 |
+| `mark_job_done` | 4537-4557 |
+| `mark_job_failed` | 4558-4576 |
+| `get_rescan_queue_summary` | 4577-4600 |
+| `get_job` | 4872-4886 |
+
+- [ ] **Step 7.1: Create file with `_JobsMixin` (REVISED per codex-review ISSUE-5: needs its own logger)**
+
+Imports + module setup:
+```python
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import psycopg
+
+from .rows import JobRow, RescanQueueSummaryRow
+
+logger = logging.getLogger(__name__)
+
+
+class _JobsMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    # ... 7 methods ...
+```
+
+The `logger.warning(...)` calls inside `mark_job_done` (line 4551) and `mark_job_failed` (line 4570) require a module-level `logger` — repository.py had one at line 514; the mixin needs its own.
+
+- [ ] **Step 7.2: Delete from repository.py + add import + add to inheritance**
+- [ ] **Step 7.3: Run tests:** `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/test_repository_jobs.py tests/integration/worker/ -v`
+- [ ] **Step 7.4: Commit:** `refactor(storage): extract _JobsMixin`
+
+---
+
+## Task 8 — health.py: extract 7 health/heartbeat methods
+
+**Files:**
+- Create: `src/uw_scan/storage/health.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods moved:**
+
+| Method | Current lines |
+|---|---|
+| `fetch_stock_history_rollup` | 4666-4711 |
+| `count_active_watchlist` | 4712-4719 |
+| `_discover_record_health_rules` | 4720-4757 |
+| `list_record_health` | 4758-4818 |
+| `upsert_heartbeat` | 4819-4830 |
+| `get_heartbeat` | 4831-4839 |
+| `get_latest_heartbeat` | 4840-4853 |
+
+- [ ] **Step 8.1: Create file with `_HealthMixin` (REVISED per codex-review ISSUE-4: also move 2 module constants + 3 imports)**
+
+Also move these 3 module constants (verified via grep — all 3 are used ONLY by `_discover_record_health_rules`/`list_record_health`, so safe to move):
+- `_RECORD_HEALTH_TIMESTAMP_COLUMNS` (line 388)
+- `_RECORD_HEALTH_TICKER_COLUMNS` (line 389)
+- `_RECORD_HEALTH_EXCLUDED_TABLES` (line 390, used only at line 4735 — confirmed via `grep -rn`)
+
+Imports + module setup:
+```python
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+import psycopg
+from psycopg import sql as psql
+
+from .rows import RecordHealthRow
+
+_RECORD_HEALTH_TIMESTAMP_COLUMNS = ("updated_at", "inserted_at")
+_RECORD_HEALTH_TICKER_COLUMNS = ("ticker", "underlying_symbol")
+_RECORD_HEALTH_EXCLUDED_TABLES = {
+    # ... copied verbatim from repository.py:390 ...
+}
+
+
+class _HealthMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    # ... 7 methods ...
+```
+
+- [ ] **Step 8.2: Delete from repository.py + add import + add to inheritance**
+
+Also remove the moved constants from repository.py and (if `_RECORD_HEALTH_EXCLUDED_TABLES` was also moved) re-export them or just import them back if any non-health code still needs them.
+
+- [ ] **Step 8.3: Run tests:** `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/api/test_health.py tests/integration/storage/ -v`
+- [ ] **Step 8.4: Commit:** `refactor(storage): extract _HealthMixin`
+
+---
+
+## Task 9 — flow.py: extract 3 flow methods + 2 module helpers
+
+**Files:**
+- Create: `src/uw_scan/storage/flow.py`
+- Modify: `src/uw_scan/storage/repository.py`
+
+**Methods/helpers moved (REVISED per codex-review ISSUEs 6, 7, 11):**
+
+| Symbol | Current lines | Visibility |
+|---|---|---|
+| `_flow_footprint_label` (module-level) | 220-235 | externally imported by `scripts/backfill_flow_footprint.py:21` — must re-export from repository.py |
+| `_aggressor_label_confidence` (module-level) | 236-249 | externally imported by `scripts/backfill_flow_footprint.py:21` — must re-export |
+| `insert_flow_events` (mixin method) | 1034-1093 | internal |
+| `upsert_flow_alerts_daily_rollup` (mixin method) | 1094-1162 | internal |
+| `_flow_alert_trade_date` (becomes module-level function in flow.py) | 1163-1172 | internal; codex ISSUE-11 confirmed it doesn't use `self` |
+
+**Two visibility wrinkles:**
+- The 2 module helpers (`_flow_footprint_label`, `_aggressor_label_confidence`) are used by `scripts/backfill_flow_footprint.py`. After the move, `scripts/backfill_flow_footprint.py` continues to do `from uw_scan.storage.repository import _flow_footprint_label, _aggressor_label_confidence` — we MUST re-export these from `repository.py` (similar to how `redact_params` is re-exported in Task 2).
+- `_flow_alert_trade_date` becomes module-level (codex ISSUE-11); the call inside `upsert_flow_alerts_daily_rollup` changes from `self._flow_alert_trade_date(...)` to `_flow_alert_trade_date(...)`.
+
+- [ ] **Step 9.1: Create `src/uw_scan/storage/flow.py`**
+
+```python
+"""Flow events + flow_alerts_daily_rollup writes.
+
+Module-level helpers (_flow_footprint_label, _aggressor_label_confidence,
+_flow_alert_trade_date) live here because they're either used by callers
+outside this mixin (the first two are used by scripts/backfill_flow_footprint.py
+and re-exported from repository.py) or don't need self (the last one)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from datetime import date as _date, datetime
+from decimal import Decimal
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+from uw_scan import models
+
+
+def _flow_footprint_label(row: models.FlowAlert) -> str:
+    ...  # copied verbatim from repository.py:220-235
+
+
+def _aggressor_label_confidence(row: models.FlowAlert) -> Decimal | None:
+    ...  # copied verbatim from repository.py:236-249
+
+
+def _flow_alert_trade_date(rows: list[models.FlowAlert]) -> _date:
+    """Now module-level — doesn't use self."""
+    ...  # copied verbatim from repository.py:1163-1172, drop `self` param
+
+
+class _FlowMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_flow_events(
+        self, run_id: int, ticker: str, alerts: Iterable[models.FlowAlert]
+    ) -> int:
+        ...  # uses _flow_footprint_label, _aggressor_label_confidence
+
+    def upsert_flow_alerts_daily_rollup(self, ...) -> int:
+        ...  # uses _flow_alert_trade_date — call without self
+```
+
+- [ ] **Step 9.2: Delete from repository.py**
+
+Delete `_flow_footprint_label` (220-235), `_aggressor_label_confidence` (236-249), `insert_flow_events` (1034-1093), `upsert_flow_alerts_daily_rollup` (1094-1162), `_flow_alert_trade_date` (1163-1172). At the top of repository.py, add the import + re-export:
+
+```python
+# Flow helpers re-exported because scripts/backfill_flow_footprint.py imports them
+# directly from this module.
+from .flow import _aggressor_label_confidence, _flow_footprint_label
+```
+
+Add `_flow_footprint_label` and `_aggressor_label_confidence` to `__all__` (and document why — both are leading-underscore "private" but treated as external API by the backfill script).
+
+- [ ] **Step 9.3: Verify external import survives**
+
+```bash
+uv run python -c "from uw_scan.storage.repository import _flow_footprint_label, _aggressor_label_confidence; print('ok')"
+```
+
+- [ ] **Step 9.4: Run tests + backfill smoke**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/storage/ tests/integration/test_repository_real_pg.py -v
+uv run python -c "import scripts.backfill_flow_footprint; print('backfill script import: ok')"
+```
+
+- [ ] **Step 9.5: Commit:** `refactor(storage): extract _FlowMixin + module helpers`
+
+---
+
+## Task 10 — Final assembly verification + storage/CLAUDE.md update
+
+**Files:**
+- Modify: `src/uw_scan/storage/CLAUDE.md` (document the mixin pattern for the PR-1 modules)
+- Verify: `src/uw_scan/storage/repository.py` is the assembled shell + remaining (~120) methods
+
+- [ ] **Step 10.1: Verify final Repository signature**
+
+```bash
+grep -n "^class Repository" src/uw_scan/storage/repository.py
+wc -l src/uw_scan/storage/repository.py
+ls src/uw_scan/storage/*.py
+```
+
+Expected:
+- `class Repository(_FlowMixin, _HealthMixin, _JobsMixin, _MarketDataMixin, _ScanOutputsMixin, _AuditMixin, _BaseMixin):`
+- `repository.py` line count ~4000 (down from 5173)
+- 9 new files in `storage/`
+
+- [ ] **Step 10.2: Update `src/uw_scan/storage/CLAUDE.md`**
+
+Add a "Mixin pattern" section explaining:
+- repository.py is the assembled shell; do NOT add new methods directly to it
+- New methods go in the appropriate per-domain mixin file
+- New domains get a new `_<Domain>Mixin` in `<domain>.py`
+- Row dataclasses go in `rows.py`
+- Private utilities go in `_helpers.py`
+- The PR-1 split covered audit/flow/health/jobs/market_data/scan_outputs; PR-2 and PR-3 will cover the remaining domains
+
+- [ ] **Step 10.3: Run full test suite**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest 2>&1 | tail -5
+```
+
+Expect same pass/skip counts as pre-PR-1 baseline (346+ pass).
+
+- [ ] **Step 10.4: Lint + idempotency rerun**
+
+```bash
+uv run python scripts/_lint_except.py src
+set -a; source ../../../.env; set +a; bash scripts/migrate.sh 2>&1 | grep -cE "Applying"  # expect 36
+```
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add src/uw_scan/storage/CLAUDE.md
+git commit -m "docs(storage): document mixin pattern after PR-1 split"
+```
+
+---
+
+## Final PR steps
+
+- [ ] Push branch + open PR with title `refactor(storage): split repository.py PR 1/3 (leaf modules)`
+- [ ] Watch CI
+- [ ] Squash-merge on green
+
+## Out of scope (deferred)
+
+- **PR-2:** extract domains — `external_api.py`, `volatility_raw.py`, `options.py`, `scan_runs.py`, `scan_results.py`, `watchlist.py` (~1500 lines)
+- **PR-3:** extract heavy — `trade_insights_ai.py`, `volatility_v2.py`, `fetchers.py` (~1300 lines)
+- **Cockpit module helpers** (`_pin_candidate`, `_vanna_conditional_reading`, `_charm_regime`, etc.): stay in `repository.py` for PR-1; move to PR-2 with their domain modules
+- **`__init__.py` re-export migration:** if we later want `from uw_scan.storage import Repository` to be the canonical import path, that's a separate breaking-change PR after PR-3 lands
+
+## Risks
+
+1. **Mixin MRO collision.** Two mixins defining the same method name would silently shadow each other. We hand-checked each method name is unique within its mixin set; pytest would catch a regression. Future drift is the risk.
+
+2. **`__all__` drift.** A caller that imports a row type via `from uw_scan.storage.repository import SomeRow` would fail if I forget to add `SomeRow` to `__all__`. The integration tests cover most callers but not exhaustively — verify with `grep -rn "from uw_scan.storage.repository import" src/ tests/` after each task.
+
+3. **The 2 cockpit-specific module helpers using `models`.** `_flow_footprint_label` and `_aggressor_label_confidence` use `from uw_scan import models`. The new `flow.py` needs this import. Confirmed in Step 9.1's template.
+
+4. **Test fixture pattern**: integration tests use `Repository(conn, schema=...)`. The mixin pattern preserves this exact constructor signature via `_BaseMixin.__init__`. Verified by running each task's targeted test gate.

--- a/src/uw_scan/storage/CLAUDE.md
+++ b/src/uw_scan/storage/CLAUDE.md
@@ -2,8 +2,39 @@
 
 ## Files
 
-- `repository.py` — `Repository` class. One method per insert/select. No `**kwargs` splatting from arbitrary dicts.
+- `repository.py` — assembled `Repository` class. Composes per-domain mixins (see "Mixin pattern" below). Methods not yet extracted live directly on `Repository`; PR-2/PR-3 will move the rest.
+- `_base.py` — `_BaseMixin` (Repository `__init__` + `conn` property). MUST be LAST in MRO.
+- `_helpers.py` — pure utility functions (`_d`, `_nullable_int/float`, `provider_day_bounds`, `redact_params`, `status_family_for`).
+- `rows.py` — frozen `@dataclass` row types + `WatchlistCardRow`.
+- `audit.py` / `flow.py` / `health.py` / `jobs.py` / `market_data.py` / `scan_outputs.py` — per-domain mixins extracted in PR-1.
+- `provider_usage.py` — `ExternalApiRequestRecorder` (out-of-band telemetry writer). Not part of `Repository`.
 - `migrations/*.sql` — applied lexically by `scripts/migrate.sh`
+
+## Mixin pattern (post-2026-05-16 PR-1 split)
+
+`Repository` is the assembled class:
+
+```python
+class Repository(
+    _AuditMixin, _FlowMixin, _HealthMixin, _JobsMixin,
+    _MarketDataMixin, _ScanOutputsMixin,
+    _BaseMixin,  # MUST be last — owns __init__ and the conn property
+):
+    # PR-2/PR-3 will move the remaining methods to per-domain mixins.
+    # New methods go in the appropriate mixin file, NOT here.
+    ...
+```
+
+Conventions for the mixin pattern:
+
+- **One mixin class per file.** Naming: `_<Domain>Mixin` in `<domain>.py`.
+- **`from __future__ import annotations`** at top of every storage file.
+- **No `__init__` on domain mixins.** Only `_BaseMixin` defines it; Python's MRO calls only the leftmost class's `__init__`, so any other mixin defining one would break construction.
+- **Type hints for `self._conn` and `self._schema`** as class-level annotations (`_conn: psycopg.Connection`). Values are set by `_BaseMixin.__init__` at runtime.
+- **Adding a new domain** → new file `<domain>.py` + `_<Domain>Mixin` class + add to `repository.py`'s import block and inheritance list (above `_BaseMixin`).
+- **Adding a new row dataclass** → goes in `rows.py`; re-export from `repository.py`'s `from .rows import (...)` block and `__all__`.
+- **Adding a new pure helper** → goes in `_helpers.py`; if externally importable, also re-export from `repository.py`.
+- **Backward compat**: callers' `from uw_scan.storage.repository import X` paths MUST keep working — all moved names are explicitly re-exported.
 
 ## Repository conventions
 

--- a/src/uw_scan/storage/_base.py
+++ b/src/uw_scan/storage/_base.py
@@ -1,0 +1,25 @@
+"""Repository base mixin: owns __init__, conn property, and the _schema /
+_conn attributes that every per-domain mixin reads.
+
+Mixed in LAST in the Repository inheritance order so domain mixins can
+shadow specific behavior if needed (none do today). Domain mixins MUST NOT
+define their own __init__ — Python's MRO calls only the leftmost __init__,
+and skipping super() chains the way mixin __init__ would creates
+hard-to-debug initialization gaps."""
+
+from __future__ import annotations
+
+import psycopg
+
+
+class _BaseMixin:
+    """Owns the connection and schema. Other mixins reference self._conn and
+    self._schema; this class is what makes them concrete."""
+
+    def __init__(self, conn: psycopg.Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+
+    @property
+    def conn(self) -> psycopg.Connection:
+        return self._conn

--- a/src/uw_scan/storage/_helpers.py
+++ b/src/uw_scan/storage/_helpers.py
@@ -1,0 +1,84 @@
+"""Pure-utility helpers used by Repository methods.
+
+Three of these are externally importable from `uw_scan.storage.repository`
+(provider_day_bounds, status_family_for, redact_params) and stay re-exported
+there for backward compat with callers in sources/, api/, and tests/.
+Internal-only helpers (_d, _nullable_int, _nullable_float) live here too for
+cohesion.
+
+Moved from repository.py during the PR-1 split (docs/superpowers/plans/
+2026-05-16-repository-split-pr1.md). Cockpit-specific helpers
+(_pin_candidate, _vanna_conditional_reading, _charm_regime, etc.) stay in
+repository.py for PR-1 and will move with their domain modules in PR-2.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from zoneinfo import ZoneInfo
+
+_PROVIDER_DAY_TZ = ZoneInfo("America/New_York")
+
+_REDACTED_PARAM_KEYS = {
+    "apikey",
+    "api_key",
+    "authorization",
+    "auth",
+    "token",
+}
+
+
+def _d(value: Decimal | None) -> Any:
+    """psycopg handles Decimal natively; keep this for symmetry with other casters."""
+    return value
+
+
+def provider_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
+    current = now or datetime.now(tz=_PROVIDER_DAY_TZ)
+    local = current.astimezone(_PROVIDER_DAY_TZ)
+    reset = local.replace(hour=20, minute=0, second=0, microsecond=0)
+    if local < reset:
+        reset -= timedelta(days=1)
+    return reset, reset + timedelta(days=1)
+
+
+def status_family_for(status_code: int | None, *, transport_error: bool = False) -> str:
+    if transport_error:
+        return "transport_error"
+    if status_code is None:
+        return "transport_error"
+    if 200 <= status_code <= 299:
+        return "2xx"
+    if 300 <= status_code <= 399:
+        return "3xx"
+    if 400 <= status_code <= 499:
+        return "4xx"
+    if 500 <= status_code <= 599:
+        return "5xx"
+    return "transport_error"
+
+
+def redact_params(params: dict[str, object] | None) -> dict[str, object]:
+    redacted: dict[str, object] = {}
+    for key, value in (params or {}).items():
+        if key.lower() in _REDACTED_PARAM_KEYS:
+            continue
+        if isinstance(value, str) and len(value) > 256:
+            redacted[key] = value[:253] + "..."
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _nullable_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(round(float(value)))
+
+
+def _nullable_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)

--- a/src/uw_scan/storage/audit.py
+++ b/src/uw_scan/storage/audit.py
@@ -1,0 +1,72 @@
+"""Audit + raw payload writes.
+
+API/worker fetchers call insert_audit_row immediately before any UW HTTP
+request (so even failures leave a row), then insert_raw_payload with the
+response body. The two-step shape lets us trace any UW call back to its
+HTTP request even when normalization fails."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+
+class _AuditMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_audit_row(
+        self,
+        run_id: int,
+        endpoint_slug: str,
+        endpoint_path: str,
+        params: dict[str, Any],
+        status_code: int,
+        started_at: datetime,
+        finished_at: datetime,
+        daily_req_count: int | None,
+        minute_req_remaining: int | None,
+        minute_req_reset: str | None,
+        error_message: str | None = None,
+    ) -> int:
+        sql = (
+            f"INSERT INTO {self._schema}.api_request_audit ("
+            "run_id, endpoint_slug, endpoint_path, params_json, status_code, "
+            "request_started_at, request_finished_at, daily_req_count, "
+            "minute_req_remaining, minute_req_reset, error_message) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING audit_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    run_id,
+                    endpoint_slug,
+                    endpoint_path,
+                    Jsonb(params),
+                    status_code,
+                    started_at,
+                    finished_at,
+                    daily_req_count,
+                    minute_req_remaining,
+                    minute_req_reset,
+                    error_message,
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def insert_raw_payload(self, audit_id: int, payload: dict | list) -> int:
+        sql = (
+            f"INSERT INTO {self._schema}.raw_payloads (audit_id, payload_jsonb) "
+            "VALUES (%s, %s) RETURNING payload_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (audit_id, Jsonb(payload)))
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])

--- a/src/uw_scan/storage/flow.py
+++ b/src/uw_scan/storage/flow.py
@@ -1,0 +1,201 @@
+"""Flow events + flow_alerts_daily_rollup writes.
+
+Module-level helpers (_flow_footprint_label, _aggressor_label_confidence)
+are used by insert_flow_events AND by scripts/backfill_flow_footprint.py
+(which imports them via `from uw_scan.storage.repository import …`). The
+script's import path must keep working, so repository.py re-exports both
+helpers from this module.
+
+_flow_alert_trade_date is module-level here because it doesn't use self —
+upsert_flow_alerts_daily_rollup calls it as a plain function."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from datetime import date as _date
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+from .. import models
+
+
+def _flow_footprint_label(row: models.FlowAlert) -> str:
+    ask = row.total_ask_side_prem or Decimal(0)
+    bid = row.total_bid_side_prem or Decimal(0)
+    total = row.total_premium or ask + bid
+    ask_ratio = ask / total if total and total > 0 else None
+    if row.has_sweep and ask_ratio is not None and ask_ratio >= Decimal("0.65"):
+        return "directional_whale"
+    if row.has_multileg:
+        return "hedge_flow"
+    if row.has_floor:
+        return "dealer_hedge"
+    if ask_ratio is not None and Decimal("0.40") <= ask_ratio <= Decimal("0.60"):
+        return "gamma_scalper"
+    return "unclassified"
+
+
+def _aggressor_label_confidence(row: models.FlowAlert) -> Decimal | None:
+    ask = row.total_ask_side_prem or Decimal(0)
+    bid = row.total_bid_side_prem or Decimal(0)
+    total = row.total_premium or ask + bid
+    if total is None or total <= 0:
+        return None
+    dominant_side_ratio = max(ask, bid) / total
+    structure_penalty = Decimal("0.05") if row.has_multileg else Decimal(0)
+    confidence = min(
+        Decimal("1"), max(Decimal("0"), dominant_side_ratio - structure_penalty)
+    )
+    return confidence.quantize(Decimal("0.01"))
+
+
+def _flow_alert_trade_date(rows: list[models.FlowAlert]) -> _date:
+    """Pick the trade date for a batch of flow alerts. Was a Repository method
+    in pre-split repository.py but didn't use self — moved to module-level."""
+    market_tz = ZoneInfo("America/New_York")
+    for row in rows:
+        if row.created_at is None:
+            continue
+        created_at = row.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=market_tz)
+        return created_at.astimezone(market_tz).date()
+    return datetime.now(market_tz).date()
+
+
+class _FlowMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_flow_events(
+        self, run_id: int, ticker: str, alerts: Iterable[models.FlowAlert]
+    ) -> int:
+        rows = list(alerts)
+        if not rows:
+            return 0
+        sql = (
+            f"INSERT INTO {self._schema}.flow_events ("
+            "run_id, alert_id, ticker, option_chain, expiry, strike, option_type, "
+            "price, underlying_price, total_size, total_premium, "
+            "total_ask_side_prem, total_bid_side_prem, volume, open_interest, "
+            "volume_oi_ratio, has_sweep, has_floor, has_multileg, "
+            "all_opening_trades, iv_start, iv_end, alert_rule, "
+            "flow_footprint_label, aggressor_label_confidence, "
+            "rule_id, sector, issue_type, next_earnings_date, created_at) VALUES ("
+            "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, "
+            "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (run_id, alert_id) DO NOTHING"
+        )
+        with self._conn.cursor() as cur:
+            for r in rows:
+                cur.execute(
+                    sql,
+                    (
+                        run_id,
+                        r.id,
+                        r.ticker,
+                        r.option_chain,
+                        r.expiry,
+                        r.strike,
+                        r.type,
+                        r.price,
+                        r.underlying_price,
+                        r.total_size,
+                        r.total_premium,
+                        r.total_ask_side_prem,
+                        r.total_bid_side_prem,
+                        r.volume,
+                        r.open_interest,
+                        r.volume_oi_ratio,
+                        r.has_sweep,
+                        r.has_floor,
+                        r.has_multileg,
+                        r.all_opening_trades,
+                        r.iv_start,
+                        r.iv_end,
+                        r.alert_rule,
+                        r.flow_footprint_label or _flow_footprint_label(r),
+                        r.aggressor_label_confidence
+                        if r.aggressor_label_confidence is not None
+                        else _aggressor_label_confidence(r),
+                        r.rule_id,
+                        r.sector,
+                        r.issue_type,
+                        r.next_earnings_date,
+                        r.created_at,
+                    ),
+                )
+        return len(rows)
+
+    def upsert_flow_alerts_daily_rollup(
+        self,
+        *,
+        run_id: int,
+        ticker: str,
+        alerts: Iterable[models.FlowAlert],
+        alert_limit: int,
+        trade_date: _date | None = None,
+    ) -> None:
+        rows = list(alerts)
+        if trade_date is None:
+            trade_date = _flow_alert_trade_date(rows)
+
+        bull_premium = Decimal("0")
+        bear_premium = Decimal("0")
+        ask_side_premium = Decimal("0")
+        bid_side_premium = Decimal("0")
+        total_premium = Decimal("0")
+        rules: Counter[str] = Counter()
+
+        for row in rows:
+            premium = row.total_premium or Decimal("0")
+            total_premium += premium
+            opt_type = (row.type or "").lower()
+            if opt_type == "call":
+                bull_premium += premium
+            elif opt_type == "put":
+                bear_premium += premium
+            ask_side_premium += row.total_ask_side_prem or Decimal("0")
+            bid_side_premium += row.total_bid_side_prem or Decimal("0")
+            if row.alert_rule:
+                rules[row.alert_rule] += 1
+
+        top_alert_rule = rules.most_common(1)[0][0] if rules else None
+
+        sql = (
+            f"INSERT INTO {self._schema}.flow_alerts_daily_rollup ("
+            "ticker, trade_date, run_id, alert_count, alert_count_is_limited, "
+            "total_premium, bull_premium, bear_premium, ask_side_premium, "
+            "bid_side_premium, top_alert_rule) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+            "ON CONFLICT (ticker, trade_date) DO UPDATE SET "
+            "run_id=EXCLUDED.run_id, alert_count=EXCLUDED.alert_count, "
+            "alert_count_is_limited=EXCLUDED.alert_count_is_limited, "
+            "total_premium=EXCLUDED.total_premium, "
+            "bull_premium=EXCLUDED.bull_premium, "
+            "bear_premium=EXCLUDED.bear_premium, "
+            "ask_side_premium=EXCLUDED.ask_side_premium, "
+            "bid_side_premium=EXCLUDED.bid_side_premium, "
+            "top_alert_rule=EXCLUDED.top_alert_rule, updated_at=now()"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    ticker.upper(),
+                    trade_date,
+                    run_id,
+                    len(rows),
+                    len(rows) >= alert_limit,
+                    total_premium,
+                    bull_premium,
+                    bear_premium,
+                    ask_side_premium,
+                    bid_side_premium,
+                    top_alert_rule,
+                ),
+            )

--- a/src/uw_scan/storage/health.py
+++ b/src/uw_scan/storage/health.py
@@ -1,0 +1,231 @@
+"""Health observability: per-table record coverage, watchlist count,
+worker heartbeats, stock history rollup.
+
+list_record_health auto-discovers all uw_scan tables and reports how many
+rows landed in the rolling window for each table that looks tickered (has
+both a timestamp and ticker column). The 3 _RECORD_HEALTH_* constants
+filter what counts as 'tickered' and which tables to skip."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from datetime import datetime
+
+import psycopg
+from psycopg import sql as psql
+
+from .rows import RecordHealthRow
+
+_RECORD_HEALTH_TIMESTAMP_COLUMNS = ("updated_at", "inserted_at")
+_RECORD_HEALTH_TICKER_COLUMNS = ("ticker", "underlying_symbol")
+_RECORD_HEALTH_EXCLUDED_TABLES = {
+    # Request logs and orchestration tables are covered by provider usage /
+    # scheduler health, not per-ticker persisted data coverage.
+    "external_api_requests",
+    "scan_results",
+    "scan_universe",
+    # Not watchlist-scoped periodic UW source tables.
+    "index_ohlc_daily",
+    "opportunity_scores",
+    "structure_ideas",
+    # Derived/backfill tables that do not update for every ticker each RTH window.
+    "iv_smile_snapshots",
+    "oi_by_expiry",
+    "option_surface_snapshots",
+    "stock_analytics_daily",
+    "vrp_daily",
+}
+
+
+class _HealthMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    # ---- stock history rollup (for Market Structure history table) ----
+    def fetch_stock_history_rollup(self, ticker: str, limit: int = 30) -> list[dict]:
+        """One row per trading day, latest successful scan_run on that date.
+
+        Joins to daily_ohlc for end-of-day spot. Returns dicts shaped for
+        api.routers.stock to wrap in StockHistoryRow models.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                WITH daily_runs AS (
+                    SELECT DISTINCT ON (started_at::date)
+                        started_at::date AS market_date,
+                        strike_gex_curve,
+                        aggregates
+                    FROM {self._schema}.scan_runs
+                    WHERE ticker = %s
+                      AND status = 'ok'
+                      AND strike_gex_curve IS NOT NULL
+                    ORDER BY started_at::date DESC, started_at DESC
+                )
+                SELECT
+                    r.market_date,
+                    d.close AS spot,
+                    r.aggregates->>'iv30d' AS iv30d,
+                    r.aggregates->>'pcr_vol' AS pcr_vol,
+                    r.strike_gex_curve
+                FROM daily_runs r
+                LEFT JOIN {self._schema}.daily_ohlc d
+                  ON d.ticker = %s AND d.date = r.market_date
+                ORDER BY r.market_date DESC
+                LIMIT %s
+                """,
+                (ticker, ticker, limit),
+            )
+            return [
+                {
+                    "market_date": row[0],
+                    "spot": row[1],
+                    "iv30d": row[2],
+                    "pcr_vol": row[3],
+                    "strike_gex_curve": row[4],
+                }
+                for row in cur.fetchall()
+            ]
+
+    # ---- watchlist count (for HealthPanel) ----
+    def count_active_watchlist(self) -> int:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT COUNT(*) FROM {self._schema}.watchlist WHERE removed_at IS NULL"
+            )
+            row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+    def _discover_record_health_rules(self) -> dict[str, tuple[str, str, int]]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT table_name, array_agg(column_name::text ORDER BY ordinal_position)
+                FROM information_schema.columns
+                WHERE table_schema = %s
+                GROUP BY table_name
+                ORDER BY table_name
+                """,
+                (self._schema,),
+            )
+            discovered: dict[str, tuple[str, str, int]] = {}
+            for table, column_list in cur.fetchall():
+                table_name = str(table)
+                if table_name in _RECORD_HEALTH_EXCLUDED_TABLES:
+                    continue
+                columns = set(column_list or [])
+                timestamp_col = next(
+                    (
+                        column
+                        for column in _RECORD_HEALTH_TIMESTAMP_COLUMNS
+                        if column in columns
+                    ),
+                    None,
+                )
+                ticker_col = next(
+                    (
+                        column
+                        for column in _RECORD_HEALTH_TICKER_COLUMNS
+                        if column in columns
+                    ),
+                    None,
+                )
+                if timestamp_col is not None and ticker_col is not None:
+                    discovered[table_name] = (timestamp_col, ticker_col, 1)
+            return discovered
+
+    def list_record_health(
+        self,
+        *,
+        since: datetime,
+        expected_tickers: int,
+        min_coverage: float = 0.9,
+        tables: Iterable[str] | None = None,
+    ) -> list[RecordHealthRow]:
+        rules = self._discover_record_health_rules()
+        selected = list(tables) if tables is not None else list(rules)
+        unknown = sorted(set(selected) - set(rules))
+        if unknown:
+            raise ValueError(f"unknown record health table(s): {', '.join(unknown)}")
+
+        expected_min_tickers = (
+            0 if expected_tickers <= 0 else math.ceil(expected_tickers * min_coverage)
+        )
+        rows: list[RecordHealthRow] = []
+        with self._conn.cursor() as cur:
+            for table in selected:
+                timestamp_col, ticker_col, min_rows_per_ticker = rules[table]
+                cur.execute(
+                    psql.SQL(
+                        """
+                        SELECT
+                            COUNT(*)::int AS actual_rows,
+                            COUNT(DISTINCT {ticker_col})::int AS actual_tickers,
+                            MAX({timestamp_col}) AS latest_at
+                        FROM {schema}.{table}
+                        WHERE {timestamp_col} >= %s
+                        """
+                    ).format(
+                        schema=psql.Identifier(self._schema),
+                        table=psql.Identifier(table),
+                        timestamp_col=psql.Identifier(timestamp_col),
+                        ticker_col=psql.Identifier(ticker_col),
+                    ),
+                    (since,),
+                )
+                actual_rows, actual_tickers, latest_at = cur.fetchone() or (0, 0, None)
+                expected_min_rows = expected_min_tickers * min_rows_per_ticker
+                ok = (
+                    int(actual_tickers or 0) >= expected_min_tickers
+                    and int(actual_rows or 0) >= expected_min_rows
+                )
+                rows.append(
+                    RecordHealthRow(
+                        table=table,
+                        window_start=since,
+                        expected_tickers=expected_tickers,
+                        expected_min_tickers=expected_min_tickers,
+                        actual_tickers=int(actual_tickers or 0),
+                        expected_min_rows=expected_min_rows,
+                        actual_rows=int(actual_rows or 0),
+                        latest_at=latest_at,
+                        ok=ok,
+                    )
+                )
+        return rows
+
+    # ---- worker_heartbeat ----
+    def upsert_heartbeat(self, job_name: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.worker_heartbeat (job_name, last_beat_at)
+                VALUES (%s, now())
+                ON CONFLICT (job_name) DO UPDATE SET last_beat_at = now()
+                """,
+                (job_name,),
+            )
+        self._conn.commit()
+
+    def get_heartbeat(self, job_name: str) -> datetime | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT last_beat_at FROM {self._schema}.worker_heartbeat WHERE job_name=%s",
+                (job_name,),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+
+    def get_latest_heartbeat(self) -> tuple[str, datetime] | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT job_name, last_beat_at
+                FROM {self._schema}.worker_heartbeat
+                ORDER BY last_beat_at DESC
+                LIMIT 1
+                """
+            )
+            row = cur.fetchone()
+        return (str(row[0]), row[1]) if row else None

--- a/src/uw_scan/storage/jobs.py
+++ b/src/uw_scan/storage/jobs.py
@@ -1,0 +1,166 @@
+"""Rescan jobs queue: enqueue/claim/requeue/mark + summary.
+
+Owns the claim-token race-protection logic from the 2026-05-16 review (B1).
+mark_job_done and mark_job_failed gate UPDATE on (id, claim_token) so a
+worker whose token was cleared by requeue_stale_running_jobs can't clobber
+a fresh claim from a different worker."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+import psycopg
+
+from .rows import JobRow, RescanQueueSummaryRow
+
+logger = logging.getLogger(__name__)
+
+
+class _JobsMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def enqueue_rescan_job(self, ticker: str, *, priority: int = 0) -> str:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.jobs (ticker, status, priority)
+                VALUES (%s, 'queued', %s)
+                ON CONFLICT (ticker) WHERE status IN ('queued', 'running')
+                DO UPDATE SET
+                    priority = GREATEST(
+                        {self._schema}.jobs.priority,
+                        EXCLUDED.priority
+                    ),
+                    requested_at = EXCLUDED.requested_at
+                RETURNING id
+                """,
+                (ticker, priority),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            job_id = row[0]
+        self._conn.commit()
+        return str(job_id)
+
+    def claim_next_queued_job(self) -> JobRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE {self._schema}.jobs
+                SET status='running',
+                    started_at=NOW(),
+                    claim_token=gen_random_uuid()
+                WHERE id = (
+                  SELECT id FROM {self._schema}.jobs
+                  WHERE status='queued'
+                  ORDER BY priority DESC, requested_at ASC, id ASC
+                  FOR UPDATE SKIP LOCKED
+                  LIMIT 1
+                )
+                RETURNING id, ticker, status, run_id, error,
+                          requested_at, started_at, finished_at, claim_token
+                """
+            )
+            row = cur.fetchone()
+        self._conn.commit()
+        return JobRow(*row) if row else None
+
+    def requeue_stale_running_jobs(self, older_than: timedelta) -> int:
+        # Clear claim_token so the original worker's stored token will not
+        # match anything if/when it tries mark_job_done later (review
+        # 2026-05-16, B1; claim-token approach per codex review).
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE {self._schema}.jobs
+                SET status='queued',
+                    started_at=NULL,
+                    error=NULL,
+                    claim_token=NULL
+                WHERE status='running'
+                  AND started_at < NOW() - %s
+                """,
+                (older_than,),
+            )
+            count = cur.rowcount
+        self._conn.commit()
+        return count
+
+    def mark_job_done(self, job_id: str, run_id: int, claim_token: Any) -> None:
+        # Claim-token guard against the requeue race (review 2026-05-16, B1):
+        # if requeue_stale_running_jobs cleared our token, or another worker
+        # has since reclaimed (with a fresh token), our update must be rejected.
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE {self._schema}.jobs
+                SET status='done', run_id=%s, finished_at=NOW()
+                WHERE id=%s AND claim_token=%s
+                """,
+                (run_id, job_id, claim_token),
+            )
+            if cur.rowcount == 0:
+                logger.warning(
+                    "mark_job_done lost claim on job_id=%s "
+                    "(token mismatch; another worker may have reclaimed)",
+                    job_id,
+                )
+        self._conn.commit()
+
+    def mark_job_failed(self, job_id: str, error: str, claim_token: Any) -> None:
+        # Claim-token guard (review 2026-05-16, B1).
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE {self._schema}.jobs
+                SET status='failed', error=%s, finished_at=NOW()
+                WHERE id=%s AND claim_token=%s
+                """,
+                (error[:2000], job_id, claim_token),
+            )
+            if cur.rowcount == 0:
+                logger.warning(
+                    "mark_job_failed lost claim on job_id=%s "
+                    "(token mismatch; another worker may have reclaimed)",
+                    job_id,
+                )
+        self._conn.commit()
+
+    def get_rescan_queue_summary(self) -> RescanQueueSummaryRow:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                  count(*) FILTER (WHERE status IN ('queued', 'running')) AS total,
+                  count(*) FILTER (WHERE status = 'queued') AS queued,
+                  count(*) FILTER (WHERE status = 'running') AS running,
+                  min(requested_at) FILTER (
+                    WHERE status IN ('queued', 'running')
+                  ) AS oldest_requested_at
+                FROM {self._schema}.jobs
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return RescanQueueSummaryRow(
+            total=row[0],
+            queued=row[1],
+            running=row[2],
+            oldest_requested_at=row[3],
+        )
+
+    def get_job(self, job_id: str) -> JobRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT id, ticker, status, run_id, error,
+                       requested_at, started_at, finished_at, claim_token
+                FROM {self._schema}.jobs WHERE id=%s
+                """,
+                (job_id,),
+            )
+            row = cur.fetchone()
+            return JobRow(*row) if row else None

--- a/src/uw_scan/storage/market_data.py
+++ b/src/uw_scan/storage/market_data.py
@@ -1,0 +1,181 @@
+"""Market-data persistence: daily OHLC, intraday quote, PCR history, ETF AUM cache."""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import psycopg
+
+from .rows import DailyOhlcRow, IntradayQuoteRow, PcrHistoryRow
+
+
+class _MarketDataMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    # ---- daily_ohlc ----
+    def upsert_daily_ohlc(
+        self,
+        *,
+        ticker: str,
+        date: _date,
+        open: Decimal | None,
+        high: Decimal | None,
+        low: Decimal | None,
+        close: Decimal,
+        volume: int | None,
+        source: str,
+    ) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.daily_ohlc
+                  (ticker, date, open, high, low, close, volume, source)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (ticker, date) DO UPDATE
+                  SET open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low,
+                      close=EXCLUDED.close, volume=EXCLUDED.volume,
+                      source=EXCLUDED.source, fetched_at=NOW()
+                """,
+                (ticker, date, open, high, low, close, volume, source),
+            )
+        self._conn.commit()
+
+    def list_daily_ohlc(self, ticker: str, *, limit: int = 30) -> list[DailyOhlcRow]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT ticker, date, open, high, low, close, volume, source, fetched_at
+                FROM {self._schema}.daily_ohlc
+                WHERE ticker=%s
+                ORDER BY date DESC
+                LIMIT %s
+                """,
+                (ticker, limit),
+            )
+            return [DailyOhlcRow(*row) for row in cur.fetchall()]
+
+    # ---- intraday_quote ----
+    def upsert_intraday_quote(
+        self, ticker: str, price: Decimal, quoted_at: datetime
+    ) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.intraday_quote (ticker, price, quoted_at)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (ticker) DO UPDATE
+                  SET price=EXCLUDED.price, quoted_at=EXCLUDED.quoted_at, fetched_at=NOW()
+                """,
+                (ticker, price, quoted_at),
+            )
+        self._conn.commit()
+
+    def get_intraday_quote(self, ticker: str) -> IntradayQuoteRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT ticker, price, quoted_at, fetched_at
+                FROM {self._schema}.intraday_quote WHERE ticker=%s
+                """,
+                (ticker,),
+            )
+            row = cur.fetchone()
+            return IntradayQuoteRow(*row) if row else None
+
+    def get_latest_intraday_quote_times(self) -> tuple[datetime, datetime] | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT MAX(quoted_at), MAX(fetched_at)
+                FROM {self._schema}.intraday_quote
+                """
+            )
+            row = cur.fetchone()
+        if row and row[0] is not None and row[1] is not None:
+            return (row[0], row[1])
+        return None
+
+    # ---- pcr_history ----
+    def append_pcr_history(
+        self,
+        ticker: str,
+        snapshot_date: _date,
+        pcr_oi: Decimal | None,
+        pcr_vol: Decimal | None,
+    ) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.pcr_history (ticker, snapshot_date, pcr_oi, pcr_vol)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (ticker, snapshot_date) DO UPDATE
+                  SET pcr_oi=EXCLUDED.pcr_oi, pcr_vol=EXCLUDED.pcr_vol
+                """,
+                (ticker, snapshot_date, pcr_oi, pcr_vol),
+            )
+        self._conn.commit()
+
+    def get_pcr_history_30d_ago(
+        self, ticker: str, today: _date
+    ) -> PcrHistoryRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT ticker, snapshot_date, pcr_oi, pcr_vol
+                FROM {self._schema}.pcr_history
+                WHERE ticker=%s AND snapshot_date <= %s - INTERVAL '30 days'
+                ORDER BY snapshot_date DESC
+                LIMIT 1
+                """,
+                (ticker, today),
+            )
+            row = cur.fetchone()
+            return PcrHistoryRow(*row) if row else None
+
+    def get_pcr_history_row(
+        self, ticker: str, snapshot_date: _date
+    ) -> PcrHistoryRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT ticker, snapshot_date, pcr_oi, pcr_vol
+                FROM {self._schema}.pcr_history
+                WHERE ticker=%s AND snapshot_date=%s
+                """,
+                (ticker, snapshot_date),
+            )
+            row = cur.fetchone()
+        return PcrHistoryRow(*row) if row else None
+
+    # ---- etf_aum_cache (A1 review fix: skip per-scan UW round trip) ----
+    def get_recent_etf_aum(self, ticker: str, *, max_age: timedelta) -> Decimal | None:
+        """Return cached AUM if fetched within max_age, else None.
+        None means the caller should fetch fresh (cache miss or stale)."""
+        ticker = ticker.upper()  # cache keys are canonical UPPER
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT aum FROM {self._schema}.etf_aum_cache
+                WHERE ticker = %s AND fetched_at > NOW() - %s
+                """,
+                (ticker, max_age),
+            )
+            row = cur.fetchone()
+        return row[0] if row else None
+
+    def upsert_etf_aum(self, ticker: str, aum: Decimal) -> None:
+        ticker = ticker.upper()
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.etf_aum_cache (ticker, aum, fetched_at)
+                VALUES (%s, %s, NOW())
+                ON CONFLICT (ticker) DO UPDATE
+                  SET aum = EXCLUDED.aum, fetched_at = EXCLUDED.fetched_at
+                """,
+                (ticker, aum),
+            )
+        self._conn.commit()

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -22,16 +22,39 @@ from psycopg.types.json import Jsonb
 
 from .. import models
 
+# Row dataclasses live in rows.py since the PR-1 split. Re-exported here so
+# existing callers (`from uw_scan.storage.repository import JobRow`) continue
+# to work without changing import paths.
+from .rows import (
+    DailyOhlcRow,
+    ExternalApiBreakdownRow,
+    ExternalApiRequestRow,
+    ExternalApiUsageSummary,
+    IntradayQuoteRow,
+    JobRow,
+    PcrHistoryRow,
+    RecordHealthRow,
+    RescanQueueSummaryRow,
+    ThroughputSummaryRow,
+    WatchlistCardRow,
+    WatchlistRow,
+)
 
-@dataclass(frozen=True)
-class WatchlistRow:
-    ticker: str
-    sector: str
-    notes: str | None
-    pinned: bool
-    sort_rank: int
-    added_at: datetime
-    removed_at: datetime | None
+__all__ = [
+    "Repository",
+    "DailyOhlcRow",
+    "ExternalApiBreakdownRow",
+    "ExternalApiRequestRow",
+    "ExternalApiUsageSummary",
+    "IntradayQuoteRow",
+    "JobRow",
+    "PcrHistoryRow",
+    "RecordHealthRow",
+    "RescanQueueSummaryRow",
+    "ThroughputSummaryRow",
+    "WatchlistCardRow",
+    "WatchlistRow",
+]
 
 
 def _row_for_date(
@@ -263,128 +286,6 @@ def _vrp_sign_flip_status_from_db(value: Any) -> bool | str:
     return value or "insufficient_history"
 
 
-@dataclass(frozen=True)
-class DailyOhlcRow:
-    ticker: str
-    date: _date
-    open: Decimal | None
-    high: Decimal | None
-    low: Decimal | None
-    close: Decimal
-    volume: int | None
-    source: str
-    fetched_at: datetime
-
-
-@dataclass(frozen=True)
-class IntradayQuoteRow:
-    ticker: str
-    price: Decimal
-    quoted_at: datetime
-    fetched_at: datetime
-
-
-@dataclass(frozen=True)
-class PcrHistoryRow:
-    ticker: str
-    snapshot_date: _date
-    pcr_oi: Decimal | None
-    pcr_vol: Decimal | None
-
-
-@dataclass(frozen=True)
-class JobRow:
-    id: Any
-    ticker: str
-    status: str
-    run_id: int | None
-    error: str | None
-    requested_at: datetime
-    started_at: datetime | None
-    finished_at: datetime | None
-    claim_token: Any = None  # UUID, set on claim, gates mark_job_done/failed
-
-
-@dataclass(frozen=True)
-class RescanQueueSummaryRow:
-    total: int
-    queued: int
-    running: int
-    oldest_requested_at: datetime | None
-
-
-@dataclass(frozen=True)
-class ExternalApiUsageSummary:
-    total_requests: int
-    http_2xx: int
-    http_3xx: int
-    http_4xx: int
-    http_5xx: int
-    transport_errors: int
-    latency_p95_ms: int | None
-    uw_latest_daily_count: int | None
-    uw_latest_daily_limit: int | None
-
-
-@dataclass(frozen=True)
-class ExternalApiBreakdownRow:
-    key: str | None
-    total_requests: int
-    http_2xx: int
-    http_3xx: int
-    http_4xx: int
-    http_5xx: int
-    transport_errors: int
-    latency_p95_ms: int | None
-
-
-@dataclass(frozen=True)
-class ThroughputSummaryRow:
-    window_minutes: float
-    requests_per_minute: float
-    http_429: int
-    avg_scan_duration_seconds: float | None
-    queue_drain_rate_per_minute: float | None
-
-
-@dataclass(frozen=True)
-class ExternalApiRequestRow:
-    request_id: int
-    provider: str
-    endpoint_key: str
-    method: str
-    path: str
-    ticker: str | None
-    params: dict[str, Any]
-    status_code: int | None
-    status_family: str
-    request_started_at: datetime
-    request_finished_at: datetime
-    latency_ms: int
-    attempt: int
-    run_id: int | None
-    job_name: str | None
-    provider_request_id: str | None
-    official_daily_count: int | None
-    official_daily_limit: int | None
-    official_minute_remaining: int | None
-    official_minute_reset: str | None
-    error_message: str | None
-
-
-@dataclass(frozen=True)
-class RecordHealthRow:
-    table: str
-    window_start: datetime
-    expected_tickers: int
-    expected_min_tickers: int
-    actual_tickers: int
-    expected_min_rows: int
-    actual_rows: int
-    latest_at: datetime | None
-    ok: bool
-
-
 _RECORD_HEALTH_TIMESTAMP_COLUMNS = ("updated_at", "inserted_at")
 _RECORD_HEALTH_TICKER_COLUMNS = ("ticker", "underlying_symbol")
 _RECORD_HEALTH_EXCLUDED_TABLES = {
@@ -404,111 +305,6 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
     "stock_analytics_daily",
     "vrp_daily",
 }
-
-
-class WatchlistCardRow:
-    """Variable-shaped: 37 fields in the list shape, fewer in single-row shape.
-
-    Two constructors:
-      - from_list_row(row, desc) — strict, validates against _LIST_FIELDS.
-        Use this in list_watchlist_cards so SELECT-alias typos fail loudly.
-      - from_db(row, desc) — lenient, accepts any column set.
-        Use this in get_watchlist_card which does SELECT * FROM watchlist_card
-        and returns a different column shape (no watchlist fields, has updated_at).
-    """
-
-    # Canonical column list returned by list_watchlist_cards. Keep in sync
-    # with the SELECT projection in that method — drift is caught at the
-    # first /api/watchlist request thanks to from_list_row's validation.
-    _LIST_FIELDS: frozenset[str] = frozenset(
-        {
-            # watchlist
-            "ticker",
-            "sector",
-            "pinned",
-            "sort_rank",
-            # card metadata
-            "run_id",
-            "scanned_at",
-            "spot",
-            "spot_quoted_at",
-            "spot_source",
-            "iv_atm",
-            "iv_rank",
-            "setup_type",
-            "setup_direction",
-            "setup_score",
-            "aggression_pct",
-            "ret_1d",
-            "ret_1w",
-            "ret_30d",
-            "market_cap",
-            "aum",
-            "gex_flip_distance",
-            "gex_flip_price",
-            "gex_per_1pct_move",
-            "max_gex_strike",
-            "gex_expiring_pct",
-            "gex_expiring_date",
-            "skew_25d_30dte",
-            "call_oi_total",
-            "put_oi_total",
-            "pcr_oi",
-            "pcr_vol",
-            "pcr_delta_30d",
-            # active job columns (LEFT JOIN — all nullable)
-            "active_job_id",
-            "active_job_status",
-            "active_job_queue_position",
-            "active_job_requested_at",
-            "active_job_started_at",
-        }
-    )
-
-    def __init__(self, data: dict):
-        self._data = data
-
-    def __getattr__(self, name: str):
-        try:
-            data = object.__getattribute__(self, "_data")
-        except AttributeError as e:
-            raise AttributeError(name) from e
-        if name in data:
-            return data[name]
-        raise AttributeError(name)
-
-    @classmethod
-    def from_db(cls, row: tuple, description) -> "WatchlistCardRow":
-        """Lenient: accept whatever columns the cursor returned. Used by
-        get_watchlist_card (SELECT *)."""
-        return cls({col.name: val for col, val in zip(description, row, strict=False)})
-
-    @classmethod
-    def from_list_row(cls, row: tuple, description) -> "WatchlistCardRow":
-        """Strict: validate against _LIST_FIELDS. Use only for the
-        list_watchlist_cards projection so SELECT-alias typos fail loudly."""
-        names = [col.name for col in description]
-        if len(set(names)) != len(names):
-            raise ValueError(
-                f"WatchlistCardRow.from_list_row got duplicate column(s) in description: {names}"
-            )
-        seen = set(names)
-        unknown = seen - cls._LIST_FIELDS
-        if unknown:
-            raise ValueError(
-                f"WatchlistCardRow.from_list_row got unknown column(s): {sorted(unknown)}. "
-                f"Add to _LIST_FIELDS if the SELECT was intentionally extended."
-            )
-        missing = cls._LIST_FIELDS - seen
-        if missing:
-            raise ValueError(
-                f"WatchlistCardRow.from_list_row missing column(s): {sorted(missing)}. "
-                f"Either restore them to the SELECT or remove from _LIST_FIELDS."
-            )
-        return cls({name: val for name, val in zip(names, row, strict=False)})
-
-    def to_dict(self) -> dict:
-        return dict(self._data)
 
 
 logger = logging.getLogger(__name__)

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -38,6 +38,7 @@ from ._helpers import (
     status_family_for,
 )
 from .audit import _AuditMixin
+from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
 
 # Row dataclasses live in rows.py since the PR-1 split. Re-exported here so
@@ -332,7 +333,13 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 logger = logging.getLogger(__name__)
 
 
-class Repository(_AuditMixin, _MarketDataMixin, _ScanOutputsMixin, _BaseMixin):
+class Repository(
+    _AuditMixin,
+    _JobsMixin,
+    _MarketDataMixin,
+    _ScanOutputsMixin,
+    _BaseMixin,
+):
     """Repository wraps a psycopg connection and exposes typed CRUD.
 
     Inherits __init__ and the conn property from _BaseMixin. As PR-1/2/3
@@ -3984,137 +3991,7 @@ class Repository(_AuditMixin, _MarketDataMixin, _ScanOutputsMixin, _BaseMixin):
 
     # daily_ohlc / intraday_quote / pcr_history methods moved to _MarketDataMixin
 
-    # ---- jobs ----
-    def enqueue_rescan_job(self, ticker: str, *, priority: int = 0) -> str:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.jobs (ticker, status, priority)
-                VALUES (%s, 'queued', %s)
-                ON CONFLICT (ticker) WHERE status IN ('queued', 'running')
-                DO UPDATE SET
-                    priority = GREATEST(
-                        {self._schema}.jobs.priority,
-                        EXCLUDED.priority
-                    ),
-                    requested_at = EXCLUDED.requested_at
-                RETURNING id
-                """,
-                (ticker, priority),
-            )
-            row = cur.fetchone()
-            assert row is not None
-            job_id = row[0]
-        self._conn.commit()
-        return str(job_id)
-
-    def claim_next_queued_job(self) -> JobRow | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                UPDATE {self._schema}.jobs
-                SET status='running',
-                    started_at=NOW(),
-                    claim_token=gen_random_uuid()
-                WHERE id = (
-                  SELECT id FROM {self._schema}.jobs
-                  WHERE status='queued'
-                  ORDER BY priority DESC, requested_at ASC, id ASC
-                  FOR UPDATE SKIP LOCKED
-                  LIMIT 1
-                )
-                RETURNING id, ticker, status, run_id, error,
-                          requested_at, started_at, finished_at, claim_token
-                """
-            )
-            row = cur.fetchone()
-        self._conn.commit()
-        return JobRow(*row) if row else None
-
-    def requeue_stale_running_jobs(self, older_than: timedelta) -> int:
-        # Clear claim_token so the original worker's stored token will not
-        # match anything if/when it tries mark_job_done later (review
-        # 2026-05-16, B1; claim-token approach per codex review).
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                UPDATE {self._schema}.jobs
-                SET status='queued',
-                    started_at=NULL,
-                    error=NULL,
-                    claim_token=NULL
-                WHERE status='running'
-                  AND started_at < NOW() - %s
-                """,
-                (older_than,),
-            )
-            count = cur.rowcount
-        self._conn.commit()
-        return count
-
-    def mark_job_done(self, job_id: str, run_id: int, claim_token: Any) -> None:
-        # Claim-token guard against the requeue race (review 2026-05-16, B1):
-        # if requeue_stale_running_jobs cleared our token, or another worker
-        # has since reclaimed (with a fresh token), our update must be rejected.
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                UPDATE {self._schema}.jobs
-                SET status='done', run_id=%s, finished_at=NOW()
-                WHERE id=%s AND claim_token=%s
-                """,
-                (run_id, job_id, claim_token),
-            )
-            if cur.rowcount == 0:
-                logger.warning(
-                    "mark_job_done lost claim on job_id=%s "
-                    "(token mismatch; another worker may have reclaimed)",
-                    job_id,
-                )
-        self._conn.commit()
-
-    def mark_job_failed(self, job_id: str, error: str, claim_token: Any) -> None:
-        # Claim-token guard (review 2026-05-16, B1).
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                UPDATE {self._schema}.jobs
-                SET status='failed', error=%s, finished_at=NOW()
-                WHERE id=%s AND claim_token=%s
-                """,
-                (error[:2000], job_id, claim_token),
-            )
-            if cur.rowcount == 0:
-                logger.warning(
-                    "mark_job_failed lost claim on job_id=%s "
-                    "(token mismatch; another worker may have reclaimed)",
-                    job_id,
-                )
-        self._conn.commit()
-
-    def get_rescan_queue_summary(self) -> RescanQueueSummaryRow:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT
-                  count(*) FILTER (WHERE status IN ('queued', 'running')) AS total,
-                  count(*) FILTER (WHERE status = 'queued') AS queued,
-                  count(*) FILTER (WHERE status = 'running') AS running,
-                  min(requested_at) FILTER (
-                    WHERE status IN ('queued', 'running')
-                  ) AS oldest_requested_at
-                FROM {self._schema}.jobs
-                """
-            )
-            row = cur.fetchone()
-        assert row is not None
-        return RescanQueueSummaryRow(
-            total=row[0],
-            queued=row[1],
-            running=row[2],
-            oldest_requested_at=row[3],
-        )
-
+    # jobs queue methods moved to _JobsMixin
     # etf_aum_cache methods moved to _MarketDataMixin
 
     # ---- aggregates (JSONB on scan_runs) ----
@@ -4346,18 +4223,7 @@ class Repository(_AuditMixin, _MarketDataMixin, _ScanOutputsMixin, _BaseMixin):
             row = cur.fetchone()
         return row[0] if row and row[0] else []
 
-    def get_job(self, job_id: str) -> JobRow | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT id, ticker, status, run_id, error,
-                       requested_at, started_at, finished_at, claim_token
-                FROM {self._schema}.jobs WHERE id=%s
-                """,
-                (job_id,),
-            )
-            row = cur.fetchone()
-            return JobRow(*row) if row else None
+    # get_job moved to _JobsMixin
 
     # ---- Volatility Tab v2 helpers (spec 2026-05-13) ----
 

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -38,6 +38,7 @@ from ._helpers import (
     status_family_for,
 )
 from .audit import _AuditMixin
+from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
 
@@ -309,25 +310,7 @@ def _vrp_sign_flip_status_from_db(value: Any) -> bool | str:
     return value or "insufficient_history"
 
 
-_RECORD_HEALTH_TIMESTAMP_COLUMNS = ("updated_at", "inserted_at")
-_RECORD_HEALTH_TICKER_COLUMNS = ("ticker", "underlying_symbol")
-_RECORD_HEALTH_EXCLUDED_TABLES = {
-    # Request logs and orchestration tables are covered by provider usage /
-    # scheduler health, not per-ticker persisted data coverage.
-    "external_api_requests",
-    "scan_results",
-    "scan_universe",
-    # Not watchlist-scoped periodic UW source tables.
-    "index_ohlc_daily",
-    "opportunity_scores",
-    "structure_ideas",
-    # Derived/backfill tables that do not update for every ticker each RTH window.
-    "iv_smile_snapshots",
-    "oi_by_expiry",
-    "option_surface_snapshots",
-    "stock_analytics_daily",
-    "vrp_daily",
-}
+# _RECORD_HEALTH_* constants moved to health.py with _HealthMixin
 
 
 logger = logging.getLogger(__name__)
@@ -335,6 +318,7 @@ logger = logging.getLogger(__name__)
 
 class Repository(
     _AuditMixin,
+    _HealthMixin,
     _JobsMixin,
     _MarketDataMixin,
     _ScanOutputsMixin,
@@ -4016,193 +4000,7 @@ class Repository(
 
     # get_pcr_history_row moved to _MarketDataMixin
 
-    # ---- stock history rollup (for Market Structure history table) ----
-    def fetch_stock_history_rollup(self, ticker: str, limit: int = 30) -> list[dict]:
-        """One row per trading day, latest successful scan_run on that date.
-
-        Joins to daily_ohlc for end-of-day spot. Returns dicts shaped for
-        api.routers.stock to wrap in StockHistoryRow models.
-        """
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                WITH daily_runs AS (
-                    SELECT DISTINCT ON (started_at::date)
-                        started_at::date AS market_date,
-                        strike_gex_curve,
-                        aggregates
-                    FROM {self._schema}.scan_runs
-                    WHERE ticker = %s
-                      AND status = 'ok'
-                      AND strike_gex_curve IS NOT NULL
-                    ORDER BY started_at::date DESC, started_at DESC
-                )
-                SELECT
-                    r.market_date,
-                    d.close AS spot,
-                    r.aggregates->>'iv30d' AS iv30d,
-                    r.aggregates->>'pcr_vol' AS pcr_vol,
-                    r.strike_gex_curve
-                FROM daily_runs r
-                LEFT JOIN {self._schema}.daily_ohlc d
-                  ON d.ticker = %s AND d.date = r.market_date
-                ORDER BY r.market_date DESC
-                LIMIT %s
-                """,
-                (ticker, ticker, limit),
-            )
-            return [
-                {
-                    "market_date": row[0],
-                    "spot": row[1],
-                    "iv30d": row[2],
-                    "pcr_vol": row[3],
-                    "strike_gex_curve": row[4],
-                }
-                for row in cur.fetchall()
-            ]
-
-    # ---- watchlist count (for HealthPanel) ----
-    def count_active_watchlist(self) -> int:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"SELECT COUNT(*) FROM {self._schema}.watchlist WHERE removed_at IS NULL"
-            )
-            row = cur.fetchone()
-        return int(row[0]) if row else 0
-
-    def _discover_record_health_rules(self) -> dict[str, tuple[str, str, int]]:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT table_name, array_agg(column_name::text ORDER BY ordinal_position)
-                FROM information_schema.columns
-                WHERE table_schema = %s
-                GROUP BY table_name
-                ORDER BY table_name
-                """,
-                (self._schema,),
-            )
-            discovered: dict[str, tuple[str, str, int]] = {}
-            for table, column_list in cur.fetchall():
-                table_name = str(table)
-                if table_name in _RECORD_HEALTH_EXCLUDED_TABLES:
-                    continue
-                columns = set(column_list or [])
-                timestamp_col = next(
-                    (
-                        column
-                        for column in _RECORD_HEALTH_TIMESTAMP_COLUMNS
-                        if column in columns
-                    ),
-                    None,
-                )
-                ticker_col = next(
-                    (
-                        column
-                        for column in _RECORD_HEALTH_TICKER_COLUMNS
-                        if column in columns
-                    ),
-                    None,
-                )
-                if timestamp_col is not None and ticker_col is not None:
-                    discovered[table_name] = (timestamp_col, ticker_col, 1)
-            return discovered
-
-    def list_record_health(
-        self,
-        *,
-        since: datetime,
-        expected_tickers: int,
-        min_coverage: float = 0.9,
-        tables: Iterable[str] | None = None,
-    ) -> list[RecordHealthRow]:
-        rules = self._discover_record_health_rules()
-        selected = list(tables) if tables is not None else list(rules)
-        unknown = sorted(set(selected) - set(rules))
-        if unknown:
-            raise ValueError(f"unknown record health table(s): {', '.join(unknown)}")
-
-        expected_min_tickers = (
-            0 if expected_tickers <= 0 else math.ceil(expected_tickers * min_coverage)
-        )
-        rows: list[RecordHealthRow] = []
-        with self._conn.cursor() as cur:
-            for table in selected:
-                timestamp_col, ticker_col, min_rows_per_ticker = rules[table]
-                cur.execute(
-                    psql.SQL(
-                        """
-                        SELECT
-                            COUNT(*)::int AS actual_rows,
-                            COUNT(DISTINCT {ticker_col})::int AS actual_tickers,
-                            MAX({timestamp_col}) AS latest_at
-                        FROM {schema}.{table}
-                        WHERE {timestamp_col} >= %s
-                        """
-                    ).format(
-                        schema=psql.Identifier(self._schema),
-                        table=psql.Identifier(table),
-                        timestamp_col=psql.Identifier(timestamp_col),
-                        ticker_col=psql.Identifier(ticker_col),
-                    ),
-                    (since,),
-                )
-                actual_rows, actual_tickers, latest_at = cur.fetchone() or (0, 0, None)
-                expected_min_rows = expected_min_tickers * min_rows_per_ticker
-                ok = (
-                    int(actual_tickers or 0) >= expected_min_tickers
-                    and int(actual_rows or 0) >= expected_min_rows
-                )
-                rows.append(
-                    RecordHealthRow(
-                        table=table,
-                        window_start=since,
-                        expected_tickers=expected_tickers,
-                        expected_min_tickers=expected_min_tickers,
-                        actual_tickers=int(actual_tickers or 0),
-                        expected_min_rows=expected_min_rows,
-                        actual_rows=int(actual_rows or 0),
-                        latest_at=latest_at,
-                        ok=ok,
-                    )
-                )
-        return rows
-
-    # ---- worker_heartbeat ----
-    def upsert_heartbeat(self, job_name: str) -> None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.worker_heartbeat (job_name, last_beat_at)
-                VALUES (%s, now())
-                ON CONFLICT (job_name) DO UPDATE SET last_beat_at = now()
-                """,
-                (job_name,),
-            )
-        self._conn.commit()
-
-    def get_heartbeat(self, job_name: str) -> datetime | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"SELECT last_beat_at FROM {self._schema}.worker_heartbeat WHERE job_name=%s",
-                (job_name,),
-            )
-            row = cur.fetchone()
-        return row[0] if row else None
-
-    def get_latest_heartbeat(self) -> tuple[str, datetime] | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT job_name, last_beat_at
-                FROM {self._schema}.worker_heartbeat
-                ORDER BY last_beat_at DESC
-                LIMIT 1
-                """
-            )
-            row = cur.fetchone()
-        return (str(row[0]), row[1]) if row else None
+    # stock_history_rollup, watchlist count, record health, heartbeat methods moved to _HealthMixin
 
     # ---- strike_gex_curve (JSONB on scan_runs) ----
     def set_strike_gex_curve(self, run_id: int, curve: list[dict]) -> None:

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -56,6 +56,7 @@ from .rows import (
     WatchlistCardRow,
     WatchlistRow,
 )
+from .scan_outputs import _ScanOutputsMixin
 
 __all__ = [
     "Repository",
@@ -330,7 +331,7 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 logger = logging.getLogger(__name__)
 
 
-class Repository(_AuditMixin, _BaseMixin):
+class Repository(_AuditMixin, _ScanOutputsMixin, _BaseMixin):
     """Repository wraps a psycopg connection and exposes typed CRUD.
 
     Inherits __init__ and the conn property from _BaseMixin. As PR-1/2/3
@@ -2716,66 +2717,6 @@ class Repository(_AuditMixin, _BaseMixin):
                 ),
             )
         return 1
-
-    # ------------------------------------------------------------------
-    # opportunity_scores + structure_ideas
-    # ------------------------------------------------------------------
-    def insert_opportunity_score(
-        self,
-        run_id: int,
-        ticker: str,
-        score: Decimal,
-        setup_types: list[str],
-        direction: str | None,
-        confirmations: list[str],
-        warnings: list[str],
-        notes: str,
-    ) -> int:
-        sql = (
-            f"INSERT INTO {self._schema}.opportunity_scores "
-            "(run_id, ticker, score, setup_types, direction, confirmations, "
-            "warnings, notes) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING score_id"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(
-                sql,
-                (
-                    run_id,
-                    ticker,
-                    score,
-                    setup_types,
-                    direction,
-                    confirmations,
-                    warnings,
-                    notes,
-                ),
-            )
-            row = cur.fetchone()
-        assert row is not None
-        return int(row[0])
-
-    def insert_structure_idea(
-        self,
-        run_id: int,
-        ticker: str,
-        structure: str,
-        legs: list[dict[str, Any]],
-        rationale: str,
-    ) -> int:
-        sql = (
-            f"INSERT INTO {self._schema}.structure_ideas "
-            "(run_id, ticker, structure, legs_json, rationale) "
-            "VALUES (%s, %s, %s, %s, %s) RETURNING idea_id"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(
-                sql,
-                (run_id, ticker, structure, Jsonb(legs), rationale),
-            )
-            row = cur.fetchone()
-        assert row is not None
-        return int(row[0])
 
     # ------------------------------------------------------------------
     # SELECT helpers — used by reports/single_stock.py

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -6,17 +6,12 @@ One method per insert/select. No `**kwargs` splatting from arbitrary dicts.
 from __future__ import annotations
 
 import logging
-import math
-from collections import Counter
 from collections.abc import Iterable
-from dataclasses import dataclass
 from datetime import date as _date
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
-from zoneinfo import ZoneInfo
 
-import psycopg
 from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
@@ -28,9 +23,6 @@ from ._base import _BaseMixin
 # sources/ohlc.py, api/client.py, api/routers/health.py, api/routers/provider_usage.py,
 # and tests — keep them re-exported.
 from ._helpers import (
-    _PROVIDER_DAY_TZ,
-    _REDACTED_PARAM_KEYS,
-    _d,
     _nullable_float,
     _nullable_int,
     provider_day_bounds,
@@ -38,7 +30,15 @@ from ._helpers import (
     status_family_for,
 )
 from .audit import _AuditMixin
-from .flow import _aggressor_label_confidence, _flow_footprint_label, _FlowMixin
+
+# noqa: F401 below — _aggressor_label_confidence and _flow_footprint_label
+# are re-exports for scripts/backfill_flow_footprint.py which imports them
+# from uw_scan.storage.repository. Removing them would break the script.
+from .flow import (
+    _aggressor_label_confidence,  # noqa: F401
+    _flow_footprint_label,  # noqa: F401
+    _FlowMixin,
+)
 from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -22,6 +22,21 @@ from psycopg.types.json import Jsonb
 
 from .. import models
 
+# Pure helpers live in _helpers.py since the PR-1 split. provider_day_bounds,
+# status_family_for, and redact_params are imported from this module by
+# sources/ohlc.py, api/client.py, api/routers/health.py, api/routers/provider_usage.py,
+# and tests — keep them re-exported.
+from ._helpers import (
+    _PROVIDER_DAY_TZ,
+    _REDACTED_PARAM_KEYS,
+    _d,
+    _nullable_float,
+    _nullable_int,
+    provider_day_bounds,
+    redact_params,
+    status_family_for,
+)
+
 # Row dataclasses live in rows.py since the PR-1 split. Re-exported here so
 # existing callers (`from uw_scan.storage.repository import JobRow`) continue
 # to work without changing import paths.
@@ -54,6 +69,9 @@ __all__ = [
     "ThroughputSummaryRow",
     "WatchlistCardRow",
     "WatchlistRow",
+    "provider_day_bounds",
+    "redact_params",
+    "status_family_for",
 ]
 
 
@@ -308,68 +326,6 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 
 
 logger = logging.getLogger(__name__)
-_PROVIDER_DAY_TZ = ZoneInfo("America/New_York")
-_REDACTED_PARAM_KEYS = {
-    "apikey",
-    "api_key",
-    "authorization",
-    "auth",
-    "token",
-}
-
-
-def _d(value: Decimal | None) -> Any:
-    """psycopg handles Decimal natively; keep this for symmetry with other casters."""
-    return value
-
-
-def provider_day_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
-    current = now or datetime.now(tz=_PROVIDER_DAY_TZ)
-    local = current.astimezone(_PROVIDER_DAY_TZ)
-    reset = local.replace(hour=20, minute=0, second=0, microsecond=0)
-    if local < reset:
-        reset -= timedelta(days=1)
-    return reset, reset + timedelta(days=1)
-
-
-def status_family_for(status_code: int | None, *, transport_error: bool = False) -> str:
-    if transport_error:
-        return "transport_error"
-    if status_code is None:
-        return "transport_error"
-    if 200 <= status_code <= 299:
-        return "2xx"
-    if 300 <= status_code <= 399:
-        return "3xx"
-    if 400 <= status_code <= 499:
-        return "4xx"
-    if 500 <= status_code <= 599:
-        return "5xx"
-    return "transport_error"
-
-
-def redact_params(params: dict[str, object] | None) -> dict[str, object]:
-    redacted: dict[str, object] = {}
-    for key, value in (params or {}).items():
-        if key.lower() in _REDACTED_PARAM_KEYS:
-            continue
-        if isinstance(value, str) and len(value) > 256:
-            redacted[key] = value[:253] + "..."
-        else:
-            redacted[key] = value
-    return redacted
-
-
-def _nullable_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    return int(round(float(value)))
-
-
-def _nullable_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    return float(value)
 
 
 class Repository:

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -37,6 +37,7 @@ from ._helpers import (
     redact_params,
     status_family_for,
 )
+from .audit import _AuditMixin
 
 # Row dataclasses live in rows.py since the PR-1 split. Re-exported here so
 # existing callers (`from uw_scan.storage.repository import JobRow`) continue
@@ -329,7 +330,7 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 logger = logging.getLogger(__name__)
 
 
-class Repository(_BaseMixin):
+class Repository(_AuditMixin, _BaseMixin):
     """Repository wraps a psycopg connection and exposes typed CRUD.
 
     Inherits __init__ and the conn property from _BaseMixin. As PR-1/2/3
@@ -396,62 +397,6 @@ class Repository(_BaseMixin):
     def release_advisory_lock(self, key: int) -> None:
         with self._conn.cursor() as cur:
             cur.execute("SELECT pg_advisory_unlock(%s)", (key,))
-
-    # ------------------------------------------------------------------
-    # api_request_audit + raw_payloads
-    # ------------------------------------------------------------------
-    def insert_audit_row(
-        self,
-        run_id: int,
-        endpoint_slug: str,
-        endpoint_path: str,
-        params: dict[str, Any],
-        status_code: int,
-        started_at: datetime,
-        finished_at: datetime,
-        daily_req_count: int | None,
-        minute_req_remaining: int | None,
-        minute_req_reset: str | None,
-        error_message: str | None = None,
-    ) -> int:
-        sql = (
-            f"INSERT INTO {self._schema}.api_request_audit ("
-            "run_id, endpoint_slug, endpoint_path, params_json, status_code, "
-            "request_started_at, request_finished_at, daily_req_count, "
-            "minute_req_remaining, minute_req_reset, error_message) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING audit_id"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(
-                sql,
-                (
-                    run_id,
-                    endpoint_slug,
-                    endpoint_path,
-                    Jsonb(params),
-                    status_code,
-                    started_at,
-                    finished_at,
-                    daily_req_count,
-                    minute_req_remaining,
-                    minute_req_reset,
-                    error_message,
-                ),
-            )
-            row = cur.fetchone()
-        assert row is not None
-        return int(row[0])
-
-    def insert_raw_payload(self, audit_id: int, payload: dict | list) -> int:
-        sql = (
-            f"INSERT INTO {self._schema}.raw_payloads (audit_id, payload_jsonb) "
-            "VALUES (%s, %s) RETURNING payload_id"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(sql, (audit_id, Jsonb(payload)))
-            row = cur.fetchone()
-        assert row is not None
-        return int(row[0])
 
     # ------------------------------------------------------------------
     # external_api_requests

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -38,6 +38,7 @@ from ._helpers import (
     status_family_for,
 )
 from .audit import _AuditMixin
+from .market_data import _MarketDataMixin
 
 # Row dataclasses live in rows.py since the PR-1 split. Re-exported here so
 # existing callers (`from uw_scan.storage.repository import JobRow`) continue
@@ -331,7 +332,7 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 logger = logging.getLogger(__name__)
 
 
-class Repository(_AuditMixin, _ScanOutputsMixin, _BaseMixin):
+class Repository(_AuditMixin, _MarketDataMixin, _ScanOutputsMixin, _BaseMixin):
     """Repository wraps a psycopg connection and exposes typed CRUD.
 
     Inherits __init__ and the conn property from _BaseMixin. As PR-1/2/3
@@ -3981,125 +3982,7 @@ class Repository(_AuditMixin, _ScanOutputsMixin, _BaseMixin):
         ]
         return cards, summary
 
-    # ---- daily_ohlc ----
-    def upsert_daily_ohlc(
-        self,
-        *,
-        ticker: str,
-        date: _date,
-        open: Decimal | None,
-        high: Decimal | None,
-        low: Decimal | None,
-        close: Decimal,
-        volume: int | None,
-        source: str,
-    ) -> None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.daily_ohlc
-                  (ticker, date, open, high, low, close, volume, source)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (ticker, date) DO UPDATE
-                  SET open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low,
-                      close=EXCLUDED.close, volume=EXCLUDED.volume,
-                      source=EXCLUDED.source, fetched_at=NOW()
-                """,
-                (ticker, date, open, high, low, close, volume, source),
-            )
-        self._conn.commit()
-
-    def list_daily_ohlc(self, ticker: str, *, limit: int = 30) -> list[DailyOhlcRow]:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT ticker, date, open, high, low, close, volume, source, fetched_at
-                FROM {self._schema}.daily_ohlc
-                WHERE ticker=%s
-                ORDER BY date DESC
-                LIMIT %s
-                """,
-                (ticker, limit),
-            )
-            return [DailyOhlcRow(*row) for row in cur.fetchall()]
-
-    # ---- intraday_quote ----
-    def upsert_intraday_quote(
-        self, ticker: str, price: Decimal, quoted_at: datetime
-    ) -> None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.intraday_quote (ticker, price, quoted_at)
-                VALUES (%s, %s, %s)
-                ON CONFLICT (ticker) DO UPDATE
-                  SET price=EXCLUDED.price, quoted_at=EXCLUDED.quoted_at, fetched_at=NOW()
-                """,
-                (ticker, price, quoted_at),
-            )
-        self._conn.commit()
-
-    def get_intraday_quote(self, ticker: str) -> IntradayQuoteRow | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT ticker, price, quoted_at, fetched_at
-                FROM {self._schema}.intraday_quote WHERE ticker=%s
-                """,
-                (ticker,),
-            )
-            row = cur.fetchone()
-            return IntradayQuoteRow(*row) if row else None
-
-    def get_latest_intraday_quote_times(self) -> tuple[datetime, datetime] | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT MAX(quoted_at), MAX(fetched_at)
-                FROM {self._schema}.intraday_quote
-                """
-            )
-            row = cur.fetchone()
-        if row and row[0] is not None and row[1] is not None:
-            return (row[0], row[1])
-        return None
-
-    # ---- pcr_history ----
-    def append_pcr_history(
-        self,
-        ticker: str,
-        snapshot_date: _date,
-        pcr_oi: Decimal | None,
-        pcr_vol: Decimal | None,
-    ) -> None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.pcr_history (ticker, snapshot_date, pcr_oi, pcr_vol)
-                VALUES (%s, %s, %s, %s)
-                ON CONFLICT (ticker, snapshot_date) DO UPDATE
-                  SET pcr_oi=EXCLUDED.pcr_oi, pcr_vol=EXCLUDED.pcr_vol
-                """,
-                (ticker, snapshot_date, pcr_oi, pcr_vol),
-            )
-        self._conn.commit()
-
-    def get_pcr_history_30d_ago(
-        self, ticker: str, today: _date
-    ) -> PcrHistoryRow | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT ticker, snapshot_date, pcr_oi, pcr_vol
-                FROM {self._schema}.pcr_history
-                WHERE ticker=%s AND snapshot_date <= %s - INTERVAL '30 days'
-                ORDER BY snapshot_date DESC
-                LIMIT 1
-                """,
-                (ticker, today),
-            )
-            row = cur.fetchone()
-            return PcrHistoryRow(*row) if row else None
+    # daily_ohlc / intraday_quote / pcr_history methods moved to _MarketDataMixin
 
     # ---- jobs ----
     def enqueue_rescan_job(self, ticker: str, *, priority: int = 0) -> str:
@@ -4232,35 +4115,7 @@ class Repository(_AuditMixin, _ScanOutputsMixin, _BaseMixin):
             oldest_requested_at=row[3],
         )
 
-    # ---- etf_aum_cache (A1 review fix: skip per-scan UW round trip) ----
-    def get_recent_etf_aum(self, ticker: str, *, max_age: timedelta) -> Decimal | None:
-        """Return cached AUM if fetched within max_age, else None.
-        None means the caller should fetch fresh (cache miss or stale)."""
-        ticker = ticker.upper()  # cache keys are canonical UPPER
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT aum FROM {self._schema}.etf_aum_cache
-                WHERE ticker = %s AND fetched_at > NOW() - %s
-                """,
-                (ticker, max_age),
-            )
-            row = cur.fetchone()
-        return row[0] if row else None
-
-    def upsert_etf_aum(self, ticker: str, aum: Decimal) -> None:
-        ticker = ticker.upper()
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                INSERT INTO {self._schema}.etf_aum_cache (ticker, aum, fetched_at)
-                VALUES (%s, %s, NOW())
-                ON CONFLICT (ticker) DO UPDATE
-                  SET aum = EXCLUDED.aum, fetched_at = EXCLUDED.fetched_at
-                """,
-                (ticker, aum),
-            )
-        self._conn.commit()
+    # etf_aum_cache methods moved to _MarketDataMixin
 
     # ---- aggregates (JSONB on scan_runs) ----
     def set_aggregates(self, run_id: int, agg: "models.MarketAggregates") -> None:
@@ -4282,20 +4137,7 @@ class Repository(_AuditMixin, _ScanOutputsMixin, _BaseMixin):
             return None
         return models.MarketAggregates.model_validate(row[0])
 
-    def get_pcr_history_row(
-        self, ticker: str, snapshot_date: _date
-    ) -> PcrHistoryRow | None:
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"""
-                SELECT ticker, snapshot_date, pcr_oi, pcr_vol
-                FROM {self._schema}.pcr_history
-                WHERE ticker=%s AND snapshot_date=%s
-                """,
-                (ticker, snapshot_date),
-            )
-            row = cur.fetchone()
-        return PcrHistoryRow(*row) if row else None
+    # get_pcr_history_row moved to _MarketDataMixin
 
     # ---- stock history rollup (for Market Structure history table) ----
     def fetch_stock_history_rollup(self, ticker: str, limit: int = 30) -> list[dict]:

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -21,6 +21,7 @@ from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
 from .. import models
+from ._base import _BaseMixin
 
 # Pure helpers live in _helpers.py since the PR-1 split. provider_day_bounds,
 # status_family_for, and redact_params are imported from this module by
@@ -328,16 +329,12 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
 logger = logging.getLogger(__name__)
 
 
-class Repository:
-    """Repository wraps a psycopg connection and exposes typed CRUD."""
+class Repository(_BaseMixin):
+    """Repository wraps a psycopg connection and exposes typed CRUD.
 
-    def __init__(self, conn: psycopg.Connection, schema: str = "uw_scan") -> None:
-        self._conn = conn
-        self._schema = schema
-
-    @property
-    def conn(self) -> psycopg.Connection:
-        return self._conn
+    Inherits __init__ and the conn property from _BaseMixin. As PR-1/2/3
+    progress this class will gain per-domain mixins (_AuditMixin,
+    _FlowMixin, ...); _BaseMixin stays LAST in the inheritance list."""
 
     # ------------------------------------------------------------------
     # scan_runs

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -38,6 +38,7 @@ from ._helpers import (
     status_family_for,
 )
 from .audit import _AuditMixin
+from .flow import _aggressor_label_confidence, _flow_footprint_label, _FlowMixin
 from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
@@ -264,36 +265,6 @@ def _oi_change_bias(rows: list[dict[str, Any]]) -> str | None:
     return "mixed"
 
 
-def _flow_footprint_label(row: models.FlowAlert) -> str:
-    ask = row.total_ask_side_prem or Decimal(0)
-    bid = row.total_bid_side_prem or Decimal(0)
-    total = row.total_premium or ask + bid
-    ask_ratio = ask / total if total and total > 0 else None
-    if row.has_sweep and ask_ratio is not None and ask_ratio >= Decimal("0.65"):
-        return "directional_whale"
-    if row.has_multileg:
-        return "hedge_flow"
-    if row.has_floor:
-        return "dealer_hedge"
-    if ask_ratio is not None and Decimal("0.40") <= ask_ratio <= Decimal("0.60"):
-        return "gamma_scalper"
-    return "unclassified"
-
-
-def _aggressor_label_confidence(row: models.FlowAlert) -> Decimal | None:
-    ask = row.total_ask_side_prem or Decimal(0)
-    bid = row.total_bid_side_prem or Decimal(0)
-    total = row.total_premium or ask + bid
-    if total is None or total <= 0:
-        return None
-    dominant_side_ratio = max(ask, bid) / total
-    structure_penalty = Decimal("0.05") if row.has_multileg else Decimal(0)
-    confidence = min(
-        Decimal("1"), max(Decimal("0"), dominant_side_ratio - structure_penalty)
-    )
-    return confidence.quantize(Decimal("0.01"))
-
-
 def _vrp_sign_flip_status_for_db(value: bool | str | None) -> str | None:
     if value is True:
         return "true"
@@ -318,6 +289,7 @@ logger = logging.getLogger(__name__)
 
 class Repository(
     _AuditMixin,
+    _FlowMixin,
     _HealthMixin,
     _JobsMixin,
     _MarketDataMixin,
@@ -715,148 +687,8 @@ class Repository(
             for row in rows
         ]
 
-    # ------------------------------------------------------------------
-    # flow_events
-    # ------------------------------------------------------------------
-    def insert_flow_events(
-        self, run_id: int, ticker: str, alerts: Iterable[models.FlowAlert]
-    ) -> int:
-        rows = list(alerts)
-        if not rows:
-            return 0
-        sql = (
-            f"INSERT INTO {self._schema}.flow_events ("
-            "run_id, alert_id, ticker, option_chain, expiry, strike, option_type, "
-            "price, underlying_price, total_size, total_premium, "
-            "total_ask_side_prem, total_bid_side_prem, volume, open_interest, "
-            "volume_oi_ratio, has_sweep, has_floor, has_multileg, "
-            "all_opening_trades, iv_start, iv_end, alert_rule, "
-            "flow_footprint_label, aggressor_label_confidence, "
-            "rule_id, sector, issue_type, next_earnings_date, created_at) VALUES ("
-            "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, "
-            "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
-            "ON CONFLICT (run_id, alert_id) DO NOTHING"
-        )
-        with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        r.id,
-                        r.ticker,
-                        r.option_chain,
-                        r.expiry,
-                        r.strike,
-                        r.type,
-                        r.price,
-                        r.underlying_price,
-                        r.total_size,
-                        r.total_premium,
-                        r.total_ask_side_prem,
-                        r.total_bid_side_prem,
-                        r.volume,
-                        r.open_interest,
-                        r.volume_oi_ratio,
-                        r.has_sweep,
-                        r.has_floor,
-                        r.has_multileg,
-                        r.all_opening_trades,
-                        r.iv_start,
-                        r.iv_end,
-                        r.alert_rule,
-                        r.flow_footprint_label or _flow_footprint_label(r),
-                        r.aggressor_label_confidence
-                        if r.aggressor_label_confidence is not None
-                        else _aggressor_label_confidence(r),
-                        r.rule_id,
-                        r.sector,
-                        r.issue_type,
-                        r.next_earnings_date,
-                        r.created_at,
-                    ),
-                )
-        return len(rows)
-
-    def upsert_flow_alerts_daily_rollup(
-        self,
-        *,
-        run_id: int,
-        ticker: str,
-        alerts: Iterable[models.FlowAlert],
-        alert_limit: int,
-        trade_date: _date | None = None,
-    ) -> None:
-        rows = list(alerts)
-        if trade_date is None:
-            trade_date = self._flow_alert_trade_date(rows)
-
-        bull_premium = Decimal("0")
-        bear_premium = Decimal("0")
-        ask_side_premium = Decimal("0")
-        bid_side_premium = Decimal("0")
-        total_premium = Decimal("0")
-        rules: Counter[str] = Counter()
-
-        for row in rows:
-            premium = row.total_premium or Decimal("0")
-            total_premium += premium
-            opt_type = (row.type or "").lower()
-            if opt_type == "call":
-                bull_premium += premium
-            elif opt_type == "put":
-                bear_premium += premium
-            ask_side_premium += row.total_ask_side_prem or Decimal("0")
-            bid_side_premium += row.total_bid_side_prem or Decimal("0")
-            if row.alert_rule:
-                rules[row.alert_rule] += 1
-
-        top_alert_rule = rules.most_common(1)[0][0] if rules else None
-
-        sql = (
-            f"INSERT INTO {self._schema}.flow_alerts_daily_rollup ("
-            "ticker, trade_date, run_id, alert_count, alert_count_is_limited, "
-            "total_premium, bull_premium, bear_premium, ask_side_premium, "
-            "bid_side_premium, top_alert_rule) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
-            "ON CONFLICT (ticker, trade_date) DO UPDATE SET "
-            "run_id=EXCLUDED.run_id, alert_count=EXCLUDED.alert_count, "
-            "alert_count_is_limited=EXCLUDED.alert_count_is_limited, "
-            "total_premium=EXCLUDED.total_premium, "
-            "bull_premium=EXCLUDED.bull_premium, "
-            "bear_premium=EXCLUDED.bear_premium, "
-            "ask_side_premium=EXCLUDED.ask_side_premium, "
-            "bid_side_premium=EXCLUDED.bid_side_premium, "
-            "top_alert_rule=EXCLUDED.top_alert_rule, updated_at=now()"
-        )
-        with self._conn.cursor() as cur:
-            cur.execute(
-                sql,
-                (
-                    ticker.upper(),
-                    trade_date,
-                    run_id,
-                    len(rows),
-                    len(rows) >= alert_limit,
-                    total_premium,
-                    bull_premium,
-                    bear_premium,
-                    ask_side_premium,
-                    bid_side_premium,
-                    top_alert_rule,
-                ),
-            )
-
-    def _flow_alert_trade_date(self, rows: list[models.FlowAlert]) -> _date:
-        market_tz = ZoneInfo("America/New_York")
-        for row in rows:
-            if row.created_at is None:
-                continue
-            created_at = row.created_at
-            if created_at.tzinfo is None:
-                created_at = created_at.replace(tzinfo=market_tz)
-            return created_at.astimezone(market_tz).date()
-        return datetime.now(market_tz).date()
+    # flow_events + flow_alerts_daily_rollup methods moved to _FlowMixin
+    # _flow_alert_trade_date is now module-level in flow.py (doesn't use self)
 
     # ------------------------------------------------------------------
     # Time-series history (UPSERT by (ticker, market_date))

--- a/src/uw_scan/storage/rows.py
+++ b/src/uw_scan/storage/rows.py
@@ -1,0 +1,253 @@
+"""Frozen dataclasses + WatchlistCardRow used by the Repository methods.
+
+Moved from repository.py during the PR-1 split (see
+docs/superpowers/plans/2026-05-16-repository-split-pr1.md). All row types
+are re-exported from repository.py for backward compat with existing callers
+(`from uw_scan.storage.repository import JobRow` still works).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date as _date
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WatchlistRow:
+    ticker: str
+    sector: str
+    notes: str | None
+    pinned: bool
+    sort_rank: int
+    added_at: datetime
+    removed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class DailyOhlcRow:
+    ticker: str
+    date: _date
+    open: Decimal | None
+    high: Decimal | None
+    low: Decimal | None
+    close: Decimal
+    volume: int | None
+    source: str
+    fetched_at: datetime
+
+
+@dataclass(frozen=True)
+class IntradayQuoteRow:
+    ticker: str
+    price: Decimal
+    quoted_at: datetime
+    fetched_at: datetime
+
+
+@dataclass(frozen=True)
+class PcrHistoryRow:
+    ticker: str
+    snapshot_date: _date
+    pcr_oi: Decimal | None
+    pcr_vol: Decimal | None
+
+
+@dataclass(frozen=True)
+class JobRow:
+    id: Any
+    ticker: str
+    status: str
+    run_id: int | None
+    error: str | None
+    requested_at: datetime
+    started_at: datetime | None
+    finished_at: datetime | None
+    claim_token: Any = None  # UUID, set on claim, gates mark_job_done/failed
+
+
+@dataclass(frozen=True)
+class RescanQueueSummaryRow:
+    total: int
+    queued: int
+    running: int
+    oldest_requested_at: datetime | None
+
+
+@dataclass(frozen=True)
+class ExternalApiUsageSummary:
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+    uw_latest_daily_count: int | None
+    uw_latest_daily_limit: int | None
+
+
+@dataclass(frozen=True)
+class ExternalApiBreakdownRow:
+    key: str | None
+    total_requests: int
+    http_2xx: int
+    http_3xx: int
+    http_4xx: int
+    http_5xx: int
+    transport_errors: int
+    latency_p95_ms: int | None
+
+
+@dataclass(frozen=True)
+class ThroughputSummaryRow:
+    window_minutes: float
+    requests_per_minute: float
+    http_429: int
+    avg_scan_duration_seconds: float | None
+    queue_drain_rate_per_minute: float | None
+
+
+@dataclass(frozen=True)
+class ExternalApiRequestRow:
+    request_id: int
+    provider: str
+    endpoint_key: str
+    method: str
+    path: str
+    ticker: str | None
+    params: dict[str, Any]
+    status_code: int | None
+    status_family: str
+    request_started_at: datetime
+    request_finished_at: datetime
+    latency_ms: int
+    attempt: int
+    run_id: int | None
+    job_name: str | None
+    provider_request_id: str | None
+    official_daily_count: int | None
+    official_daily_limit: int | None
+    official_minute_remaining: int | None
+    official_minute_reset: str | None
+    error_message: str | None
+
+
+@dataclass(frozen=True)
+class RecordHealthRow:
+    table: str
+    window_start: datetime
+    expected_tickers: int
+    expected_min_tickers: int
+    actual_tickers: int
+    expected_min_rows: int
+    actual_rows: int
+    latest_at: datetime | None
+    ok: bool
+
+
+class WatchlistCardRow:
+    """Variable-shaped: 37 fields in the list shape, fewer in single-row shape.
+
+    Two constructors:
+      - from_list_row(row, desc) — strict, validates against _LIST_FIELDS.
+        Use this in list_watchlist_cards so SELECT-alias typos fail loudly.
+      - from_db(row, desc) — lenient, accepts any column set.
+        Use this in get_watchlist_card which does SELECT * FROM watchlist_card
+        and returns a different column shape (no watchlist fields, has updated_at).
+    """
+
+    # Canonical column list returned by list_watchlist_cards. Keep in sync
+    # with the SELECT projection in that method — drift is caught at the
+    # first /api/watchlist request thanks to from_list_row's validation.
+    _LIST_FIELDS: frozenset[str] = frozenset(
+        {
+            # watchlist
+            "ticker",
+            "sector",
+            "pinned",
+            "sort_rank",
+            # card metadata
+            "run_id",
+            "scanned_at",
+            "spot",
+            "spot_quoted_at",
+            "spot_source",
+            "iv_atm",
+            "iv_rank",
+            "setup_type",
+            "setup_direction",
+            "setup_score",
+            "aggression_pct",
+            "ret_1d",
+            "ret_1w",
+            "ret_30d",
+            "market_cap",
+            "aum",
+            "gex_flip_distance",
+            "gex_flip_price",
+            "gex_per_1pct_move",
+            "max_gex_strike",
+            "gex_expiring_pct",
+            "gex_expiring_date",
+            "skew_25d_30dte",
+            "call_oi_total",
+            "put_oi_total",
+            "pcr_oi",
+            "pcr_vol",
+            "pcr_delta_30d",
+            # active job columns (LEFT JOIN — all nullable)
+            "active_job_id",
+            "active_job_status",
+            "active_job_queue_position",
+            "active_job_requested_at",
+            "active_job_started_at",
+        }
+    )
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getattr__(self, name: str):
+        try:
+            data = object.__getattribute__(self, "_data")
+        except AttributeError as e:
+            raise AttributeError(name) from e
+        if name in data:
+            return data[name]
+        raise AttributeError(name)
+
+    @classmethod
+    def from_db(cls, row: tuple, description) -> "WatchlistCardRow":
+        """Lenient: accept whatever columns the cursor returned. Used by
+        get_watchlist_card (SELECT *)."""
+        return cls({col.name: val for col, val in zip(description, row, strict=False)})
+
+    @classmethod
+    def from_list_row(cls, row: tuple, description) -> "WatchlistCardRow":
+        """Strict: validate against _LIST_FIELDS. Use only for the
+        list_watchlist_cards projection so SELECT-alias typos fail loudly."""
+        names = [col.name for col in description]
+        if len(set(names)) != len(names):
+            raise ValueError(
+                f"WatchlistCardRow.from_list_row got duplicate column(s) in description: {names}"
+            )
+        seen = set(names)
+        unknown = seen - cls._LIST_FIELDS
+        if unknown:
+            raise ValueError(
+                f"WatchlistCardRow.from_list_row got unknown column(s): {sorted(unknown)}. "
+                f"Add to _LIST_FIELDS if the SELECT was intentionally extended."
+            )
+        missing = cls._LIST_FIELDS - seen
+        if missing:
+            raise ValueError(
+                f"WatchlistCardRow.from_list_row missing column(s): {sorted(missing)}. "
+                f"Either restore them to the SELECT or remove from _LIST_FIELDS."
+            )
+        return cls({name: val for name, val in zip(names, row, strict=False)})
+
+    def to_dict(self) -> dict:
+        return dict(self._data)

--- a/src/uw_scan/storage/scan_outputs.py
+++ b/src/uw_scan/storage/scan_outputs.py
@@ -1,0 +1,71 @@
+"""Scan output writes: opportunity_scores + structure_ideas."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+
+class _ScanOutputsMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_opportunity_score(
+        self,
+        run_id: int,
+        ticker: str,
+        score: Decimal,
+        setup_types: list[str],
+        direction: str | None,
+        confirmations: list[str],
+        warnings: list[str],
+        notes: str,
+    ) -> int:
+        sql = (
+            f"INSERT INTO {self._schema}.opportunity_scores "
+            "(run_id, ticker, score, setup_types, direction, confirmations, "
+            "warnings, notes) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING score_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    run_id,
+                    ticker,
+                    score,
+                    setup_types,
+                    direction,
+                    confirmations,
+                    warnings,
+                    notes,
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def insert_structure_idea(
+        self,
+        run_id: int,
+        ticker: str,
+        structure: str,
+        legs: list[dict[str, Any]],
+        rationale: str,
+    ) -> int:
+        sql = (
+            f"INSERT INTO {self._schema}.structure_ideas "
+            "(run_id, ticker, structure, legs_json, rationale) "
+            "VALUES (%s, %s, %s, %s, %s) RETURNING idea_id"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (run_id, ticker, structure, Jsonb(legs), rationale),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])


### PR DESCRIPTION
## Summary

PR 1 of 3 in the modularization plan from `docs/reviews/2026-05-16-backend-modularization-and-reuse.md`. Pure code-move + import-update split of the 5173-line `repository.py` into per-domain mixin modules.

**Net result:** `repository.py` shrinks from 5173 → 4146 lines (-1027, -20%). Mixin pattern established for PR-2 and PR-3 to follow.

## Commits (12)

1. **docs**: add module size budget standing rule (CLAUDE.md + AGENTS.md) — what caused this refactor in the first place
2. **docs(plan)**: PR-1 split plan, codex-reviewed (13 tribunal findings applied pre-execution)
3-10. **refactor(storage)**: 8 mixin extractions in low → high blast-radius order:
   - `rows.py` (12 dataclass row types + `WatchlistCardRow`)
   - `_helpers.py` (5 utility functions + 2 module constants)
   - `_base.py` (`_BaseMixin` — Repository `__init__` + `conn` property)
   - `audit.py` (`_AuditMixin` — 2 methods)
   - `scan_outputs.py` (`_ScanOutputsMixin` — 2 methods)
   - `market_data.py` (`_MarketDataMixin` — 10 methods)
   - `jobs.py` (`_JobsMixin` — 7 methods + module logger)
   - `health.py` (`_HealthMixin` — 7 methods + 3 module constants)
   - `flow.py` (`_FlowMixin` — 2 methods + 3 module helpers)
11. **docs(storage)**: document mixin pattern post-split

## Architecture: mixin pattern

```python
class Repository(
    _AuditMixin, _FlowMixin, _HealthMixin, _JobsMixin,
    _MarketDataMixin, _ScanOutputsMixin,
    _BaseMixin,  # MUST be last — owns __init__ and the conn property
):
    pass  # plus the ~125 methods not yet moved (PR-2/PR-3)
```

`_BaseMixin` is last in MRO so domain mixins shadow it. Domain mixins declare `_conn: psycopg.Connection` and `_schema: str` as class-level type hints (set at runtime by `_BaseMixin.__init__`).

## Tribunal-caught risks (all pre-fixed before execution)

The plan went through Codex + Claude bilateral review — 13 issues raised, all consensus or self-verified, all applied:
- Task 1 line ranges were off (would have deleted cockpit module helpers along with the dataclasses)
- Task 2 missed externally-imported helpers (`redact_params`, `status_family_for`, `_PROVIDER_DAY_TZ`) that 5+ callers import from repository.py
- Task 6 silently absorbed `get_pcr_history_30d_ago` (sits inside the claimed `append_pcr_history` line range)
- Task 7 missed module-level `logger` needed by `mark_job_done`/`mark_job_failed`
- Task 8 missed `_RECORD_HEALTH_*` constants + math/Iterable/psql imports
- Task 9 would have broken `scripts/backfill_flow_footprint.py` which imports `_flow_footprint_label` + `_aggressor_label_confidence` from repository.py (now re-exported)
- Plus 7 more

Full audit trail at top of `docs/superpowers/plans/2026-05-16-repository-split-pr1.md`.

## Backward compat — zero blast radius for callers

All 30+ existing `from uw_scan.storage.repository import …` paths still work unchanged:

- `Repository` (unchanged import path)
- 12 row dataclasses (re-exported from `rows.py`)
- 3 external helpers `provider_day_bounds`, `redact_params`, `status_family_for` (re-exported from `_helpers.py`)
- 2 flow helpers `_flow_footprint_label`, `_aggressor_label_confidence` (re-exported from `flow.py` for `scripts/backfill_flow_footprint.py`)

## Pre-execution mitigations confirmed

- ✅ Cross-mixin self-calls: 0 (methods are self-contained)
- ✅ Dynamic Repository introspection: 0
- ✅ Mock/patch references to repository functions: 0
- ✅ Circular dep with models.py: 0
- ✅ `**kwargs` splat patterns: 0
- ✅ Baseline test count: 388

## Test plan

- [x] `uv run pytest` — 387 passed, 1 pre-existing failure (`test_pipeline_e2e_tsla_exit_gate` is live-marked, skipped in CI)
- [x] `uv run python scripts/_lint_except.py src` — ok: no banned except patterns
- [x] `bash scripts/migrate.sh` — 36 migrations, all idempotent on rerun
- [x] `from uw_scan.storage.repository import _flow_footprint_label, _aggressor_label_confidence` — works
- [x] `import scripts.backfill_flow_footprint` — works

## Out of scope (deferred to follow-up PRs)

- **PR-2** (~1500 lines): extract domains — `external_api.py`, `volatility_raw.py`, `options.py`, `scan_runs.py`, `scan_results.py`, `watchlist.py`
- **PR-3** (~1300 lines): extract heavy — `trade_insights_ai.py`, `volatility_v2.py`, `fetchers.py`
- After PR-3, `repository.py` shrinks to ~100 lines (just the mixin assembly)