### PR TITLE
feat(regime): port /regime page from xenon (GEX + CRI + VCG live)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md
+++ b/docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md
@@ -1,0 +1,1923 @@
+# Regime Port from xenon — Implementation Plan (LONG-TERM ROADMAP)
+
+> **⚠️ This is the LONG-TERM roadmap, NOT the executable plan for this iteration.**
+>
+> The executable plan is **`2026-05-16-regime-gex-first.md`** — it ships `/regime` with GEX live (UW-driven) and CRI/VCG as "pending" placeholders, deferring backend work for CRI/VCG until the IB-via-R2 reader is wired (separate project, currently flaky).
+>
+> This file remains useful as the **full-fidelity reference** for when CRI/VCG land:
+> - Pydantic schema shapes for CRI and VCG (Task 2)
+> - Repository method signatures for `fetch_latest_cri`, `fetch_cri_history`, `fetch_latest_vcg` (Task 3)
+> - FastAPI router shape for the full CRI/VCG endpoints (Task 4)
+> - CRI sub-tab visual port spec — `RegimeStrip`, `RegimeRelationshipView`, `CriHistoryChart` (Tasks 7-8)
+> - VCG sub-tab visual port spec (Task 9)
+> - The 3-round review history (Round 1 self-review, Round 2 codex tribunal, Round 3 self-review w/ patches) is preserved for future re-execution context.
+>
+> When the IB-via-R2 reader lands, the follow-up plan should:
+> 1. Add `src/uw_scan/sources/r2_ib.py` — reads VIX/VVIX/COR1M/SPY parquet from R2 via boto3 with R2 endpoint
+> 2. Port the CRI and VCG scanners (math only, no IB code), reading from R2 + UW
+> 3. Cherry-pick the CRI/VCG frontend work specified below
+>
+> ---
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Review history (latest first):**
+- 2026-05-16 Round 3 (Claude self-review + codex-review tribunal, bilateral mode after Gemini sandbox-blocked):
+  - 🔴 Replaced fabricated `get_db_connection` with real `get_repo` from `src/uw_scan/api/deps.py`
+  - 🔴 Pydantic models moved from invented `src/uw_scan/api/models/regime.py` into existing `src/uw_scan/api/schemas.py`; full xenon field set ported (VcgSignal + attribution, GexData with profile/bias/iv/mq/source_delta — 18+ extra fields)
+  - 🔴 Repository methods on existing `Repository` class (CLAUDE.md "one method per query") — dropped standalone `regime_repository.py` module
+  - 🔴 Frontend hooks now use `process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400"` via new `web/lib/regime/api.ts` wrapper (bare `/api/regime` was hitting Next.js port 3001)
+  - 🔴 Ported `useSyncHook` (236 LOC) so hooks return `UseSyncReturn<T>` with `{loading, syncing, syncNow, ...}` — copied VcgPanel/GexPanel destructure these
+  - 🔴 Added `d3` + `@types/d3` install + ported `charts/ChartPanel` and `charts/ChartLegend` wrappers (user-approved deviation from "no chart library" rule for 1:1 mirror)
+  - 🟡 Pydantic validators replicate xenon's `normalizeCriPayload` (numeric-string coercion, bad-level fallback to LOW, filter non-numeric `spy_closes`)
+  - 🟡 Migration extended to mirror xenon's full computed-column set (~20 more across VCG + GEX): attribution_*, ro, edr, tier, bounce, vvix_severity, sign_ok, level_*_strike/gamma
+  - 🟡 Test fixtures fixed: integration tests use `seeded_db_empty_cards: Repository` + `client: TestClient` (fabricated `pg_conn` removed)
+  - 🟡 Task 5 fixed: keep API running between Task 4 and Task 5 (gen:types fetches from localhost:8400)
+  - 🟡 CSS extraction now uses a brace-balanced parser that preserves `@media` boundaries
+  - 🟡 Sync Now button KEPT in CRI empty state — wired to POST /api/regime/scan (1:1 visual fidelity)
+  - 🟢 Sidebar nav target: `web/components/shared/Sidebar.tsx` (NAV array). Was incorrectly Header.tsx.
+  - 🟢 GEX default ticker is `SPX` everywhere (was inconsistent SPY/SPX)
+  - 🟢 `chartSeriesColor` is string-keyed (`"caution"`, `"dislocation"`); numeric-index fallback removed
+  - 🟢 Task 8 duplicate compile/commit step blocks merged
+- 2026-05-16 Round 1 (Claude self-review): added RegimeStrip, RegimeRelationshipView, useMarketHours, pricesProtocol, VCG/GEX scan stubs, market_open runtime override; clarified d3 + scope deviations.
+- 2026-05-16 Initial draft.
+
+**Goal:** Port xenon's `/regime` top-level page and its three sub-tabs (CRI / VCG / GEX) into unusual-whales as a 1:1 visual + structural mirror. Data sources stay stubbed (empty payloads) until a separate backfill phase.
+
+**Architecture:**
+- **DB**: Three new `uw_scan.*` tables (`cri_series`, `vcg_series`, `gex_snapshots`) mirroring xenon's full JSONB-payload-with-computed-columns shape (`src/xenon/db/schema.py:458-642`). Every generated column xenon exposes (~40 across the 3 tables) is replicated so future analytics queries are field-compatible. Idempotent SQL migration.
+- **Backend**: New `regime` FastAPI router under `src/uw_scan/api/routers/regime.py` exposing `GET /api/regime` + `POST /api/regime/scan` (CRI), `GET /api/regime/vcg` + `POST /api/regime/vcg/scan`, `GET /api/regime/gex` + `POST /api/regime/gex/scan`. Each GET reads the latest row via Repository methods; with empty tables they return the same `EMPTY_*` shape xenon's Next.js route uses for upstream-down fallback. POST `/scan` endpoints are 202 stubs until backfill phase.
+  - **URL adaptation**: xenon FastAPI mounts these at `/regime`, `/vcg`, `/gex` (top-level). This repo's convention is `prefix="/api"` for every router (`server.py:34-42`), so we mount at `/api/regime/*`. The frontend fetches via the existing `API` constant in `web/lib/api.ts:3` — `process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400"` — NOT bare `/api/...` paths (which would hit Next.js port 3001).
+  - **Pydantic location**: Response shapes extend `src/uw_scan/api/schemas.py` (the existing API-contract file with docstring "Pydantic response models — over-the-wire contract"). **No new `api/models/` directory** — that's not this repo's pattern.
+  - **Repository pattern**: Per CLAUDE.md "one method per query", new methods (`fetch_latest_cri`, `fetch_cri_history`, `fetch_latest_vcg`, `fetch_latest_gex`) live on the existing `Repository` class at `src/uw_scan/storage/repository.py:579`. **No standalone `regime_repository.py` module** — violates the convention.
+  - **DI pattern**: Routers use `Annotated[Repository, Depends(get_repo)]` from `src/uw_scan/api/deps.py`. **`get_db_connection` does NOT exist** — never reference it.
+  - **Shape normalization**: xenon's Next.js `normalizeCriPayload` (`route.ts:55-114` — coerces strings to numbers, filters bad arrays, backfills realized vol, fallback bad CRI levels to LOW) moves into Pydantic v2 `field_validator`s on `CriResponse`. Equivalent semantics, validated at the FastAPI boundary instead of Next.js.
+  - **market_open runtime override**: xenon `route.ts:198-201` overrides stored `market_open` with current ET clock. Replicated in the router's GET handler via `_is_market_open_now()`.
+- **Frontend**: New `web/app/regime/page.tsx` + `web/components/regime/*` mirroring xenon's `RegimePanel` and **all visual sub-components** rendered inside the CRI tab — `RegimeStrip` + cells (`RegimePanel.tsx:354-407`) and `RegimeRelationshipView` (693 LOC, `RegimePanel.tsx:507`).
+  - **d3 dependency** (deviation from CLAUDE.md "no chart library" — user-approved 2026-05-16 for 1:1 visual mirror). `CriHistoryChart` and `RegimeRelationshipView` both import `* as d3 from "d3"` (xenon source lines 4 of each). Trying to rewrite as hand-rolled SVG is ~1000 LOC of work and loses visual fidelity. The plan installs `d3` + `@types/d3` and ports the two chart wrappers (`charts/ChartPanel.tsx`, `charts/ChartLegend.tsx`, 96 LOC). Document this deviation in the PR description.
+  - **Hook contract**: xenon hooks all return `UseSyncReturn<T>` (`{data, loading, syncing, syncNow, lastSync, ...}`) and accept a `marketState` arg — see `lib/useSyncHook.ts`. Port `useSyncHook` so the copied VcgPanel/GexPanel destructure `loading` / `syncNow` without rewriting them. Ported hooks call through to `web/lib/regime/api.ts` which wraps the existing `API` constant from `web/lib/api.ts`.
+  - **Ported but degraded** (no live data source yet): strip's `LiveBadge`s read CACHED; `MarketState` reports CLOSED outside ET market hours via the ported `useMarketHours`. `prices={}` empty map for live overlays.
+  - **Empty state Sync Now button**: kept (1:1 visual). Wires to POST `/api/regime/scan` which returns the 202 stub; UI shows the returned `message: "scanner_pending: ..."` as a toast.
+  - **Stripped (xenon-only)**: `ShareReportModal` + X share routes (`/regime/share`, `/vcg/share`, `/gex/share`), `xenonFetch`, account scope guards, IB-specific scanner subprocess hooks.
+- **Out of scope (this plan)**: Scanner internals (`cri.py` / `vcg.py` / `gex.py` ≈ 3700 LOC), share-to-X social posting + its FastAPI routes, `regime_overrides` table (governance gate, unrelated to the 3 sub-tabs), Cboe / FMP / IB data source wiring, holiday-aware market hours.
+
+**Tech Stack:** Python 3.13 / FastAPI / psycopg / Pydantic v2 (backend) — Next.js 16 / React 19 / TypeScript / hand-rolled SVG charts (frontend) — pytest / Vitest / Playwright.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/uw_scan/storage/migrations/037_regime_tables.sql` — schema for cri_series, vcg_series, gex_snapshots (with FULL generated-column set from xenon)
+- `src/uw_scan/api/routers/regime.py` — FastAPI router with 6 endpoints (3 GET, 3 POST stubs)
+- `tests/integration/api/test_regime_router.py` — API shape + empty-state tests (uses `client: TestClient` fixture)
+
+**Modify (extend existing files, do NOT create new dirs):**
+- `src/uw_scan/api/schemas.py` — append regime response models (`CriResponse`, `VcgResponse`, `GexResponse` + sub-models + validators)
+- `src/uw_scan/storage/repository.py` — append methods to `Repository` class: `fetch_latest_cri`, `fetch_cri_history`, `fetch_latest_vcg`, `fetch_latest_gex`
+- `src/uw_scan/api/server.py` — register router (line 42-ish, after `trade_insights.router`)
+- `web/components/shared/Sidebar.tsx` — append `{ href: "/regime", label: "Regime", icon: ... }` to the `NAV` array
+- `web/app/globals.css` — append regime-specific styles (with `@media` boundaries preserved)
+- `web/package.json` — add `d3` + `@types/d3` to dependencies (user-approved deviation from "no chart library" rule for 1:1 mirror)
+
+**Frontend files (new):**
+- `web/app/regime/page.tsx` — top-level page route
+- `web/components/regime/RegimePanel.tsx` — main panel with 3 sub-tab nav
+- `web/components/regime/CriSubTab.tsx` — CRI hero + components + history
+- `web/components/regime/VcgSubTab.tsx` — VCG signal panel
+- `web/components/regime/GexSubTab.tsx` — GEX profile + levels panel
+- `web/components/regime/CriHistoryChart.tsx` — 20-session VIX/VVIX/RVOL/COR1M chart (346 LOC port; uses d3)
+- `web/components/regime/GexProfileChart.tsx` — gamma profile by strike (port; uses d3)
+- `web/components/regime/RegimeStrip.tsx` — top status strip + named exports `LiveBadge` / `DayChange` / `PointChange` / `RegimeStripCell` (79 LOC port)
+- `web/components/regime/RegimeRelationshipView.tsx` — VIX/COR1M scatter + history (693 LOC port; uses d3)
+- `web/components/regime/charts/ChartPanel.tsx` — d3-aware chart container (69 LOC port)
+- `web/components/regime/charts/ChartLegend.tsx` — shared chart legend (27 LOC port)
+- `web/components/regime/InfoTooltip.tsx` — shared tooltip (95 LOC port if not already present)
+- `web/components/regime/ui/MetricCard.tsx` — `MetricCard` + `SourceBadge` named exports (87 LOC port)
+- `web/lib/regime/api.ts` — typed regime API wrapper consuming the shared `API` constant from `web/lib/api.ts:3` (`process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400"`)
+- `web/lib/regime/useSyncHook.ts` — generic `useSyncHook<T>(endpoint, opts): UseSyncReturn<T>` (port from `xenon/web/lib/useSyncHook.ts`)
+- `web/lib/regime/useRegime.ts` — `useRegime(marketState, opts): UseSyncReturn<CriData>`
+- `web/lib/regime/useVcg.ts` — `useVcg(marketState): UseSyncReturn<VcgData>`
+- `web/lib/regime/useGex.ts` — `useGex(marketState, ticker?): UseSyncReturn<GexData>` (default ticker `"SPX"`)
+- `web/lib/regime/useMarketHours.ts` — `MarketState` enum + ET-clock hook (81 LOC port)
+- `web/lib/regime/pricesProtocol.ts` — `PriceData` type (207 LOC port for type surface)
+- `web/lib/regime/regimeLiveStrip.ts` — `resolveRegimeStripLiveState` (97 LOC port)
+- `web/lib/regime/regimeRelationships.ts` — model behind `RegimeRelationshipView` (174 LOC port)
+- `web/lib/regime/criCalc.ts` — `computeCri` + `CriLevel` + `CriResult` (103 LOC port)
+- `web/lib/regime/criStaleness.ts` — `isCriDataStale` (57 LOC port)
+- `web/lib/regime/regimeHistory.ts` — `backfillRealizedVolHistory` (66 LOC port)
+- `web/lib/regime/sectionTooltips.ts` — `SECTION_TOOLTIPS` for CRI/VCG/GEX keys only (subset of xenon's 151 LOC)
+- `web/lib/regime/chartSystem.ts` — `chartSeriesColor(name: string)` + named-token map (subset of xenon's 48 LOC; **string-keyed, NOT index-based**)
+- `web/lib/regime/types.ts` — re-exports under stable names: `CriData`, `VcgData`, `VcgSignal`, `VcgHistoryEntry`, `GexData`, `GexLevel`, `GexBucket`, `GexBias`, `GexHistoryEntry`, `MqLevels`, `SourceDelta`, `IvData`
+- `web/tests/unit/regime-page.test.ts` — Vitest: page renders + tabs swap + empty state
+- `web/tests/e2e/regime-page.spec.ts` — Playwright: smoke test for /regime route
+
+---
+
+## Task 1: DB schema migration
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/037_regime_tables.sql`
+
+- [ ] **Step 1: Write migration SQL**
+
+```sql
+-- 037_regime_tables.sql
+--
+-- Mirror xenon's regime persistence: three append-only series tables, JSONB
+-- payloads with computed columns for indexable scalars. Idempotent (IF NOT
+-- EXISTS). Tables stay empty until backfill phase wires data sources.
+
+BEGIN;
+
+-- ── CRI series: market-wide crash risk indicator snapshots ──────────────
+CREATE TABLE IF NOT EXISTS uw_scan.cri_series (
+    id              BIGSERIAL PRIMARY KEY,
+    cri_level       NUMERIC(8,4) NOT NULL,
+    alert           BOOLEAN NOT NULL DEFAULT FALSE,
+    payload         JSONB,
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    recorded_date   DATE GENERATED ALWAYS AS (
+        CASE WHEN payload->>'date' ~ '^\d{4}-\d{2}-\d{2}$'
+             THEN make_date(
+                 split_part(payload->>'date','-',1)::int,
+                 split_part(payload->>'date','-',2)::int,
+                 split_part(payload->>'date','-',3)::int)
+        END
+    ) STORED,
+    vix             NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vix')::numeric) STORED,
+    vvix            NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vvix')::numeric) STORED,
+    spy             NUMERIC(10,4) GENERATED ALWAYS AS ((payload->>'spy')::numeric) STORED,
+    vix_5d_roc      NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vix_5d_roc')::numeric) STORED,
+    vvix_vix_ratio  NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vvix_vix_ratio')::numeric) STORED,
+    spx_100d_ma     NUMERIC(10,4) GENERATED ALWAYS AS ((payload->>'spx_100d_ma')::numeric) STORED,
+    spx_distance_pct NUMERIC(8,4) GENERATED ALWAYS AS ((payload->>'spx_distance_pct')::numeric) STORED,
+    cor1m           NUMERIC(6,4)  GENERATED ALWAYS AS ((payload->>'cor1m')::numeric) STORED,
+    cor1m_previous_close NUMERIC(6,4) GENERATED ALWAYS AS ((payload->>'cor1m_previous_close')::numeric) STORED,
+    cor1m_5d_change NUMERIC(6,4)  GENERATED ALWAYS AS ((payload->>'cor1m_5d_change')::numeric) STORED,
+    realized_vol    NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'realized_vol')::numeric) STORED,
+    cri_score       NUMERIC(8,4)  GENERATED ALWAYS AS (((payload->'cri')->>'score')::numeric) STORED,
+    cri_components  JSONB         GENERATED ALWAYS AS (payload->'cri'->'components') STORED,
+    cta_exposure_pct NUMERIC(6,2) GENERATED ALWAYS AS (((payload->'cta')->>'exposure_pct')::numeric) STORED,
+    cta_forced_reduction BOOLEAN  GENERATED ALWAYS AS (((payload->'cta')->>'forced_reduction')::boolean) STORED,
+    cta_selling_usd_b NUMERIC(8,2) GENERATED ALWAYS AS (((payload->'cta')->>'selling_usd_b')::numeric) STORED,
+    crash_trigger_fired BOOLEAN   GENERATED ALWAYS AS (((payload->'crash_trigger')->>'fired')::boolean) STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_cri_recorded_date ON uw_scan.cri_series (recorded_date);
+CREATE INDEX IF NOT EXISTS ix_cri_recorded_at   ON uw_scan.cri_series (recorded_at DESC);
+
+-- ── VCG series: vol-curve gauge snapshots (full column set from xenon db/schema.py:514-575) ──
+CREATE TABLE IF NOT EXISTS uw_scan.vcg_series (
+    id                   BIGSERIAL PRIMARY KEY,
+    scanned_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    market_open          BOOLEAN,
+    credit_proxy         TEXT,
+    payload              JSONB NOT NULL,
+    vcg                  NUMERIC(10,6) GENERATED ALWAYS AS (((payload->'signal')->>'vcg')::numeric) STORED,
+    vcg_adj              NUMERIC(10,6) GENERATED ALWAYS AS (((payload->'signal')->>'vcg_adj')::numeric) STORED,
+    residual             NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal')->>'residual')::numeric) STORED,
+    beta1_vvix           NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal')->>'beta1_vvix')::numeric) STORED,
+    beta2_vix            NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal')->>'beta2_vix')::numeric) STORED,
+    alpha                NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal')->>'alpha')::numeric) STORED,
+    vix                  NUMERIC(8,4)  GENERATED ALWAYS AS (((payload->'signal')->>'vix')::numeric) STORED,
+    vvix                 NUMERIC(8,4)  GENERATED ALWAYS AS (((payload->'signal')->>'vvix')::numeric) STORED,
+    credit_price         NUMERIC(10,4) GENERATED ALWAYS AS (((payload->'signal')->>'credit_price')::numeric) STORED,
+    credit_5d_return_pct NUMERIC(8,4)  GENERATED ALWAYS AS (((payload->'signal')->>'credit_5d_return_pct')::numeric) STORED,
+    ro                   SMALLINT      GENERATED ALWAYS AS (((payload->'signal')->>'ro')::int) STORED,
+    edr                  SMALLINT      GENERATED ALWAYS AS (((payload->'signal')->>'edr')::int) STORED,
+    tier                 SMALLINT      GENERATED ALWAYS AS (((payload->'signal')->>'tier')::int) STORED,
+    bounce               SMALLINT      GENERATED ALWAYS AS (((payload->'signal')->>'bounce')::int) STORED,
+    vvix_severity        TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'vvix_severity') STORED,
+    sign_ok              BOOLEAN       GENERATED ALWAYS AS (((payload->'signal')->>'sign_ok')::boolean) STORED,
+    sign_suppressed      BOOLEAN       GENERATED ALWAYS AS (((payload->'signal')->>'sign_suppressed')::boolean) STORED,
+    pi_panic             NUMERIC(8,4)  GENERATED ALWAYS AS (((payload->'signal')->>'pi_panic')::numeric) STORED,
+    regime               TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'regime') STORED,
+    interpretation       TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'interpretation') STORED,
+    attr_vvix_pct        NUMERIC(6,2)  GENERATED ALWAYS AS (((payload->'signal'->'attribution')->>'vvix_pct')::numeric) STORED,
+    attr_vix_pct         NUMERIC(6,2)  GENERATED ALWAYS AS (((payload->'signal'->'attribution')->>'vix_pct')::numeric) STORED,
+    attr_vvix_component  NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal'->'attribution')->>'vvix_component')::numeric) STORED,
+    attr_vix_component   NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal'->'attribution')->>'vix_component')::numeric) STORED,
+    attr_model_implied   NUMERIC(12,8) GENERATED ALWAYS AS (((payload->'signal'->'attribution')->>'model_implied')::numeric) STORED,
+    CONSTRAINT uq_vcg_series_scanned_at UNIQUE (scanned_at)
+);
+
+CREATE INDEX IF NOT EXISTS ix_vcg_scanned_at ON uw_scan.vcg_series (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_vcg_regime     ON uw_scan.vcg_series (regime);
+CREATE INDEX IF NOT EXISTS ix_vcg_tier       ON uw_scan.vcg_series (tier) WHERE tier IS NOT NULL;
+
+-- ── GEX snapshots: gamma exposure per ticker per scan (full column set from xenon db/schema.py:577-641) ──
+CREATE TABLE IF NOT EXISTS uw_scan.gex_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    ticker          TEXT NOT NULL,
+    data_date       DATE,
+    scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    payload         JSONB NOT NULL,
+    spot            NUMERIC(12,4) GENERATED ALWAYS AS ((payload->>'spot')::numeric) STORED,
+    net_gex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_gex')::numeric) STORED,
+    net_dex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_dex')::numeric) STORED,
+    vol_pc          NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vol_pc')::numeric) STORED,
+    iv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'iv30d')::numeric) STORED,
+    iv_rank         NUMERIC(6,2)  GENERATED ALWAYS AS (((payload->'iv')->>'iv_rank')::numeric) STORED,
+    hv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'hv30')::numeric) STORED,
+    mq_iv_30d       NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'mq_iv30d')::numeric) STORED,
+    level_max_magnet_strike       NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'strike')::numeric) STORED,
+    level_max_magnet_gamma        NUMERIC(14,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'gamma')::numeric) STORED,
+    level_second_magnet_strike    NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'second_magnet')->>'strike')::numeric) STORED,
+    level_second_magnet_gamma     NUMERIC(14,4) GENERATED ALWAYS AS (((payload->'levels'->'second_magnet')->>'gamma')::numeric) STORED,
+    level_max_accelerator_strike  NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_accelerator')->>'strike')::numeric) STORED,
+    level_max_accelerator_gamma   NUMERIC(14,4) GENERATED ALWAYS AS (((payload->'levels'->'max_accelerator')->>'gamma')::numeric) STORED,
+    level_put_wall_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'put_wall')->>'strike')::numeric) STORED,
+    level_call_wall_strike        NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'call_wall')->>'strike')::numeric) STORED,
+    level_gex_flip_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'gex_flip')->>'strike')::numeric) STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_gex_ticker_time ON uw_scan.gex_snapshots (ticker, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_scanned_at  ON uw_scan.gex_snapshots (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_data_date   ON uw_scan.gex_snapshots (data_date);
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply migration**
+
+Run: `bash scripts/migrate.sh`
+Expected: `Applying src/uw_scan/storage/migrations/037_regime_tables.sql...` followed by a `COMMIT` line, no errors. Re-running is a no-op.
+
+- [ ] **Step 3: Verify tables**
+
+Run:
+```bash
+psql "$(uv run python -c 'from uw_scan.config import Settings; print(Settings.from_env().db_dsn())')" -c "\d uw_scan.cri_series uw_scan.vcg_series uw_scan.gex_snapshots"
+```
+Expected: All three tables listed with `payload jsonb` column and generated columns visible.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/037_regime_tables.sql
+git commit -m "feat(regime): add cri_series, vcg_series, gex_snapshots tables"
+```
+
+---
+
+## Task 2: Pydantic response models — extend `src/uw_scan/api/schemas.py`
+
+**Critical**: this repo's API-contract Pydantic models live in `src/uw_scan/api/schemas.py` (existing file; docstring: "Pydantic response models — over-the-wire contract for the watchlist API"). **Do NOT create `src/uw_scan/api/models/regime.py` — that directory does not exist and inventing it diverges from convention.**
+
+**Files:**
+- Modify (append to existing): `src/uw_scan/api/schemas.py`
+- Create: `tests/unit/test_regime_schemas.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_regime_schemas.py`:
+
+```python
+from uw_scan.api.schemas import (
+    CriResponse,
+    EMPTY_CRI_RESPONSE,
+    VcgResponse,
+    EMPTY_VCG_RESPONSE,
+    GexResponse,
+    EMPTY_GEX_RESPONSE,
+)
+
+
+def test_empty_cri_response_serializes_with_nulls():
+    payload = EMPTY_CRI_RESPONSE.model_dump()
+    assert payload["vix"] is None
+    assert payload["vvix"] is None
+    assert payload["cri"]["score"] == 0
+    assert payload["cri"]["level"] == "LOW"
+    assert payload["history"] == []
+    assert payload["spy_closes"] == []
+    assert payload["crash_trigger"]["triggered"] is False
+
+
+def test_cri_validator_coerces_string_numerics():
+    """Replicates xenon normalizeCriPayload's asNumber behavior — strings cast to floats."""
+    src = {"vix": "18.5", "vvix": "110.0", "spy": "580.2"}
+    parsed = CriResponse.model_validate(src)
+    assert parsed.vix == 18.5
+    assert parsed.vvix == 110.0
+
+
+def test_cri_validator_falls_back_invalid_level():
+    """Bad CRI level strings should fall back to LOW per xenon route.ts:92-95."""
+    src = {"cri": {"score": 50, "level": "WEIRD", "components": {"vix": 5, "vvix": 5, "correlation": 5, "momentum": 5}}}
+    parsed = CriResponse.model_validate(src)
+    assert parsed.cri.level == "LOW"
+
+
+def test_cri_validator_filters_bad_spy_closes():
+    """Non-numeric spy_closes entries dropped (xenon route.ts:77-81)."""
+    src = {"spy_closes": [580.0, "not-a-number", 581.5, None, 582.0]}
+    parsed = CriResponse.model_validate(src)
+    assert parsed.spy_closes == [580.0, 581.5, 582.0]
+
+
+def test_empty_vcg_response_includes_attribution_skeleton():
+    payload = EMPTY_VCG_RESPONSE.model_dump()
+    assert payload["signal"]["vcg"] is None
+    assert payload["signal"]["attribution"]["vvix_pct"] is None
+    assert payload["signal"]["credit_proxy"] is None or payload["credit_proxy"] is None
+
+
+def test_empty_gex_response_uses_profile_not_buckets():
+    """Frontend VcgPanel destructures data.profile, not data.buckets."""
+    payload = EMPTY_GEX_RESPONSE.model_dump()
+    assert "profile" in payload
+    assert payload["profile"] == []
+    assert payload["levels"]["max_magnet"] is None  # GexLevel is `... | null` in xenon
+    assert "bias" in payload
+    assert "iv" in payload
+    assert "mq" in payload
+    assert payload["mq"] is None  # MQ data optional
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_regime_schemas.py -v`
+Expected: FAIL with `ImportError: cannot import name 'CriResponse' from 'uw_scan.api.schemas'`
+
+- [ ] **Step 3: Implement models — append to `src/uw_scan/api/schemas.py`**
+
+The model field set mirrors xenon's `CriData` (`web/lib/useRegime.ts`), `VcgData` (`web/lib/useVcg.ts:55-60`), `GexData` (`web/lib/useGex.ts:86-121`) **exactly**. Missing fields silently get filtered by FastAPI `response_model` and break the copied frontend panels.
+
+Append at the end of `src/uw_scan/api/schemas.py`:
+
+```python
+# ─── Regime: CRI / VCG / GEX response shapes (ported from xenon 2026-05-16) ──
+# Field sets mirror xenon/web/lib/useRegime.ts, useVcg.ts, useGex.ts. Adding/removing
+# fields means rerunning `cd web && npm run gen:types` and updating the FE.
+
+from typing import Literal
+from pydantic import field_validator
+
+
+CriLevel = Literal["LOW", "ELEVATED", "HIGH", "CRITICAL"]
+
+
+class CriComponents(BaseModel):
+    vix: float = 0
+    vvix: float = 0
+    correlation: float = 0
+    momentum: float = 0
+
+
+class Cri(BaseModel):
+    score: float = 0
+    level: CriLevel = "LOW"
+    components: CriComponents = Field(default_factory=CriComponents)
+
+    @field_validator("level", mode="before")
+    @classmethod
+    def _coerce_level(cls, v):
+        """Mirror xenon route.ts:92-95 — unknown levels fall back to LOW."""
+        return v if v in ("LOW", "ELEVATED", "HIGH", "CRITICAL") else "LOW"
+
+
+class Cta(BaseModel):
+    realized_vol: float = 0
+    exposure_pct: float = 200
+    forced_reduction_pct: float = 0
+    est_selling_bn: float = 0
+
+
+class CrashTriggerConditions(BaseModel):
+    spx_below_100d_ma: bool = False
+    realized_vol_gt_25: bool = False
+    cor1m_gt_60: bool = False
+
+
+class CrashTrigger(BaseModel):
+    triggered: bool = False
+    conditions: CrashTriggerConditions = Field(default_factory=CrashTriggerConditions)
+    values: dict = Field(default_factory=dict)
+
+
+class CriHistoryEntry(BaseModel):
+    date: str
+    vix: float | None = None
+    vvix: float | None = None
+    spy: float | None = None
+    cor1m: float | None = None
+    realized_vol: float | None = None
+    spx_vs_ma_pct: float | None = None
+    vix_5d_roc: float | None = None
+
+
+class CriResponse(BaseModel):
+    scan_time: str = ""
+    date: str = ""
+    market_open: bool | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    spy: float | None = None
+    vix_5d_roc: float | None = None
+    vvix_vix_ratio: float | None = None
+    spx_100d_ma: float | None = None
+    spx_distance_pct: float | None = None
+    cor1m: float | None = None
+    cor1m_previous_close: float | None = None
+    cor1m_5d_change: float | None = None
+    realized_vol: float | None = None
+    cri: Cri = Field(default_factory=Cri)
+    cta: Cta = Field(default_factory=Cta)
+    menthorq_cta: dict | None = None
+    crash_trigger: CrashTrigger = Field(default_factory=CrashTrigger)
+    history: list[CriHistoryEntry] = Field(default_factory=list)
+    spy_closes: list[float] = Field(default_factory=list)
+
+    @field_validator(
+        "vix", "vvix", "spy", "vix_5d_roc", "vvix_vix_ratio", "spx_100d_ma",
+        "spx_distance_pct", "cor1m", "cor1m_previous_close", "cor1m_5d_change",
+        "realized_vol",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_number_or_none(cls, v):
+        """Mirror xenon route.ts:55-61 — numeric strings cast to float; bad values → None."""
+        if v is None:
+            return None
+        if isinstance(v, (int, float)):
+            import math
+            return v if math.isfinite(v) else None
+        if isinstance(v, str):
+            try:
+                f = float(v)
+                import math
+                return f if math.isfinite(f) else None
+            except ValueError:
+                return None
+        return None
+
+    @field_validator("spy_closes", mode="before")
+    @classmethod
+    def _filter_bad_spy_closes(cls, v):
+        """Mirror xenon route.ts:77-81 — drop non-numeric entries."""
+        if not isinstance(v, list):
+            return []
+        out = []
+        for entry in v:
+            if isinstance(entry, (int, float)):
+                import math
+                if math.isfinite(entry):
+                    out.append(float(entry))
+            elif isinstance(entry, str):
+                try:
+                    f = float(entry)
+                    import math
+                    if math.isfinite(f):
+                        out.append(f)
+                except ValueError:
+                    pass
+        return out
+
+
+EMPTY_CRI_RESPONSE = CriResponse()
+
+
+# ── VCG ─────────────────────────────────────────────────────────────────
+
+class VcgAttribution(BaseModel):
+    vvix_pct: float | None = None
+    vix_pct: float | None = None
+    vvix_component: float | None = None
+    vix_component: float | None = None
+    model_implied: float | None = None
+
+
+class VcgSignal(BaseModel):
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    residual: float | None = None
+    beta1_vvix: float | None = None
+    beta2_vix: float | None = None
+    alpha: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    credit_price: float | None = None
+    credit_5d_return_pct: float | None = None
+    ro: int | None = None
+    edr: int | None = None
+    tier: int | None = None
+    bounce: int | None = None
+    vvix_severity: Literal["extreme", "elevated", "moderate"] | None = None
+    sign_ok: bool | None = None
+    sign_suppressed: bool | None = None
+    pi_panic: float | None = None
+    regime: Literal["PANIC", "TRANSITION", "DIVERGENCE"] | None = None
+    interpretation: (
+        Literal["RISK_OFF", "EDR", "WATCH", "BOUNCE", "NORMAL", "SUPPRESSED", "PANIC"]
+        | None
+    ) = None
+    attribution: VcgAttribution = Field(default_factory=VcgAttribution)
+
+
+class VcgHistoryEntry(BaseModel):
+    date: str
+    residual: float | None = None
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    beta1: float | None = None
+    beta2: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    credit: float | None = None
+
+
+class VcgResponse(BaseModel):
+    scan_time: str = ""
+    market_open: bool | None = None
+    credit_proxy: str | None = None
+    signal: VcgSignal = Field(default_factory=VcgSignal)
+    history: list[VcgHistoryEntry] = Field(default_factory=list)
+
+
+EMPTY_VCG_RESPONSE = VcgResponse()
+
+
+# ── GEX ─────────────────────────────────────────────────────────────────
+
+class GexLevel(BaseModel):
+    strike: float
+    gamma: float
+    distance: float
+    distance_pct: float
+
+
+class GexLevels(BaseModel):
+    # Each level is nullable (xenon: `GexLevel | null`)
+    gex_flip: GexLevel | None = None
+    max_magnet: GexLevel | None = None
+    second_magnet: GexLevel | None = None
+    max_accelerator: GexLevel | None = None
+    put_wall: GexLevel | None = None
+    call_wall: GexLevel | None = None
+
+
+class GexBucket(BaseModel):
+    strike: float
+    call_gex: float
+    put_gex: float
+    net_gex: float
+    pct_from_spot: float
+    tag: str | None = None
+
+
+class GexBiasFlipMigration(BaseModel):
+    date: str
+    flip: float
+
+
+class GexBias(BaseModel):
+    direction: Literal["BULL", "CAUTIOUS_BULL", "NEUTRAL", "CAUTIOUS_BEAR", "BEAR"] | None = None
+    reasons: list[str] = Field(default_factory=list)
+    days_above_flip: int | None = None
+    flip_migration: list[GexBiasFlipMigration] = Field(default_factory=list)
+
+
+class GexExpectedRange(BaseModel):
+    low: float | None = None
+    high: float | None = None
+    iv_1d: float | None = None
+
+
+class GexHistoryEntry(BaseModel):
+    date: str
+    net_gex: float | None = None
+    net_dex: float | None = None
+    gex_flip: float | None = None
+    spot: float | None = None
+    atm_iv: float | None = None
+    vol_pc: float | None = None
+    bias: str | None = None
+
+
+class GexIvData(BaseModel):
+    iv30d: float | None = None
+    iv_rank: float | None = None
+    hv30: float | None = None
+    mq_iv30d: float | None = None
+    mq_iv_rank: str | None = None
+    source: Literal["uw", "mq", "both"] | None = None
+
+
+class GexMqLevels(BaseModel):
+    source_date: str | None = None
+    spot: float | None = None
+    hvl: float | None = None
+    call_resistance_all: float | None = None
+    call_resistance_0dte: float | None = None
+    put_support_all: float | None = None
+    put_support_0dte: float | None = None
+    expected_high: float | None = None
+    expected_low: float | None = None
+    distance_to_hvl_pct: str | None = None
+    iv30d: float | None = None
+    hv30: float | None = None
+    iv_rank: str | None = None
+    top_gex_strikes: list[float] = Field(default_factory=list)
+
+
+class GexSourceDeltaEntry(BaseModel):
+    uw: float
+    mq: float
+    delta: float
+
+
+class GexSourceDelta(BaseModel):
+    flip_vs_hvl: GexSourceDeltaEntry | None = None
+    put_wall_vs_support_all: GexSourceDeltaEntry | None = None
+    put_wall_vs_support_0dte: GexSourceDeltaEntry | None = None
+    call_wall_vs_resistance_all: GexSourceDeltaEntry | None = None
+    call_wall_vs_resistance_0dte: GexSourceDeltaEntry | None = None
+
+
+class GexResponse(BaseModel):
+    scan_time: str = ""
+    market_open: bool | None = None
+    ticker: str = "SPX"
+    spot: float | None = None
+    close: float | None = None
+    day_change: float | None = None
+    day_change_pct: float | None = None
+    data_date: str | None = None
+    net_gex: float | None = None
+    net_dex: float | None = None
+    atm_iv: float | None = None
+    vol_pc: float | None = None
+    levels: GexLevels = Field(default_factory=GexLevels)
+    profile: list[GexBucket] = Field(default_factory=list)
+    expected_range: GexExpectedRange = Field(default_factory=GexExpectedRange)
+    bias: GexBias = Field(default_factory=GexBias)
+    history: list[GexHistoryEntry] = Field(default_factory=list)
+    iv: GexIvData | None = None
+    mq: GexMqLevels | None = None
+    source_delta: GexSourceDelta | None = None
+
+
+EMPTY_GEX_RESPONSE = GexResponse()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_regime_schemas.py -v`
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/api/schemas.py tests/unit/test_regime_schemas.py
+git commit -m "feat(regime): add CRI/VCG/GEX Pydantic schemas with normalize validators"
+```
+
+---
+
+## Task 3: Repository methods on existing `Repository` class
+
+**Critical**: per `CLAUDE.md` ("Repository pattern: src/uw_scan/storage/repository.py (one method per query)") and the existing 30+ methods on the class (see `repository.py:579` `class Repository`), regime queries are **methods on the existing class**, not a separate module. Test fixture is `seeded_db_empty_cards: Repository` from `tests/integration/conftest.py` — there is **no `pg_conn` fixture**.
+
+**Files:**
+- Modify (append methods to): `src/uw_scan/storage/repository.py`
+- Create: `tests/integration/test_regime_repository.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/test_regime_repository.py`:
+
+```python
+import json
+
+from uw_scan.storage.repository import Repository
+
+
+def test_fetch_latest_cri_returns_none_when_empty(seeded_db_empty_cards: Repository) -> None:
+    assert seeded_db_empty_cards.fetch_latest_cri() is None
+
+
+def test_fetch_latest_cri_returns_payload(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    payload = {"vix": 18.5, "vvix": 110.0, "cri": {"score": 42, "level": "ELEVATED"}}
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.cri_series (cri_level, payload) VALUES (%s, %s::jsonb)",
+            (42, json.dumps(payload)),
+        )
+    repo.conn.commit()
+    result = repo.fetch_latest_cri()
+    assert result is not None
+    assert result["vix"] == 18.5
+    assert result["cri"]["score"] == 42
+
+
+def test_fetch_cri_history_orders_by_date(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    with repo.conn.cursor() as cur:
+        for day, score in [("2026-05-14", 30), ("2026-05-15", 40), ("2026-05-16", 50)]:
+            cur.execute(
+                "INSERT INTO uw_scan.cri_series (cri_level, payload) VALUES (%s, %s::jsonb)",
+                (score, json.dumps({"date": day, "cri": {"score": score}})),
+            )
+    repo.conn.commit()
+    history = repo.fetch_cri_history(limit=10)
+    assert len(history) == 3
+    assert [h["cri_score"] for h in history] == [30, 40, 50]
+
+
+def test_fetch_latest_gex_filters_by_ticker(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.gex_snapshots (ticker, payload) VALUES (%s, %s::jsonb)",
+            ("SPX", json.dumps({"spot": 5800.0})),
+        )
+        cur.execute(
+            "INSERT INTO uw_scan.gex_snapshots (ticker, payload) VALUES (%s, %s::jsonb)",
+            ("SPY", json.dumps({"spot": 580.0})),
+        )
+    repo.conn.commit()
+    spx = repo.fetch_latest_gex(ticker="SPX")
+    spy = repo.fetch_latest_gex(ticker="SPY")
+    assert spx["spot"] == 5800.0
+    assert spy["spot"] == 580.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/integration/test_regime_repository.py -v`
+Expected: FAIL with `AttributeError: 'Repository' object has no attribute 'fetch_latest_cri'`.
+
+- [ ] **Step 3: Add methods to the `Repository` class**
+
+Open `src/uw_scan/storage/repository.py`. Find the `class Repository:` line (around line 579). Append these methods inside the class body (anywhere after the existing methods is fine — match the existing indentation):
+
+```python
+    # ─── Regime (CRI / VCG / GEX) — ported from xenon 2026-05-16 ──────────
+
+    def fetch_latest_cri(self) -> dict | None:
+        """Return the most-recent cri_series payload, or None when empty."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, recorded_at FROM {self._schema}.cri_series "
+                f"ORDER BY recorded_at DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, recorded_at = row[0] or {}, row[1]
+        out = dict(payload)
+        out.setdefault("scan_time", recorded_at.isoformat() if recorded_at else "")
+        return out
+
+    def fetch_cri_history(self, *, limit: int = 90) -> list[dict]:
+        """Return CRI history ascending (oldest first), for line-chart rendering."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, recorded_date, recorded_at, vix, vvix, spy, cor1m, "
+                f"cri_score, realized_vol "
+                f"FROM {self._schema}.cri_series "
+                f"ORDER BY recorded_at DESC LIMIT %s",
+                (limit,),
+            )
+            rows = cur.fetchall()
+        rows.reverse()
+        out: list[dict] = []
+        for payload, recorded_date, recorded_at, vix, vvix, spy, cor1m, cri_score, rvol in rows:
+            data = dict(payload or {})
+            out.append({
+                "date": data.get("date") or (recorded_date.isoformat() if recorded_date else (recorded_at.isoformat() if recorded_at else "")),
+                "cri_score": float(cri_score) if cri_score is not None else None,
+                "vix": float(vix) if vix is not None else None,
+                "vvix": float(vvix) if vvix is not None else None,
+                "spy": float(spy) if spy is not None else None,
+                "cor1m": float(cor1m) if cor1m is not None else None,
+                "realized_vol": float(rvol) if rvol is not None else None,
+            })
+        return out
+
+    def fetch_latest_vcg(self) -> dict | None:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, scanned_at, market_open FROM {self._schema}.vcg_series "
+                f"ORDER BY scanned_at DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at, market_open = row[0] or {}, row[1], row[2]
+        out = dict(payload)
+        out.setdefault("scan_time", scanned_at.isoformat() if scanned_at else "")
+        if "market_open" not in out:
+            out["market_open"] = market_open
+        return out
+
+    def fetch_latest_gex(self, *, ticker: str = "SPX") -> dict | None:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, scanned_at, ticker FROM {self._schema}.gex_snapshots "
+                f"WHERE ticker = %s ORDER BY scanned_at DESC LIMIT 1",
+                (ticker,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at, t = row[0] or {}, row[1], row[2]
+        out = dict(payload)
+        out.setdefault("scan_time", scanned_at.isoformat() if scanned_at else "")
+        out.setdefault("ticker", t)
+        return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/test_regime_repository.py -v`
+Expected: 4 PASSED. (The `UW_SCAN_TEST_DB_NAME` is set in `tests/conftest.py` to default `option_wizard_test`; exporting explicitly is just defensive.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/repository.py tests/integration/test_regime_repository.py
+git commit -m "feat(regime): add fetch_latest_cri / fetch_cri_history / fetch_latest_vcg / fetch_latest_gex"
+```
+
+---
+
+## Task 4: FastAPI regime router
+
+**Critical conventions** (verified against `src/uw_scan/api/routers/cockpit.py` and `tests/integration/api/conftest.py`):
+- DI is `Annotated[Repository, Depends(get_repo)]` from `uw_scan.api.deps`. **`get_db_connection` does NOT exist — never reference it.**
+- Tests use the `client: TestClient` fixture from `tests/integration/api/conftest.py:30` which already wires `app.dependency_overrides[get_repo]` to the test DB. **Do NOT instantiate `TestClient(app)` directly** — that bypasses overrides.
+- For monkeypatching repo methods on the `Repository` class, use `monkeypatch.setattr(Repository, "fetch_latest_cri", ...)` style.
+
+**Files:**
+- Create: `src/uw_scan/api/routers/regime.py`
+- Modify: `src/uw_scan/api/server.py` (imports + `include_router` line after `trade_insights.router`)
+- Create: `tests/integration/api/test_regime_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/api/test_regime_router.py`:
+
+```python
+from fastapi.testclient import TestClient
+
+from uw_scan.storage.repository import Repository
+
+
+def test_get_regime_returns_empty_shape_when_no_data(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(Repository, "fetch_latest_cri", lambda self: None)
+    monkeypatch.setattr(Repository, "fetch_cri_history", lambda self, *, limit=90: [])
+    response = client.get("/api/regime")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["vix"] is None
+    assert data["cri"]["score"] == 0
+    assert data["cri"]["level"] == "LOW"
+    assert data["history"] == []
+    assert data["crash_trigger"]["triggered"] is False
+
+
+def test_post_cri_scan_returns_202_with_stub_body(client: TestClient) -> None:
+    response = client.post("/api/regime/scan")
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "queued"
+    assert body["scanner"] == "cri"
+    assert "scanner_pending" in body["message"].lower()
+
+
+def test_post_vcg_scan_returns_202(client: TestClient) -> None:
+    response = client.post("/api/regime/vcg/scan")
+    assert response.status_code == 202
+    assert response.json()["scanner"] == "vcg"
+
+
+def test_post_gex_scan_returns_202_with_ticker_echo(client: TestClient) -> None:
+    response = client.post("/api/regime/gex/scan?ticker=spy")
+    assert response.status_code == 202
+    body = response.json()
+    assert body["scanner"] == "gex"
+    assert body["ticker"] == "SPY"
+
+
+def test_get_vcg_returns_empty_shape_when_no_data(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(Repository, "fetch_latest_vcg", lambda self: None)
+    response = client.get("/api/regime/vcg")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["signal"]["vcg"] is None
+    assert data["history"] == []
+    assert data["signal"]["attribution"]["vvix_pct"] is None  # full xenon shape
+
+
+def test_get_gex_defaults_to_spx_and_uppercases_ticker(client: TestClient, monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    def _stub_fetch(self, *, ticker="SPX"):
+        seen["ticker"] = ticker
+        return None
+
+    monkeypatch.setattr(Repository, "fetch_latest_gex", _stub_fetch)
+
+    response = client.get("/api/regime/gex")
+    assert response.status_code == 200
+    assert seen["ticker"] == "SPX"  # default
+
+    response = client.get("/api/regime/gex?ticker=spy")
+    assert seen["ticker"] == "SPY"  # uppercased
+
+    data = response.json()
+    assert data["spot"] is None
+    assert data["levels"]["max_magnet"] is None  # GexLevel | None
+    assert data["profile"] == []  # NOT "buckets" — xenon uses `profile`
+    assert data["bias"]["direction"] is None
+    assert data["mq"] is None
+
+
+def test_get_regime_market_open_overrides_stored_value(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(Repository, "fetch_latest_cri", lambda self: {"market_open": False, "vix": 18.5})
+    monkeypatch.setattr(Repository, "fetch_cri_history", lambda self, *, limit=90: [])
+    monkeypatch.setattr("uw_scan.api.routers.regime._is_market_open_now", lambda: True)
+    response = client.get("/api/regime")
+    assert response.json()["market_open"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/integration/api/test_regime_router.py -v`
+Expected: FAIL — `/api/regime` returns 404 (router not registered).
+
+- [ ] **Step 3: Implement router**
+
+Create `src/uw_scan/api/routers/regime.py`:
+
+```python
+"""Read-only /regime surface — CRI, VCG, GEX summaries.
+
+Mirrors the payload shape that xenon's Next.js /api/regime expects after
+``normalizeCriPayload``. Scanner internals are out of scope here; this router
+hands back the latest persisted row (or the EMPTY_* default when tables are
+empty) and a 202 stub for /scan until the backfill phase wires data sources.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, Query
+
+from uw_scan.api.deps import get_repo
+from uw_scan.api.schemas import (
+    EMPTY_CRI_RESPONSE,
+    EMPTY_GEX_RESPONSE,
+    EMPTY_VCG_RESPONSE,
+    CriResponse,
+    GexResponse,
+    VcgResponse,
+)
+from uw_scan.storage.repository import Repository
+
+router = APIRouter(prefix="/regime")
+
+
+def _is_market_open_now() -> bool:
+    """Mirror xenon's isMarketOpenNow() — current ET clock, Mon-Fri 09:30-16:00."""
+    now = datetime.now(ZoneInfo("America/New_York"))
+    if now.weekday() >= 5:
+        return False
+    minutes = now.hour * 60 + now.minute
+    return 9 * 60 + 30 <= minutes <= 16 * 60
+
+
+@router.get("", response_model=CriResponse)
+def get_regime(
+    repo: Annotated[Repository, Depends(get_repo)],
+) -> CriResponse:
+    raw = repo.fetch_latest_cri()
+    if raw is None:
+        empty = EMPTY_CRI_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        return empty
+    raw.setdefault("history", repo.fetch_cri_history(limit=90))
+    raw["market_open"] = _is_market_open_now()
+    return CriResponse.model_validate(raw)
+
+
+@router.post("/scan", status_code=202)
+def trigger_cri_scan() -> dict[str, str]:
+    """Stub: CRI scanner port happens in a follow-up backfill plan."""
+    return {
+        "status": "queued",
+        "scanner": "cri",
+        "message": "scanner_pending: data sources not yet wired (VIX/VVIX/COR1M)",
+    }
+
+
+@router.get("/vcg", response_model=VcgResponse)
+def get_vcg(
+    repo: Annotated[Repository, Depends(get_repo)],
+) -> VcgResponse:
+    raw = repo.fetch_latest_vcg()
+    if raw is None:
+        empty = EMPTY_VCG_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        return empty
+    raw["market_open"] = _is_market_open_now()
+    return VcgResponse.model_validate(raw)
+
+
+@router.post("/vcg/scan", status_code=202)
+def trigger_vcg_scan() -> dict[str, str]:
+    """Stub: VCG scanner port happens in a follow-up backfill plan."""
+    return {
+        "status": "queued",
+        "scanner": "vcg",
+        "message": "scanner_pending: vcg.py port not yet wired",
+    }
+
+
+@router.get("/gex", response_model=GexResponse)
+def get_gex(
+    repo: Annotated[Repository, Depends(get_repo)],
+    ticker: str = Query("SPX"),
+) -> GexResponse:
+    raw = repo.fetch_latest_gex(ticker=ticker.upper())
+    if raw is None:
+        empty = EMPTY_GEX_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        empty.ticker = ticker.upper()
+        return empty
+    raw["market_open"] = _is_market_open_now()
+    return GexResponse.model_validate(raw)
+
+
+@router.post("/gex/scan", status_code=202)
+def trigger_gex_scan(ticker: str = Query("SPX")) -> dict[str, str]:
+    """Stub: GEX scanner port happens in a follow-up backfill plan."""
+    return {
+        "status": "queued",
+        "scanner": "gex",
+        "ticker": ticker.upper(),
+        "message": "scanner_pending: gex.py port not yet wired",
+    }
+```
+
+- [ ] **Step 4: Register router in server.py**
+
+In `src/uw_scan/api/server.py`, find the block of `app.include_router(...)` calls. After the last existing line in that block (currently `trade_insights.router`), add:
+
+```python
+from uw_scan.api.routers import regime  # add to imports near the other router imports
+
+app.include_router(regime.router, prefix="/api", tags=["regime"])
+```
+
+(Place the import next to the other router imports near the top of `server.py`. Place the `include_router` call after the last existing one in the sequential block around `server.py:42`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/api/test_regime_router.py -v`
+Expected: 7 PASSED.
+
+- [ ] **Step 6: Smoke test the route locally — KEEP THE API RUNNING FOR TASK 5**
+
+Start API: `uv run uvicorn uw_scan.api.server:app --port 8400 &` (or `bash scripts/dev.sh` in a separate terminal — `dev.sh` also starts the web app + workers, which is fine)
+Run: `curl -s http://localhost:8400/api/regime | python -m json.tool | head -30`
+Expected: JSON with `"vix": null`, `"cri": {"score": 0, "level": "LOW", ...}`, `"history": []`.
+
+**Do NOT stop the API yet** — Task 5 (`gen:types`) needs it running on port 8400.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/api/routers/regime.py src/uw_scan/api/server.py tests/integration/api/test_regime_router.py
+git commit -m "feat(regime): expose GET /api/regime, POST /scan, GET /vcg, GET /gex"
+```
+
+---
+
+## Task 5: Regenerate openapi types for frontend
+
+**Prerequisite**: API server must be running on port 8400 (continued from Task 4 Step 6). `web/package.json`:`gen:types` fetches `http://127.0.0.1:8400/openapi.json`. If the API isn't running, this task fails immediately.
+
+- [ ] **Step 1: Confirm API is reachable**
+
+Run: `curl -sI http://localhost:8400/openapi.json | head -1`
+Expected: `HTTP/1.1 200 OK`. If 404 or connection refused, restart the API: `uv run uvicorn uw_scan.api.server:app --port 8400 &`.
+
+- [ ] **Step 2: Run codegen**
+
+Run: `cd web && npm run gen:types`
+Expected: `web/lib/types.ts` updated; diff shows new `CriResponse`/`VcgResponse`/`GexResponse`/`VcgSignal`/`VcgAttribution`/`GexLevel`/`GexBucket`/`GexBias`/`GexIvData`/`GexMqLevels`/`GexSourceDelta` schemas in `components.schemas`.
+
+- [ ] **Step 3: Verify types compile**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 4: Stop the API server**
+
+Run: `kill %1` (if you backgrounded uvicorn earlier) or Ctrl+C in the terminal running it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/lib/types.ts
+git commit -m "chore(regime): regenerate openapi types for regime endpoints"
+```
+
+---
+
+## Task 6: Frontend lib — fetch hooks + helpers
+
+Before this task, inspect this repo's existing fetch pattern: `grep -rn "fetch(" web/lib/ web/components/ | head -10`. Hooks must use the same pattern (likely a typed `apiFetch` wrapper or direct `fetch`). The xenon `xenonFetch` is xenon-specific — DO NOT copy.
+
+**Files:**
+- Create: `web/lib/regime/types.ts` (re-exports of generated types under stable names)
+- Create: `web/lib/regime/useRegime.ts`
+- Create: `web/lib/regime/useVcg.ts`
+- Create: `web/lib/regime/useGex.ts`
+- Create: `web/lib/regime/useMarketHours.ts` (ports xenon's 81-LOC `MarketState` enum + ET clock hook)
+- Create: `web/lib/regime/pricesProtocol.ts` (`PriceData` type only — kept for prop signatures even with empty prices)
+- Create: `web/lib/regime/criCalc.ts`
+- Create: `web/lib/regime/criStaleness.ts`
+- Create: `web/lib/regime/regimeHistory.ts`
+- Create: `web/lib/regime/regimeLiveStrip.ts`
+- Create: `web/lib/regime/regimeRelationships.ts`
+- Create: `web/lib/regime/sectionTooltips.ts` (verbatim port of CRI/VCG/GEX tooltip text constants)
+- Create: `web/lib/regime/chartSystem.ts` (only `chartSeriesColor`'s string-keyed lookup map)
+
+**Critical**: hooks must use the existing `API` constant from `web/lib/api.ts:3` (`process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400"`). Bare `fetch("/api/regime")` in dev hits Next.js port 3001, not the FastAPI server.
+
+Hook signatures must mirror xenon: each returns `UseSyncReturn<T>` and accepts `marketState` (and `useGex` also accepts `ticker`). The copied VcgPanel/GexPanel files destructure `loading` / `syncNow` from these returns — changing the shape forces rewriting both 400+ LOC components.
+
+- [ ] **Step 1: Verify generated type names**
+
+Run: `grep -nE 'CriResponse|VcgResponse|GexResponse' web/lib/types.ts | head -10`
+Expected: At least one match per response type (under `components.schemas`).
+
+- [ ] **Step 2: Create stable type re-exports**
+
+Write `web/lib/regime/types.ts`:
+
+```typescript
+import type { components } from "@/lib/types";
+
+// CRI — xenon: CriData
+export type CriData = components["schemas"]["CriResponse"];
+export type CriHistoryEntry = components["schemas"]["CriHistoryEntry"];
+export type Cri = components["schemas"]["Cri"];
+export type CriLevel = Cri["level"];
+export type Cta = components["schemas"]["Cta"];
+export type CrashTrigger = components["schemas"]["CrashTrigger"];
+
+// VCG — xenon: VcgData, VcgSignal, VcgHistoryEntry
+export type VcgData = components["schemas"]["VcgResponse"];
+export type VcgSignal = components["schemas"]["VcgSignal"];
+export type VcgAttribution = components["schemas"]["VcgAttribution"];
+export type VcgHistoryEntry = components["schemas"]["VcgHistoryEntry"];
+
+// GEX — xenon: GexData, GexLevel, GexBucket, GexBias, GexHistoryEntry, MqLevels, SourceDelta, IvData
+export type GexData = components["schemas"]["GexResponse"];
+export type GexLevel = components["schemas"]["GexLevel"] | null;
+export type GexLevels = components["schemas"]["GexLevels"];
+export type GexBucket = components["schemas"]["GexBucket"];
+export type GexBias = components["schemas"]["GexBias"];
+export type GexHistoryEntry = components["schemas"]["GexHistoryEntry"];
+export type GexExpectedRange = components["schemas"]["GexExpectedRange"];
+export type MqLevels = components["schemas"]["GexMqLevels"];
+export type SourceDelta = components["schemas"]["GexSourceDelta"];
+export type SourceDeltaEntry = components["schemas"]["GexSourceDeltaEntry"];
+export type IvData = components["schemas"]["GexIvData"];
+```
+
+- [ ] **Step 3: Port `useSyncHook` (REQUIRED — all 3 hooks depend on it)**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/useSyncHook.ts` (236 LOC) → `web/lib/regime/useSyncHook.ts`. No external imports beyond React — should compile as-is. Exports: `useSyncHook<T>(config)`, type `UseSyncReturn<T>` (`{data, loading, syncing, error, lastSync, syncNow}`).
+
+- [ ] **Step 4: Create `web/lib/regime/api.ts` — typed wrapper using the shared API base URL**
+
+Write `web/lib/regime/api.ts`:
+
+```typescript
+const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400";
+
+export const regimeApi = {
+  cri: () => `${API}/api/regime`,
+  cri_scan: () => `${API}/api/regime/scan`,
+  vcg: () => `${API}/api/regime/vcg`,
+  vcg_scan: () => `${API}/api/regime/vcg/scan`,
+  gex: (ticker: string) => `${API}/api/regime/gex?ticker=${encodeURIComponent(ticker)}`,
+  gex_scan: (ticker: string) => `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
+} as const;
+```
+
+- [ ] **Step 5: Port useRegime / useVcg / useGex (mirror xenon signatures via `useSyncHook`)**
+
+Open `/Users/chenxi/projects/xenon/web/lib/useRegime.ts`. Copy → `web/lib/regime/useRegime.ts`. Adjust:
+- `import { useSyncHook, type UseSyncReturn } from "./useSyncHook"` stays (sibling, ported in Step 3)
+- `import { MarketState } from "./useMarketHours"` stays (ported in Step 7 below)
+- Replace any hardcoded endpoint string with `regimeApi.cri()` from `./api`
+
+Open `/Users/chenxi/projects/xenon/web/lib/useVcg.ts`. Copy → `web/lib/regime/useVcg.ts`. Same adjustments; endpoint `regimeApi.vcg()`.
+
+Open `/Users/chenxi/projects/xenon/web/lib/useGex.ts`. Copy → `web/lib/regime/useGex.ts`. Same adjustments; endpoint `regimeApi.gex(ticker)`. **Change the default `ticker` parameter from `"SPY"` (xenon Next.js wrapper) to `"SPX"`** — matches the FastAPI default and the GEX panel's primary use case.
+
+The hook signatures, return shapes, retry/poll logic, and module-level cache all come from xenon unchanged. Do NOT rewrite the bodies inline.
+
+- [ ] **Step 6: Port criCalc helper**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/criCalc.ts` (103 LOC) → `web/lib/regime/criCalc.ts`. No external `@/lib/...` imports — copies as-is.
+
+- [ ] **Step 7: Port useMarketHours**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/useMarketHours.ts` (81 LOC, no external deps) → `web/lib/regime/useMarketHours.ts`. Exports: `MarketState` enum + `useMarketHours()` hook.
+
+- [ ] **Step 8: Port pricesProtocol type**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/pricesProtocol.ts` (207 LOC) → `web/lib/regime/pricesProtocol.ts`. Exports `PriceData` type used in component signatures.
+
+- [ ] **Step 9: Port regimeHistory**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/regimeHistory.ts` (66 LOC) → `web/lib/regime/regimeHistory.ts`. Exports `backfillRealizedVolHistory`.
+
+- [ ] **Step 10: Port criStaleness**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/criStaleness.ts` (57 LOC) → `web/lib/regime/criStaleness.ts`. Exports `isCriDataStale`.
+
+- [ ] **Step 11: Port regimeLiveStrip**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/regimeLiveStrip.ts` (97 LOC) → `web/lib/regime/regimeLiveStrip.ts`. Adjust any `@/lib/criStaleness` → `@/lib/regime/criStaleness` etc.
+
+- [ ] **Step 12: Port regimeRelationships**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/regimeRelationships.ts` (174 LOC) → `web/lib/regime/regimeRelationships.ts`. Adjust imports to point at `@/lib/regime/*`.
+
+- [ ] **Step 13: Port sectionTooltips (subset — regime keys only)**
+
+Open `/Users/chenxi/projects/xenon/web/lib/sectionTooltips.ts`. Identify which keys regime files reference:
+
+```bash
+grep -RhE 'SECTION_TOOLTIPS\["[^"]+"\]' \
+  /Users/chenxi/projects/xenon/web/components/RegimePanel.tsx \
+  /Users/chenxi/projects/xenon/web/components/VcgPanel.tsx \
+  /Users/chenxi/projects/xenon/web/components/GexPanel.tsx \
+  /Users/chenxi/projects/xenon/web/components/RegimeRelationshipView.tsx \
+  | sort -u
+```
+
+Create `web/lib/regime/sectionTooltips.ts` exporting **only those keys** as a `SECTION_TOOLTIPS` const. Do NOT pull xenon-only keys (positions/orders/wizards).
+
+- [ ] **Step 14: Port chartSystem (named-color helper only, STRING-keyed)**
+
+Open `/Users/chenxi/projects/xenon/web/lib/chartSystem.ts` (48 LOC). Port `chartSeriesColor(name: string): string` + its name→CSS-var lookup map. **The function signature takes a string token (e.g. `"caution"`, `"dislocation"`), NOT a numeric index** — see `RegimePanel.tsx:460-461`. A numeric-index fallback would break call sites. Skip any unused exports.
+
+- [ ] **Step 15: Verify the lib bundle type-checks**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors. If any helper still references a missing `@/lib/...` path, adjust by either:
+  - Pointing at the ported sibling under `@/lib/regime/*`, OR
+  - Inlining the missing constant/type if it's tiny (1-5 lines).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add web/lib/regime/
+git commit -m "feat(regime): port frontend regime libs (useSyncHook + hooks + market hours + relationships)"
+```
+
+---
+
+## Task 7: Frontend components — RegimePanel shell with 3 sub-tabs
+
+**Files:**
+- Create: `web/components/regime/RegimePanel.tsx`
+- Create: `web/components/regime/InfoTooltip.tsx` (skip if already present anywhere — check first)
+
+- [ ] **Step 1: Check for existing InfoTooltip**
+
+Run: `find web/components -name "InfoTooltip.tsx" -not -path "*/regime/*"`
+Expected: Empty result OR one path.
+
+If found: reuse it; skip Step 2. If not: continue to Step 2.
+
+- [ ] **Step 2: Port InfoTooltip from xenon**
+
+Copy `/Users/chenxi/projects/xenon/web/components/InfoTooltip.tsx` → `web/components/regime/InfoTooltip.tsx`. Adjust imports if needed.
+
+- [ ] **Step 3: Write RegimePanel shell**
+
+The shell owns `marketState` (from `useMarketHours`) and the `prices` map (empty `{}` for now — see `MetricCard.tsx` prop drilling), then forwards both to each sub-tab. This mirrors xenon's RegimePanel signature so the eventual live-price wiring is a one-line change.
+
+Write `web/components/regime/RegimePanel.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import CriSubTab from "./CriSubTab";
+import VcgSubTab from "./VcgSubTab";
+import GexSubTab from "./GexSubTab";
+import { useMarketHours } from "@/lib/regime/useMarketHours";
+import type { PriceData } from "@/lib/regime/pricesProtocol";
+
+type RegimeTab = "cri" | "vcg" | "gex";
+
+const EMPTY_PRICES: Record<string, PriceData> = {};
+
+export default function RegimePanel() {
+  const [activeTab, setActiveTab] = useState<RegimeTab>("cri");
+  const marketState = useMarketHours();
+
+  const tabBar = (
+    <div className="ticker-tabs" style={{ marginBottom: "16px" }} data-testid="regime-tabs">
+      <button
+        className={`ticker-tab ${activeTab === "cri" ? "active" : ""}`}
+        onClick={() => setActiveTab("cri")}
+        data-testid="regime-tab-cri"
+      >
+        CRI
+      </button>
+      <button
+        className={`ticker-tab ${activeTab === "vcg" ? "active" : ""}`}
+        onClick={() => setActiveTab("vcg")}
+        data-testid="regime-tab-vcg"
+      >
+        VCG
+      </button>
+      <button
+        className={`ticker-tab ${activeTab === "gex" ? "active" : ""}`}
+        onClick={() => setActiveTab("gex")}
+        data-testid="regime-tab-gex"
+      >
+        GEX
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="regime-panel" data-testid="regime-panel">
+      {tabBar}
+      {activeTab === "cri" && <CriSubTab prices={EMPTY_PRICES} marketState={marketState} />}
+      {activeTab === "vcg" && <VcgSubTab prices={EMPTY_PRICES} marketState={marketState} />}
+      {activeTab === "gex" && <GexSubTab marketState={marketState} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/components/regime/RegimePanel.tsx web/components/regime/InfoTooltip.tsx
+git commit -m "feat(regime): RegimePanel shell with CRI/VCG/GEX tab nav"
+```
+
+---
+
+## Task 8: CRI sub-tab (visual port — incl. d3 install + chart wrappers + Sync Now)
+
+**d3 dependency** (deviation from CLAUDE.md "no chart library", user-approved 2026-05-16 for 1:1 visual mirror): both `CriHistoryChart.tsx:4` and `RegimeRelationshipView.tsx:4` import `* as d3 from "d3"`. The plan installs `d3` + `@types/d3` and ports xenon's `charts/ChartPanel.tsx` (69 LOC) + `charts/ChartLegend.tsx` (27 LOC) so the copied components compile.
+
+**Files:**
+- Modify: `web/package.json` (add `d3` + `@types/d3`)
+- Create: `web/components/regime/CriSubTab.tsx`
+- Create: `web/components/regime/CriHistoryChart.tsx`
+- Create: `web/components/regime/RegimeStrip.tsx`
+- Create: `web/components/regime/RegimeRelationshipView.tsx`
+- Create: `web/components/regime/charts/ChartPanel.tsx`
+- Create: `web/components/regime/charts/ChartLegend.tsx`
+
+- [ ] **Step 1: Install d3**
+
+```bash
+cd web && npm install d3 @types/d3 --save
+```
+Expected: `package.json` gains `"d3"` under `dependencies` and `"@types/d3"` under `devDependencies`. No errors.
+
+Document the deviation: append a comment near the new entries in `package.json`:
+
+```jsonc
+// d3 + @types/d3 added 2026-05-16 for regime/* CriHistoryChart + RegimeRelationshipView
+// (1:1 port from xenon). Scoped use only — other charts in this repo remain hand-rolled SVG
+// per CLAUDE.md.
+```
+
+(JSON doesn't support comments — put this note in the PR description and any new top-level README/docs reference instead. The package.json itself stays as standard JSON.)
+
+- [ ] **Step 2: Port ChartPanel + ChartLegend wrappers**
+
+Copy `/Users/chenxi/projects/xenon/web/components/charts/ChartPanel.tsx` → `web/components/regime/charts/ChartPanel.tsx`.
+Copy `/Users/chenxi/projects/xenon/web/components/charts/ChartLegend.tsx` → `web/components/regime/charts/ChartLegend.tsx`.
+
+Both are small (~95 LOC combined) and have no further `@/lib/...` dependencies. Adjust imports only if they reference `@/lib/chartSystem` — point at `@/lib/regime/chartSystem`.
+
+- [ ] **Step 3: Port CriHistoryChart**
+
+Copy `/Users/chenxi/projects/xenon/web/components/CriHistoryChart.tsx` (346 LOC) → `web/components/regime/CriHistoryChart.tsx`. Adjust:
+- `import * as d3 from "d3"` stays (now installed in Step 1)
+- `import ChartPanel from "./charts/ChartPanel"` stays (now sibling under regime/charts/)
+- Any `@/lib/chartSystem` → `@/lib/regime/chartSystem`
+
+- [ ] **Step 4: Port RegimeStrip**
+
+Copy `/Users/chenxi/projects/xenon/web/components/RegimeStrip.tsx` (79 LOC) → `web/components/regime/RegimeStrip.tsx`. Exports: `LiveBadge`, `DayChange`, `PointChange`, `RegimeStripCell`, default `RegimeStrip`. No external deps beyond `lucide-react`.
+
+- [ ] **Step 5: Port RegimeRelationshipView**
+
+Copy `/Users/chenxi/projects/xenon/web/components/RegimeRelationshipView.tsx` (693 LOC) → `web/components/regime/RegimeRelationshipView.tsx`. Adjust imports:
+- `import * as d3 from "d3"` stays (installed in Step 1)
+- `@/lib/regimeRelationships` → `@/lib/regime/regimeRelationships`
+- `@/lib/chartSystem` → `@/lib/regime/chartSystem`
+- `@/lib/sectionTooltips` → `@/lib/regime/sectionTooltips`
+- `./charts/ChartLegend` → `./charts/ChartLegend` (sibling stays, file is at `web/components/regime/charts/ChartLegend.tsx`)
+- `./charts/ChartPanel` → `./charts/ChartPanel` (sibling stays)
+- `./InfoTooltip` stays (sibling in regime/)
+
+With empty history (`data.history === []`), it renders the empty-state skeleton.
+
+- [ ] **Step 6: Port CriSubTab from RegimePanel.tsx**
+
+Open `/Users/chenxi/projects/xenon/web/components/RegimePanel.tsx`. The CRI rendering spans:
+- Lines 105–270: hook calls, state, derived values (`computeCri`, `levelColor`, helpers)
+- Lines 300–407: `RegimeStrip` with 6 `RegimeStripCell`s (VIX/VVIX/SPY/COR1M/RVOL/CRI)
+- Lines 408–474: hero (score + level badge + LIVE/CACHED), component bars (4×), trigger rows (3×)
+- Lines 475–516: 20-session history grid (2× `CriHistoryChart`) + `RegimeRelationshipView`
+
+Extract into `web/components/regime/CriSubTab.tsx`. Adaptations:
+- Component signature: `export default function CriSubTab({ prices, marketState }: { prices: Record<string, PriceData>; marketState: MarketState })`
+- Import path adjustments: every `@/lib/<x>` → `@/lib/regime/<x>`. Sibling `./RegimeStrip`/`./RegimeRelationshipView`/`./CriHistoryChart`/`./InfoTooltip` stay.
+- `useRegime(marketState)` from `@/lib/regime/useRegime` — call with `marketState` per the ported hook signature (NOT zero-arg)
+- Delete `ShareReportModal` import + `shareModal` JSX + `shareEndpoint`/`shareContentEndpoint`/`shareModalTitle`/`shareButtonTitle`/`shareContentTitle` references (share-to-X out of scope)
+- Delete the `dataEndpoint` prop branching (always use the default endpoint via the ported hook)
+- Keep `prices` / `marketState` — both fed into `resolveRegimeStripLiveState(prices, data)`. With empty `prices={}` the strip shows all CACHED.
+- Keep `SECTION_TOOLTIPS` import (now `@/lib/regime/sectionTooltips`)
+- **Keep the "Sync Now" button in the empty state** — wire it to POST `/api/regime/scan` and surface the returned `message` as a toast / banner. The button is part of xenon's UI; for 1:1 mirror it stays. The toast text becomes the existing 202 stub: `"scanner_pending: data sources not yet wired (VIX/VVIX/COR1M)"`. Use the project's existing toast / inline message pattern (search `grep -rn "useToast\|toast\." web/components | head -5` to find it).
+
+Sketch for the Sync Now wiring:
+
+```typescript
+const handleSyncClick = async () => {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400"}/api/regime/scan`, { method: "POST" });
+    const body = await res.json();
+    // Replace with project's toast util; this inline label is a placeholder.
+    setSyncMessage(body.message ?? `HTTP ${res.status}`);
+  } catch (err) {
+    setSyncMessage(err instanceof Error ? err.message : String(err));
+  }
+};
+```
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors. Most likely fixes:
+- Missing import for `regimeLiveStrip`, `criCalc`, `criStaleness` — point at `@/lib/regime/<name>`
+- `@types/d3` resolution: if d3 functions like `d3.scaleLinear` are typed `any`, ensure `@types/d3` is in `devDependencies` and re-run `npm install`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/package.json web/package-lock.json web/components/regime/charts/ web/components/regime/CriSubTab.tsx web/components/regime/CriHistoryChart.tsx web/components/regime/RegimeStrip.tsx web/components/regime/RegimeRelationshipView.tsx
+git commit -m "feat(regime): port CRI sub-tab + d3 dep + chart wrappers (strip + hero + history + relationship)"
+```
+
+---
+
+## Task 9: VCG sub-tab (visual port)
+
+**Files:**
+- Create: `web/components/regime/VcgSubTab.tsx`
+
+- [ ] **Step 1: Port VcgPanel as VcgSubTab**
+
+Copy `/Users/chenxi/projects/xenon/web/components/VcgPanel.tsx` (453 LOC) → `web/components/regime/VcgSubTab.tsx`. Adjust:
+- `useVcg` import path → `@/lib/regime/useVcg`
+- `useMarketHours` / `MarketState` → `@/lib/regime/useMarketHours`
+- `PriceData` → `@/lib/regime/pricesProtocol`
+- `InfoTooltip` stays (sibling)
+- **Keep** `prices` and `marketState` props — passed from RegimePanel for the eventual live overlay
+- **Strip** `ShareReportModal` import + JSX
+- Default export name: `VcgSubTab`
+- Component signature: `export default function VcgSubTab({ prices, marketState }: { prices: Record<string, PriceData>; marketState: MarketState })`
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors. Fix imports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/components/regime/VcgSubTab.tsx
+git commit -m "feat(regime): port VCG sub-tab"
+```
+
+---
+
+## Task 10: GEX sub-tab (visual port)
+
+**Files:**
+- Create: `web/components/regime/GexSubTab.tsx`
+- Create: `web/components/regime/GexProfileChart.tsx`
+- Create: `web/components/regime/ui/MetricCard.tsx`
+
+- [ ] **Step 1: Port MetricCard + SourceBadge (required, not optional)**
+
+Copy `/Users/chenxi/projects/xenon/web/components/ui/MetricCard.tsx` → `web/components/regime/ui/MetricCard.tsx`. Both `MetricCard` and `SourceBadge` are named exports used by `GexSubTab`; without them the GEX sub-tab won't compile.
+
+- [ ] **Step 2: Port GexProfileChart**
+
+Copy `/Users/chenxi/projects/xenon/web/components/charts/GexProfileChart.tsx` → `web/components/regime/GexProfileChart.tsx`. Update the `chartSeriesColor` import to `@/lib/regime/chartSystem`.
+
+- [ ] **Step 3: Port GexPanel as GexSubTab**
+
+Copy `/Users/chenxi/projects/xenon/web/components/GexPanel.tsx` (901 LOC) → `web/components/regime/GexSubTab.tsx`. Adjust:
+- `useGex` → `@/lib/regime/useGex` (and default it to `"SPX"` to match xenon FastAPI default)
+- `useMarketHours` / `MarketState` → `@/lib/regime/useMarketHours`
+- `MetricCard, SourceBadge` from `./ui/MetricCard` (sibling, no path change needed since file is at `web/components/regime/ui/MetricCard.tsx`)
+- `GexProfileChart` from `./GexProfileChart` (sibling)
+- `InfoTooltip` stays (sibling)
+- **Keep** `marketState` prop
+- **Strip** `ShareReportModal` import + JSX
+- Default export name: `GexSubTab`
+- Component signature: `export default function GexSubTab({ marketState }: { marketState: MarketState })`
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors. Fix imports.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/regime/GexSubTab.tsx web/components/regime/GexProfileChart.tsx web/components/regime/ui/
+git commit -m "feat(regime): port GEX sub-tab + strike profile chart + MetricCard"
+```
+
+---
+
+## Task 11: Wire /regime page route + global styles
+
+**Files:**
+- Create: `web/app/regime/page.tsx`
+- Modify: `web/app/globals.css` (append `.regime-*` block from xenon)
+- Modify: Top-nav component (TBD — verify by reading `web/app/layout.tsx` and the components it pulls in)
+
+- [ ] **Step 1: Create the page route**
+
+Write `web/app/regime/page.tsx`:
+
+```typescript
+import RegimePanel from "@/components/regime/RegimePanel";
+
+export const metadata = {
+  title: "Regime — Unusual Whales",
+  description: "Market-wide regime indicators: CRI, VCG, GEX",
+};
+
+export default function RegimePage() {
+  return (
+    <main className="regime-page">
+      <header className="regime-page-header">
+        <h1>Regime</h1>
+        <p className="regime-page-subtitle">
+          Crash Risk Indicator · Vol-Curve Gauge · Gamma Exposure
+        </p>
+      </header>
+      <RegimePanel />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Copy regime-specific CSS (@media-aware extraction)**
+
+The xenon CSS isn't contiguous AND many regime-related rules live inside `@media` blocks (responsive layouts at `globals.css:4691-4829`). A naive `\.regime-*\{...\}` regex strips the wrapping `@media` braces and breaks mobile/tablet layouts. Use a CSS parser instead. Install once if needed:
+
+```bash
+cd web && npx --yes postcss-cli --version >/dev/null 2>&1 || npm install --no-save postcss postcss-selector-parser
+```
+
+Extraction script (handles `@media` + top-level rules):
+
+```bash
+XEN=/Users/chenxi/projects/xenon/web/app/globals.css
+OUT=/tmp/regime-css.css
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync(process.env.XEN, "utf8");
+const PREFIXES = [".regime-", ".cri-", ".vcg-", ".gex-", ".ticker-tab",
+  ".section-header", ".section-title", ".metric-card", ".live-badge",
+  ".regime-strip", ".regime-relationship", ".regime-history",
+  ".regime-component-", ".regime-trigger-", ".regime-hero",
+  ".regime-level-badge", ".regime-empty", ".regime-page",
+  ".regime-tier-strip", ".regime-badge"];
+const SKIP_PREFIXES = [".share-report-modal", ".regime-block-modal"];
+
+function selectorMatches(sel) {
+  if (SKIP_PREFIXES.some(p => sel.includes(p))) return false;
+  return PREFIXES.some(p => sel.includes(p));
+}
+
+// Tokenize on balanced braces. Track depth so @media{...} containing
+// matching nested rules survives intact.
+let out = [];
+let i = 0;
+function readRule(depth) {
+  const start = i;
+  while (i < src.length && src[i] !== "{" && src[i] !== "}") i++;
+  if (src[i] !== "{") return null;
+  const sel = src.slice(start, i).trim();
+  let braces = 1; i++;
+  const bodyStart = i;
+  while (i < src.length && braces > 0) {
+    if (src[i] === "{") braces++;
+    else if (src[i] === "}") braces--;
+    i++;
+  }
+  const body = src.slice(bodyStart, i - 1);
+  return { sel, body };
+}
+
+while (i < src.length) {
+  while (i < src.length && /\s/.test(src[i])) i++;
+  if (i >= src.length) break;
+  if (src.slice(i, i + 7) === "@media ") {
+    const r = readRule(0);
+    if (r) {
+      // Recurse into @media body to filter inner rules
+      const inner = (function () {
+        let j = 0, kept = [];
+        const inner = r.body;
+        while (j < inner.length) {
+          while (j < inner.length && /\s/.test(inner[j])) j++;
+          const s0 = j;
+          while (j < inner.length && inner[j] !== "{" && inner[j] !== "}") j++;
+          if (inner[j] !== "{") break;
+          const sel = inner.slice(s0, j).trim();
+          let br = 1; j++; const bodyS = j;
+          while (j < inner.length && br > 0) {
+            if (inner[j] === "{") br++;
+            else if (inner[j] === "}") br--;
+            j++;
+          }
+          if (selectorMatches(sel)) kept.push(`  ${sel} {${inner.slice(bodyS, j - 1)}}`);
+        }
+        return kept.join("\n");
+      })();
+      if (inner.trim()) out.push(`${r.sel} {\n${inner}\n}`);
+    }
+  } else {
+    const r = readRule(0);
+    if (r && selectorMatches(r.sel)) out.push(`${r.sel} {${r.body}}`);
+  }
+}
+fs.writeFileSync(process.env.OUT, out.join("\n\n"));
+console.log(`Extracted ${out.length} rules`);
+' && head -5 "$OUT"
+```
+
+Then append the contents of `/tmp/regime-css.css` to `web/app/globals.css` under a marker comment:
+
+```css
+/* ─── Regime panel (ported from xenon 2026-05-16) ───────────────────── */
+/* contents of /tmp/regime-css.css */
+```
+
+After appending, review for selectors that depend on `--chart-live-badge-bg`, `--chart-live-badge-text`, or other CSS custom properties not defined here. For any missing var: add to `:root` near other Argon tokens OR substitute an existing token (`var(--accent)`, `var(--positive)`, `var(--text-muted)`).
+
+(Selectors for `ShareReportModal`/`RegimeBlockModal` are skipped automatically by the script's `SKIP_PREFIXES`.)
+
+- [ ] **Step 3: Add /regime to the Sidebar nav (verified location)**
+
+The nav is at `web/components/shared/Sidebar.tsx` — a `NAV` array near the top. Add an entry:
+
+```diff
+ import { LayoutDashboard, Radar, ScanLine } from "lucide-react";
++import { Activity } from "lucide-react";  // or another suitable icon
+ import { HealthPanel } from "./HealthPanel";
+
+ const NAV = [
+   { href: "/", label: "Dashboard", icon: LayoutDashboard },
+   { href: "/scanner", label: "Scanner", icon: ScanLine },
+   { href: "/cockpit/SPY", label: "Cockpit", icon: Radar },
++  { href: "/regime", label: "Regime", icon: Activity },
+ ];
+```
+
+(Pick `Activity` or another `lucide-react` icon — `BarChart3`, `Gauge`, `Signal`, etc. all fit. Confirm the icon is in `lucide-react` by running `node -e "console.log(Object.keys(require('lucide-react')).slice(0,5))"` from `web/`.)
+
+- [ ] **Step 4: Verify page renders**
+
+Run dev server: `bash scripts/dev.sh`
+Navigate to `http://localhost:3001/regime`.
+Expected:
+- Sidebar shows the new Regime link
+- Page renders with title "Regime"
+- Three tab buttons: CRI / VCG / GEX
+- Default tab (CRI) shows the empty-state "No CRI data available. Click Sync Now to run a scan."
+- Sync Now button is present and clickable; clicking it surfaces the 202 stub message ("scanner_pending: ...")
+- Clicking VCG / GEX swaps content; each shows empty-state placeholder
+- No console errors (in particular, no `d3 is not defined` or `Cannot read properties of undefined (reading 'profile')`)
+
+Stop the dev server (Ctrl+C).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app/regime/ web/app/globals.css web/components/shared/Sidebar.tsx
+git commit -m "feat(regime): /regime page route + Sidebar nav link + ported styles"
+```
+
+---
+
+## Task 12: Vitest + Playwright smoke tests
+
+**Files:**
+- Create: `web/tests/unit/regime-page.test.tsx`
+- Create: `web/tests/e2e/regime-page.spec.ts`
+
+- [ ] **Step 1: Write Vitest component test**
+
+Write `web/tests/unit/regime-page.test.tsx`:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RegimePanel from "@/components/regime/RegimePanel";
+
+// Mock all 3 regime endpoints with empty-state payloads matching the EMPTY_*_RESPONSE
+// shapes in src/uw_scan/api/schemas.py. The ported VcgPanel + GexPanel destructure
+// fields like `signal.attribution`, `data.profile`, `data.bias` — they must be present.
+beforeEach(() => {
+  const empty = {
+    cri: {
+      scan_time: "", date: "", market_open: false,
+      vix: null, vvix: null, spy: null,
+      vix_5d_roc: null, vvix_vix_ratio: null, spx_100d_ma: null,
+      spx_distance_pct: null, cor1m: null, cor1m_previous_close: null,
+      cor1m_5d_change: null, realized_vol: null,
+      cri: { score: 0, level: "LOW", components: { vix: 0, vvix: 0, correlation: 0, momentum: 0 } },
+      cta: { realized_vol: 0, exposure_pct: 200, forced_reduction_pct: 0, est_selling_bn: 0 },
+      menthorq_cta: null,
+      crash_trigger: { triggered: false, conditions: { spx_below_100d_ma: false, realized_vol_gt_25: false, cor1m_gt_60: false }, values: {} },
+      history: [], spy_closes: [],
+    },
+    vcg: {
+      scan_time: "", market_open: false, credit_proxy: null,
+      signal: {
+        vcg: null, vcg_adj: null, residual: null, beta1_vvix: null, beta2_vix: null,
+        alpha: null, vix: null, vvix: null, credit_price: null, credit_5d_return_pct: null,
+        ro: null, edr: null, tier: null, bounce: null, vvix_severity: null,
+        sign_ok: null, sign_suppressed: null, pi_panic: null, regime: null, interpretation: null,
+        attribution: { vvix_pct: null, vix_pct: null, vvix_component: null, vix_component: null, model_implied: null },
+      },
+      history: [],
+    },
+    gex: {
+      scan_time: "", market_open: false, ticker: "SPX",
+      spot: null, close: null, day_change: null, day_change_pct: null, data_date: null,
+      net_gex: null, net_dex: null, atm_iv: null, vol_pc: null,
+      levels: { gex_flip: null, max_magnet: null, second_magnet: null, max_accelerator: null, put_wall: null, call_wall: null },
+      profile: [],
+      expected_range: { low: null, high: null, iv_1d: null },
+      bias: { direction: null, reasons: [], days_above_flip: null, flip_migration: [] },
+      history: [], iv: null, mq: null, source_delta: null,
+    },
+  };
+  vi.stubGlobal("fetch", vi.fn((url: string) => {
+    const u = String(url);
+    let body: object = empty.cri;
+    if (u.includes("/regime/vcg")) body = empty.vcg;
+    else if (u.includes("/regime/gex")) body = empty.gex;
+    return Promise.resolve({ ok: true, json: async () => body });
+  }));
+});
+
+describe("RegimePanel", () => {
+  it("renders three sub-tab buttons", () => {
+    render(<RegimePanel />);
+    expect(screen.getByTestId("regime-tab-cri")).toHaveTextContent("CRI");
+    expect(screen.getByTestId("regime-tab-vcg")).toHaveTextContent("VCG");
+    expect(screen.getByTestId("regime-tab-gex")).toHaveTextContent("GEX");
+  });
+
+  it("swaps to VCG tab on click", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-vcg"));
+    expect(screen.getByTestId("regime-tab-vcg")).toHaveClass("active");
+  });
+
+  it("swaps to GEX tab on click", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-gex"));
+    expect(screen.getByTestId("regime-tab-gex")).toHaveClass("active");
+  });
+});
+```
+
+- [ ] **Step 2: Run Vitest**
+
+Run: `cd web && npm run test -- regime-page`
+Expected: 3 PASSED.
+
+- [ ] **Step 3: Write Playwright smoke test**
+
+Write `web/tests/e2e/regime-page.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test("/regime renders with three sub-tabs and an empty CRI state", async ({ page }) => {
+  await page.goto("/regime");
+  await expect(page.getByRole("heading", { name: "Regime" })).toBeVisible();
+  await expect(page.getByTestId("regime-tab-cri")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-vcg")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-gex")).toBeVisible();
+  await expect(page.getByText(/No CRI data available/i)).toBeVisible();
+});
+
+test("clicking VCG and GEX swaps the active tab", async ({ page }) => {
+  await page.goto("/regime");
+  await page.getByTestId("regime-tab-vcg").click();
+  await expect(page.getByTestId("regime-tab-vcg")).toHaveClass(/active/);
+  await page.getByTestId("regime-tab-gex").click();
+  await expect(page.getByTestId("regime-tab-gex")).toHaveClass(/active/);
+});
+```
+
+- [ ] **Step 4: Run Playwright**
+
+Run: `cd web && npx playwright test regime-page`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/tests/unit/regime-page.test.tsx web/tests/e2e/regime-page.spec.ts
+git commit -m "test(regime): vitest + playwright smoke for /regime page"
+```
+
+---
+
+## Task 13: PR
+
+- [ ] **Step 1: Create branch + PR**
+
+```bash
+git checkout -b feat/regime-skeleton-port
+git push -u origin feat/regime-skeleton-port
+gh pr create --title "feat(regime): port /regime skeleton from xenon (CRI/VCG/GEX)" --body "$(cat <<'EOF'
+## Summary
+- Mirrors xenon's /regime top-level page with three sub-tabs: CRI, VCG, GEX
+- Adds DB tables (cri_series, vcg_series, gex_snapshots) and FastAPI endpoints (/api/regime, /api/regime/scan, /api/regime/vcg, /api/regime/gex)
+- Endpoints return empty/null payloads in the exact shape xenon's frontend expects; tables stay empty until backfill phase wires VIX/VVIX/COR1M/SPY sources
+- /scan endpoint is a 202 stub — scanner ports come in a follow-up plan
+
+## Out of scope
+- Scanner internals (cri.py / vcg.py / gex.py — ~3700 LOC)
+- Data source wiring (IB Gateway, FMP, Cboe COR1M scraper)
+- regime_overrides table + governance gate (xenon-specific, not part of the three sub-tabs)
+- Share-to-X social posting
+
+## Test plan
+- [x] `uv run pytest tests/integration/api/test_regime_router.py tests/integration/test_regime_repository.py tests/unit/test_regime_schemas.py`
+- [x] `cd web && npm run test -- regime-page`
+- [x] `cd web && npx playwright test regime-page`
+- [x] Manual: `/regime` route renders, all 3 tabs swap, empty state shown
+EOF
+)"
+```
+
+---
+
+## Backfill phase (separate plan — outline only)
+
+Once this skeleton lands, the backfill plan will need to:
+1. **Pick data sources for VIX, VVIX, COR1M** — three options:
+   - Cboe direct dashboard URL (free, narrow — xenon already has a scraper for COR1M only)
+   - FMP API (paid, broad — adds new dependency)
+   - Polygon / Tradier / etc.
+2. **Add SPY OHLC backfill from massive** (already in this repo)
+3. **Port xenon's CRI scoring formula** from `src/xenon/scanners/cri.py` into a much smaller `src/uw_scan/cards/regime_cri.py` (skip the IB/Yahoo plumbing — just the math + DB write)
+4. **Wire APScheduler job** in `src/uw_scan/worker/scheduler.py` to call the scanner every N minutes
+5. **VCG and GEX** are larger scanners — likely separate plans each
+
+This is intentionally not scoped here; the user said "then we can think about backfill the data."
+
+---
+
+## Self-review notes
+
+- All file paths are absolute or repo-relative.
+- Each code-bearing step shows the actual code (no `# TODO`).
+- The "copy from xenon" steps for large components do not inline 500+ lines but DO list specific imports to adjust and props to strip — the executor has a deterministic checklist.
+- Empty-state handling is the cornerstone: with no data wired, every panel falls back to the existing "No data" branch the xenon code already has.
+- Tests verify shape (backend) and rendering + tab nav (frontend) — both are independent of data presence.

--- a/docs/superpowers/plans/2026-05-16-regime-gex-first.md
+++ b/docs/superpowers/plans/2026-05-16-regime-gex-first.md
@@ -1,0 +1,1807 @@
+# Regime Port — GEX-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Checkbox (`- [ ]`) syntax.
+
+> **Status:** This is the **executable plan for the GEX-first iteration**. The companion file `2026-05-16-port-regime-from-xenon.md` is the long-term roadmap (CRI/VCG + IB-via-R2 + full 3-tab visual port) — it is NOT the spec to execute. Both plans share design decisions (Pydantic in `api/schemas.py`, Repository methods, `get_repo` DI, frontend base URL, `useSyncHook` port, d3 dependency). Where this plan needs detail that the roadmap already specifies precisely, this plan references it by section.
+
+**Goal:** Ship `/regime` as a 3-tab page (CRI / VCG / GEX). GEX renders live UW data end-to-end (UW → scheduled scanner → Postgres → API → React). CRI and VCG render a small "coming soon — IB-via-R2 reader pending" placeholder card. Sidebar nav gains a Regime entry.
+
+**Architecture (this iteration):**
+- **Data flow (GEX only)**: UW client → `GexScanner.run(ticker)` (background worker, 5-min cadence) → `repo.upsert_gex_snapshot(...)` → `gex_snapshots` table → `GET /api/regime/gex` → React `GexSubTab` via `useGex` hook.
+- **Data flow (CRI/VCG)**: nothing. Both endpoints return a sentinel `{status: "pending", reason: "ib_via_r2_not_wired"}` body. The frontend's `CriSubTab` / `VcgSubTab` placeholders never actually fetch.
+- **No IB, no R2, no Yahoo** in this iteration. UW is the sole external data source. CLAUDE.md priority `UW → FMP → massive` is unchanged; IB stays out of this codebase entirely (the IB-reading project lives elsewhere and will eventually publish parquet to R2 — that's a future plan).
+- **No MenthorQ** — Playwright dep is out of scope. GEX panel renders without MQ key levels in v1; the UI degrades gracefully (`mq: null`, `source_delta: null`).
+- **d3 dependency** is added (deviation from CLAUDE.md "no chart library" — user-approved 2026-05-16 for 1:1 visual mirror). Required by `GexProfileChart`. See Task 9.
+
+**Tech stack:** Python 3.13 / FastAPI / Pydantic v2 / psycopg 3 / APScheduler (backend) — Next.js 16 / React 19 / TypeScript / d3 + hand-rolled SVG (frontend) — pytest / vitest / playwright.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/uw_scan/storage/migrations/037_gex_snapshots.sql`
+- `src/uw_scan/api/routers/regime.py`
+- `src/uw_scan/scanners/__init__.py` (if missing)
+- `src/uw_scan/scanners/gex.py` — scanner port (~400-500 LOC ported from xenon `src/xenon/scanners/gex.py`, minus MQ/CLI/HTML)
+- `src/uw_scan/worker/jobs/gex_scan.py` — APScheduler job wrapper
+- `tests/integration/api/test_regime_router.py`
+- `tests/integration/test_gex_scanner.py`
+- `tests/unit/test_regime_schemas.py`
+- `web/app/regime/page.tsx`
+- `web/components/regime/RegimePanel.tsx`
+- `web/components/regime/GexSubTab.tsx` — port of `xenon/web/components/GexPanel.tsx`
+- `web/components/regime/PendingSubTab.tsx` — generic placeholder for CRI/VCG tabs
+- `web/components/regime/GexProfileChart.tsx` — port (d3-using)
+- `web/components/regime/ui/MetricCard.tsx` — port
+- `web/components/regime/charts/ChartPanel.tsx` — port
+- `web/components/regime/charts/ChartLegend.tsx` — port
+- `web/components/regime/InfoTooltip.tsx` — port (skip if already present elsewhere)
+- `web/lib/regime/api.ts` — typed API URL builder
+- `web/lib/regime/useSyncHook.ts` — port (236 LOC)
+- `web/lib/regime/useGex.ts` — port
+- `web/lib/regime/useMarketHours.ts` — port (81 LOC)
+- `web/lib/regime/pricesProtocol.ts` — port (207 LOC)
+- `web/lib/regime/chartSystem.ts` — subset port (`chartSeriesColor` + lookup)
+- `web/lib/regime/sectionTooltips.ts` — subset port (GEX keys only)
+- `web/lib/regime/types.ts` — re-exports of generated openapi types
+- `web/tests/unit/regime-page.test.tsx`
+- `web/tests/e2e/regime-page.spec.ts`
+
+**Modify (extend existing files):**
+- `src/uw_scan/api/schemas.py` — append GEX response models + validators
+- `src/uw_scan/storage/repository.py` — append `fetch_latest_gex` + `upsert_gex_snapshot` methods
+- `src/uw_scan/api/server.py` — register `regime` router after the existing `trade_insights.router` line
+- `src/uw_scan/worker/scheduler.py` — add GEX scan job to the APScheduler schedule
+- `web/components/shared/Sidebar.tsx` — add `{ href: "/regime", label: "Regime", icon: Activity }` to `NAV`
+- `web/app/globals.css` — append GEX-related styles (selector-list extraction from xenon, `@media`-aware)
+- `web/package.json` — add `d3` + `@types/d3`
+
+---
+
+## Task 1: DB migration — `gex_snapshots` only
+
+**File:** `src/uw_scan/storage/migrations/037_gex_snapshots.sql`
+
+- [ ] **Step 1: Write SQL**
+
+```sql
+-- 037_gex_snapshots.sql
+--
+-- GEX snapshots table — mirrors xenon's src/xenon/db/schema.py:577-641
+-- JSONB payload + generated columns for indexable scalars.
+-- Idempotent (IF NOT EXISTS).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.gex_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    ticker          TEXT NOT NULL,
+    data_date       DATE,
+    scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    payload         JSONB NOT NULL,
+    spot            NUMERIC(12,4) GENERATED ALWAYS AS ((payload->>'spot')::numeric) STORED,
+    net_gex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_gex')::numeric) STORED,
+    net_dex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_dex')::numeric) STORED,
+    vol_pc          NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vol_pc')::numeric) STORED,
+    iv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'iv30d')::numeric) STORED,
+    iv_rank         NUMERIC(6,2)  GENERATED ALWAYS AS (((payload->'iv')->>'iv_rank')::numeric) STORED,
+    hv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'hv30')::numeric) STORED,
+    mq_iv_30d       NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'mq_iv30d')::numeric) STORED,
+    level_max_magnet_strike       NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'strike')::numeric) STORED,
+    level_max_magnet_gamma        NUMERIC(14,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'gamma')::numeric) STORED,
+    level_second_magnet_strike    NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'second_magnet')->>'strike')::numeric) STORED,
+    level_max_accelerator_strike  NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_accelerator')->>'strike')::numeric) STORED,
+    level_put_wall_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'put_wall')->>'strike')::numeric) STORED,
+    level_call_wall_strike        NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'call_wall')->>'strike')::numeric) STORED,
+    level_gex_flip_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'gex_flip')->>'strike')::numeric) STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_gex_ticker_time ON uw_scan.gex_snapshots (ticker, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_scanned_at  ON uw_scan.gex_snapshots (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_data_date   ON uw_scan.gex_snapshots (data_date);
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply migration**
+
+```bash
+bash scripts/migrate.sh
+```
+Expected: `Applying src/uw_scan/storage/migrations/037_gex_snapshots.sql...` followed by `COMMIT`. Re-running is a no-op.
+
+- [ ] **Step 3: Verify**
+
+```bash
+psql "$(uv run python -c 'from uw_scan.config import Settings; print(Settings.from_env().db_dsn())')" \
+  -c "\d uw_scan.gex_snapshots"
+```
+Expected: table listed with `payload jsonb` + generated columns.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/037_gex_snapshots.sql
+git commit -m "feat(regime): add gex_snapshots table"
+```
+
+---
+
+## Task 2: GEX Pydantic schemas
+
+**Critical conventions** (verified):
+- API contract schemas live in `src/uw_scan/api/schemas.py` (existing file, docstring confirms: "Pydantic response models — over-the-wire contract for the watchlist API"). **Do NOT create `src/uw_scan/api/models/regime.py`** — that dir does not exist.
+- Pydantic v2 with `field_validator(mode="before")` for the numeric-string coercion semantics xenon's `normalizeCriPayload` has on the client side.
+
+**Files:**
+- Modify: `src/uw_scan/api/schemas.py` (append GEX schemas)
+- Create: `tests/unit/test_regime_schemas.py`
+
+- [ ] **Step 1: Write failing test**
+
+`tests/unit/test_regime_schemas.py`:
+
+```python
+from uw_scan.api.schemas import GexResponse, EMPTY_GEX_RESPONSE, RegimePendingResponse
+
+
+def test_empty_gex_response_uses_profile_not_buckets():
+    payload = EMPTY_GEX_RESPONSE.model_dump()
+    assert "profile" in payload
+    assert payload["profile"] == []
+    assert payload["levels"]["max_magnet"] is None
+    assert payload["bias"]["direction"] is None
+    assert payload["mq"] is None
+
+
+def test_gex_response_round_trip_with_full_xenon_shape():
+    src = {
+        "scan_time": "2026-05-16T13:15:00Z",
+        "market_open": True,
+        "ticker": "SPX",
+        "spot": 5800.12,
+        "net_gex": -2400000000.0,
+        "levels": {
+            "gex_flip": {"strike": 5750, "gamma": 0, "distance": -50.12, "distance_pct": -0.86},
+            "max_magnet": {"strike": 5780, "gamma": 1.5e9, "distance": -20.12, "distance_pct": -0.34},
+        },
+        "profile": [{"strike": 5750, "call_gex": 1e8, "put_gex": -2e8, "net_gex": -1e8, "pct_from_spot": -0.86, "tag": None}],
+        "bias": {"direction": "BEAR", "reasons": ["net_gex<0", "spot<flip"], "days_above_flip": 0, "flip_migration": []},
+    }
+    parsed = GexResponse.model_validate(src)
+    assert parsed.spot == 5800.12
+    assert parsed.bias.direction == "BEAR"
+    assert parsed.profile[0].strike == 5750
+
+
+def test_regime_pending_response_shape():
+    payload = RegimePendingResponse(scanner="cri").model_dump()
+    assert payload["status"] == "pending"
+    assert payload["scanner"] == "cri"
+    assert payload["reason"] == "ib_via_r2_not_wired"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — `ImportError`)**
+
+```bash
+uv run pytest tests/unit/test_regime_schemas.py -v
+```
+
+- [ ] **Step 3: Implement — append to `src/uw_scan/api/schemas.py`**
+
+The full schema is identical to what the roadmap plan specifies for GEX. Copy from `docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md` (Task 2 Step 3, the section starting `# ── GEX ─────────────`) and append to `src/uw_scan/api/schemas.py`.
+
+Field set (canonical, mirrors `xenon/web/lib/useGex.ts:86-121`):
+
+- Top-level: `scan_time, market_open, ticker, spot, close, day_change, day_change_pct, data_date, net_gex, net_dex, atm_iv, vol_pc, levels, profile, expected_range, bias, history, iv, mq, source_delta`
+- `GexLevel`: `{strike, gamma, distance, distance_pct}` — nullable at each level slot
+- `GexLevels`: `{gex_flip, max_magnet, second_magnet, max_accelerator, put_wall, call_wall}` — each `GexLevel | None`
+- `GexBucket`: `{strike, call_gex, put_gex, net_gex, pct_from_spot, tag}`
+- `GexBias`: `{direction, reasons, days_above_flip, flip_migration}`
+- `GexExpectedRange`: `{low, high, iv_1d}`
+- `GexHistoryEntry`: `{date, net_gex, net_dex, gex_flip, spot, atm_iv, vol_pc, bias}`
+- `GexIvData`: `{iv30d, iv_rank, hv30, mq_iv30d, mq_iv_rank, source}`
+- `GexMqLevels`: `{source_date, spot, hvl, call_resistance_all, ..., top_gex_strikes}` (skipped in v1 — present as type only, populated null)
+- `GexSourceDelta`: 5 nullable `SourceDeltaEntry` slots (skipped in v1)
+
+Also append the pending-response sentinel:
+
+```python
+from typing import Literal as _Lit_Pending
+from pydantic import BaseModel as _BM_Pending
+
+class RegimePendingResponse(_BM_Pending):
+    """Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands."""
+    status: _Lit_Pending["pending"] = "pending"
+    scanner: _Lit_Pending["cri", "vcg"]
+    reason: _Lit_Pending["ib_via_r2_not_wired"] = "ib_via_r2_not_wired"
+    message: str = "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the IB-via-R2 reader (separate project)."
+```
+
+(`_Lit_Pending` and `_BM_Pending` aliases avoid clashing with whatever `Literal` / `BaseModel` imports exist already in `schemas.py` — the executor can collapse them to plain `Literal` / `BaseModel` if the existing file already imports them at the top.)
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_regime_schemas.py -v
+```
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/api/schemas.py tests/unit/test_regime_schemas.py
+git commit -m "feat(regime): GEX Pydantic schemas + RegimePendingResponse sentinel"
+```
+
+---
+
+## Task 3: Repository methods — `fetch_latest_gex` + `upsert_gex_snapshot`
+
+**File:** `src/uw_scan/storage/repository.py` (append methods to existing `Repository` class)
+
+- [ ] **Step 1: Write failing test**
+
+`tests/integration/test_gex_repository.py`:
+
+```python
+import json
+
+from uw_scan.storage.repository import Repository
+
+
+def test_upsert_and_fetch_latest_gex(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    payload = {
+        "ticker": "SPX", "spot": 5800.12, "net_gex": -2_400_000_000,
+        "levels": {"max_magnet": {"strike": 5780, "gamma": 1.5e9}},
+        "profile": [],
+    }
+    repo.upsert_gex_snapshot(ticker="SPX", payload=payload)
+    result = repo.fetch_latest_gex(ticker="SPX")
+    assert result is not None
+    assert result["spot"] == 5800.12
+    assert result["levels"]["max_magnet"]["strike"] == 5780
+
+
+def test_fetch_latest_gex_filters_by_ticker(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    repo.upsert_gex_snapshot(ticker="SPX", payload={"spot": 5800})
+    repo.upsert_gex_snapshot(ticker="SPY", payload={"spot": 580})
+    assert repo.fetch_latest_gex(ticker="SPX")["spot"] == 5800
+    assert repo.fetch_latest_gex(ticker="SPY")["spot"] == 580
+
+
+def test_fetch_latest_gex_returns_none_for_unknown_ticker(seeded_db_empty_cards: Repository) -> None:
+    assert seeded_db_empty_cards.fetch_latest_gex(ticker="UNKNOWN") is None
+```
+
+- [ ] **Step 2: Run test (expect FAIL — `AttributeError`)**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/test_gex_repository.py -v
+```
+
+- [ ] **Step 3: Implement — append methods to `Repository` class**
+
+Find `class Repository:` at `src/uw_scan/storage/repository.py:579`. Append inside the class body:
+
+```python
+    # ─── Regime / GEX (ported from xenon 2026-05-16) ──────────
+
+    def fetch_latest_gex(self, *, ticker: str = "SPX") -> dict | None:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, scanned_at, ticker FROM {self._schema}.gex_snapshots "
+                f"WHERE ticker = %s ORDER BY scanned_at DESC LIMIT 1",
+                (ticker,),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at, t = row[0] or {}, row[1], row[2]
+        out = dict(payload)
+        out.setdefault("scan_time", scanned_at.isoformat() if scanned_at else "")
+        out.setdefault("ticker", t)
+        return out
+
+    def upsert_gex_snapshot(self, *, ticker: str, payload: dict, data_date=None) -> int:
+        """Insert a new gex_snapshots row. Returns the inserted row id."""
+        import json
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"INSERT INTO {self._schema}.gex_snapshots (ticker, data_date, payload) "
+                f"VALUES (%s, %s, %s::jsonb) RETURNING id",
+                (ticker.upper(), data_date, json.dumps(payload)),
+            )
+            row_id = cur.fetchone()[0]
+        self.conn.commit()
+        return row_id
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/test_gex_repository.py -v
+```
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/repository.py tests/integration/test_gex_repository.py
+git commit -m "feat(regime): add fetch_latest_gex + upsert_gex_snapshot Repository methods"
+```
+
+---
+
+## Task 4: GEX scanner port
+
+**The big one.** Port `xenon/src/xenon/scanners/gex.py` math + UW calls. Skip MenthorQ, CLI, HTML output.
+
+### Verified gaps in this repo's UW client (must be filled BEFORE porting the scanner)
+
+Three concrete issues were verified against the codebase + sample payloads on 2026-05-16:
+
+1. **Wrong endpoint mapped**: this repo's `EndpointSlug.GREEK_EXPOSURE` → `/api/stock/{ticker}/greek-exposure/strike-expiry` (per-strike-per-expiry, requires an `expiry` param). xenon's GEX scanner needs `/strike` (aggregated across expiries, no `expiry` param). Different endpoint, different shape.
+2. **Aggregate `/greek-exposure` endpoint not wired** at all (used by xenon's `fetch_aggregate_gex` for net_dex calculation).
+3. **No `STOCK_INFO` endpoint** in this repo's UW client — xenon's `fetch_spot_price` uses `/api/stock/{ticker}/info` as the primary spot source. We resolve this by dropping that source entirely and using only the `iv_rank.close` fallback (still functional; verified against `docs/uw-samples/iv_rank.json`).
+
+### Verified field shapes (all match xenon's expectations — float casts handle string values)
+
+| Source | Field | Type | Sample value | Verified |
+|---|---|---|---|---|
+| `iv_rank` rows | `date`, `close`, `volatility`, `iv_rank_1y` | string | `"2026-05-05"`, `"389.37"`, `"0.4096"`, `"5.1532"` | `docs/uw-samples/iv_rank.json` |
+| `screener` rows | `ticker`, `put_call_ratio` | string + numeric | `"TSLA"`, present in key list | `docs/uw-samples/bulk_screener_stocks_sp500.json` |
+| `greek-exposure/strike` rows | `strike`, `call_gex`, `put_gex`, `call_delta`, `put_delta` | string numerics | not yet sampled in this repo — verify in Step 1c smoke test against live UW | UW API spec doc `docs/uw-samples/unusual_whales_api.md:146` confirms endpoint exists |
+
+xenon already casts via `float(...)` so string→float coercion is handled at port time, no plan change needed.
+
+### Functions to port (from `xenon/src/xenon/scanners/gex.py`)
+
+| Xenon function | Lines | Keep? | Adaptation notes |
+|---|---|---|---|
+| `_bucket_size_for` | 41-46 | ✅ verbatim | Pure logic |
+| `fetch_strike_gex` | 63-91 | ✅ adapt | Replace `client.get_greek_exposure_by_strike(ticker)` with `uw_source.fetch_greek_exposure_by_strike(client, repo, run_id, ticker)` — new fetcher added in Step 1a below |
+| `fetch_aggregate_gex` | 91-112 | ✅ adapt | Replace `client.get_greek_exposure(ticker)` with `uw_source.fetch_greek_exposure_history(client, repo, run_id, ticker)` — new fetcher added in Step 1a |
+| `fetch_atm_iv` | 112-131 | ✅ adapt | Replace `client.get_iv_rank(ticker)` with `uw_source.fetch_iv_rank_raw(client, repo, run_id, ticker)` (or restructure to consume already-fetched iv_rank rows — see Step 2 for the consolidated single-call pattern) |
+| `fetch_iv_rank` | 132-145 | ✅ adapt | Same source as `fetch_atm_iv` — both read from iv_rank rows; consolidate into one fetch |
+| `fetch_vol_pc` | 146-164 | ✅ adapt | Replace `client.get_stock_screener(ticker=ticker)` with `uw_source.fetch_bulk_screener_ticker(client, repo, run_id, ticker)` |
+| `fetch_mq_levels` | 189-265 | ❌ skip | Playwright dep — `mq: None`, `source_delta: None` always |
+| `compute_source_delta` | 288-322 | ❌ skip | only meaningful w/ MQ |
+| `fetch_spot_price` | 323-377 | ✅ adapt | **Drop UW stock-info source (not in this repo) and Yahoo source (banned).** Use only iv_rank `close` field. If iv_rank is empty, raise (scanner aborts via orchestration). |
+| `bucket_profile` | 378-414 | ✅ verbatim | Pure logic |
+| `compute_gex_flip` | 415-431 | ✅ verbatim | Pure logic |
+| `find_key_levels` | 432-476 | ✅ verbatim | Pure logic |
+| `tag_profile` | 477-510 | ✅ verbatim | Pure logic |
+| `compute_expected_range` | 511-523 | ✅ verbatim | Pure logic |
+| `compute_directional_bias` | 524-582 | ✅ verbatim | Pure logic |
+| `compute_days_above_flip` | 583-611 | ✅ adapt | xenon reads file cache; here either skip for v1 (leave `bias.days_above_flip` as `None`) or add `repo.fetch_gex_history(ticker, days=20)` method (small extension). v1 default: **skip** — leave `None`. |
+| `build_history_from_cache` | 612-623 | ❌ skip | replaced by future Postgres-based history reader |
+| `merge_history` | 624-640 | ❌ skip | same |
+| `is_market_open` | 641-667 | ❌ skip | router has `_is_market_open_now` (already specified in Task 5) |
+| `build_gex_output` | 668-811 | ❌ skip (inline) | the `run()` orchestrator in Step 2 below replicates this function's behavior, simplified — see Step 2 |
+| `main` | 812+ | ❌ skip | CLI entry |
+
+### Step 1a: Add two new UW endpoint slugs
+
+Open `src/uw_scan/api/endpoints.py`. After the existing `EndpointSlug.GREEK_EXPOSURE = "greek_exposure"` line, add:
+
+```python
+    GREEK_EXPOSURE_BY_STRIKE = "greek_exposure_by_strike"
+    GREEK_EXPOSURE_HISTORY = "greek_exposure_history"
+```
+
+Then in the endpoint mapping table (search for `EndpointSlug.GREEK_EXPOSURE: Endpoint(...)`), add two new entries:
+
+```python
+    EndpointSlug.GREEK_EXPOSURE_BY_STRIKE: Endpoint(
+        EndpointSlug.GREEK_EXPOSURE_BY_STRIKE,
+        "/api/stock/{ticker}/greek-exposure/strike",
+        (),  # no required params
+    ),
+    EndpointSlug.GREEK_EXPOSURE_HISTORY: Endpoint(
+        EndpointSlug.GREEK_EXPOSURE_HISTORY,
+        "/api/stock/{ticker}/greek-exposure",
+        (),
+    ),
+```
+
+### Step 1b: Add two new fetch functions to `src/uw_scan/sources/uw.py`
+
+Append after the existing `fetch_greek_exposure` (around line 171-186 of `uw.py`):
+
+```python
+def fetch_greek_exposure_by_strike(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> dict:
+    """Fetch /api/stock/{ticker}/greek-exposure/strike — aggregated per-strike GEX.
+
+    Returns the raw body; scanner consumes ``body["data"]`` as a list of rows
+    with string-valued ``strike``, ``call_gex``, ``put_gex``, ``call_delta``,
+    ``put_delta`` fields (caster handles ``float()``).
+    """
+    return _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.GREEK_EXPOSURE_BY_STRIKE,
+        ticker,
+    )
+
+
+def fetch_greek_exposure_history(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> dict:
+    """Fetch /api/stock/{ticker}/greek-exposure — aggregate GEX over time.
+
+    Used for net_dex computation and (eventually) historical bias trend.
+    """
+    return _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.GREEK_EXPOSURE_HISTORY,
+        ticker,
+    )
+```
+
+(Both return the raw body dict. The scanner reads `body["data"]` to get the row list. No normalizer needed in v1 — scanner does its own parsing. Add normalizers later if any other code consumes these payloads.)
+
+### Step 1c: Smoke-test the new endpoints against live UW (requires `UW_SCAN_API_KEY`)
+
+```bash
+uv run python -c "
+from uw_scan.config import Settings
+from uw_scan.api.client import UwClient
+import psycopg
+from uw_scan.storage.repository import Repository
+from uw_scan.sources import uw
+
+s = Settings.from_env()
+client = UwClient.from_settings(s)
+conn = psycopg.connect(s.db_dsn())
+repo = Repository(conn, schema=s.db_schema)
+run_id = repo.insert_scan_run('SPX', notes='gex_endpoint_smoke')
+
+# Per-strike
+body = uw.fetch_greek_exposure_by_strike(client, repo, run_id, 'SPX')
+rows = body.get('data', [])
+print(f'/strike rows: {len(rows)}')
+if rows:
+    sample = rows[0]
+    print(f'  sample keys: {sorted(sample.keys())}')
+    for key in ('strike', 'call_gex', 'put_gex', 'call_delta', 'put_delta'):
+        print(f'  {key} = {sample.get(key)!r}  (type {type(sample.get(key)).__name__})')
+
+# Aggregate
+body2 = uw.fetch_greek_exposure_history(client, repo, run_id, 'SPX')
+rows2 = body2.get('data', [])
+print(f'/greek-exposure rows: {len(rows2)}')
+if rows2:
+    print(f'  sample keys: {sorted(rows2[0].keys())}')
+
+repo.finish_scan_run(run_id, status='ok')
+conn.close()
+"
+```
+
+Expected output (worst-case ranges):
+- `/strike rows: N` where N is the strike count (typically 50-200 for SPX)
+- Sample keys include at minimum: `strike`, `call_gex`, `put_gex`, `call_delta`, `put_delta` (values as strings)
+- `/greek-exposure rows: M` where M is the time-series length (typically 60-90 days)
+
+**Stop and patch the plan** if either fails or the field names differ from xenon's expectation. The scanner code in Step 2 hard-codes these field names. Diverging here costs less than diverging at execution time.
+
+If the live call returns 403 (subscription gate), skip this smoke and rely on the Task 4 Step 6 integration test (uses monkeypatched fetchers) — defer the live verification to Task 6 Step 4 instead.
+
+### Step 1d: Commit endpoint additions
+
+```bash
+git add src/uw_scan/api/endpoints.py src/uw_scan/sources/uw.py
+git commit -m "feat(uw): add /greek-exposure/strike + /greek-exposure endpoints for GEX scanner"
+```
+
+- [ ] **Step 2: Write the scanner module shell**
+
+The scanner now follows this repo's run_id audit pattern: `repo.insert_scan_run("SPX", notes="gex_scan")` to create an audit row, pass `run_id` to every UW fetcher, then `repo.finish_scan_run(run_id, status="ok")` (or `"error"`) at the end. Matches the existing convention used by `cockpit_daily_snapshot.py:65` and `flow_data_refresh.py:64`.
+
+`src/uw_scan/scanners/gex.py`:
+
+```python
+"""GEX scanner — UW-driven. Ported from xenon/src/xenon/scanners/gex.py 2026-05-16.
+
+Differences from xenon:
+- No MenthorQ (Playwright dep skipped); ``mq`` and ``source_delta`` always None.
+- No file cache; history is read/written via ``Repository.fetch_latest_gex`` /
+  ``upsert_gex_snapshot`` against the ``gex_snapshots`` Postgres table.
+- No CLI; no HTML rendering.
+- This repo's UW pattern requires a ``run_id`` from ``repo.insert_scan_run(...)``
+  for the per-call audit trail. xenon's stateless client doesn't have this.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from uw_scan.api.client import UwClient
+from uw_scan.sources import uw as uw_source
+from uw_scan.storage.repository import Repository
+
+log = logging.getLogger(__name__)
+
+INDEX_TICKERS = {"SPX", "NDX"}
+BUCKET_SIZE_INDEX = 25
+BUCKET_SIZE_ETF = 5
+PROFILE_RANGE_PCT = 0.10
+HISTORY_DAYS = 20
+TRADING_DAYS_PER_YEAR = 252
+
+
+def _bucket_size_for(ticker: str, spot: float) -> int:
+    if ticker in INDEX_TICKERS:
+        return BUCKET_SIZE_INDEX
+    if ticker in ("SPY", "QQQ"):
+        return BUCKET_SIZE_ETF
+    return max(1, round(spot * 0.005))
+
+
+# ─── Pure-logic compute functions ──────────────────────────────────
+# Copy verbatim from xenon `gex.py` lines 378-582 (bucket_profile through
+# compute_directional_bias). They're side-effect-free and need no adaptation.
+#
+# [paste these from xenon: bucket_profile, compute_gex_flip, find_key_levels,
+#  tag_profile, compute_expected_range, compute_directional_bias]
+
+
+# ─── UW-driven fetchers (adapted for this repo's client + run_id pattern) ──
+
+def fetch_strike_gex(client: UwClient, repo: Repository, run_id: int, ticker: str) -> list[dict[str, Any]]:
+    """Per-strike GEX rows. Aggregates the UW response into the canonical shape."""
+    body = uw_source.fetch_greek_exposure_by_strike(client, repo, run_id, ticker)
+    rows = body.get("data", [])
+    parsed = []
+    for r in rows:
+        try:
+            strike = float(r["strike"])
+            call_gex = float(r.get("call_gex", 0))
+            put_gex = float(r.get("put_gex", 0))
+            call_delta = float(r.get("call_delta", 0))
+            put_delta = float(r.get("put_delta", 0))
+            parsed.append({
+                "strike": strike,
+                "call_gex": call_gex,
+                "put_gex": put_gex,
+                "net_gex": call_gex + put_gex,
+                "call_delta": call_delta,
+                "put_delta": put_delta,
+                "net_delta": call_delta + put_delta,
+            })
+        except (KeyError, ValueError, TypeError):
+            continue
+    return parsed
+
+
+def fetch_aggregate_gex(client: UwClient, repo: Repository, run_id: int, ticker: str) -> list[dict[str, Any]]:
+    """Aggregate GEX time series (used for net_dex calculation, eventual history)."""
+    body = uw_source.fetch_greek_exposure_history(client, repo, run_id, ticker)
+    rows = body.get("data", [])
+    parsed = []
+    for r in rows:
+        try:
+            parsed.append({
+                "date": r["date"],
+                "call_gex": float(r.get("call_gex", 0)),
+                "put_gex": float(r.get("put_gex", 0)),
+                "call_delta": float(r.get("call_delta", 0)),
+                "put_delta": float(r.get("put_delta", 0)),
+            })
+        except (KeyError, ValueError, TypeError):
+            continue
+    return parsed
+
+
+def fetch_iv_rank_rows(client: UwClient, repo: Repository, run_id: int, ticker: str) -> list[dict[str, Any]]:
+    """Raw iv_rank rows — atm_iv, iv_rank, and spot all consume the same data."""
+    # This repo's normalize.normalize_iv_rank returns typed Decimal rows.
+    # The scanner needs the raw response so we can pick latest by date.
+    # Call _fetch_json directly to bypass the normalizer:
+    from uw_scan.api.endpoints import EndpointSlug
+    from uw_scan.sources.uw import _fetch_json
+    body = _fetch_json(client, repo, run_id, EndpointSlug.IV_RANK, ticker)
+    return body.get("data", [])
+
+
+def _latest_iv_rank_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda r: r.get("date", ""))
+
+
+def fetch_atm_iv(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """30D ATM IV from latest iv_rank row's ``volatility`` field."""
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    v = row.get("volatility")
+    try:
+        return float(v) if v is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_iv_rank(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """1Y IV rank percentile from latest row's ``iv_rank_1y`` field."""
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    r = row.get("iv_rank_1y")
+    try:
+        return float(r) if r is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_spot_price(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """Spot from latest iv_rank row's ``close`` field.
+
+    xenon's primary source (UW /stock/{ticker}/info) is not wired in this repo.
+    Yahoo fallback is banned per CLAUDE.md. iv_rank.close is the surviving path.
+    """
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    p = row.get("close")
+    try:
+        return float(p) if p is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_vol_pc(client: UwClient, repo: Repository, run_id: int, ticker: str) -> float | None:
+    """Volume put/call ratio from the screener row for this ticker."""
+    try:
+        # fetch_bulk_screener_ticker returns typed rows; we want the raw put_call_ratio.
+        # Use the lower-level _fetch_json to get the raw dict so we don't dep on
+        # whatever normalizer shape the typed return uses.
+        from uw_scan.api.endpoints import EndpointSlug
+        from uw_scan.sources.uw import _fetch_json
+        body = _fetch_json(
+            client, repo, run_id, EndpointSlug.BULK_SCREENER_STOCKS, None,
+            params={"ticker": ticker.upper()},
+        )
+        rows = body.get("data", [])
+        for r in rows:
+            t = r.get("ticker", r.get("symbol", ""))
+            if str(t).upper() == ticker.upper():
+                pc = r.get("put_call_ratio")
+                return float(pc) if pc is not None else None
+        return None
+    except Exception as exc:
+        log.warning("vol_pc_fetch_failed ticker=%s err=%s", ticker, exc)
+        return None
+
+
+# ─── Orchestration ─────────────────────────────────────────────────
+
+def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
+    """Run a full GEX scan against UW and persist to gex_snapshots.
+
+    Returns the inserted row id. Raises if spot cannot be determined.
+    """
+    ticker = ticker.upper()
+    run_id = repo.insert_scan_run(ticker, notes=f"gex_scan_{ticker}")
+    log.info("gex_scan_start ticker=%s run_id=%d", ticker, run_id)
+
+    try:
+        # iv_rank is fetched once and shared by 3 derived helpers (atm_iv, iv_rank, spot).
+        iv_rows = fetch_iv_rank_rows(client, repo, run_id, ticker)
+        spot = fetch_spot_price(iv_rows)
+        if spot is None:
+            log.warning("gex_scan_aborted_no_spot ticker=%s run_id=%d", ticker, run_id)
+            repo.finish_scan_run(run_id, status="error")
+            raise RuntimeError(f"could not fetch spot for {ticker}")
+
+        strike_rows = fetch_strike_gex(client, repo, run_id, ticker)
+        aggregate_rows = fetch_aggregate_gex(client, repo, run_id, ticker)
+        atm_iv = fetch_atm_iv(iv_rows)
+        iv_rank = fetch_iv_rank(iv_rows)
+        vol_pc = fetch_vol_pc(client, repo, run_id, ticker)
+
+        bucket_size = _bucket_size_for(ticker, spot)
+        profile = bucket_profile(strike_rows, spot, bucket_size)
+        levels = find_key_levels(profile, spot)
+        levels = tag_profile(profile, levels, spot)
+        gex_flip_strike = compute_gex_flip(profile, spot)
+        expected_range = compute_expected_range(spot, atm_iv)
+        bias = compute_directional_bias(profile, spot, gex_flip_strike, vol_pc, atm_iv)
+
+        net_gex = sum(b["net_gex"] for b in profile)
+        net_dex = sum(r.get("call_delta", 0) + r.get("put_delta", 0) for r in aggregate_rows)
+
+        payload: dict[str, Any] = {
+            "scan_time": datetime.now(timezone.utc).isoformat(),
+            "ticker": ticker,
+            "spot": spot,
+            "close": spot,  # iv_rank's close IS the prior session close
+            "day_change": None,         # populated by future enhancement
+            "day_change_pct": None,
+            "data_date": datetime.now(timezone.utc).date().isoformat(),
+            "net_gex": net_gex,
+            "net_dex": net_dex,
+            "atm_iv": atm_iv,
+            "vol_pc": vol_pc,
+            "levels": levels,
+            "profile": profile,
+            "expected_range": expected_range,
+            "bias": bias,
+            "history": [],   # v1: empty; v2 reads from gex_snapshots history
+            "iv": {
+                "iv30d": atm_iv,
+                "iv_rank": iv_rank,
+                "hv30": None,
+                "mq_iv30d": None,
+                "mq_iv_rank": None,
+                "source": "uw" if atm_iv is not None else None,
+            },
+            "mq": None,           # v1: MenthorQ disabled
+            "source_delta": None,
+        }
+
+        row_id = repo.upsert_gex_snapshot(ticker=ticker, payload=payload)
+        repo.finish_scan_run(run_id, status="ok")
+        log.info("gex_scan_done ticker=%s row_id=%d net_gex=%.2e", ticker, row_id, net_gex)
+        return row_id
+    except Exception:
+        # finish_scan_run is idempotent — safe to call even if already finished
+        repo.finish_scan_run(run_id, status="error")
+        raise
+```
+
+Note: `run()` signature now takes `(client, repo, ticker)` — not `(repo, ticker)` as in an earlier draft. The UW client must be constructed at the caller (router / worker) and passed in. This matches the pattern used by `volatility.py:75-90` and the existing worker jobs.
+
+- [ ] **Step 3: Copy the pure-logic functions verbatim from xenon**
+
+For each of `bucket_profile`, `compute_gex_flip`, `find_key_levels`, `tag_profile`, `compute_expected_range`, `compute_directional_bias`: open the corresponding xenon range and copy the function body unchanged. These have no external deps and the math IS the contract.
+
+Source: `/Users/chenxi/projects/xenon/src/xenon/scanners/gex.py:378-582`
+
+- [ ] **Step 4: Write integration test (uses monkeypatched UW fetchers — no live calls)**
+
+`tests/integration/test_gex_scanner.py`:
+
+```python
+import pytest
+
+from uw_scan.api.client import UwClient
+from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.repository import Repository
+
+
+@pytest.fixture
+def mock_client() -> UwClient:
+    """Real UwClient instance — UW calls are monkeypatched at the scanner-fetcher level."""
+    from uw_scan.config import Settings
+    return UwClient.from_settings(Settings.from_env())
+
+
+def test_run_persists_payload_with_full_xenon_shape(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    # Stub the scanner's UW fetchers — bypasses real network entirely.
+    monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [
+        {"date": "2026-05-16", "close": "5800.0", "volatility": "0.18", "iv_rank_1y": "35.0"},
+    ])
+    monkeypatch.setattr(gex_scanner, "fetch_strike_gex", lambda c, r, rid, t: [
+        {"strike": 5750, "call_gex": 1e8, "put_gex": -3e8, "net_gex": -2e8, "call_delta": 0.4, "put_delta": -0.6, "net_delta": -0.2},
+        {"strike": 5800, "call_gex": 2e8, "put_gex": -2e8, "net_gex": 0, "call_delta": 0.5, "put_delta": -0.5, "net_delta": 0},
+        {"strike": 5850, "call_gex": 3e8, "put_gex": -1e8, "net_gex": 2e8, "call_delta": 0.6, "put_delta": -0.4, "net_delta": 0.2},
+    ])
+    monkeypatch.setattr(gex_scanner, "fetch_aggregate_gex", lambda c, r, rid, t: [
+        {"date": "2026-05-16", "call_gex": 1e10, "put_gex": -1e10, "call_delta": 0.5, "put_delta": -0.5},
+    ])
+    monkeypatch.setattr(gex_scanner, "fetch_vol_pc", lambda c, r, rid, t: 0.85)
+
+    row_id = gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    assert row_id > 0
+
+    payload = seeded_db_empty_cards.fetch_latest_gex(ticker="SPX")
+    assert payload["spot"] == 5800.0
+    assert payload["ticker"] == "SPX"
+    assert payload["mq"] is None  # v1 always
+    assert "profile" in payload
+    assert isinstance(payload["profile"], list)
+    assert payload["iv"]["source"] == "uw"
+    assert payload["iv"]["iv30d"] == 0.18
+    assert payload["iv"]["iv_rank"] == 35.0
+    assert payload["vol_pc"] == 0.85
+
+
+def test_run_raises_when_iv_rank_empty(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [])
+    with pytest.raises(RuntimeError, match="could not fetch spot"):
+        gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+
+
+def test_run_marks_scan_run_error_when_aborted(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [])
+    with pytest.raises(RuntimeError):
+        gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    # Verify finish_scan_run("error") was called — query scan_runs:
+    with seeded_db_empty_cards.conn.cursor() as cur:
+        cur.execute("SELECT status FROM uw_scan.scan_runs ORDER BY run_id DESC LIMIT 1")
+        status = cur.fetchone()[0]
+    assert status == "error"
+```
+
+- [ ] **Step 5: Run test**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/test_gex_scanner.py -v
+```
+Expected: 3 PASSED.
+
+- [ ] **Step 6: Smoke against real UW (if `UW_SCAN_API_KEY` set)**
+
+```bash
+uv run python -c "
+from uw_scan.config import Settings
+from uw_scan.api.client import UwClient
+import psycopg
+from uw_scan.storage.repository import Repository
+from uw_scan.scanners import gex
+s = Settings.from_env()
+client = UwClient.from_settings(s)
+conn = psycopg.connect(s.db_dsn())
+try:
+    repo = Repository(conn, schema=s.db_schema)
+    row_id = gex.run(client, repo, ticker='SPX')
+    payload = repo.fetch_latest_gex(ticker='SPX')
+    import json; print(json.dumps({'row_id': row_id, 'spot': payload['spot'], 'net_gex': payload['net_gex']}, indent=2))
+finally:
+    conn.close()
+"
+```
+Expected: real numbers, no errors. Skip this step if no live UW key.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/scanners/ tests/integration/test_gex_scanner.py
+git commit -m "feat(regime): port GEX scanner from xenon (UW-driven, no MQ)"
+```
+
+---
+
+## Task 5: FastAPI router — `/api/regime/*`
+
+**File:** `src/uw_scan/api/routers/regime.py`
+
+- [ ] **Step 1: Write failing test**
+
+`tests/integration/api/test_regime_router.py`:
+
+```python
+from fastapi.testclient import TestClient
+
+from uw_scan.storage.repository import Repository
+
+
+def test_get_gex_returns_empty_shape_when_no_data(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(Repository, "fetch_latest_gex", lambda self, *, ticker="SPX": None)
+    r = client.get("/api/regime/gex")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["spot"] is None
+    assert data["levels"]["max_magnet"] is None
+    assert data["profile"] == []
+    assert data["mq"] is None
+
+
+def test_get_gex_defaults_to_spx_and_uppercases_ticker(client: TestClient, monkeypatch) -> None:
+    seen = {}
+    def stub(self, *, ticker="SPX"):
+        seen["ticker"] = ticker
+        return None
+    monkeypatch.setattr(Repository, "fetch_latest_gex", stub)
+    client.get("/api/regime/gex")
+    assert seen["ticker"] == "SPX"
+    client.get("/api/regime/gex?ticker=spy")
+    assert seen["ticker"] == "SPY"
+
+
+def test_get_cri_returns_pending_sentinel(client: TestClient) -> None:
+    r = client.get("/api/regime")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["scanner"] == "cri"
+    assert body["reason"] == "ib_via_r2_not_wired"
+
+
+def test_get_vcg_returns_pending_sentinel(client: TestClient) -> None:
+    r = client.get("/api/regime/vcg")
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["scanner"] == "vcg"
+
+
+def test_post_gex_scan_runs_scanner(client: TestClient, monkeypatch) -> None:
+    """The router must construct a UwClient and pass (client, repo, ticker) to scanner.run."""
+    calls = []
+    def _stub_run(client_arg, repo_arg, ticker="SPX"):
+        calls.append(("client_passed" if client_arg is not None else "no_client", ticker))
+        return 42
+    monkeypatch.setattr("uw_scan.scanners.gex.run", _stub_run)
+    r = client.post("/api/regime/gex/scan?ticker=spy")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["scanner"] == "gex"
+    assert body["ticker"] == "SPY"
+    assert body["row_id"] == 42
+    assert calls == [("client_passed", "SPY")]
+
+
+def test_post_cri_scan_returns_pending(client: TestClient) -> None:
+    r = client.post("/api/regime/scan")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["scanner"] == "cri"
+    assert "ib_via_r2_not_wired" in body["reason"]
+```
+
+- [ ] **Step 2: Run test (expect FAIL — 404)**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/api/test_regime_router.py -v
+```
+
+- [ ] **Step 3: Implement router**
+
+`src/uw_scan/api/routers/regime.py`:
+
+```python
+"""/regime — GEX live (UW-driven), CRI/VCG pending IB-via-R2 reader."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, Query
+
+from uw_scan.api.client import UwClient
+from uw_scan.api.deps import get_repo, get_settings
+from uw_scan.api.schemas import (
+    EMPTY_GEX_RESPONSE,
+    GexResponse,
+    RegimePendingResponse,
+)
+from uw_scan.config import Settings
+from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.repository import Repository
+
+router = APIRouter(prefix="/regime")
+
+
+def _is_market_open_now() -> bool:
+    """Mon-Fri 09:30-16:00 ET."""
+    now = datetime.now(ZoneInfo("America/New_York"))
+    if now.weekday() >= 5:
+        return False
+    minutes = now.hour * 60 + now.minute
+    return 9 * 60 + 30 <= minutes <= 16 * 60
+
+
+# ─── GEX (live) ──────────────────────────────────────────────────
+
+@router.get("/gex", response_model=GexResponse)
+def get_gex(
+    repo: Annotated[Repository, Depends(get_repo)],
+    ticker: str = Query("SPX"),
+) -> GexResponse:
+    raw = repo.fetch_latest_gex(ticker=ticker.upper())
+    if raw is None:
+        empty = EMPTY_GEX_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        empty.ticker = ticker.upper()
+        return empty
+    raw["market_open"] = _is_market_open_now()
+    return GexResponse.model_validate(raw)
+
+
+@router.post("/gex/scan", status_code=202)
+def trigger_gex_scan(
+    repo: Annotated[Repository, Depends(get_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    ticker: str = Query("SPX"),
+) -> dict:
+    """Run a GEX scan synchronously and persist. Returns scan summary."""
+    uw_client = UwClient.from_settings(settings)
+    row_id = gex_scanner.run(uw_client, repo, ticker=ticker.upper())
+    return {
+        "status": "queued",
+        "scanner": "gex",
+        "ticker": ticker.upper(),
+        "row_id": row_id,
+    }
+
+
+# ─── CRI (pending) ───────────────────────────────────────────────
+
+@router.get("", response_model=RegimePendingResponse)
+def get_regime() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="cri")
+
+
+@router.post("/scan", status_code=202, response_model=RegimePendingResponse)
+def trigger_cri_scan() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="cri")
+
+
+# ─── VCG (pending) ───────────────────────────────────────────────
+
+@router.get("/vcg", response_model=RegimePendingResponse)
+def get_vcg() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="vcg")
+
+
+@router.post("/vcg/scan", status_code=202, response_model=RegimePendingResponse)
+def trigger_vcg_scan() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="vcg")
+```
+
+- [ ] **Step 4: Register router in `server.py`**
+
+In `src/uw_scan/api/server.py`, add `regime` to the `from uw_scan.api.routers import (...)` block at line 8-ish, then add this line after the last `app.include_router(...)` (currently `trade_insights.router` at line 42):
+
+```python
+app.include_router(regime.router, prefix="/api", tags=["regime"])
+```
+
+- [ ] **Step 5: Run tests (expect PASS)**
+
+```bash
+UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/api/test_regime_router.py -v
+```
+Expected: 6 PASSED.
+
+- [ ] **Step 6: Smoke test — KEEP API RUNNING for Task 7**
+
+In another terminal:
+```bash
+uv run uvicorn uw_scan.api.server:app --port 8400 &
+sleep 2
+curl -s http://localhost:8400/api/regime | python -m json.tool
+curl -s http://localhost:8400/api/regime/gex | python -m json.tool | head -20
+```
+Expected: `/api/regime` returns pending sentinel, `/api/regime/gex` returns empty GEX shape with `"profile": []`.
+
+**Do NOT stop the API** — Task 7 (`gen:types`) needs it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/api/routers/regime.py src/uw_scan/api/server.py tests/integration/api/test_regime_router.py
+git commit -m "feat(regime): /api/regime router (GEX live, CRI/VCG pending)"
+```
+
+---
+
+## Task 6: APScheduler GEX scan job
+
+**File:** `src/uw_scan/worker/scheduler.py` (modify existing scheduler)
+
+The worker should periodically (every 5 minutes, configurable) run `gex_scanner.run(uw_client, repo, ticker="SPX")` and persist. Skip during weekends.
+
+- [ ] **Step 1: Inspect existing scheduler**
+
+```bash
+grep -nE "add_job|scheduled_full_scan|scheduled" src/uw_scan/worker/scheduler.py | head -20
+```
+
+- [ ] **Step 2: Add the new scheduled job**
+
+Open `src/uw_scan/worker/scheduler.py`. Find where other jobs are registered (e.g., `scheduled_full_scan`, OHLC refresh). Add:
+
+```python
+def scheduled_gex_scan(settings: Settings) -> None:
+    """Run GEX scan against UW for primary index tickers."""
+    if datetime.now(ZoneInfo("America/New_York")).weekday() >= 5:
+        log.info("gex_scan_skipped_weekend")
+        return
+    import psycopg
+    from uw_scan.api.client import UwClient
+    from uw_scan.scanners import gex as gex_scanner
+    from uw_scan.storage.repository import Repository
+
+    tickers = ["SPX", "SPY"]  # extend as needed
+    uw_client = UwClient.from_settings(settings)
+    conn = psycopg.connect(settings.db_dsn())
+    try:
+        repo = Repository(conn, schema=settings.db_schema)
+        for ticker in tickers:
+            try:
+                gex_scanner.run(uw_client, repo, ticker=ticker)
+            except Exception as exc:
+                log.warning("gex_scan_failed ticker=%s err=%s", ticker, exc)
+    finally:
+        conn.close()
+```
+
+Register it with the scheduler — match the pattern used by other jobs:
+
+```python
+scheduler.add_job(
+    scheduled_gex_scan,
+    "interval",
+    minutes=settings.gex_scan_interval_minutes,
+    args=[settings],
+    id="regime_gex_scan",
+    replace_existing=True,
+    next_run_time=datetime.now() + timedelta(seconds=30),  # warm scan after startup
+)
+```
+
+- [ ] **Step 3: Add settings field**
+
+In `src/uw_scan/config.py` (or wherever `Settings` is defined), add:
+
+```python
+gex_scan_interval_minutes: int = Field(default=5, validation_alias="GEX_SCAN_INTERVAL_MINUTES")
+```
+
+- [ ] **Step 4: Manual smoke**
+
+Start the worker (in a separate terminal):
+```bash
+uv run python -m uw_scan.worker
+```
+Watch logs for `gex_scan_start ticker=SPX` within 30 seconds. After a successful scan, verify:
+
+```bash
+psql "$(uv run python -c 'from uw_scan.config import Settings; print(Settings.from_env().db_dsn())')" \
+  -c "SELECT id, ticker, scanned_at, spot, net_gex FROM uw_scan.gex_snapshots ORDER BY scanned_at DESC LIMIT 3;"
+```
+Expected: at least one row for SPX (and SPY if UW returns data).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/worker/scheduler.py src/uw_scan/config.py
+git commit -m "feat(regime): schedule GEX scan job (5min cadence, weekday-only)"
+```
+
+---
+
+## Task 7: Regenerate openapi types
+
+**Prerequisite:** API server running on port 8400 from Task 5 Step 6.
+
+- [ ] **Step 1: Confirm API reachable**
+
+```bash
+curl -sI http://localhost:8400/openapi.json | head -1
+```
+Expected: `HTTP/1.1 200 OK`.
+
+- [ ] **Step 2: Run codegen**
+
+```bash
+cd web && npm run gen:types
+```
+Expected: `web/lib/types.ts` updated with new `GexResponse`, `GexLevel`, `GexLevels`, `GexBucket`, `GexBias`, `GexIvData`, `GexMqLevels`, `GexSourceDelta`, `RegimePendingResponse` schemas.
+
+- [ ] **Step 3: Verify types compile**
+
+```bash
+cd web && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 4: Stop the API**
+
+```bash
+kill %1   # or Ctrl+C in the terminal running uvicorn
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/lib/types.ts
+git commit -m "chore(regime): regenerate openapi types for /api/regime endpoints"
+```
+
+---
+
+## Task 8: Frontend libs (GEX-only subset)
+
+**Files** — create:
+- `web/lib/regime/api.ts`
+- `web/lib/regime/useSyncHook.ts` (port 236 LOC)
+- `web/lib/regime/useGex.ts` (port)
+- `web/lib/regime/useMarketHours.ts` (port 81 LOC)
+- `web/lib/regime/pricesProtocol.ts` (port 207 LOC)
+- `web/lib/regime/chartSystem.ts` (subset)
+- `web/lib/regime/sectionTooltips.ts` (subset — GEX keys only)
+- `web/lib/regime/types.ts` (re-exports)
+
+- [ ] **Step 1: `web/lib/regime/api.ts`**
+
+```typescript
+const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400";
+
+export const regimeApi = {
+  cri:        () => `${API}/api/regime`,
+  cri_scan:   () => `${API}/api/regime/scan`,
+  vcg:        () => `${API}/api/regime/vcg`,
+  vcg_scan:   () => `${API}/api/regime/vcg/scan`,
+  gex:        (ticker: string) => `${API}/api/regime/gex?ticker=${encodeURIComponent(ticker)}`,
+  gex_scan:   (ticker: string) => `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
+} as const;
+```
+
+- [ ] **Step 2: Port `useSyncHook`**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/useSyncHook.ts` → `web/lib/regime/useSyncHook.ts`. No external imports beyond React. Exports `useSyncHook<T>(config)` and type `UseSyncReturn<T>` (`{data, loading, syncing, error, lastSync, syncNow}`).
+
+- [ ] **Step 3: Port `useGex`**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/useGex.ts` → `web/lib/regime/useGex.ts`. Adjust:
+- `./useSyncHook` import stays (sibling)
+- `./useMarketHours` import stays (sibling, ported in Step 4)
+- Endpoint string → call `regimeApi.gex(ticker)` from `./api`
+- Default `ticker` parameter → `"SPX"` (was `"SPY"` in xenon — match FastAPI default)
+
+- [ ] **Step 4: Port `useMarketHours`**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/useMarketHours.ts` → `web/lib/regime/useMarketHours.ts`. No deps. Exports `MarketState` enum + `useMarketHours()` hook.
+
+- [ ] **Step 5: Port `pricesProtocol`**
+
+Copy `/Users/chenxi/projects/xenon/web/lib/pricesProtocol.ts` → `web/lib/regime/pricesProtocol.ts`. Exports `PriceData` type (kept even with empty prices map).
+
+- [ ] **Step 6: Port `chartSystem` (subset)**
+
+Port only `chartSeriesColor(name: string): string` from `/Users/chenxi/projects/xenon/web/lib/chartSystem.ts` and its name→CSS-var lookup map. **Function takes a string key, NOT a numeric index** — `GexProfileChart` and other callers pass tokens like `"caution"`, `"dislocation"`. Numeric-index fallback would break them.
+
+- [ ] **Step 7: Port `sectionTooltips` (GEX-only)**
+
+Find which keys GEX uses:
+```bash
+grep -hoE 'SECTION_TOOLTIPS\["[^"]+"\]' \
+  /Users/chenxi/projects/xenon/web/components/GexPanel.tsx | sort -u
+```
+
+Create `web/lib/regime/sectionTooltips.ts` exporting `SECTION_TOOLTIPS` with **only those keys** (lifted verbatim from xenon's file). Do not pull CRI/VCG/positions/orders keys.
+
+- [ ] **Step 8: `web/lib/regime/types.ts`**
+
+```typescript
+import type { components } from "@/lib/types";
+
+export type GexData = components["schemas"]["GexResponse"];
+export type GexLevel = components["schemas"]["GexLevel"] | null;
+export type GexLevels = components["schemas"]["GexLevels"];
+export type GexBucket = components["schemas"]["GexBucket"];
+export type GexBias = components["schemas"]["GexBias"];
+export type GexHistoryEntry = components["schemas"]["GexHistoryEntry"];
+export type GexExpectedRange = components["schemas"]["GexExpectedRange"];
+export type MqLevels = components["schemas"]["GexMqLevels"];
+export type SourceDelta = components["schemas"]["GexSourceDelta"];
+export type SourceDeltaEntry = components["schemas"]["GexSourceDeltaEntry"];
+export type IvData = components["schemas"]["GexIvData"];
+
+export type RegimePendingResponse = components["schemas"]["RegimePendingResponse"];
+```
+
+- [ ] **Step 9: Type-check**
+
+```bash
+cd web && npx tsc --noEmit
+```
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/lib/regime/
+git commit -m "feat(regime): port frontend libs for GEX (useSyncHook, useGex, market hours, tooltips)"
+```
+
+---
+
+## Task 9: GEX components + d3 install
+
+**Files** — create:
+- `web/components/regime/GexSubTab.tsx` (port from `xenon/web/components/GexPanel.tsx`)
+- `web/components/regime/GexProfileChart.tsx` (port; uses d3)
+- `web/components/regime/charts/ChartPanel.tsx` (69 LOC port)
+- `web/components/regime/charts/ChartLegend.tsx` (27 LOC port)
+- `web/components/regime/ui/MetricCard.tsx` (87 LOC port)
+- `web/components/regime/InfoTooltip.tsx` (port if not present elsewhere)
+- `web/components/regime/PendingSubTab.tsx` (new — placeholder for CRI/VCG)
+
+- [ ] **Step 1: Install d3**
+
+```bash
+cd web && npm install d3 @types/d3 --save
+```
+Expected: `d3` under `dependencies`, `@types/d3` under `devDependencies` in `package.json`.
+
+Document the CLAUDE.md deviation in the PR description: "d3 added 2026-05-16 — scoped to `web/components/regime/*` for 1:1 visual port of xenon's GEX profile chart. Other charts remain hand-rolled SVG."
+
+- [ ] **Step 2: Port chart wrappers**
+
+- Copy `/Users/chenxi/projects/xenon/web/components/charts/ChartPanel.tsx` → `web/components/regime/charts/ChartPanel.tsx`.
+- Copy `/Users/chenxi/projects/xenon/web/components/charts/ChartLegend.tsx` → `web/components/regime/charts/ChartLegend.tsx`.
+
+Adjust any `@/lib/chartSystem` → `@/lib/regime/chartSystem`.
+
+- [ ] **Step 3: Port `GexProfileChart`**
+
+Copy `/Users/chenxi/projects/xenon/web/components/charts/GexProfileChart.tsx` → `web/components/regime/GexProfileChart.tsx`. Adjust:
+- `import * as d3 from "d3"` stays
+- `./ChartPanel` → `./charts/ChartPanel` (sibling moved into `charts/` subdir)
+- `@/lib/chartSystem` → `@/lib/regime/chartSystem`
+
+- [ ] **Step 4: Port `MetricCard`**
+
+Copy `/Users/chenxi/projects/xenon/web/components/ui/MetricCard.tsx` → `web/components/regime/ui/MetricCard.tsx`. Both `MetricCard` and `SourceBadge` named exports — required by `GexSubTab`.
+
+- [ ] **Step 5: Port `InfoTooltip`**
+
+If not already present in this repo:
+```bash
+find web/components -name "InfoTooltip.tsx" -not -path "*/regime/*"
+```
+- If found: re-export from sibling location or just import the existing one.
+- If not found: copy `/Users/chenxi/projects/xenon/web/components/InfoTooltip.tsx` → `web/components/regime/InfoTooltip.tsx`.
+
+- [ ] **Step 6: Port `GexPanel` as `GexSubTab`**
+
+Copy `/Users/chenxi/projects/xenon/web/components/GexPanel.tsx` (901 LOC) → `web/components/regime/GexSubTab.tsx`. Adjust:
+- `useGex` → `@/lib/regime/useGex`
+- `useMarketHours` / `MarketState` → `@/lib/regime/useMarketHours`
+- `MetricCard, SourceBadge` from `./ui/MetricCard` (sibling)
+- `GexProfileChart` from `./GexProfileChart` (sibling)
+- `InfoTooltip` from `./InfoTooltip` (sibling)
+- `SECTION_TOOLTIPS` → `@/lib/regime/sectionTooltips`
+- **Strip:** `ShareReportModal` import + JSX (share-to-X out of scope)
+- **Keep:** `marketState` prop
+- Default export name: `GexSubTab`
+- Component signature: `export default function GexSubTab({ marketState }: { marketState: MarketState })`
+
+- [ ] **Step 7: Write `PendingSubTab` placeholder**
+
+`web/components/regime/PendingSubTab.tsx`:
+
+```typescript
+import Link from "next/link";
+import { Clock } from "lucide-react";
+
+type Props = {
+  name: "CRI" | "VCG";
+  description: string;
+};
+
+export default function PendingSubTab({ name, description }: Props) {
+  return (
+    <div className="regime-pending" data-testid={`regime-pending-${name.toLowerCase()}`}>
+      <Clock size={48} strokeWidth={1.5} />
+      <h2>{name} — coming soon</h2>
+      <p>{description}</p>
+      <p className="regime-pending-link">
+        Pending IB-via-R2 reader integration. See{" "}
+        <Link href="/docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md">
+          the long-term roadmap
+        </Link>{" "}
+        for the full plan.
+      </p>
+    </div>
+  );
+}
+```
+
+(The `<Link href="/docs/...">` won't render as a real link in Next.js since the docs aren't routed — leave it for now; the executor can swap to a plain text reference if `next/link` complains. Cosmetic only.)
+
+- [ ] **Step 8: Type-check**
+
+```bash
+cd web && npx tsc --noEmit
+```
+Expected: clean. If `@types/d3` resolution issues, re-run `npm install`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/package.json web/package-lock.json web/components/regime/
+git commit -m "feat(regime): port GEX components + d3 + chart wrappers + pending placeholder"
+```
+
+---
+
+## Task 10: `RegimePanel` tab shell
+
+**File:** `web/components/regime/RegimePanel.tsx`
+
+- [ ] **Step 1: Write the shell**
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import GexSubTab from "./GexSubTab";
+import PendingSubTab from "./PendingSubTab";
+import { useMarketHours } from "@/lib/regime/useMarketHours";
+
+type RegimeTab = "cri" | "vcg" | "gex";
+
+const TABS: { id: RegimeTab; label: string }[] = [
+  { id: "cri", label: "CRI" },
+  { id: "vcg", label: "VCG" },
+  { id: "gex", label: "GEX" },
+];
+
+const CRI_DESC = "Crash Risk Indicator — composite score from VIX, VVIX, COR1M implied correlation, and SPX momentum. Renders when VIX/VVIX/COR1M data is wired.";
+const VCG_DESC = "Volatility-Credit Gap — rolling OLS residual between the vol complex (VIX/VVIX) and cash credit (HYG/JNK/LQD). Renders when VIX/VVIX data is wired.";
+
+export default function RegimePanel() {
+  const [activeTab, setActiveTab] = useState<RegimeTab>("gex");  // default to the working tab
+  const marketState = useMarketHours();
+
+  return (
+    <div className="regime-panel" data-testid="regime-panel">
+      <div className="ticker-tabs" style={{ marginBottom: "16px" }} data-testid="regime-tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            className={`ticker-tab ${activeTab === tab.id ? "active" : ""}`}
+            onClick={() => setActiveTab(tab.id)}
+            data-testid={`regime-tab-${tab.id}`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === "gex" && <GexSubTab marketState={marketState} />}
+      {activeTab === "cri" && <PendingSubTab name="CRI" description={CRI_DESC} />}
+      {activeTab === "vcg" && <PendingSubTab name="VCG" description={VCG_DESC} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add web/components/regime/RegimePanel.tsx
+git commit -m "feat(regime): RegimePanel tab shell (GEX default, CRI/VCG pending)"
+```
+
+---
+
+## Task 11: Page route + Sidebar nav
+
+**Files:**
+- Create: `web/app/regime/page.tsx`
+- Modify: `web/components/shared/Sidebar.tsx`
+
+- [ ] **Step 1: Create the page route**
+
+```typescript
+// web/app/regime/page.tsx
+import RegimePanel from "@/components/regime/RegimePanel";
+
+export const metadata = {
+  title: "Regime — Unusual Whales",
+  description: "Market-wide regime indicators: CRI, VCG, GEX",
+};
+
+export default function RegimePage() {
+  return (
+    <main className="regime-page">
+      <header className="regime-page-header">
+        <h1>Regime</h1>
+        <p className="regime-page-subtitle">
+          Crash Risk Indicator · Vol-Curve Gauge · Gamma Exposure
+        </p>
+      </header>
+      <RegimePanel />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Add nav link**
+
+Edit `web/components/shared/Sidebar.tsx`. Find the `NAV` array (near line 7-11):
+
+```diff
+-import { LayoutDashboard, Radar, ScanLine } from "lucide-react";
++import { LayoutDashboard, Radar, ScanLine, Activity } from "lucide-react";
+
+ const NAV = [
+   { href: "/", label: "Dashboard", icon: LayoutDashboard },
+   { href: "/scanner", label: "Scanner", icon: ScanLine },
+   { href: "/cockpit/SPY", label: "Cockpit", icon: Radar },
++  { href: "/regime", label: "Regime", icon: Activity },
+ ];
+```
+
+- [ ] **Step 3: Smoke**
+
+```bash
+bash scripts/dev.sh
+```
+Navigate to `http://localhost:3001/regime`:
+- Sidebar shows new Regime link
+- Page renders with GEX tab selected by default
+- GEX tab shows real data (if scanner has run) or empty card (if not)
+- Click CRI → shows pending placeholder with description text
+- Click VCG → shows pending placeholder
+- No console errors
+
+Stop dev server (Ctrl+C).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/app/regime/ web/components/shared/Sidebar.tsx
+git commit -m "feat(regime): /regime page route + Sidebar nav"
+```
+
+---
+
+## Task 12: CSS extraction (GEX selectors only)
+
+**File:** `web/app/globals.css` (append)
+
+- [ ] **Step 1: Extract GEX-relevant rules (preserving `@media`)**
+
+Use the brace-balanced parser from the roadmap plan (`2026-05-16-port-regime-from-xenon.md` Task 11 Step 2). Narrow the prefix list to GEX scope:
+
+```bash
+XEN=/Users/chenxi/projects/xenon/web/app/globals.css
+OUT=/tmp/regime-gex-css.css
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync(process.env.XEN, "utf8");
+const PREFIXES = [".regime-panel", ".regime-page", ".regime-pending",
+  ".gex-", ".ticker-tab", ".section-header", ".section-title",
+  ".metric-card", ".chart-panel", ".chart-legend"];
+const SKIP = [".regime-strip", ".regime-relationship", ".regime-history",
+  ".regime-component-", ".regime-trigger-", ".regime-hero", ".cri-", ".vcg-",
+  ".share-report-modal"];
+
+function selectorMatches(sel) {
+  if (SKIP.some(p => sel.includes(p))) return false;
+  return PREFIXES.some(p => sel.includes(p));
+}
+// [parser body identical to roadmap plan Task 11 — handles @media wrappers]
+' > $OUT
+```
+
+Then append `/tmp/regime-gex-css.css` to `web/app/globals.css` under a marker:
+
+```css
+/* ─── Regime/GEX (ported from xenon 2026-05-16) ──────────────────────── */
+```
+
+Add a `.regime-pending` block manually (xenon doesn't have it):
+
+```css
+.regime-pending {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 48px 24px; gap: 12px; color: var(--text-muted);
+  text-align: center;
+}
+.regime-pending h2 { font-size: 1.25rem; font-weight: 500; }
+.regime-pending p { max-width: 480px; font-size: 0.95rem; line-height: 1.5; }
+.regime-pending-link { font-size: 0.85rem; opacity: 0.7; }
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Run `bash scripts/dev.sh`, navigate to `/regime`, eyeball the layout against `xenon`'s `/regime` (open in another tab). Note any visual gaps. Fix missing CSS vars (`--chart-live-badge-bg`, etc.) by either adding to `:root` or substituting existing tokens.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/app/globals.css
+git commit -m "feat(regime): port GEX-related styles + add regime-pending block"
+```
+
+---
+
+## Task 13: Tests — vitest + playwright
+
+**Files:**
+- Create: `web/tests/unit/regime-page.test.tsx`
+- Create: `web/tests/e2e/regime-page.spec.ts`
+
+- [ ] **Step 1: Vitest component test**
+
+```typescript
+// web/tests/unit/regime-page.test.tsx
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RegimePanel from "@/components/regime/RegimePanel";
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      scan_time: "", market_open: false, ticker: "SPX",
+      spot: null, close: null, day_change: null, day_change_pct: null, data_date: null,
+      net_gex: null, net_dex: null, atm_iv: null, vol_pc: null,
+      levels: { gex_flip: null, max_magnet: null, second_magnet: null, max_accelerator: null, put_wall: null, call_wall: null },
+      profile: [],
+      expected_range: { low: null, high: null, iv_1d: null },
+      bias: { direction: null, reasons: [], days_above_flip: null, flip_migration: [] },
+      history: [], iv: null, mq: null, source_delta: null,
+    }),
+  }));
+});
+
+describe("RegimePanel", () => {
+  it("renders three sub-tab buttons with GEX active by default", () => {
+    render(<RegimePanel />);
+    expect(screen.getByTestId("regime-tab-cri")).toHaveTextContent("CRI");
+    expect(screen.getByTestId("regime-tab-vcg")).toHaveTextContent("VCG");
+    expect(screen.getByTestId("regime-tab-gex")).toHaveTextContent("GEX");
+    expect(screen.getByTestId("regime-tab-gex")).toHaveClass("active");
+  });
+
+  it("shows pending placeholder on CRI tab", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-cri"));
+    expect(screen.getByTestId("regime-pending-cri")).toBeInTheDocument();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+
+  it("shows pending placeholder on VCG tab", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-vcg"));
+    expect(screen.getByTestId("regime-pending-vcg")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run Vitest**
+
+```bash
+cd web && npm run test -- regime-page
+```
+Expected: 3 PASSED.
+
+- [ ] **Step 3: Playwright smoke**
+
+```typescript
+// web/tests/e2e/regime-page.spec.ts
+import { test, expect } from "@playwright/test";
+
+test("/regime renders with three tabs and GEX default", async ({ page }) => {
+  await page.goto("/regime");
+  await expect(page.getByRole("heading", { name: "Regime" })).toBeVisible();
+  await expect(page.getByTestId("regime-tab-cri")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-vcg")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-gex")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-gex")).toHaveClass(/active/);
+});
+
+test("CRI tab shows pending placeholder", async ({ page }) => {
+  await page.goto("/regime");
+  await page.getByTestId("regime-tab-cri").click();
+  await expect(page.getByText(/coming soon/i)).toBeVisible();
+});
+```
+
+- [ ] **Step 4: Run Playwright**
+
+```bash
+cd web && npx playwright test regime-page
+```
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/tests/unit/regime-page.test.tsx web/tests/e2e/regime-page.spec.ts
+git commit -m "test(regime): vitest + playwright smoke for /regime page"
+```
+
+---
+
+## Task 14: PR
+
+- [ ] **Step 1: Push branch + open PR**
+
+```bash
+git push -u origin worktree-regime-port-from-xenon
+gh pr create --title "feat(regime): port /regime page from xenon (GEX live, CRI/VCG pending)" --body "$(cat <<'EOF'
+## Summary
+- New `/regime` page with 3 sub-tabs (CRI / VCG / GEX), default GEX.
+- GEX renders live UW data end-to-end: UW → scheduled scanner (5min) → Postgres → API → React via d3-using `GexProfileChart`.
+- CRI and VCG render a friendly "coming soon — IB-via-R2 reader pending" placeholder.
+- Sidebar gains a Regime nav entry.
+- Pydantic schemas + Repository methods + APScheduler job + frontend hooks + tab shell all wired.
+
+## Out of scope (follow-up plans)
+- CRI / VCG backends — pending the IB-via-R2 parquet reader (separate project, currently flaky).
+- MenthorQ key levels in GEX — Playwright dep, skipped for v1.
+- Postgres → R2 backup — separate DB-ops concern.
+- Full CRI/VCG frontend port (RegimeStrip, RegimeRelationshipView, CriHistoryChart) — see `docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md` for the long-term roadmap.
+
+## CLAUDE.md deviations (documented)
+- **d3 + @types/d3 added** to `web/package.json`. Scoped to `web/components/regime/*` for the 1:1 visual port of xenon's `GexProfileChart`. Other charts in this repo remain hand-rolled SVG per CLAUDE.md. User-approved 2026-05-16.
+
+## Test plan
+- [x] `uv run pytest tests/unit/test_regime_schemas.py tests/integration/test_gex_repository.py tests/integration/test_gex_scanner.py tests/integration/api/test_regime_router.py`
+- [x] `cd web && npm run test -- regime-page`
+- [x] `cd web && npx playwright test regime-page`
+- [x] Manual: `/regime` route renders, GEX tab default, CRI/VCG show placeholders
+- [x] Manual: APScheduler GEX job populates `gex_snapshots` table within 30s of worker start
+EOF
+)"
+```
+
+---
+
+## Backfill / follow-up plans (NOT scoped here)
+
+When the IB-via-R2 reader stabilizes, the follow-up work to enable CRI/VCG is:
+
+1. **New data source module**: `src/uw_scan/sources/r2_ib.py` — reads VIX/VVIX/COR1M/SPY (and HYG/JNK/LQD if useful) parquet files from R2 via `boto3` with R2 endpoint URL + token auth. ~150 LOC.
+2. **CRI scanner**: port `xenon/src/xenon/scanners/cri.py` math + `_fetch_uw` for SPY + `r2_ib.fetch_index_history` for VIX/VVIX/COR1M. Drop IB code entirely. ~400 LOC.
+3. **VCG scanner**: same pattern but for the VCG residual model.
+4. **CRI/VCG frontend port**: pull from the long-term roadmap (`2026-05-16-port-regime-from-xenon.md` Tasks 7-9 — RegimeStrip, RegimeRelationshipView, CriHistoryChart, full VcgPanel).
+5. **R2 → Postgres polling job**: APScheduler reads the latest R2 parquet every 5 min, persists to `cri_series` / `vcg_series`.
+
+That's a separate plan when you're ready. For now, this iteration ships GEX.
+
+---
+
+## Self-review checks
+
+- [x] All file paths are absolute or repo-relative.
+- [x] Every step that writes code shows the code.
+- [x] No `# TODO` / "TBD" placeholders.
+- [x] Hooks return shape matches xenon's `UseSyncReturn<T>` (the copied `GexPanel` destructures `loading` and `syncNow`).
+- [x] Default ticker is `SPX` everywhere (FastAPI, hooks, scheduler tickers list).
+- [x] Tests cover: empty-state shape, pending sentinel, ticker uppercasing, real scan persists.
+- [x] `gen:types` sequenced AFTER the API is started, BEFORE it's stopped.
+- [x] Sidebar update targets `web/components/shared/Sidebar.tsx`.
+- [x] CSS extraction preserves `@media` wrappers.
+- [x] d3 deviation documented in PR description.
+- [x] **Verified field shapes** against `docs/uw-samples/*.json` — iv_rank has `volatility`/`iv_rank_1y`/`close`/`date`; screener has `put_call_ratio`/`ticker`. All strings; xenon's `float()` casts handle coercion.
+- [x] **Missing UW endpoints identified and added in Task 4 Step 1** — `GREEK_EXPOSURE_BY_STRIKE` + `GREEK_EXPOSURE_HISTORY` slugs and fetch functions. Endpoint paths match UW spec doc (`/api/stock/{ticker}/greek-exposure/strike` + `/api/stock/{ticker}/greek-exposure`).
+- [x] **Spot price source corrected** — xenon's primary `/stock/{ticker}/info` not wired in this repo; Yahoo banned. Scanner uses iv_rank's `close` field as the sole spot source. iv_rank rows fetched once and shared by 3 derived helpers (atm_iv, iv_rank percentile, spot).
+- [x] **Run-id audit threaded** through every UW call — matches existing pattern in `worker/jobs/cockpit_daily_snapshot.py:65` and `worker/jobs/flow_data_refresh.py:64`. Scanner inserts a `scan_runs` row at start and marks it `ok` / `error` at finish (idempotent).
+- [x] **Scanner signature** `run(client, repo, ticker)` — UW client constructed at caller (router + scheduler) and passed in. Matches `volatility.py:75-90`.
+
+## Review history
+
+- 2026-05-16 Round 4 (Field-name + endpoint verification — push confidence to ~95%):
+  - Verified UW field shapes against `docs/uw-samples/iv_rank.json` and `docs/uw-samples/bulk_screener_stocks_sp500.json`. All match xenon's expectations (string-valued numerics; `float()` casts handle coercion).
+  - Found and patched 3 concrete gaps:
+    1. This repo's `EndpointSlug.GREEK_EXPOSURE` maps to `/greek-exposure/strike-expiry` (per-strike-per-expiry); xenon's GEX scanner needs `/strike` (aggregated). Added new slug `GREEK_EXPOSURE_BY_STRIKE` + fetcher.
+    2. Aggregate `/greek-exposure` endpoint wasn't wired. Added new slug `GREEK_EXPOSURE_HISTORY` + fetcher.
+    3. Spot-price source `/stock/{ticker}/info` not in this repo. Dropped that fallback chain; scanner now uses only iv_rank's `close` field. iv_rank fetched once, shared by 3 derived helpers.
+  - Scanner orchestration updated to use this repo's run-id audit pattern (`repo.insert_scan_run(...)` + `finish_scan_run(...)`) — matches existing scanner conventions.
+  - Scanner signature changed: `run(client, repo, ticker)` — UwClient passed in by caller (router uses `Depends(get_settings)` + `UwClient.from_settings(s)`; scheduler builds it once per tick).
+  - Integration tests adjusted: monkeypatch the scanner's fetch_* functions (not at uw client level) — bypasses real network; covers the new `finish_scan_run("error")` path on abort.
+- 2026-05-16 Initial draft (this plan, after long-term roadmap was deferred).

--- a/docs/superpowers/plans/2026-05-17-regime-history-and-vol-backdrop.md
+++ b/docs/superpowers/plans/2026-05-17-regime-history-and-vol-backdrop.md
@@ -1,0 +1,2505 @@
+# Regime History + Vol Backdrop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 90-day GEX history to the regime page (per-ticker, including SPX) and a global vol-backdrop strip (VIX / VIX3M / VVIX / COR1M), backed by two new Postgres persistence domains.
+
+**Architecture:**
+- Local parquet lake (`~/market-warehouse/data-lake/bronze/asset_class=volatility/`) is the source of truth for SPX daily OHLC and the CBOE vol indices. UW `/ohlc/1d` is tier-blocked for SPX and we don't want to fall back to Yahoo, so the lake closes the SPX gap.
+- A nightly APScheduler job (`vol_index_lake_sync_job`) upserts the lake's parquet tail into `uw_scan.vol_index_daily`. Idempotent: same row twice = no-op.
+- The GEX scanner already calls `/greek-exposure` for today's snapshot — that payload also carries ~250 daily history rows. We persist the tail to `uw_scan.greek_exposure_daily` (one row per ticker × date) during each scan.
+- `/api/regime/gex` is extended to return a `history` array (90 daily entries) sourced from `greek_exposure_daily` joined with `daily_ohlc` (ETFs) or `vol_index_daily` (SPX).
+- A new `/api/regime/vol-backdrop` returns the global vol complex time series (VIX/VIX3M/VVIX/COR1M).
+- Frontend gains `<HistoryChart>` (inside `GexSubTab`) and `<VolBackdropStrip>` (top of the regime page).
+
+**Tech Stack:** Python 3.13 (uv), pyarrow (new dep), psycopg 3, APScheduler 3, FastAPI, Pydantic v2, Next.js 16, React 19, hand-rolled SVG.
+
+---
+
+## Verified Facts (2026-05-17)
+
+These are the facts the plan rests on, confirmed by direct file inspection. The plan was revised after the initial draft to incorporate them.
+
+| Fact | Location | Implication |
+|---|---|---|
+| `fetch_greek_exposure_history(client, repo, run_id, ticker)` already exists, returns raw dict body | `src/uw_scan/sources/uw.py:210` | Don't write a new fetcher. Reuse. Audit-write happens inside `_fetch_json`. |
+| `fetch_aggregate_gex` parser already exists, returns `[{date, call_gex, put_gex, call_delta, put_delta}, ...]` | `src/uw_scan/scanners/gex.py:290-310` | This is the **shared util** the user asked for. Promote it to `cards/greek_exposure_history.py` so persistence + scanner both consume it. |
+| `Repository.conn` is already a public property | `src/uw_scan/storage/repository.py:586-588` | Sub-domain repos can do `Repository(repo.conn, schema=repo._schema)`. No new property needed. |
+| Schema attribute access: `repo._schema` is the established pattern | `tests/integration/conftest.py:99` uses `repo._schema` directly | Mirror this — don't add a public property just for new code. |
+| `seeded_db_empty_cards` fixture yields a `Repository` (not a bare `Connection`) | `tests/integration/conftest.py:50-59` | All integration tests use this fixture, not `pg_conn`. Reset+migrate happens inside. |
+| `finiteDomain(values)` returns `{lo, hi, count} \| null` (NOT a tuple) | `web/lib/svgChart.ts` (verified) | `linearScale([d.lo, d.hi], range)` and null-guard for the empty case. |
+| `regimeApi` is an object literal at `web/lib/regime/api.ts` with snake_case methods (`gex`, `gex_scan`, `cri_scan`, `vcg_scan`) | `web/lib/regime/api.ts` | New method must be `vol_backdrop`, not `volBackdrop`. |
+| Regime page is `web/app/regime/page.tsx`, mounts `<RegimePanel />` from `web/components/regime/RegimePanel.tsx` | both verified | `<VolBackdropStrip>` mounts inside `page.tsx`, above `<RegimePanel />` — survives tab switches. |
+| `_stub_minimal_chain(monkeypatch)` helper exists | `tests/integration/test_gex_scanner.py:127` | Reuse for new tests. |
+| UW `/greek-exposure` history payload row keys: `date, call_gex, put_gex, call_delta, put_delta` (no `gex_flip`, no `price`, no `net_gex`) | scanner parsing at `gex.py:290` | `gex_flip` and `atm_iv` columns in history chart will be NULL until our own daily `gex_snapshots` build up. Plan reflects this honestly — UI degrades gracefully. |
+| Integration tests need `UW_SCAN_TEST_DB_NAME` env var | `tests/integration/conftest.py:25-31` | Executor must set this before running pytest. |
+
+### API call separation (user requirement)
+
+The user asked: regime greek-exposure API should be **distinct** from stock-page greek-exposure, but **share util functions** where possible.
+
+Current state already satisfies this at the UW client layer:
+
+| Path | Fetcher | UW endpoint | Persistence | Consumer |
+|---|---|---|---|---|
+| Stock / Cockpit | `fetch_greek_exposure(..., expiry)` | `/api/stock/{t}/greek-exposure?expiry=X` | `greek_exposure_rows` table | `pipeline.py`, `cockpit_daily_snapshot.py` |
+| Regime | `fetch_greek_exposure_history(..., NO expiry)` | `/api/stock/{t}/greek-exposure` | `greek_exposure_daily` (this plan, new) | `scanners/gex.py`, `routers/regime.py` |
+
+Different fetchers → different endpoints → different normalizers → different tables. The shared piece is the *pure parser util* (Task B2.5 below) — a function `parse_greek_exposure_history(body) -> list[dict]` that anyone can call without needing a UW client. Scanner uses it, persistence uses it, and any future consumer can use it.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/uw_scan/storage/migrations/038_vol_index_daily.sql`
+- `src/uw_scan/storage/migrations/039_greek_exposure_daily.sql`
+- `src/uw_scan/sources/lake.py` — parquet reader
+- `src/uw_scan/cards/greek_exposure_history.py` — **shared parser util** (consumed by scanner + persistence)
+- `src/uw_scan/storage/vol_index_repository.py` — new domain (memory: never extend `repository.py`)
+- `src/uw_scan/storage/greek_exposure_repository.py` — new domain
+- `src/uw_scan/worker/jobs/vol_index_lake_sync.py` — nightly sync job
+- `tests/unit/test_lake_reader.py`
+- `tests/unit/test_greek_exposure_history_parser.py`
+- `tests/integration/storage/test_vol_index_repository.py`
+- `tests/integration/storage/test_greek_exposure_repository.py`
+- `tests/integration/test_vol_index_lake_sync.py`
+- `tests/integration/test_regime_history_endpoint.py`
+- `tests/integration/test_regime_vol_backdrop.py`
+- `web/components/regime/HistoryChart.tsx`
+- `web/components/regime/VolBackdropStrip.tsx`
+- `web/lib/regime/useVolBackdrop.ts`
+- `web/tests/unit/historyChart.test.tsx`
+- `web/tests/unit/volBackdropStrip.test.tsx`
+
+**Modify:**
+- `pyproject.toml` — add `pyarrow>=18.0` to main deps
+- `src/uw_scan/config.py` — add `lake_vol_index_root` setting
+- `src/uw_scan/scanners/gex.py` — `fetch_aggregate_gex` body delegates to the new shared parser util; persist the same parsed rows via `GreekExposureDailyRepository`
+- `src/uw_scan/api/routers/regime.py` — extend `/gex` (add `history`); add `/vol-backdrop`
+- `src/uw_scan/api/schemas.py` — add `RegimeHistoryEntry`, `VolBackdropResponse`; extend `GexResponse.history`
+- `src/uw_scan/worker/scheduler.py` — register `vol_index_lake_sync_job` (cron: nightly 03:15 ET)
+- `src/uw_scan/storage/repository.py` — possibly add `fetch_daily_ohlc_history` / `fetch_flip_strike_history` read methods (verify existence first — these are reads against existing tables, not new domains, so they belong in `repository.py`)
+- `web/components/regime/GexSubTab.tsx` — mount `<HistoryChart>`
+- `web/lib/regime/api.ts` — add `vol_backdrop` URL builder
+- `web/lib/regime/useGex.ts` — already exposes `history` field (verified); nothing to change there
+- `web/app/regime/page.tsx` — mount `<VolBackdropStrip>` above `<RegimePanel />`
+- `web/lib/types.ts` — regenerated via `npm run gen:types`
+
+---
+
+## Phase A: Lake Sync Infrastructure
+
+### Task A1: Add pyarrow dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add pyarrow to main deps**
+
+Open `pyproject.toml`, find the `dependencies = [` list under `[project]`, add `"pyarrow>=18.0",` in alphabetical position.
+
+- [ ] **Step 2: Sync**
+
+Run: `uv sync --extra postgres`
+Expected: pyarrow installed, lock file updated.
+
+- [ ] **Step 3: Smoke check**
+
+Run: `uv run python -c "import pyarrow.parquet as pq; print(pq.__name__)"`
+Expected: `pyarrow.parquet`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat(deps): add pyarrow for parquet lake reader"
+```
+
+---
+
+### Task A2: Config setting for lake root
+
+**Files:**
+- Modify: `src/uw_scan/config.py`
+
+- [ ] **Step 1: Add setting**
+
+In `config.py`, find the `Settings` class and add (after the existing path-like settings):
+
+```python
+lake_vol_index_root: Path = Field(
+    default=Path.home()
+    / "market-warehouse/data-lake/bronze/asset_class=volatility",
+    description=(
+        "Local parquet lake root for CBOE vol indices and SPX daily OHLC. "
+        "Symbol subdirs are named symbol=<TICKER>."
+    ),
+)
+```
+
+If `Path` and `Field` are not yet imported, add `from pathlib import Path` and `from pydantic import Field` as needed.
+
+- [ ] **Step 2: Verify**
+
+Run: `uv run python -c "from uw_scan.config import Settings; s = Settings(); print(s.lake_vol_index_root)"`
+Expected: `/Users/chenxi/market-warehouse/data-lake/bronze/asset_class=volatility`
+
+---
+
+### Task A3: Migration 038 — vol_index_daily
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/038_vol_index_daily.sql`
+
+- [ ] **Step 1: Write migration**
+
+```sql
+-- 038_vol_index_daily.sql
+--
+-- CBOE volatility index daily OHLC, sourced from the local parquet lake.
+-- Covers SPX (filling the UW /ohlc/1d gap for indices) and the vol complex
+-- (VIX, VIX3M, VVIX, COR1M, COR3M, OVX, RVX, VXN, VXEEM, etc.).
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.vol_index_daily (
+    symbol      TEXT NOT NULL,
+    trade_date  DATE NOT NULL,
+    open        NUMERIC(14,4),
+    high        NUMERIC(14,4),
+    low         NUMERIC(14,4),
+    close       NUMERIC(14,4),
+    adj_close   NUMERIC(14,4),
+    volume      BIGINT,
+    PRIMARY KEY (symbol, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS ix_vol_index_symbol_date
+    ON uw_scan.vol_index_daily (symbol, trade_date DESC);
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `bash scripts/migrate.sh`
+Expected: migration 038 applied; re-running yields no-op.
+
+- [ ] **Step 3: Verify table**
+
+Run: `uv run python -c "
+from uw_scan.api.deps import _conn
+import os
+conn = _conn()
+with conn.cursor() as c:
+    c.execute(\"SELECT to_regclass('uw_scan.vol_index_daily')\")
+    print(c.fetchone())
+"`
+Expected: `('uw_scan.vol_index_daily',)`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/038_vol_index_daily.sql
+git commit -m "feat(db): vol_index_daily for SPX OHLC and CBOE vol complex"
+```
+
+---
+
+### Task A4: Lake reader
+
+**Files:**
+- Create: `src/uw_scan/sources/lake.py`
+- Test: `tests/unit/test_lake_reader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_lake_reader.py
+"""Lake reader: parquet → list[dict] for vol_index_daily upserts."""
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from uw_scan.sources.lake import read_vol_index_parquet, list_vol_index_symbols
+
+
+def _write_fixture(root: Path, symbol: str, rows: list[dict]) -> None:
+    d = root / f"symbol={symbol}"
+    d.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, d / "1d.parquet")
+
+
+def test_read_vol_index_parquet_returns_rows(tmp_path: Path) -> None:
+    _write_fixture(tmp_path, "VIX", [
+        {"trade_date": date(2026, 5, 14), "open": 17.5, "high": 18.0,
+         "low": 17.2, "close": 17.8, "adj_close": 17.8, "volume": 0},
+        {"trade_date": date(2026, 5, 15), "open": 18.07, "high": 19.27,
+         "low": 17.8, "close": 18.43, "adj_close": 18.43, "volume": 0},
+    ])
+    rows = read_vol_index_parquet(tmp_path, "VIX")
+    assert len(rows) == 2
+    assert rows[0]["symbol"] == "VIX"
+    assert rows[0]["trade_date"] == date(2026, 5, 14)
+    assert rows[1]["close"] == pytest.approx(18.43)
+
+
+def test_read_vol_index_parquet_since(tmp_path: Path) -> None:
+    _write_fixture(tmp_path, "VIX", [
+        {"trade_date": date(2026, 5, 1), "open": 1, "high": 1, "low": 1,
+         "close": 1, "adj_close": 1, "volume": 0},
+        {"trade_date": date(2026, 5, 15), "open": 2, "high": 2, "low": 2,
+         "close": 2, "adj_close": 2, "volume": 0},
+    ])
+    rows = read_vol_index_parquet(tmp_path, "VIX", since=date(2026, 5, 10))
+    assert len(rows) == 1
+    assert rows[0]["trade_date"] == date(2026, 5, 15)
+
+
+def test_list_vol_index_symbols(tmp_path: Path) -> None:
+    for sym in ["VIX", "VVIX", "SPX"]:
+        (tmp_path / f"symbol={sym}").mkdir(parents=True)
+        (tmp_path / f"symbol={sym}" / "1d.parquet").touch()
+    syms = list_vol_index_symbols(tmp_path)
+    assert set(syms) == {"VIX", "VVIX", "SPX"}
+
+
+def test_read_missing_symbol_returns_empty(tmp_path: Path) -> None:
+    assert read_vol_index_parquet(tmp_path, "NONEXISTENT") == []
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/unit/test_lake_reader.py -v`
+Expected: ImportError (module doesn't exist).
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/uw_scan/sources/lake.py
+"""Parquet reader for ~/market-warehouse/data-lake.
+
+Used by the nightly vol_index_lake_sync job. No business logic — pure I/O.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+VOL_INDEX_FILENAME = "1d.parquet"
+
+
+def list_vol_index_symbols(root: Path) -> list[str]:
+    """Return all symbols under root/symbol=<TICKER>/1d.parquet."""
+    if not root.exists():
+        return []
+    out: list[str] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        name = child.name
+        if not name.startswith("symbol="):
+            continue
+        if not (child / VOL_INDEX_FILENAME).exists():
+            continue
+        out.append(name[len("symbol=") :])
+    return sorted(out)
+
+
+def read_vol_index_parquet(
+    root: Path,
+    symbol: str,
+    *,
+    since: date | None = None,
+) -> list[dict]:
+    """Read symbol=<S>/1d.parquet → list[dict] with normalized columns.
+
+    Output dicts contain: symbol, trade_date, open, high, low, close,
+    adj_close, volume. Rows are sorted by trade_date ascending.
+    """
+    path = root / f"symbol={symbol}" / VOL_INDEX_FILENAME
+    if not path.exists():
+        return []
+    table = pq.read_table(path)
+    df = table.to_pandas()
+    if "trade_date" not in df.columns:
+        return []
+    if since is not None:
+        df = df[df["trade_date"] >= since]
+    df = df.sort_values("trade_date")
+    rows: list[dict] = []
+    for r in df.itertuples(index=False):
+        rd = r._asdict()
+        rows.append(
+            {
+                "symbol": symbol,
+                "trade_date": rd["trade_date"],
+                "open": _maybe_float(rd.get("open")),
+                "high": _maybe_float(rd.get("high")),
+                "low": _maybe_float(rd.get("low")),
+                "close": _maybe_float(rd.get("close")),
+                "adj_close": _maybe_float(rd.get("adj_close")),
+                "volume": int(rd["volume"]) if rd.get("volume") is not None else None,
+            }
+        )
+    return rows
+
+
+def _maybe_float(x) -> float | None:
+    if x is None:
+        return None
+    try:
+        f = float(x)
+    except (TypeError, ValueError):
+        return None
+    return f
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `uv run pytest tests/unit/test_lake_reader.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/sources/lake.py tests/unit/test_lake_reader.py
+git commit -m "feat(sources): parquet lake reader for vol_index_daily sync"
+```
+
+---
+
+### Task A5: vol_index_repository
+
+**Files:**
+- Create: `src/uw_scan/storage/vol_index_repository.py`
+- Test: `tests/integration/storage/test_vol_index_repository.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/storage/test_vol_index_repository.py
+from datetime import date
+
+import pytest
+
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def test_upsert_inserts_then_updates(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07, "high": 19.27, "low": 17.8, "close": 18.43,
+                "adj_close": 18.43, "volume": 0,
+            }
+        ]
+    )
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07, "high": 19.50, "low": 17.8, "close": 18.50,
+                "adj_close": 18.50, "volume": 0,
+            }
+        ]
+    )
+    rows = repo.fetch_history("VIX", days=5)
+    assert len(rows) == 1
+    assert rows[0]["close"] == pytest.approx(18.50)
+    assert rows[0]["high"] == pytest.approx(19.50)
+
+
+def test_fetch_history_window(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn, schema=seeded_db_empty_cards._schema,
+    )
+    rows = [
+        {"symbol": "VIX", "trade_date": date(2026, 5, d), "open": d, "high": d,
+         "low": d, "close": d, "adj_close": d, "volume": 0}
+        for d in range(1, 16)
+    ]
+    repo.upsert_rows(rows)
+    out = repo.fetch_history("VIX", days=7)
+    assert len(out) == 7
+    # Sorted ascending by trade_date
+    assert out[0]["trade_date"] < out[-1]["trade_date"]
+
+
+def test_fetch_history_for_missing_symbol(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn, schema=seeded_db_empty_cards._schema,
+    )
+    assert repo.fetch_history("DOESNOTEXIST", days=30) == []
+```
+
+> **Note:** Integration tests require `UW_SCAN_TEST_DB_NAME` env var. Set it before running pytest (the existing conftest fails loudly without it).
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/integration/storage/test_vol_index_repository.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/uw_scan/storage/vol_index_repository.py
+"""Persistence for CBOE vol-complex and SPX daily OHLC sourced from the lake.
+
+New domain — kept in its own file rather than extending the 5,000-line
+repository.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import date
+
+from psycopg import Connection
+
+
+class VolIndexRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def upsert_rows(self, rows: Iterable[dict]) -> int:
+        """Insert or update vol_index_daily rows. Returns count."""
+        rows = list(rows)
+        if not rows:
+            return 0
+        sql = """
+            INSERT INTO vol_index_daily
+                (symbol, trade_date, open, high, low, close, adj_close, volume)
+            VALUES
+                (%(symbol)s, %(trade_date)s, %(open)s, %(high)s, %(low)s,
+                 %(close)s, %(adj_close)s, %(volume)s)
+            ON CONFLICT (symbol, trade_date) DO UPDATE SET
+                open      = EXCLUDED.open,
+                high      = EXCLUDED.high,
+                low       = EXCLUDED.low,
+                close     = EXCLUDED.close,
+                adj_close = EXCLUDED.adj_close,
+                volume    = EXCLUDED.volume
+        """
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, rows)
+        self._conn.commit()
+        return len(rows)
+
+    def fetch_history(self, symbol: str, days: int) -> list[dict]:
+        """Return up to `days` most-recent rows for symbol, ascending."""
+        sql = """
+            SELECT symbol, trade_date,
+                   open::float8, high::float8, low::float8,
+                   close::float8, adj_close::float8, volume
+              FROM vol_index_daily
+             WHERE symbol = %s
+             ORDER BY trade_date DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbol, days))
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        return rows
+
+    def latest_date_for(self, symbol: str) -> date | None:
+        """Return latest trade_date stored, or None."""
+        sql = "SELECT MAX(trade_date) FROM vol_index_daily WHERE symbol = %s"
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbol,))
+            row = cur.fetchone()
+        return row[0] if row and row[0] else None
+
+    def fetch_multi_history(
+        self, symbols: Sequence[str], days: int
+    ) -> dict[str, list[dict]]:
+        """Bulk variant — returns symbol → rows."""
+        if not symbols:
+            return {}
+        sql = """
+            SELECT symbol, trade_date, close::float8
+              FROM vol_index_daily
+             WHERE symbol = ANY(%s)
+               AND trade_date >= (CURRENT_DATE - %s::int)
+             ORDER BY symbol, trade_date
+        """
+        out: dict[str, list[dict]] = {s: [] for s in symbols}
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (list(symbols), days))
+            for sym, td, close in cur.fetchall():
+                out[sym].append({"trade_date": td, "close": close})
+        return out
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `uv run pytest tests/integration/storage/test_vol_index_repository.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/vol_index_repository.py \
+        tests/integration/storage/test_vol_index_repository.py
+git commit -m "feat(storage): VolIndexRepository — upsert + history reads"
+```
+
+---
+
+### Task A6: Nightly sync job
+
+**Files:**
+- Create: `src/uw_scan/worker/jobs/vol_index_lake_sync.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Test: `tests/integration/test_vol_index_lake_sync.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/test_vol_index_lake_sync.py
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+
+
+def _seed(root: Path, symbol: str, rows: list[dict]) -> None:
+    d = root / f"symbol={symbol}"
+    d.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), d / "1d.parquet")
+
+
+def test_run_sync_inserts_all_symbols(
+    tmp_path: Path, seeded_db_empty_cards
+) -> None:
+    pg_conn = seeded_db_empty_cards.conn
+    _seed(tmp_path, "VIX", [
+        {"trade_date": date(2026, 5, 14), "open": 17.5, "high": 18.0,
+         "low": 17.2, "close": 17.8, "adj_close": 17.8, "volume": 0},
+    ])
+    _seed(tmp_path, "SPX", [
+        {"trade_date": date(2026, 5, 14), "open": 7400, "high": 7450,
+         "low": 7390, "close": 7430, "adj_close": 7430, "volume": 0},
+    ])
+    summary = run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    assert summary["symbols"] == 2
+    assert summary["rows"] == 2
+    repo = VolIndexRepository(pg_conn, schema="uw_scan")
+    assert len(repo.fetch_history("VIX", days=5)) == 1
+    assert len(repo.fetch_history("SPX", days=5)) == 1
+
+
+def test_run_sync_incremental_refreshes_tail(
+    tmp_path: Path, seeded_db_empty_cards
+) -> None:
+    """Incremental mode: re-upsert the latest row (in case its close changed
+    intra-session) AND pull any strictly newer rows.
+
+    Two-row return is the desired behavior — re-upsert is idempotent."""
+    pg_conn = seeded_db_empty_cards.conn
+    _seed(tmp_path, "VIX", [
+        {"trade_date": date(2026, 5, 14), "open": 17.5, "high": 18.0,
+         "low": 17.2, "close": 17.8, "adj_close": 17.8, "volume": 0},
+    ])
+    run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    # Append a newer row plus same-day refresh
+    _seed(tmp_path, "VIX", [
+        {"trade_date": date(2026, 5, 14), "open": 17.5, "high": 18.0,
+         "low": 17.2, "close": 17.9, "adj_close": 17.9, "volume": 0},
+        {"trade_date": date(2026, 5, 15), "open": 18.07, "high": 19.27,
+         "low": 17.8, "close": 18.43, "adj_close": 18.43, "volume": 0},
+    ])
+    summary = run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    assert summary["rows"] == 2  # latest re-upsert + new row
+    repo = VolIndexRepository(pg_conn, schema="uw_scan")
+    rows = repo.fetch_history("VIX", days=5)
+    assert len(rows) == 2
+    # Refreshed close took effect
+    assert rows[0]["close"] == pytest.approx(17.9)
+
+
+def test_run_sync_empty_root_is_noop(
+    tmp_path: Path, seeded_db_empty_cards
+) -> None:
+    summary = run_vol_index_lake_sync(
+        seeded_db_empty_cards.conn, root=tmp_path,
+    )
+    assert summary == {"symbols": 0, "rows": 0}
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/integration/test_vol_index_lake_sync.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Implement job**
+
+```python
+# src/uw_scan/worker/jobs/vol_index_lake_sync.py
+"""Nightly: parquet lake → uw_scan.vol_index_daily.
+
+Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
+the next read. First run backfills the entire history.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from pathlib import Path
+
+from psycopg import Connection
+
+from uw_scan.sources.lake import (
+    list_vol_index_symbols,
+    read_vol_index_parquet,
+)
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+logger = logging.getLogger(__name__)
+
+
+def run_vol_index_lake_sync(
+    conn: Connection, *, root: Path
+) -> dict:
+    """Sync all symbols under root into uw_scan.vol_index_daily.
+
+    Returns a summary dict: {symbols: int, rows: int}.
+    """
+    symbols = list_vol_index_symbols(root)
+    if not symbols:
+        logger.info("vol_index_lake_sync: no symbols at %s", root)
+        return {"symbols": 0, "rows": 0}
+
+    repo = VolIndexRepository(conn, schema="uw_scan")
+    total = 0
+    for symbol in symbols:
+        latest = repo.latest_date_for(symbol)
+        # Read from one day before latest (so we re-upsert the most recent
+        # row in case it was a same-day snapshot that closed differently).
+        since = (latest - timedelta(days=1)) if latest else None
+        rows = read_vol_index_parquet(root, symbol, since=since)
+        if rows:
+            n = repo.upsert_rows(rows)
+            total += n
+            logger.info(
+                "vol_index_lake_sync: %s — %d rows since %s", symbol, n, since
+            )
+    return {"symbols": len(symbols), "rows": total}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `uv run pytest tests/integration/test_vol_index_lake_sync.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Register in scheduler**
+
+In `src/uw_scan/worker/scheduler.py`, find the section where other cron jobs are registered. Add (near other nightly jobs):
+
+```python
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+
+def _vol_index_sync_tick() -> None:
+    settings = get_settings()
+    with _conn_factory() as conn:
+        run_vol_index_lake_sync(conn, root=settings.lake_vol_index_root)
+
+scheduler.add_job(
+    _vol_index_sync_tick,
+    trigger=CronTrigger(hour=3, minute=15, timezone="America/New_York"),
+    id="vol_index_lake_sync",
+    name="vol_index_lake_sync",
+    replace_existing=True,
+    max_instances=1,
+    coalesce=True,
+)
+```
+
+Adjust to match existing patterns in `scheduler.py` — use the same `_conn_factory()` / `get_settings()` helpers as adjacent jobs. If `CronTrigger` isn't already imported, add `from apscheduler.triggers.cron import CronTrigger`.
+
+- [ ] **Step 6: Verify scheduler still imports cleanly**
+
+Run: `uv run python -c "from uw_scan.worker.scheduler import build_scheduler; build_scheduler()"`
+Expected: no traceback.
+
+- [ ] **Step 7: One-time backfill (manual smoke)**
+
+```bash
+uv run python -c "
+from pathlib import Path
+from uw_scan.api.deps import _conn
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+print(run_vol_index_lake_sync(_conn(), root=Path.home() / 'market-warehouse/data-lake/bronze/asset_class=volatility'))
+"
+```
+
+Expected output approximately: `{'symbols': 14, 'rows': ~60000}` on first run (full backfill). Re-run = `~14` rows (just yesterday).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/uw_scan/worker/jobs/vol_index_lake_sync.py \
+        src/uw_scan/worker/scheduler.py \
+        tests/integration/test_vol_index_lake_sync.py
+git commit -m "feat(worker): nightly vol_index_daily sync from parquet lake"
+```
+
+---
+
+## Phase B: GEX History Wiring
+
+### Task B1: Migration 039 — greek_exposure_daily
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/039_greek_exposure_daily.sql`
+
+- [ ] **Step 1: Write migration**
+
+```sql
+-- 039_greek_exposure_daily.sql
+--
+-- Daily history of UW's /greek-exposure for each watchlist ticker. The endpoint
+-- returns ~250 trailing daily rows in every call; we persist the tail so the
+-- regime page can render a 90-day history chart without re-fetching.
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+-- Columns mirror UW's /greek-exposure (history) payload exactly:
+--   date, call_gex, put_gex, call_delta, put_delta
+-- Computed convenience columns: net_gex, net_dex.
+--
+-- NOT stored here (UW doesn't return them in this payload):
+--   - gex_flip (per-day): computed from per-strike GEX; we only have
+--     today's via /greek-exposure/strike. Historical flip values come
+--     from gex_snapshots over time (forward-only).
+--   - price/spot: comes from daily_ohlc (ETFs) or vol_index_daily (SPX).
+CREATE TABLE IF NOT EXISTS uw_scan.greek_exposure_daily (
+    ticker         TEXT NOT NULL,
+    trade_date     DATE NOT NULL,
+    call_gex       NUMERIC(20,4),
+    put_gex        NUMERIC(20,4),
+    call_delta     NUMERIC(20,4),
+    put_delta      NUMERIC(20,4),
+    net_gex        NUMERIC(20,4) GENERATED ALWAYS AS (call_gex + put_gex) STORED,
+    net_dex        NUMERIC(20,4) GENERATED ALWAYS AS (call_delta + put_delta) STORED,
+    payload        JSONB,           -- raw row, for forward compatibility
+    PRIMARY KEY (ticker, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS ix_greek_exposure_daily_ticker_date
+    ON uw_scan.greek_exposure_daily (ticker, trade_date DESC);
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply**
+
+Run: `bash scripts/migrate.sh`
+Expected: 039 applied; re-running = no-op.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/039_greek_exposure_daily.sql
+git commit -m "feat(db): greek_exposure_daily — UW per-day GEX history"
+```
+
+---
+
+### Task B1.5: Extract shared parser util (`cards/greek_exposure_history.py`)
+
+**Why:** `fetch_aggregate_gex` currently lives inline at `scanners/gex.py:290-310`, parsing the UW `/greek-exposure` history payload into typed rows. The scanner uses it for `net_dex` computation; persistence will use it for daily history. Per user requirement, the **parse logic is shared, the fetcher stays distinct**.
+
+**Files:**
+- Create: `src/uw_scan/cards/greek_exposure_history.py`
+- Modify: `src/uw_scan/scanners/gex.py` — replace the inline `fetch_aggregate_gex` body with a call to the new util
+- Test: `tests/unit/test_greek_exposure_history_parser.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_greek_exposure_history_parser.py
+"""Pure parser tests — no DB, no network."""
+
+from datetime import date
+
+import pytest
+
+from uw_scan.cards.greek_exposure_history import (
+    parse_greek_exposure_history,
+)
+
+
+def test_parses_well_formed_payload() -> None:
+    body = {
+        "data": [
+            {"date": "2026-05-14", "call_gex": "1000000000",
+             "put_gex": "-500000000", "call_delta": "10000000",
+             "put_delta": "-5000000"},
+            {"date": "2026-05-15", "call_gex": "1100000000",
+             "put_gex": "-550000000", "call_delta": "11000000",
+             "put_delta": "-5500000"},
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 2
+    assert rows[0]["date"] == date(2026, 5, 14)
+    assert rows[0]["call_gex"] == pytest.approx(1e9)
+    assert rows[0]["net_gex"] == pytest.approx(5e8)   # 1e9 + -5e8
+    assert rows[0]["net_dex"] == pytest.approx(5e6)   # 1e7 + -5e6
+
+
+def test_skips_malformed_rows() -> None:
+    body = {
+        "data": [
+            {"date": "2026-05-14", "call_gex": "ok-string-not-number",
+             "put_gex": "0", "call_delta": "0", "put_delta": "0"},
+            {"date": "2026-05-15", "call_gex": "1", "put_gex": "1",
+             "call_delta": "1", "put_delta": "1"},
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 1
+    assert rows[0]["date"] == date(2026, 5, 15)
+
+
+def test_handles_empty_or_missing_data() -> None:
+    assert parse_greek_exposure_history({}) == []
+    assert parse_greek_exposure_history({"data": None}) == []
+    assert parse_greek_exposure_history({"data": []}) == []
+
+
+def test_accepts_iso_date_strings_or_date_objects() -> None:
+    body = {"data": [
+        {"date": "2026-05-15", "call_gex": "1", "put_gex": "1",
+         "call_delta": "1", "put_delta": "1"},
+        {"date": date(2026, 5, 16), "call_gex": "1", "put_gex": "1",
+         "call_delta": "1", "put_delta": "1"},
+    ]}
+    rows = parse_greek_exposure_history(body)
+    assert rows[0]["date"] == date(2026, 5, 15)
+    assert rows[1]["date"] == date(2026, 5, 16)
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+```bash
+UW_SCAN_TEST_DB_NAME=skip uv run pytest tests/unit/test_greek_exposure_history_parser.py -v
+```
+
+Expected: ImportError.
+
+- [ ] **Step 3: Implement util**
+
+```python
+# src/uw_scan/cards/greek_exposure_history.py
+"""Pure parser for UW /greek-exposure (history aggregate) payload.
+
+Used by:
+- ``scanners/gex.py``   — to compute net_dex from the daily tail.
+- ``scanners/gex.py``   — to feed ``greek_exposure_daily`` for the regime
+                          history chart (via GreekExposureDailyRepository).
+
+No DB, no network. Pure dict → list[dict] transformation.
+
+Note: UW returns ``call_gex / put_gex / call_delta / put_delta`` per day
+(aggregated across all strikes). It does NOT return historical gex_flip
+or historical price — those have to come from other sources (our own
+``gex_snapshots`` for flip, ``daily_ohlc`` / ``vol_index_daily`` for spot).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+
+def parse_greek_exposure_history(body: dict | None) -> list[dict]:
+    """Body envelope → list of typed daily rows.
+
+    Each output row carries:
+        date, call_gex, put_gex, call_delta, put_delta,
+        net_gex (call_gex + put_gex), net_dex (call_delta + put_delta).
+
+    Malformed individual rows are dropped (logged downstream by caller),
+    not raised — partial data is more useful than nothing for a history chart.
+    """
+    if not body or not isinstance(body, dict):
+        return []
+    raw = body.get("data") or []
+    if not isinstance(raw, list):
+        return []
+
+    out: list[dict] = []
+    for r in raw:
+        try:
+            d = _coerce_date(r.get("date"))
+            if d is None:
+                continue
+            call_gex = float(r.get("call_gex", 0) or 0)
+            put_gex = float(r.get("put_gex", 0) or 0)
+            call_delta = float(r.get("call_delta", 0) or 0)
+            put_delta = float(r.get("put_delta", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        out.append(
+            {
+                "date": d,
+                "call_gex": call_gex,
+                "put_gex": put_gex,
+                "call_delta": call_delta,
+                "put_delta": put_delta,
+                "net_gex": call_gex + put_gex,
+                "net_dex": call_delta + put_delta,
+            }
+        )
+    out.sort(key=lambda r: r["date"])
+    return out
+
+
+def _coerce_date(v: Any) -> date | None:
+    if isinstance(v, date):
+        return v
+    if isinstance(v, str):
+        try:
+            return date.fromisoformat(v)
+        except ValueError:
+            return None
+    return None
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `UW_SCAN_TEST_DB_NAME=skip uv run pytest tests/unit/test_greek_exposure_history_parser.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Refactor scanner to use the util**
+
+In `src/uw_scan/scanners/gex.py`, find `fetch_aggregate_gex` (around line 290) and replace its body. The function is still the scanner's entry point for the parsed history, but it now delegates:
+
+```python
+def fetch_aggregate_gex(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> list[dict[str, Any]]:
+    """Aggregate GEX time series (used for net_dex calculation + history persistence)."""
+    from uw_scan.cards.greek_exposure_history import parse_greek_exposure_history
+    body = uw_source.fetch_greek_exposure_history(client, repo, run_id, ticker)
+    return parse_greek_exposure_history(body)
+```
+
+- [ ] **Step 6: Run all scanner tests**
+
+Run: `uv run pytest tests/integration/test_gex_scanner.py -v`
+Expected: all pass (no behavior change — util produces a superset of the old shape, with additional `net_gex` / `net_dex` keys callers can ignore).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/cards/greek_exposure_history.py \
+        src/uw_scan/scanners/gex.py \
+        tests/unit/test_greek_exposure_history_parser.py
+git commit -m "refactor(cards): extract greek_exposure_history parser as shared util"
+```
+
+---
+
+### Task B2: greek_exposure_repository
+
+**Files:**
+- Create: `src/uw_scan/storage/greek_exposure_repository.py`
+- Test: `tests/integration/storage/test_greek_exposure_repository.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/storage/test_greek_exposure_repository.py
+from datetime import date
+
+import pytest
+
+from uw_scan.storage.greek_exposure_repository import (
+    GreekExposureDailyRepository,
+)
+
+
+def test_upsert_then_fetch(seeded_db_empty_cards) -> None:
+    repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows(
+        "SPY",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "call_gex": 2.1e9, "put_gex": -0.9e9,
+                "call_delta": 7.0e7, "put_delta": -1.5e7,
+                "payload": {"raw": "ok"},
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "call_gex": 2.0e9, "put_gex": -1.0e9,
+                "call_delta": 6.5e7, "put_delta": -1.5e7,
+                "payload": {"raw": "ok"},
+            },
+        ],
+    )
+    rows = repo.fetch_history("SPY", days=10)
+    assert len(rows) == 2
+    # net_gex is a generated column = call_gex + put_gex
+    assert rows[-1]["net_gex"] == pytest.approx(1.0e9)
+    assert rows[-1]["net_dex"] == pytest.approx(5.0e7)
+
+
+def test_upsert_overwrites_on_conflict(seeded_db_empty_cards) -> None:
+    repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    base = {
+        "trade_date": date(2026, 5, 15),
+        "call_gex": 1.0, "put_gex": -1.0,
+        "call_delta": 1.0, "put_delta": -1.0,
+        "payload": {},
+    }
+    repo.upsert_rows("SPY", [base])
+    repo.upsert_rows("SPY", [{**base, "call_gex": 99.0}])
+    rows = repo.fetch_history("SPY", days=2)
+    assert rows[0]["call_gex"] == pytest.approx(99.0)
+    # Generated net_gex reflects the new call_gex
+    assert rows[0]["net_gex"] == pytest.approx(98.0)
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/integration/storage/test_greek_exposure_repository.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/uw_scan/storage/greek_exposure_repository.py
+"""Persistence for UW /greek-exposure daily history. New domain — own file."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from psycopg import Connection
+from psycopg.types.json import Jsonb
+
+
+class GreekExposureDailyRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def upsert_rows(self, ticker: str, rows: Iterable[dict]) -> int:
+        rows = list(rows)
+        if not rows:
+            return 0
+        params = [
+            {
+                "ticker": ticker,
+                "trade_date": r["trade_date"],
+                "call_gex": r.get("call_gex"),
+                "put_gex": r.get("put_gex"),
+                "call_delta": r.get("call_delta"),
+                "put_delta": r.get("put_delta"),
+                "payload": Jsonb(r.get("payload") or {}),
+            }
+            for r in rows
+        ]
+        sql = """
+            INSERT INTO greek_exposure_daily
+                (ticker, trade_date, call_gex, put_gex,
+                 call_delta, put_delta, payload)
+            VALUES
+                (%(ticker)s, %(trade_date)s, %(call_gex)s, %(put_gex)s,
+                 %(call_delta)s, %(put_delta)s, %(payload)s)
+            ON CONFLICT (ticker, trade_date) DO UPDATE SET
+                call_gex   = EXCLUDED.call_gex,
+                put_gex    = EXCLUDED.put_gex,
+                call_delta = EXCLUDED.call_delta,
+                put_delta  = EXCLUDED.put_delta,
+                payload    = EXCLUDED.payload
+        """
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, params)
+        self._conn.commit()
+        return len(params)
+
+    def fetch_history(self, ticker: str, days: int) -> list[dict]:
+        """Return up to `days` most-recent rows, ascending by trade_date."""
+        sql = """
+            SELECT ticker, trade_date,
+                   call_gex::float8,   put_gex::float8,
+                   call_delta::float8, put_delta::float8,
+                   net_gex::float8,    net_dex::float8
+              FROM greek_exposure_daily
+             WHERE ticker = %s
+             ORDER BY trade_date DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (ticker, days))
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        return rows
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `uv run pytest tests/integration/storage/test_greek_exposure_repository.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/greek_exposure_repository.py \
+        tests/integration/storage/test_greek_exposure_repository.py
+git commit -m "feat(storage): GreekExposureDailyRepository"
+```
+
+---
+
+### Task B3: Scanner persists /greek-exposure tail
+
+The shared parser is already in place (Task B1.5). Now the scanner calls it once for `net_dex` (existing path) AND feeds the parsed rows to `GreekExposureDailyRepository`.
+
+**Files:**
+- Modify: `src/uw_scan/scanners/gex.py`
+- Test: `tests/integration/test_gex_scanner.py` (extend existing)
+
+- [ ] **Step 1: Locate insertion point**
+
+Read `src/uw_scan/scanners/gex.py` and find where `fetch_aggregate_gex` is called inside `run()` (the call point that consumes daily history for `net_dex`). Persistence will happen right after that call — we already have the parsed list at no extra cost.
+
+- [ ] **Step 2: Write the failing test (extend existing scanner test file)**
+
+Append to `tests/integration/test_gex_scanner.py`:
+
+```python
+def test_run_persists_greek_exposure_daily_tail(
+    seeded_db_empty_cards: Repository,
+    mock_client: UwClient,
+    monkeypatch,
+) -> None:
+    """After a scan, the /greek-exposure history rows land in
+    uw_scan.greek_exposure_daily — via the shared parser util.
+
+    Uses the same `mock_client` + `seeded_db_empty_cards` fixtures as the
+    other scanner tests in this file (see test_run_uses_stock_state_*
+    above for the established pattern)."""
+    from datetime import date
+
+    from uw_scan.storage.greek_exposure_repository import (
+        GreekExposureDailyRepository,
+    )
+
+    _stub_minimal_chain(monkeypatch)  # existing helper (line 127)
+    monkeypatch.setattr(
+        gex_scanner, "fetch_stock_state_snapshot",
+        lambda c, r, rid, t: None,
+    )
+
+    # Override fetch_aggregate_gex (whose body now delegates to the shared
+    # parser util — see Task B1.5) to return rows the scanner will both use
+    # for net_dex AND persist into greek_exposure_daily.
+    fake_rows = [
+        {"date": date(2026, 5, 13), "call_gex": 2e9, "put_gex": -1e9,
+         "call_delta": 1e7, "put_delta": -1e6,
+         "net_gex": 1e9, "net_dex": 9e6},
+        {"date": date(2026, 5, 14), "call_gex": 2.1e9, "put_gex": -1.0e9,
+         "call_delta": 1.1e7, "put_delta": -1.1e6,
+         "net_gex": 1.1e9, "net_dex": 9.9e6},
+        {"date": date(2026, 5, 15), "call_gex": 1.9e9, "put_gex": -1.0e9,
+         "call_delta": 0.9e7, "put_delta": -0.9e6,
+         "net_gex": 0.9e9, "net_dex": 8.1e6},
+    ]
+    monkeypatch.setattr(
+        gex_scanner, "fetch_aggregate_gex",
+        lambda c, r, rid, t: fake_rows,
+    )
+
+    gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+
+    daily_repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    rows = daily_repo.fetch_history("SPX", days=10)
+    assert len(rows) == 3
+    assert rows[-1]["call_gex"] == pytest.approx(1.9e9)
+    assert rows[-1]["net_gex"] == pytest.approx(0.9e9)  # generated col
+```
+
+- [ ] **Step 3: Run, verify fails**
+
+```bash
+UW_SCAN_TEST_DB_NAME=uw_scan_test \
+  uv run pytest tests/integration/test_gex_scanner.py::test_run_persists_greek_exposure_daily_tail -v
+```
+Expected: AssertionError (0 rows).
+
+- [ ] **Step 4: Implement in scanner**
+
+In `src/uw_scan/scanners/gex.py`, find where `fetch_aggregate_gex(client, repo, run_id, ticker)` is called inside `run()`. Right after that call, insert:
+
+```python
+# Persist the daily tail for the regime history chart. We already have
+# the parsed rows in `gex_history` (or whatever the local name is from
+# fetch_aggregate_gex above) — no extra UW call. Failures here are
+# non-fatal: the scan's primary outcome is the snapshot row.
+try:
+    from uw_scan.storage.greek_exposure_repository import (
+        GreekExposureDailyRepository,
+    )
+    GreekExposureDailyRepository(
+        repo.conn, schema=repo._schema,
+    ).upsert_rows(
+        ticker,
+        [
+            {
+                "trade_date": h["date"],
+                "call_gex": h["call_gex"],
+                "put_gex": h["put_gex"],
+                "call_delta": h["call_delta"],
+                "put_delta": h["put_delta"],
+                "payload": h,
+            }
+            for h in gex_history
+        ],
+    )
+except Exception as exc:  # noqa: BLE001
+    logger.warning(
+        "greek_exposure_daily upsert failed for %s: %r", ticker, exc
+    )
+```
+
+(Adjust `gex_history` to the local variable name from the existing `fetch_aggregate_gex` call.)
+
+- [ ] **Step 5: Run all GEX scanner tests**
+
+Run: `UW_SCAN_TEST_DB_NAME=uw_scan_test uv run pytest tests/integration/test_gex_scanner.py -v`
+Expected: existing tests + new test all pass.
+
+- [ ] **Step 6: Live smoke**
+
+```bash
+curl -s -X POST 'http://localhost:8400/api/regime/gex/scan?ticker=SPY' | jq .
+uv run python -c "
+import psycopg
+from uw_scan.config import Settings
+from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
+s = Settings.from_env()
+conn = psycopg.connect(s.db_dsn())
+repo = GreekExposureDailyRepository(conn, schema=s.db_schema)
+rows = repo.fetch_history('SPY', days=5)
+print(f'{len(rows)} rows; latest: {rows[-1] if rows else None}')
+"
+```
+
+Expected: ≥1 row for SPY.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/scanners/gex.py tests/integration/test_gex_scanner.py
+git commit -m "feat(gex): persist /greek-exposure daily tail on every scan"
+```
+
+---
+
+### Task B4: Extend GexResponse with history
+
+**Files:**
+- Modify: `src/uw_scan/api/schemas.py`
+- Modify: `src/uw_scan/api/routers/regime.py`
+- Test: `tests/integration/test_regime_history_endpoint.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/test_regime_history_endpoint.py
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from uw_scan.api.server import app
+from uw_scan.storage.greek_exposure_repository import (
+    GreekExposureDailyRepository,
+)
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed_history(repo_obj) -> None:
+    schema = repo_obj._schema
+    conn = repo_obj.conn
+    g = GreekExposureDailyRepository(conn, schema=schema)
+    g.upsert_rows("SPX", [
+        {
+            "trade_date": date(2026, 5, d),
+            "call_gex": 2e9, "put_gex": -1e9,
+            "call_delta": 1e7, "put_delta": -1e6,
+            "payload": {},
+        }
+        for d in range(1, 16)
+    ])
+    v = VolIndexRepository(conn, schema=schema)
+    v.upsert_rows([
+        {"symbol": "SPX", "trade_date": date(2026, 5, d),
+         "open": 7400 + d, "high": 7410 + d, "low": 7390 + d,
+         "close": 7405 + d, "adj_close": 7405 + d, "volume": 0}
+        for d in range(1, 16)
+    ])
+
+
+def test_gex_endpoint_returns_history_for_spx(seeded_db_empty_cards) -> None:
+    _seed_history(seeded_db_empty_cards)
+    client = TestClient(app)
+    res = client.get("/api/regime/gex?ticker=SPX")
+    assert res.status_code == 200
+    body = res.json()
+    assert "history" in body
+    assert isinstance(body["history"], list)
+    assert len(body["history"]) > 0
+    entry = body["history"][-1]
+    for k in ("date", "net_gex", "spot"):
+        assert k in entry
+    # net_gex is non-null (call_gex + put_gex = 1e9 from seed)
+    assert entry["net_gex"] is not None
+    # spot from vol_index_daily for SPX
+    assert entry["spot"] is not None
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/integration/test_regime_history_endpoint.py -v`
+Expected: KeyError or 0-length history.
+
+- [ ] **Step 3: Add schema**
+
+In `src/uw_scan/api/schemas.py`, add (alongside `GexResponse`):
+
+```python
+class RegimeHistoryEntry(BaseModel):
+    date: date
+    net_gex: float | None = None
+    net_dex: float | None = None
+    gex_flip: float | None = None  # NULL pre-deployment; populated from gex_snapshots forward
+    spot: float | None = None      # underlying close that day
+```
+
+> **gex_flip caveat:** UW's `/greek-exposure` history payload does NOT carry a per-day flip strike (only aggregated call_gex/put_gex). Per-day flip comes from our own `gex_snapshots` rows as they accumulate. The frontend should render `gex_flip` as a sparse line (gaps for pre-deployment dates).
+
+Extend `GexResponse`:
+
+```python
+class GexResponse(BaseModel):
+    # ... existing fields ...
+    history: list[RegimeHistoryEntry] = Field(default_factory=list)
+```
+
+Update `EMPTY_GEX_RESPONSE` to include `history=[]`.
+
+- [ ] **Step 4: Add assembler in router**
+
+`Repository.conn` is already a public property (verified — line 586). `_schema` is accessed via the private attribute (matching the project's conftest pattern at line 99). No property additions needed.
+
+In `src/uw_scan/api/routers/regime.py`, factor out a helper above `get_gex`:
+
+```python
+from uw_scan.storage.greek_exposure_repository import (
+    GreekExposureDailyRepository,
+)
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+# Tickers whose spot history we source from the parquet lake (UW's
+# /ohlc/1d is tier-blocked for indices; massive doesn't quote indices).
+_SPOT_FROM_LAKE = {"SPX"}
+
+
+def _assemble_history(repo: Repository, ticker: str, days: int = 90) -> list[dict]:
+    g = GreekExposureDailyRepository(repo.conn, schema=repo._schema)
+    gex_rows = g.fetch_history(ticker, days=days)
+    if not gex_rows:
+        return []
+
+    if ticker in _SPOT_FROM_LAKE:
+        v = VolIndexRepository(repo.conn, schema=repo._schema)
+        spot_rows = v.fetch_history(ticker, days=days)
+        spot_by_date = {r["trade_date"]: r["close"] for r in spot_rows}
+    else:
+        # ETFs: use daily_ohlc.close (massive). repo.fetch_daily_ohlc_history
+        # returns rows ordered ascending by market_date.
+        ohlc = repo.fetch_daily_ohlc_history(ticker=ticker, limit=days)
+        spot_by_date = {r["market_date"]: float(r["close"]) for r in ohlc}
+
+    # gex_snapshots flip migration — sparse, forward-only.
+    flip_by_date = repo.fetch_flip_strike_history(ticker=ticker, limit=days)
+
+    return [
+        {
+            "date": row["trade_date"],
+            "net_gex": row["net_gex"],
+            "net_dex": row["net_dex"],
+            "gex_flip": flip_by_date.get(row["trade_date"]),
+            "spot": spot_by_date.get(row["trade_date"]),
+        }
+        for row in gex_rows
+    ]
+```
+
+> **Note:** `repo.fetch_daily_ohlc_history` and `repo.fetch_flip_strike_history` are not assumed to exist yet — they may or may not. **Before implementing this step**, run:
+>
+> ```bash
+> rg "def fetch_daily_ohlc|def fetch.*flip|def.*gex_snapshots" src/uw_scan/storage/repository.py | head
+> ```
+>
+> If absent, add them as small read methods in `repository.py` (these belong with the existing read API for `daily_ohlc` and `gex_snapshots` — they're not new domains, so the "no extending repository.py" rule doesn't apply). If `daily_ohlc.market_date` isn't the column name, adjust. Either way, the test in Step 2 will catch shape mismatches.
+
+Modify `get_gex`:
+
+```python
+@router.get("/gex", response_model=GexResponse)
+def get_gex(
+    repo: Annotated[Repository, Depends(get_repo)],
+    ticker: str = Query("SPX"),
+) -> GexResponse:
+    t = ticker.upper()
+    raw = repo.fetch_latest_gex(ticker=t)
+    history = _assemble_history(repo, t, days=90)
+    if raw is None:
+        empty = EMPTY_GEX_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        empty.ticker = t
+        empty.history = history
+        return empty
+    raw["market_open"] = _is_market_open_now()
+    raw["history"] = history
+    return GexResponse.model_validate(raw)
+```
+
+- [ ] **Step 5: Run, verify passes**
+
+Run: `uv run pytest tests/integration/test_regime_history_endpoint.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 6: Regen types**
+
+```bash
+cd web && npm run gen:types
+```
+
+Verify `web/lib/types.ts` has `history` array on the `GexResponse` interface.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/api/schemas.py src/uw_scan/api/routers/regime.py \
+        src/uw_scan/storage/repository.py web/lib/types.ts \
+        tests/integration/test_regime_history_endpoint.py
+git commit -m "feat(api): /regime/gex returns 90-day history with SPX spot from lake"
+```
+
+---
+
+### Task B5: Frontend HistoryChart component
+
+**Files:**
+- Create: `web/components/regime/HistoryChart.tsx`
+- Create: `web/tests/unit/historyChart.test.tsx`
+- Modify: `web/components/regime/GexSubTab.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/historyChart.test.tsx
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HistoryChart } from "@/components/regime/HistoryChart";
+
+const sample = [
+  { date: "2026-05-01", net_gex: 1e9, net_dex: 1e8, gex_flip: 7395, spot: 7400 },
+  { date: "2026-05-02", net_gex: 1.1e9, net_dex: 1.1e8, gex_flip: 7398, spot: 7430 },
+  { date: "2026-05-03", net_gex: 0.9e9, net_dex: 0.9e8, gex_flip: 7402, spot: 7408 },
+];
+
+describe("HistoryChart", () => {
+  it("renders an SVG with the right title", () => {
+    render(<HistoryChart history={sample} ticker="SPX" />);
+    expect(screen.getByRole("img", { name: /history/i })).toBeTruthy();
+  });
+
+  it("renders empty state for no history", () => {
+    render(<HistoryChart history={[]} ticker="SPX" />);
+    expect(screen.getByText(/no history/i)).toBeTruthy();
+  });
+
+  it("plots net_gex line and gex_flip line", () => {
+    const { container } = render(
+      <HistoryChart history={sample} ticker="SPX" />,
+    );
+    const paths = container.querySelectorAll("path");
+    // At least one path for net_gex and one for gex_flip migration
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `cd web && npm run test -- historyChart`
+Expected: file not found / import error.
+
+- [ ] **Step 3: Implement component**
+
+```tsx
+// web/components/regime/HistoryChart.tsx
+"use client";
+
+import { linearScale, finiteDomain, pathFromPoints } from "@/lib/svgChart";
+import type { GexHistoryEntry } from "@/lib/regime/useGex";
+
+const WIDTH = 760;
+const HEIGHT = 220;
+const PAD = { top: 12, right: 56, bottom: 28, left: 56 };
+
+export function HistoryChart({
+  history,
+  ticker,
+}: {
+  history: GexHistoryEntry[];
+  ticker: string;
+}) {
+  if (!history.length) {
+    return (
+      <div
+        style={{
+          padding: "24px",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+        }}
+      >
+        No history available
+      </div>
+    );
+  }
+
+  const xScale = linearScale(
+    [0, Math.max(history.length - 1, 1)],
+    [PAD.left, WIDTH - PAD.right],
+  );
+
+  // finiteDomain returns {lo, hi, count} | null — null on <2 finite values
+  const netGexD = finiteDomain(history.map((h) => h.net_gex));
+  const priceD = finiteDomain(
+    history.flatMap((h) => [h.spot, h.gex_flip]),
+  );
+
+  const yGex = netGexD
+    ? linearScale([netGexD.lo, netGexD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+  const yPrice = priceD
+    ? linearScale([priceD.lo, priceD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+
+  const netGexPath =
+    yGex == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.net_gex == null ? null : [xScale(i), yGex(h.net_gex)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  const flipPath =
+    yPrice == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.gex_flip == null ? null : [xScale(i), yPrice(h.gex_flip)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  const spotPath =
+    yPrice == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.spot == null ? null : [xScale(i), yPrice(h.spot)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  return (
+    <svg
+      role="img"
+      aria-label={`${ticker} 90-day GEX history`}
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      style={{ width: "100%", height: HEIGHT, display: "block" }}
+    >
+      <title>{`${ticker} — net GEX, flip migration, spot`}</title>
+
+      {/* zero line for net GEX (only when scale exists and crosses zero) */}
+      {yGex != null && netGexD != null && netGexD.lo <= 0 && netGexD.hi >= 0 && (
+        <line
+          x1={PAD.left}
+          x2={WIDTH - PAD.right}
+          y1={yGex(0)}
+          y2={yGex(0)}
+          stroke="var(--border-dim)"
+          strokeDasharray="2 3"
+        />
+      )}
+
+      {/* net_gex (left axis) */}
+      <path
+        d={netGexPath}
+        fill="none"
+        stroke="var(--accent-bg)"
+        strokeWidth={1.5}
+      />
+
+      {/* gex_flip (right axis) */}
+      <path
+        d={flipPath}
+        fill="none"
+        stroke="var(--accent-warm)"
+        strokeWidth={1.2}
+        strokeDasharray="3 2"
+      />
+
+      {/* spot (right axis) */}
+      <path
+        d={spotPath}
+        fill="none"
+        stroke="var(--text-primary)"
+        strokeWidth={1.2}
+      />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 4: Run, verify passes**
+
+Run: `cd web && npm run test -- historyChart`
+Expected: 3 passed.
+
+- [ ] **Step 5: Mount in GexSubTab**
+
+In `web/components/regime/GexSubTab.tsx`, find the spot below the metrics row (where the gamma profile chart sits) and add `<HistoryChart history={data.history} ticker={data.ticker} />` in an appropriate position (likely below the gamma profile, above the bias panel). Match surrounding section styling — section title, border-top spacing, etc.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Visual smoke (browser)**
+
+If the dev stack is up on `3001`, open `http://localhost:3001/regime?ticker=SPX` and visually confirm:
+- History chart renders with 3 series (net_gex green, gex_flip dashed warm, spot white)
+- For SPX: spot line is non-flat (sourced from lake)
+- For SPY: similar shape, sourced from in-row UW price
+
+If the dev stack is not up, note it and skip — the test passes on data, not pixels.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/components/regime/HistoryChart.tsx \
+        web/components/regime/GexSubTab.tsx \
+        web/tests/unit/historyChart.test.tsx
+git commit -m "feat(regime): 90-day history chart with net_gex / flip / spot"
+```
+
+---
+
+## Phase C: Vol Backdrop Endpoint + UI
+
+### Task C1: /api/regime/vol-backdrop endpoint
+
+**Files:**
+- Modify: `src/uw_scan/api/schemas.py`
+- Modify: `src/uw_scan/api/routers/regime.py`
+- Test: `tests/integration/test_regime_vol_backdrop.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/test_regime_vol_backdrop.py
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from uw_scan.api.server import app
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def test_vol_backdrop_returns_four_series(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    for sym, base in [("VIX", 18), ("VIX3M", 21), ("VVIX", 90), ("COR1M", 11)]:
+        repo.upsert_rows([
+            {"symbol": sym, "trade_date": date(2026, 5, d),
+             "open": base + d * 0.1, "high": base + d * 0.1,
+             "low": base + d * 0.1, "close": base + d * 0.1,
+             "adj_close": base + d * 0.1, "volume": 0}
+            for d in range(1, 16)
+        ])
+
+    client = TestClient(app)
+    res = client.get("/api/regime/vol-backdrop?days=10")
+    assert res.status_code == 200
+    body = res.json()
+    assert set(body["series"].keys()) == {"VIX", "VIX3M", "VVIX", "COR1M"}
+    assert len(body["series"]["VIX"]) <= 10
+    assert body["series"]["VIX"][-1]["close"] > 0
+    assert "term_structure_ratio" in body
+
+
+def test_vol_backdrop_term_structure_ratio(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows([
+        {"symbol": "VIX", "trade_date": date(2026, 5, 15),
+         "open": 20, "high": 20, "low": 20, "close": 20,
+         "adj_close": 20, "volume": 0},
+        {"symbol": "VIX3M", "trade_date": date(2026, 5, 15),
+         "open": 25, "high": 25, "low": 25, "close": 25,
+         "adj_close": 25, "volume": 0},
+    ])
+    client = TestClient(app)
+    res = client.get("/api/regime/vol-backdrop?days=5")
+    body = res.json()
+    # 20 / 25 = 0.80, contango
+    assert body["term_structure_ratio"] == pytest.approx(0.80, rel=1e-2)
+    assert body["term_structure_state"] == "contango"
+```
+
+- [ ] **Step 2: Run, verify fails**
+
+Run: `uv run pytest tests/integration/test_regime_vol_backdrop.py -v`
+Expected: 404.
+
+- [ ] **Step 3: Add schemas**
+
+In `src/uw_scan/api/schemas.py`:
+
+```python
+class VolBackdropPoint(BaseModel):
+    date: date
+    close: float
+
+class VolBackdropResponse(BaseModel):
+    series: dict[str, list[VolBackdropPoint]]
+    term_structure_ratio: float | None = None  # VIX / VIX3M
+    term_structure_state: str | None = None    # "contango" | "backwardation"
+    as_of: date | None = None
+```
+
+- [ ] **Step 4: Add route**
+
+In `src/uw_scan/api/routers/regime.py`:
+
+```python
+from uw_scan.api.schemas import VolBackdropResponse
+
+_VOL_BACKDROP_SYMBOLS = ("VIX", "VIX3M", "VVIX", "COR1M")
+
+@router.get("/vol-backdrop", response_model=VolBackdropResponse)
+def get_vol_backdrop(
+    repo: Annotated[Repository, Depends(get_repo)],
+    days: int = Query(90, ge=5, le=365),
+) -> VolBackdropResponse:
+    v = VolIndexRepository(repo.conn, schema=repo._schema)
+    multi = v.fetch_multi_history(_VOL_BACKDROP_SYMBOLS, days=days)
+
+    series = {
+        sym: [{"date": r["trade_date"], "close": r["close"]} for r in rows]
+        for sym, rows in multi.items()
+    }
+
+    # Term structure: latest VIX / latest VIX3M
+    latest_vix = series["VIX"][-1]["close"] if series.get("VIX") else None
+    latest_vix3m = series["VIX3M"][-1]["close"] if series.get("VIX3M") else None
+    ratio = None
+    state = None
+    as_of = None
+    if latest_vix is not None and latest_vix3m:
+        ratio = latest_vix / latest_vix3m
+        state = "contango" if ratio < 1 else "backwardation"
+        as_of = series["VIX"][-1]["date"]
+
+    return VolBackdropResponse(
+        series=series,
+        term_structure_ratio=ratio,
+        term_structure_state=state,
+        as_of=as_of,
+    )
+```
+
+- [ ] **Step 5: Run, verify passes**
+
+Run: `uv run pytest tests/integration/test_regime_vol_backdrop.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 6: Regen types**
+
+```bash
+cd web && npm run gen:types
+```
+
+Verify `VolBackdropResponse` shows up.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/uw_scan/api/schemas.py src/uw_scan/api/routers/regime.py \
+        web/lib/types.ts tests/integration/test_regime_vol_backdrop.py
+git commit -m "feat(api): /regime/vol-backdrop with VIX term-structure ratio"
+```
+
+---
+
+### Task C2: useVolBackdrop hook
+
+**Files:**
+- Create: `web/lib/regime/useVolBackdrop.ts`
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// web/lib/regime/useVolBackdrop.ts
+"use client";
+
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type VolBackdropPoint = { date: string; close: number };
+
+export type VolBackdropData = {
+  series: Record<"VIX" | "VIX3M" | "VVIX" | "COR1M", VolBackdropPoint[]>;
+  term_structure_ratio: number | null;
+  term_structure_state: "contango" | "backwardation" | null;
+  as_of: string | null;
+};
+
+export function useVolBackdrop(): UseSyncReturn<VolBackdropData> {
+  return useSyncHook<VolBackdropData>(
+    {
+      endpoint: regimeApi.vol_backdrop(),
+      interval: 3_600_000, // 1h — slow data
+      hasPost: false,
+      extractTimestamp: (d) => d.as_of,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "GET",
+    },
+    true,
+  );
+}
+```
+
+Add `vol_backdrop` to `web/lib/regime/api.ts`. The file is an object literal — verified shape:
+
+```typescript
+// web/lib/regime/api.ts (add inside the regimeApi object, alongside gex/gex_scan)
+vol_backdrop: () => `${API}/api/regime/vol-backdrop`,
+```
+
+Note the snake_case naming matches the existing convention (`gex_scan`, `cri_scan`, `vcg_scan`).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/lib/regime/useVolBackdrop.ts web/lib/regime/api.ts
+git commit -m "feat(regime): useVolBackdrop hook + api binding"
+```
+
+---
+
+### Task C3: VolBackdropStrip component
+
+**Files:**
+- Create: `web/components/regime/VolBackdropStrip.tsx`
+- Create: `web/tests/unit/volBackdropStrip.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/volBackdropStrip.test.tsx
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VolBackdropStripView } from "@/components/regime/VolBackdropStrip";
+
+const sample = {
+  series: {
+    VIX: [
+      { date: "2026-05-14", close: 18.1 },
+      { date: "2026-05-15", close: 18.4 },
+    ],
+    VIX3M: [
+      { date: "2026-05-14", close: 21.0 },
+      { date: "2026-05-15", close: 21.4 },
+    ],
+    VVIX: [
+      { date: "2026-05-14", close: 92.1 },
+      { date: "2026-05-15", close: 92.9 },
+    ],
+    COR1M: [
+      { date: "2026-05-14", close: 10.5 },
+      { date: "2026-05-15", close: 10.8 },
+    ],
+  },
+  term_structure_ratio: 0.86,
+  term_structure_state: "contango" as const,
+  as_of: "2026-05-15",
+};
+
+describe("VolBackdropStripView", () => {
+  it("renders all four tiles", () => {
+    render(<VolBackdropStripView data={sample} />);
+    expect(screen.getByText("VIX")).toBeTruthy();
+    expect(screen.getByText("VIX3M")).toBeTruthy();
+    expect(screen.getByText("VVIX")).toBeTruthy();
+    expect(screen.getByText("COR1M")).toBeTruthy();
+  });
+
+  it("shows term-structure state badge", () => {
+    render(<VolBackdropStripView data={sample} />);
+    expect(screen.getByText(/contango/i)).toBeTruthy();
+  });
+
+  it("renders nothing when data is null", () => {
+    const { container } = render(<VolBackdropStripView data={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```tsx
+// web/components/regime/VolBackdropStrip.tsx
+"use client";
+
+import { useVolBackdrop, type VolBackdropData } from "@/lib/regime/useVolBackdrop";
+import { fmtDecimal } from "@/lib/formatters";
+
+const SYMBOLS = ["VIX", "VIX3M", "VVIX", "COR1M"] as const;
+
+const labels: Record<(typeof SYMBOLS)[number], string> = {
+  VIX: "VIX",
+  VIX3M: "VIX3M",
+  VVIX: "VVIX",
+  COR1M: "COR1M",
+};
+
+const tooltips: Record<(typeof SYMBOLS)[number], string> = {
+  VIX: "S&P 500 30-day implied vol",
+  VIX3M: "S&P 500 3-month implied vol",
+  VVIX: "Vol-of-vol (VIX of VIX)",
+  COR1M: "1-month implied correlation among S&P components",
+};
+
+function lastClose(points: { close: number }[] | undefined): number | null {
+  if (!points || !points.length) return null;
+  return points[points.length - 1].close;
+}
+
+function pctChange(points: { close: number }[] | undefined): number | null {
+  if (!points || points.length < 2) return null;
+  const prev = points[points.length - 2].close;
+  const last = points[points.length - 1].close;
+  if (!prev) return null;
+  return ((last - prev) / prev) * 100;
+}
+
+export function VolBackdropStripView({ data }: { data: VolBackdropData | null }) {
+  if (!data) return null;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${SYMBOLS.length + 1}, 1fr)`,
+        gap: 8,
+        padding: "12px 16px",
+        borderTop: "1px solid var(--border-dim)",
+        borderBottom: "1px solid var(--border-dim)",
+        background: "var(--bg-panel)",
+      }}
+    >
+      {SYMBOLS.map((s) => {
+        const close = lastClose(data.series[s]);
+        const chg = pctChange(data.series[s]);
+        return (
+          <div key={s} title={tooltips[s]}>
+            <div
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.15em",
+                color: "var(--text-muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              {labels[s]}
+            </div>
+            <div
+              style={{
+                fontSize: 18,
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {close != null ? fmtDecimal(close, 2) : "—"}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color:
+                  chg == null
+                    ? "var(--text-muted)"
+                    : chg >= 0
+                      ? "var(--positive)"
+                      : "var(--negative)",
+              }}
+            >
+              {chg != null
+                ? `${chg >= 0 ? "+" : ""}${fmtDecimal(chg, 2)}%`
+                : "—"}
+            </div>
+          </div>
+        );
+      })}
+
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.15em",
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+          }}
+        >
+          Term Structure
+        </div>
+        <div
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            fontFamily: "var(--font-mono)",
+            color:
+              data.term_structure_state === "backwardation"
+                ? "var(--warning)"
+                : "var(--text-primary)",
+          }}
+        >
+          {data.term_structure_ratio != null
+            ? fmtDecimal(data.term_structure_ratio, 3)
+            : "—"}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color:
+              data.term_structure_state === "backwardation"
+                ? "var(--warning)"
+                : "var(--text-secondary)",
+          }}
+        >
+          {data.term_structure_state ?? "—"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VolBackdropStrip() {
+  const { data } = useVolBackdrop();
+  return <VolBackdropStripView data={data ?? null} />;
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd web && npm run test -- volBackdropStrip`
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/components/regime/VolBackdropStrip.tsx \
+        web/tests/unit/volBackdropStrip.test.tsx
+git commit -m "feat(regime): vol backdrop strip — VIX/VIX3M/VVIX/COR1M + term structure"
+```
+
+---
+
+### Task C4: Mount VolBackdropStrip on the regime page
+
+Verified: `web/app/regime/page.tsx` exists and renders `<RegimePanel />`. The strip mounts in `page.tsx` above the panel so it stays visible across tab switches.
+
+**Files:**
+- Modify: `web/app/regime/page.tsx`
+
+- [ ] **Step 1: Edit the regime page**
+
+Current content (verified):
+
+```tsx
+import RegimePanel from "@/components/regime/RegimePanel";
+
+export const metadata = { title: "Regime — Unusual Whales", ... };
+
+export default function RegimePage() {
+  return (
+    <main className="regime-page">
+      <header className="regime-page-header">
+        <h1>Regime</h1>
+        <p className="regime-page-subtitle">…</p>
+      </header>
+      <RegimePanel />
+    </main>
+  );
+}
+```
+
+Add `VolBackdropStrip` between the header and `<RegimePanel />`:
+
+```tsx
+import RegimePanel from "@/components/regime/RegimePanel";
+import VolBackdropStrip from "@/components/regime/VolBackdropStrip";
+
+export default function RegimePage() {
+  return (
+    <main className="regime-page">
+      <header className="regime-page-header">
+        <h1>Regime</h1>
+        <p className="regime-page-subtitle">…</p>
+      </header>
+      <VolBackdropStrip />
+      <RegimePanel />
+    </main>
+  );
+}
+```
+
+> **RSC note:** `page.tsx` is a Server Component. `VolBackdropStrip` is `"use client"` (it consumes `useVolBackdrop`), so it imports cleanly into the server page — Next.js handles the boundary.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Browser smoke**
+
+If the dev stack is up, open the regime page and confirm:
+- Four vol tiles render with values from the lake (VIX ~18, VVIX ~93, COR1M ~11)
+- Term structure shows "CONTANGO" at a ratio around 0.86
+- Strip stays mounted across ticker / tab switches
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/app/regime/page.tsx
+git commit -m "feat(regime): mount VolBackdropStrip on regime page"
+```
+
+---
+
+## Phase D: Final Verification
+
+### Task D1: End-to-end smoke
+
+- [ ] **Step 1: Full backend test suite**
+
+Run: `UW_SCAN_TEST_DB_NAME=uw_scan_test uv run pytest`
+Expected: all pass, no new warnings. (Integration tests refuse to run without the env var.)
+
+- [ ] **Step 2: Full frontend test suite**
+
+Run: `cd web && npm run test`
+Expected: all pass.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 4: One-time historical backfill**
+
+```bash
+uv run python -c "
+import psycopg
+from pathlib import Path
+from uw_scan.config import Settings
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+
+s = Settings.from_env()
+conn = psycopg.connect(s.db_dsn())
+print(run_vol_index_lake_sync(conn,
+      root=Path.home() / 'market-warehouse/data-lake/bronze/asset_class=volatility'))
+"
+```
+
+Expected: ~60,000+ rows across ~14 symbols on first run. Re-running produces a near-zero count (just the most-recent rows refreshed).
+
+- [ ] **Step 5: Force a GEX rescan for each watchlist ticker**
+
+```bash
+for t in SPX SPY QQQ IWM; do
+  curl -s -X POST "http://localhost:8400/api/regime/gex/scan?ticker=$t" | jq .
+done
+```
+
+Expected: 4 scans queued; greek_exposure_daily populated.
+
+- [ ] **Step 6: Verify each API surface**
+
+```bash
+curl -s 'http://localhost:8400/api/regime/gex?ticker=SPX' | jq '{has_history: (.history | length > 0), latest: .history[-1]}'
+curl -s 'http://localhost:8400/api/regime/vol-backdrop?days=30' | jq '.series | keys'
+```
+
+Expected:
+- `has_history: true`, latest entry has non-null `spot` and `gex_flip`
+- Keys: `["COR1M", "VIX", "VIX3M", "VVIX"]`
+
+- [ ] **Step 7: Codex tribunal review**
+
+Invoke the `codex-review` skill on the merged change set (uncommitted diff or PR).
+
+- [ ] **Step 8: Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(regime): 90-day history + vol-complex backdrop" \
+  --body "$(cat <<'EOF'
+## Summary
+- Lake-sourced SPX OHLC closes the index-data gap (UW /ohlc/1d is tier-blocked)
+- `vol_index_daily` table + nightly APScheduler sync from `~/market-warehouse/.../volatility/`
+- `greek_exposure_daily` populated on every GEX scan from the existing `/greek-exposure` payload tail (no new UW calls)
+- `/api/regime/gex` extended with a 90-day `history` array (net_gex / gex_flip / spot)
+- New `/api/regime/vol-backdrop` returns VIX / VIX3M / VVIX / COR1M time series plus VIX-term-structure ratio
+- Frontend: HistoryChart inside GexSubTab + VolBackdropStrip mounted on regime page
+
+## Test plan
+- [x] `uv run pytest` — full backend
+- [x] `cd web && npm run test` — full vitest
+- [x] `cd web && npm run typecheck`
+- [x] Visual: regime page renders both new components for SPX/SPY/QQQ/IWM
+- [x] Idempotency: re-running `vol_index_lake_sync` is a no-op
+- [x] Codex tribunal review
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- SPX history gap → Tasks A3 + B4 (lake source wired)
+- GEX 90-day chart → Tasks B1–B5
+- Vol-complex backdrop → Tasks C1–C4
+- "Different API call, shared util" → Task B1.5 extracts the parser; sources/uw.py fetchers stay distinct (history vs per-expiry)
+- Persistence rule (results to Postgres) → all writes go through the new repositories
+
+**Memory compliance:**
+- ✅ No extension of `repository.py` for new persistence domains — `VolIndexRepository` and `GreekExposureDailyRepository` get their own files
+- ✅ Yahoo not touched
+- ✅ No IB dependency added
+- ✅ uv only — all commands use `uv run`
+- ✅ Migrations idempotent (`IF NOT EXISTS`, `ON CONFLICT`)
+
+**Verification artifacts (raise confidence ~70% → ~90%):**
+- ✅ `fetch_greek_exposure_history` exists at `sources/uw.py:210`
+- ✅ `fetch_aggregate_gex` parser exists at `scanners/gex.py:290` (promoting to shared util)
+- ✅ `Repository.conn` already public; `_schema` accessed directly per project convention
+- ✅ `seeded_db_empty_cards` fixture is the integration-test entry point
+- ✅ `finiteDomain` returns object (not tuple); HistoryChart code corrected
+- ✅ `regimeApi` is an object literal with snake_case methods; `vol_backdrop` follows
+- ✅ Regime page is `web/app/regime/page.tsx`; mount happens above `<RegimePanel />`
+- ✅ Lake has 14 symbols, ~60K rows, updated through 2026-05-15
+
+**Remaining unknowns (~8% risk):**
+- `repo.fetch_daily_ohlc_history` / `repo.fetch_flip_strike_history` — Task B4 says "verify first, add if missing". Reads against existing tables (`daily_ohlc`, `gex_snapshots`); not a new domain. If missing, ~10 lines of SQL each.
+- ✅ B3 test fixtures verified: `mock_client` is local to `test_gex_scanner.py:10`; `seeded_db_empty_cards` is in `tests/integration/conftest.py`. Both already in scope for the new test.
+
+**Out of scope (deliberately deferred):**
+- Backfilling `greek_exposure_daily` from historical scans pre-deployment — forward-only persistence. If older history is needed, a one-shot script walking `/greek-exposure` per ticker can fill the gap; the UW endpoint already returns ~250 trailing days per call.
+- A "VIX vs flip" overlay on the `HistoryChart` — interesting but extra wiring.
+- Per-day `gex_flip` historical column — UW doesn't expose it. Frontend renders it sparse, populated forward from our own `gex_snapshots`.
+
+---
+
+## Design Rationale & Data Flow
+
+Captured from the design discussion before execution. Executors should read this section before starting Phase A — it explains *why* the plan is shaped the way it is, which informs how to handle edge cases that the per-task instructions don't anticipate.
+
+### Two parallel pipelines
+
+The plan has two independent data pipelines that only converge inside the React layer. They never share a fetcher, never share a table, never share an API endpoint.
+
+**Pipeline 1 — Parquet lake → `vol_index_daily`**
+
+```
+~/market-warehouse/.../symbol=*/1d.parquet
+    │
+    ▼  (nightly 3:15 AM ET, also one-time backfill on first run)
+sources/lake.py::read_vol_index_parquet
+    │
+    ▼  pure I/O, no math
+worker/jobs/vol_index_lake_sync.py
+    │
+    ▼  upsert with since = latest_in_db - 1 day
+uw_scan.vol_index_daily  (PK: symbol, trade_date)
+    │
+    ▼  read at request time
+/api/regime/vol-backdrop  AND  /api/regime/gex (SPX spot column only)
+    │
+    ▼
+useVolBackdrop / useGex hooks
+    │
+    ▼
+<VolBackdropStrip /> AND <HistoryChart />
+```
+
+**Pipeline 2 — UW `/greek-exposure` → `greek_exposure_daily`**
+
+```
+UW: GET /api/stock/{ticker}/greek-exposure
+    │
+    ▼  fired on every GEX scan (manual /gex/scan, scheduled rescan-poll)
+sources/uw.py::fetch_greek_exposure_history  (audit-first: writes api_request_audit + raw_payloads)
+    │
+    ▼
+cards/greek_exposure_history.py::parse_greek_exposure_history  (pure parser — shared util)
+    │
+    ▼  same parsed rows consumed by TWO callers:
+scanners/gex.py::run                                  GreekExposureDailyRepository.upsert_rows
+    │ (existing net_dex calculation)                   │ (NEW)
+    │                                                  ▼
+    │                                       uw_scan.greek_exposure_daily
+    │                                       (PK: ticker, trade_date; net_gex/net_dex are
+    │                                        GENERATED ALWAYS AS (call_gex + put_gex / call_delta + put_delta))
+    │                                                  │
+    │                                                  ▼
+    │                                       read at request time
+    │                                       /api/regime/gex  (history array)
+    │                                                  │
+    │                                                  ▼
+    │                                       useGex hook → <HistoryChart /> net_gex line
+    ▼
+(existing snapshot insert, unchanged)
+```
+
+### The three places "compute" happens
+
+Math is intentionally tiny in this plan. Three places, no more:
+
+1. **Parser** (`cards/greek_exposure_history.py`): `net_gex = call_gex + put_gex`, `net_dex = call_delta + put_delta`. Lets in-memory consumers skip a DB roundtrip.
+2. **Postgres generated columns** (`greek_exposure_daily.net_gex`, `.net_dex`): same formula, recomputed by the DB. Guarantees parser-result and stored-result can never drift. Insurance against future bypass.
+3. **API assembler** (`routers/regime.py`):
+   - `_assemble_history()` — joins `greek_exposure_daily` × (`vol_index_daily` for SPX | `daily_ohlc` for ETFs) × `gex_snapshots.level_gex_flip_strike` into the response's `history[]`.
+   - `term_structure_ratio = latest_VIX_close / latest_VIX3M_close`, `state = "contango" if ratio < 1 else "backwardation"`.
+
+No model fitting, no rolling windows, no statistical work. Everything heavy was already done by the lake maintainer and by UW.
+
+### Cadence table
+
+| Step | When | Cost | Notes |
+|---|---|---|---|
+| Parquet read | Nightly 3:15 AM ET | ~14 symbols × ~7 row delta = sub-second | First run backfills ~60K rows in ~5 seconds |
+| UW `/greek-exposure` fetch | Every GEX scan | ~250 rows parsed + upserted per scan | Already happens today; we're just persisting the tail |
+| `/api/regime/gex` request | Dashboard load + 60s poll | One indexed read per source table | ~5ms typical |
+| `/api/regime/vol-backdrop` request | Dashboard load + 1h poll | One indexed read per symbol | ~5ms typical |
+
+### Reasoning behind major choices
+
+**Why two pipelines instead of one?** Different upstream owners, different failure modes, different latencies. The lake is maintained by the `market-data-warehouse` peer project; UW is an external API. Coupling them via a unified fetcher means a parquet outage breaks UW persistence and vice versa.
+
+**Why Postgres in the middle instead of reading parquet at request time?** Three reasons: (1) project rule — analytical results to Postgres; (2) parquet is great for batch reads but poor for "last 90 rows for one symbol" — has to read the whole file; (3) the API server already has Postgres connection pooling, adding a filesystem dependency per request is regression.
+
+**Why a generated column for `net_gex` when the parser already computes it?** Guarantees the stored value is always `call_gex + put_gex`, even if a future code path bypasses the parser (manual backfill via SQL, downstream tool that writes directly). Cheap insurance.
+
+**Why mount `VolBackdropStrip` at page level, not inside `RegimePanel`?** Vol regime is a *global* state — VIX doesn't change when you switch tickers or sub-tabs. Mounting once at the top means the data persists across tab switches and the hourly poll only fires once per session.
+
+**Why is the gex_flip column NULL for pre-deployment dates?** UW does not expose historical per-day flip strikes — flip is computed from per-strike GEX, which they only give us for *today*. Our own `gex_snapshots` table captures flip going forward. Accepting this gap honestly beats faking it with interpolation.
+
+### Risks in plain English (top 5)
+
+1. **Nightly job silently skipping.** If the worker is down at 3:15 AM, the sync gets skipped without alarm. Mitigation deferred: add row count to `/health` endpoint as a follow-up. For v1, manual inspection.
+
+2. **Parquet read race.** If the lake maintainer is writing during our sync window, we could see torn data. The lake writes atomically (write-temp-then-rename, standard pattern) so risk is low — but nonzero if the maintainer's tooling changes.
+
+3. **UW payload shape change.** A renamed key (e.g., `call_gex` → `callGex`) would silently produce empty rows. Mitigation: parser's `float(r.get("call_gex"))` raises on type errors, which the loop catches and skips; integration tests assert specific keys exist on returned rows.
+
+4. **Stale SPX history if lake stops updating.** Sync keeps running, but `vol_index_daily` stops gaining new dates. The history chart's spot line goes flat on the right edge. No surface alert. Worth surfacing via the `as_of` field on the response.
+
+5. **Sparse flip line at launch.** `gex_flip` historical values populate forward-only from our scans. For the first few weeks, the flip line will be very thin and users may think it's a bug. Plan calls for graceful empty state; doesn't add explanatory UI copy. Worth a small annotation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "httpx>=0.27,<1.0",
   "pandas>=2.2",
   "playwright>=1.44",
+  "pyarrow>=18.0",
   "pydantic>=2.7",
   "fastapi>=0.117,<1.0",
   "uvicorn[standard]>=0.32,<1.0",

--- a/src/uw_scan/api/endpoints.py
+++ b/src/uw_scan/api/endpoints.py
@@ -34,6 +34,7 @@ class EndpointSlug(StrEnum):
     BULK_SCREENER_STOCKS = "bulk_screener_stocks"
     ETF_INFO = "etf_info"
     OPTIONS_VOLUME_DAILY = "options_volume_daily"
+    STOCK_STATE = "stock_state"
 
 
 @dataclass(frozen=True)
@@ -122,6 +123,11 @@ REGISTRY: dict[EndpointSlug, Endpoint] = {
     EndpointSlug.OPTIONS_VOLUME_DAILY: Endpoint(
         EndpointSlug.OPTIONS_VOLUME_DAILY,
         "/api/stock/{ticker}/options-volume",
+        (),
+    ),
+    EndpointSlug.STOCK_STATE: Endpoint(
+        EndpointSlug.STOCK_STATE,
+        "/api/stock/{ticker}/stock-state",
         (),
     ),
 }

--- a/src/uw_scan/api/endpoints.py
+++ b/src/uw_scan/api/endpoints.py
@@ -20,6 +20,8 @@ class EndpointSlug(StrEnum):
     INTERPOLATED_IV = "interpolated_iv"
     SKEW = "skew"
     GREEK_EXPOSURE = "greek_exposure"
+    GREEK_EXPOSURE_BY_STRIKE = "greek_exposure_by_strike"
+    GREEK_EXPOSURE_HISTORY = "greek_exposure_history"
     SPOT_EXPOSURES = "spot_exposures"
     GREEKS = "greeks"
     OI_PER_STRIKE = "oi_per_strike"
@@ -69,6 +71,16 @@ REGISTRY: dict[EndpointSlug, Endpoint] = {
         EndpointSlug.GREEK_EXPOSURE,
         "/api/stock/{ticker}/greek-exposure/strike-expiry",
         ("expiry",),
+    ),
+    EndpointSlug.GREEK_EXPOSURE_BY_STRIKE: Endpoint(
+        EndpointSlug.GREEK_EXPOSURE_BY_STRIKE,
+        "/api/stock/{ticker}/greek-exposure/strike",
+        (),
+    ),
+    EndpointSlug.GREEK_EXPOSURE_HISTORY: Endpoint(
+        EndpointSlug.GREEK_EXPOSURE_HISTORY,
+        "/api/stock/{ticker}/greek-exposure",
+        (),
     ),
     EndpointSlug.SPOT_EXPOSURES: Endpoint(
         EndpointSlug.SPOT_EXPOSURES,

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -15,6 +15,7 @@ from uw_scan.api.schemas import (
     GexHistoryEntry,
     GexResponse,
     RegimePendingResponse,
+    VolBackdropResponse,
 )
 from uw_scan.config import Settings
 from uw_scan.scanners import gex as gex_scanner
@@ -111,6 +112,42 @@ def trigger_gex_scan(
         "ticker": ticker.upper(),
         "row_id": row_id,
     }
+
+
+# ─── Vol backdrop ────────────────────────────────────────────────
+
+_VOL_BACKDROP_SYMBOLS = ("VIX", "VIX3M", "VVIX", "COR1M")
+
+
+@router.get("/vol-backdrop", response_model=VolBackdropResponse)
+def get_vol_backdrop(
+    repo: Annotated[Repository, Depends(get_repo)],
+    days: int = Query(90, ge=5, le=365),
+) -> VolBackdropResponse:
+    v = VolIndexRepository(repo.conn, schema=repo._schema)
+    multi = v.fetch_multi_history(_VOL_BACKDROP_SYMBOLS, days=days)
+
+    series = {
+        sym: [{"date": r["trade_date"], "close": r["close"]} for r in rows]
+        for sym, rows in multi.items()
+    }
+
+    latest_vix = series["VIX"][-1]["close"] if series.get("VIX") else None
+    latest_vix3m = series["VIX3M"][-1]["close"] if series.get("VIX3M") else None
+    ratio = None
+    state = None
+    as_of = None
+    if latest_vix is not None and latest_vix3m:
+        ratio = latest_vix / latest_vix3m
+        state = "contango" if ratio < 1 else "backwardation"
+        as_of = series["VIX"][-1]["date"]
+
+    return VolBackdropResponse(
+        series=series,
+        term_structure_ratio=ratio,
+        term_structure_state=state,
+        as_of=as_of,
+    )
 
 
 # ─── CRI (pending) ───────────────────────────────────────────────

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -12,14 +12,21 @@ from uw_scan.api.client import UwClient
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.schemas import (
     EMPTY_GEX_RESPONSE,
+    GexHistoryEntry,
     GexResponse,
     RegimePendingResponse,
 )
 from uw_scan.config import Settings
 from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
 from uw_scan.storage.repository import Repository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 router = APIRouter(prefix="/regime")
+
+# Tickers whose spot history is sourced from the parquet lake. UW
+# /ohlc/1d is tier-blocked for indices; massive doesn't quote indices.
+_SPOT_FROM_LAKE = {"SPX"}
 
 
 def _is_market_open_now() -> bool:
@@ -31,6 +38,35 @@ def _is_market_open_now() -> bool:
     return 9 * 60 + 30 <= minutes <= 16 * 60
 
 
+def _assemble_history(repo: Repository, ticker: str, days: int = 90) -> list[dict]:
+    """Join greek_exposure_daily × (vol_index_daily | daily_ohlc) × flip history."""
+    g = GreekExposureDailyRepository(repo.conn, schema=repo._schema)
+    gex_rows = g.fetch_history(ticker, days=days)
+    if not gex_rows:
+        return []
+
+    if ticker in _SPOT_FROM_LAKE:
+        v = VolIndexRepository(repo.conn, schema=repo._schema)
+        spot_rows = v.fetch_history(ticker, days=days)
+        spot_by_date = {r["trade_date"]: r["close"] for r in spot_rows}
+    else:
+        ohlc = repo.list_daily_ohlc(ticker, limit=days)
+        spot_by_date = {r.date: float(r.close) for r in ohlc}
+
+    flip_by_date = repo.fetch_flip_strike_history(ticker=ticker, limit=days)
+
+    return [
+        {
+            "date": row["trade_date"].isoformat(),
+            "net_gex": row["net_gex"],
+            "net_dex": row["net_dex"],
+            "gex_flip": flip_by_date.get(row["trade_date"]),
+            "spot": spot_by_date.get(row["trade_date"]),
+        }
+        for row in gex_rows
+    ]
+
+
 # ─── GEX (live) ──────────────────────────────────────────────────
 
 
@@ -39,13 +75,17 @@ def get_gex(
     repo: Annotated[Repository, Depends(get_repo)],
     ticker: str = Query("SPX"),
 ) -> GexResponse:
-    raw = repo.fetch_latest_gex(ticker=ticker.upper())
+    t = ticker.upper()
+    raw = repo.fetch_latest_gex(ticker=t)
+    history = _assemble_history(repo, t, days=90)
     if raw is None:
         empty = EMPTY_GEX_RESPONSE.model_copy(deep=True)
         empty.market_open = _is_market_open_now()
-        empty.ticker = ticker.upper()
+        empty.ticker = t
+        empty.history = [GexHistoryEntry.model_validate(h) for h in history]
         return empty
     raw["market_open"] = _is_market_open_now()
+    raw["history"] = history
     return GexResponse.model_validate(raw)
 
 

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -1,4 +1,4 @@
-"""/regime — GEX live (UW-driven), CRI/VCG pending IB-via-R2 reader."""
+"""/regime — GEX + CRI live, VCG still pending."""
 
 from __future__ import annotations
 
@@ -11,14 +11,19 @@ from fastapi import APIRouter, Depends, Query
 from uw_scan.api.client import UwClient
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.schemas import (
+    EMPTY_CRI_RESPONSE,
     EMPTY_GEX_RESPONSE,
+    CriResponse,
+    CriScanResponse,
     GexHistoryEntry,
     GexResponse,
     RegimePendingResponse,
     VolBackdropResponse,
 )
 from uw_scan.config import Settings
+from uw_scan.scanners import cri as cri_scanner
 from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
 from uw_scan.storage.repository import Repository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
@@ -150,17 +155,29 @@ def get_vol_backdrop(
     )
 
 
-# ─── CRI (pending) ───────────────────────────────────────────────
+# ─── CRI (live) ──────────────────────────────────────────────────
 
 
-@router.get("", response_model=RegimePendingResponse)
-def get_regime() -> RegimePendingResponse:
-    return RegimePendingResponse(scanner="cri")
+@router.get("", response_model=CriResponse)
+def get_regime(
+    repo: Annotated[Repository, Depends(get_repo)],
+) -> CriResponse:
+    snap_repo = CriSnapshotRepository(repo.conn, schema=repo._schema)
+    latest = snap_repo.fetch_latest()
+    if latest is None:
+        return EMPTY_CRI_RESPONSE.model_copy(deep=True)
+    return CriResponse.model_validate({"status": "ok", **latest})
 
 
-@router.post("/scan", status_code=202, response_model=RegimePendingResponse)
-def trigger_cri_scan() -> RegimePendingResponse:
-    return RegimePendingResponse(scanner="cri")
+@router.post("/scan", status_code=202, response_model=CriScanResponse)
+def trigger_cri_scan(
+    repo: Annotated[Repository, Depends(get_repo)],
+) -> CriScanResponse:
+    """Run a CRI scan synchronously off the warm store; persist a snapshot."""
+    row_id = cri_scanner.run(repo.conn, schema=repo._schema)
+    if row_id is None:
+        return CriScanResponse(status="skipped", reason="thin_data")
+    return CriScanResponse(status="ok", row_id=row_id)
 
 
 # ─── VCG (pending) ───────────────────────────────────────────────

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -1,4 +1,4 @@
-"""/regime — GEX + CRI live, VCG still pending."""
+"""/regime — GEX, CRI, and VCG (all live)."""
 
 from __future__ import annotations
 
@@ -13,19 +13,23 @@ from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.schemas import (
     EMPTY_CRI_RESPONSE,
     EMPTY_GEX_RESPONSE,
+    EMPTY_VCG_RESPONSE,
     CriResponse,
     CriScanResponse,
     GexHistoryEntry,
     GexResponse,
-    RegimePendingResponse,
+    VcgResponse,
+    VcgScanResponse,
     VolBackdropResponse,
 )
 from uw_scan.config import Settings
 from uw_scan.scanners import cri as cri_scanner
 from uw_scan.scanners import gex as gex_scanner
+from uw_scan.scanners import vcg as vcg_scanner
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
 from uw_scan.storage.repository import Repository
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 router = APIRouter(prefix="/regime")
@@ -180,14 +184,31 @@ def trigger_cri_scan(
     return CriScanResponse(status="ok", row_id=row_id)
 
 
-# ─── VCG (pending) ───────────────────────────────────────────────
+# ─── VCG (live) ──────────────────────────────────────────────────
 
 
-@router.get("/vcg", response_model=RegimePendingResponse)
-def get_vcg() -> RegimePendingResponse:
-    return RegimePendingResponse(scanner="vcg")
+@router.get("/vcg", response_model=VcgResponse)
+def get_vcg(
+    repo: Annotated[Repository, Depends(get_repo)],
+    proxy: str = Query("HYG"),
+) -> VcgResponse:
+    snap_repo = VcgSnapshotRepository(repo.conn, schema=repo._schema)
+    latest = snap_repo.fetch_latest(proxy=proxy.upper())
+    if latest is None:
+        empty = EMPTY_VCG_RESPONSE.model_copy(deep=True)
+        empty.credit_proxy = proxy.upper()
+        return empty
+    return VcgResponse.model_validate({"status": "ok", **latest})
 
 
-@router.post("/vcg/scan", status_code=202, response_model=RegimePendingResponse)
-def trigger_vcg_scan() -> RegimePendingResponse:
-    return RegimePendingResponse(scanner="vcg")
+@router.post("/vcg/scan", status_code=202, response_model=VcgScanResponse)
+def trigger_vcg_scan(
+    repo: Annotated[Repository, Depends(get_repo)],
+    proxy: str = Query("HYG"),
+) -> VcgScanResponse:
+    """Run a VCG scan synchronously off the warm store; persist a snapshot."""
+    proxy_upper = proxy.upper()
+    row_id = vcg_scanner.run(repo.conn, proxy=proxy_upper, schema=repo._schema)
+    if row_id is None:
+        return VcgScanResponse(status="skipped", proxy=proxy_upper, reason="thin_data")
+    return VcgScanResponse(status="ok", proxy=proxy_upper, row_id=row_id)

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -1,0 +1,99 @@
+"""/regime — GEX live (UW-driven), CRI/VCG pending IB-via-R2 reader."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, Query
+
+from uw_scan.api.client import UwClient
+from uw_scan.api.deps import get_repo, get_settings
+from uw_scan.api.schemas import (
+    EMPTY_GEX_RESPONSE,
+    GexResponse,
+    RegimePendingResponse,
+)
+from uw_scan.config import Settings
+from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.repository import Repository
+
+router = APIRouter(prefix="/regime")
+
+
+def _is_market_open_now() -> bool:
+    """Mon-Fri 09:30-16:00 ET."""
+    now = datetime.now(ZoneInfo("America/New_York"))
+    if now.weekday() >= 5:
+        return False
+    minutes = now.hour * 60 + now.minute
+    return 9 * 60 + 30 <= minutes <= 16 * 60
+
+
+# ─── GEX (live) ──────────────────────────────────────────────────
+
+
+@router.get("/gex", response_model=GexResponse)
+def get_gex(
+    repo: Annotated[Repository, Depends(get_repo)],
+    ticker: str = Query("SPX"),
+) -> GexResponse:
+    raw = repo.fetch_latest_gex(ticker=ticker.upper())
+    if raw is None:
+        empty = EMPTY_GEX_RESPONSE.model_copy(deep=True)
+        empty.market_open = _is_market_open_now()
+        empty.ticker = ticker.upper()
+        return empty
+    raw["market_open"] = _is_market_open_now()
+    return GexResponse.model_validate(raw)
+
+
+@router.post("/gex/scan", status_code=202)
+def trigger_gex_scan(
+    repo: Annotated[Repository, Depends(get_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    ticker: str = Query("SPX"),
+) -> dict:
+    """Run a GEX scan synchronously against UW and persist."""
+    uw_client = UwClient(
+        api_key=settings.api_key.get_secret_value(),
+        base_url=settings.base_url,
+        timeout=settings.request_timeout_seconds,
+    )
+    try:
+        row_id = gex_scanner.run(uw_client, repo, ticker=ticker.upper())
+    finally:
+        uw_client.close()
+    return {
+        "status": "queued",
+        "scanner": "gex",
+        "ticker": ticker.upper(),
+        "row_id": row_id,
+    }
+
+
+# ─── CRI (pending) ───────────────────────────────────────────────
+
+
+@router.get("", response_model=RegimePendingResponse)
+def get_regime() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="cri")
+
+
+@router.post("/scan", status_code=202, response_model=RegimePendingResponse)
+def trigger_cri_scan() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="cri")
+
+
+# ─── VCG (pending) ───────────────────────────────────────────────
+
+
+@router.get("/vcg", response_model=RegimePendingResponse)
+def get_vcg() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="vcg")
+
+
+@router.post("/vcg/scan", status_code=202, response_model=RegimePendingResponse)
+def trigger_vcg_scan() -> RegimePendingResponse:
+    return RegimePendingResponse(scanner="vcg")

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -145,7 +145,8 @@ def _to_float(v):
         return v
     try:
         return float(v)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        _ = repr(exc)  # CI Guardrail 2: coercion failures fold to None silently
         return None
 
 

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class SetupBlock(BaseModel):
@@ -129,3 +130,196 @@ class OhlcRow(BaseModel):
     low: Decimal | None = None
     close: Decimal
     volume: int | None = None
+
+
+# ─── GEX (regime port from xenon 2026-05-16) ─────────────────────────────
+
+
+def _to_float(v):
+    """Pydantic v2 before-validator: coerce string-valued numerics from UW."""
+    if v is None or isinstance(v, (int, float)):
+        return v
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+class GexLevel(BaseModel):
+    strike: float | None = None
+    gamma: float | None = None
+    distance: float | None = None
+    distance_pct: float | None = None
+
+    _coerce_floats = field_validator(
+        "strike", "gamma", "distance", "distance_pct", mode="before"
+    )(_to_float)
+
+
+class GexLevels(BaseModel):
+    gex_flip: GexLevel | None = None
+    max_magnet: GexLevel | None = None
+    second_magnet: GexLevel | None = None
+    max_accelerator: GexLevel | None = None
+    put_wall: GexLevel | None = None
+    call_wall: GexLevel | None = None
+
+
+class GexBucket(BaseModel):
+    strike: float | None = None
+    call_gex: float | None = None
+    put_gex: float | None = None
+    net_gex: float | None = None
+    pct_from_spot: float | None = None
+    tag: str | None = None
+
+    _coerce_floats = field_validator(
+        "strike", "call_gex", "put_gex", "net_gex", "pct_from_spot", mode="before"
+    )(_to_float)
+
+
+class GexFlipMigrationEntry(BaseModel):
+    date: str
+    flip: float | None = None
+
+    _coerce_floats = field_validator("flip", mode="before")(_to_float)
+
+
+class GexBias(BaseModel):
+    direction: str | None = None
+    reasons: list[str] = Field(default_factory=list)
+    days_above_flip: int | None = None
+    flip_migration: list[GexFlipMigrationEntry] = Field(default_factory=list)
+
+
+class GexExpectedRange(BaseModel):
+    low: float | None = None
+    high: float | None = None
+    iv_1d: float | None = None
+
+    _coerce_floats = field_validator("low", "high", "iv_1d", mode="before")(_to_float)
+
+
+class GexHistoryEntry(BaseModel):
+    date: str
+    net_gex: float | None = None
+    net_dex: float | None = None
+    gex_flip: float | None = None
+    spot: float | None = None
+    atm_iv: float | None = None
+    vol_pc: float | None = None
+    bias: str | None = None
+
+    _coerce_floats = field_validator(
+        "net_gex", "net_dex", "gex_flip", "spot", "atm_iv", "vol_pc", mode="before"
+    )(_to_float)
+
+
+class GexIvData(BaseModel):
+    iv30d: float | None = None
+    iv_rank: float | None = None
+    hv30: float | None = None
+    mq_iv30d: float | None = None
+    mq_iv_rank: str | None = None
+    source: str | None = None
+
+    _coerce_floats = field_validator(
+        "iv30d", "iv_rank", "hv30", "mq_iv30d", mode="before"
+    )(_to_float)
+
+
+class GexMqLevels(BaseModel):
+    source_date: str | None = None
+    spot: float | None = None
+    hvl: float | None = None
+    call_resistance_all: float | None = None
+    call_resistance_0dte: float | None = None
+    put_support_all: float | None = None
+    put_support_0dte: float | None = None
+    expected_high: float | None = None
+    expected_low: float | None = None
+    distance_to_hvl_pct: str | None = None
+    iv30d: float | None = None
+    hv30: float | None = None
+    iv_rank: str | None = None
+    top_gex_strikes: list[float] = Field(default_factory=list)
+
+    _coerce_floats = field_validator(
+        "spot",
+        "hvl",
+        "call_resistance_all",
+        "call_resistance_0dte",
+        "put_support_all",
+        "put_support_0dte",
+        "expected_high",
+        "expected_low",
+        "iv30d",
+        "hv30",
+        mode="before",
+    )(_to_float)
+
+
+class GexSourceDeltaEntry(BaseModel):
+    uw: float | None = None
+    mq: float | None = None
+    delta: float | None = None
+
+    _coerce_floats = field_validator("uw", "mq", "delta", mode="before")(_to_float)
+
+
+class GexSourceDelta(BaseModel):
+    flip_vs_hvl: GexSourceDeltaEntry | None = None
+    put_wall_vs_support_all: GexSourceDeltaEntry | None = None
+    put_wall_vs_support_0dte: GexSourceDeltaEntry | None = None
+    call_wall_vs_resistance_all: GexSourceDeltaEntry | None = None
+    call_wall_vs_resistance_0dte: GexSourceDeltaEntry | None = None
+
+
+class GexResponse(BaseModel):
+    scan_time: str = ""
+    market_open: bool = False
+    ticker: str = "SPX"
+    spot: float | None = None
+    close: float | None = None
+    day_change: float | None = None
+    day_change_pct: float | None = None
+    data_date: str | None = None
+    net_gex: float | None = None
+    net_dex: float | None = None
+    atm_iv: float | None = None
+    vol_pc: float | None = None
+    levels: GexLevels = Field(default_factory=GexLevels)
+    profile: list[GexBucket] = Field(default_factory=list)
+    expected_range: GexExpectedRange = Field(default_factory=GexExpectedRange)
+    bias: GexBias = Field(default_factory=GexBias)
+    history: list[GexHistoryEntry] = Field(default_factory=list)
+    iv: GexIvData | None = None
+    mq: GexMqLevels | None = None
+    source_delta: GexSourceDelta | None = None
+
+    _coerce_floats = field_validator(
+        "spot",
+        "close",
+        "day_change",
+        "day_change_pct",
+        "net_gex",
+        "net_dex",
+        "atm_iv",
+        "vol_pc",
+        mode="before",
+    )(_to_float)
+
+
+EMPTY_GEX_RESPONSE = GexResponse()
+
+
+class RegimePendingResponse(BaseModel):
+    """Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands."""
+
+    status: Literal["pending"] = "pending"
+    scanner: Literal["cri", "vcg"]
+    reason: Literal["ib_via_r2_not_wired"] = "ib_via_r2_not_wired"
+    message: str = (
+        "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the "
+        "IB-via-R2 reader (separate project)."
+    )

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -328,3 +328,17 @@ class RegimePendingResponse(BaseModel):
         "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the "
         "IB-via-R2 reader (separate project)."
     )
+
+
+class VolBackdropPoint(BaseModel):
+    date: date
+    close: float
+
+
+class VolBackdropResponse(BaseModel):
+    """Vol-complex time series + VIX term-structure (regime page header strip)."""
+
+    series: dict[str, list[VolBackdropPoint]] = Field(default_factory=dict)
+    term_structure_ratio: float | None = None  # VIX / VIX3M, latest close
+    term_structure_state: str | None = None  # "contango" | "backwardation"
+    as_of: date | None = None

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -281,6 +281,10 @@ class GexResponse(BaseModel):
     ticker: str = "SPX"
     spot: float | None = None
     close: float | None = None
+    prev_close: float | None = None
+    market_time: str | None = None
+    tape_time: str | None = None
+    spot_source: str | None = None
     day_change: float | None = None
     day_change_pct: float | None = None
     data_date: str | None = None
@@ -300,6 +304,7 @@ class GexResponse(BaseModel):
     _coerce_floats = field_validator(
         "spot",
         "close",
+        "prev_close",
         "day_change",
         "day_change_pct",
         "net_gex",

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -342,3 +342,95 @@ class VolBackdropResponse(BaseModel):
     term_structure_ratio: float | None = None  # VIX / VIX3M, latest close
     term_structure_state: str | None = None  # "contango" | "backwardation"
     as_of: date | None = None
+
+
+# ─── CRI (Crash Risk Indicator) ──────────────────────────────────
+
+
+class CriComponents(BaseModel):
+    """Four 0-25 component scores summed into the composite 0-100."""
+
+    vix: float = 0.0
+    vvix: float = 0.0
+    correlation: float = 0.0
+    momentum: float = 0.0
+
+
+class CriBlock(BaseModel):
+    score: float = 0.0
+    level: Literal["LOW", "ELEVATED", "HIGH", "CRITICAL"] = "LOW"
+    components: CriComponents = Field(default_factory=CriComponents)
+
+
+class CtaBlock(BaseModel):
+    realized_vol: float | None = None
+    exposure_pct: float | None = None
+    forced_reduction_pct: float | None = None
+    forced_reduction: bool = False
+    est_selling_bn: float | None = None
+    selling_usd_b: float | None = None
+
+
+class CrashTriggerConditions(BaseModel):
+    spx_below_100d_ma: bool = False
+    realized_vol_gt_25: bool = False
+    cor1m_gt_60: bool = False
+
+
+class CrashTriggerValues(BaseModel):
+    realized_vol: float | None = None
+    cor1m: float | None = None
+
+
+class CrashTriggerBlock(BaseModel):
+    fired: bool = False
+    triggered: bool = False
+    conditions: CrashTriggerConditions = Field(default_factory=CrashTriggerConditions)
+    values: CrashTriggerValues = Field(default_factory=CrashTriggerValues)
+
+
+class CriHistoryEntry(BaseModel):
+    date: str
+    vix: float | None = None
+    vvix: float | None = None
+    spy: float | None = None
+    cor1m: float | None = None
+    realized_vol: float | None = None
+    spx_vs_ma_pct: float | None = None
+    vix_5d_roc: float | None = None
+
+
+class CriResponse(BaseModel):
+    """Crash Risk Indicator snapshot (latest scan)."""
+
+    status: Literal["ok", "empty"] = "empty"
+    scan_time: str = ""
+    date: str | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    spy: float | None = None
+    vix_5d_roc: float | None = None
+    vvix_vix_ratio: float | None = None
+    spx_100d_ma: float | None = None
+    spx_distance_pct: float | None = None
+    cor1m: float | None = None
+    cor1m_previous_close: float | None = None
+    cor1m_5d_change: float | None = None
+    realized_vol: float | None = None
+    cri: CriBlock = Field(default_factory=CriBlock)
+    cta: CtaBlock = Field(default_factory=CtaBlock)
+    crash_trigger: CrashTriggerBlock = Field(default_factory=CrashTriggerBlock)
+    history: list[CriHistoryEntry] = Field(default_factory=list)
+    spy_closes: list[float] = Field(default_factory=list)
+
+
+EMPTY_CRI_RESPONSE = CriResponse()
+
+
+class CriScanResponse(BaseModel):
+    """Response body for POST /api/regime/scan."""
+
+    status: Literal["ok", "skipped"] = "ok"
+    scanner: Literal["cri"] = "cri"
+    row_id: int | None = None
+    reason: str | None = None

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -318,18 +318,6 @@ class GexResponse(BaseModel):
 EMPTY_GEX_RESPONSE = GexResponse()
 
 
-class RegimePendingResponse(BaseModel):
-    """Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands."""
-
-    status: Literal["pending"] = "pending"
-    scanner: Literal["cri", "vcg"]
-    reason: Literal["ib_via_r2_not_wired"] = "ib_via_r2_not_wired"
-    message: str = (
-        "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the "
-        "IB-via-R2 reader (separate project)."
-    )
-
-
 class VolBackdropPoint(BaseModel):
     date: date
     close: float
@@ -432,5 +420,89 @@ class CriScanResponse(BaseModel):
 
     status: Literal["ok", "skipped"] = "ok"
     scanner: Literal["cri"] = "cri"
+    row_id: int | None = None
+    reason: str | None = None
+
+
+# ─── VCG (Volatility-Credit Gap) ─────────────────────────────────
+
+
+class VcgAttribution(BaseModel):
+    vvix_pct: float = 0.0
+    vix_pct: float = 0.0
+    vvix_component: float = 0.0
+    vix_component: float = 0.0
+    model_implied: float = 0.0
+
+
+class VcgSignal(BaseModel):
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    residual: float | None = None
+    beta1_vvix: float | None = None
+    beta2_vix: float | None = None
+    alpha: float | None = None
+    vix: float = 0.0
+    vvix: float = 0.0
+    credit_price: float = 0.0
+    credit_5d_return_pct: float = 0.0
+    ro: int = 0
+    edr: int = 0
+    tier: int | None = None
+    bounce: int = 0
+    vvix_severity: Literal["extreme", "elevated", "moderate"] = "moderate"
+    sign_ok: bool = True
+    sign_suppressed: bool = False
+    pi_panic: float = 0.0
+    regime: Literal["PANIC", "TRANSITION", "DIVERGENCE"] = "DIVERGENCE"
+    interpretation: Literal[
+        "RISK_OFF",
+        "EDR",
+        "WATCH",
+        "BOUNCE",
+        "NORMAL",
+        "SUPPRESSED",
+        "PANIC",
+        "INSUFFICIENT_DATA",
+    ] = "NORMAL"
+    attribution: VcgAttribution = Field(default_factory=VcgAttribution)
+
+
+class VcgHistoryEntry(BaseModel):
+    date: str
+    residual: float | None = None
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    beta1: float | None = None
+    beta2: float | None = None
+    vix: float = 0.0
+    vvix: float = 0.0
+    credit: float = 0.0
+    ro: int = 0
+    edr: int = 0
+    tier: int | None = None
+    bounce: int = 0
+
+
+class VcgResponse(BaseModel):
+    """Volatility-Credit Gap snapshot (latest scan)."""
+
+    status: Literal["ok", "empty"] = "empty"
+    scan_time: str = ""
+    date: str | None = None
+    credit_proxy: str = "HYG"
+    signal: VcgSignal = Field(default_factory=VcgSignal)
+    history: list[VcgHistoryEntry] = Field(default_factory=list)
+
+
+EMPTY_VCG_RESPONSE = VcgResponse()
+
+
+class VcgScanResponse(BaseModel):
+    """Response body for POST /api/regime/vcg/scan."""
+
+    status: Literal["ok", "skipped"] = "ok"
+    scanner: Literal["vcg"] = "vcg"
+    proxy: str = "HYG"
     row_id: int | None = None
     reason: str | None = None

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -26,8 +26,10 @@ def create_app() -> FastAPI:
         allow_origins=[
             "http://127.0.0.1:3001",
             "http://127.0.0.1:3002",
+            "http://127.0.0.1:3003",
             "http://localhost:3001",
             "http://localhost:3002",
+            "http://localhost:3003",
         ],
         allow_methods=["*"],
         allow_headers=["*"],

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -11,6 +11,7 @@ from uw_scan.api.routers import (
     jobs,
     ohlc,
     provider_usage,
+    regime,
     stock,
     trade_insights,
     volatility,
@@ -40,6 +41,7 @@ def create_app() -> FastAPI:
     app.include_router(volatility.router, prefix="/api", tags=["volatility"])
     app.include_router(provider_usage.router, prefix="/api", tags=["provider-usage"])
     app.include_router(trade_insights.router, prefix="/api", tags=["trade-insights"])
+    app.include_router(regime.router, prefix="/api", tags=["regime"])
     return app
 
 

--- a/src/uw_scan/cards/cri_scoring.py
+++ b/src/uw_scan/cards/cri_scoring.py
@@ -1,0 +1,365 @@
+"""Crash Risk Indicator (CRI) — pure scoring functions.
+
+Ported from xenon/src/xenon/scanners/cri.py (component scorers + composite
++ CTA exposure model + crash trigger + realized vol + COR1M helper).
+
+No DB, no network. Pure math. Inputs are floats / numpy arrays; outputs
+are floats / typed dicts.
+
+Strategy reference: docs/research/regime/ (TBD).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+# ── constants ─────────────────────────────────────────────────────
+MA_WINDOW = 100  # SPX moving average window
+VOL_WINDOW = 20  # Realized vol window (annualized)
+
+# CTA model parameters
+CTA_VOL_TARGET = 10.0  # 10% target volatility
+CTA_MAX_EXPOSURE = 200.0  # Max 200% exposure (leverage)
+CTA_AUM_BN = 350.0  # Estimated systematic-CTA AUM in $B
+
+# Crash trigger thresholds
+CRASH_REALIZED_VOL_THRESHOLD = 25.0  # 25% annualized
+CRASH_COR1M_THRESHOLD = 60.0  # 60 percentage points
+
+
+# ══════════════════════════════════════════════════════════════════
+# Realized Volatility
+# ══════════════════════════════════════════════════════════════════
+
+
+def compute_realized_vol(prices: np.ndarray, window: int = VOL_WINDOW) -> float:
+    """Annualized realized volatility from the trailing window, in % points.
+
+    Returns NaN if fewer than ``window + 1`` prices are provided.
+    """
+    if len(prices) < window + 1:
+        return float("nan")
+    log_returns = np.log(prices[-window:] / prices[-window - 1 : -1])
+    return float(np.std(log_returns, ddof=1) * np.sqrt(252) * 100)
+
+
+# ══════════════════════════════════════════════════════════════════
+# COR1M helper
+# ══════════════════════════════════════════════════════════════════
+
+
+def cor1m_level_and_change(cor1m_values: np.ndarray) -> tuple[float, float]:
+    """Current COR1M level and 5-session change (both in % points).
+
+    COR1M is already quoted as a percentage index (e.g. 31.1 means 31.1%
+    implied average correlation), so no scaling.
+    """
+    if cor1m_values is None or len(cor1m_values) == 0:
+        return float("nan"), float("nan")
+    if np.all(np.isnan(cor1m_values)):
+        return float("nan"), float("nan")
+    current = float(cor1m_values[-1])
+    if math.isnan(current):
+        return float("nan"), float("nan")
+    if len(cor1m_values) >= 6:
+        prev = float(cor1m_values[-6])
+        change = current - prev if not math.isnan(prev) else float("nan")
+    else:
+        change = float("nan")
+    return current, change
+
+
+# ══════════════════════════════════════════════════════════════════
+# Component Scoring (each 0-25)
+# ══════════════════════════════════════════════════════════════════
+
+
+def score_vix_component(vix: float, vix_5d_roc: float) -> float:
+    """Score VIX component (0-25). vix_5d_roc is in %."""
+    if math.isnan(vix) or math.isnan(vix_5d_roc):
+        return 0.0
+    level_score = np.clip((vix - 15.0) / (40.0 - 15.0) * 15.0, 0.0, 15.0)
+    roc_score = np.clip(max(vix_5d_roc, 0.0) / 60.0 * 10.0, 0.0, 10.0)
+    return float(np.clip(level_score + roc_score, 0.0, 25.0))
+
+
+def score_vvix_component(vvix: float, vvix_vix_ratio: float) -> float:
+    """Score VVIX component (0-25)."""
+    if math.isnan(vvix) or math.isnan(vvix_vix_ratio):
+        return 0.0
+    level_score = np.clip((vvix - 90.0) / (140.0 - 90.0) * 17.0, 0.0, 17.0)
+    ratio_score = np.clip((vvix_vix_ratio - 5.0) / (8.0 - 5.0) * 8.0, 0.0, 8.0)
+    return float(np.clip(level_score + ratio_score, 0.0, 25.0))
+
+
+def score_correlation_component(corr: float, corr_5d_change: float) -> float:
+    """Score COR1M component (0-25). corr in % points."""
+    if math.isnan(corr):
+        return 0.0
+    if math.isnan(corr_5d_change):
+        corr_5d_change = 0.0
+    level_score = np.clip((corr - 25.0) / (70.0 - 25.0) * 17.0, 0.0, 17.0)
+    spike_score = np.clip(max(corr_5d_change, 0.0) / 20.0 * 8.0, 0.0, 8.0)
+    return float(np.clip(level_score + spike_score, 0.0, 25.0))
+
+
+def score_momentum_component(spx_distance_pct: float) -> float:
+    """Score momentum component (0-25). Rises as SPX falls below 100d MA."""
+    if math.isnan(spx_distance_pct):
+        return 0.0
+    if spx_distance_pct >= 0:
+        return 0.0
+    return float(np.clip(abs(spx_distance_pct) / 10.0 * 25.0, 0.0, 25.0))
+
+
+# ══════════════════════════════════════════════════════════════════
+# Composite CRI
+# ══════════════════════════════════════════════════════════════════
+
+
+def cri_level(score: float) -> str:
+    if score < 25:
+        return "LOW"
+    if score < 50:
+        return "ELEVATED"
+    if score < 75:
+        return "HIGH"
+    return "CRITICAL"
+
+
+def compute_cri(
+    vix: float,
+    vix_5d_roc: float,
+    vvix: float,
+    vvix_vix_ratio: float,
+    corr: float,
+    corr_5d_change: float,
+    spx_distance_pct: float,
+) -> dict[str, Any]:
+    """Composite 0-100 score from the four components."""
+    vix_score = score_vix_component(vix, vix_5d_roc)
+    vvix_score = score_vvix_component(vvix, vvix_vix_ratio)
+    corr_score = score_correlation_component(corr, corr_5d_change)
+    momentum_score = score_momentum_component(spx_distance_pct)
+    total = float(
+        np.clip(vix_score + vvix_score + corr_score + momentum_score, 0.0, 100.0)
+    )
+    return {
+        "score": round(total, 1),
+        "level": cri_level(total),
+        "components": {
+            "vix": round(vix_score, 1),
+            "vvix": round(vvix_score, 1),
+            "correlation": round(corr_score, 1),
+            "momentum": round(momentum_score, 1),
+        },
+    }
+
+
+# ══════════════════════════════════════════════════════════════════
+# CTA exposure
+# ══════════════════════════════════════════════════════════════════
+
+
+def cta_exposure_model(
+    realized_vol: float,
+    vol_target: float = CTA_VOL_TARGET,
+    aum_bn: float = CTA_AUM_BN,
+) -> dict[str, Any]:
+    """Estimate CTA exposure from vol-targeting.
+
+    exposure_pct = min(vol_target / realized_vol * 100, CTA_MAX_EXPOSURE)
+    forced_reduction = max(0, 1 - exposure / 100)
+    """
+    if math.isnan(realized_vol) or realized_vol <= 0:
+        return {
+            "realized_vol": realized_vol if not math.isnan(realized_vol) else 0.0,
+            "exposure_pct": CTA_MAX_EXPOSURE,
+            "forced_reduction_pct": 0.0,
+            "forced_reduction": False,
+            "est_selling_bn": 0.0,
+            "selling_usd_b": 0.0,
+        }
+    exposure = min(vol_target / realized_vol * 100.0, CTA_MAX_EXPOSURE)
+    reduction = max(0.0, 1.0 - exposure / 100.0)
+    est_selling = reduction * aum_bn
+    return {
+        "realized_vol": round(realized_vol, 2),
+        "exposure_pct": round(exposure, 1),
+        "forced_reduction_pct": round(reduction * 100.0, 1),
+        "forced_reduction": reduction > 0.0,
+        "est_selling_bn": round(est_selling, 1),
+        "selling_usd_b": round(est_selling, 1),
+    }
+
+
+# ══════════════════════════════════════════════════════════════════
+# Crash trigger
+# ══════════════════════════════════════════════════════════════════
+
+
+def crash_trigger(
+    spx_below_ma: bool,
+    realized_vol: float,
+    cor1m: float,
+) -> dict[str, Any]:
+    """Three-condition crash trigger.
+
+    All three must fire:
+      1. SPX < 100-day MA
+      2. 20d realized vol > 25% annualized
+      3. COR1M > 60 percentage points
+    """
+    vol_ok = (
+        not math.isnan(realized_vol)
+    ) and realized_vol > CRASH_REALIZED_VOL_THRESHOLD
+    corr_ok = (not math.isnan(cor1m)) and cor1m > CRASH_COR1M_THRESHOLD
+    triggered = spx_below_ma and vol_ok and corr_ok
+    return {
+        "triggered": triggered,
+        "fired": triggered,
+        "conditions": {
+            "spx_below_100d_ma": spx_below_ma,
+            "realized_vol_gt_25": vol_ok,
+            "cor1m_gt_60": corr_ok,
+        },
+        "values": {
+            "realized_vol": round(realized_vol, 2)
+            if not math.isnan(realized_vol)
+            else None,
+            "cor1m": round(cor1m, 2) if not math.isnan(cor1m) else None,
+        },
+    }
+
+
+# ══════════════════════════════════════════════════════════════════
+# Full analysis orchestrator (pure — takes aligned arrays)
+# ══════════════════════════════════════════════════════════════════
+
+
+def run_analysis(
+    aligned: dict[str, np.ndarray],
+    common_dates: list[str],
+) -> dict[str, Any]:
+    """Compute the full CRI snapshot from aligned daily-close arrays.
+
+    Required keys in ``aligned``: VIX, VVIX, SPY, COR1M.
+    All arrays must be the same length and aligned to ``common_dates``.
+    """
+    vix = aligned["VIX"]
+    vvix = aligned["VVIX"]
+    spy = aligned["SPY"]
+    cor1m_values = aligned["COR1M"]
+
+    vix_now = float(vix[-1])
+    vvix_now = float(vvix[-1])
+    spy_now = float(spy[-1])
+
+    # VIX 5-day RoC (%)
+    if len(vix) >= 6 and vix[-6] > 0:
+        vix_5d_roc = (vix[-1] / vix[-6] - 1) * 100
+    else:
+        vix_5d_roc = 0.0
+
+    vvix_vix_ratio = vvix_now / vix_now if vix_now > 0 else float("nan")
+
+    # SPX vs 100d MA (using SPY as the SPX proxy — UW/lake don't give us a
+    # tradeable SPX, and SPY tracks SPX 1:10).
+    if len(spy) >= MA_WINDOW:
+        ma_100 = float(np.mean(spy[-MA_WINDOW:]))
+        spx_distance_pct = (spy_now / ma_100 - 1) * 100
+        spx_below_ma = spy_now < ma_100
+    else:
+        ma_100 = float("nan")
+        spx_distance_pct = 0.0
+        spx_below_ma = False
+
+    cor1m_now, cor1m_5d_change = cor1m_level_and_change(cor1m_values)
+    cor1m_previous_close = (
+        float(cor1m_values[-1]) if len(cor1m_values) > 0 else float("nan")
+    )
+
+    realized_vol = compute_realized_vol(spy, VOL_WINDOW)
+
+    cri = compute_cri(
+        vix=vix_now,
+        vix_5d_roc=float(vix_5d_roc),
+        vvix=vvix_now,
+        vvix_vix_ratio=float(vvix_vix_ratio),
+        corr=cor1m_now,
+        corr_5d_change=cor1m_5d_change,
+        spx_distance_pct=float(spx_distance_pct),
+    )
+    cta = cta_exposure_model(realized_vol)
+    trigger = crash_trigger(
+        spx_below_ma=spx_below_ma, realized_vol=realized_vol, cor1m=cor1m_now
+    )
+
+    # 20-session rolling history for the mini-chart
+    history: list[dict[str, Any]] = []
+    n = len(vix)
+    for i in range(max(0, n - 20), n):
+        v = float(vix[i])
+        vv = float(vvix[i])
+        s = float(spy[i])
+        if i >= MA_WINDOW - 1:
+            day_ma = float(np.mean(spy[i - MA_WINDOW + 1 : i + 1]))
+            day_dist = (s / day_ma - 1) * 100
+        else:
+            day_ma = float("nan")
+            day_dist = 0.0
+        if i >= 5 and vix[i - 5] > 0:
+            day_vix_roc = (vix[i] / vix[i - 5] - 1) * 100
+        else:
+            day_vix_roc = 0.0
+        if i >= VOL_WINDOW:
+            day_rvol = compute_realized_vol(spy[: i + 1], VOL_WINDOW)
+        else:
+            day_rvol = float("nan")
+        history.append(
+            {
+                "date": common_dates[i],
+                "vix": round(v, 2),
+                "vvix": round(vv, 2),
+                "spy": round(s, 2),
+                "cor1m": round(float(cor1m_values[i]), 2),
+                "realized_vol": round(day_rvol, 2)
+                if not math.isnan(day_rvol)
+                else None,
+                "spx_vs_ma_pct": round(float(day_dist), 2),
+                "vix_5d_roc": round(float(day_vix_roc), 1),
+            }
+        )
+
+    return {
+        "date": common_dates[-1],
+        "vix": round(vix_now, 2),
+        "vvix": round(vvix_now, 2),
+        "spy": round(spy_now, 2),
+        "vix_5d_roc": round(float(vix_5d_roc), 1),
+        "vvix_vix_ratio": round(float(vvix_vix_ratio), 2)
+        if not math.isnan(vvix_vix_ratio)
+        else None,
+        "spx_100d_ma": round(ma_100, 2) if not math.isnan(ma_100) else None,
+        "spx_distance_pct": round(float(spx_distance_pct), 2),
+        "cor1m": round(cor1m_now, 2) if not math.isnan(cor1m_now) else None,
+        "cor1m_previous_close": round(cor1m_previous_close, 2)
+        if not math.isnan(cor1m_previous_close)
+        else None,
+        "cor1m_5d_change": round(cor1m_5d_change, 2)
+        if not math.isnan(cor1m_5d_change)
+        else None,
+        "realized_vol": round(realized_vol, 2)
+        if not math.isnan(realized_vol)
+        else None,
+        "cri": cri,
+        "cta": cta,
+        "crash_trigger": trigger,
+        "history": history,
+        # Last 40 SPY daily closes so the UI/API can rebuild a trailing
+        # 20-session realized-vol curve client-side if needed.
+        "spy_closes": [round(float(p), 4) for p in spy[-(VOL_WINDOW * 2) :]],
+    }

--- a/src/uw_scan/cards/greek_exposure_history.py
+++ b/src/uw_scan/cards/greek_exposure_history.py
@@ -45,7 +45,8 @@ def parse_greek_exposure_history(body: dict | None) -> list[dict]:
             put_gex = float(r.get("put_gex", 0) or 0)
             call_delta = float(r.get("call_delta", 0) or 0)
             put_delta = float(r.get("put_delta", 0) or 0)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
+            _ = repr(exc)  # CI Guardrail 2: malformed row skipped
             continue
         out.append(
             {
@@ -68,6 +69,7 @@ def _coerce_date(v: Any) -> date | None:
     if isinstance(v, str):
         try:
             return date.fromisoformat(v)
-        except ValueError:
+        except ValueError as exc:
+            _ = repr(exc)  # CI Guardrail 2: bad ISO string → None
             return None
     return None

--- a/src/uw_scan/cards/greek_exposure_history.py
+++ b/src/uw_scan/cards/greek_exposure_history.py
@@ -1,0 +1,73 @@
+"""Pure parser for UW /greek-exposure (history aggregate) payload.
+
+Used by:
+- ``scanners/gex.py``   — to compute net_dex from the daily tail.
+- ``scanners/gex.py``   — to feed ``greek_exposure_daily`` for the regime
+                          history chart (via GreekExposureDailyRepository).
+
+No DB, no network. Pure dict → list[dict] transformation.
+
+Note: UW returns ``call_gex / put_gex / call_delta / put_delta`` per day
+(aggregated across all strikes). It does NOT return historical gex_flip
+or historical price — those have to come from other sources (our own
+``gex_snapshots`` for flip, ``daily_ohlc`` / ``vol_index_daily`` for spot).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+
+def parse_greek_exposure_history(body: dict | None) -> list[dict]:
+    """Body envelope → list of typed daily rows.
+
+    Each output row carries:
+        date, call_gex, put_gex, call_delta, put_delta,
+        net_gex (call_gex + put_gex), net_dex (call_delta + put_delta).
+
+    Malformed individual rows are dropped (logged downstream by caller),
+    not raised — partial data is more useful than nothing for a history chart.
+    """
+    if not body or not isinstance(body, dict):
+        return []
+    raw = body.get("data") or []
+    if not isinstance(raw, list):
+        return []
+
+    out: list[dict] = []
+    for r in raw:
+        try:
+            d = _coerce_date(r.get("date"))
+            if d is None:
+                continue
+            call_gex = float(r.get("call_gex", 0) or 0)
+            put_gex = float(r.get("put_gex", 0) or 0)
+            call_delta = float(r.get("call_delta", 0) or 0)
+            put_delta = float(r.get("put_delta", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+        out.append(
+            {
+                "date": d,
+                "call_gex": call_gex,
+                "put_gex": put_gex,
+                "call_delta": call_delta,
+                "put_delta": put_delta,
+                "net_gex": call_gex + put_gex,
+                "net_dex": call_delta + put_delta,
+            }
+        )
+    out.sort(key=lambda r: r["date"])
+    return out
+
+
+def _coerce_date(v: Any) -> date | None:
+    if isinstance(v, date):
+        return v
+    if isinstance(v, str):
+        try:
+            return date.fromisoformat(v)
+        except ValueError:
+            return None
+    return None

--- a/src/uw_scan/cards/vcg_scoring.py
+++ b/src/uw_scan/cards/vcg_scoring.py
@@ -84,7 +84,8 @@ def rolling_ols(
         A = np.column_stack([np.ones(window), X_w])
         try:
             coeff, _, rank, _ = np.linalg.lstsq(A, y_w, rcond=None)
-        except np.linalg.LinAlgError:
+        except np.linalg.LinAlgError as exc:
+            _ = repr(exc)  # CI Guardrail 2: window silently dropped, OLS will skip
             continue
         if rank < A.shape[1]:
             continue

--- a/src/uw_scan/cards/vcg_scoring.py
+++ b/src/uw_scan/cards/vcg_scoring.py
@@ -1,0 +1,400 @@
+"""Volatility-Credit Gap (VCG) — pure scoring functions.
+
+Ported from xenon/src/xenon/scanners/vcg.py. The xenon scanner combines data
+fetching (IB/UW/Yahoo) with math; this module is just the math. No DB, no
+network. Inputs are np.ndarrays of aligned daily closes; output is a payload
+dict shaped for the API contract.
+
+Model:
+    Δlog(credit_t) = α + β1·Δlog(VVIX_t) + β2·Δlog(VIX_t) + ε_t
+
+Rolling 21-day OLS produces residuals; standardising residuals over 63 days
+gives the VCG z-score. A panic-adjusted variant suppresses the signal when
+VIX is already crashing (π = clamp((VIX-40)/8, 0, 1) damps the signal).
+
+Strategy reference: xenon docs/VCG_institutional_research_note.md.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+# ── windows ───────────────────────────────────────────────────────
+OLS_WINDOW = 21  # Rolling regression window (business days)
+Z_WINDOW = 63  # Residual standardisation lookback
+MIN_BARS = OLS_WINDOW + Z_WINDOW + 10  # Floor for a meaningful scan
+
+# ── thresholds (mirror xenon constants exactly) ──────────────────
+VIX_PANIC_LOW = 40.0  # π clamp lower bound
+VIX_PANIC_HIGH = 48.0  # π clamp upper bound
+VIX_FLOOR = 28.0  # RO gate: VIX must exceed this
+VIX_EDR = 25.0  # EDR watch gate
+VCG_TRIGGER = 2.0  # EDR / Watch threshold
+VCG_RO_TRIGGER = 2.5  # Risk-Off threshold
+BOUNCE_TRIGGER = -3.5  # Counter-signal (tactical long)
+VVIX_EXTREME = 120.0  # VVIX amplifier: extreme
+VVIX_ELEVATED = 100.0  # VVIX amplifier: elevated (below = moderate)
+
+
+# ══════════════════════════════════════════════════════════════════
+# Math primitives
+# ══════════════════════════════════════════════════════════════════
+
+
+def log_returns(prices: np.ndarray) -> np.ndarray:
+    """ln(P_t / P_{t-1}). Returns has length N-1.
+
+    Non-finite / non-positive inputs (NaN, Inf, 0, negative) propagate as NaN
+    rather than Inf — protects downstream OLS and JSONB persistence from a
+    bad parquet row leaking into the model.
+    """
+    arr = np.asarray(prices, dtype=float)
+    bad = ~(np.isfinite(arr) & (arr > 0))
+    safe = np.where(bad, np.nan, arr)
+    return np.log(safe[1:] / safe[:-1])
+
+
+def rolling_ols(
+    y: np.ndarray, X: np.ndarray, window: int = OLS_WINDOW
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Rolling OLS: y = α + β₁·X[:,0] + β₂·X[:,1] + ε.
+
+    Returns aligned arrays (alpha, beta1, beta2, residual) where indices
+    [0, window-2] are NaN (insufficient history).
+    """
+    n = len(y)
+    alphas = np.full(n, np.nan)
+    beta1s = np.full(n, np.nan)
+    beta2s = np.full(n, np.nan)
+    residuals = np.full(n, np.nan)
+
+    for t in range(window - 1, n):
+        start = t - window + 1
+        y_w = y[start : t + 1]
+        X_w = X[start : t + 1]
+        # np.linalg.lstsq does not raise on collinear / rank-deficient windows;
+        # it silently returns a reduced-rank solution with meaningless betas
+        # that would still drive sign_ok/ro. Skip windows where any input is
+        # non-finite or the design matrix is not full-rank.
+        if not (np.isfinite(y_w).all() and np.isfinite(X_w).all()):
+            continue
+        A = np.column_stack([np.ones(window), X_w])
+        try:
+            coeff, _, rank, _ = np.linalg.lstsq(A, y_w, rcond=None)
+        except np.linalg.LinAlgError:
+            continue
+        if rank < A.shape[1]:
+            continue
+        alphas[t] = coeff[0]
+        beta1s[t] = coeff[1]
+        beta2s[t] = coeff[2]
+        y_hat = A @ coeff
+        residuals[t] = y_w[-1] - y_hat[-1]
+    return alphas, beta1s, beta2s, residuals
+
+
+def standardise_residuals(residuals: np.ndarray, window: int = Z_WINDOW) -> np.ndarray:
+    """Trailing z-score of residuals."""
+    n = len(residuals)
+    z = np.full(n, np.nan)
+    for t in range(window - 1, n):
+        start = t - window + 1
+        chunk = residuals[start : t + 1]
+        valid = chunk[~np.isnan(chunk)]
+        if len(valid) < 10:
+            continue
+        mu = float(np.mean(valid))
+        sigma = float(np.std(valid, ddof=1))
+        if sigma < 1e-12:
+            continue
+        z[t] = (residuals[t] - mu) / sigma
+    return z
+
+
+def compute_vcg(
+    vix_prices: np.ndarray,
+    vvix_prices: np.ndarray,
+    credit_prices: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Full VCG model. Returns dict of per-day arrays (length = N-1)."""
+    vix_ret = log_returns(vix_prices)
+    vvix_ret = log_returns(vvix_prices)
+    credit_ret = log_returns(credit_prices)
+
+    X = np.column_stack([vvix_ret, vix_ret])
+    alphas, beta1s, beta2s, residuals = rolling_ols(credit_ret, X, OLS_WINDOW)
+    vcg = standardise_residuals(residuals, Z_WINDOW)
+
+    vix_levels = vix_prices[1:]
+    pi = np.clip(
+        (vix_levels - VIX_PANIC_LOW) / (VIX_PANIC_HIGH - VIX_PANIC_LOW), 0.0, 1.0
+    )
+    vcg_div = (1.0 - pi) * vcg
+
+    return {
+        "vcg": vcg,
+        "vcg_adj": vcg_div,
+        "residuals": residuals,
+        "alpha": alphas,
+        "beta1": beta1s,
+        "beta2": beta2s,
+        "vix_ret": vix_ret,
+        "vvix_ret": vvix_ret,
+        "credit_ret": credit_ret,
+        "vix_levels": vix_levels,
+        "vvix_levels": vvix_prices[1:],
+        "credit_levels": credit_prices[1:],
+        "pi": pi,
+    }
+
+
+# ══════════════════════════════════════════════════════════════════
+# Signal evaluation
+# ══════════════════════════════════════════════════════════════════
+
+
+def _vvix_severity(vvix: float) -> str:
+    if vvix > VVIX_EXTREME:
+        return "extreme"
+    if vvix >= VVIX_ELEVATED:
+        return "elevated"
+    return "moderate"
+
+
+def _round_or_none(value: float, ndigits: int) -> float | None:
+    if math.isnan(value):
+        return None
+    return round(float(value), ndigits)
+
+
+def _signal_for_index(
+    model: dict[str, np.ndarray],
+    idx: int,
+    *,
+    vix_floor: float = VIX_FLOOR,
+    vcg_trigger: float = VCG_RO_TRIGGER,
+) -> dict[str, Any]:
+    """Evaluate ro/edr/tier/bounce/sign_ok for a single index.
+
+    Gates compare against panic-adjusted ``vcg_adj`` rather than raw ``vcg`` —
+    when π → 1 (VIX ≥ 48) vcg_adj → 0, so ro/edr/tier/bounce naturally fall
+    to zero. Without this, a VIX-50 day persists regime="PANIC" alongside
+    ro=1/tier=1 and the UI renders the RISK-OFF badge atop the PANIC label.
+    Bounce additionally requires sign discipline (β₁,β₂ ≤ 0); a contrarian
+    long signal is not actionable when the model's correlation signs flip.
+    """
+    vcg_eff = float(model["vcg_adj"][idx])
+    beta1 = float(model["beta1"][idx])
+    beta2 = float(model["beta2"][idx])
+    vix = float(model["vix_levels"][idx])
+
+    sign_ok = (
+        not math.isnan(beta1) and beta1 <= 0 and not math.isnan(beta2) and beta2 <= 0
+    )
+
+    ro = bool(
+        not math.isnan(vcg_eff)
+        and vix > vix_floor
+        and vcg_eff > vcg_trigger
+        and sign_ok
+    )
+    edr = bool(
+        not math.isnan(vcg_eff) and vix > VIX_EDR and vcg_eff > VCG_TRIGGER and sign_ok
+    )
+    tier: int | None = None
+    if ro:
+        tier = 1 if vix > 30.0 else 2
+    elif edr:
+        tier = 3
+    bounce = bool(not math.isnan(vcg_eff) and vcg_eff < BOUNCE_TRIGGER and sign_ok)
+    return {
+        "ro": int(ro),
+        "edr": int(edr),
+        "tier": tier,
+        "bounce": int(bounce),
+        "sign_ok": bool(sign_ok),
+    }
+
+
+def evaluate_signal(
+    model: dict[str, np.ndarray],
+    credit_prices: np.ndarray,
+    *,
+    vix_floor: float = VIX_FLOOR,
+    vcg_trigger: float = VCG_RO_TRIGGER,
+) -> dict[str, Any]:
+    """Build the latest-bar signal payload."""
+    idx = -1
+    flags = _signal_for_index(model, idx, vix_floor=vix_floor, vcg_trigger=vcg_trigger)
+
+    vcg_val = float(model["vcg"][idx])
+    vcg_adj_val = float(model["vcg_adj"][idx])
+    beta1 = float(model["beta1"][idx])
+    beta2 = float(model["beta2"][idx])
+    alpha = float(model["alpha"][idx])
+    vix = float(model["vix_levels"][idx])
+    vvix = float(model["vvix_levels"][idx])
+    credit = float(model["credit_levels"][idx])
+    residual = float(model["residuals"][idx])
+    pi_val = float(model["pi"][idx])
+
+    if len(credit_prices) >= 6:
+        credit_5d_ret = (credit_prices[-1] / credit_prices[-6]) - 1.0
+    else:
+        credit_5d_ret = 0.0
+
+    sign_suppressed = not flags["sign_ok"]
+    vvix_sev = _vvix_severity(vvix)
+
+    # Attribution split
+    vvix_component = (
+        beta1 * float(model["vvix_ret"][idx]) if not math.isnan(beta1) else 0.0
+    )
+    vix_component = (
+        beta2 * float(model["vix_ret"][idx]) if not math.isnan(beta2) else 0.0
+    )
+    model_implied = (
+        alpha + vvix_component + vix_component if not math.isnan(alpha) else 0.0
+    )
+    total_component = (
+        abs(vvix_component) + abs(vix_component)
+        if (abs(vvix_component) + abs(vix_component)) > 1e-12
+        else 1.0
+    )
+    vvix_pct = abs(vvix_component) / total_component * 100.0
+    vix_pct = abs(vix_component) / total_component * 100.0
+
+    # Regime label
+    if pi_val >= 1.0:
+        regime = "PANIC"
+    elif pi_val > 0.0:
+        regime = "TRANSITION"
+    else:
+        regime = "DIVERGENCE"
+
+    # Interpretation
+    if math.isnan(vcg_val):
+        interpretation = "INSUFFICIENT_DATA"
+    elif not flags["sign_ok"]:
+        interpretation = "SUPPRESSED"
+    elif pi_val >= 1.0:
+        interpretation = "PANIC"
+    elif flags["ro"]:
+        interpretation = "RISK_OFF"
+    elif flags["edr"]:
+        interpretation = "EDR"
+    elif flags["bounce"]:
+        interpretation = "BOUNCE"
+    elif not math.isnan(vcg_adj_val) and vcg_adj_val > VCG_TRIGGER:
+        interpretation = "WATCH"
+    else:
+        interpretation = "NORMAL"
+
+    return {
+        "vcg": _round_or_none(vcg_val, 4),
+        "vcg_adj": _round_or_none(vcg_adj_val, 4),
+        "residual": _round_or_none(residual, 6),
+        "beta1_vvix": _round_or_none(beta1, 6),
+        "beta2_vix": _round_or_none(beta2, 6),
+        "alpha": _round_or_none(alpha, 6),
+        "vix": round(vix, 2),
+        "vvix": round(vvix, 2),
+        "credit_price": round(credit, 2),
+        "credit_5d_return_pct": round(credit_5d_ret * 100.0, 3),
+        "ro": flags["ro"],
+        "edr": flags["edr"],
+        "tier": flags["tier"],
+        "bounce": flags["bounce"],
+        "vvix_severity": vvix_sev,
+        "sign_ok": bool(flags["sign_ok"]),
+        "sign_suppressed": bool(sign_suppressed),
+        "pi_panic": round(pi_val, 4),
+        "regime": regime,
+        "interpretation": interpretation,
+        "attribution": {
+            "vvix_pct": round(vvix_pct, 1),
+            "vix_pct": round(vix_pct, 1),
+            "vvix_component": round(vvix_component, 6),
+            "vix_component": round(vix_component, 6),
+            "model_implied": round(model_implied, 6),
+        },
+    }
+
+
+def _history_row(
+    model: dict[str, np.ndarray],
+    i: int,
+    date_iso: str,
+    *,
+    vix_floor: float,
+    vcg_trigger: float,
+) -> dict[str, Any]:
+    flags = _signal_for_index(model, i, vix_floor=vix_floor, vcg_trigger=vcg_trigger)
+    return {
+        "date": date_iso,
+        "residual": _round_or_none(float(model["residuals"][i]), 6),
+        "vcg": _round_or_none(float(model["vcg"][i]), 4),
+        "vcg_adj": _round_or_none(float(model["vcg_adj"][i]), 4),
+        "beta1": _round_or_none(float(model["beta1"][i]), 6),
+        "beta2": _round_or_none(float(model["beta2"][i]), 6),
+        "vix": round(float(model["vix_levels"][i]), 2),
+        "vvix": round(float(model["vvix_levels"][i]), 2),
+        "credit": round(float(model["credit_levels"][i]), 2),
+        "ro": flags["ro"],
+        "edr": flags["edr"],
+        "tier": flags["tier"],
+        "bounce": flags["bounce"],
+    }
+
+
+# ══════════════════════════════════════════════════════════════════
+# Orchestrator (pure)
+# ══════════════════════════════════════════════════════════════════
+
+
+def run_analysis(
+    aligned: dict[str, np.ndarray],
+    common_dates: list[str],
+    *,
+    proxy: str = "HYG",
+    vix_floor: float = VIX_FLOOR,
+    vcg_trigger: float = VCG_RO_TRIGGER,
+) -> dict[str, Any]:
+    """Compute the full VCG snapshot from aligned daily closes.
+
+    Required keys in ``aligned``: VIX, VVIX, <proxy>. All arrays must be the
+    same length and aligned to ``common_dates``.
+    """
+    vix_prices = aligned["VIX"]
+    vvix_prices = aligned["VVIX"]
+    credit_prices = aligned[proxy]
+
+    model = compute_vcg(vix_prices, vvix_prices, credit_prices)
+    signal = evaluate_signal(
+        model, credit_prices, vix_floor=vix_floor, vcg_trigger=vcg_trigger
+    )
+
+    # Last 20 sessions of history. Returns are length N-1 of common_dates,
+    # so date index = i + 1.
+    n = len(model["residuals"])
+    history: list[dict[str, Any]] = []
+    for i in range(max(0, n - 20), n):
+        date_idx = i + 1
+        date_iso = common_dates[date_idx] if date_idx < len(common_dates) else None
+        if date_iso is None:
+            continue
+        history.append(
+            _history_row(
+                model, i, date_iso, vix_floor=vix_floor, vcg_trigger=vcg_trigger
+            )
+        )
+
+    return {
+        "date": common_dates[-1],
+        "credit_proxy": proxy,
+        "signal": signal,
+        "history": history,
+    }

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -108,6 +108,19 @@ class Settings(BaseModel):
             "Symbol subdirs are named symbol=<TICKER>."
         ),
     )
+    # Parquet lake root for equity-asset credit-proxy ETFs (HYG, JNK, LQD),
+    # used by the VCG scanner. Same layout as the vol-index lake.
+    lake_credit_etf_root: Path = Field(
+        default=Path.home() / "market-warehouse/data-lake/bronze/asset_class=equity",
+        description=(
+            "Local parquet lake root for credit-proxy ETF daily OHLC "
+            "(HYG/JNK/LQD). Symbol subdirs are named symbol=<TICKER>."
+        ),
+    )
+    # Credit-proxy ETFs synced from the equity lake into vol_index_daily.
+    # The VCG scanner reads from this list; the first entry is the default
+    # proxy unless overridden by the API caller.
+    credit_etf_symbols: list[str] = ["HYG", "JNK", "LQD"]
 
     @classmethod
     def from_env(cls, env_path: Path | None = None) -> "Settings":
@@ -188,6 +201,24 @@ class Settings(BaseModel):
             gex_scan_tickers=_parse_csv_env("GEX_SCAN_TICKERS", default=["SPX", "SPY"]),
             gex_scan_interval_minutes=int(
                 os.environ.get("GEX_SCAN_INTERVAL_MINUTES", "5")
+            ),
+            # Parquet-lake roots are env-overridable so deployments without
+            # the user's home-dir layout (containers, CI) can point at their
+            # own mount. Blank/unset → fall back to the field-level defaults.
+            lake_vol_index_root=(
+                Path(_lake_vol)
+                if (_lake_vol := os.environ.get("LAKE_VOL_INDEX_ROOT", "").strip())
+                else Path.home()
+                / "market-warehouse/data-lake/bronze/asset_class=volatility"
+            ),
+            lake_credit_etf_root=(
+                Path(_lake_credit)
+                if (_lake_credit := os.environ.get("LAKE_CREDIT_ETF_ROOT", "").strip())
+                else Path.home()
+                / "market-warehouse/data-lake/bronze/asset_class=equity"
+            ),
+            credit_etf_symbols=_parse_csv_env(
+                "CREDIT_ETF_SYMBOLS", default=["HYG", "JNK", "LQD"]
             ),
         )
 

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -97,6 +97,17 @@ class Settings(BaseModel):
     # Regime / GEX scanner (port from xenon — ships GEX live; CRI/VCG pending)
     gex_scan_tickers: list[str] = ["SPX", "SPY"]
     gex_scan_interval_minutes: int = 5
+    # Parquet lake root for CBOE vol indices and SPX daily OHLC.
+    # Maintained by the peer ``market-data-warehouse`` project. Symbol subdirs
+    # are named ``symbol=<TICKER>`` with a ``1d.parquet`` payload inside.
+    lake_vol_index_root: Path = Field(
+        default=Path.home()
+        / "market-warehouse/data-lake/bronze/asset_class=volatility",
+        description=(
+            "Local parquet lake root for CBOE vol indices and SPX daily OHLC. "
+            "Symbol subdirs are named symbol=<TICKER>."
+        ),
+    )
 
     @classmethod
     def from_env(cls, env_path: Path | None = None) -> "Settings":

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -94,6 +94,9 @@ class Settings(BaseModel):
     cockpit_target_dtes: list[int] = [0, 14, 30, 90]
     cockpit_oi_band_pct: Decimal = Decimal("0.10")
     cockpit_oi_max_dte: int = 7
+    # Regime / GEX scanner (port from xenon — ships GEX live; CRI/VCG pending)
+    gex_scan_tickers: list[str] = ["SPX", "SPY"]
+    gex_scan_interval_minutes: int = 5
 
     @classmethod
     def from_env(cls, env_path: Path | None = None) -> "Settings":
@@ -169,10 +172,12 @@ class Settings(BaseModel):
             cockpit_target_dtes=_parse_int_csv_env(
                 "COCKPIT_TARGET_DTES", default=[0, 14, 30, 90]
             ),
-            cockpit_oi_band_pct=Decimal(
-                os.environ.get("COCKPIT_OI_BAND_PCT", "0.10")
-            ),
+            cockpit_oi_band_pct=Decimal(os.environ.get("COCKPIT_OI_BAND_PCT", "0.10")),
             cockpit_oi_max_dte=int(os.environ.get("COCKPIT_OI_MAX_DTE", "7")),
+            gex_scan_tickers=_parse_csv_env("GEX_SCAN_TICKERS", default=["SPX", "SPY"]),
+            gex_scan_interval_minutes=int(
+                os.environ.get("GEX_SCAN_INTERVAL_MINUTES", "5")
+            ),
         )
 
     def db_dsn(self) -> str:

--- a/src/uw_scan/scanners/cri.py
+++ b/src/uw_scan/scanners/cri.py
@@ -1,0 +1,104 @@
+"""CRI scanner — orchestrator on top of cards/cri_scoring.
+
+Reads VIX/VVIX/COR1M from vol_index_daily (parquet-lake-backed) and SPY
+closes from daily_ohlc (massive-backed). Aligns to a common date set,
+runs ``cards/cri_scoring.run_analysis``, persists the snapshot.
+
+No external API calls — purely local DB reads + math + write.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as _date
+
+import numpy as np
+from psycopg import Connection
+
+from uw_scan.cards import cri_scoring
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+from uw_scan.storage.repository import Repository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+log = logging.getLogger(__name__)
+
+# Lookback window — enough for the 100d MA + the trailing 20-day history.
+# 200 days gives slack for weekends/holidays so we still have ~140 trading days.
+LOOKBACK_DAYS = 200
+
+# Minimum aligned bars before we attempt a scan. Anything less and the
+# MA / realized-vol blocks return NaN and downstream scores collapse to 0.
+MIN_ALIGNED_BARS = cri_scoring.MA_WINDOW + cri_scoring.VOL_WINDOW
+
+
+def _load_vol_series(
+    vol_repo: VolIndexRepository, symbol: str, days: int
+) -> dict[_date, float]:
+    rows = vol_repo.fetch_history(symbol, days=days)
+    return {
+        r["trade_date"]: float(r["close"]) for r in rows if r.get("close") is not None
+    }
+
+
+def _load_spy_series(repo: Repository, days: int) -> dict[_date, float]:
+    rows = repo.list_daily_ohlc("SPY", limit=days)
+    return {r.date: float(r.close) for r in rows}
+
+
+def _align(
+    series: dict[str, dict[_date, float]],
+) -> tuple[dict[str, np.ndarray], list[str]]:
+    """Inner-join the series on shared dates; return aligned arrays + ISO date list."""
+    if not series:
+        return {}, []
+    keys = list(series.keys())
+    common = set(series[keys[0]].keys())
+    for k in keys[1:]:
+        common &= set(series[k].keys())
+    if not common:
+        return {sym: np.array([]) for sym in keys}, []
+    sorted_dates = sorted(common)
+    aligned = {
+        sym: np.array([series[sym][d] for d in sorted_dates], dtype=float)
+        for sym in keys
+    }
+    return aligned, [d.isoformat() for d in sorted_dates]
+
+
+def run(conn: Connection, schema: str = "uw_scan") -> int | None:
+    """Run a CRI scan against the warm store; persist a new snapshot row.
+
+    Returns the inserted row id, or None if there isn't enough aligned data.
+    """
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    repo = Repository(conn, schema=schema)
+
+    raw = {
+        "VIX": _load_vol_series(vol_repo, "VIX", LOOKBACK_DAYS),
+        "VVIX": _load_vol_series(vol_repo, "VVIX", LOOKBACK_DAYS),
+        "COR1M": _load_vol_series(vol_repo, "COR1M", LOOKBACK_DAYS),
+        "SPY": _load_spy_series(repo, LOOKBACK_DAYS),
+    }
+    aligned, common_dates = _align(raw)
+
+    if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
+        log.warning(
+            "cri_scan_skipped_thin_data aligned_bars=%d need=%d",
+            len(common_dates),
+            MIN_ALIGNED_BARS,
+        )
+        return None
+
+    payload = cri_scoring.run_analysis(aligned, common_dates)
+
+    snap_repo = CriSnapshotRepository(conn, schema=schema)
+    data_date = _date.fromisoformat(payload["date"])
+    row_id = snap_repo.insert_snapshot(payload=payload, data_date=data_date)
+    log.info(
+        "cri_scan_persisted row_id=%d score=%.1f level=%s fired=%s",
+        row_id,
+        payload["cri"]["score"],
+        payload["cri"]["level"],
+        payload["crash_trigger"]["fired"],
+    )
+    return row_id

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -1,0 +1,486 @@
+"""GEX scanner — UW-driven. Ported from xenon/src/xenon/scanners/gex.py 2026-05-16.
+
+Differences from xenon:
+- No MenthorQ (Playwright dep skipped); ``mq`` and ``source_delta`` always None.
+- No file cache; history is read/written via ``Repository.fetch_latest_gex`` /
+  ``upsert_gex_snapshot`` against the ``gex_snapshots`` Postgres table.
+- No CLI; no HTML rendering.
+- This repo's UW pattern threads ``run_id`` from ``repo.insert_scan_run(...)``
+  through every fetcher for audit trail.
+- Spot source: only iv_rank ``close`` (UW ``/stock/{ticker}/info`` not wired;
+  Yahoo banned). ``compute_days_above_flip`` set to 0 in v1 (no history reader).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from uw_scan.api.client import UwClient
+from uw_scan.api.endpoints import EndpointSlug
+from uw_scan.sources import uw as uw_source
+from uw_scan.storage.repository import Repository
+
+log = logging.getLogger(__name__)
+
+INDEX_TICKERS = {"SPX", "NDX"}
+BUCKET_SIZE_INDEX = 25
+BUCKET_SIZE_ETF = 5
+PROFILE_RANGE_PCT = 0.10
+TRADING_DAYS_PER_YEAR = 252
+
+
+def _bucket_size_for(ticker: str, spot: float) -> int:
+    if ticker in INDEX_TICKERS:
+        return BUCKET_SIZE_INDEX
+    if ticker in ("SPY", "QQQ"):
+        return BUCKET_SIZE_ETF
+    return max(1, round(spot * 0.005))
+
+
+# ─── Pure-logic compute functions (verbatim from xenon gex.py:378-582) ──────
+
+
+def bucket_profile(
+    strike_data: list[dict[str, Any]],
+    bucket_size: int,
+    spot: float,
+    range_pct: float = PROFILE_RANGE_PCT,
+) -> list[dict[str, Any]]:
+    """Aggregate per-strike GEX into buckets within range of spot."""
+    low_bound = spot * (1 - range_pct)
+    high_bound = spot * (1 + range_pct)
+
+    buckets: dict[float, dict[str, float]] = defaultdict(
+        lambda: {"call_gex": 0.0, "put_gex": 0.0, "net_gex": 0.0}
+    )
+
+    for row in strike_data:
+        s = row["strike"]
+        if s < low_bound or s > high_bound:
+            continue
+        b = round(s / bucket_size) * bucket_size
+        buckets[b]["call_gex"] += row["call_gex"]
+        buckets[b]["put_gex"] += row["put_gex"]
+        buckets[b]["net_gex"] += row["net_gex"]
+
+    result = []
+    for strike in sorted(buckets.keys()):
+        vals = buckets[strike]
+        result.append(
+            {
+                "strike": strike,
+                "call_gex": round(vals["call_gex"], 2),
+                "put_gex": round(vals["put_gex"], 2),
+                "net_gex": round(vals["net_gex"], 2),
+                "pct_from_spot": round((strike - spot) / spot * 100, 2),
+                "tag": None,
+            }
+        )
+    return result
+
+
+def compute_gex_flip(profile: list[dict[str, Any]], spot: float) -> float | None:
+    """Find the GEX flip: last strike below spot where net GEX crosses from negative to positive."""
+    flip = None
+    for i in range(1, len(profile)):
+        prev_net = profile[i - 1]["net_gex"]
+        curr_net = profile[i]["net_gex"]
+        strike = profile[i]["strike"]
+        if prev_net < 0 and curr_net > 0 and strike <= spot:
+            flip = strike
+    return flip
+
+
+def find_key_levels(
+    profile: list[dict[str, Any]], spot: float
+) -> dict[str, dict[str, Any] | None]:
+    """Identify max magnet, 2nd magnet, max accelerator, put wall, call wall."""
+    if not profile:
+        return {
+            "max_magnet": None,
+            "second_magnet": None,
+            "max_accelerator": None,
+            "put_wall": None,
+            "call_wall": None,
+        }
+
+    positive = [b for b in profile if b["net_gex"] > 0]
+    negative = [b for b in profile if b["net_gex"] < 0]
+
+    positive_sorted = sorted(positive, key=lambda b: b["net_gex"], reverse=True)
+    negative_sorted = sorted(negative, key=lambda b: b["net_gex"])
+
+    def _make_level(bucket):
+        if bucket is None:
+            return None
+        return {
+            "strike": bucket["strike"],
+            "gamma": round(bucket["net_gex"], 2),
+            "distance": round(bucket["strike"] - spot, 2),
+            "distance_pct": round((bucket["strike"] - spot) / spot * 100, 2),
+        }
+
+    max_magnet = _make_level(positive_sorted[0] if positive_sorted else None)
+    second_magnet = _make_level(
+        positive_sorted[1] if len(positive_sorted) > 1 else None
+    )
+    max_accel = _make_level(negative_sorted[0] if negative_sorted else None)
+
+    put_wall_bucket = max(profile, key=lambda b: abs(b["put_gex"])) if profile else None
+    call_wall_bucket = max(profile, key=lambda b: b["call_gex"]) if profile else None
+
+    return {
+        "max_magnet": max_magnet,
+        "second_magnet": second_magnet,
+        "max_accelerator": max_accel,
+        "put_wall": _make_level(put_wall_bucket),
+        "call_wall": _make_level(call_wall_bucket),
+    }
+
+
+def tag_profile(
+    profile: list[dict[str, Any]],
+    spot: float,
+    flip: float | None,
+    levels: dict[str, dict[str, Any] | None],
+) -> list[dict[str, Any]]:
+    """Add tags to profile buckets for chart annotation."""
+    spot_bucket = None
+    min_dist = float("inf")
+    for b in profile:
+        d = abs(b["strike"] - spot)
+        if d < min_dist:
+            min_dist = d
+            spot_bucket = b["strike"]
+
+    tag_map: dict[float, str] = {}
+    if spot_bucket is not None:
+        tag_map[spot_bucket] = "SPOT"
+    if flip is not None:
+        tag_map[flip] = "GEX FLIP"
+
+    for name, level in levels.items():
+        if level is None:
+            continue
+        label = name.upper().replace("_", " ")
+        s = level["strike"]
+        if s not in tag_map:
+            tag_map[s] = label
+
+    for b in profile:
+        b["tag"] = tag_map.get(b["strike"])
+    return profile
+
+
+def compute_expected_range(spot: float, atm_iv: float | None) -> dict[str, Any]:
+    """Compute 1-day expected range from ATM IV."""
+    if atm_iv is None or atm_iv <= 0:
+        return {"low": None, "high": None, "iv_1d": None}
+    iv_1d = atm_iv / math.sqrt(TRADING_DAYS_PER_YEAR)
+    move = spot * iv_1d
+    return {
+        "low": round(spot - move, 2),
+        "high": round(spot + move, 2),
+        "iv_1d": round(iv_1d * 100, 4),
+    }
+
+
+def compute_directional_bias(
+    spot: float,
+    flip: float | None,
+    net_gex: float,
+    levels: dict[str, dict[str, Any] | None],
+    days_above_flip: int,
+) -> dict[str, Any]:
+    """Determine directional bias heuristic."""
+    reasons = []
+
+    if flip is None:
+        return {
+            "direction": "NEUTRAL",
+            "reasons": ["GEX flip not computable"],
+            "days_above_flip": 0,
+            "flip_migration": [],
+        }
+
+    above_flip = spot > flip
+    magnet_above = (
+        levels.get("max_magnet") is not None and levels["max_magnet"]["strike"] > spot
+    )
+
+    if above_flip and net_gex > 0 and magnet_above:
+        direction = "BULL"
+        reasons.append(f"Spot above flip ({flip:.0f})")
+        reasons.append("Net GEX positive (stabilizing)")
+        reasons.append(
+            f"Max magnet at {levels['max_magnet']['strike']:.0f} pulls higher"
+        )
+    elif above_flip and magnet_above:
+        direction = "CAUTIOUS_BULL"
+        reasons.append(f"Spot above flip ({flip:.0f})")
+        if net_gex < 0:
+            reasons.append("Net GEX still negative")
+        if magnet_above:
+            reasons.append(f"Magnet at {levels['max_magnet']['strike']:.0f} above spot")
+    elif not above_flip and net_gex < 0:
+        direction = "BEAR"
+        reasons.append(f"Spot below flip ({flip:.0f})")
+        reasons.append("Net GEX negative (destabilizing)")
+        accel = levels.get("max_accelerator")
+        if accel and accel["strike"] < spot:
+            reasons.append(f"Accelerator at {accel['strike']:.0f} below")
+    elif not above_flip:
+        direction = "CAUTIOUS_BEAR"
+        reasons.append(f"Spot below flip ({flip:.0f})")
+    else:
+        direction = "NEUTRAL"
+        reasons.append("Near flip level")
+
+    if abs(days_above_flip) >= 3:
+        side = "above" if days_above_flip > 0 else "below"
+        reasons.append(f"{abs(days_above_flip)} consecutive days {side} flip")
+
+    return {
+        "direction": direction,
+        "reasons": reasons,
+        "days_above_flip": days_above_flip,
+        "flip_migration": [],
+    }
+
+
+# ─── UW-driven fetchers (adapted for this repo's client + run_id pattern) ──
+
+
+def fetch_strike_gex(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> list[dict[str, Any]]:
+    """Per-strike GEX rows. Aggregates the UW response into the canonical shape."""
+    body = uw_source.fetch_greek_exposure_by_strike(client, repo, run_id, ticker)
+    rows = body.get("data", []) or []
+    parsed = []
+    for r in rows:
+        try:
+            strike = float(r["strike"])
+            call_gex = float(r.get("call_gex", 0) or 0)
+            put_gex = float(r.get("put_gex", 0) or 0)
+            call_delta = float(r.get("call_delta", 0) or 0)
+            put_delta = float(r.get("put_delta", 0) or 0)
+            parsed.append(
+                {
+                    "strike": strike,
+                    "call_gex": call_gex,
+                    "put_gex": put_gex,
+                    "net_gex": call_gex + put_gex,
+                    "call_delta": call_delta,
+                    "put_delta": put_delta,
+                    "net_delta": call_delta + put_delta,
+                }
+            )
+        except (KeyError, ValueError, TypeError):
+            continue
+    return parsed
+
+
+def fetch_aggregate_gex(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> list[dict[str, Any]]:
+    """Aggregate GEX time series (used for net_dex calculation)."""
+    body = uw_source.fetch_greek_exposure_history(client, repo, run_id, ticker)
+    rows = body.get("data", []) or []
+    parsed = []
+    for r in rows:
+        try:
+            parsed.append(
+                {
+                    "date": r.get("date"),
+                    "call_gex": float(r.get("call_gex", 0) or 0),
+                    "put_gex": float(r.get("put_gex", 0) or 0),
+                    "call_delta": float(r.get("call_delta", 0) or 0),
+                    "put_delta": float(r.get("put_delta", 0) or 0),
+                }
+            )
+        except (KeyError, ValueError, TypeError):
+            continue
+    return parsed
+
+
+def fetch_iv_rank_rows(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> list[dict[str, Any]]:
+    """Raw iv_rank rows — atm_iv, iv_rank, and spot all consume the same data."""
+    body = uw_source._fetch_json(client, repo, run_id, EndpointSlug.IV_RANK, ticker)
+    return body.get("data", []) or []
+
+
+def _latest_iv_rank_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not rows:
+        return None
+    return max(rows, key=lambda r: r.get("date", "") or "")
+
+
+def fetch_atm_iv(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """30D ATM IV from latest iv_rank row's ``volatility`` field."""
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    v = row.get("volatility")
+    try:
+        return float(v) if v is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_iv_rank(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """1Y IV rank percentile from latest row's ``iv_rank_1y`` field."""
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    r = row.get("iv_rank_1y")
+    try:
+        return float(r) if r is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_spot_price(iv_rank_rows: list[dict[str, Any]]) -> float | None:
+    """Spot from latest iv_rank row's ``close`` field.
+
+    xenon's primary source (UW /stock/{ticker}/info) is not wired in this repo.
+    Yahoo fallback is banned. iv_rank.close is the surviving path.
+    """
+    row = _latest_iv_rank_row(iv_rank_rows)
+    if row is None:
+        return None
+    p = row.get("close")
+    try:
+        return float(p) if p is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_vol_pc(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> float | None:
+    """Volume put/call ratio from the screener row for this ticker."""
+    try:
+        body = uw_source._fetch_json(
+            client,
+            repo,
+            run_id,
+            EndpointSlug.BULK_SCREENER_STOCKS,
+            None,
+            params={"ticker": ticker.upper()},
+        )
+        rows = body.get("data", []) or []
+        for r in rows:
+            t = r.get("ticker", r.get("symbol", ""))
+            if str(t).upper() == ticker.upper():
+                pc = r.get("put_call_ratio")
+                return float(pc) if pc is not None else None
+        return None
+    except Exception as exc:
+        log.warning("vol_pc_fetch_failed ticker=%s err=%s", ticker, repr(exc))
+        return None
+
+
+# ─── Orchestration ─────────────────────────────────────────────────────────
+
+
+def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
+    """Run a full GEX scan against UW and persist to gex_snapshots.
+
+    Returns the inserted row id. Raises if spot cannot be determined.
+    """
+    ticker = ticker.upper()
+    run_id = repo.insert_scan_run(ticker, notes=f"gex_scan_{ticker}")
+    log.info("gex_scan_start ticker=%s run_id=%d", ticker, run_id)
+
+    try:
+        iv_rows = fetch_iv_rank_rows(client, repo, run_id, ticker)
+        spot = fetch_spot_price(iv_rows)
+        if spot is None:
+            log.warning("gex_scan_aborted_no_spot ticker=%s run_id=%d", ticker, run_id)
+            repo.finish_scan_run(run_id, status="error")
+            raise RuntimeError(f"could not fetch spot for {ticker}")
+
+        strike_rows = fetch_strike_gex(client, repo, run_id, ticker)
+        aggregate_rows = fetch_aggregate_gex(client, repo, run_id, ticker)
+        atm_iv = fetch_atm_iv(iv_rows)
+        iv_rank = fetch_iv_rank(iv_rows)
+        vol_pc = fetch_vol_pc(client, repo, run_id, ticker)
+
+        bucket_size = _bucket_size_for(ticker, spot)
+        profile = bucket_profile(strike_rows, bucket_size, spot)
+        levels = find_key_levels(profile, spot)
+        gex_flip_strike = compute_gex_flip(profile, spot)
+        profile = tag_profile(profile, spot, gex_flip_strike, levels)
+        expected_range = compute_expected_range(spot, atm_iv)
+
+        net_gex = sum(b["net_gex"] for b in profile)
+        net_dex = sum(
+            r.get("call_delta", 0) + r.get("put_delta", 0) for r in aggregate_rows
+        )
+
+        days_above_flip = 0  # v1: history reader not wired yet
+        bias = compute_directional_bias(
+            spot, gex_flip_strike, net_gex, levels, days_above_flip
+        )
+
+        # Inject GEX flip into levels block (xenon does this in build_gex_output)
+        if gex_flip_strike is not None:
+            levels = dict(levels)
+            levels["gex_flip"] = {
+                "strike": gex_flip_strike,
+                "gamma": 0.0,
+                "distance": round(gex_flip_strike - spot, 2),
+                "distance_pct": round((gex_flip_strike - spot) / spot * 100, 2),
+            }
+        else:
+            levels = dict(levels)
+            levels["gex_flip"] = None
+
+        payload: dict[str, Any] = {
+            "scan_time": datetime.now(timezone.utc).isoformat(),
+            "ticker": ticker,
+            "spot": spot,
+            "close": spot,
+            "day_change": None,
+            "day_change_pct": None,
+            "data_date": datetime.now(timezone.utc).date().isoformat(),
+            "net_gex": net_gex,
+            "net_dex": net_dex,
+            "atm_iv": atm_iv,
+            "vol_pc": vol_pc,
+            "levels": levels,
+            "profile": profile,
+            "expected_range": expected_range,
+            "bias": bias,
+            "history": [],
+            "iv": {
+                "iv30d": atm_iv,
+                "iv_rank": iv_rank,
+                "hv30": None,
+                "mq_iv30d": None,
+                "mq_iv_rank": None,
+                "source": "uw" if atm_iv is not None else None,
+            },
+            "mq": None,
+            "source_delta": None,
+        }
+
+        row_id = repo.upsert_gex_snapshot(ticker=ticker, payload=payload)
+        repo.finish_scan_run(run_id, status="ok")
+        log.info(
+            "gex_scan_done ticker=%s row_id=%d net_gex=%.2e",
+            ticker,
+            row_id,
+            net_gex,
+        )
+        return row_id
+    except Exception:
+        repo.finish_scan_run(run_id, status="error")
+        raise

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -445,6 +445,36 @@ def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
 
         strike_rows = fetch_strike_gex(client, repo, run_id, ticker)
         aggregate_rows = fetch_aggregate_gex(client, repo, run_id, ticker)
+        # Persist the daily tail for the regime history chart. We already
+        # have the parsed rows in aggregate_rows — no extra UW call. Failures
+        # here are non-fatal: the scan's primary outcome is the snapshot row.
+        try:
+            from uw_scan.storage.greek_exposure_repository import (
+                GreekExposureDailyRepository,
+            )
+
+            GreekExposureDailyRepository(repo.conn, schema=repo._schema).upsert_rows(
+                ticker,
+                [
+                    {
+                        "trade_date": h["date"],
+                        "call_gex": h["call_gex"],
+                        "put_gex": h["put_gex"],
+                        "call_delta": h["call_delta"],
+                        "put_delta": h["put_delta"],
+                        # JSONB needs a serializable form — date stays in
+                        # the trade_date column, so drop it from payload.
+                        "payload": {k: v for k, v in h.items() if k != "date"},
+                    }
+                    for h in aggregate_rows
+                ],
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "greek_exposure_daily_upsert_failed ticker=%s err=%s",
+                ticker,
+                repr(exc),
+            )
         atm_iv = fetch_atm_iv(iv_rows)
         iv_rank = fetch_iv_rank(iv_rows)
         vol_pc = fetch_vol_pc(client, repo, run_id, ticker)

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from uw_scan.api.client import UwClient
 from uw_scan.api.endpoints import EndpointSlug
+from uw_scan.cards.greek_exposure_history import parse_greek_exposure_history
 from uw_scan.sources import uw as uw_source
 from uw_scan.storage.repository import Repository
 
@@ -290,24 +291,13 @@ def fetch_strike_gex(
 def fetch_aggregate_gex(
     client: UwClient, repo: Repository, run_id: int, ticker: str
 ) -> list[dict[str, Any]]:
-    """Aggregate GEX time series (used for net_dex calculation)."""
+    """Aggregate GEX time series.
+
+    Delegates parsing to the shared ``cards/greek_exposure_history`` util so
+    the same logic is reused by the regime-page history persistence path.
+    """
     body = uw_source.fetch_greek_exposure_history(client, repo, run_id, ticker)
-    rows = body.get("data", []) or []
-    parsed = []
-    for r in rows:
-        try:
-            parsed.append(
-                {
-                    "date": r.get("date"),
-                    "call_gex": float(r.get("call_gex", 0) or 0),
-                    "put_gex": float(r.get("put_gex", 0) or 0),
-                    "call_delta": float(r.get("call_delta", 0) or 0),
-                    "put_delta": float(r.get("put_delta", 0) or 0),
-                }
-            )
-        except (KeyError, ValueError, TypeError):
-            continue
-    return parsed
+    return parse_greek_exposure_history(body)
 
 
 def fetch_iv_rank_rows(

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -283,7 +283,8 @@ def fetch_strike_gex(
                     "net_delta": call_delta + put_delta,
                 }
             )
-        except (KeyError, ValueError, TypeError):
+        except (KeyError, ValueError, TypeError) as exc:
+            log.debug("gex strike row skipped: %s", repr(exc))
             continue
     return parsed
 
@@ -322,7 +323,8 @@ def fetch_atm_iv(iv_rank_rows: list[dict[str, Any]]) -> float | None:
     v = row.get("volatility")
     try:
         return float(v) if v is not None else None
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        log.debug("atm_iv coercion failed: %s", repr(exc))
         return None
 
 
@@ -334,7 +336,8 @@ def fetch_iv_rank(iv_rank_rows: list[dict[str, Any]]) -> float | None:
     r = row.get("iv_rank_1y")
     try:
         return float(r) if r is not None else None
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        log.debug("iv_rank coercion failed: %s", repr(exc))
         return None
 
 
@@ -351,7 +354,8 @@ def fetch_spot_price(iv_rank_rows: list[dict[str, Any]]) -> float | None:
     p = row.get("close")
     try:
         return float(p) if p is not None else None
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        log.debug("spot_price coercion failed: %s", repr(exc))
         return None
 
 

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -7,8 +7,10 @@ Differences from xenon:
 - No CLI; no HTML rendering.
 - This repo's UW pattern threads ``run_id`` from ``repo.insert_scan_run(...)``
   through every fetcher for audit trail.
-- Spot source: only iv_rank ``close`` (UW ``/stock/{ticker}/info`` not wired;
-  Yahoo banned). ``compute_days_above_flip`` set to 0 in v1 (no history reader).
+- Spot source: ``/stock/{ticker}/stock-state`` (intraday) with iv_rank.close as
+  EOD fallback (xenon uses /stock-state; ``/info`` returns only metadata, no
+  price). Yahoo banned. ``compute_days_above_flip`` set to 0 in v1 (no history
+  reader).
 """
 
 from __future__ import annotations
@@ -347,10 +349,11 @@ def fetch_iv_rank(iv_rank_rows: list[dict[str, Any]]) -> float | None:
 
 
 def fetch_spot_price(iv_rank_rows: list[dict[str, Any]]) -> float | None:
-    """Spot from latest iv_rank row's ``close`` field.
+    """EOD fallback spot from latest iv_rank row's ``close`` field.
 
-    xenon's primary source (UW /stock/{ticker}/info) is not wired in this repo.
-    Yahoo fallback is banned. iv_rank.close is the surviving path.
+    ``stock-state`` (intraday) is the primary spot source; this lags by hours
+    because iv_rank updates once per day at ~22:35 UTC. Kept as graceful
+    fallback when ``stock-state`` errors. Yahoo banned project-wide.
     """
     row = _latest_iv_rank_row(iv_rank_rows)
     if row is None:
@@ -359,6 +362,37 @@ def fetch_spot_price(iv_rank_rows: list[dict[str, Any]]) -> float | None:
     try:
         return float(p) if p is not None else None
     except (TypeError, ValueError):
+        return None
+
+
+def fetch_stock_state_snapshot(
+    client: UwClient, repo: Repository, run_id: int, ticker: str
+) -> dict[str, Any] | None:
+    """Live spot snapshot from /stock-state. Returns None on any failure.
+
+    Normalized keys: ``spot, prev_close, market_time, tape_time, source``.
+    ``source`` is always ``"stock_state"`` when this returns a dict — callers
+    use it to distinguish from the iv_rank fallback in the payload.
+    """
+    try:
+        body = uw_source.fetch_stock_state(client, repo, run_id, ticker)
+        data = body.get("data") if isinstance(body, dict) else None
+        if not isinstance(data, dict):
+            return None
+        close = data.get("close")
+        if close is None:
+            return None
+        return {
+            "spot": float(close),
+            "prev_close": float(data["prev_close"])
+            if data.get("prev_close") is not None
+            else None,
+            "market_time": data.get("market_time"),
+            "tape_time": data.get("tape_time"),
+            "source": "stock_state",
+        }
+    except Exception as exc:
+        log.warning("stock_state_fetch_failed ticker=%s err=%s", ticker, repr(exc))
         return None
 
 
@@ -401,7 +435,19 @@ def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
 
     try:
         iv_rows = fetch_iv_rank_rows(client, repo, run_id, ticker)
-        spot = fetch_spot_price(iv_rows)
+        snapshot = fetch_stock_state_snapshot(client, repo, run_id, ticker)
+        if snapshot is not None:
+            spot = snapshot["spot"]
+            prev_close = snapshot["prev_close"]
+            market_time = snapshot["market_time"]
+            tape_time = snapshot["tape_time"]
+            spot_source = snapshot["source"]
+        else:
+            spot = fetch_spot_price(iv_rows)
+            prev_close = None
+            market_time = None
+            tape_time = None
+            spot_source = "iv_rank_eod" if spot is not None else None
         if spot is None:
             log.warning("gex_scan_aborted_no_spot ticker=%s run_id=%d", ticker, run_id)
             repo.finish_scan_run(run_id, status="error")
@@ -443,13 +489,23 @@ def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
             levels = dict(levels)
             levels["gex_flip"] = None
 
+        day_change = round(spot - prev_close, 4) if prev_close is not None else None
+        day_change_pct = (
+            round((spot - prev_close) / prev_close * 100, 4)
+            if prev_close is not None and prev_close != 0
+            else None
+        )
         payload: dict[str, Any] = {
             "scan_time": datetime.now(timezone.utc).isoformat(),
             "ticker": ticker,
             "spot": spot,
             "close": spot,
-            "day_change": None,
-            "day_change_pct": None,
+            "prev_close": prev_close,
+            "market_time": market_time,
+            "tape_time": tape_time,
+            "spot_source": spot_source,
+            "day_change": day_change,
+            "day_change_pct": day_change_pct,
             "data_date": datetime.now(timezone.utc).date().isoformat(),
             "net_gex": net_gex,
             "net_dex": net_dex,

--- a/src/uw_scan/scanners/vcg.py
+++ b/src/uw_scan/scanners/vcg.py
@@ -1,0 +1,121 @@
+"""VCG scanner — orchestrator on top of cards/vcg_scoring.
+
+Reads VIX/VVIX/<credit-proxy> from vol_index_daily, aligns to a common date
+set, runs ``cards/vcg_scoring.run_analysis``, persists the snapshot via
+``VcgSnapshotRepository``.
+
+No external API calls — all inputs come from the parquet-lake-backed
+vol_index_daily table.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as _date
+
+import numpy as np
+from psycopg import Connection
+
+from uw_scan.cards import vcg_scoring
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+log = logging.getLogger(__name__)
+
+# Lookback — enough for the 21d OLS, the 63d z-window, the 20-day history,
+# plus slack for weekends/holidays so we still have ≥ MIN_BARS aligned days.
+LOOKBACK_DAYS = 200
+MIN_ALIGNED_BARS = vcg_scoring.MIN_BARS
+
+DEFAULT_PROXY = "HYG"
+
+
+def _load_series(
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    days: int,
+    *,
+    prefer_adj_close: bool = False,
+) -> dict[_date, float]:
+    """Build {date: price} from vol_index_daily.
+
+    Credit ETFs (HYG/JNK/LQD) distribute monthly; using raw ``close`` would
+    surface every ex-dividend drop as a log-return spike that the OLS reads
+    as credit stress. Set ``prefer_adj_close=True`` for the credit proxy so
+    distributions are absorbed at source; VIX/VVIX have no such adjustment
+    and keep raw ``close``.
+    """
+    rows = vol_repo.fetch_history(symbol, days=days)
+    out: dict[_date, float] = {}
+    for r in rows:
+        price = r.get("adj_close") if prefer_adj_close else None
+        if price is None:
+            price = r.get("close")
+        if price is None:
+            continue
+        out[r["trade_date"]] = float(price)
+    return out
+
+
+def _align(
+    series: dict[str, dict[_date, float]],
+) -> tuple[dict[str, np.ndarray], list[str]]:
+    """Inner-join the series on shared dates."""
+    if not series:
+        return {}, []
+    keys = list(series.keys())
+    common = set(series[keys[0]].keys())
+    for k in keys[1:]:
+        common &= set(series[k].keys())
+    if not common:
+        return {sym: np.array([]) for sym in keys}, []
+    sorted_dates = sorted(common)
+    aligned = {
+        sym: np.array([series[sym][d] for d in sorted_dates], dtype=float)
+        for sym in keys
+    }
+    return aligned, [d.isoformat() for d in sorted_dates]
+
+
+def run(
+    conn: Connection,
+    *,
+    proxy: str = DEFAULT_PROXY,
+    schema: str = "uw_scan",
+) -> int | None:
+    """Run a VCG scan; persist a new snapshot row.
+
+    Returns the inserted row id, or None if there isn't enough aligned data.
+    """
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    raw = {
+        "VIX": _load_series(vol_repo, "VIX", LOOKBACK_DAYS),
+        "VVIX": _load_series(vol_repo, "VVIX", LOOKBACK_DAYS),
+        proxy: _load_series(vol_repo, proxy, LOOKBACK_DAYS, prefer_adj_close=True),
+    }
+    aligned, common_dates = _align(raw)
+
+    if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
+        log.warning(
+            "vcg_scan_skipped_thin_data proxy=%s aligned_bars=%d need=%d",
+            proxy,
+            len(common_dates),
+            MIN_ALIGNED_BARS,
+        )
+        return None
+
+    payload = vcg_scoring.run_analysis(aligned, common_dates, proxy=proxy)
+    snap_repo = VcgSnapshotRepository(conn, schema=schema)
+    data_date = _date.fromisoformat(payload["date"])
+    row_id = snap_repo.insert_snapshot(payload=payload, data_date=data_date)
+    sig = payload["signal"]
+    log.info(
+        "vcg_scan_persisted row_id=%d proxy=%s vcg=%s interp=%s ro=%d edr=%d",
+        row_id,
+        proxy,
+        sig.get("vcg"),
+        sig.get("interpretation"),
+        sig.get("ro", 0),
+        sig.get("edr", 0),
+    )
+    return row_id

--- a/src/uw_scan/sources/lake.py
+++ b/src/uw_scan/sources/lake.py
@@ -74,6 +74,7 @@ def _maybe_float(x) -> float | None:
         return None
     try:
         f = float(x)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        _ = repr(exc)  # CI Guardrail 2: coercion failure folds to None
         return None
     return f

--- a/src/uw_scan/sources/lake.py
+++ b/src/uw_scan/sources/lake.py
@@ -1,0 +1,79 @@
+"""Parquet reader for ~/market-warehouse/data-lake.
+
+Used by the nightly vol_index_lake_sync job. No business logic — pure I/O.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+VOL_INDEX_FILENAME = "1d.parquet"
+
+
+def list_vol_index_symbols(root: Path) -> list[str]:
+    """Return all symbols under root/symbol=<TICKER>/1d.parquet."""
+    if not root.exists():
+        return []
+    out: list[str] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        name = child.name
+        if not name.startswith("symbol="):
+            continue
+        if not (child / VOL_INDEX_FILENAME).exists():
+            continue
+        out.append(name[len("symbol=") :])
+    return sorted(out)
+
+
+def read_vol_index_parquet(
+    root: Path,
+    symbol: str,
+    *,
+    since: date | None = None,
+) -> list[dict]:
+    """Read symbol=<S>/1d.parquet → list[dict] with normalized columns.
+
+    Output dicts contain: symbol, trade_date, open, high, low, close,
+    adj_close, volume. Rows are sorted by trade_date ascending.
+    """
+    path = root / f"symbol={symbol}" / VOL_INDEX_FILENAME
+    if not path.exists():
+        return []
+    table = pq.read_table(path)
+    df = table.to_pandas()
+    if "trade_date" not in df.columns:
+        return []
+    if since is not None:
+        df = df[df["trade_date"] >= since]
+    df = df.sort_values("trade_date")
+    rows: list[dict] = []
+    for r in df.itertuples(index=False):
+        rd = r._asdict()
+        rows.append(
+            {
+                "symbol": symbol,
+                "trade_date": rd["trade_date"],
+                "open": _maybe_float(rd.get("open")),
+                "high": _maybe_float(rd.get("high")),
+                "low": _maybe_float(rd.get("low")),
+                "close": _maybe_float(rd.get("close")),
+                "adj_close": _maybe_float(rd.get("adj_close")),
+                "volume": int(rd["volume"]) if rd.get("volume") is not None else None,
+            }
+        )
+    return rows
+
+
+def _maybe_float(x) -> float | None:
+    if x is None:
+        return None
+    try:
+        f = float(x)
+    except (TypeError, ValueError):
+        return None
+    return f

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -226,6 +226,31 @@ def fetch_greek_exposure_history(
     )
 
 
+def fetch_stock_state(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> dict:
+    """Fetch /api/stock/{ticker}/stock-state — last trade snapshot.
+
+    Returns the body envelope; ``body["data"]`` carries
+    ``close, prev_close, open, high, low, volume, total_volume, market_time, tape_time``.
+
+    Works uniformly for indices (SPX) and ETFs (SPY/QQQ/IWM). For SPX,
+    ``volume`` and ``total_volume`` are 0 by design (indices don't trade), and
+    ``market_time`` stays "regular" past 16:00 ET because SPX has no postmarket
+    — use ``tape_time`` to judge freshness, not ``market_time``.
+    """
+    return _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.STOCK_STATE,
+        ticker,
+    )
+
+
 def fetch_spot_exposures(
     client: UwClient,
     repo: Repository,

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -186,6 +186,46 @@ def fetch_greek_exposure(
     return normalize.normalize_greek_exposure(body)
 
 
+def fetch_greek_exposure_by_strike(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> dict:
+    """Fetch /api/stock/{ticker}/greek-exposure/strike — aggregated per-strike GEX.
+
+    Returns the raw body; scanner consumes ``body["data"]`` as a list of rows
+    with string-valued ``strike``, ``call_gex``, ``put_gex``, ``call_delta``,
+    ``put_delta`` fields (caller does ``float()`` casting).
+    """
+    return _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.GREEK_EXPOSURE_BY_STRIKE,
+        ticker,
+    )
+
+
+def fetch_greek_exposure_history(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> dict:
+    """Fetch /api/stock/{ticker}/greek-exposure — aggregate GEX over time.
+
+    Used for net_dex computation and (eventually) historical bias trend.
+    """
+    return _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.GREEK_EXPOSURE_HISTORY,
+        ticker,
+    )
+
+
 def fetch_spot_exposures(
     client: UwClient,
     repo: Repository,

--- a/src/uw_scan/storage/cri_snapshot_repository.py
+++ b/src/uw_scan/storage/cri_snapshot_repository.py
@@ -1,0 +1,83 @@
+"""Persistence for Crash Risk Indicator (CRI) snapshots.
+
+New domain — own file rather than extending repository.py.
+Append-only; latest-wins on read.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from psycopg import Connection
+from psycopg.types.json import Jsonb
+
+
+class CriSnapshotRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def insert_snapshot(self, *, payload: dict, data_date: date | None = None) -> int:
+        sql = """
+            INSERT INTO cri_snapshots (data_date, payload)
+            VALUES (%s, %s)
+            RETURNING id
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (data_date, Jsonb(payload)))
+            row = cur.fetchone()
+        assert row is not None
+        self._conn.commit()
+        return int(row[0])
+
+    def fetch_latest(self) -> dict | None:
+        """Return most-recent payload, or None."""
+        sql = """
+            SELECT payload, scanned_at
+              FROM cri_snapshots
+             ORDER BY scanned_at DESC
+             LIMIT 1
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql)
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at = row
+        out = dict(payload or {})
+        if scanned_at is not None and not out.get("scan_time"):
+            out["scan_time"] = scanned_at.isoformat()
+        return out
+
+    def fetch_history(self, *, limit: int = 30) -> list[dict]:
+        """Return up to `limit` most-recent rows, ascending by scanned_at.
+
+        Output rows include the indexable scalars (cri_score, cri_level,
+        trigger_fired, vix, vvix, cor1m, spx_distance_pct, realized_vol)
+        plus scan_time.
+        """
+        sql = """
+            SELECT scanned_at,
+                   cri_score::float8,
+                   cri_level,
+                   trigger_fired,
+                   vix::float8,
+                   vvix::float8,
+                   cor1m::float8,
+                   spx_distance_pct::float8,
+                   realized_vol::float8
+              FROM cri_snapshots
+             ORDER BY scanned_at DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (limit,))
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        for r in rows:
+            if r.get("scanned_at") is not None:
+                r["scan_time"] = r["scanned_at"].isoformat()
+        return rows

--- a/src/uw_scan/storage/greek_exposure_repository.py
+++ b/src/uw_scan/storage/greek_exposure_repository.py
@@ -1,0 +1,70 @@
+"""Persistence for UW /greek-exposure daily history. New domain — own file."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from psycopg import Connection
+from psycopg.types.json import Jsonb
+
+
+class GreekExposureDailyRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def upsert_rows(self, ticker: str, rows: Iterable[dict]) -> int:
+        rows = list(rows)
+        if not rows:
+            return 0
+        params = [
+            {
+                "ticker": ticker,
+                "trade_date": r["trade_date"],
+                "call_gex": r.get("call_gex"),
+                "put_gex": r.get("put_gex"),
+                "call_delta": r.get("call_delta"),
+                "put_delta": r.get("put_delta"),
+                "payload": Jsonb(r.get("payload") or {}),
+            }
+            for r in rows
+        ]
+        sql = """
+            INSERT INTO greek_exposure_daily
+                (ticker, trade_date, call_gex, put_gex,
+                 call_delta, put_delta, payload)
+            VALUES
+                (%(ticker)s, %(trade_date)s, %(call_gex)s, %(put_gex)s,
+                 %(call_delta)s, %(put_delta)s, %(payload)s)
+            ON CONFLICT (ticker, trade_date) DO UPDATE SET
+                call_gex   = EXCLUDED.call_gex,
+                put_gex    = EXCLUDED.put_gex,
+                call_delta = EXCLUDED.call_delta,
+                put_delta  = EXCLUDED.put_delta,
+                payload    = EXCLUDED.payload
+        """
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, params)
+        self._conn.commit()
+        return len(params)
+
+    def fetch_history(self, ticker: str, days: int) -> list[dict]:
+        """Return up to `days` most-recent rows, ascending by trade_date."""
+        sql = """
+            SELECT ticker, trade_date,
+                   call_gex::float8,   put_gex::float8,
+                   call_delta::float8, put_delta::float8,
+                   net_gex::float8,    net_dex::float8
+              FROM greek_exposure_daily
+             WHERE ticker = %s
+             ORDER BY trade_date DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (ticker, days))
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        return rows

--- a/src/uw_scan/storage/migrations/037_gex_snapshots.sql
+++ b/src/uw_scan/storage/migrations/037_gex_snapshots.sql
@@ -1,0 +1,36 @@
+-- 037_gex_snapshots.sql
+--
+-- GEX snapshots table — mirrors xenon's src/xenon/db/schema.py:577-641
+-- JSONB payload + generated columns for indexable scalars.
+-- Idempotent (IF NOT EXISTS).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.gex_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    ticker          TEXT NOT NULL,
+    data_date       DATE,
+    scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    payload         JSONB NOT NULL,
+    spot            NUMERIC(12,4) GENERATED ALWAYS AS ((payload->>'spot')::numeric) STORED,
+    net_gex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_gex')::numeric) STORED,
+    net_dex         NUMERIC(14,2) GENERATED ALWAYS AS ((payload->>'net_dex')::numeric) STORED,
+    vol_pc          NUMERIC(8,4)  GENERATED ALWAYS AS ((payload->>'vol_pc')::numeric) STORED,
+    iv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'iv30d')::numeric) STORED,
+    iv_rank         NUMERIC(6,2)  GENERATED ALWAYS AS (((payload->'iv')->>'iv_rank')::numeric) STORED,
+    hv_30d          NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'hv30')::numeric) STORED,
+    mq_iv_30d       NUMERIC(6,4)  GENERATED ALWAYS AS (((payload->'iv')->>'mq_iv30d')::numeric) STORED,
+    level_max_magnet_strike       NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'strike')::numeric) STORED,
+    level_max_magnet_gamma        NUMERIC(14,4) GENERATED ALWAYS AS (((payload->'levels'->'max_magnet')->>'gamma')::numeric) STORED,
+    level_second_magnet_strike    NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'second_magnet')->>'strike')::numeric) STORED,
+    level_max_accelerator_strike  NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'max_accelerator')->>'strike')::numeric) STORED,
+    level_put_wall_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'put_wall')->>'strike')::numeric) STORED,
+    level_call_wall_strike        NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'call_wall')->>'strike')::numeric) STORED,
+    level_gex_flip_strike         NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'levels'->'gex_flip')->>'strike')::numeric) STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_gex_ticker_time ON uw_scan.gex_snapshots (ticker, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_scanned_at  ON uw_scan.gex_snapshots (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_gex_data_date   ON uw_scan.gex_snapshots (data_date);
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/038_vol_index_daily.sql
+++ b/src/uw_scan/storage/migrations/038_vol_index_daily.sql
@@ -1,0 +1,27 @@
+-- 038_vol_index_daily.sql
+--
+-- CBOE volatility index daily OHLC, sourced from the local parquet lake.
+-- Covers SPX (filling the UW /ohlc/1d gap for indices) and the vol complex
+-- (VIX, VIX3M, VVIX, COR1M, COR3M, OVX, RVX, VXN, VXEEM, etc.).
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.vol_index_daily (
+    symbol      TEXT NOT NULL,
+    trade_date  DATE NOT NULL,
+    open        NUMERIC(14,4),
+    high        NUMERIC(14,4),
+    low         NUMERIC(14,4),
+    close       NUMERIC(14,4),
+    adj_close   NUMERIC(14,4),
+    volume      BIGINT,
+    PRIMARY KEY (symbol, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS ix_vol_index_symbol_date
+    ON uw_scan.vol_index_daily (symbol, trade_date DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/039_greek_exposure_daily.sql
+++ b/src/uw_scan/storage/migrations/039_greek_exposure_daily.sql
@@ -1,0 +1,37 @@
+-- 039_greek_exposure_daily.sql
+--
+-- Daily history of UW's /greek-exposure for each watchlist ticker. The endpoint
+-- returns ~250 trailing daily rows in every call; we persist the tail so the
+-- regime page can render a 90-day history chart without re-fetching.
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+-- Columns mirror UW's /greek-exposure (history) payload exactly:
+--   date, call_gex, put_gex, call_delta, put_delta
+-- Computed convenience columns: net_gex, net_dex.
+--
+-- NOT stored here (UW doesn't return them in this payload):
+--   - gex_flip (per-day): computed from per-strike GEX; we only have
+--     today's via /greek-exposure/strike. Historical flip values come
+--     from gex_snapshots over time (forward-only).
+--   - price/spot: comes from daily_ohlc (ETFs) or vol_index_daily (SPX).
+CREATE TABLE IF NOT EXISTS uw_scan.greek_exposure_daily (
+    ticker         TEXT NOT NULL,
+    trade_date     DATE NOT NULL,
+    call_gex       NUMERIC(20,4),
+    put_gex        NUMERIC(20,4),
+    call_delta     NUMERIC(20,4),
+    put_delta      NUMERIC(20,4),
+    net_gex        NUMERIC(20,4) GENERATED ALWAYS AS (call_gex + put_gex) STORED,
+    net_dex        NUMERIC(20,4) GENERATED ALWAYS AS (call_delta + put_delta) STORED,
+    payload        JSONB,
+    PRIMARY KEY (ticker, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS ix_greek_exposure_daily_ticker_date
+    ON uw_scan.greek_exposure_daily (ticker, trade_date DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/040_cri_snapshots.sql
+++ b/src/uw_scan/storage/migrations/040_cri_snapshots.sql
@@ -1,0 +1,34 @@
+-- 040_cri_snapshots.sql
+--
+-- Crash Risk Indicator (CRI) scanner snapshots. Append-only — every scan
+-- inserts a new row. Latest-wins via ORDER BY scanned_at DESC LIMIT 1.
+-- Indexable scalars are generated columns extracted from the JSONB payload
+-- (mirrors the gex_snapshots pattern).
+--
+-- Schema: docs/superpowers/research/regime/ (TBD)
+-- Source scanner: src/uw_scan/scanners/cri.py
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.cri_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    data_date       DATE,
+    payload         JSONB NOT NULL,
+    cri_score       NUMERIC(6,2) GENERATED ALWAYS AS (((payload->'cri')->>'score')::numeric) STORED,
+    cri_level       TEXT         GENERATED ALWAYS AS ((payload->'cri')->>'level') STORED,
+    trigger_fired   BOOLEAN      GENERATED ALWAYS AS (((payload->'crash_trigger')->>'fired')::boolean) STORED,
+    vix             NUMERIC(8,2) GENERATED ALWAYS AS ((payload->>'vix')::numeric) STORED,
+    vvix            NUMERIC(8,2) GENERATED ALWAYS AS ((payload->>'vvix')::numeric) STORED,
+    cor1m           NUMERIC(8,2) GENERATED ALWAYS AS ((payload->>'cor1m')::numeric) STORED,
+    spx_distance_pct NUMERIC(8,4) GENERATED ALWAYS AS ((payload->>'spx_distance_pct')::numeric) STORED,
+    realized_vol    NUMERIC(8,2) GENERATED ALWAYS AS ((payload->>'realized_vol')::numeric) STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_cri_scanned_at ON uw_scan.cri_snapshots (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_cri_data_date  ON uw_scan.cri_snapshots (data_date DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/041_vcg_snapshots.sql
+++ b/src/uw_scan/storage/migrations/041_vcg_snapshots.sql
@@ -1,0 +1,41 @@
+-- 041_vcg_snapshots.sql
+--
+-- Volatility-Credit Gap (VCG) scanner snapshots. Append-only — every scan
+-- inserts a new row. Latest-wins via ORDER BY scanned_at DESC LIMIT 1.
+-- Indexable scalars are generated columns extracted from the JSONB payload
+-- (mirrors the cri_snapshots / gex_snapshots pattern).
+--
+-- Schema: see src/uw_scan/cards/vcg_scoring.py for payload shape.
+-- Source scanner: src/uw_scan/scanners/vcg.py
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.vcg_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    data_date       DATE,
+    payload         JSONB NOT NULL,
+
+    credit_proxy    TEXT          GENERATED ALWAYS AS (payload->>'credit_proxy') STORED,
+    vcg_score       NUMERIC(10,4) GENERATED ALWAYS AS (((payload->'signal')->>'vcg')::numeric) STORED,
+    vcg_adj         NUMERIC(10,4) GENERATED ALWAYS AS (((payload->'signal')->>'vcg_adj')::numeric) STORED,
+    interpretation  TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'interpretation') STORED,
+    regime          TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'regime') STORED,
+    tier            INTEGER       GENERATED ALWAYS AS (((payload->'signal')->>'tier')::int) STORED,
+    ro              INTEGER       GENERATED ALWAYS AS (((payload->'signal')->>'ro')::int) STORED,
+    edr             INTEGER       GENERATED ALWAYS AS (((payload->'signal')->>'edr')::int) STORED,
+    bounce          INTEGER       GENERATED ALWAYS AS (((payload->'signal')->>'bounce')::int) STORED,
+    vix             NUMERIC(8,2)  GENERATED ALWAYS AS (((payload->'signal')->>'vix')::numeric) STORED,
+    vvix            NUMERIC(8,2)  GENERATED ALWAYS AS (((payload->'signal')->>'vvix')::numeric) STORED,
+    credit_price    NUMERIC(12,4) GENERATED ALWAYS AS (((payload->'signal')->>'credit_price')::numeric) STORED,
+    vvix_severity   TEXT          GENERATED ALWAYS AS ((payload->'signal')->>'vvix_severity') STORED
+);
+
+CREATE INDEX IF NOT EXISTS ix_vcg_scanned_at        ON uw_scan.vcg_snapshots (scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_vcg_data_date         ON uw_scan.vcg_snapshots (data_date DESC);
+CREATE INDEX IF NOT EXISTS ix_vcg_credit_proxy_date ON uw_scan.vcg_snapshots (credit_proxy, data_date DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/migrations/042_vcg_proxy_scanned_at_index.sql
+++ b/src/uw_scan/storage/migrations/042_vcg_proxy_scanned_at_index.sql
@@ -1,0 +1,17 @@
+-- 042_vcg_proxy_scanned_at_index.sql
+--
+-- VcgSnapshotRepository.fetch_latest(proxy=...) / fetch_history(proxy=...) run
+--   WHERE credit_proxy = ?  ORDER BY scanned_at DESC, id DESC  LIMIT ?
+-- but 041 only adds (credit_proxy, data_date DESC). Adds the matching covering
+-- index; id is included so latest-wins ordering is deterministic even when two
+-- snapshots land in the same scanned_at microsecond (manual + scheduled scan).
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS ix_vcg_credit_proxy_scanned_at
+    ON uw_scan.vcg_snapshots (credit_proxy, scanned_at DESC, id DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -5158,6 +5158,58 @@ class Repository:
                 (ticker, status, started_at, finished_at, error_message),
             )
 
+    # ------------------------------------------------------------------
+    # Regime / GEX (ported from xenon 2026-05-16)
+    # ------------------------------------------------------------------
+
+    def fetch_latest_gex(self, *, ticker: str = "SPX") -> dict | None:
+        """Return the most recent GEX snapshot payload for ``ticker``, or None.
+
+        ``scan_time`` and ``ticker`` are populated from the row when absent
+        from the payload so the API response always carries them.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT payload, scanned_at, ticker "
+                f"FROM {self._schema}.gex_snapshots "
+                f"WHERE ticker = %s ORDER BY scanned_at DESC LIMIT 1",
+                (ticker.upper(),),
+            )
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at, row_ticker = row
+        out = dict(payload or {})
+        if not out.get("scan_time") and scanned_at is not None:
+            out["scan_time"] = scanned_at.isoformat()
+        out.setdefault("ticker", row_ticker)
+        return out
+
+    def upsert_gex_snapshot(
+        self,
+        *,
+        ticker: str,
+        payload: dict,
+        data_date=None,
+    ) -> int:
+        """Insert a new gex_snapshots row. Returns the inserted row id.
+
+        Each scan appends a row — the table is append-only so we can
+        reconstruct history from gex_snapshots later. Latest-wins via
+        ``ORDER BY scanned_at DESC LIMIT 1`` in ``fetch_latest_gex``.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"INSERT INTO {self._schema}.gex_snapshots "
+                "(ticker, data_date, payload) "
+                "VALUES (%s, %s, %s) RETURNING id",
+                (ticker.upper(), data_date, Jsonb(payload)),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        self._conn.commit()
+        return int(row[0])
+
 
 # Re-export for convenience
 __all__ = [

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -5185,6 +5185,28 @@ class Repository:
         out.setdefault("ticker", row_ticker)
         return out
 
+    def fetch_flip_strike_history(self, *, ticker: str, limit: int = 90) -> dict:
+        """Return ``{trade_date: gex_flip_strike}`` for the most recent N days.
+
+        Multiple snapshots per day may exist; the latest scan wins (max
+        ``scanned_at`` per ``data_date``). Days without a flip strike are
+        omitted — UI renders sparse.
+        """
+        sql = f"""
+            SELECT DISTINCT ON (data_date)
+                   data_date,
+                   level_gex_flip_strike::float8 AS flip
+              FROM {self._schema}.gex_snapshots
+             WHERE ticker = %s
+               AND data_date IS NOT NULL
+               AND level_gex_flip_strike IS NOT NULL
+             ORDER BY data_date DESC, scanned_at DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (ticker.upper(), limit))
+            return {row[0]: row[1] for row in cur.fetchall()}
+
     def upsert_gex_snapshot(
         self,
         *,

--- a/src/uw_scan/storage/vcg_snapshot_repository.py
+++ b/src/uw_scan/storage/vcg_snapshot_repository.py
@@ -1,0 +1,125 @@
+"""Persistence for Volatility-Credit Gap (VCG) snapshots.
+
+New domain — own file, never extending repository.py. Append-only;
+latest-wins on read. Mirrors CriSnapshotRepository.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from psycopg import Connection
+from psycopg.types.json import Jsonb
+
+
+class VcgSnapshotRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def insert_snapshot(self, *, payload: dict, data_date: date | None = None) -> int:
+        sql = """
+            INSERT INTO vcg_snapshots (data_date, payload)
+            VALUES (%s, %s)
+            RETURNING id
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (data_date, Jsonb(payload)))
+            row = cur.fetchone()
+        assert row is not None
+        self._conn.commit()
+        return int(row[0])
+
+    def fetch_latest(self, *, proxy: str | None = None) -> dict | None:
+        """Return the most recent payload (optionally filtered by proxy).
+
+        ``id DESC`` is the tie-breaker for the rare case where two snapshots
+        share a ``scanned_at`` microsecond (manual scan racing the cron tick).
+        """
+        if proxy is None:
+            sql = """
+                SELECT payload, scanned_at
+                  FROM vcg_snapshots
+                 ORDER BY scanned_at DESC, id DESC
+                 LIMIT 1
+            """
+            params: tuple = ()
+        else:
+            sql = """
+                SELECT payload, scanned_at
+                  FROM vcg_snapshots
+                 WHERE credit_proxy = %s
+                 ORDER BY scanned_at DESC, id DESC
+                 LIMIT 1
+            """
+            params = (proxy,)
+        with self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+        if row is None:
+            return None
+        payload, scanned_at = row
+        out = dict(payload or {})
+        if scanned_at is not None and not out.get("scan_time"):
+            out["scan_time"] = scanned_at.isoformat()
+        return out
+
+    def fetch_history(self, *, proxy: str | None = None, limit: int = 30) -> list[dict]:
+        """Return up to `limit` most-recent rows, ascending by scanned_at.
+
+        Output rows expose the indexable scalars plus scan_time.
+        """
+        if proxy is None:
+            sql = """
+                SELECT scanned_at,
+                       credit_proxy,
+                       vcg_score::float8,
+                       vcg_adj::float8,
+                       interpretation,
+                       regime,
+                       tier,
+                       ro,
+                       edr,
+                       bounce,
+                       vix::float8,
+                       vvix::float8,
+                       credit_price::float8,
+                       vvix_severity
+                  FROM vcg_snapshots
+                 ORDER BY scanned_at DESC, id DESC
+                 LIMIT %s
+            """
+            params: tuple = (limit,)
+        else:
+            sql = """
+                SELECT scanned_at,
+                       credit_proxy,
+                       vcg_score::float8,
+                       vcg_adj::float8,
+                       interpretation,
+                       regime,
+                       tier,
+                       ro,
+                       edr,
+                       bounce,
+                       vix::float8,
+                       vvix::float8,
+                       credit_price::float8,
+                       vvix_severity
+                  FROM vcg_snapshots
+                 WHERE credit_proxy = %s
+                 ORDER BY scanned_at DESC, id DESC
+                 LIMIT %s
+            """
+            params = (proxy, limit)
+        with self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        for r in rows:
+            if r.get("scanned_at") is not None:
+                r["scan_time"] = r["scanned_at"].isoformat()
+        return rows

--- a/src/uw_scan/storage/vol_index_repository.py
+++ b/src/uw_scan/storage/vol_index_repository.py
@@ -1,0 +1,90 @@
+"""Persistence for CBOE vol-complex and SPX daily OHLC sourced from the lake.
+
+New domain — kept in its own file rather than extending the 5,000-line
+repository.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import date
+
+from psycopg import Connection
+
+
+class VolIndexRepository:
+    def __init__(self, conn: Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+        with conn.cursor() as cur:
+            cur.execute(f"SET search_path TO {schema}, public")
+
+    def upsert_rows(self, rows: Iterable[dict]) -> int:
+        """Insert or update vol_index_daily rows. Returns count."""
+        rows = list(rows)
+        if not rows:
+            return 0
+        sql = """
+            INSERT INTO vol_index_daily
+                (symbol, trade_date, open, high, low, close, adj_close, volume)
+            VALUES
+                (%(symbol)s, %(trade_date)s, %(open)s, %(high)s, %(low)s,
+                 %(close)s, %(adj_close)s, %(volume)s)
+            ON CONFLICT (symbol, trade_date) DO UPDATE SET
+                open      = EXCLUDED.open,
+                high      = EXCLUDED.high,
+                low       = EXCLUDED.low,
+                close     = EXCLUDED.close,
+                adj_close = EXCLUDED.adj_close,
+                volume    = EXCLUDED.volume
+        """
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, rows)
+        self._conn.commit()
+        return len(rows)
+
+    def fetch_history(self, symbol: str, days: int) -> list[dict]:
+        """Return up to `days` most-recent rows for symbol, ascending."""
+        sql = """
+            SELECT symbol, trade_date,
+                   open::float8, high::float8, low::float8,
+                   close::float8, adj_close::float8, volume
+              FROM vol_index_daily
+             WHERE symbol = %s
+             ORDER BY trade_date DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbol, days))
+            cols = [c.name for c in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
+        return rows
+
+    def latest_date_for(self, symbol: str) -> date | None:
+        """Return latest trade_date stored, or None."""
+        sql = "SELECT MAX(trade_date) FROM vol_index_daily WHERE symbol = %s"
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbol,))
+            row = cur.fetchone()
+        return row[0] if row and row[0] else None
+
+    def fetch_multi_history(
+        self, symbols: Sequence[str], days: int
+    ) -> dict[str, list[dict]]:
+        """Bulk variant — returns symbol → rows."""
+        if not symbols:
+            return {}
+        sql = """
+            SELECT symbol, trade_date, close::float8
+              FROM vol_index_daily
+             WHERE symbol = ANY(%s)
+               AND trade_date >= (CURRENT_DATE - %s::int)
+             ORDER BY symbol, trade_date
+        """
+        out: dict[str, list[dict]] = {s: [] for s in symbols}
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (list(symbols), days))
+            for sym, td, close in cur.fetchall():
+                out[sym].append({"trade_date": td, "close": close})
+        return out

--- a/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+++ b/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
@@ -1,0 +1,63 @@
+"""Nightly: equity-asset parquet lake → uw_scan.vol_index_daily for credit ETFs.
+
+Mirrors ``vol_index_lake_sync`` but walks the ``asset_class=equity`` root and
+filters down to a configured allow-list (HYG/JNK/LQD by default — the VCG
+scanner's credit proxies). All rows land in ``vol_index_daily`` so the scanner
+can read VIX/VVIX/<proxy> through a single repository.
+
+Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
+the next read. First run backfills the full available history.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import timedelta
+from pathlib import Path
+
+from psycopg import Connection
+
+from uw_scan.sources.lake import read_vol_index_parquet
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+logger = logging.getLogger(__name__)
+
+
+def run_credit_etf_lake_sync(
+    conn: Connection,
+    *,
+    root: Path,
+    symbols: Sequence[str],
+) -> dict:
+    """Sync `symbols` under root into uw_scan.vol_index_daily.
+
+    `read_vol_index_parquet` is reused as-is — it's symbol-keyed and assumes
+    `<root>/symbol=<SYM>/1d.parquet`, which is the same layout the equity
+    asset_class folder uses. Returns {symbols: int, rows: int}.
+    """
+    if not symbols:
+        return {"symbols": 0, "rows": 0}
+
+    repo = VolIndexRepository(conn, schema="uw_scan")
+    total = 0
+    synced = 0
+    for symbol in symbols:
+        latest = repo.latest_date_for(symbol)
+        # Read from one day before latest so a same-day snapshot that closes
+        # differently still gets re-upserted.
+        since = (latest - timedelta(days=1)) if latest else None
+        rows = read_vol_index_parquet(root, symbol, since=since)
+        if not rows:
+            logger.info(
+                "credit_etf_lake_sync: %s — no rows under %s/symbol=%s",
+                symbol,
+                root,
+                symbol,
+            )
+            continue
+        n = repo.upsert_rows(rows)
+        total += n
+        synced += 1
+        logger.info("credit_etf_lake_sync: %s — %d rows since %s", symbol, n, since)
+    return {"symbols": synced, "rows": total}

--- a/src/uw_scan/worker/jobs/vol_index_lake_sync.py
+++ b/src/uw_scan/worker/jobs/vol_index_lake_sync.py
@@ -1,0 +1,43 @@
+"""Nightly: parquet lake → uw_scan.vol_index_daily.
+
+Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
+the next read. First run backfills the entire history.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from pathlib import Path
+
+from psycopg import Connection
+
+from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+logger = logging.getLogger(__name__)
+
+
+def run_vol_index_lake_sync(conn: Connection, *, root: Path) -> dict:
+    """Sync all symbols under root into uw_scan.vol_index_daily.
+
+    Returns a summary dict: {symbols: int, rows: int}.
+    """
+    symbols = list_vol_index_symbols(root)
+    if not symbols:
+        logger.info("vol_index_lake_sync: no symbols at %s", root)
+        return {"symbols": 0, "rows": 0}
+
+    repo = VolIndexRepository(conn, schema="uw_scan")
+    total = 0
+    for symbol in symbols:
+        latest = repo.latest_date_for(symbol)
+        # Read from one day before latest (so we re-upsert the most recent
+        # row in case it was a same-day snapshot that closed differently).
+        since = (latest - timedelta(days=1)) if latest else None
+        rows = read_vol_index_parquet(root, symbol, since=since)
+        if rows:
+            n = repo.upsert_rows(rows)
+            total += n
+            logger.info("vol_index_lake_sync: %s — %d rows since %s", symbol, n, since)
+    return {"symbols": len(symbols), "rows": total}

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -333,6 +333,18 @@ def main() -> int:
         with _repo(settings) as repo:
             run_vol_index_lake_sync(repo.conn, root=settings.lake_vol_index_root)
 
+    def _regime_cri_scan() -> None:
+        # Reads vol_index_daily + daily_ohlc; writes cri_snapshots. No external
+        # API spend. Append-only — running twice in an hour is harmless.
+        from uw_scan.scanners import cri as cri_scanner
+
+        with _repo(settings) as repo:
+            row_id = cri_scanner.run(repo.conn, schema=settings.db_schema)
+            if row_id is None:
+                logger.info("regime_cri_scan_skipped_thin_data")
+            else:
+                logger.info("regime_cri_scan_persisted row_id=%d", row_id)
+
     def _regime_gex_scan() -> None:
         # Weekday gate — UW data only meaningful during regular sessions.
         if datetime.now(ZoneInfo(settings.rth_tz)).weekday() >= 5:
@@ -453,6 +465,16 @@ def main() -> int:
             CronTrigger(hour=3, minute=15, timezone=settings.rth_tz),
             id="vol_index_lake_sync",
             name="Vol-complex parquet lake sync",
+            max_instances=1,
+            coalesce=True,
+        )
+        # CRI scan — refreshes cri_snapshots on the hour. Pure DB-read math,
+        # no provider spend. Append-only; safe to re-run.
+        sched.add_job(
+            _regime_cri_scan,
+            CronTrigger(minute=20, timezone=settings.rth_tz),
+            id="regime_cri_scan",
+            name="Regime CRI scan",
             max_instances=1,
             coalesce=True,
         )

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -30,6 +30,7 @@ from uw_scan.worker.jobs.ohlc_pull import ohlc_pull_once
 from uw_scan.worker.jobs.rescan_loop import rescan_tick
 from uw_scan.worker.jobs.spot_refresh import spot_refresh_once
 from uw_scan.worker.jobs.trade_insights_ai import trade_insights_ai_tick
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
 from uw_scan.worker.volatility_jobs import (
     daily_spy_ohlc_refresh,
     nightly_vol_analytics_rollup,
@@ -325,6 +326,13 @@ def main() -> int:
     def _trade_insights_ai_tick() -> None:
         trade_insights_ai_tick(settings)
 
+    def _vol_index_lake_sync() -> None:
+        # Parquet lake (~/market-warehouse/.../volatility) → vol_index_daily.
+        # Local I/O + Postgres only — no external API spend, no UW/Massive role
+        # binding required. Primary worker runs it to avoid duplicate upserts.
+        with _repo(settings) as repo:
+            run_vol_index_lake_sync(repo.conn, root=settings.lake_vol_index_root)
+
     def _regime_gex_scan() -> None:
         # Weekday gate — UW data only meaningful during regular sessions.
         if datetime.now(ZoneInfo(settings.rth_tz)).weekday() >= 5:
@@ -435,6 +443,18 @@ def main() -> int:
             max_instances=1,
             coalesce=True,
             misfire_grace_time=max(30, settings.trade_insights_ai_poll_seconds * 5),
+        )
+
+    if _is_primary_worker(settings):
+        # Vol-complex parquet lake sync — nightly, 03:15 ET. Local I/O only,
+        # no provider role required. Idempotent (UPSERT) so safe to re-run.
+        sched.add_job(
+            _vol_index_lake_sync,
+            CronTrigger(hour=3, minute=15, timezone=settings.rth_tz),
+            id="vol_index_lake_sync",
+            name="Vol-complex parquet lake sync",
+            max_instances=1,
+            coalesce=True,
         )
 
     stopping = False

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -325,6 +325,28 @@ def main() -> int:
     def _trade_insights_ai_tick() -> None:
         trade_insights_ai_tick(settings)
 
+    def _regime_gex_scan() -> None:
+        # Weekday gate — UW data only meaningful during regular sessions.
+        if datetime.now(ZoneInfo(settings.rth_tz)).weekday() >= 5:
+            logger.info("regime_gex_scan_skipped_weekend")
+            return
+        from uw_scan.scanners import gex as gex_scanner
+
+        with _external_api_recorder(settings) as recorder:
+            with _uw_client(
+                settings, telemetry_recorder=recorder, job_name="regime_gex_scan"
+            ) as uw:
+                with _repo(settings) as repo:
+                    for ticker in settings.gex_scan_tickers:
+                        try:
+                            gex_scanner.run(uw, repo, ticker=ticker)
+                        except Exception as exc:
+                            logger.warning(
+                                "regime_gex_scan_failed ticker=%s err=%s",
+                                ticker,
+                                repr(exc),
+                            )
+
     sched.add_job(
         lambda: _record_worker_heartbeat(settings),
         IntervalTrigger(seconds=1),
@@ -392,6 +414,16 @@ def main() -> int:
                 ),
                 id="cockpit_daily_snapshot",
                 name="Cockpit 6-dim matrix daily snapshot",
+            )
+            # Regime / GEX scan — refreshes gex_snapshots every N minutes.
+            # Primary-uw-only to avoid duplicate UW spend across shards.
+            sched.add_job(
+                _regime_gex_scan,
+                IntervalTrigger(minutes=settings.gex_scan_interval_minutes),
+                id="regime_gex_scan",
+                name="Regime GEX scan (UW)",
+                max_instances=1,
+                coalesce=True,
             )
 
     if "ai" in groups and settings.trade_insights_ai_enabled:

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -24,6 +24,7 @@ from uw_scan.sources.ohlc import MassiveOhlcProvider
 from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.cockpit_daily_snapshot import cockpit_daily_snapshot
+from uw_scan.worker.jobs.credit_etf_lake_sync import run_credit_etf_lake_sync
 from uw_scan.worker.jobs.flow_data_refresh import flow_data_refresh
 from uw_scan.worker.jobs.full_scan import full_scan_once
 from uw_scan.worker.jobs.ohlc_pull import ohlc_pull_once
@@ -333,6 +334,32 @@ def main() -> int:
         with _repo(settings) as repo:
             run_vol_index_lake_sync(repo.conn, root=settings.lake_vol_index_root)
 
+    def _credit_etf_lake_sync() -> None:
+        # Equity asset_class lake → vol_index_daily for the VCG credit proxies
+        # (HYG / JNK / LQD). Pure local I/O; same idempotency guarantees as the
+        # vol-complex sync. Primary worker only.
+        with _repo(settings) as repo:
+            run_credit_etf_lake_sync(
+                repo.conn,
+                root=settings.lake_credit_etf_root,
+                symbols=settings.credit_etf_symbols,
+            )
+
+    def _regime_vcg_scan() -> None:
+        # Reads vol_index_daily (VIX/VVIX + the credit proxies); writes
+        # vcg_snapshots. No external API spend. Append-only.
+        from uw_scan.scanners import vcg as vcg_scanner
+
+        proxy = settings.credit_etf_symbols[0] if settings.credit_etf_symbols else "HYG"
+        with _repo(settings) as repo:
+            row_id = vcg_scanner.run(repo.conn, proxy=proxy, schema=settings.db_schema)
+            if row_id is None:
+                logger.info("regime_vcg_scan_skipped_thin_data proxy=%s", proxy)
+            else:
+                logger.info(
+                    "regime_vcg_scan_persisted proxy=%s row_id=%d", proxy, row_id
+                )
+
     def _regime_cri_scan() -> None:
         # Reads vol_index_daily + daily_ohlc; writes cri_snapshots. No external
         # API spend. Append-only — running twice in an hour is harmless.
@@ -475,6 +502,26 @@ def main() -> int:
             CronTrigger(minute=20, timezone=settings.rth_tz),
             id="regime_cri_scan",
             name="Regime CRI scan",
+            max_instances=1,
+            coalesce=True,
+        )
+        # Credit ETF parquet lake sync — nightly, 03:20 ET. Mirrors the
+        # vol-complex sync but pulls HYG/JNK/LQD from asset_class=equity.
+        sched.add_job(
+            _credit_etf_lake_sync,
+            CronTrigger(hour=3, minute=20, timezone=settings.rth_tz),
+            id="credit_etf_lake_sync",
+            name="Credit-ETF parquet lake sync",
+            max_instances=1,
+            coalesce=True,
+        )
+        # VCG scan — refreshes vcg_snapshots on :25. Reads VIX/VVIX/<proxy>
+        # from vol_index_daily. Append-only.
+        sched.add_job(
+            _regime_vcg_scan,
+            CronTrigger(minute=25, timezone=settings.rth_tz),
+            id="regime_vcg_scan",
+            name="Regime VCG scan",
             max_instances=1,
             coalesce=True,
         )

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -6001,41 +6001,6 @@
         "title": "RecordHealthCheck",
         "type": "object"
       },
-      "RegimePendingResponse": {
-        "description": "Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands.",
-        "properties": {
-          "message": {
-            "default": "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the IB-via-R2 reader (separate project).",
-            "title": "Message",
-            "type": "string"
-          },
-          "reason": {
-            "const": "ib_via_r2_not_wired",
-            "default": "ib_via_r2_not_wired",
-            "title": "Reason",
-            "type": "string"
-          },
-          "scanner": {
-            "enum": [
-              "cri",
-              "vcg"
-            ],
-            "title": "Scanner",
-            "type": "string"
-          },
-          "status": {
-            "const": "pending",
-            "default": "pending",
-            "title": "Status",
-            "type": "string"
-          }
-        },
-        "required": [
-          "scanner"
-        ],
-        "title": "RegimePendingResponse",
-        "type": "object"
-      },
       "RegimeQuadrantBlock": {
         "properties": {
           "cutoff_corr": {
@@ -8344,6 +8309,413 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "VcgAttribution": {
+        "properties": {
+          "model_implied": {
+            "default": 0.0,
+            "title": "Model Implied",
+            "type": "number"
+          },
+          "vix_component": {
+            "default": 0.0,
+            "title": "Vix Component",
+            "type": "number"
+          },
+          "vix_pct": {
+            "default": 0.0,
+            "title": "Vix Pct",
+            "type": "number"
+          },
+          "vvix_component": {
+            "default": 0.0,
+            "title": "Vvix Component",
+            "type": "number"
+          },
+          "vvix_pct": {
+            "default": 0.0,
+            "title": "Vvix Pct",
+            "type": "number"
+          }
+        },
+        "title": "VcgAttribution",
+        "type": "object"
+      },
+      "VcgHistoryEntry": {
+        "properties": {
+          "beta1": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta1"
+          },
+          "beta2": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta2"
+          },
+          "bounce": {
+            "default": 0,
+            "title": "Bounce",
+            "type": "integer"
+          },
+          "credit": {
+            "default": 0.0,
+            "title": "Credit",
+            "type": "number"
+          },
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "edr": {
+            "default": 0,
+            "title": "Edr",
+            "type": "integer"
+          },
+          "residual": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Residual"
+          },
+          "ro": {
+            "default": 0,
+            "title": "Ro",
+            "type": "integer"
+          },
+          "tier": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tier"
+          },
+          "vcg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg"
+          },
+          "vcg_adj": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg Adj"
+          },
+          "vix": {
+            "default": 0.0,
+            "title": "Vix",
+            "type": "number"
+          },
+          "vvix": {
+            "default": 0.0,
+            "title": "Vvix",
+            "type": "number"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "VcgHistoryEntry",
+        "type": "object"
+      },
+      "VcgResponse": {
+        "description": "Volatility-Credit Gap snapshot (latest scan).",
+        "properties": {
+          "credit_proxy": {
+            "default": "HYG",
+            "title": "Credit Proxy",
+            "type": "string"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/VcgHistoryEntry"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "scan_time": {
+            "default": "",
+            "title": "Scan Time",
+            "type": "string"
+          },
+          "signal": {
+            "$ref": "#/components/schemas/VcgSignal"
+          },
+          "status": {
+            "default": "empty",
+            "enum": [
+              "ok",
+              "empty"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "VcgResponse",
+        "type": "object"
+      },
+      "VcgScanResponse": {
+        "description": "Response body for POST /api/regime/vcg/scan.",
+        "properties": {
+          "proxy": {
+            "default": "HYG",
+            "title": "Proxy",
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "row_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Row Id"
+          },
+          "scanner": {
+            "const": "vcg",
+            "default": "vcg",
+            "title": "Scanner",
+            "type": "string"
+          },
+          "status": {
+            "default": "ok",
+            "enum": [
+              "ok",
+              "skipped"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "VcgScanResponse",
+        "type": "object"
+      },
+      "VcgSignal": {
+        "properties": {
+          "alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alpha"
+          },
+          "attribution": {
+            "$ref": "#/components/schemas/VcgAttribution"
+          },
+          "beta1_vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta1 Vvix"
+          },
+          "beta2_vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta2 Vix"
+          },
+          "bounce": {
+            "default": 0,
+            "title": "Bounce",
+            "type": "integer"
+          },
+          "credit_5d_return_pct": {
+            "default": 0.0,
+            "title": "Credit 5D Return Pct",
+            "type": "number"
+          },
+          "credit_price": {
+            "default": 0.0,
+            "title": "Credit Price",
+            "type": "number"
+          },
+          "edr": {
+            "default": 0,
+            "title": "Edr",
+            "type": "integer"
+          },
+          "interpretation": {
+            "default": "NORMAL",
+            "enum": [
+              "RISK_OFF",
+              "EDR",
+              "WATCH",
+              "BOUNCE",
+              "NORMAL",
+              "SUPPRESSED",
+              "PANIC",
+              "INSUFFICIENT_DATA"
+            ],
+            "title": "Interpretation",
+            "type": "string"
+          },
+          "pi_panic": {
+            "default": 0.0,
+            "title": "Pi Panic",
+            "type": "number"
+          },
+          "regime": {
+            "default": "DIVERGENCE",
+            "enum": [
+              "PANIC",
+              "TRANSITION",
+              "DIVERGENCE"
+            ],
+            "title": "Regime",
+            "type": "string"
+          },
+          "residual": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Residual"
+          },
+          "ro": {
+            "default": 0,
+            "title": "Ro",
+            "type": "integer"
+          },
+          "sign_ok": {
+            "default": true,
+            "title": "Sign Ok",
+            "type": "boolean"
+          },
+          "sign_suppressed": {
+            "default": false,
+            "title": "Sign Suppressed",
+            "type": "boolean"
+          },
+          "tier": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tier"
+          },
+          "vcg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg"
+          },
+          "vcg_adj": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg Adj"
+          },
+          "vix": {
+            "default": 0.0,
+            "title": "Vix",
+            "type": "number"
+          },
+          "vvix": {
+            "default": 0.0,
+            "title": "Vvix",
+            "type": "number"
+          },
+          "vvix_severity": {
+            "default": "moderate",
+            "enum": [
+              "extreme",
+              "elevated",
+              "moderate"
+            ],
+            "title": "Vvix Severity",
+            "type": "string"
+          }
+        },
+        "title": "VcgSignal",
+        "type": "object"
+      },
       "VolBackdropPoint": {
         "properties": {
           "close": {
@@ -10224,16 +10596,38 @@
     "/api/regime/vcg": {
       "get": {
         "operationId": "get_vcg_api_regime_vcg_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "proxy",
+            "required": false,
+            "schema": {
+              "default": "HYG",
+              "title": "Proxy",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegimePendingResponse"
+                  "$ref": "#/components/schemas/VcgResponse"
                 }
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Vcg",
@@ -10244,17 +10638,40 @@
     },
     "/api/regime/vcg/scan": {
       "post": {
+        "description": "Run a VCG scan synchronously off the warm store; persist a snapshot.",
         "operationId": "trigger_vcg_scan_api_regime_vcg_scan_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "proxy",
+            "required": false,
+            "schema": {
+              "default": "HYG",
+              "title": "Proxy",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "202": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegimePendingResponse"
+                  "$ref": "#/components/schemas/VcgScanResponse"
                 }
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Trigger Vcg Scan",

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1148,6 +1148,505 @@
         "title": "CockpitVrpResponse",
         "type": "object"
       },
+      "CrashTriggerBlock": {
+        "properties": {
+          "conditions": {
+            "$ref": "#/components/schemas/CrashTriggerConditions"
+          },
+          "fired": {
+            "default": false,
+            "title": "Fired",
+            "type": "boolean"
+          },
+          "triggered": {
+            "default": false,
+            "title": "Triggered",
+            "type": "boolean"
+          },
+          "values": {
+            "$ref": "#/components/schemas/CrashTriggerValues"
+          }
+        },
+        "title": "CrashTriggerBlock",
+        "type": "object"
+      },
+      "CrashTriggerConditions": {
+        "properties": {
+          "cor1m_gt_60": {
+            "default": false,
+            "title": "Cor1M Gt 60",
+            "type": "boolean"
+          },
+          "realized_vol_gt_25": {
+            "default": false,
+            "title": "Realized Vol Gt 25",
+            "type": "boolean"
+          },
+          "spx_below_100d_ma": {
+            "default": false,
+            "title": "Spx Below 100D Ma",
+            "type": "boolean"
+          }
+        },
+        "title": "CrashTriggerConditions",
+        "type": "object"
+      },
+      "CrashTriggerValues": {
+        "properties": {
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          }
+        },
+        "title": "CrashTriggerValues",
+        "type": "object"
+      },
+      "CriBlock": {
+        "properties": {
+          "components": {
+            "$ref": "#/components/schemas/CriComponents"
+          },
+          "level": {
+            "default": "LOW",
+            "enum": [
+              "LOW",
+              "ELEVATED",
+              "HIGH",
+              "CRITICAL"
+            ],
+            "title": "Level",
+            "type": "string"
+          },
+          "score": {
+            "default": 0.0,
+            "title": "Score",
+            "type": "number"
+          }
+        },
+        "title": "CriBlock",
+        "type": "object"
+      },
+      "CriComponents": {
+        "description": "Four 0-25 component scores summed into the composite 0-100.",
+        "properties": {
+          "correlation": {
+            "default": 0.0,
+            "title": "Correlation",
+            "type": "number"
+          },
+          "momentum": {
+            "default": 0.0,
+            "title": "Momentum",
+            "type": "number"
+          },
+          "vix": {
+            "default": 0.0,
+            "title": "Vix",
+            "type": "number"
+          },
+          "vvix": {
+            "default": 0.0,
+            "title": "Vvix",
+            "type": "number"
+          }
+        },
+        "title": "CriComponents",
+        "type": "object"
+      },
+      "CriHistoryEntry": {
+        "properties": {
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "spx_vs_ma_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Vs Ma Pct"
+          },
+          "spy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vix_5d_roc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix 5D Roc"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "CriHistoryEntry",
+        "type": "object"
+      },
+      "CriResponse": {
+        "description": "Crash Risk Indicator snapshot (latest scan).",
+        "properties": {
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "cor1m_5d_change": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M 5D Change"
+          },
+          "cor1m_previous_close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M Previous Close"
+          },
+          "crash_trigger": {
+            "$ref": "#/components/schemas/CrashTriggerBlock"
+          },
+          "cri": {
+            "$ref": "#/components/schemas/CriBlock"
+          },
+          "cta": {
+            "$ref": "#/components/schemas/CtaBlock"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/CriHistoryEntry"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "scan_time": {
+            "default": "",
+            "title": "Scan Time",
+            "type": "string"
+          },
+          "spx_100d_ma": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx 100D Ma"
+          },
+          "spx_distance_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Distance Pct"
+          },
+          "spy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy"
+          },
+          "spy_closes": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Spy Closes",
+            "type": "array"
+          },
+          "status": {
+            "default": "empty",
+            "enum": [
+              "ok",
+              "empty"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vix_5d_roc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix 5D Roc"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          },
+          "vvix_vix_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix Vix Ratio"
+          }
+        },
+        "title": "CriResponse",
+        "type": "object"
+      },
+      "CriScanResponse": {
+        "description": "Response body for POST /api/regime/scan.",
+        "properties": {
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "row_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Row Id"
+          },
+          "scanner": {
+            "const": "cri",
+            "default": "cri",
+            "title": "Scanner",
+            "type": "string"
+          },
+          "status": {
+            "default": "ok",
+            "enum": [
+              "ok",
+              "skipped"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "CriScanResponse",
+        "type": "object"
+      },
+      "CtaBlock": {
+        "properties": {
+          "est_selling_bn": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Est Selling Bn"
+          },
+          "exposure_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exposure Pct"
+          },
+          "forced_reduction": {
+            "default": false,
+            "title": "Forced Reduction",
+            "type": "boolean"
+          },
+          "forced_reduction_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forced Reduction Pct"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "selling_usd_b": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selling Usd B"
+          }
+        },
+        "title": "CtaBlock",
+        "type": "object"
+      },
       "DivergencePoint": {
         "properties": {
           "date": {
@@ -9598,7 +10097,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegimePendingResponse"
+                  "$ref": "#/components/schemas/CriResponse"
                 }
               }
             },
@@ -9702,13 +10201,14 @@
     },
     "/api/regime/scan": {
       "post": {
+        "description": "Run a CRI scan synchronously off the warm store; persist a snapshot.",
         "operationId": "trigger_cri_scan_api_regime_scan_post",
         "responses": {
           "202": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RegimePendingResponse"
+                  "$ref": "#/components/schemas/CriScanResponse"
                 }
               }
             },

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1700,26 +1700,65 @@
         "title": "GammaBlock",
         "type": "object"
       },
-      "GexLevel": {
-        "description": "One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).\n\n`gamma_per_dollar` is the per-strike net_gex used as the \"$N per $1\" sensitivity\nfigure on the tile \u2014 the dollar value of dealer hedging triggered by a $1 move.",
+      "GexBias": {
         "properties": {
-          "gamma_per_dollar": {
+          "days_above_flip": {
             "anyOf": [
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Above Flip"
+          },
+          "direction": {
+            "anyOf": [
+              {
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "title": "Gamma Per Dollar"
+            "title": "Direction"
+          },
+          "flip_migration": {
+            "items": {
+              "$ref": "#/components/schemas/GexFlipMigrationEntry"
+            },
+            "title": "Flip Migration",
+            "type": "array"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reasons",
+            "type": "array"
+          }
+        },
+        "title": "GexBias",
+        "type": "object"
+      },
+      "GexBucket": {
+        "properties": {
+          "call_gex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Gex"
           },
           "net_gex": {
             "anyOf": [
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -1730,8 +1769,7 @@
           "pct_from_spot": {
             "anyOf": [
               {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
+                "type": "number"
               },
               {
                 "type": "null"
@@ -1739,16 +1777,800 @@
             ],
             "title": "Pct From Spot"
           },
+          "put_gex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Gex"
+          },
           "strike": {
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike"
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag"
+          }
+        },
+        "title": "GexBucket",
+        "type": "object"
+      },
+      "GexExpectedRange": {
+        "properties": {
+          "high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High"
+          },
+          "iv_1d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv 1D"
+          },
+          "low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Low"
+          }
+        },
+        "title": "GexExpectedRange",
+        "type": "object"
+      },
+      "GexFlipMigrationEntry": {
+        "properties": {
+          "date": {
+            "title": "Date",
             "type": "string"
+          },
+          "flip": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flip"
           }
         },
         "required": [
-          "strike"
+          "date"
         ],
-        "title": "GexLevel",
+        "title": "GexFlipMigrationEntry",
+        "type": "object"
+      },
+      "GexHistoryEntry": {
+        "properties": {
+          "atm_iv": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atm Iv"
+          },
+          "bias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bias"
+          },
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "gex_flip": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gex Flip"
+          },
+          "net_dex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Dex"
+          },
+          "net_gex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Gex"
+          },
+          "spot": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
+          "vol_pc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Pc"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "GexHistoryEntry",
+        "type": "object"
+      },
+      "GexIvData": {
+        "properties": {
+          "hv30": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hv30"
+          },
+          "iv30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv30D"
+          },
+          "iv_rank": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Rank"
+          },
+          "mq_iv30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mq Iv30D"
+          },
+          "mq_iv_rank": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mq Iv Rank"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "title": "GexIvData",
+        "type": "object"
+      },
+      "GexLevels": {
+        "properties": {
+          "call_wall": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gex_flip": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_accelerator": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_magnet": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "put_wall": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "second_magnet": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "GexLevels",
+        "type": "object"
+      },
+      "GexMqLevels": {
+        "properties": {
+          "call_resistance_0dte": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Resistance 0Dte"
+          },
+          "call_resistance_all": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Resistance All"
+          },
+          "distance_to_hvl_pct": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance To Hvl Pct"
+          },
+          "expected_high": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected High"
+          },
+          "expected_low": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Low"
+          },
+          "hv30": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hv30"
+          },
+          "hvl": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hvl"
+          },
+          "iv30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv30D"
+          },
+          "iv_rank": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv Rank"
+          },
+          "put_support_0dte": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Support 0Dte"
+          },
+          "put_support_all": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Support All"
+          },
+          "source_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Date"
+          },
+          "spot": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
+          "top_gex_strikes": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Top Gex Strikes",
+            "type": "array"
+          }
+        },
+        "title": "GexMqLevels",
+        "type": "object"
+      },
+      "GexResponse": {
+        "properties": {
+          "atm_iv": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atm Iv"
+          },
+          "bias": {
+            "$ref": "#/components/schemas/GexBias"
+          },
+          "close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Close"
+          },
+          "data_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Date"
+          },
+          "day_change": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Change"
+          },
+          "day_change_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Change Pct"
+          },
+          "expected_range": {
+            "$ref": "#/components/schemas/GexExpectedRange"
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/GexHistoryEntry"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "iv": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexIvData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "levels": {
+            "$ref": "#/components/schemas/GexLevels"
+          },
+          "market_open": {
+            "default": false,
+            "title": "Market Open",
+            "type": "boolean"
+          },
+          "market_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Time"
+          },
+          "mq": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexMqLevels"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "net_dex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Dex"
+          },
+          "net_gex": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Gex"
+          },
+          "prev_close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prev Close"
+          },
+          "profile": {
+            "items": {
+              "$ref": "#/components/schemas/GexBucket"
+            },
+            "title": "Profile",
+            "type": "array"
+          },
+          "scan_time": {
+            "default": "",
+            "title": "Scan Time",
+            "type": "string"
+          },
+          "source_delta": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDelta"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "spot": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
+          "spot_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Source"
+          },
+          "tape_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tape Time"
+          },
+          "ticker": {
+            "default": "SPX",
+            "title": "Ticker",
+            "type": "string"
+          },
+          "vol_pc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Pc"
+          }
+        },
+        "title": "GexResponse",
+        "type": "object"
+      },
+      "GexSourceDelta": {
+        "properties": {
+          "call_wall_vs_resistance_0dte": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "call_wall_vs_resistance_all": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "flip_vs_hvl": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "put_wall_vs_support_0dte": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "put_wall_vs_support_all": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "GexSourceDelta",
+        "type": "object"
+      },
+      "GexSourceDeltaEntry": {
+        "properties": {
+          "delta": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delta"
+          },
+          "mq": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mq"
+          },
+          "uw": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uw"
+          }
+        },
+        "title": "GexSourceDeltaEntry",
         "type": "object"
       },
       "HTTPValidationError": {
@@ -2427,6 +3249,18 @@
       "MarketAggregates": {
         "description": "Per-ticker aggregate fields sourced from the bulk-screener endpoint.\n\nPopulated by pipeline.run_single_stock alongside the existing per-section\nsub-models. Feeds the watchlist card POSITIONING and SKEW blocks.",
         "properties": {
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
           "call_oi_total": {
             "anyOf": [
               {
@@ -2494,18 +3328,6 @@
               }
             ],
             "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
           },
           "pcr_oi": {
             "anyOf": [
@@ -2705,7 +3527,7 @@
           "call_wall": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -2715,7 +3537,7 @@
           "gex_flip": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -2725,7 +3547,7 @@
           "max_accel": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -2735,7 +3557,7 @@
           "max_magnet": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -2745,7 +3567,7 @@
           "put_wall": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -2755,7 +3577,7 @@
           "second_magnet": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/GexLevel"
+                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
               },
               {
                 "type": "null"
@@ -4678,6 +5500,41 @@
           "ok"
         ],
         "title": "RecordHealthCheck",
+        "type": "object"
+      },
+      "RegimePendingResponse": {
+        "description": "Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands.",
+        "properties": {
+          "message": {
+            "default": "Data source pending. CRI/VCG require VIX/VVIX/COR1M from the IB-via-R2 reader (separate project).",
+            "title": "Message",
+            "type": "string"
+          },
+          "reason": {
+            "const": "ib_via_r2_not_wired",
+            "default": "ib_via_r2_not_wired",
+            "title": "Reason",
+            "type": "string"
+          },
+          "scanner": {
+            "enum": [
+              "cri",
+              "vcg"
+            ],
+            "title": "Scanner",
+            "type": "string"
+          },
+          "status": {
+            "const": "pending",
+            "default": "pending",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scanner"
+        ],
+        "title": "RegimePendingResponse",
         "type": "object"
       },
       "RegimeQuadrantBlock": {
@@ -6988,6 +7845,76 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "VolBackdropPoint": {
+        "properties": {
+          "close": {
+            "title": "Close",
+            "type": "number"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "close"
+        ],
+        "title": "VolBackdropPoint",
+        "type": "object"
+      },
+      "VolBackdropResponse": {
+        "description": "Vol-complex time series + VIX term-structure (regime page header strip).",
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "series": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/VolBackdropPoint"
+              },
+              "type": "array"
+            },
+            "title": "Series",
+            "type": "object"
+          },
+          "term_structure_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Term Structure Ratio"
+          },
+          "term_structure_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Term Structure State"
+          }
+        },
+        "title": "VolBackdropResponse",
+        "type": "object"
+      },
       "VolHeaderBlock": {
         "properties": {
           "implied_move_30d_perc": {
@@ -7475,6 +8402,18 @@
             ],
             "title": "Aggression Pct"
           },
+          "aum": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
           "gamma": {
             "$ref": "#/components/schemas/GammaBlock"
           },
@@ -7513,18 +8452,6 @@
               }
             ],
             "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
           },
           "pinned": {
             "title": "Pinned",
@@ -7822,6 +8749,107 @@
           "heartbeat_name"
         ],
         "title": "WorkerHealth",
+        "type": "object"
+      },
+      "uw_scan__api__schemas__GexLevel": {
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance"
+          },
+          "distance_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance Pct"
+          },
+          "gamma": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gamma"
+          },
+          "strike": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike"
+          }
+        },
+        "title": "GexLevel",
+        "type": "object"
+      },
+      "uw_scan__models__GexLevel": {
+        "description": "One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).\n\n`gamma_per_dollar` is the per-strike net_gex used as the \"$N per $1\" sensitivity\nfigure on the tile \u2014 the dollar value of dealer hedging triggered by a $1 move.",
+        "properties": {
+          "gamma_per_dollar": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gamma Per Dollar"
+          },
+          "net_gex": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Net Gex"
+          },
+          "pct_from_spot": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pct From Spot"
+          },
+          "strike": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Strike",
+            "type": "string"
+          }
+        },
+        "required": [
+          "strike"
+        ],
+        "title": "GexLevel",
         "type": "object"
       }
     }
@@ -8559,6 +9587,224 @@
         "summary": "Provider Usage Tickers",
         "tags": [
           "provider-usage"
+        ]
+      }
+    },
+    "/api/regime": {
+      "get": {
+        "operationId": "get_regime_api_regime_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegimePendingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Regime",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/gex": {
+      "get": {
+        "operationId": "get_gex_api_regime_gex_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ticker",
+            "required": false,
+            "schema": {
+              "default": "SPX",
+              "title": "Ticker",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gex",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/gex/scan": {
+      "post": {
+        "description": "Run a GEX scan synchronously against UW and persist.",
+        "operationId": "trigger_gex_scan_api_regime_gex_scan_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ticker",
+            "required": false,
+            "schema": {
+              "default": "SPX",
+              "title": "Ticker",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Trigger Gex Scan Api Regime Gex Scan Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Trigger Gex Scan",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/scan": {
+      "post": {
+        "operationId": "trigger_cri_scan_api_regime_scan_post",
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegimePendingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Trigger Cri Scan",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vcg": {
+      "get": {
+        "operationId": "get_vcg_api_regime_vcg_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegimePendingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Vcg",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vcg/scan": {
+      "post": {
+        "operationId": "trigger_vcg_scan_api_regime_vcg_scan_post",
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegimePendingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Trigger Vcg Scan",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vol-backdrop": {
+      "get": {
+        "operationId": "get_vol_backdrop_api_regime_vol_backdrop_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 90,
+              "maximum": 365,
+              "minimum": 5,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolBackdropResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vol Backdrop",
+        "tags": [
+          "regime"
         ]
       }
     },

--- a/tests/integration/api/test_regime_history_endpoint.py
+++ b/tests/integration/api/test_regime_history_endpoint.py
@@ -1,0 +1,61 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed_history(repo_obj) -> None:
+    schema = repo_obj._schema
+    conn = repo_obj.conn
+    g = GreekExposureDailyRepository(conn, schema=schema)
+    g.upsert_rows(
+        "SPX",
+        [
+            {
+                "trade_date": date(2026, 5, d),
+                "call_gex": 2e9,
+                "put_gex": -1e9,
+                "call_delta": 1e7,
+                "put_delta": -1e6,
+                "payload": {},
+            }
+            for d in range(1, 16)
+        ],
+    )
+    v = VolIndexRepository(conn, schema=schema)
+    v.upsert_rows(
+        [
+            {
+                "symbol": "SPX",
+                "trade_date": date(2026, 5, d),
+                "open": 7400 + d,
+                "high": 7410 + d,
+                "low": 7390 + d,
+                "close": 7405 + d,
+                "adj_close": 7405 + d,
+                "volume": 0,
+            }
+            for d in range(1, 16)
+        ]
+    )
+
+
+def test_gex_endpoint_returns_history_for_spx(
+    client: TestClient, seeded_db_empty_cards
+) -> None:
+    _seed_history(seeded_db_empty_cards)
+    res = client.get("/api/regime/gex?ticker=SPX")
+    assert res.status_code == 200
+    body = res.json()
+    assert "history" in body
+    assert isinstance(body["history"], list)
+    assert len(body["history"]) > 0
+    entry = body["history"][-1]
+    for k in ("date", "net_gex", "spot"):
+        assert k in entry
+    # net_gex is non-null (call_gex + put_gex = 1e9 from seed)
+    assert entry["net_gex"] is not None
+    # spot from vol_index_daily for SPX
+    assert entry["spot"] is not None

--- a/tests/integration/api/test_regime_router.py
+++ b/tests/integration/api/test_regime_router.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.repository import Repository
 
 
@@ -34,13 +35,73 @@ def test_get_gex_defaults_to_spx_and_uppercases_ticker(
     assert seen["ticker"] == "SPY"
 
 
-def test_get_cri_returns_pending_sentinel(client: TestClient) -> None:
+def test_get_cri_returns_empty_when_no_snapshot(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setattr(CriSnapshotRepository, "fetch_latest", lambda self: None)
     r = client.get("/api/regime")
     assert r.status_code == 200
     body = r.json()
-    assert body["status"] == "pending"
-    assert body["scanner"] == "cri"
-    assert body["reason"] == "ib_via_r2_not_wired"
+    assert body["status"] == "empty"
+    assert body["cri"]["score"] == 0.0
+    assert body["cri"]["level"] == "LOW"
+    assert body["history"] == []
+
+
+def test_get_cri_returns_payload_when_snapshot_exists(
+    client: TestClient, monkeypatch
+) -> None:
+    def stub(self):
+        return {
+            "date": "2026-05-15",
+            "vix": 18.43,
+            "vvix": 92.9,
+            "cor1m": 10.8,
+            "spx_distance_pct": -2.5,
+            "realized_vol": 14.2,
+            "cri": {
+                "score": 33.4,
+                "level": "ELEVATED",
+                "components": {
+                    "vix": 8.0,
+                    "vvix": 12.0,
+                    "correlation": 6.4,
+                    "momentum": 7.0,
+                },
+            },
+            "cta": {
+                "realized_vol": 14.2,
+                "exposure_pct": 70.4,
+                "forced_reduction_pct": 29.6,
+                "forced_reduction": True,
+                "est_selling_bn": 103.6,
+                "selling_usd_b": 103.6,
+            },
+            "crash_trigger": {
+                "fired": False,
+                "triggered": False,
+                "conditions": {
+                    "spx_below_100d_ma": True,
+                    "realized_vol_gt_25": False,
+                    "cor1m_gt_60": False,
+                },
+                "values": {"realized_vol": 14.2, "cor1m": 10.8},
+            },
+            "history": [],
+            "spy_closes": [],
+            "scan_time": "2026-05-15T20:30:00+00:00",
+        }
+
+    monkeypatch.setattr(CriSnapshotRepository, "fetch_latest", stub)
+    r = client.get("/api/regime")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["cri"]["score"] == 33.4
+    assert body["cri"]["level"] == "ELEVATED"
+    assert body["cri"]["components"]["vvix"] == 12.0
+    assert body["cta"]["forced_reduction"] is True
+    assert body["crash_trigger"]["conditions"]["spx_below_100d_ma"] is True
 
 
 def test_get_vcg_returns_pending_sentinel(client: TestClient) -> None:
@@ -70,9 +131,31 @@ def test_post_gex_scan_runs_scanner(client: TestClient, monkeypatch) -> None:
     assert calls == [("client_passed", "SPY")]
 
 
-def test_post_cri_scan_returns_pending(client: TestClient) -> None:
+def test_post_cri_scan_runs_scanner(client: TestClient, monkeypatch) -> None:
+    """Router must call scanner.run(conn, schema=...) and surface the row_id."""
+    calls = []
+
+    def _stub_run(conn_arg, schema: str = "uw_scan"):
+        calls.append(("conn_passed" if conn_arg is not None else "no_conn", schema))
+        return 99
+
+    monkeypatch.setattr("uw_scan.scanners.cri.run", _stub_run)
     r = client.post("/api/regime/scan")
     assert r.status_code == 202
     body = r.json()
+    assert body["status"] == "ok"
     assert body["scanner"] == "cri"
-    assert "ib_via_r2_not_wired" in body["reason"]
+    assert body["row_id"] == 99
+    assert calls[0][0] == "conn_passed"
+
+
+def test_post_cri_scan_returns_skipped_on_thin_data(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setattr("uw_scan.scanners.cri.run", lambda conn, schema="uw_scan": None)
+    r = client.post("/api/regime/scan")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "skipped"
+    assert body["reason"] == "thin_data"
+    assert body["row_id"] is None

--- a/tests/integration/api/test_regime_router.py
+++ b/tests/integration/api/test_regime_router.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.repository import Repository
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
 
 
 def test_get_gex_returns_empty_shape_when_no_data(
@@ -104,11 +105,120 @@ def test_get_cri_returns_payload_when_snapshot_exists(
     assert body["crash_trigger"]["conditions"]["spx_below_100d_ma"] is True
 
 
-def test_get_vcg_returns_pending_sentinel(client: TestClient) -> None:
+def test_get_vcg_returns_empty_when_no_snapshot(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        VcgSnapshotRepository, "fetch_latest", lambda self, *, proxy=None: None
+    )
     r = client.get("/api/regime/vcg")
+    assert r.status_code == 200
     body = r.json()
-    assert body["status"] == "pending"
+    assert body["status"] == "empty"
+    assert body["credit_proxy"] == "HYG"
+    assert body["history"] == []
+    assert body["signal"]["interpretation"] == "NORMAL"
+
+
+def test_get_vcg_uppercases_proxy_param(client: TestClient, monkeypatch) -> None:
+    seen = {}
+
+    def stub(self, *, proxy=None):
+        seen["proxy"] = proxy
+        return None
+
+    monkeypatch.setattr(VcgSnapshotRepository, "fetch_latest", stub)
+    client.get("/api/regime/vcg?proxy=jnk")
+    assert seen["proxy"] == "JNK"
+
+
+def test_get_vcg_returns_payload_when_snapshot_exists(
+    client: TestClient, monkeypatch
+) -> None:
+    def stub(self, *, proxy=None):
+        return {
+            "date": "2026-05-15",
+            "credit_proxy": "HYG",
+            "scan_time": "2026-05-15T20:30:00+00:00",
+            "signal": {
+                "vcg": 2.85,
+                "vcg_adj": 2.85,
+                "residual": -0.0012,
+                "beta1_vvix": -0.05,
+                "beta2_vix": -0.03,
+                "alpha": 0.0001,
+                "vix": 30.2,
+                "vvix": 125.0,
+                "credit_price": 78.4,
+                "credit_5d_return_pct": -1.2,
+                "ro": 1,
+                "edr": 1,
+                "tier": 1,
+                "bounce": 0,
+                "vvix_severity": "extreme",
+                "sign_ok": True,
+                "sign_suppressed": False,
+                "pi_panic": 0.0,
+                "regime": "DIVERGENCE",
+                "interpretation": "RISK_OFF",
+                "attribution": {
+                    "vvix_pct": 60.0,
+                    "vix_pct": 40.0,
+                    "vvix_component": -0.001,
+                    "vix_component": -0.0006,
+                    "model_implied": -0.00159,
+                },
+            },
+            "history": [],
+        }
+
+    monkeypatch.setattr(VcgSnapshotRepository, "fetch_latest", stub)
+    r = client.get("/api/regime/vcg")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["credit_proxy"] == "HYG"
+    assert body["signal"]["vcg"] == 2.85
+    assert body["signal"]["interpretation"] == "RISK_OFF"
+    assert body["signal"]["tier"] == 1
+    assert body["signal"]["attribution"]["vvix_pct"] == 60.0
+
+
+def test_post_vcg_scan_runs_scanner(client: TestClient, monkeypatch) -> None:
+    calls = []
+
+    def _stub_run(conn_arg, *, proxy="HYG", schema="uw_scan"):
+        calls.append(
+            ("conn_passed" if conn_arg is not None else "no_conn", proxy, schema)
+        )
+        return 77
+
+    monkeypatch.setattr("uw_scan.scanners.vcg.run", _stub_run)
+    r = client.post("/api/regime/vcg/scan?proxy=jnk")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "ok"
     assert body["scanner"] == "vcg"
+    assert body["proxy"] == "JNK"
+    assert body["row_id"] == 77
+    assert calls[0][0] == "conn_passed"
+    assert calls[0][1] == "JNK"
+
+
+def test_post_vcg_scan_returns_skipped_on_thin_data(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "uw_scan.scanners.vcg.run",
+        lambda conn, *, proxy="HYG", schema="uw_scan": None,
+    )
+    r = client.post("/api/regime/vcg/scan")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["status"] == "skipped"
+    assert body["reason"] == "thin_data"
+    assert body["proxy"] == "HYG"
+    assert body["row_id"] is None
 
 
 def test_post_gex_scan_runs_scanner(client: TestClient, monkeypatch) -> None:

--- a/tests/integration/api/test_regime_router.py
+++ b/tests/integration/api/test_regime_router.py
@@ -1,0 +1,78 @@
+from fastapi.testclient import TestClient
+
+from uw_scan.storage.repository import Repository
+
+
+def test_get_gex_returns_empty_shape_when_no_data(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        Repository, "fetch_latest_gex", lambda self, *, ticker="SPX": None
+    )
+    r = client.get("/api/regime/gex")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["spot"] is None
+    assert data["levels"]["max_magnet"] is None
+    assert data["profile"] == []
+    assert data["mq"] is None
+
+
+def test_get_gex_defaults_to_spx_and_uppercases_ticker(
+    client: TestClient, monkeypatch
+) -> None:
+    seen = {}
+
+    def stub(self, *, ticker="SPX"):
+        seen["ticker"] = ticker
+        return None
+
+    monkeypatch.setattr(Repository, "fetch_latest_gex", stub)
+    client.get("/api/regime/gex")
+    assert seen["ticker"] == "SPX"
+    client.get("/api/regime/gex?ticker=spy")
+    assert seen["ticker"] == "SPY"
+
+
+def test_get_cri_returns_pending_sentinel(client: TestClient) -> None:
+    r = client.get("/api/regime")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["scanner"] == "cri"
+    assert body["reason"] == "ib_via_r2_not_wired"
+
+
+def test_get_vcg_returns_pending_sentinel(client: TestClient) -> None:
+    r = client.get("/api/regime/vcg")
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["scanner"] == "vcg"
+
+
+def test_post_gex_scan_runs_scanner(client: TestClient, monkeypatch) -> None:
+    """Router must construct a UwClient and pass (client, repo, ticker) to scanner.run."""
+    calls = []
+
+    def _stub_run(client_arg, repo_arg, ticker="SPX"):
+        calls.append(
+            ("client_passed" if client_arg is not None else "no_client", ticker)
+        )
+        return 42
+
+    monkeypatch.setattr("uw_scan.scanners.gex.run", _stub_run)
+    r = client.post("/api/regime/gex/scan?ticker=spy")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["scanner"] == "gex"
+    assert body["ticker"] == "SPY"
+    assert body["row_id"] == 42
+    assert calls == [("client_passed", "SPY")]
+
+
+def test_post_cri_scan_returns_pending(client: TestClient) -> None:
+    r = client.post("/api/regime/scan")
+    assert r.status_code == 202
+    body = r.json()
+    assert body["scanner"] == "cri"
+    assert "ib_via_r2_not_wired" in body["reason"]

--- a/tests/integration/api/test_regime_vol_backdrop.py
+++ b/tests/integration/api/test_regime_vol_backdrop.py
@@ -1,0 +1,77 @@
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def test_vol_backdrop_returns_four_series(
+    client: TestClient, seeded_db_empty_cards
+) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    for sym, base in [("VIX", 18), ("VIX3M", 21), ("VVIX", 90), ("COR1M", 11)]:
+        repo.upsert_rows(
+            [
+                {
+                    "symbol": sym,
+                    "trade_date": date(2026, 5, d),
+                    "open": base + d * 0.1,
+                    "high": base + d * 0.1,
+                    "low": base + d * 0.1,
+                    "close": base + d * 0.1,
+                    "adj_close": base + d * 0.1,
+                    "volume": 0,
+                }
+                for d in range(1, 16)
+            ]
+        )
+
+    res = client.get("/api/regime/vol-backdrop?days=365")
+    assert res.status_code == 200
+    body = res.json()
+    assert set(body["series"].keys()) == {"VIX", "VIX3M", "VVIX", "COR1M"}
+    assert len(body["series"]["VIX"]) <= 15
+    assert body["series"]["VIX"][-1]["close"] > 0
+    assert "term_structure_ratio" in body
+
+
+def test_vol_backdrop_term_structure_ratio(
+    client: TestClient, seeded_db_empty_cards
+) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 20,
+                "high": 20,
+                "low": 20,
+                "close": 20,
+                "adj_close": 20,
+                "volume": 0,
+            },
+            {
+                "symbol": "VIX3M",
+                "trade_date": date(2026, 5, 15),
+                "open": 25,
+                "high": 25,
+                "low": 25,
+                "close": 25,
+                "adj_close": 25,
+                "volume": 0,
+            },
+        ]
+    )
+    res = client.get("/api/regime/vol-backdrop?days=365")
+    body = res.json()
+    # 20 / 25 = 0.80, contango
+    assert body["term_structure_ratio"] == pytest.approx(0.80, rel=1e-2)
+    assert body["term_structure_state"] == "contango"

--- a/tests/integration/storage/test_cri_snapshot_repository.py
+++ b/tests/integration/storage/test_cri_snapshot_repository.py
@@ -1,0 +1,85 @@
+from datetime import date, datetime, timezone
+
+import pytest
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+
+
+def _payload(score: float, level: str, fired: bool) -> dict:
+    return {
+        "date": "2026-05-15",
+        "vix": 18.43,
+        "vvix": 92.9,
+        "cor1m": 10.8,
+        "spx_distance_pct": -2.5,
+        "realized_vol": 14.2,
+        "cri": {
+            "score": score,
+            "level": level,
+            "components": {
+                "vix": 5.0,
+                "vvix": 4.0,
+                "correlation": 3.0,
+                "momentum": 2.5,
+            },
+        },
+        "crash_trigger": {
+            "fired": fired,
+            "triggered": fired,
+            "conditions": {},
+            "values": {},
+        },
+        "cta": {
+            "realized_vol": 14.2,
+            "exposure_pct": 100.0,
+            "forced_reduction_pct": 0.0,
+        },
+        "history": [],
+        "spy_closes": [],
+    }
+
+
+def test_insert_returns_id_and_fetch_latest_roundtrip(seeded_db_empty_cards) -> None:
+    repo = CriSnapshotRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    rid = repo.insert_snapshot(payload=_payload(14.5, "LOW", False))
+    assert rid > 0
+    latest = repo.fetch_latest()
+    assert latest is not None
+    assert latest["cri"]["score"] == pytest.approx(14.5)
+    assert latest["cri"]["level"] == "LOW"
+
+
+def test_fetch_latest_returns_most_recent(seeded_db_empty_cards) -> None:
+    repo = CriSnapshotRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.insert_snapshot(payload=_payload(20.0, "LOW", False))
+    repo.insert_snapshot(payload=_payload(80.0, "CRITICAL", True))
+    latest = repo.fetch_latest()
+    assert latest["cri"]["level"] == "CRITICAL"
+    assert latest["crash_trigger"]["fired"] is True
+
+
+def test_fetch_history_returns_list_ascending(seeded_db_empty_cards) -> None:
+    repo = CriSnapshotRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    for score in (10.0, 30.0, 60.0):
+        repo.insert_snapshot(payload=_payload(score, "LOW", False))
+    rows = repo.fetch_history(limit=5)
+    assert len(rows) == 3
+    # Ascending by scanned_at — earliest first
+    assert rows[0]["cri_score"] == pytest.approx(10.0)
+    assert rows[-1]["cri_score"] == pytest.approx(60.0)
+
+
+def test_fetch_latest_returns_none_when_empty(seeded_db_empty_cards) -> None:
+    repo = CriSnapshotRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    assert repo.fetch_latest() is None

--- a/tests/integration/storage/test_cri_snapshot_repository.py
+++ b/tests/integration/storage/test_cri_snapshot_repository.py
@@ -1,4 +1,3 @@
-from datetime import date, datetime, timezone
 
 import pytest
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository

--- a/tests/integration/storage/test_greek_exposure_repository.py
+++ b/tests/integration/storage/test_greek_exposure_repository.py
@@ -1,0 +1,58 @@
+from datetime import date
+
+import pytest
+from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
+
+
+def test_upsert_then_fetch(seeded_db_empty_cards) -> None:
+    repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows(
+        "SPY",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "call_gex": 2.1e9,
+                "put_gex": -0.9e9,
+                "call_delta": 7.0e7,
+                "put_delta": -1.5e7,
+                "payload": {"raw": "ok"},
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "call_gex": 2.0e9,
+                "put_gex": -1.0e9,
+                "call_delta": 6.5e7,
+                "put_delta": -1.5e7,
+                "payload": {"raw": "ok"},
+            },
+        ],
+    )
+    rows = repo.fetch_history("SPY", days=10)
+    assert len(rows) == 2
+    # net_gex is a generated column = call_gex + put_gex
+    assert rows[-1]["net_gex"] == pytest.approx(1.0e9)
+    assert rows[-1]["net_dex"] == pytest.approx(5.0e7)
+
+
+def test_upsert_overwrites_on_conflict(seeded_db_empty_cards) -> None:
+    repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    base = {
+        "trade_date": date(2026, 5, 15),
+        "call_gex": 1.0,
+        "put_gex": -1.0,
+        "call_delta": 1.0,
+        "put_delta": -1.0,
+        "payload": {},
+    }
+    repo.upsert_rows("SPY", [base])
+    repo.upsert_rows("SPY", [{**base, "call_gex": 99.0}])
+    rows = repo.fetch_history("SPY", days=2)
+    assert rows[0]["call_gex"] == pytest.approx(99.0)
+    # Generated net_gex reflects the new call_gex
+    assert rows[0]["net_gex"] == pytest.approx(98.0)

--- a/tests/integration/storage/test_vol_index_repository.py
+++ b/tests/integration/storage/test_vol_index_repository.py
@@ -1,0 +1,76 @@
+from datetime import date
+
+import pytest
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def test_upsert_inserts_then_updates(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07,
+                "high": 19.27,
+                "low": 17.8,
+                "close": 18.43,
+                "adj_close": 18.43,
+                "volume": 0,
+            }
+        ]
+    )
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07,
+                "high": 19.50,
+                "low": 17.8,
+                "close": 18.50,
+                "adj_close": 18.50,
+                "volume": 0,
+            }
+        ]
+    )
+    rows = repo.fetch_history("VIX", days=5)
+    assert len(rows) == 1
+    assert rows[0]["close"] == pytest.approx(18.50)
+    assert rows[0]["high"] == pytest.approx(19.50)
+
+
+def test_fetch_history_window(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    rows = [
+        {
+            "symbol": "VIX",
+            "trade_date": date(2026, 5, d),
+            "open": d,
+            "high": d,
+            "low": d,
+            "close": d,
+            "adj_close": d,
+            "volume": 0,
+        }
+        for d in range(1, 16)
+    ]
+    repo.upsert_rows(rows)
+    out = repo.fetch_history("VIX", days=7)
+    assert len(out) == 7
+    # Sorted ascending by trade_date
+    assert out[0]["trade_date"] < out[-1]["trade_date"]
+
+
+def test_fetch_history_for_missing_symbol(seeded_db_empty_cards) -> None:
+    repo = VolIndexRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    assert repo.fetch_history("DOESNOTEXIST", days=30) == []

--- a/tests/integration/test_cri_scanner.py
+++ b/tests/integration/test_cri_scanner.py
@@ -1,0 +1,122 @@
+"""Integration test for src/uw_scan/scanners/cri.py:run().
+
+Seeds vol_index_daily (VIX/VVIX/COR1M) + daily_ohlc (SPY) with enough rows
+to clear MIN_ALIGNED_BARS, runs the scanner, asserts a snapshot is persisted.
+Also exercises the thin-data early-return branch.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+
+from uw_scan.scanners import cri as cri_scanner
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed_vol(
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    values: list[float],
+    *,
+    start: date,
+) -> None:
+    rows = []
+    for i, v in enumerate(values):
+        rows.append(
+            {
+                "symbol": symbol,
+                "trade_date": start + timedelta(days=i),
+                "open": v,
+                "high": v,
+                "low": v,
+                "close": v,
+                "adj_close": v,
+                "volume": 0,
+            }
+        )
+    vol_repo.upsert_rows(rows)
+
+
+def _seed_spy(repo, closes: list[float], *, start: date) -> None:
+    for i, px in enumerate(closes):
+        repo.upsert_daily_ohlc(
+            ticker="SPY",
+            date=start + timedelta(days=i),
+            open=Decimal(str(px)),
+            high=Decimal(str(px)),
+            low=Decimal(str(px)),
+            close=Decimal(str(px)),
+            volume=0,
+            source="massive.com",
+        )
+
+
+def test_run_persists_snapshot_when_data_is_sufficient(
+    seeded_db_empty_cards,
+) -> None:
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    n = 140  # > MIN_ALIGNED_BARS (120)
+    start = date(2026, 1, 1)
+    _seed_vol(vol_repo, "VIX", [16.0] * n, start=start)
+    _seed_vol(vol_repo, "VVIX", [95.0] * n, start=start)
+    _seed_vol(vol_repo, "COR1M", [20.0] * n, start=start)
+    spy_closes = [450.0 + i * (150.0 / n) for i in range(n)]  # trending up
+    _seed_spy(repo, spy_closes, start=start)
+
+    row_id = cri_scanner.run(conn, schema=repo._schema)
+    assert row_id is not None
+    assert row_id > 0
+
+    snap_repo = CriSnapshotRepository(conn, schema=repo._schema)
+    latest = snap_repo.fetch_latest()
+    assert latest is not None
+    score = latest["cri"]["score"]
+    assert math.isfinite(score)
+    assert 0.0 <= score <= 100.0
+    assert latest["cri"]["level"] in {"LOW", "ELEVATED", "HIGH", "CRITICAL"}
+    # Calm market should land in LOW or ELEVATED
+    assert latest["cri"]["level"] in {"LOW", "ELEVATED"}
+    # Crash trigger is off on calm data
+    assert latest["crash_trigger"]["fired"] is False
+    assert math.isfinite(latest["vix"])
+    assert latest["vix"] == 16.0
+
+
+def test_run_returns_none_when_data_is_thin(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    n = 30  # << MIN_ALIGNED_BARS (120)
+    start = date(2026, 1, 1)
+    _seed_vol(vol_repo, "VIX", [16.0] * n, start=start)
+    _seed_vol(vol_repo, "VVIX", [95.0] * n, start=start)
+    _seed_vol(vol_repo, "COR1M", [20.0] * n, start=start)
+    _seed_spy(repo, [500.0 + i for i in range(n)], start=start)
+
+    row_id = cri_scanner.run(conn, schema=repo._schema)
+    assert row_id is None
+
+    snap_repo = CriSnapshotRepository(conn, schema=repo._schema)
+    assert snap_repo.fetch_latest() is None
+
+
+def test_run_returns_none_when_no_overlap(seeded_db_empty_cards) -> None:
+    """VIX dates and SPY dates don't intersect → 0 aligned bars."""
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    _seed_vol(vol_repo, "VIX", [16.0] * 140, start=date(2026, 1, 1))
+    _seed_vol(vol_repo, "VVIX", [95.0] * 140, start=date(2026, 1, 1))
+    _seed_vol(vol_repo, "COR1M", [20.0] * 140, start=date(2026, 1, 1))
+    # SPY starts a year later — zero overlap with vol series
+    _seed_spy(repo, [500.0 + i for i in range(140)], start=date(2027, 1, 1))
+
+    assert cri_scanner.run(conn, schema=repo._schema) is None

--- a/tests/integration/test_gex_repository.py
+++ b/tests/integration/test_gex_repository.py
@@ -1,0 +1,44 @@
+from uw_scan.storage.repository import Repository
+
+
+def test_upsert_and_fetch_latest_gex(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    payload = {
+        "ticker": "SPX",
+        "spot": 5800.12,
+        "net_gex": -2_400_000_000,
+        "levels": {"max_magnet": {"strike": 5780, "gamma": 1.5e9}},
+        "profile": [],
+    }
+    repo.upsert_gex_snapshot(ticker="SPX", payload=payload)
+    result = repo.fetch_latest_gex(ticker="SPX")
+    assert result is not None
+    assert result["spot"] == 5800.12
+    assert result["levels"]["max_magnet"]["strike"] == 5780
+
+
+def test_fetch_latest_gex_filters_by_ticker(seeded_db_empty_cards: Repository) -> None:
+    repo = seeded_db_empty_cards
+    repo.upsert_gex_snapshot(ticker="SPX", payload={"spot": 5800})
+    repo.upsert_gex_snapshot(ticker="SPY", payload={"spot": 580})
+    spx = repo.fetch_latest_gex(ticker="SPX")
+    spy = repo.fetch_latest_gex(ticker="SPY")
+    assert spx is not None and spx["spot"] == 5800
+    assert spy is not None and spy["spot"] == 580
+
+
+def test_fetch_latest_gex_returns_none_for_unknown_ticker(
+    seeded_db_empty_cards: Repository,
+) -> None:
+    assert seeded_db_empty_cards.fetch_latest_gex(ticker="UNKNOWN") is None
+
+
+def test_fetch_latest_gex_populates_scan_time_and_ticker_when_missing(
+    seeded_db_empty_cards: Repository,
+) -> None:
+    repo = seeded_db_empty_cards
+    repo.upsert_gex_snapshot(ticker="SPX", payload={"spot": 5800})
+    result = repo.fetch_latest_gex(ticker="SPX")
+    assert result is not None
+    assert result["ticker"] == "SPX"
+    assert result["scan_time"]  # populated from scanned_at

--- a/tests/integration/test_gex_scanner.py
+++ b/tests/integration/test_gex_scanner.py
@@ -79,6 +79,11 @@ def test_run_persists_payload_with_full_xenon_shape(
         ],
     )
     monkeypatch.setattr(gex_scanner, "fetch_vol_pc", lambda c, r, rid, t: 0.85)
+    # Force the iv_rank fallback path so this test asserts on iv_rank.close = 5800.0
+    # rather than whatever /stock-state currently returns for SPX.
+    monkeypatch.setattr(
+        gex_scanner, "fetch_stock_state_snapshot", lambda c, r, rid, t: None
+    )
 
     row_id = gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
     assert row_id > 0
@@ -108,9 +113,99 @@ def test_run_marks_scan_run_error_when_aborted(
     seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
 ):
     monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [])
+    monkeypatch.setattr(
+        gex_scanner, "fetch_stock_state_snapshot", lambda c, r, rid, t: None
+    )
     with pytest.raises(RuntimeError):
         gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
     with seeded_db_empty_cards.conn.cursor() as cur:
         cur.execute("SELECT status FROM uw_scan.scan_runs ORDER BY run_id DESC LIMIT 1")
         status = cur.fetchone()[0]
     assert status == "error"
+
+
+def _stub_minimal_chain(monkeypatch):
+    """Stub iv_rank + strike + aggregate fetchers with bare minimum rows."""
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_iv_rank_rows",
+        lambda c, r, rid, t: [
+            {
+                "date": "2026-05-16",
+                "close": "7400.0",
+                "volatility": "0.15",
+                "iv_rank_1y": "30.0",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_strike_gex",
+        lambda c, r, rid, t: [
+            {
+                "strike": 7400,
+                "call_gex": 1e8,
+                "put_gex": -1e8,
+                "net_gex": 0,
+                "call_delta": 0.5,
+                "put_delta": -0.5,
+                "net_delta": 0,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_aggregate_gex",
+        lambda c, r, rid, t: [],
+    )
+    monkeypatch.setattr(gex_scanner, "fetch_vol_pc", lambda c, r, rid, t: None)
+
+
+def test_run_uses_stock_state_when_available(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    """When /stock-state returns, scanner uses its intraday close, not iv_rank.close."""
+    _stub_minimal_chain(monkeypatch)
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_stock_state_snapshot",
+        lambda c, r, rid, t: {
+            "spot": 7408.5,
+            "prev_close": 7501.24,
+            "market_time": "regular",
+            "tape_time": "2026-05-15T20:46:05Z",
+            "source": "stock_state",
+        },
+    )
+
+    gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    payload = seeded_db_empty_cards.fetch_latest_gex(ticker="SPX")
+
+    assert payload["spot"] == 7408.5  # stock-state, not iv_rank.close (7400.0)
+    assert payload["prev_close"] == 7501.24
+    assert payload["market_time"] == "regular"
+    assert payload["tape_time"] == "2026-05-15T20:46:05Z"
+    assert payload["spot_source"] == "stock_state"
+    assert payload["day_change"] == round(7408.5 - 7501.24, 4)
+    assert payload["day_change_pct"] == round((7408.5 - 7501.24) / 7501.24 * 100, 4)
+
+
+def test_run_falls_back_to_iv_rank_when_stock_state_fails(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    """When /stock-state fetcher returns None, scanner uses iv_rank.close + tags source."""
+    _stub_minimal_chain(monkeypatch)
+    monkeypatch.setattr(
+        gex_scanner, "fetch_stock_state_snapshot", lambda c, r, rid, t: None
+    )
+
+    gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    payload = seeded_db_empty_cards.fetch_latest_gex(ticker="SPX")
+
+    assert payload["spot"] == 7400.0  # iv_rank.close
+    assert payload["prev_close"] is None
+    assert payload["market_time"] is None
+    assert payload["tape_time"] is None
+    assert payload["spot_source"] == "iv_rank_eod"
+    assert payload["day_change"] is None
+    assert payload["day_change_pct"] is None

--- a/tests/integration/test_gex_scanner.py
+++ b/tests/integration/test_gex_scanner.py
@@ -1,0 +1,116 @@
+import pytest
+
+from uw_scan.api.client import UwClient
+from uw_scan.config import Settings
+from uw_scan.scanners import gex as gex_scanner
+from uw_scan.storage.repository import Repository
+
+
+@pytest.fixture
+def mock_client() -> UwClient:
+    """Real UwClient instance — UW calls are monkeypatched at the scanner-fetcher level."""
+    s = Settings.from_env()
+    return UwClient(
+        api_key=s.api_key.get_secret_value(),
+        base_url=s.base_url,
+        timeout=s.request_timeout_seconds,
+    )
+
+
+def test_run_persists_payload_with_full_xenon_shape(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_iv_rank_rows",
+        lambda c, r, rid, t: [
+            {
+                "date": "2026-05-16",
+                "close": "5800.0",
+                "volatility": "0.18",
+                "iv_rank_1y": "35.0",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_strike_gex",
+        lambda c, r, rid, t: [
+            {
+                "strike": 5750,
+                "call_gex": 1e8,
+                "put_gex": -3e8,
+                "net_gex": -2e8,
+                "call_delta": 0.4,
+                "put_delta": -0.6,
+                "net_delta": -0.2,
+            },
+            {
+                "strike": 5800,
+                "call_gex": 2e8,
+                "put_gex": -2e8,
+                "net_gex": 0,
+                "call_delta": 0.5,
+                "put_delta": -0.5,
+                "net_delta": 0,
+            },
+            {
+                "strike": 5850,
+                "call_gex": 3e8,
+                "put_gex": -1e8,
+                "net_gex": 2e8,
+                "call_delta": 0.6,
+                "put_delta": -0.4,
+                "net_delta": 0.2,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        gex_scanner,
+        "fetch_aggregate_gex",
+        lambda c, r, rid, t: [
+            {
+                "date": "2026-05-16",
+                "call_gex": 1e10,
+                "put_gex": -1e10,
+                "call_delta": 0.5,
+                "put_delta": -0.5,
+            },
+        ],
+    )
+    monkeypatch.setattr(gex_scanner, "fetch_vol_pc", lambda c, r, rid, t: 0.85)
+
+    row_id = gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    assert row_id > 0
+
+    payload = seeded_db_empty_cards.fetch_latest_gex(ticker="SPX")
+    assert payload is not None
+    assert payload["spot"] == 5800.0
+    assert payload["ticker"] == "SPX"
+    assert payload["mq"] is None
+    assert "profile" in payload
+    assert isinstance(payload["profile"], list)
+    assert payload["iv"]["source"] == "uw"
+    assert payload["iv"]["iv30d"] == 0.18
+    assert payload["iv"]["iv_rank"] == 35.0
+    assert payload["vol_pc"] == 0.85
+
+
+def test_run_raises_when_iv_rank_empty(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [])
+    with pytest.raises(RuntimeError, match="could not fetch spot"):
+        gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+
+
+def test_run_marks_scan_run_error_when_aborted(
+    seeded_db_empty_cards: Repository, mock_client: UwClient, monkeypatch
+):
+    monkeypatch.setattr(gex_scanner, "fetch_iv_rank_rows", lambda c, r, rid, t: [])
+    with pytest.raises(RuntimeError):
+        gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+    with seeded_db_empty_cards.conn.cursor() as cur:
+        cur.execute("SELECT status FROM uw_scan.scan_runs ORDER BY run_id DESC LIMIT 1")
+        status = cur.fetchone()[0]
+    assert status == "error"

--- a/tests/integration/test_gex_scanner.py
+++ b/tests/integration/test_gex_scanner.py
@@ -209,3 +209,69 @@ def test_run_falls_back_to_iv_rank_when_stock_state_fails(
     assert payload["spot_source"] == "iv_rank_eod"
     assert payload["day_change"] is None
     assert payload["day_change_pct"] is None
+
+
+def test_run_persists_greek_exposure_daily_tail(
+    seeded_db_empty_cards: Repository,
+    mock_client: UwClient,
+    monkeypatch,
+) -> None:
+    """After a scan, the /greek-exposure history rows land in
+    uw_scan.greek_exposure_daily — via the shared parser util."""
+    from datetime import date
+
+    from uw_scan.storage.greek_exposure_repository import (
+        GreekExposureDailyRepository,
+    )
+
+    _stub_minimal_chain(monkeypatch)
+    monkeypatch.setattr(
+        gex_scanner, "fetch_stock_state_snapshot", lambda c, r, rid, t: None
+    )
+
+    # Override fetch_aggregate_gex (whose body now delegates to the shared
+    # parser util — see B1.5) to return rows the scanner will both use for
+    # net_dex AND persist into greek_exposure_daily.
+    fake_rows = [
+        {
+            "date": date(2026, 5, 13),
+            "call_gex": 2e9,
+            "put_gex": -1e9,
+            "call_delta": 1e7,
+            "put_delta": -1e6,
+            "net_gex": 1e9,
+            "net_dex": 9e6,
+        },
+        {
+            "date": date(2026, 5, 14),
+            "call_gex": 2.1e9,
+            "put_gex": -1.0e9,
+            "call_delta": 1.1e7,
+            "put_delta": -1.1e6,
+            "net_gex": 1.1e9,
+            "net_dex": 9.9e6,
+        },
+        {
+            "date": date(2026, 5, 15),
+            "call_gex": 1.9e9,
+            "put_gex": -1.0e9,
+            "call_delta": 0.9e7,
+            "put_delta": -0.9e6,
+            "net_gex": 0.9e9,
+            "net_dex": 8.1e6,
+        },
+    ]
+    monkeypatch.setattr(
+        gex_scanner, "fetch_aggregate_gex", lambda c, r, rid, t: fake_rows
+    )
+
+    gex_scanner.run(mock_client, seeded_db_empty_cards, ticker="SPX")
+
+    daily_repo = GreekExposureDailyRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    rows = daily_repo.fetch_history("SPX", days=10)
+    assert len(rows) == 3
+    assert rows[-1]["call_gex"] == pytest.approx(1.9e9)
+    assert rows[-1]["net_gex"] == pytest.approx(0.9e9)  # generated column

--- a/tests/integration/test_vcg_scanner.py
+++ b/tests/integration/test_vcg_scanner.py
@@ -1,0 +1,129 @@
+"""Integration test for src/uw_scan/scanners/vcg.py:run().
+
+Seeds vol_index_daily (VIX / VVIX / HYG) with enough rows to clear
+MIN_ALIGNED_BARS, runs the scanner, asserts a snapshot is persisted.
+Also exercises the thin-data + zero-overlap early-return branches.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
+
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed(
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    values: list[float],
+    *,
+    start: date,
+) -> None:
+    rows = []
+    for i, v in enumerate(values):
+        rows.append(
+            {
+                "symbol": symbol,
+                "trade_date": start + timedelta(days=i),
+                "open": v,
+                "high": v,
+                "low": v,
+                "close": v,
+                "adj_close": v,
+                "volume": 0,
+            }
+        )
+    vol_repo.upsert_rows(rows)
+
+
+def test_run_persists_snapshot_when_data_is_sufficient(
+    seeded_db_empty_cards,
+) -> None:
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    n = 120  # > MIN_ALIGNED_BARS (94)
+    start = date(2026, 1, 1)
+    # Slightly drifting VIX/VVIX so log-returns are non-trivial; HYG ticks
+    # down so credit returns are non-zero and the OLS regression converges.
+    _seed(vol_repo, "VIX", [16.0 + 0.05 * (i % 7) for i in range(n)], start=start)
+    _seed(vol_repo, "VVIX", [90.0 + 0.3 * (i % 11) for i in range(n)], start=start)
+    _seed(
+        vol_repo,
+        "HYG",
+        [80.0 - 0.02 * i + 0.05 * (i % 5) for i in range(n)],
+        start=start,
+    )
+
+    row_id = vcg_scanner.run(conn, proxy="HYG", schema=repo._schema)
+    assert row_id is not None
+    assert row_id > 0
+
+    snap_repo = VcgSnapshotRepository(conn, schema=repo._schema)
+    latest = snap_repo.fetch_latest()
+    assert latest is not None
+    sig = latest["signal"]
+    # vcg may be NaN at the very edge; assert structural keys
+    assert latest["credit_proxy"] == "HYG"
+    assert "vcg" in sig
+    assert "interpretation" in sig
+    assert sig["interpretation"] in {
+        "INSUFFICIENT_DATA",
+        "NORMAL",
+        "WATCH",
+        "RISK_OFF",
+        "EDR",
+        "BOUNCE",
+        "SUPPRESSED",
+        "PANIC",
+    }
+    assert sig["ro"] in (0, 1)
+    assert sig["edr"] in (0, 1)
+    assert sig["bounce"] in (0, 1)
+    # Quiet seeded vol → no RO / EDR / Bounce
+    assert sig["ro"] == 0
+    assert sig["edr"] == 0
+    assert sig["bounce"] == 0
+    # 20-session rolling history
+    assert isinstance(latest["history"], list)
+    assert len(latest["history"]) == 20
+    last = latest["history"][-1]
+    assert {"date", "vcg", "vcg_adj", "vix", "vvix", "credit"} <= set(last)
+    if last["vcg"] is not None:
+        assert math.isfinite(last["vcg"])
+
+
+def test_run_returns_none_when_data_is_thin(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    n = 50  # << MIN_ALIGNED_BARS (94)
+    start = date(2026, 1, 1)
+    _seed(vol_repo, "VIX", [16.0] * n, start=start)
+    _seed(vol_repo, "VVIX", [95.0] * n, start=start)
+    _seed(vol_repo, "HYG", [80.0] * n, start=start)
+
+    assert vcg_scanner.run(conn, proxy="HYG", schema=repo._schema) is None
+
+    snap_repo = VcgSnapshotRepository(conn, schema=repo._schema)
+    assert snap_repo.fetch_latest() is None
+
+
+def test_run_returns_none_when_no_overlap(seeded_db_empty_cards) -> None:
+    """VIX dates and HYG dates don't intersect → 0 aligned bars."""
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    _seed(vol_repo, "VIX", [16.0] * 120, start=date(2026, 1, 1))
+    _seed(vol_repo, "VVIX", [95.0] * 120, start=date(2026, 1, 1))
+    # HYG starts a year later → zero overlap with vol series
+    _seed(vol_repo, "HYG", [80.0] * 120, start=date(2027, 1, 1))
+
+    assert vcg_scanner.run(conn, proxy="HYG", schema=repo._schema) is None

--- a/tests/integration/test_vol_index_lake_sync.py
+++ b/tests/integration/test_vol_index_lake_sync.py
@@ -1,0 +1,121 @@
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed(root: Path, symbol: str, rows: list[dict]) -> None:
+    d = root / f"symbol={symbol}"
+    d.mkdir(parents=True, exist_ok=True)
+    pq.write_table(pa.Table.from_pylist(rows), d / "1d.parquet")
+
+
+def test_run_sync_inserts_all_symbols(tmp_path: Path, seeded_db_empty_cards) -> None:
+    pg_conn = seeded_db_empty_cards.conn
+    _seed(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 17.5,
+                "high": 18.0,
+                "low": 17.2,
+                "close": 17.8,
+                "adj_close": 17.8,
+                "volume": 0,
+            },
+        ],
+    )
+    _seed(
+        tmp_path,
+        "SPX",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 7400,
+                "high": 7450,
+                "low": 7390,
+                "close": 7430,
+                "adj_close": 7430,
+                "volume": 0,
+            },
+        ],
+    )
+    summary = run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    assert summary["symbols"] == 2
+    assert summary["rows"] == 2
+    repo = VolIndexRepository(pg_conn, schema="uw_scan")
+    assert len(repo.fetch_history("VIX", days=5)) == 1
+    assert len(repo.fetch_history("SPX", days=5)) == 1
+
+
+def test_run_sync_incremental_refreshes_tail(
+    tmp_path: Path, seeded_db_empty_cards
+) -> None:
+    """Incremental mode: re-upsert the latest row (in case its close changed
+    intra-session) AND pull any strictly newer rows.
+
+    Two-row return is the desired behavior — re-upsert is idempotent."""
+    pg_conn = seeded_db_empty_cards.conn
+    _seed(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 17.5,
+                "high": 18.0,
+                "low": 17.2,
+                "close": 17.8,
+                "adj_close": 17.8,
+                "volume": 0,
+            },
+        ],
+    )
+    run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    # Append a newer row plus same-day refresh
+    _seed(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 17.5,
+                "high": 18.0,
+                "low": 17.2,
+                "close": 17.9,
+                "adj_close": 17.9,
+                "volume": 0,
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07,
+                "high": 19.27,
+                "low": 17.8,
+                "close": 18.43,
+                "adj_close": 18.43,
+                "volume": 0,
+            },
+        ],
+    )
+    summary = run_vol_index_lake_sync(pg_conn, root=tmp_path)
+    assert summary["rows"] == 2  # latest re-upsert + new row
+    repo = VolIndexRepository(pg_conn, schema="uw_scan")
+    rows = repo.fetch_history("VIX", days=5)
+    assert len(rows) == 2
+    # Refreshed close took effect
+    assert rows[0]["close"] == pytest.approx(17.9)
+
+
+def test_run_sync_empty_root_is_noop(tmp_path: Path, seeded_db_empty_cards) -> None:
+    summary = run_vol_index_lake_sync(
+        seeded_db_empty_cards.conn,
+        root=tmp_path,
+    )
+    assert summary == {"symbols": 0, "rows": 0}

--- a/tests/unit/test_cri_scoring.py
+++ b/tests/unit/test_cri_scoring.py
@@ -1,0 +1,209 @@
+"""Unit tests for CRI pure scoring functions."""
+
+import math
+
+import numpy as np
+import pytest
+
+from uw_scan.cards.cri_scoring import (
+    compute_cri,
+    compute_realized_vol,
+    cor1m_level_and_change,
+    crash_trigger,
+    cri_level,
+    cta_exposure_model,
+    run_analysis,
+    score_correlation_component,
+    score_momentum_component,
+    score_vix_component,
+    score_vvix_component,
+)
+
+# ── component scorers ──────────────────────────────────────────────
+
+
+def test_score_vix_zero_when_calm() -> None:
+    # VIX 15 with no movement → both subscores 0
+    assert score_vix_component(15.0, 0.0) == pytest.approx(0.0)
+
+
+def test_score_vix_max_at_high_vix_and_roc() -> None:
+    # VIX >= 40 → level_score 15; RoC >= 60% → roc_score 10; total 25
+    assert score_vix_component(40.0, 60.0) == pytest.approx(25.0)
+    assert score_vix_component(99.0, 200.0) == pytest.approx(25.0)
+
+
+def test_score_vix_nan_returns_zero() -> None:
+    assert score_vix_component(float("nan"), 10.0) == 0.0
+    assert score_vix_component(20.0, float("nan")) == 0.0
+
+
+def test_score_vvix_zero_at_baseline() -> None:
+    assert score_vvix_component(90.0, 5.0) == pytest.approx(0.0)
+
+
+def test_score_vvix_max_at_extreme() -> None:
+    # VVIX 140 → level 17; ratio 8 → ratio 8; total 25
+    assert score_vvix_component(140.0, 8.0) == pytest.approx(25.0)
+
+
+def test_score_correlation_zero_below_threshold() -> None:
+    assert score_correlation_component(25.0, 0.0) == pytest.approx(0.0)
+
+
+def test_score_correlation_max() -> None:
+    # COR1M 70 → level 17; 5d spike 20 → spike 8; total 25
+    assert score_correlation_component(70.0, 20.0) == pytest.approx(25.0)
+
+
+def test_score_momentum_zero_above_ma() -> None:
+    assert score_momentum_component(5.0) == 0.0
+    assert score_momentum_component(0.0) == 0.0
+
+
+def test_score_momentum_max_at_minus_10() -> None:
+    # -10% distance → full 25
+    assert score_momentum_component(-10.0) == pytest.approx(25.0)
+    assert score_momentum_component(-25.0) == pytest.approx(25.0)  # clipped
+
+
+def test_score_momentum_nan_returns_zero() -> None:
+    assert score_momentum_component(float("nan")) == 0.0
+
+
+# ── composite / level ─────────────────────────────────────────────
+
+
+def test_cri_level_thresholds() -> None:
+    assert cri_level(0.0) == "LOW"
+    assert cri_level(24.9) == "LOW"
+    assert cri_level(25.0) == "ELEVATED"
+    assert cri_level(49.9) == "ELEVATED"
+    assert cri_level(50.0) == "HIGH"
+    assert cri_level(74.9) == "HIGH"
+    assert cri_level(75.0) == "CRITICAL"
+    assert cri_level(100.0) == "CRITICAL"
+
+
+def test_compute_cri_calm_market_low() -> None:
+    out = compute_cri(
+        vix=14.0,
+        vix_5d_roc=0.0,
+        vvix=85.0,
+        vvix_vix_ratio=6.0,
+        corr=20.0,
+        corr_5d_change=0.0,
+        spx_distance_pct=5.0,
+    )
+    assert out["score"] < 10
+    assert out["level"] == "LOW"
+
+
+def test_compute_cri_critical_market() -> None:
+    out = compute_cri(
+        vix=40.0,
+        vix_5d_roc=60.0,
+        vvix=140.0,
+        vvix_vix_ratio=8.0,
+        corr=70.0,
+        corr_5d_change=20.0,
+        spx_distance_pct=-12.0,
+    )
+    assert out["score"] == pytest.approx(100.0)
+    assert out["level"] == "CRITICAL"
+    assert set(out["components"].keys()) == {"vix", "vvix", "correlation", "momentum"}
+
+
+# ── realized vol ──────────────────────────────────────────────────
+
+
+def test_realized_vol_nan_for_short_series() -> None:
+    assert math.isnan(compute_realized_vol(np.array([100.0, 101.0]), window=20))
+
+
+def test_realized_vol_returns_finite_for_long_series() -> None:
+    # 30 daily closes with ~1% std → ~16% annualized
+    np.random.seed(0)
+    closes = np.cumprod(1 + np.random.normal(0, 0.01, 30)) * 100
+    rv = compute_realized_vol(closes, window=20)
+    assert math.isfinite(rv)
+    assert 5.0 < rv < 40.0
+
+
+# ── cor1m helper ──────────────────────────────────────────────────
+
+
+def test_cor1m_empty_returns_nan() -> None:
+    cur, chg = cor1m_level_and_change(np.array([]))
+    assert math.isnan(cur)
+    assert math.isnan(chg)
+
+
+def test_cor1m_change_over_5_sessions() -> None:
+    arr = np.array([10.0, 12.0, 14.0, 16.0, 18.0, 20.0])  # 6 values; -6 is 10
+    cur, chg = cor1m_level_and_change(arr)
+    assert cur == pytest.approx(20.0)
+    assert chg == pytest.approx(10.0)
+
+
+# ── cta + crash trigger ───────────────────────────────────────────
+
+
+def test_cta_exposure_below_target_max_exposure() -> None:
+    # Realized vol 5% (well below 10% target) → 200% capped exposure
+    out = cta_exposure_model(realized_vol=5.0)
+    assert out["exposure_pct"] == pytest.approx(200.0)
+    assert out["forced_reduction"] is False
+
+
+def test_cta_exposure_high_vol_forces_reduction() -> None:
+    # Realized vol 25% → 40% exposure → 60% reduction
+    out = cta_exposure_model(realized_vol=25.0)
+    assert out["exposure_pct"] == pytest.approx(40.0)
+    assert out["forced_reduction"] is True
+    assert out["forced_reduction_pct"] == pytest.approx(60.0)
+    assert out["est_selling_bn"] > 0
+
+
+def test_crash_trigger_fires_when_all_three() -> None:
+    out = crash_trigger(spx_below_ma=True, realized_vol=30.0, cor1m=65.0)
+    assert out["fired"] is True
+
+
+def test_crash_trigger_silent_when_only_one() -> None:
+    out = crash_trigger(spx_below_ma=False, realized_vol=30.0, cor1m=65.0)
+    assert out["fired"] is False
+
+
+# ── full run_analysis orchestration ───────────────────────────────
+
+
+def _make_aligned(n: int = 120) -> tuple[dict[str, np.ndarray], list[str]]:
+    """Synthetic, calm-market arrays — vix ~16, vvix ~95, spy trending up."""
+    from datetime import date, timedelta
+
+    days = [(date(2026, 1, 1) + timedelta(days=i)).isoformat() for i in range(n)]
+    aligned = {
+        "VIX": np.full(n, 16.0),
+        "VVIX": np.full(n, 95.0),
+        "SPY": np.linspace(450, 600, n),
+        "COR1M": np.full(n, 20.0),
+    }
+    return aligned, days
+
+
+def test_run_analysis_calm_market_yields_low_cri() -> None:
+    aligned, dates = _make_aligned()
+    out = run_analysis(aligned, dates)
+    assert out["cri"]["level"] == "LOW"
+    assert out["cri"]["score"] < 25
+    assert out["crash_trigger"]["fired"] is False
+    assert len(out["history"]) == 20
+    assert len(out["spy_closes"]) == 40  # VOL_WINDOW * 2
+
+
+def test_run_analysis_history_dates_monotonic() -> None:
+    aligned, dates = _make_aligned()
+    out = run_analysis(aligned, dates)
+    hist_dates = [h["date"] for h in out["history"]]
+    assert hist_dates == sorted(hist_dates)

--- a/tests/unit/test_greek_exposure_history_parser.py
+++ b/tests/unit/test_greek_exposure_history_parser.py
@@ -1,0 +1,87 @@
+"""Pure parser tests — no DB, no network."""
+
+from datetime import date
+
+import pytest
+from uw_scan.cards.greek_exposure_history import parse_greek_exposure_history
+
+
+def test_parses_well_formed_payload() -> None:
+    body = {
+        "data": [
+            {
+                "date": "2026-05-14",
+                "call_gex": "1000000000",
+                "put_gex": "-500000000",
+                "call_delta": "10000000",
+                "put_delta": "-5000000",
+            },
+            {
+                "date": "2026-05-15",
+                "call_gex": "1100000000",
+                "put_gex": "-550000000",
+                "call_delta": "11000000",
+                "put_delta": "-5500000",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 2
+    assert rows[0]["date"] == date(2026, 5, 14)
+    assert rows[0]["call_gex"] == pytest.approx(1e9)
+    assert rows[0]["net_gex"] == pytest.approx(5e8)
+    assert rows[0]["net_dex"] == pytest.approx(5e6)
+
+
+def test_skips_malformed_rows() -> None:
+    body = {
+        "data": [
+            {
+                "date": "2026-05-14",
+                "call_gex": "ok-string-not-number",
+                "put_gex": "0",
+                "call_delta": "0",
+                "put_delta": "0",
+            },
+            {
+                "date": "2026-05-15",
+                "call_gex": "1",
+                "put_gex": "1",
+                "call_delta": "1",
+                "put_delta": "1",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 1
+    assert rows[0]["date"] == date(2026, 5, 15)
+
+
+def test_handles_empty_or_missing_data() -> None:
+    assert parse_greek_exposure_history({}) == []
+    assert parse_greek_exposure_history({"data": None}) == []
+    assert parse_greek_exposure_history({"data": []}) == []
+
+
+def test_accepts_iso_date_strings_or_date_objects() -> None:
+    body = {
+        "data": [
+            {
+                "date": "2026-05-15",
+                "call_gex": "1",
+                "put_gex": "1",
+                "call_delta": "1",
+                "put_delta": "1",
+            },
+            {
+                "date": date(2026, 5, 16),
+                "call_gex": "1",
+                "put_gex": "1",
+                "call_delta": "1",
+                "put_delta": "1",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert rows[0]["date"] == date(2026, 5, 15)
+    assert rows[1]["date"] == date(2026, 5, 16)

--- a/tests/unit/test_lake_reader.py
+++ b/tests/unit/test_lake_reader.py
@@ -1,0 +1,90 @@
+"""Lake reader: parquet → list[dict] for vol_index_daily upserts."""
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
+
+
+def _write_fixture(root: Path, symbol: str, rows: list[dict]) -> None:
+    d = root / f"symbol={symbol}"
+    d.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, d / "1d.parquet")
+
+
+def test_read_vol_index_parquet_returns_rows(tmp_path: Path) -> None:
+    _write_fixture(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 17.5,
+                "high": 18.0,
+                "low": 17.2,
+                "close": 17.8,
+                "adj_close": 17.8,
+                "volume": 0,
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "open": 18.07,
+                "high": 19.27,
+                "low": 17.8,
+                "close": 18.43,
+                "adj_close": 18.43,
+                "volume": 0,
+            },
+        ],
+    )
+    rows = read_vol_index_parquet(tmp_path, "VIX")
+    assert len(rows) == 2
+    assert rows[0]["symbol"] == "VIX"
+    assert rows[0]["trade_date"] == date(2026, 5, 14)
+    assert rows[1]["close"] == pytest.approx(18.43)
+
+
+def test_read_vol_index_parquet_since(tmp_path: Path) -> None:
+    _write_fixture(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 1),
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+                "adj_close": 1,
+                "volume": 0,
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "open": 2,
+                "high": 2,
+                "low": 2,
+                "close": 2,
+                "adj_close": 2,
+                "volume": 0,
+            },
+        ],
+    )
+    rows = read_vol_index_parquet(tmp_path, "VIX", since=date(2026, 5, 10))
+    assert len(rows) == 1
+    assert rows[0]["trade_date"] == date(2026, 5, 15)
+
+
+def test_list_vol_index_symbols(tmp_path: Path) -> None:
+    for sym in ["VIX", "VVIX", "SPX"]:
+        (tmp_path / f"symbol={sym}").mkdir(parents=True)
+        (tmp_path / f"symbol={sym}" / "1d.parquet").touch()
+    syms = list_vol_index_symbols(tmp_path)
+    assert set(syms) == {"VIX", "VVIX", "SPX"}
+
+
+def test_read_missing_symbol_returns_empty(tmp_path: Path) -> None:
+    assert read_vol_index_parquet(tmp_path, "NONEXISTENT") == []

--- a/tests/unit/test_regime_schemas.py
+++ b/tests/unit/test_regime_schemas.py
@@ -1,4 +1,4 @@
-from uw_scan.api.schemas import EMPTY_GEX_RESPONSE, GexResponse, RegimePendingResponse
+from uw_scan.api.schemas import EMPTY_GEX_RESPONSE, GexResponse
 
 
 def test_empty_gex_response_uses_profile_not_buckets():
@@ -52,14 +52,6 @@ def test_gex_response_round_trip_with_full_xenon_shape():
     assert parsed.spot == 5800.12
     assert parsed.bias.direction == "BEAR"
     assert parsed.profile[0].strike == 5750
-
-
-def test_regime_pending_response_shape():
-    # VCG is the only remaining pending scanner; CRI is live as of 040.
-    payload = RegimePendingResponse(scanner="vcg").model_dump()
-    assert payload["status"] == "pending"
-    assert payload["scanner"] == "vcg"
-    assert payload["reason"] == "ib_via_r2_not_wired"
 
 
 def test_gex_response_coerces_string_numerics():

--- a/tests/unit/test_regime_schemas.py
+++ b/tests/unit/test_regime_schemas.py
@@ -55,9 +55,10 @@ def test_gex_response_round_trip_with_full_xenon_shape():
 
 
 def test_regime_pending_response_shape():
-    payload = RegimePendingResponse(scanner="cri").model_dump()
+    # VCG is the only remaining pending scanner; CRI is live as of 040.
+    payload = RegimePendingResponse(scanner="vcg").model_dump()
     assert payload["status"] == "pending"
-    assert payload["scanner"] == "cri"
+    assert payload["scanner"] == "vcg"
     assert payload["reason"] == "ib_via_r2_not_wired"
 
 

--- a/tests/unit/test_regime_schemas.py
+++ b/tests/unit/test_regime_schemas.py
@@ -1,0 +1,74 @@
+from uw_scan.api.schemas import EMPTY_GEX_RESPONSE, GexResponse, RegimePendingResponse
+
+
+def test_empty_gex_response_uses_profile_not_buckets():
+    payload = EMPTY_GEX_RESPONSE.model_dump()
+    assert "profile" in payload
+    assert payload["profile"] == []
+    assert payload["levels"]["max_magnet"] is None
+    assert payload["bias"]["direction"] is None
+    assert payload["mq"] is None
+
+
+def test_gex_response_round_trip_with_full_xenon_shape():
+    src = {
+        "scan_time": "2026-05-16T13:15:00Z",
+        "market_open": True,
+        "ticker": "SPX",
+        "spot": 5800.12,
+        "net_gex": -2400000000.0,
+        "levels": {
+            "gex_flip": {
+                "strike": 5750,
+                "gamma": 0,
+                "distance": -50.12,
+                "distance_pct": -0.86,
+            },
+            "max_magnet": {
+                "strike": 5780,
+                "gamma": 1.5e9,
+                "distance": -20.12,
+                "distance_pct": -0.34,
+            },
+        },
+        "profile": [
+            {
+                "strike": 5750,
+                "call_gex": 1e8,
+                "put_gex": -2e8,
+                "net_gex": -1e8,
+                "pct_from_spot": -0.86,
+                "tag": None,
+            }
+        ],
+        "bias": {
+            "direction": "BEAR",
+            "reasons": ["net_gex<0", "spot<flip"],
+            "days_above_flip": 0,
+            "flip_migration": [],
+        },
+    }
+    parsed = GexResponse.model_validate(src)
+    assert parsed.spot == 5800.12
+    assert parsed.bias.direction == "BEAR"
+    assert parsed.profile[0].strike == 5750
+
+
+def test_regime_pending_response_shape():
+    payload = RegimePendingResponse(scanner="cri").model_dump()
+    assert payload["status"] == "pending"
+    assert payload["scanner"] == "cri"
+    assert payload["reason"] == "ib_via_r2_not_wired"
+
+
+def test_gex_response_coerces_string_numerics():
+    src = {
+        "spot": "5800.12",
+        "net_gex": "-2400000000",
+        "profile": [{"strike": "5750", "call_gex": "1e8", "tag": "magnet"}],
+    }
+    parsed = GexResponse.model_validate(src)
+    assert parsed.spot == 5800.12
+    assert parsed.net_gex == -2_400_000_000.0
+    assert parsed.profile[0].strike == 5750.0
+    assert parsed.profile[0].tag == "magnet"

--- a/uv.lock
+++ b/uv.lock
@@ -631,6 +631,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c9/a47ab7ece0d86cbe6678418a0fbd1ac4bb493b9184a3891dfa0e7f287ae0/pyarrow-24.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74", size = 35068898, upload-time = "2026-04-21T10:46:36.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/8db86617a9a58008acf8913d6fed68ea2a46acb6de928db28d724c891a68/pyarrow-24.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3", size = 36679915, upload-time = "2026-04-21T10:46:42.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8e/fb178720400ef69db251eb4a9c3ccf4af269bc1feb5055529b8fc87170d1/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868", size = 45697931, upload-time = "2026-04-21T10:46:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/27/99c42abe8e21b44f4917f62631f3aa31404882a2c41d8a4cd5c110e13d52/pyarrow-24.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e", size = 48837449, upload-time = "2026-04-21T10:46:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/333749e2666e9032891125bf9c691146e92901bece62030ac1430e2e7c88/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57", size = 49395949, upload-time = "2026-04-21T10:47:01.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/25/c5201706a2dd374e8ba6ee3fd7a8c89fb7ffc16eed5217a91fd2bd7f7626/pyarrow-24.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c", size = 51912986, upload-time = "2026-04-21T10:47:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/4d1bbba65320b21a49678d6fbdc6ff7c649251359fdcfc03568c4136231d/pyarrow-24.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981", size = 27255371, upload-time = "2026-04-21T10:47:15.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1122,6 +1172,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pandas" },
     { name = "playwright" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1149,6 +1200,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2" },
     { name = "playwright", specifier = ">=1.44" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
+    { name = "pyarrow", specifier = ">=18.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "tzdata", specifier = ">=2024.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1.0" },

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -7012,3 +7012,77 @@ tr {
     max-width: 100vw;
   }
 }
+
+/* ─── Regime page (ported from xenon 2026-05-16) ─────────────────── */
+
+.regime-page {
+  padding: 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.regime-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-dim);
+}
+
+.regime-page-header h1 {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.regime-page-subtitle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.regime-pending {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 24px;
+  gap: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-dim);
+}
+
+.regime-pending h2 {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  letter-spacing: 0.05em;
+}
+
+.regime-pending p {
+  max-width: 480px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.regime-pending-link {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.regime-pending code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  background: var(--bg-hover);
+  padding: 1px 5px;
+  border-radius: 2px;
+}

--- a/web/app/regime/page.tsx
+++ b/web/app/regime/page.tsx
@@ -1,0 +1,20 @@
+import RegimePanel from "@/components/regime/RegimePanel";
+
+export const metadata = {
+  title: "Regime — Unusual Whales",
+  description: "Market-wide regime indicators: CRI, VCG, GEX",
+};
+
+export default function RegimePage() {
+  return (
+    <main className="regime-page">
+      <header className="regime-page-header">
+        <h1>Regime</h1>
+        <p className="regime-page-subtitle">
+          Crash Risk Indicator · Vol-Curve Gauge · Gamma Exposure
+        </p>
+      </header>
+      <RegimePanel />
+    </main>
+  );
+}

--- a/web/app/regime/page.tsx
+++ b/web/app/regime/page.tsx
@@ -1,4 +1,5 @@
 import RegimePanel from "@/components/regime/RegimePanel";
+import VolBackdropStrip from "@/components/regime/VolBackdropStrip";
 
 export const metadata = {
   title: "Regime — Unusual Whales",
@@ -14,6 +15,7 @@ export default function RegimePage() {
           Crash Risk Indicator · Vol-Curve Gauge · Gamma Exposure
         </p>
       </header>
+      <VolBackdropStrip />
       <RegimePanel />
     </main>
   );

--- a/web/components/regime/CriHistoryChart.tsx
+++ b/web/components/regime/CriHistoryChart.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { finiteDomain, linearScale } from "@/lib/svgChart";
+
+export interface CriHistoryEntry {
+  date: string;
+  vix: number | null | undefined;
+  vvix: number | null | undefined;
+  spy?: number | null | undefined;
+  cor1m?: number | null | undefined;
+  realized_vol?: number | null | undefined;
+  spx_vs_ma_pct?: number | null | undefined;
+  vix_5d_roc?: number | null | undefined;
+}
+
+export interface ChartSeries {
+  key: keyof CriHistoryEntry;
+  label: string;
+  color: string;
+  axis: "left" | "right";
+  format?: (v: number) => string;
+}
+
+interface CriHistoryChartProps {
+  history: CriHistoryEntry[];
+  series: [ChartSeries, ChartSeries];
+  title: string;
+  liveValues?: Partial<Record<keyof CriHistoryEntry, number>>;
+}
+
+const MARGIN = { top: 20, right: 56, bottom: 32, left: 48 };
+const HEIGHT = 440;
+
+function defaultFormat(v: number): string {
+  return v.toFixed(2);
+}
+
+function pickVal(
+  d: CriHistoryEntry,
+  key: keyof CriHistoryEntry,
+): number | null {
+  const raw = d[key];
+  if (raw == null) return null;
+  if (typeof raw !== "number") return null;
+  return Number.isFinite(raw) ? raw : null;
+}
+
+function niceDateTicks(dates: Date[], maxTicks: number): Date[] {
+  if (dates.length <= maxTicks) return dates.slice();
+  const step = Math.ceil(dates.length / maxTicks);
+  const out: Date[] = [];
+  for (let i = 0; i < dates.length; i += step) out.push(dates[i]);
+  if (out[out.length - 1] !== dates[dates.length - 1])
+    out.push(dates[dates.length - 1]);
+  return out;
+}
+
+function fmtDateLabel(d: Date): string {
+  const m = d.toLocaleString("en-US", { month: "short" });
+  return `${m} ${d.getDate()}`;
+}
+
+export default function CriHistoryChart({
+  history,
+  series,
+  title,
+  liveValues,
+}: CriHistoryChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [width, setWidth] = useState(400);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0];
+      if (e) setWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    setWidth(el.getBoundingClientRect().width);
+    return () => ro.disconnect();
+  }, []);
+
+  // Merge live values into the last data point (for the live overlay dot).
+  const chartData = useMemo<CriHistoryEntry[]>(() => {
+    if (!history || history.length === 0) return [];
+    if (!liveValues || Object.keys(liveValues).length === 0) return history;
+    const out = [...history];
+    const last = { ...out[out.length - 1] };
+    for (const [k, v] of Object.entries(liveValues)) {
+      if (v != null) (last as Record<string, unknown>)[k] = v;
+    }
+    out[out.length - 1] = last;
+    return out;
+  }, [history, liveValues]);
+
+  const [leftSeries, rightSeries] = series;
+  const innerW = Math.max(0, width - MARGIN.left - MARGIN.right);
+  const innerH = HEIGHT - MARGIN.top - MARGIN.bottom;
+
+  if (chartData.length < 2) {
+    return (
+      <div className="cri-history-chart-panel">
+        <div
+          className="section-header"
+          style={{ marginBottom: 12, padding: 0 }}
+        >
+          <div className="section-title">{title}</div>
+        </div>
+        <div className="cri-history-chart-shell">
+          <div className="chart-surface cri-history-chart-surface">
+            <div
+              className="chart-empty-state cri-history-chart-empty"
+              data-testid="cri-history-chart-empty"
+            >
+              NO HISTORY AVAILABLE
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const dates = chartData.map((d) => new Date(d.date));
+  const x = linearScale([0, chartData.length - 1], [0, innerW]);
+
+  function buildY(s: ChartSeries) {
+    const vals = chartData.map((d) => pickVal(d, s.key));
+    const dom = finiteDomain(vals);
+    if (!dom) return null;
+    const pad = (dom.hi - dom.lo) * 0.15 || 2;
+    return linearScale([dom.lo - pad, dom.hi + pad], [innerH, 0]);
+  }
+
+  const yLeft = buildY(leftSeries);
+  const yRight = buildY(rightSeries);
+
+  function pathFor(s: ChartSeries, y: ((v: number) => number) | null): string {
+    if (!y) return "";
+    const pts = chartData
+      .map((d, i) => {
+        const v = pickVal(d, s.key);
+        return v == null ? null : ([x(i), y(v)] as [number, number]);
+      })
+      .filter((p): p is [number, number] => p != null);
+    return pts
+      .map(([px, py], i) => `${i === 0 ? "M" : "L"}${px},${py}`)
+      .join(" ");
+  }
+
+  const leftPath = pathFor(leftSeries, yLeft);
+  const rightPath = pathFor(rightSeries, yRight);
+
+  function dotsFor(s: ChartSeries, y: ((v: number) => number) | null) {
+    if (!y) return [];
+    return chartData.flatMap((d, i) => {
+      const v = pickVal(d, s.key);
+      if (v == null) return [];
+      return [{ cx: x(i), cy: y(v), i }];
+    });
+  }
+
+  const leftDots = dotsFor(leftSeries, yLeft);
+  const rightDots = dotsFor(rightSeries, yRight);
+
+  // Grid ticks (5 evenly distributed on left axis range)
+  const gridYs = yLeft
+    ? Array.from({ length: 5 }, (_, k) => (innerH / 4) * k)
+    : [];
+
+  // Left-axis tick labels (5 ticks)
+  function axisTicks(y: ((v: number) => number) | null) {
+    if (!y) return [];
+    // Reconstruct the domain from the scale by sampling — easier to just compute
+    // ticks against the original domain. We'll recompute here.
+    return [];
+  }
+
+  // For axis labels, recompute domain explicitly
+  function domainOf(s: ChartSeries) {
+    const vals = chartData.map((d) => pickVal(d, s.key));
+    const dom = finiteDomain(vals);
+    if (!dom) return null;
+    const pad = (dom.hi - dom.lo) * 0.15 || 2;
+    return { lo: dom.lo - pad, hi: dom.hi + pad };
+  }
+  const leftDom = domainOf(leftSeries);
+  const rightDom = domainOf(rightSeries);
+
+  function ticksFor(dom: { lo: number; hi: number } | null) {
+    if (!dom) return [] as number[];
+    const span = dom.hi - dom.lo || 1;
+    const step = span / 4;
+    return [0, 1, 2, 3, 4].map((k) => dom.lo + step * k);
+  }
+
+  const leftTicks = ticksFor(leftDom);
+  const rightTicks = ticksFor(rightDom);
+
+  // X tick dates — 5–7 evenly spaced
+  const xTickCount = Math.max(2, Math.min(7, Math.floor(innerW / 80)));
+  const xTickIdx = Array.from({ length: xTickCount }, (_, k) =>
+    Math.round(((chartData.length - 1) * k) / (xTickCount - 1)),
+  );
+
+  // Hover handlers — snap to nearest index
+  function onMove(e: React.MouseEvent<SVGRectElement>) {
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const localX = e.clientX - rect.left - MARGIN.left;
+    const frac = innerW > 0 ? localX / innerW : 0;
+    let i = Math.round(frac * (chartData.length - 1));
+    i = Math.max(0, Math.min(chartData.length - 1, i));
+    setHoverIdx(i);
+    setHoverPos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+  }
+
+  function onLeave() {
+    setHoverIdx(null);
+    setHoverPos(null);
+  }
+
+  const hoverEntry = hoverIdx != null ? chartData[hoverIdx] : null;
+  const tooltipSide =
+    hoverPos && hoverPos.x > width / 2
+      ? { right: width - hoverPos.x + 12 }
+      : { left: (hoverPos?.x ?? 0) + 12 };
+
+  const leftFmt = leftSeries.format ?? defaultFormat;
+  const rightFmt = rightSeries.format ?? defaultFormat;
+
+  return (
+    <div className="cri-history-chart-panel">
+      <div
+        className="section-header"
+        style={{
+          marginBottom: 12,
+          padding: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div className="section-title" style={{ padding: 0 }}>
+          {title}
+        </div>
+        <div style={{ display: "flex", gap: 12 }}>
+          {series.map((s) => (
+            <div
+              key={String(s.key)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: "var(--text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+              }}
+            >
+              <span
+                style={{
+                  width: 10,
+                  height: 2,
+                  background: s.color,
+                  display: "inline-block",
+                }}
+              />
+              {s.label}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div ref={containerRef} className="cri-history-chart-shell">
+        <div className="chart-surface cri-history-chart-surface">
+          <svg
+            ref={svgRef}
+            className="cri-history-chart-svg"
+            viewBox={`0 0 ${width} ${HEIGHT}`}
+            role="img"
+            aria-label={`${title} 20-session chart`}
+            data-testid="cri-history-chart"
+          >
+            <g transform={`translate(${MARGIN.left},${MARGIN.top})`}>
+              {/* Grid lines */}
+              {gridYs.map((y, i) => (
+                <line
+                  key={i}
+                  x1={0}
+                  x2={innerW}
+                  y1={y}
+                  y2={y}
+                  stroke="var(--chart-grid)"
+                  strokeWidth={1}
+                />
+              ))}
+
+              {/* Left series path + dots */}
+              <path
+                d={leftPath}
+                fill="none"
+                stroke={leftSeries.color}
+                strokeWidth={2}
+              />
+              {leftDots.map((p) => (
+                <circle
+                  key={`l-${p.i}`}
+                  cx={p.cx}
+                  cy={p.cy}
+                  r={2}
+                  fill={leftSeries.color}
+                  stroke="var(--bg-panel)"
+                  strokeWidth={1}
+                />
+              ))}
+
+              {/* Right series path + dots */}
+              <path
+                d={rightPath}
+                fill="none"
+                stroke={rightSeries.color}
+                strokeWidth={2}
+              />
+              {rightDots.map((p) => (
+                <circle
+                  key={`r-${p.i}`}
+                  cx={p.cx}
+                  cy={p.cy}
+                  r={2}
+                  fill={rightSeries.color}
+                  stroke="var(--bg-panel)"
+                  strokeWidth={1}
+                />
+              ))}
+
+              {/* Live overlay halo on the last point of each series */}
+              {liveValues &&
+                Object.keys(liveValues).length > 0 &&
+                yLeft &&
+                (() => {
+                  const last = leftDots[leftDots.length - 1];
+                  return last ? (
+                    <circle
+                      cx={last.cx}
+                      cy={last.cy}
+                      r={4}
+                      fill={leftSeries.color}
+                      stroke={leftSeries.color}
+                      opacity={0.5}
+                    />
+                  ) : null;
+                })()}
+              {liveValues &&
+                Object.keys(liveValues).length > 0 &&
+                yRight &&
+                (() => {
+                  const last = rightDots[rightDots.length - 1];
+                  return last ? (
+                    <circle
+                      cx={last.cx}
+                      cy={last.cy}
+                      r={4}
+                      fill={rightSeries.color}
+                      stroke={rightSeries.color}
+                      opacity={0.5}
+                    />
+                  ) : null;
+                })()}
+
+              {/* Left axis ticks */}
+              {leftTicks.map((v, i) => (
+                <text
+                  key={`lt-${i}`}
+                  x={-8}
+                  y={
+                    (innerH * (leftTicks.length - 1 - i)) /
+                    (leftTicks.length - 1)
+                  }
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fontFamily="var(--font-mono)"
+                  fill={leftSeries.color}
+                >
+                  {leftFmt(v)}
+                </text>
+              ))}
+
+              {/* Right axis ticks */}
+              {rightTicks.map((v, i) => (
+                <text
+                  key={`rt-${i}`}
+                  x={innerW + 8}
+                  y={
+                    (innerH * (rightTicks.length - 1 - i)) /
+                    (rightTicks.length - 1)
+                  }
+                  textAnchor="start"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fontFamily="var(--font-mono)"
+                  fill={rightSeries.color}
+                >
+                  {rightFmt(v)}
+                </text>
+              ))}
+
+              {/* X axis baseline */}
+              <line
+                x1={0}
+                x2={innerW}
+                y1={innerH}
+                y2={innerH}
+                stroke="var(--chart-axis)"
+              />
+
+              {/* X axis ticks */}
+              {xTickIdx.map((i) => (
+                <text
+                  key={`xt-${i}`}
+                  x={x(i)}
+                  y={innerH + 18}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fontFamily="var(--font-mono)"
+                  fill="var(--chart-axis-muted)"
+                >
+                  {fmtDateLabel(dates[i])}
+                </text>
+              ))}
+
+              {/* Hover crosshair */}
+              {hoverEntry && hoverIdx != null && (
+                <line
+                  x1={x(hoverIdx)}
+                  x2={x(hoverIdx)}
+                  y1={0}
+                  y2={innerH}
+                  stroke="var(--border-dim)"
+                  strokeDasharray="2 3"
+                />
+              )}
+
+              {/* Invisible capture overlay */}
+              <rect
+                x={0}
+                y={0}
+                width={innerW}
+                height={innerH}
+                fill="transparent"
+                onMouseMove={onMove}
+                onMouseLeave={onLeave}
+              />
+            </g>
+          </svg>
+        </div>
+
+        {hoverEntry && hoverPos && (
+          <div
+            className="chart-tooltip"
+            style={{
+              ...tooltipSide,
+              top: hoverPos.y - 10,
+            }}
+          >
+            <div className="chart-tooltip-date">{hoverEntry.date}</div>
+            {series.map((s) => {
+              const v = pickVal(hoverEntry, s.key);
+              const f = s.format ?? defaultFormat;
+              return (
+                <div key={String(s.key)} className="chart-tooltip-row">
+                  <span className="chart-tooltip-label">{s.label}</span>
+                  <span
+                    className="chart-tooltip-value"
+                    style={{ color: s.color }}
+                  >
+                    {v != null ? f(v) : "---"}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -1,455 +1,425 @@
 "use client";
 
-import { fmtDecimal } from "@/lib/formatters";
-import { finiteDomain, linearScale, pathFromPoints } from "@/lib/svgChart";
-import {
+import { useMemo } from "react";
+import { AlertTriangle, Check, Shield, X, Zap } from "lucide-react";
+
+import CriHistoryChart, {
+  type ChartSeries,
   type CriHistoryEntry,
-  type CriResponse,
-  useCri,
-} from "@/lib/regime/useCri";
+} from "./CriHistoryChart";
+import InfoTooltip from "./InfoTooltip";
+import {
+  DayChange,
+  LiveBadge,
+  PointChange,
+  RegimeStrip,
+  RegimeStripCell,
+} from "./RegimeStrip";
+import { type CriBlock, type CriResponse, useCri } from "@/lib/regime/useCri";
 
-const LEVEL_COLOR: Record<"LOW" | "ELEVATED" | "HIGH" | "CRITICAL", string> = {
-  LOW: "var(--positive)",
-  ELEVATED: "var(--accent-warm)",
-  HIGH: "var(--warning)",
-  CRITICAL: "var(--negative)",
+type CriLevel = "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
+
+const COMPONENT_TOOLTIPS: Record<string, string> = {
+  VIX: "CBOE Volatility Index — 30-day implied vol of SPX. Score rises as VIX exceeds 20 (elevated) and 30 (high).",
+  VVIX: "Vol-of-VIX — measures expected volatility of VIX itself. Score rises with absolute level and VVIX/VIX ratio >5.",
+  CORRELATION:
+    "Cboe 1-Month Implied Correlation Index (COR1M). High COR1M (>60) means large-cap S&P names are expected to move together.",
+  MOMENTUM:
+    "SPX distance below 100-day MA combined with VIX 5-day rate of change. Captures trend stress + vol acceleration.",
 };
 
-const COMPONENT_LABELS: Record<keyof CriComponentsShape, string> = {
-  vix: "VIX",
-  vvix: "VVIX",
-  correlation: "COR1M",
-  momentum: "SPX MOM",
+const SECTION_TOOLTIPS: Record<string, string> = {
+  "CRI COMPONENTS":
+    "Crash Risk Index broken into 4 sub-scores (0-25 each, 100 total). VIX/VVIX measure implied vol stress. Correlation tracks COR1M herding. Momentum captures SPX trend breakdown.",
+  "CRASH TRIGGER CONDITIONS":
+    "Three simultaneous conditions that signal a potential crash regime: SPX below 100d MA, realized vol > 25%, and COR1M > 60. All three must fire.",
+  "20-SESSION HISTORY":
+    "Left chart tracks VIX and VVIX. Right chart compares realized volatility with COR1M over the same window. Latest point is the most recent session.",
 };
 
-type CriComponentsShape = {
-  vix: number;
-  vvix: number;
-  correlation: number;
-  momentum: number;
-};
-
-function componentColor(score: number): string {
-  if (score < 12.5) return "var(--positive)";
-  if (score < 20) return "var(--accent-warm)";
-  return "var(--negative)";
+function levelColor(level: CriLevel): string {
+  switch (level) {
+    case "LOW":
+      return "var(--positive)";
+    case "ELEVATED":
+      return "var(--warning)";
+    case "HIGH":
+      return "var(--negative)";
+    case "CRITICAL":
+      return "var(--negative)";
+  }
 }
 
-function Tile({
+function fmt(v: number | null | undefined, decimals = 2): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return v.toFixed(decimals);
+}
+
+function fmtPct(v: number | null | undefined, decimals = 2): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(decimals)}%`;
+}
+
+function fmtSigned(v: number | null | undefined, decimals = 2): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(decimals)}`;
+}
+
+function ComponentBar({
   label,
-  children,
-  hint,
+  score,
+  live,
 }: {
   label: string;
-  children: React.ReactNode;
-  hint?: string;
+  score: number;
+  live: boolean;
 }) {
+  const pct = (score / 25) * 100;
+  const barColor =
+    score < 8
+      ? "var(--positive)"
+      : score > 16
+        ? "var(--negative)"
+        : "var(--warning)";
+  const tooltip = COMPONENT_TOOLTIPS[label];
   return (
-    <div
-      title={hint}
-      style={{
-        padding: "12px 14px",
-        background: "var(--bg-panel)",
-        border: "1px solid var(--border-dim)",
-        borderRadius: 4,
-      }}
-    >
-      <div
-        style={{
-          fontSize: 10,
-          letterSpacing: "0.15em",
-          color: "var(--text-muted)",
-          textTransform: "uppercase",
-          marginBottom: 6,
-        }}
-      >
-        {label}
+    <div className="regime-component-bar">
+      <div className="regime-component-label">
+        <span style={{ flex: 1 }}>{label}</span>
+        {tooltip && <InfoTooltip text={tooltip} />}
+        <LiveBadge live={live} />
       </div>
-      {children}
-    </div>
-  );
-}
-
-function CompositeScore({ cri }: { cri: CriResponse["cri"] }) {
-  const score = cri?.score ?? 0;
-  const level = cri?.level ?? "LOW";
-  return (
-    <Tile label="Crash Risk Indicator">
-      <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+      <div className="regime-bar-track">
         <div
-          style={{
-            fontSize: 38,
-            fontWeight: 700,
-            fontFamily: "var(--font-mono)",
-            color: LEVEL_COLOR[level],
-            lineHeight: 1,
-          }}
-          data-testid="cri-score"
-        >
-          {fmtDecimal(score, 1)}
-        </div>
-        <div
-          style={{
-            fontSize: 12,
-            fontWeight: 600,
-            letterSpacing: "0.08em",
-            color: LEVEL_COLOR[level],
-            textTransform: "uppercase",
-          }}
-          data-testid="cri-level"
-        >
-          {level}
-        </div>
-        <div
-          style={{
-            fontSize: 11,
-            color: "var(--text-muted)",
-            marginLeft: "auto",
-          }}
-        >
-          / 100
-        </div>
-      </div>
-    </Tile>
-  );
-}
-
-function ComponentBar({ name, score }: { name: string; score: number }) {
-  const pct = Math.min(100, Math.max(0, (score / 25) * 100));
-  return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "70px 1fr 44px",
-        alignItems: "center",
-        gap: 8,
-        marginBottom: 6,
-      }}
-    >
-      <div
-        style={{
-          fontSize: 10,
-          letterSpacing: "0.12em",
-          color: "var(--text-muted)",
-          textTransform: "uppercase",
-        }}
-      >
-        {name}
-      </div>
-      <div
-        style={{
-          position: "relative",
-          height: 8,
-          background: "var(--border-dim)",
-          borderRadius: 2,
-        }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: `${pct}%`,
-            height: "100%",
-            background: componentColor(score),
-            borderRadius: 2,
-          }}
+          className="regime-bar-fill"
+          style={{ width: `${pct}%`, background: barColor }}
         />
       </div>
-      <div
-        style={{
-          fontSize: 11,
-          fontFamily: "var(--font-mono)",
-          color: "var(--text-primary)",
-          textAlign: "right",
-        }}
-      >
-        {fmtDecimal(score, 1)}
-      </div>
+      <div className="regime-component-score">{score.toFixed(1)}/25</div>
     </div>
   );
 }
 
-function ComponentBreakdown({
-  components,
+function TriggerRow({
+  label,
+  met,
+  value,
+  live,
 }: {
-  components: CriComponentsShape;
+  label: string;
+  met: boolean;
+  value: string;
+  live: boolean;
 }) {
   return (
-    <Tile label="Component Scores (each 0-25)">
-      <div style={{ marginTop: 4 }}>
-        {(Object.keys(COMPONENT_LABELS) as Array<keyof CriComponentsShape>).map(
-          (key) => (
-            <ComponentBar
-              key={key}
-              name={COMPONENT_LABELS[key]}
-              score={components[key] ?? 0}
-            />
-          ),
+    <div className="regime-trigger-row">
+      <div className="regime-trigger-icon">
+        {met ? (
+          <Check size={14} color="var(--positive)" />
+        ) : (
+          <X size={14} color="var(--negative)" />
         )}
       </div>
-    </Tile>
-  );
-}
-
-function CrashTriggerCard({
-  trigger,
-}: {
-  trigger: CriResponse["crash_trigger"];
-}) {
-  const fired = trigger?.fired ?? false;
-  const c = trigger?.conditions;
-  return (
-    <Tile label="Crash Trigger">
-      <div
-        style={{
-          fontSize: 16,
-          fontWeight: 600,
-          fontFamily: "var(--font-mono)",
-          color: fired ? "var(--negative)" : "var(--positive)",
-          marginBottom: 8,
-        }}
-        data-testid="crash-trigger-state"
-      >
-        {fired ? "FIRED" : "SILENT"}
-      </div>
-      <div
-        style={{
-          fontSize: 11,
-          color: "var(--text-secondary)",
-          lineHeight: 1.7,
-        }}
-      >
-        <ConditionRow
-          label="SPX < 100d MA"
-          on={c?.spx_below_100d_ma ?? false}
-        />
-        <ConditionRow
-          label="Realized vol > 25%"
-          on={c?.realized_vol_gt_25 ?? false}
-        />
-        <ConditionRow label="COR1M > 60" on={c?.cor1m_gt_60 ?? false} />
-      </div>
-    </Tile>
-  );
-}
-
-function ConditionRow({ label, on }: { label: string; on: boolean }) {
-  return (
-    <div style={{ display: "flex", justifyContent: "space-between" }}>
-      <span>{label}</span>
-      <span
-        style={{
-          color: on ? "var(--negative)" : "var(--text-muted)",
-          fontFamily: "var(--font-mono)",
-        }}
-      >
-        {on ? "ON" : "off"}
-      </span>
+      <div className="regime-trigger-label">{label}</div>
+      <div className="regime-trigger-value">{value}</div>
+      <LiveBadge live={live} />
     </div>
   );
 }
 
-function CtaCard({ cta }: { cta: CriResponse["cta"] }) {
-  const exposure = cta?.exposure_pct ?? null;
-  const reduction = cta?.forced_reduction_pct ?? null;
-  const selling = cta?.est_selling_bn ?? null;
-  return (
-    <Tile
-      label="CTA Vol-Target Model"
-      hint="vol_target=10% · max_exposure=200% · AUM=$350B"
-    >
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          gap: 10,
-        }}
-      >
-        <Stat
-          label="Exposure"
-          value={exposure != null ? `${fmtDecimal(exposure, 0)}%` : "—"}
-          color={
-            exposure != null && exposure < 60
-              ? "var(--warning)"
-              : "var(--text-primary)"
-          }
-        />
-        <Stat
-          label="Forced Cut"
-          value={reduction != null ? `${fmtDecimal(reduction, 0)}%` : "—"}
-          color={
-            reduction != null && reduction > 0
-              ? "var(--negative)"
-              : "var(--positive)"
-          }
-        />
-        <Stat
-          label="Est. Selling"
-          value={selling != null ? `$${fmtDecimal(selling, 1)}B` : "—"}
-          color={
-            selling != null && selling > 0
-              ? "var(--negative)"
-              : "var(--text-primary)"
-          }
-        />
-      </div>
-    </Tile>
-  );
+// Pull prior-day values for DayChange from the history array (snapshot stored
+// the trailing 20 sessions including today). Today's close lives in the snapshot
+// scalars; "previous close" is history[history.length - 2][key].
+function prevClose(
+  history: CriHistoryEntry[] | undefined,
+  key: keyof CriHistoryEntry,
+): number | null {
+  if (!history || history.length < 2) return null;
+  const v = history[history.length - 2][key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
-function Stat({
-  label,
-  value,
-  color,
-}: {
-  label: string;
-  value: string;
-  color: string;
-}) {
-  return (
-    <div>
-      <div
-        style={{
-          fontSize: 10,
-          letterSpacing: "0.08em",
-          color: "var(--text-muted)",
-          textTransform: "uppercase",
-        }}
-      >
-        {label}
-      </div>
-      <div
-        style={{
-          fontSize: 16,
-          fontWeight: 600,
-          fontFamily: "var(--font-mono)",
-          color,
-        }}
-      >
-        {value}
-      </div>
-    </div>
-  );
-}
-
-const CHART_W = 760;
-const CHART_H = 160;
-const PAD = { top: 12, right: 56, bottom: 22, left: 56 };
-
-function MiniHistoryChart({ history }: { history: CriHistoryEntry[] }) {
-  if (!history.length) return null;
-
-  const xScale = linearScale(
-    [0, Math.max(history.length - 1, 1)],
-    [PAD.left, CHART_W - PAD.right],
-  );
-  const vixD = finiteDomain(history.map((h) => h.vix));
-  const corD = finiteDomain(history.map((h) => h.cor1m));
-  const yVix = vixD
-    ? linearScale([vixD.lo, vixD.hi], [CHART_H - PAD.bottom, PAD.top])
-    : null;
-  const yCor = corD
-    ? linearScale([corD.lo, corD.hi], [CHART_H - PAD.bottom, PAD.top])
-    : null;
-
-  const pathFor = (
-    pick: (h: CriHistoryEntry) => number | null | undefined,
-    y: ((v: number) => number) | null,
-  ) =>
-    y == null
-      ? ""
-      : pathFromPoints(
-          history
-            .map((h, i): [number, number] | null => {
-              const v = pick(h);
-              return v == null ? null : [xScale(i), y(v)];
-            })
-            .filter((p): p is [number, number] => p != null),
-        );
-
-  return (
-    <div style={{ marginTop: 12 }}>
-      <div
-        style={{
-          fontSize: 10,
-          letterSpacing: "0.15em",
-          color: "var(--text-muted)",
-          textTransform: "uppercase",
-          marginBottom: 4,
-        }}
-      >
-        20-day history · VIX (orange) · COR1M (blue)
-      </div>
-      <svg
-        role="img"
-        aria-label="CRI 20-day mini history"
-        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-        style={{ width: "100%", height: CHART_H, display: "block" }}
-        data-testid="cri-mini-history"
-      >
-        <title>CRI inputs — VIX and COR1M trailing 20 sessions</title>
-        <path
-          d={pathFor((h) => h.vix, yVix)}
-          fill="none"
-          stroke="var(--accent-warm)"
-          strokeWidth={1.4}
-        />
-        <path
-          d={pathFor((h) => h.cor1m, yCor)}
-          fill="none"
-          stroke="var(--accent-bg)"
-          strokeWidth={1.4}
-        />
-      </svg>
-    </div>
-  );
-}
+const VIX_VVIX_LEFT: ChartSeries = {
+  key: "vix",
+  label: "VIX",
+  color: "var(--signal-core, #05AD98)",
+  axis: "left",
+  format: (v) => v.toFixed(1),
+};
+const VIX_VVIX_RIGHT: ChartSeries = {
+  key: "vvix",
+  label: "VVIX",
+  color: "var(--extreme, #8B5CF6)",
+  axis: "right",
+  format: (v) => v.toFixed(0),
+};
+const RVOL_LEFT: ChartSeries = {
+  key: "realized_vol",
+  label: "RVOL",
+  color: "var(--warning, #F5A623)",
+  axis: "left",
+  format: (v) => `${v.toFixed(1)}%`,
+};
+const COR_RIGHT: ChartSeries = {
+  key: "cor1m",
+  label: "COR1M",
+  color: "var(--dislocation, #D946A8)",
+  axis: "right",
+  format: (v) => v.toFixed(1),
+};
 
 export function CriSubTabView({ data }: { data: CriResponse | null }) {
+  // Empty/loading state — mirrors xenon's "no CRI data" shield empty.
   if (!data || data.status === "empty") {
     return (
-      <div
-        data-testid="cri-empty-state"
-        style={{
-          padding: 32,
-          color: "var(--text-muted)",
-          fontFamily: "var(--font-mono)",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-        }}
-      >
-        No CRI snapshot yet — trigger a scan via POST /api/regime/scan.
+      <div className="regime-empty" data-testid="cri-empty-state">
+        <Shield size={32} strokeWidth={1} />
+        <p>No CRI data available. Click Sync Now to run a scan.</p>
       </div>
     );
   }
-  const cri = data.cri ?? {
+
+  const cri: CriBlock = data.cri ?? {
     score: 0,
-    level: "LOW" as const,
-    components: undefined,
+    level: "LOW",
+    components: { vix: 0, vvix: 0, correlation: 0, momentum: 0 },
   };
-  const components: CriComponentsShape = {
-    vix: cri.components?.vix ?? 0,
-    vvix: cri.components?.vvix ?? 0,
-    correlation: cri.components?.correlation ?? 0,
-    momentum: cri.components?.momentum ?? 0,
+  const level = cri.level as CriLevel;
+  const color = levelColor(level);
+  const components = cri.components ?? {
+    vix: 0,
+    vvix: 0,
+    correlation: 0,
+    momentum: 0,
   };
 
+  // We don't have IB live ticks in this project — all values are end-of-day.
+  // Drive the strip with the snapshot's scalars + history-derived prior closes.
+  const history = (data.history ?? []) as CriHistoryEntry[];
+  const vix = data.vix ?? null;
+  const vvix = data.vvix ?? null;
+  const spy = data.spy ?? null;
+  const cor1m = data.cor1m ?? null;
+  const realizedVol = data.realized_vol ?? null;
+
+  const vixClose = prevClose(history, "vix");
+  const vvixClose = prevClose(history, "vvix");
+  const spyClose = prevClose(history, "spy");
+  const cor1mPrevClose =
+    data.cor1m_previous_close ?? prevClose(history, "cor1m");
+
+  const corr5dChange = data.cor1m_5d_change ?? null;
+  const vvixVixRatio =
+    data.vvix_vix_ratio ?? (vix && vix > 0 && vvix != null ? vvix / vix : null);
+  const spxDistPct = data.spx_distance_pct ?? null;
+  const ma = data.spx_100d_ma ?? null;
+  const trigger = data.crash_trigger;
+  const triggered = trigger?.triggered ?? trigger?.fired ?? false;
+  const correlationTriggerMet =
+    trigger?.conditions?.cor1m_gt_60 ?? (cor1m != null && cor1m > 60);
+  const spxBelowMa = trigger?.conditions?.spx_below_100d_ma ?? false;
+  const rvolTriggerMet = trigger?.conditions?.realized_vol_gt_25 ?? false;
+
+  // Page is end-of-day in this project — never "live".
+  const live = false;
+  const lastSync = data.scan_time || null;
+
+  // History payload is the 20-session window (oldest → newest).
+  const liveValues = useMemo(() => ({}), []);
+
   return (
-    <div data-testid="cri-subtab">
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gap: 12,
-        }}
-      >
-        <CompositeScore cri={cri} />
-        <ComponentBreakdown components={components} />
-        <CrashTriggerCard trigger={data.crash_trigger} />
-        <CtaCard cta={data.cta} />
+    <div className="regime-panel" data-testid="cri-subtab">
+      {/* ── Row 1: Hero ───────────────────── */}
+      <div className="regime-hero">
+        <div className="regime-hero-score" style={{ color }}>
+          <span data-testid="cri-score">{cri.score.toFixed(0)}</span>
+          <span className="regime-hero-max">/100</span>
+        </div>
+        <div className="regime-hero-meta">
+          <span
+            className="regime-level-badge"
+            style={{
+              background: color,
+              color: level === "LOW" ? "#000" : "#fff",
+            }}
+            data-testid="cri-level"
+          >
+            {level}
+          </span>
+          <span
+            className="regime-live-dot"
+            style={{ background: "var(--text-muted)" }}
+          />
+          <span className="regime-hero-label">CACHED</span>
+          {lastSync && (
+            <span className="regime-hero-timestamp">
+              Last scan: {new Date(lastSync).toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+        <div className="regime-hero-bar">
+          <div
+            className="regime-hero-bar-fill"
+            style={{ width: `${cri.score}%`, background: color }}
+          />
+        </div>
+        <div className="regime-hero-scale">
+          <span>LOW</span>
+          <span>ELEVATED</span>
+          <span>HIGH</span>
+          <span>CRITICAL</span>
+        </div>
       </div>
-      <MiniHistoryChart history={data.history ?? []} />
+
+      {/* ── Row 2: Live ticker strip (DAILY badges in our project) ── */}
+      <RegimeStrip>
+        <RegimeStripCell
+          testId="strip-vix"
+          label={
+            <>
+              VIX <LiveBadge live={live} />
+            </>
+          }
+          value={fmt(vix)}
+          change={<DayChange last={vix} close={vixClose} />}
+          sub={<>5d RoC: {fmtPct(data.vix_5d_roc, 1)}</>}
+        />
+        <RegimeStripCell
+          testId="strip-vvix"
+          label={
+            <>
+              VVIX <LiveBadge live={live} />
+            </>
+          }
+          value={fmt(vvix)}
+          change={<DayChange last={vvix} close={vvixClose} />}
+          sub={<>VVIX/VIX: {fmt(vvixVixRatio)}</>}
+        />
+        <RegimeStripCell
+          testId="strip-spy"
+          label={
+            <>
+              SPY <LiveBadge live={live} />
+            </>
+          }
+          value={`$${fmt(spy)}`}
+          change={<DayChange last={spy} close={spyClose} prefix="$" />}
+          sub={<>vs 100d MA: {fmtPct(spxDistPct)}</>}
+        />
+        <RegimeStripCell
+          testId="strip-rvol"
+          label={
+            <>
+              <span className="regime-strip-label-text-full">REALIZED VOL</span>
+              <span className="regime-strip-label-text-short">RVOL</span>
+              <LiveBadge live={live} />
+            </>
+          }
+          value={realizedVol != null ? `${fmt(realizedVol)}%` : "---"}
+          change={<PointChange change={null} suffix="%" label="intraday" />}
+          sub={<>20d annualized</>}
+        />
+        <RegimeStripCell
+          testId="strip-cor1m"
+          label={
+            <>
+              COR1M <LiveBadge live={live} />
+            </>
+          }
+          value={fmt(cor1m, 2)}
+          change={<DayChange last={cor1m} close={cor1mPrevClose} />}
+          sub={
+            <>{`5d chg: ${corr5dChange != null ? `${fmtSigned(corr5dChange)} pts` : "---"}`}</>
+          }
+        />
+      </RegimeStrip>
+
+      {/* ── Row 3+4: Components + Crash trigger ── */}
+      <div className="regime-detail-grid">
+        <div className="regime-components">
+          <div className="regime-panel-title">
+            <Zap size={12} />
+            CRI COMPONENTS
+            <InfoTooltip text={SECTION_TOOLTIPS["CRI COMPONENTS"]} />
+          </div>
+          <ComponentBar label="VIX" score={components.vix} live={live} />
+          <ComponentBar label="VVIX" score={components.vvix} live={live} />
+          <ComponentBar
+            label="CORRELATION"
+            score={components.correlation}
+            live={live}
+          />
+          <ComponentBar
+            label="MOMENTUM"
+            score={components.momentum}
+            live={live}
+          />
+        </div>
+        <div className="regime-triggers">
+          <div className="regime-panel-title">
+            <AlertTriangle size={12} />
+            CRASH TRIGGER CONDITIONS
+            <InfoTooltip text={SECTION_TOOLTIPS["CRASH TRIGGER CONDITIONS"]} />
+          </div>
+          <div
+            className={`regime-trigger-status ${triggered ? "regime-triggered" : ""}`}
+            data-testid="crash-trigger-state"
+          >
+            {triggered ? "TRIGGERED" : "INACTIVE"}
+          </div>
+          <TriggerRow
+            label="SPX < 100d MA"
+            met={spxBelowMa}
+            value={`${fmtPct(spxDistPct)} (MA: $${fmt(ma)})`}
+            live={live}
+          />
+          <TriggerRow
+            label="Realized Vol > 25%"
+            met={rvolTriggerMet}
+            value={realizedVol != null ? `${fmt(realizedVol)}%` : "---"}
+            live={live}
+          />
+          <TriggerRow
+            label="COR1M > 60"
+            met={correlationTriggerMet}
+            value={fmt(cor1m, 2)}
+            live={live}
+          />
+        </div>
+      </div>
+
+      {/* ── Row 5: 20-Session History (two charts side-by-side) ── */}
+      {history.length > 0 && (
+        <>
+          <div className="section-header" data-testid="regime-history-header">
+            <div className="section-title" data-testid="regime-history-title">
+              <span>20-SESSION HISTORY</span>
+              <InfoTooltip text={SECTION_TOOLTIPS["20-SESSION HISTORY"]} />
+            </div>
+          </div>
+          <div
+            className="regime-history-grid"
+            data-testid="regime-history-grid"
+          >
+            <div data-testid="regime-history-chart-vix-vvix">
+              <CriHistoryChart
+                history={history}
+                series={[VIX_VVIX_LEFT, VIX_VVIX_RIGHT]}
+                title="VIX / VVIX"
+                liveValues={liveValues}
+              />
+            </div>
+            <div data-testid="regime-history-chart-rvol-cor1m">
+              <CriHistoryChart
+                history={history}
+                series={[RVOL_LEFT, COR_RIGHT]}
+                title="REALIZED VOL / COR1M"
+                liveValues={liveValues}
+              />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle, Check, Shield, X, Zap } from "lucide-react";
 
 import CriHistoryChart, {
@@ -167,6 +167,165 @@ const COR_RIGHT: ChartSeries = {
   axis: "right",
   format: (v) => v.toFixed(1),
 };
+
+type CriTableSortCol =
+  | "date"
+  | "vix"
+  | "vvix"
+  | "spy"
+  | "cor1m"
+  | "realized_vol"
+  | "spx_vs_ma_pct"
+  | "vix_5d_roc";
+type SortDir = "asc" | "desc";
+
+function sortIndicator(
+  col: CriTableSortCol,
+  active: CriTableSortCol | null,
+  dir: SortDir,
+): string {
+  if (active !== col) return "";
+  return dir === "asc" ? " ▲" : " ▼";
+}
+
+function fmtNum(v: number | null | undefined, dec = 2): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return v.toFixed(dec);
+}
+
+function fmtPctCell(v: number | null | undefined, dec = 2): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(dec)}%`;
+}
+
+function CriHistoryTable({ history }: { history: CriHistoryEntry[] }) {
+  const [sortCol, setSortCol] = useState<CriTableSortCol | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [expanded, setExpanded] = useState(true);
+
+  function onSort(col: CriTableSortCol) {
+    if (sortCol === col) {
+      if (sortDir === "desc") setSortDir("asc");
+      else {
+        setSortCol(null);
+        setSortDir("desc");
+      }
+    } else {
+      setSortCol(col);
+      setSortDir("desc");
+    }
+  }
+
+  const sorted = useMemo(() => {
+    if (!sortCol) return [...history].reverse(); // newest first by default
+    return [...history].sort((a, b) => {
+      const av =
+        sortCol === "date"
+          ? a.date
+          : ((a[sortCol] as number | null | undefined) ?? -Infinity);
+      const bv =
+        sortCol === "date"
+          ? b.date
+          : ((b[sortCol] as number | null | undefined) ?? -Infinity);
+      if (av < bv) return sortDir === "asc" ? -1 : 1;
+      if (av > bv) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [history, sortCol, sortDir]);
+
+  if (!history.length) return null;
+
+  const cols: { key: CriTableSortCol; label: string; align: string }[] = [
+    { key: "date", label: "Date", align: "left" },
+    { key: "vix", label: "VIX", align: "right" },
+    { key: "vvix", label: "VVIX", align: "right" },
+    { key: "spy", label: "SPY", align: "right" },
+    { key: "cor1m", label: "COR1M", align: "right" },
+    { key: "realized_vol", label: "RVOL", align: "right" },
+    { key: "spx_vs_ma_pct", label: "vs 100d MA", align: "right" },
+    { key: "vix_5d_roc", label: "VIX 5d RoC", align: "right" },
+  ];
+
+  return (
+    <div
+      className="gex-history-section"
+      data-testid="cri-history-table-section"
+    >
+      <button
+        className="gex-history-toggle"
+        onClick={() => setExpanded(!expanded)}
+        data-testid="cri-history-table-toggle"
+      >
+        History ({history.length} sessions) {expanded ? "▲" : "▼"}
+      </button>
+      {expanded && (
+        <div className="gex-history-table-wrap">
+          <table className="gex-history-table" data-testid="cri-history-table">
+            <thead>
+              <tr>
+                {cols.map((c) => (
+                  <th
+                    key={c.key}
+                    className={`text-${c.align}`}
+                    onClick={() => onSort(c.key)}
+                    style={{ cursor: "pointer", userSelect: "none" }}
+                  >
+                    {c.label}
+                    {sortIndicator(c.key, sortCol, sortDir)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.date}>
+                  <td>{row.date}</td>
+                  <td className="text-right">{fmtNum(row.vix, 2)}</td>
+                  <td className="text-right">{fmtNum(row.vvix, 1)}</td>
+                  <td className="text-right">
+                    {row.spy != null ? `$${fmtNum(row.spy, 2)}` : "—"}
+                  </td>
+                  <td className="text-right">{fmtNum(row.cor1m, 2)}</td>
+                  <td className="text-right">
+                    {row.realized_vol != null
+                      ? `${fmtNum(row.realized_vol, 1)}%`
+                      : "—"}
+                  </td>
+                  <td
+                    className="text-right"
+                    style={{
+                      color:
+                        row.spx_vs_ma_pct == null
+                          ? undefined
+                          : row.spx_vs_ma_pct >= 0
+                            ? "var(--positive)"
+                            : "var(--negative)",
+                    }}
+                  >
+                    {fmtPctCell(row.spx_vs_ma_pct, 2)}
+                  </td>
+                  <td
+                    className="text-right"
+                    style={{
+                      color:
+                        row.vix_5d_roc == null
+                          ? undefined
+                          : row.vix_5d_roc >= 0
+                            ? "var(--negative)"
+                            : "var(--positive)",
+                    }}
+                  >
+                    {fmtPctCell(row.vix_5d_roc, 1)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function CriSubTabView({ data }: { data: CriResponse | null }) {
   // Empty/loading state — mirrors xenon's "no CRI data" shield empty.
@@ -418,6 +577,7 @@ export function CriSubTabView({ data }: { data: CriResponse | null }) {
               />
             </div>
           </div>
+          <CriHistoryTable history={history} />
         </>
       )}
     </div>

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -327,13 +327,44 @@ function CriHistoryTable({ history }: { history: CriHistoryEntry[] }) {
   );
 }
 
-export function CriSubTabView({ data }: { data: CriResponse | null }) {
+export function CriSubTabView({
+  data,
+  onSyncNow,
+  syncing = false,
+}: {
+  data: CriResponse | null;
+  onSyncNow?: () => void;
+  syncing?: boolean;
+}) {
   // Empty/loading state — mirrors xenon's "no CRI data" shield empty.
   if (!data || data.status === "empty") {
     return (
       <div className="regime-empty" data-testid="cri-empty-state">
         <Shield size={32} strokeWidth={1} />
         <p>No CRI data available. Click Sync Now to run a scan.</p>
+        {onSyncNow && (
+          <button
+            type="button"
+            onClick={onSyncNow}
+            disabled={syncing}
+            data-testid="cri-sync-now"
+            style={{
+              marginTop: "12px",
+              padding: "6px 14px",
+              fontFamily: "var(--font-mono)",
+              fontSize: "11px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              background: "var(--bg-panel-raised, var(--bg-panel))",
+              border: "1px solid var(--border-dim, var(--line-grid))",
+              color: "var(--text-primary)",
+              cursor: syncing ? "default" : "pointer",
+              opacity: syncing ? 0.6 : 1,
+            }}
+          >
+            {syncing ? "Syncing…" : "Sync Now"}
+          </button>
+        )}
       </div>
     );
   }
@@ -585,6 +616,6 @@ export function CriSubTabView({ data }: { data: CriResponse | null }) {
 }
 
 export default function CriSubTab() {
-  const { data } = useCri();
-  return <CriSubTabView data={data} />;
+  const { data, syncing, syncNow } = useCri();
+  return <CriSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
 }

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { fmtDecimal } from "@/lib/formatters";
+import { finiteDomain, linearScale, pathFromPoints } from "@/lib/svgChart";
+import {
+  type CriHistoryEntry,
+  type CriResponse,
+  useCri,
+} from "@/lib/regime/useCri";
+
+const LEVEL_COLOR: Record<"LOW" | "ELEVATED" | "HIGH" | "CRITICAL", string> = {
+  LOW: "var(--positive)",
+  ELEVATED: "var(--accent-warm)",
+  HIGH: "var(--warning)",
+  CRITICAL: "var(--negative)",
+};
+
+const COMPONENT_LABELS: Record<keyof CriComponentsShape, string> = {
+  vix: "VIX",
+  vvix: "VVIX",
+  correlation: "COR1M",
+  momentum: "SPX MOM",
+};
+
+type CriComponentsShape = {
+  vix: number;
+  vvix: number;
+  correlation: number;
+  momentum: number;
+};
+
+function componentColor(score: number): string {
+  if (score < 12.5) return "var(--positive)";
+  if (score < 20) return "var(--accent-warm)";
+  return "var(--negative)";
+}
+
+function Tile({
+  label,
+  children,
+  hint,
+}: {
+  label: string;
+  children: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div
+      title={hint}
+      style={{
+        padding: "12px 14px",
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.15em",
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CompositeScore({ cri }: { cri: CriResponse["cri"] }) {
+  const score = cri?.score ?? 0;
+  const level = cri?.level ?? "LOW";
+  return (
+    <Tile label="Crash Risk Indicator">
+      <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+        <div
+          style={{
+            fontSize: 38,
+            fontWeight: 700,
+            fontFamily: "var(--font-mono)",
+            color: LEVEL_COLOR[level],
+            lineHeight: 1,
+          }}
+          data-testid="cri-score"
+        >
+          {fmtDecimal(score, 1)}
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            color: LEVEL_COLOR[level],
+            textTransform: "uppercase",
+          }}
+          data-testid="cri-level"
+        >
+          {level}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            marginLeft: "auto",
+          }}
+        >
+          / 100
+        </div>
+      </div>
+    </Tile>
+  );
+}
+
+function ComponentBar({ name, score }: { name: string; score: number }) {
+  const pct = Math.min(100, Math.max(0, (score / 25) * 100));
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "70px 1fr 44px",
+        alignItems: "center",
+        gap: 8,
+        marginBottom: 6,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.12em",
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+        }}
+      >
+        {name}
+      </div>
+      <div
+        style={{
+          position: "relative",
+          height: 8,
+          background: "var(--border-dim)",
+          borderRadius: 2,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: `${pct}%`,
+            height: "100%",
+            background: componentColor(score),
+            borderRadius: 2,
+          }}
+        />
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          fontFamily: "var(--font-mono)",
+          color: "var(--text-primary)",
+          textAlign: "right",
+        }}
+      >
+        {fmtDecimal(score, 1)}
+      </div>
+    </div>
+  );
+}
+
+function ComponentBreakdown({
+  components,
+}: {
+  components: CriComponentsShape;
+}) {
+  return (
+    <Tile label="Component Scores (each 0-25)">
+      <div style={{ marginTop: 4 }}>
+        {(Object.keys(COMPONENT_LABELS) as Array<keyof CriComponentsShape>).map(
+          (key) => (
+            <ComponentBar
+              key={key}
+              name={COMPONENT_LABELS[key]}
+              score={components[key] ?? 0}
+            />
+          ),
+        )}
+      </div>
+    </Tile>
+  );
+}
+
+function CrashTriggerCard({
+  trigger,
+}: {
+  trigger: CriResponse["crash_trigger"];
+}) {
+  const fired = trigger?.fired ?? false;
+  const c = trigger?.conditions;
+  return (
+    <Tile label="Crash Trigger">
+      <div
+        style={{
+          fontSize: 16,
+          fontWeight: 600,
+          fontFamily: "var(--font-mono)",
+          color: fired ? "var(--negative)" : "var(--positive)",
+          marginBottom: 8,
+        }}
+        data-testid="crash-trigger-state"
+      >
+        {fired ? "FIRED" : "SILENT"}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--text-secondary)",
+          lineHeight: 1.7,
+        }}
+      >
+        <ConditionRow
+          label="SPX < 100d MA"
+          on={c?.spx_below_100d_ma ?? false}
+        />
+        <ConditionRow
+          label="Realized vol > 25%"
+          on={c?.realized_vol_gt_25 ?? false}
+        />
+        <ConditionRow label="COR1M > 60" on={c?.cor1m_gt_60 ?? false} />
+      </div>
+    </Tile>
+  );
+}
+
+function ConditionRow({ label, on }: { label: string; on: boolean }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <span>{label}</span>
+      <span
+        style={{
+          color: on ? "var(--negative)" : "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        {on ? "ON" : "off"}
+      </span>
+    </div>
+  );
+}
+
+function CtaCard({ cta }: { cta: CriResponse["cta"] }) {
+  const exposure = cta?.exposure_pct ?? null;
+  const reduction = cta?.forced_reduction_pct ?? null;
+  const selling = cta?.est_selling_bn ?? null;
+  return (
+    <Tile
+      label="CTA Vol-Target Model"
+      hint="vol_target=10% · max_exposure=200% · AUM=$350B"
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 10,
+        }}
+      >
+        <Stat
+          label="Exposure"
+          value={exposure != null ? `${fmtDecimal(exposure, 0)}%` : "—"}
+          color={
+            exposure != null && exposure < 60
+              ? "var(--warning)"
+              : "var(--text-primary)"
+          }
+        />
+        <Stat
+          label="Forced Cut"
+          value={reduction != null ? `${fmtDecimal(reduction, 0)}%` : "—"}
+          color={
+            reduction != null && reduction > 0
+              ? "var(--negative)"
+              : "var(--positive)"
+          }
+        />
+        <Stat
+          label="Est. Selling"
+          value={selling != null ? `$${fmtDecimal(selling, 1)}B` : "—"}
+          color={
+            selling != null && selling > 0
+              ? "var(--negative)"
+              : "var(--text-primary)"
+          }
+        />
+      </div>
+    </Tile>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color: string;
+}) {
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.08em",
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: 16,
+          fontWeight: 600,
+          fontFamily: "var(--font-mono)",
+          color,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+const CHART_W = 760;
+const CHART_H = 160;
+const PAD = { top: 12, right: 56, bottom: 22, left: 56 };
+
+function MiniHistoryChart({ history }: { history: CriHistoryEntry[] }) {
+  if (!history.length) return null;
+
+  const xScale = linearScale(
+    [0, Math.max(history.length - 1, 1)],
+    [PAD.left, CHART_W - PAD.right],
+  );
+  const vixD = finiteDomain(history.map((h) => h.vix));
+  const corD = finiteDomain(history.map((h) => h.cor1m));
+  const yVix = vixD
+    ? linearScale([vixD.lo, vixD.hi], [CHART_H - PAD.bottom, PAD.top])
+    : null;
+  const yCor = corD
+    ? linearScale([corD.lo, corD.hi], [CHART_H - PAD.bottom, PAD.top])
+    : null;
+
+  const pathFor = (
+    pick: (h: CriHistoryEntry) => number | null | undefined,
+    y: ((v: number) => number) | null,
+  ) =>
+    y == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null => {
+              const v = pick(h);
+              return v == null ? null : [xScale(i), y(v)];
+            })
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: "0.15em",
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        20-day history · VIX (orange) · COR1M (blue)
+      </div>
+      <svg
+        role="img"
+        aria-label="CRI 20-day mini history"
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        style={{ width: "100%", height: CHART_H, display: "block" }}
+        data-testid="cri-mini-history"
+      >
+        <title>CRI inputs — VIX and COR1M trailing 20 sessions</title>
+        <path
+          d={pathFor((h) => h.vix, yVix)}
+          fill="none"
+          stroke="var(--accent-warm)"
+          strokeWidth={1.4}
+        />
+        <path
+          d={pathFor((h) => h.cor1m, yCor)}
+          fill="none"
+          stroke="var(--accent-bg)"
+          strokeWidth={1.4}
+        />
+      </svg>
+    </div>
+  );
+}
+
+export function CriSubTabView({ data }: { data: CriResponse | null }) {
+  if (!data || data.status === "empty") {
+    return (
+      <div
+        data-testid="cri-empty-state"
+        style={{
+          padding: 32,
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+        }}
+      >
+        No CRI snapshot yet — trigger a scan via POST /api/regime/scan.
+      </div>
+    );
+  }
+  const cri = data.cri ?? {
+    score: 0,
+    level: "LOW" as const,
+    components: undefined,
+  };
+  const components: CriComponentsShape = {
+    vix: cri.components?.vix ?? 0,
+    vvix: cri.components?.vvix ?? 0,
+    correlation: cri.components?.correlation ?? 0,
+    momentum: cri.components?.momentum ?? 0,
+  };
+
+  return (
+    <div data-testid="cri-subtab">
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <CompositeScore cri={cri} />
+        <ComponentBreakdown components={components} />
+        <CrashTriggerCard trigger={data.crash_trigger} />
+        <CtaCard cta={data.cta} />
+      </div>
+      <MiniHistoryChart history={data.history ?? []} />
+    </div>
+  );
+}
+
+export default function CriSubTab() {
+  const { data } = useCri();
+  return <CriSubTabView data={data} />;
+}

--- a/web/components/regime/GexProfileChart.tsx
+++ b/web/components/regime/GexProfileChart.tsx
@@ -40,11 +40,14 @@ export default function GexProfileChart({
   const chartData = useMemo(() => {
     if (!profile.length) return { buckets: [], maxAbs: 1 };
     const maxAbs = Math.max(...profile.map((b) => Math.abs(b.net_gex)), 1);
-    return { buckets: profile, maxAbs };
+    // Higher strikes at top (orderbook orientation). API returns ascending;
+    // reverse here so presentation order matches reader intuition.
+    const buckets = [...profile].sort((a, b) => b.strike - a.strike);
+    return { buckets, maxAbs };
   }, [profile]);
 
   const barHeight = 22;
-  const labelWidth = 80;
+  const labelWidth = 110;
   const rightLabelWidth = 160;
   const chartWidth = 600;
   const barAreaWidth = chartWidth - labelWidth - rightLabelWidth;

--- a/web/components/regime/GexProfileChart.tsx
+++ b/web/components/regime/GexProfileChart.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+/**
+ * GexProfileChart — divergent SVG bar chart of net gamma by strike.
+ *
+ * Extracted from web/components/GexPanel.tsx so the UW Analyze page can
+ * render the same visualization. Both consumers import this single
+ * source of truth.
+ */
+
+import { useMemo, useRef } from "react";
+import type { GexBucket } from "@/lib/regime/useGex";
+
+function fmtGex(v: number | null | undefined): string {
+  if (v == null) return "---";
+  const absVal = Math.abs(v);
+  if (absVal >= 1_000_000)
+    return `${v >= 0 ? "+" : ""}$${(v / 1_000_000).toFixed(1)}M`;
+  if (absVal >= 1_000) return `${v >= 0 ? "+" : ""}$${(v / 1_000).toFixed(1)}K`;
+  return `${v >= 0 ? "+" : ""}$${v.toFixed(0)}`;
+}
+
+function fmtPct(v: number | null | undefined): string {
+  if (v == null) return "---";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+}
+
+export type GexProfileChartProps = {
+  profile: GexBucket[];
+  spot: number;
+};
+
+export default function GexProfileChart({
+  profile,
+  spot,
+}: GexProfileChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const chartData = useMemo(() => {
+    if (!profile.length) return { buckets: [], maxAbs: 1 };
+    const maxAbs = Math.max(...profile.map((b) => Math.abs(b.net_gex)), 1);
+    return { buckets: profile, maxAbs };
+  }, [profile]);
+
+  const barHeight = 22;
+  const labelWidth = 80;
+  const rightLabelWidth = 160;
+  const chartWidth = 600;
+  const barAreaWidth = chartWidth - labelWidth - rightLabelWidth;
+  const midX = labelWidth + barAreaWidth / 2;
+  const totalHeight = chartData.buckets.length * (barHeight + 4) + 8;
+
+  return (
+    <div
+      ref={containerRef}
+      className="gex-profile-chart"
+      style={{ overflowX: "auto" }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
+        <span className="gex-chart-title">
+          GEX Profile &mdash; Net gamma by strike
+        </span>
+        <span className="gex-chart-legend">
+          <span style={{ color: "var(--signal-core)" }}>
+            &#9632; Positive (stabilizing)
+          </span>{" "}
+          <span style={{ color: "var(--fault)" }}>
+            &#9632; Negative (destabilizing)
+          </span>
+        </span>
+      </div>
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${chartWidth} ${totalHeight}`}
+        width="100%"
+        height={totalHeight}
+        style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+      >
+        <line
+          x1={midX}
+          y1={0}
+          x2={midX}
+          y2={totalHeight}
+          stroke="var(--border-dim)"
+          strokeWidth={1}
+        />
+
+        {chartData.buckets.map((bucket, i) => {
+          const y = i * (barHeight + 4) + 4;
+          const barWidthPx =
+            (Math.abs(bucket.net_gex) / chartData.maxAbs) * (barAreaWidth / 2);
+          const isPositive = bucket.net_gex >= 0;
+          const barX = isPositive ? midX : midX - barWidthPx;
+          const barColor = isPositive ? "var(--signal-core)" : "var(--fault)";
+
+          const isSpot = bucket.tag === "SPOT";
+          const tagColor =
+            bucket.tag === "GEX FLIP"
+              ? "var(--warning)"
+              : bucket.tag === "SPOT"
+                ? "var(--signal-strong)"
+                : bucket.tag?.includes("MAGNET")
+                  ? "var(--signal-core)"
+                  : bucket.tag?.includes("ACCEL")
+                    ? "var(--fault)"
+                    : "var(--text-secondary)";
+
+          return (
+            <g key={`${bucket.strike}-${i}`}>
+              <text
+                x={labelWidth - 8}
+                y={y + barHeight / 2 + 4}
+                textAnchor="end"
+                fill={isSpot ? "var(--signal-strong)" : "var(--text-secondary)"}
+                fontWeight={isSpot ? 700 : 400}
+              >
+                {bucket.strike.toLocaleString()}
+              </text>
+              <text
+                x={4}
+                y={y + barHeight / 2 + 4}
+                textAnchor="start"
+                fill="var(--text-muted)"
+                fontSize={9}
+              >
+                {fmtPct(bucket.pct_from_spot)}
+              </text>
+              <rect
+                x={barX}
+                y={y}
+                width={Math.max(barWidthPx, 1)}
+                height={barHeight}
+                fill={barColor}
+                rx={2}
+                opacity={0.85}
+              />
+              <text
+                x={chartWidth - rightLabelWidth + 8}
+                y={y + barHeight / 2 + 4}
+                textAnchor="start"
+                fill={isPositive ? "var(--signal-core)" : "var(--fault)"}
+                fontSize={10}
+              >
+                {fmtGex(bucket.net_gex)}
+              </text>
+              {bucket.tag && (
+                <text
+                  x={chartWidth - 8}
+                  y={y + barHeight / 2 + 4}
+                  textAnchor="end"
+                  fill={tagColor}
+                  fontWeight={700}
+                  fontSize={10}
+                >
+                  {bucket.tag === "MAX MAGNET"
+                    ? "MAX MAGNET \u25B2"
+                    : bucket.tag === "MAX ACCELERATOR"
+                      ? "MAX ACCEL \u25BC"
+                      : bucket.tag === "GEX FLIP"
+                        ? "GEX FLIP \u25C4"
+                        : bucket.tag === "SPOT"
+                          ? "\u25C4 SPOT"
+                          : bucket.tag}
+                </text>
+              )}
+              {isSpot && (
+                <line
+                  x1={labelWidth}
+                  y1={y + barHeight + 2}
+                  x2={chartWidth - rightLabelWidth}
+                  y2={y + barHeight + 2}
+                  stroke="var(--signal-strong)"
+                  strokeWidth={1}
+                  strokeDasharray="4 2"
+                  opacity={0.5}
+                />
+              )}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+// Helper to convert UW analyze gex_by_strike rows into GexBucket shape.
+// UW analyze rows: { strike, net_gamma, distance_pct (fraction), is_call_wall, is_put_wall }
+// GexBucket:      { strike, call_gex, put_gex, net_gex, pct_from_spot, tag }
+export function uwGexRowsToBuckets(
+  rows:
+    | Array<{
+        strike: number;
+        net_gamma: number | null;
+        call_gamma?: number | null;
+        put_gamma?: number | null;
+        distance_pct?: number | null;
+        is_call_wall?: boolean;
+        is_put_wall?: boolean;
+      }>
+    | null
+    | undefined,
+  spot: number | null,
+  gexFlipStrike: number | null,
+): GexBucket[] {
+  if (!rows || rows.length === 0) return [];
+  const sorted = [...rows].sort((a, b) => b.strike - a.strike);
+  let spotInserted = false;
+  const out: GexBucket[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const r = sorted[i];
+    const next = sorted[i + 1];
+    let tag: string | null = null;
+    if (r.is_call_wall) tag = "CALL WALL";
+    else if (r.is_put_wall) tag = "PUT WALL";
+    else if (gexFlipStrike != null && r.strike === gexFlipStrike)
+      tag = "GEX FLIP";
+
+    out.push({
+      strike: r.strike,
+      call_gex: r.call_gamma ?? 0,
+      put_gex: r.put_gamma ?? 0,
+      net_gex: r.net_gamma ?? 0,
+      pct_from_spot: (r.distance_pct ?? 0) * 100,
+      tag,
+    });
+
+    // Insert SPOT pseudo-row at the right position once we cross it.
+    if (
+      !spotInserted &&
+      spot != null &&
+      next != null &&
+      r.strike >= spot &&
+      next.strike < spot
+    ) {
+      out.push({
+        strike: spot,
+        call_gex: 0,
+        put_gex: 0,
+        net_gex: 0,
+        pct_from_spot: 0,
+        tag: "SPOT",
+      });
+      spotInserted = true;
+    }
+  }
+  return out;
+}

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -22,6 +22,7 @@ import {
 import { MarketState } from "@/lib/regime/useMarketHours";
 import InfoTooltip from "./InfoTooltip";
 import GexProfileChart from "./GexProfileChart";
+import { HistoryChart } from "./HistoryChart";
 import { MetricCard, SourceBadge } from "./ui/MetricCard";
 
 type GexSubTabProps = {
@@ -961,6 +962,9 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
             )}
           </div>
         </div>
+
+        {/* ── 90-day History Chart (net_gex / flip / spot) ── */}
+        <HistoryChart history={data.history} ticker={data.ticker} />
 
         {/* ── History Table ── */}
         <GexHistoryTable history={data.history} />

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -1,0 +1,893 @@
+"use client";
+
+import { useState, useMemo, useRef, useEffect } from "react";
+import {
+  Activity,
+  TrendingUp,
+  TrendingDown,
+  ArrowUpRight,
+  ArrowDownRight,
+} from "lucide-react";
+import {
+  useGex,
+  type GexBucket,
+  type GexData,
+  type GexHistoryEntry,
+  type GexLevel,
+  type IvData,
+  type MqLevels,
+  type SourceDelta,
+  type SourceDeltaEntry,
+} from "@/lib/regime/useGex";
+import { MarketState } from "@/lib/regime/useMarketHours";
+import InfoTooltip from "./InfoTooltip";
+import GexProfileChart from "./GexProfileChart";
+import { MetricCard, SourceBadge } from "./ui/MetricCard";
+
+type GexSubTabProps = {
+  marketState?: MarketState;
+};
+
+/* ─── Helpers ─────────────────────────────────────────── */
+
+function fmtNum(v: number | null | undefined, decimals = 2): string {
+  if (v == null) return "---";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function fmtGex(v: number | null | undefined): string {
+  if (v == null) return "---";
+  const absVal = Math.abs(v);
+  if (absVal >= 1_000_000)
+    return `${v >= 0 ? "+" : ""}$${(v / 1_000_000).toFixed(1)}M`;
+  if (absVal >= 1_000) return `${v >= 0 ? "+" : ""}$${(v / 1_000).toFixed(1)}K`;
+  return `${v >= 0 ? "+" : ""}$${v.toFixed(0)}`;
+}
+
+function fmtPct(v: number | null | undefined): string {
+  if (v == null) return "---";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+}
+
+function fmtPrice(v: number | null | undefined): string {
+  if (v == null) return "---";
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function biasColor(direction: string): string {
+  switch (direction) {
+    case "BULL":
+      return "var(--signal-core)";
+    case "CAUTIOUS_BULL":
+      return "var(--signal-core)";
+    case "BEAR":
+      return "var(--fault)";
+    case "CAUTIOUS_BEAR":
+      return "var(--fault)";
+    default:
+      return "var(--neutral)";
+  }
+}
+
+function biasLabel(direction: string): string {
+  return direction.replace("_", " ");
+}
+
+function levelColor(gamma: number | undefined): string {
+  if (gamma == null) return "var(--text-muted)";
+  return gamma >= 0 ? "var(--signal-core)" : "var(--fault)";
+}
+
+/* ─── Level Card ──────────────────────────────────────── */
+
+function LevelCard({
+  label,
+  level,
+  labelColor,
+}: {
+  label: string;
+  level: GexLevel;
+  labelColor?: string;
+}) {
+  if (!level) {
+    return (
+      <div className="gex-level-card">
+        <div className="gex-level-label" style={{ color: labelColor }}>
+          {label}
+        </div>
+        <div className="gex-level-value">---</div>
+      </div>
+    );
+  }
+  return (
+    <div className="gex-level-card">
+      <div className="gex-level-label" style={{ color: labelColor }}>
+        {label}
+      </div>
+      <div className="gex-level-value">{fmtPrice(level.strike)}</div>
+      <div className="gex-level-sub">
+        {fmtPct(level.distance_pct)} &mdash; {fmtGex(level.gamma)} per $1
+      </div>
+    </div>
+  );
+}
+
+/* ─── Expected Range Bar ─────────────────────────────── */
+
+function ExpectedRangeBar({ data }: { data: GexData }) {
+  const { expected_range, levels, spot } = data;
+  if (!expected_range.low || !expected_range.high) return null;
+
+  const low = expected_range.low;
+  const high = expected_range.high;
+  const flip = levels.gex_flip?.strike;
+  const magnet = levels.max_magnet?.strike;
+  const accel = levels.max_accelerator?.strike;
+
+  const allPoints = [low, high, spot];
+  if (flip) allPoints.push(flip);
+  if (magnet) allPoints.push(magnet);
+  if (accel) allPoints.push(accel);
+  const minVal = Math.min(...allPoints);
+  const maxVal = Math.max(...allPoints);
+  const range = maxVal - minVal || 1;
+  const pct = (v: number) => ((v - minVal) / range) * 100;
+
+  return (
+    <div className="gex-range-container">
+      <div className="gex-range-title">
+        EXPECTED RANGE &mdash; {data.data_date}
+      </div>
+      <div className="gex-range-bar">
+        <div
+          className="gex-range-fill"
+          style={{ left: `${pct(low)}%`, width: `${pct(high) - pct(low)}%` }}
+        />
+        {/* Markers */}
+        {flip && (
+          <div
+            className="gex-range-marker"
+            style={{ left: `${pct(flip)}%`, borderColor: "var(--warning)" }}
+            title={`GEX FLIP: ${fmtPrice(flip)}`}
+          />
+        )}
+        <div
+          className="gex-range-marker"
+          style={{ left: `${pct(spot)}%`, borderColor: "var(--signal-strong)" }}
+          title={`SPOT: ${fmtPrice(spot)}`}
+        />
+        {magnet && (
+          <div
+            className="gex-range-marker"
+            style={{
+              left: `${pct(magnet)}%`,
+              borderColor: "var(--signal-core)",
+            }}
+            title={`MAGNET: ${fmtPrice(magnet)}`}
+          />
+        )}
+      </div>
+      <div className="gex-range-labels">
+        <span>{fmtPrice(low)}</span>
+        {flip && (
+          <span style={{ left: `${pct(flip)}%`, color: "var(--warning)" }}>
+            {fmtPrice(flip)}
+          </span>
+        )}
+        <span style={{ marginLeft: "auto" }}>{fmtPrice(high)}</span>
+      </div>
+      <div className="gex-range-sublabels">
+        {accel && <span>MAX ACCEL</span>}
+        {flip && <span>GEX FLIP</span>}
+        <span>CLOSE</span>
+        {magnet && <span>MAX MAGNET</span>}
+      </div>
+    </div>
+  );
+}
+
+/* ─── History Table ──────────────────────────────────── */
+
+type GexSortCol =
+  | "date"
+  | "net_gex"
+  | "net_dex"
+  | "gex_flip"
+  | "spot"
+  | "atm_iv"
+  | "vol_pc"
+  | "bias";
+type SortDir = "asc" | "desc";
+
+function sortIndicator(
+  col: GexSortCol,
+  activeCol: GexSortCol | null,
+  dir: SortDir,
+): string {
+  if (col !== activeCol) return "";
+  return dir === "asc" ? " \u2191" : " \u2193";
+}
+
+/* ─── MenthorQ Levels Panel ─────────────────────────── */
+
+function MqLevelsPanel({
+  mq,
+  sourceDelta,
+}: {
+  mq: MqLevels;
+  sourceDelta: SourceDelta | null;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  function deltaStyle(d: number | undefined): React.CSSProperties {
+    if (d == null) return {};
+    if (Math.abs(d) <= 2) return { color: "var(--signal-core)" };
+    if (Math.abs(d) <= 10) return { color: "var(--warning)" };
+    return { color: "var(--fault)" };
+  }
+
+  function fmtDelta(e: SourceDeltaEntry | undefined): React.ReactNode {
+    if (!e) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+    const sign = e.delta > 0 ? "+" : "";
+    return (
+      <span style={deltaStyle(e.delta)}>
+        {sign}
+        {e.delta.toFixed(1)} &nbsp;
+        <span style={{ color: "var(--signal-core)", fontSize: 9 }}>
+          {e.uw.toFixed(0)}
+        </span>
+        <span style={{ color: "var(--text-muted)", fontSize: 9 }}> vs </span>
+        <span style={{ color: "#85b7eb", fontSize: 9 }}>{e.mq.toFixed(0)}</span>
+      </span>
+    );
+  }
+
+  return (
+    <div className="gex-history-section">
+      <button className="gex-mq-toggle" onClick={() => setExpanded(!expanded)}>
+        MenthorQ Key Levels
+        {mq.source_date && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: "var(--text-muted)",
+              marginLeft: 8,
+            }}
+          >
+            {mq.source_date}
+          </span>
+        )}
+        <SourceBadge source="mq" /> {expanded ? "▲" : "▼"}
+      </button>
+      {expanded && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 16,
+            marginTop: 10,
+          }}
+        >
+          {/* MQ Level Values */}
+          <div>
+            <div
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: "var(--text-muted)",
+                marginBottom: 8,
+              }}
+            >
+              Levels
+            </div>
+            {[
+              { label: "HVL (flip)", val: mq.hvl },
+              { label: "Call Resistance (all)", val: mq.call_resistance_all },
+              { label: "Call Resistance (0DTE)", val: mq.call_resistance_0dte },
+              { label: "Put Support (all)", val: mq.put_support_all },
+              { label: "Put Support (0DTE)", val: mq.put_support_0dte },
+              { label: "Expected High", val: mq.expected_high },
+              { label: "Expected Low", val: mq.expected_low },
+            ].map(({ label, val }) => (
+              <div
+                key={label}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  fontSize: 11,
+                  marginBottom: 5,
+                  fontFamily: "var(--font-mono)",
+                }}
+              >
+                <span style={{ color: "var(--text-secondary)", fontSize: 10 }}>
+                  {label}
+                </span>
+                <span style={{ color: "#85b7eb", fontWeight: 500 }}>
+                  {val != null ? fmtPrice(val) : "—"}
+                </span>
+              </div>
+            ))}
+            {mq.top_gex_strikes.length > 0 && (
+              <div style={{ marginTop: 8 }}>
+                <div
+                  style={{
+                    fontSize: 10,
+                    color: "var(--text-muted)",
+                    marginBottom: 4,
+                  }}
+                >
+                  Top GEX Strikes
+                </div>
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                  {mq.top_gex_strikes.map((s) => (
+                    <span
+                      key={s}
+                      style={{
+                        background: "rgba(56,138,221,0.12)",
+                        color: "#85b7eb",
+                        border: "0.5px solid rgba(56,138,221,0.3)",
+                        fontSize: 10,
+                        padding: "1px 6px",
+                        borderRadius: 2,
+                        fontFamily: "var(--font-mono)",
+                      }}
+                    >
+                      {fmtPrice(s)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Source Delta */}
+          <div>
+            <div
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: "var(--text-muted)",
+                marginBottom: 8,
+              }}
+            >
+              UW vs MQ Delta &nbsp;
+              <span
+                style={{
+                  color: "var(--text-muted)",
+                  fontStyle: "italic",
+                  textTransform: "none",
+                }}
+              >
+                (+= UW higher)
+              </span>
+            </div>
+            {sourceDelta ? (
+              [
+                { label: "Flip vs HVL", entry: sourceDelta.flip_vs_hvl },
+                {
+                  label: "Put wall vs support (all)",
+                  entry: sourceDelta.put_wall_vs_support_all,
+                },
+                {
+                  label: "Put wall vs support (0DTE)",
+                  entry: sourceDelta.put_wall_vs_support_0dte,
+                },
+                {
+                  label: "Call wall vs resist (all)",
+                  entry: sourceDelta.call_wall_vs_resistance_all,
+                },
+                {
+                  label: "Call wall vs resist (0DTE)",
+                  entry: sourceDelta.call_wall_vs_resistance_0dte,
+                },
+              ].map(({ label, entry }) => (
+                <div
+                  key={label}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: 11,
+                    marginBottom: 5,
+                    fontFamily: "var(--font-mono)",
+                  }}
+                >
+                  <span
+                    style={{ color: "var(--text-secondary)", fontSize: 10 }}
+                  >
+                    {label}
+                  </span>
+                  {fmtDelta(entry)}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: "var(--text-muted)", fontSize: 11 }}>
+                No delta data
+              </div>
+            )}
+            {/* IV comparison */}
+            {(mq.iv30d != null || mq.hv30 != null) && (
+              <div style={{ marginTop: 12 }}>
+                <div
+                  style={{
+                    fontSize: 10,
+                    color: "var(--text-muted)",
+                    marginBottom: 4,
+                  }}
+                >
+                  Volatility (MQ)
+                </div>
+                {mq.iv30d != null && (
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      fontSize: 11,
+                      marginBottom: 4,
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  >
+                    <span
+                      style={{ color: "var(--text-secondary)", fontSize: 10 }}
+                    >
+                      IV 30D
+                    </span>
+                    <span style={{ color: "#85b7eb", fontWeight: 500 }}>
+                      {(mq.iv30d * 100).toFixed(2)}%
+                    </span>
+                  </div>
+                )}
+                {mq.hv30 != null && (
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      fontSize: 11,
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  >
+                    <span
+                      style={{ color: "var(--text-secondary)", fontSize: 10 }}
+                    >
+                      HV 30D
+                    </span>
+                    <span
+                      style={{
+                        color: "var(--text-secondary)",
+                        fontWeight: 500,
+                      }}
+                    >
+                      {(mq.hv30 * 100).toFixed(2)}%
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GexHistoryTable({ history }: { history: GexHistoryEntry[] }) {
+  const [sortCol, setSortCol] = useState<GexSortCol | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [expanded, setExpanded] = useState(false);
+
+  function handleSort(col: GexSortCol) {
+    if (sortCol === col) {
+      if (sortDir === "desc") setSortDir("asc");
+      else {
+        setSortCol(null);
+        setSortDir("desc");
+      }
+    } else {
+      setSortCol(col);
+      setSortDir("desc");
+    }
+  }
+
+  const sorted = useMemo(() => {
+    if (!sortCol) return history;
+    return [...history].sort((a, b) => {
+      const av = sortCol === "date" ? a.date : (a[sortCol] ?? -Infinity);
+      const bv = sortCol === "date" ? b.date : (b[sortCol] ?? -Infinity);
+      if (av < bv) return sortDir === "asc" ? -1 : 1;
+      if (av > bv) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [history, sortCol, sortDir]);
+
+  if (!history.length) return null;
+
+  const cols: { key: GexSortCol; label: string; align: string }[] = [
+    { key: "date", label: "Date", align: "left" },
+    { key: "spot", label: "Spot", align: "right" },
+    { key: "gex_flip", label: "GEX Flip", align: "right" },
+    { key: "net_gex", label: "Net GEX", align: "right" },
+    { key: "net_dex", label: "Net DEX", align: "right" },
+    { key: "atm_iv", label: "IV 30D", align: "right" },
+    { key: "vol_pc", label: "Vol P/C", align: "right" },
+    { key: "bias", label: "Bias", align: "center" },
+  ];
+
+  return (
+    <div className="gex-history-section">
+      <button
+        className="gex-history-toggle"
+        onClick={() => setExpanded(!expanded)}
+      >
+        History ({history.length} sessions) {expanded ? "\u25B2" : "\u25BC"}
+      </button>
+      {expanded && (
+        <div className="gex-history-table-wrap">
+          <table className="gex-history-table">
+            <thead>
+              <tr>
+                {cols.map((c) => (
+                  <th
+                    key={c.key}
+                    className={`text-${c.align}`}
+                    onClick={() => handleSort(c.key)}
+                    style={{ cursor: "pointer", userSelect: "none" }}
+                  >
+                    {c.label}
+                    {sortIndicator(c.key, sortCol, sortDir)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.date}>
+                  <td>{row.date}</td>
+                  <td className="text-right">{fmtPrice(row.spot)}</td>
+                  <td className="text-right">{fmtPrice(row.gex_flip)}</td>
+                  <td
+                    className="text-right"
+                    style={{
+                      color:
+                        row.net_gex >= 0
+                          ? "var(--signal-core)"
+                          : "var(--fault)",
+                    }}
+                  >
+                    {fmtGex(row.net_gex)}
+                  </td>
+                  <td className="text-right">{fmtGex(row.net_dex)}</td>
+                  <td className="text-right">
+                    {row.atm_iv != null ? `${row.atm_iv.toFixed(1)}%` : "---"}
+                  </td>
+                  <td className="text-right">
+                    {row.vol_pc != null ? row.vol_pc.toFixed(2) : "---"}
+                  </td>
+                  <td className="text-center">
+                    <span
+                      style={{
+                        color: biasColor(row.bias || "NEUTRAL"),
+                        fontWeight: 600,
+                        fontSize: 10,
+                      }}
+                    >
+                      {biasLabel(row.bias || "NEUTRAL")}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Main component ─────────────────────────────────── */
+
+export default function GexSubTab({ marketState }: GexSubTabProps) {
+  const { data, loading, error, lastSync } = useGex(marketState ?? null);
+
+  if (loading && !data) {
+    return (
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">
+            <Activity size={14} />
+            Gamma Exposure Levels
+          </div>
+        </div>
+        <div
+          className="section-body"
+          style={{ padding: "24px", textAlign: "center" }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "11px",
+              color: "var(--text-muted)",
+            }}
+          >
+            Loading GEX scan...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">
+            <Activity size={14} />
+            Gamma Exposure Levels
+          </div>
+        </div>
+        <div className="section-body" style={{ padding: "16px" }}>
+          <div className="alert-item bearish">{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || (!data.spot && !data.profile?.length)) {
+    return (
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">
+            <Activity size={14} />
+            Gamma Exposure Levels
+          </div>
+        </div>
+        <div
+          className="section-body"
+          style={{ padding: "24px", textAlign: "center" }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "11px",
+              color: "var(--text-muted)",
+            }}
+          >
+            No GEX data available — run a scan to populate.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const { bias, levels } = data;
+  const daysAbove = bias.days_above_flip;
+  const daysSide = daysAbove > 0 ? "ABOVE" : daysAbove < 0 ? "BELOW" : "AT";
+  const daysCount = Math.abs(daysAbove);
+
+  const netGexColor = data.net_gex >= 0 ? "var(--signal-core)" : "var(--fault)";
+  const netDexColor = data.net_dex >= 0 ? "var(--signal-core)" : "var(--fault)";
+
+  return (
+    <div className="section gex-panel">
+      {/* ── Header ── */}
+      <div className="section-header">
+        <div className="section-title">
+          <Activity size={14} />
+          {data.ticker} Gamma Exposure Levels &mdash; {data.data_date}
+          <InfoTooltip
+            text="Gamma Exposure (GEX): net dealer gamma by strike. Positive = dealers long gamma (stabilizing, pins price). Negative = dealers short gamma (destabilizing, amplifies moves). Sources: Unusual Whales + MenthorQ."
+            triggerTestId="gex-section-tooltip-trigger"
+            contentTestId="gex-section-tooltip-content"
+          />
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexWrap: "wrap",
+          }}
+        >
+          {daysCount > 0 && (
+            <span
+              className="gex-day-badge"
+              style={{
+                background:
+                  daysAbove > 0 ? "var(--signal-deep)" : "var(--fault)",
+                color: "#fff",
+              }}
+            >
+              DAY {daysCount} {daysSide} GEX FLIP
+            </span>
+          )}
+          {lastSync && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: "var(--text-muted)",
+              }}
+            >
+              {new Date(lastSync).toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="section-body"
+        style={{ display: "flex", flexDirection: "column", gap: 16 }}
+      >
+        {/* ── Metrics Row ── */}
+        <div className="gex-metrics-row">
+          <MetricCard
+            label="SPOT"
+            value={fmtPrice(data.spot)}
+            sub={
+              data.day_change != null
+                ? `${data.day_change >= 0 ? "+" : ""}${fmtPrice(data.day_change)} (${fmtPct(data.day_change_pct)})`
+                : undefined
+            }
+          />
+          <MetricCard
+            label="GEX FLIP"
+            tooltip="The strike where net GEX crosses from negative (destabilizing) to positive (stabilizing). Spot above flip = dealers long gamma; below = short gamma. MQ HVL shown when UW flip uncomputable."
+            value={
+              levels.gex_flip
+                ? fmtPrice(levels.gex_flip.strike)
+                : data.mq?.hvl
+                  ? fmtPrice(data.mq.hvl as number)
+                  : "---"
+            }
+            sub={
+              levels.gex_flip
+                ? `${fmtPct(levels.gex_flip.distance_pct)} from spot`
+                : data.mq?.hvl
+                  ? "MQ HVL"
+                  : undefined
+            }
+            color="var(--warning)"
+            badge={
+              levels.gex_flip ? (
+                <SourceBadge source="uw" />
+              ) : data.mq?.hvl ? (
+                <SourceBadge source="mq" />
+              ) : undefined
+            }
+          />
+          <MetricCard
+            label="NET GEX"
+            tooltip="Net dealer gamma exposure in dollars. Negative = dealers short gamma (amplifies moves). Positive = dealers long gamma (stabilizes price)."
+            value={fmtGex(data.net_gex)}
+            color={netGexColor}
+            badge={<SourceBadge source="uw" />}
+          />
+          <MetricCard
+            label="NET DEX"
+            tooltip="Net dealer delta exposure. Negative = dealers net short delta (will sell on rallies). Large negative DEX signals structural selling pressure."
+            value={fmtGex(data.net_dex)}
+            color={netDexColor}
+            badge={<SourceBadge source="uw" />}
+          />
+          <MetricCard
+            label="IV 30D"
+            tooltip="30-day implied volatility from UW iv_rank endpoint (not 0DTE greeks). Source-tagged: UW = Unusual Whales, MQ = MenthorQ, UW+MQ = both sources agree."
+            value={
+              data.iv?.iv30d != null
+                ? `${data.iv.iv30d.toFixed(1)}%`
+                : data.iv?.mq_iv30d != null
+                  ? `${data.iv.mq_iv30d.toFixed(1)}%`
+                  : data.atm_iv != null
+                    ? `${data.atm_iv.toFixed(1)}%`
+                    : "---"
+            }
+            sub={
+              data.iv?.iv_rank != null
+                ? `rank ${data.iv.iv_rank.toFixed(0)}%${data.iv.hv30 != null ? `  HV ${data.iv.hv30.toFixed(1)}%` : ""}`
+                : data.expected_range.iv_1d != null
+                  ? `±${data.expected_range.iv_1d.toFixed(2)}% 1d`
+                  : undefined
+            }
+            badge={
+              data.iv?.source ? (
+                <SourceBadge source={data.iv.source} />
+              ) : undefined
+            }
+          />
+          <MetricCard
+            label="VOL P/C"
+            value={data.vol_pc != null ? data.vol_pc.toFixed(2) : "---"}
+            color={
+              data.vol_pc != null && data.vol_pc > 1.2
+                ? "var(--warning)"
+                : undefined
+            }
+            badge={<SourceBadge source="uw" />}
+          />
+        </div>
+
+        {/* ── Key Levels Row (UW) ── */}
+        <div className="gex-levels-row">
+          <LevelCard
+            label="GEX FLIP (SUPPORT)"
+            level={levels.gex_flip}
+            labelColor="var(--warning)"
+          />
+          <LevelCard
+            label="MAX MAGNET"
+            level={levels.max_magnet}
+            labelColor="var(--signal-core)"
+          />
+          <LevelCard
+            label="2ND MAGNET"
+            level={levels.second_magnet}
+            labelColor="var(--signal-core)"
+          />
+          <LevelCard
+            label="MAX ACCEL (BELOW FLIP)"
+            level={levels.max_accelerator}
+            labelColor="var(--fault)"
+          />
+          <LevelCard
+            label="PUT WALL"
+            level={levels.put_wall}
+            labelColor="var(--fault)"
+          />
+        </div>
+
+        {/* ── MenthorQ Levels + Delta ── */}
+        {data.mq && (
+          <MqLevelsPanel
+            mq={data.mq as MqLevels}
+            sourceDelta={data.source_delta as SourceDelta | null}
+          />
+        )}
+
+        {/* ── GEX Profile Chart ── */}
+        <GexProfileChart profile={data.profile} spot={data.spot} />
+
+        {/* ── Bottom Row: Expected Range + Bias ── */}
+        <div className="gex-bottom-row">
+          <ExpectedRangeBar data={data} />
+          <div className="gex-bias-card">
+            <div className="gex-bias-title">DIRECTIONAL BIAS</div>
+            <div
+              className="gex-bias-direction"
+              style={{ color: biasColor(bias.direction) }}
+            >
+              {biasLabel(bias.direction)}
+              {bias.direction.includes("BULL") ? (
+                <TrendingUp size={24} style={{ marginLeft: 8 }} />
+              ) : bias.direction.includes("BEAR") ? (
+                <TrendingDown size={24} style={{ marginLeft: 8 }} />
+              ) : null}
+            </div>
+            <div className="gex-bias-reasons">
+              {bias.reasons.map((r, i) => (
+                <div key={i} className="gex-bias-reason">
+                  {r}
+                </div>
+              ))}
+            </div>
+            {bias.flip_migration.length > 1 && (
+              <div className="gex-flip-migration">
+                Flip migration:{" "}
+                {bias.flip_migration.map((f) => fmtPrice(f.flip)).join(" → ")}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* ── History Table ── */}
+        <GexHistoryTable history={data.history} />
+      </div>
+    </div>
+  );
+}

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -84,6 +84,72 @@ function levelColor(gamma: number | undefined): string {
   return gamma >= 0 ? "var(--signal-core)" : "var(--fault)";
 }
 
+/* ─── Spot freshness pill ─────────────────────────────── */
+
+/**
+ * Render "LIVE", "Xm ago", or "Xh ago" based on age of `tape_time`.
+ * Color: green ≤2m, warning ≤15m, muted-warm ≤60m, muted thereafter.
+ * Returns null if tape_time is missing/invalid — caller renders nothing.
+ *
+ * Re-renders are driven by the GEX poll cycle (every N seconds); we don't
+ * run a clock interval, which keeps this trivially pure.
+ */
+export function SpotFreshnessPill({
+  tapeTime,
+  nowMs,
+}: {
+  tapeTime: string | null | undefined;
+  /** Injectable for tests; defaults to Date.now(). */
+  nowMs?: number;
+}) {
+  if (!tapeTime) return null;
+  const t = Date.parse(tapeTime);
+  if (Number.isNaN(t)) return null;
+  const now = nowMs ?? Date.now();
+  const ageMin = Math.max(0, Math.floor((now - t) / 60000));
+
+  let label: string;
+  let color: string;
+  let bg: string;
+  if (ageMin <= 2) {
+    label = "LIVE";
+    color = "var(--signal-core)";
+    bg = "rgba(15,110,86,0.18)";
+  } else if (ageMin < 60) {
+    label = `${ageMin}m ago`;
+    color = ageMin <= 15 ? "var(--warning)" : "var(--text-secondary)";
+    bg = ageMin <= 15 ? "rgba(245,166,35,0.15)" : "rgba(148,163,184,0.12)";
+  } else if (ageMin < 60 * 24) {
+    const hrs = Math.floor(ageMin / 60);
+    label = `${hrs}h ago`;
+    color = "var(--text-muted)";
+    bg = "rgba(148,163,184,0.10)";
+  } else {
+    const days = Math.floor(ageMin / (60 * 24));
+    label = `${days}d ago`;
+    color = "var(--text-muted)";
+    bg = "rgba(148,163,184,0.10)";
+  }
+
+  return (
+    <span
+      data-testid="spot-freshness-pill"
+      style={{
+        background: bg,
+        color,
+        fontSize: 9,
+        fontWeight: 500,
+        padding: "1px 5px",
+        borderRadius: 2,
+        letterSpacing: "0.06em",
+      }}
+      title={`Last tick at ${tapeTime}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 /* ─── Level Card ──────────────────────────────────────── */
 
 function LevelCard({
@@ -729,11 +795,22 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
         <div className="gex-metrics-row">
           <MetricCard
             label="SPOT"
+            badge={<SpotFreshnessPill tapeTime={data.tape_time} />}
             value={fmtPrice(data.spot)}
             sub={
-              data.day_change != null
-                ? `${data.day_change >= 0 ? "+" : ""}${fmtPrice(data.day_change)} (${fmtPct(data.day_change_pct)})`
-                : undefined
+              data.day_change != null ? (
+                <span
+                  style={{
+                    color:
+                      data.day_change >= 0
+                        ? "var(--positive)"
+                        : "var(--negative)",
+                  }}
+                >
+                  {data.day_change >= 0 ? "+" : ""}
+                  {fmtPrice(data.day_change)} ({fmtPct(data.day_change_pct)})
+                </span>
+              ) : undefined
             }
           />
           <MetricCard

--- a/web/components/regime/HistoryChart.tsx
+++ b/web/components/regime/HistoryChart.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { finiteDomain, linearScale, pathFromPoints } from "@/lib/svgChart";
+import type { GexHistoryEntry } from "@/lib/regime/useGex";
+
+const WIDTH = 760;
+const HEIGHT = 220;
+const PAD = { top: 12, right: 56, bottom: 28, left: 56 };
+
+export function HistoryChart({
+  history,
+  ticker,
+}: {
+  history: GexHistoryEntry[];
+  ticker: string;
+}) {
+  if (!history.length) {
+    return (
+      <div
+        style={{
+          padding: "24px",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+        }}
+      >
+        No history available
+      </div>
+    );
+  }
+
+  const xScale = linearScale(
+    [0, Math.max(history.length - 1, 1)],
+    [PAD.left, WIDTH - PAD.right],
+  );
+
+  // finiteDomain returns {lo, hi, count} | null — null on <2 finite values
+  const netGexD = finiteDomain(history.map((h) => h.net_gex));
+  const priceD = finiteDomain(history.flatMap((h) => [h.spot, h.gex_flip]));
+
+  const yGex = netGexD
+    ? linearScale([netGexD.lo, netGexD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+  const yPrice = priceD
+    ? linearScale([priceD.lo, priceD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+
+  const netGexPath =
+    yGex == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.net_gex == null ? null : [xScale(i), yGex(h.net_gex)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  const flipPath =
+    yPrice == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.gex_flip == null ? null : [xScale(i), yPrice(h.gex_flip)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  const spotPath =
+    yPrice == null
+      ? ""
+      : pathFromPoints(
+          history
+            .map((h, i): [number, number] | null =>
+              h.spot == null ? null : [xScale(i), yPrice(h.spot)],
+            )
+            .filter((p): p is [number, number] => p != null),
+        );
+
+  return (
+    <svg
+      role="img"
+      aria-label={`${ticker} 90-day GEX history`}
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      style={{ width: "100%", height: HEIGHT, display: "block" }}
+    >
+      <title>{`${ticker} — net GEX, flip migration, spot`}</title>
+
+      {/* zero line for net GEX (only when scale exists and crosses zero) */}
+      {yGex != null &&
+        netGexD != null &&
+        netGexD.lo <= 0 &&
+        netGexD.hi >= 0 && (
+          <line
+            x1={PAD.left}
+            x2={WIDTH - PAD.right}
+            y1={yGex(0)}
+            y2={yGex(0)}
+            stroke="var(--border-dim)"
+            strokeDasharray="2 3"
+          />
+        )}
+
+      {/* net_gex (left axis) */}
+      <path
+        d={netGexPath}
+        fill="none"
+        stroke="var(--accent-bg)"
+        strokeWidth={1.5}
+      />
+
+      {/* gex_flip (right axis) — sparse / forward-only */}
+      <path
+        d={flipPath}
+        fill="none"
+        stroke="var(--accent-warm)"
+        strokeWidth={1.2}
+        strokeDasharray="3 2"
+      />
+
+      {/* spot (right axis) */}
+      <path
+        d={spotPath}
+        fill="none"
+        stroke="var(--text-primary)"
+        strokeWidth={1.2}
+      />
+    </svg>
+  );
+}

--- a/web/components/regime/InfoTooltip.tsx
+++ b/web/components/regime/InfoTooltip.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+/**
+ * Inline hover tooltip — renders a small "?" circle that, on hover,
+ * shows a 260px-wide explanation box. Uses position:fixed so the popup
+ * escapes parent overflow:hidden/auto containers. Flips below the
+ * trigger when there isn't enough viewport space above.
+ */
+type InfoTooltipProps = {
+  text: string;
+  ariaLabel?: string;
+  triggerTestId?: string;
+  contentTestId?: string;
+};
+
+export default function InfoTooltip({ text, ariaLabel, triggerTestId, contentTestId }: InfoTooltipProps) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const ref = useRef<HTMLSpanElement>(null);
+
+  function show() {
+    const el = ref.current;
+    if (!el) return;
+    setRect(el.getBoundingClientRect());
+  }
+
+  function hide() {
+    setRect(null);
+  }
+
+  // Determine whether to flip below: if trigger is within 120px of viewport top
+  const flipBelow = rect ? rect.top < 120 : false;
+
+  return (
+    <span
+      ref={ref}
+      data-testid={triggerTestId}
+      style={{ display: "inline-flex", alignItems: "center" }}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+      aria-label={ariaLabel}
+      tabIndex={0}
+    >
+      <span
+        style={{
+          width: 13,
+          height: 13,
+          borderRadius: "50%",
+          border: "1px solid var(--text-muted)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 8,
+          color: "var(--text-muted)",
+          cursor: "default",
+          lineHeight: 1,
+          flexShrink: 0,
+        }}
+      >
+        ?
+      </span>
+      {rect && (
+        <span
+          data-testid={contentTestId}
+          style={{
+            position: "fixed",
+            ...(flipBelow
+              ? { top: rect.bottom + 6 }
+              : { top: rect.top - 6, transform: "translateY(-100%)" }),
+            left: Math.max(8, Math.min(rect.left + rect.width / 2 - 130, typeof window !== "undefined" ? window.innerWidth - 268 : 1200)),
+            background: "var(--chart-tooltip-bg, var(--bg-panel))",
+            border: "1px solid var(--chart-tooltip-border, var(--border-dim))",
+            padding: "8px 10px",
+            width: 260,
+            fontSize: 11,
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-primary)",
+            lineHeight: 1.5,
+            zIndex: 9999,
+            pointerEvents: "none",
+            whiteSpace: "normal",
+            fontWeight: 400,
+            textTransform: "none",
+            letterSpacing: "normal",
+          }}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/components/regime/PendingSubTab.tsx
+++ b/web/components/regime/PendingSubTab.tsx
@@ -1,0 +1,24 @@
+import { Clock } from "lucide-react";
+
+type Props = {
+  name: "CRI" | "VCG";
+  description: string;
+};
+
+export default function PendingSubTab({ name, description }: Props) {
+  return (
+    <div
+      className="regime-pending"
+      data-testid={`regime-pending-${name.toLowerCase()}`}
+    >
+      <Clock size={48} strokeWidth={1.5} />
+      <h2>{name} — coming soon</h2>
+      <p>{description}</p>
+      <p className="regime-pending-link">
+        Pending IB-via-R2 reader integration. See the long-term roadmap (
+        <code>docs/superpowers/plans/2026-05-16-port-regime-from-xenon.md</code>
+        ) for the full plan.
+      </p>
+    </div>
+  );
+}

--- a/web/components/regime/RegimePanel.tsx
+++ b/web/components/regime/RegimePanel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useMarketHours } from "@/lib/regime/useMarketHours";
+import GexSubTab from "./GexSubTab";
+import PendingSubTab from "./PendingSubTab";
+
+type RegimeTab = "cri" | "vcg" | "gex";
+
+const TABS: { id: RegimeTab; label: string }[] = [
+  { id: "cri", label: "CRI" },
+  { id: "vcg", label: "VCG" },
+  { id: "gex", label: "GEX" },
+];
+
+const CRI_DESC =
+  "Crash Risk Indicator — composite score from VIX, VVIX, COR1M implied correlation, and SPX momentum. Renders when VIX/VVIX/COR1M data is wired.";
+const VCG_DESC =
+  "Volatility-Credit Gap — rolling OLS residual between the vol complex (VIX/VVIX) and cash credit (HYG/JNK/LQD). Renders when VIX/VVIX data is wired.";
+
+export default function RegimePanel() {
+  const [activeTab, setActiveTab] = useState<RegimeTab>("gex");
+  const marketState = useMarketHours();
+
+  return (
+    <div className="regime-panel" data-testid="regime-panel">
+      <div
+        className="ticker-tabs"
+        style={{ marginBottom: "16px" }}
+        data-testid="regime-tabs"
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            className={`ticker-tab ${activeTab === tab.id ? "active" : ""}`}
+            onClick={() => setActiveTab(tab.id)}
+            data-testid={`regime-tab-${tab.id}`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === "gex" && <GexSubTab marketState={marketState} />}
+      {activeTab === "cri" && (
+        <PendingSubTab name="CRI" description={CRI_DESC} />
+      )}
+      {activeTab === "vcg" && (
+        <PendingSubTab name="VCG" description={VCG_DESC} />
+      )}
+    </div>
+  );
+}

--- a/web/components/regime/RegimePanel.tsx
+++ b/web/components/regime/RegimePanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
 import CriSubTab from "./CriSubTab";
 import GexSubTab from "./GexSubTab";
-import PendingSubTab from "./PendingSubTab";
+import VcgSubTab from "./VcgSubTab";
 
 type RegimeTab = "cri" | "vcg" | "gex";
 
@@ -13,9 +13,6 @@ const TABS: { id: RegimeTab; label: string }[] = [
   { id: "cri", label: "CRI" },
   { id: "vcg", label: "VCG" },
 ];
-
-const VCG_DESC =
-  "Volatility-Credit Gap — rolling OLS residual between the vol complex (VIX/VVIX) and cash credit (HYG/JNK/LQD). Renders when VIX/VVIX data is wired.";
 
 export default function RegimePanel() {
   const [activeTab, setActiveTab] = useState<RegimeTab>("gex");
@@ -41,9 +38,7 @@ export default function RegimePanel() {
       </div>
       {activeTab === "gex" && <GexSubTab marketState={marketState} />}
       {activeTab === "cri" && <CriSubTab />}
-      {activeTab === "vcg" && (
-        <PendingSubTab name="VCG" description={VCG_DESC} />
-      )}
+      {activeTab === "vcg" && <VcgSubTab />}
     </div>
   );
 }

--- a/web/components/regime/RegimePanel.tsx
+++ b/web/components/regime/RegimePanel.tsx
@@ -8,9 +8,9 @@ import PendingSubTab from "./PendingSubTab";
 type RegimeTab = "cri" | "vcg" | "gex";
 
 const TABS: { id: RegimeTab; label: string }[] = [
+  { id: "gex", label: "GEX" },
   { id: "cri", label: "CRI" },
   { id: "vcg", label: "VCG" },
-  { id: "gex", label: "GEX" },
 ];
 
 const CRI_DESC =

--- a/web/components/regime/RegimePanel.tsx
+++ b/web/components/regime/RegimePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
+import CriSubTab from "./CriSubTab";
 import GexSubTab from "./GexSubTab";
 import PendingSubTab from "./PendingSubTab";
 
@@ -13,8 +14,6 @@ const TABS: { id: RegimeTab; label: string }[] = [
   { id: "vcg", label: "VCG" },
 ];
 
-const CRI_DESC =
-  "Crash Risk Indicator — composite score from VIX, VVIX, COR1M implied correlation, and SPX momentum. Renders when VIX/VVIX/COR1M data is wired.";
 const VCG_DESC =
   "Volatility-Credit Gap — rolling OLS residual between the vol complex (VIX/VVIX) and cash credit (HYG/JNK/LQD). Renders when VIX/VVIX data is wired.";
 
@@ -41,9 +40,7 @@ export default function RegimePanel() {
         ))}
       </div>
       {activeTab === "gex" && <GexSubTab marketState={marketState} />}
-      {activeTab === "cri" && (
-        <PendingSubTab name="CRI" description={CRI_DESC} />
-      )}
+      {activeTab === "cri" && <CriSubTab />}
       {activeTab === "vcg" && (
         <PendingSubTab name="VCG" description={VCG_DESC} />
       )}

--- a/web/components/regime/RegimeStrip.tsx
+++ b/web/components/regime/RegimeStrip.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+export type BadgeVariant = "live" | "daily";
+
+export function LiveBadge({
+  live,
+  variant,
+}: {
+  live: boolean;
+  variant?: BadgeVariant;
+}) {
+  const resolved: BadgeVariant = variant ?? (live ? "live" : "daily");
+  const bg =
+    resolved === "live" ? "rgba(5,173,152,0.15)" : "rgba(226,232,240,0.06)";
+  const color = resolved === "live" ? "var(--positive)" : "var(--text-muted)";
+  const label = resolved === "live" ? "LIVE" : "DAILY";
+  return (
+    <span className="regime-badge" style={{ background: bg, color }}>
+      {label}
+    </span>
+  );
+}
+
+export function DayChange({
+  last,
+  close,
+  prefix,
+}: {
+  last: number | null;
+  close: number | null;
+  prefix?: string;
+}) {
+  if (last == null || close == null || close <= 0) return null;
+  const change = last - close;
+  const pct = (change / close) * 100;
+  const isUp = change >= 0;
+  const color = isUp ? "var(--positive)" : "var(--negative)";
+  const Arrow = isUp ? ArrowUp : ArrowDown;
+  return (
+    <div
+      className="regime-strip-day-chg"
+      style={{ color }}
+      data-testid="regime-day-chg"
+    >
+      <span>
+        {prefix}
+        {isUp ? "+" : ""}
+        {change.toFixed(2)} ({isUp ? "+" : ""}
+        {pct.toFixed(2)}%)
+      </span>
+      <Arrow size={10} />
+    </div>
+  );
+}
+
+export function PointChange({
+  change,
+  suffix,
+  label,
+}: {
+  change: number | null;
+  suffix?: string;
+  label?: string;
+}) {
+  if (change == null || Math.abs(change) < 0.005) return null;
+  const isUp = change >= 0;
+  const color = isUp ? "var(--positive)" : "var(--negative)";
+  const Arrow = isUp ? ArrowUp : ArrowDown;
+  return (
+    <div
+      className="regime-strip-day-chg"
+      style={{ color }}
+      data-testid="regime-day-chg"
+    >
+      <span>
+        {isUp ? "+" : ""}
+        {change.toFixed(2)}
+        {suffix}
+        {label ? ` ${label}` : ""}
+      </span>
+      <Arrow size={10} />
+    </div>
+  );
+}
+
+type RegimeStripCellProps = {
+  testId: string;
+  label: ReactNode;
+  value: ReactNode;
+  change?: ReactNode;
+  sub?: ReactNode;
+  timestamp?: ReactNode;
+};
+
+export function RegimeStripCell({
+  testId,
+  label,
+  value,
+  change,
+  sub,
+  timestamp,
+}: RegimeStripCellProps) {
+  return (
+    <div className="regime-strip-cell" data-testid={testId}>
+      <div className="regime-strip-primary">
+        <div className="regime-strip-label">{label}</div>
+        <div className="regime-strip-value">{value}</div>
+      </div>
+      <div className="regime-strip-meta-row">
+        {change}
+        {sub ? <div className="regime-strip-sub">{sub}</div> : null}
+        {timestamp ? <div className="regime-strip-ts">{timestamp}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+export function RegimeStrip({ children }: { children: ReactNode }) {
+  return <div className="regime-strip">{children}</div>;
+}

--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -1,0 +1,820 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Shield, TrendingUp, Zap } from "lucide-react";
+
+import InfoTooltip from "./InfoTooltip";
+import {
+  type VcgHistoryEntry,
+  type VcgResponse,
+  type VcgSignal,
+  useVcg,
+} from "@/lib/regime/useVcg";
+
+/* ─── Helpers (1:1 port from xenon VcgPanel.tsx) ───────────────── */
+
+function fmtZ(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return v >= 0 ? `+${v.toFixed(2)}` : v.toFixed(2);
+}
+
+function fmtPct(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
+}
+
+function fmtNum(v: number | null | undefined, decimals = 2): string {
+  if (v == null || !Number.isFinite(v)) return "---";
+  return v.toFixed(decimals);
+}
+
+// Persisted attribution percentages should already sum to 100, but the UI
+// renders from JSONB and a corrupted/backfilled payload could surface NaN,
+// Infinity, or values > 100 — clamp defensively so the bar can't overflow.
+function clampPct(v: number | null | undefined): number {
+  if (v == null || !Number.isFinite(v)) return 0;
+  return Math.min(100, Math.max(0, v));
+}
+
+function interpretationColor(interpretation: string): string {
+  switch (interpretation) {
+    case "RISK_OFF":
+      return "var(--fault, var(--negative))";
+    case "EDR":
+    case "WATCH":
+      return "var(--warning)";
+    case "BOUNCE":
+    case "NORMAL":
+      return "var(--signal-core, var(--positive))";
+    case "PANIC":
+      return "var(--extreme, var(--negative))";
+    case "SUPPRESSED":
+      return "var(--text-muted)";
+    default:
+      return "var(--text-muted)";
+  }
+}
+
+function interpretationLabel(interpretation: string): string {
+  switch (interpretation) {
+    case "RISK_OFF":
+      return "RISK-OFF";
+    case "EDR":
+      return "EARLY DIVERGENCE";
+    case "WATCH":
+      return "WATCH";
+    case "BOUNCE":
+      return "BOUNCE";
+    case "NORMAL":
+      return "NORMAL";
+    case "PANIC":
+      return "PANIC";
+    case "SUPPRESSED":
+      return "SUPPRESSED";
+    default:
+      return "INSUFFICIENT DATA";
+  }
+}
+
+function regimeBadgeColor(regime: string): string {
+  switch (regime) {
+    case "PANIC":
+      return "var(--extreme, var(--negative))";
+    case "TRANSITION":
+      return "var(--warning)";
+    default:
+      return "var(--signal-core, var(--positive))";
+  }
+}
+
+function tierColor(tier: number | null | undefined): string {
+  switch (tier) {
+    case 1:
+    case 2:
+      return "var(--fault, var(--negative))";
+    case 3:
+      return "var(--warning)";
+    default:
+      return "var(--text-muted)";
+  }
+}
+
+function tierLabel(tier: number | null | undefined): string {
+  switch (tier) {
+    case 1:
+      return "TIER 1 — CRITICAL";
+    case 2:
+      return "TIER 2 — HIGH";
+    case 3:
+      return "TIER 3 — ELEVATED";
+    default:
+      return "NO ACTIVE TIER";
+  }
+}
+
+function vvixSeverityColor(sev: string): string {
+  switch (sev) {
+    case "extreme":
+      return "var(--fault, var(--negative))";
+    case "elevated":
+      return "var(--warning)";
+    default:
+      return "var(--signal-core, var(--positive))";
+  }
+}
+
+function vvixSeverityDesc(sev: string): string {
+  switch (sev) {
+    case "extreme":
+      return "VVIX far above 120 — maximum vol-of-vol stress";
+    case "elevated":
+      return "VVIX above 110 — second-order stress signal";
+    default:
+      return "VVIX below 110 — vol regime stable";
+  }
+}
+
+/* ─── Sortable history (1:1 port of xenon table) ─────────────── */
+
+type VcgSortCol =
+  | "date"
+  | "vcg"
+  | "vcg_adj"
+  | "residual"
+  | "beta1"
+  | "beta2"
+  | "vix"
+  | "vvix"
+  | "credit";
+type SortDir = "asc" | "desc";
+
+function sortIndicator(
+  col: VcgSortCol,
+  activeCol: VcgSortCol | null,
+  dir: SortDir,
+): string {
+  if (col !== activeCol) return "";
+  return dir === "asc" ? " ↑" : " ↓";
+}
+
+function sortHistory(
+  rows: VcgHistoryEntry[],
+  col: VcgSortCol | null,
+  dir: SortDir,
+): VcgHistoryEntry[] {
+  if (!col) return rows;
+  return [...rows].sort((a, b) => {
+    const av =
+      col === "date"
+        ? a.date
+        : ((a[col] as number | null | undefined) ?? -Infinity);
+    const bv =
+      col === "date"
+        ? b.date
+        : ((b[col] as number | null | undefined) ?? -Infinity);
+    if (av < bv) return dir === "asc" ? -1 : 1;
+    if (av > bv) return dir === "asc" ? 1 : -1;
+    return 0;
+  });
+}
+
+/* ─── Main view (1:1 mirror of xenon VcgPanel) ───────────────── */
+
+export function VcgSubTabView({
+  data,
+  onSyncNow,
+  syncing = false,
+}: {
+  data: VcgResponse | null;
+  onSyncNow?: () => void;
+  syncing?: boolean;
+}) {
+  const [sortCol, setSortCol] = useState<VcgSortCol | null>("date");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  function handleSort(col: VcgSortCol) {
+    if (sortCol === col) {
+      if (sortDir === "desc") {
+        setSortDir("asc");
+      } else {
+        setSortCol(null);
+        setSortDir("desc");
+      }
+    } else {
+      setSortCol(col);
+      setSortDir("desc");
+    }
+  }
+
+  if (
+    !data ||
+    data.status === "empty" ||
+    (!data.signal?.vcg && data.signal?.vcg !== 0)
+  ) {
+    return (
+      <div className="regime-empty" data-testid="vcg-empty-state">
+        <Shield size={32} strokeWidth={1} />
+        <p>
+          No VCG data available. Click Sync Now to run a scan for{" "}
+          {data?.credit_proxy ?? "HYG"}.
+        </p>
+        {onSyncNow && (
+          <button
+            type="button"
+            onClick={onSyncNow}
+            disabled={syncing}
+            data-testid="vcg-sync-now"
+            style={{
+              marginTop: "12px",
+              padding: "6px 14px",
+              fontFamily: "var(--font-mono)",
+              fontSize: "11px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              background: "var(--bg-panel-raised, var(--bg-panel))",
+              border: "1px solid var(--border-dim, var(--line-grid))",
+              color: "var(--text-primary)",
+              cursor: syncing ? "default" : "pointer",
+              opacity: syncing ? 0.6 : 1,
+            }}
+          >
+            {syncing ? "Syncing…" : "Sync Now"}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const sig: VcgSignal = data.signal;
+  const attr = sig.attribution ?? {
+    vvix_pct: 0,
+    vix_pct: 0,
+    vvix_component: 0,
+    vix_component: 0,
+    model_implied: 0,
+  };
+  const interpColor = interpretationColor(sig.interpretation);
+  const lastSync = data.scan_time;
+  const history = data.history ?? [];
+
+  return (
+    <div className="regime-panel" data-testid="vcg-subtab">
+      {/* ── Signal strip ───────────────────────────────────── */}
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">
+            <Zap size={14} />
+            VCG Signal
+            <InfoTooltip text="Volatility-Credit Gap: detects divergence between the vol complex (VIX/VVIX) and credit markets (HYG/JNK/LQD). Signals: RISK_OFF (tier 1–2), EDR (early divergence), BOUNCE (counter-signal), NORMAL." />
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              flexWrap: "wrap",
+            }}
+          >
+            {/* Regime badge */}
+            <span
+              className="pill"
+              style={{
+                background: regimeBadgeColor(sig.regime),
+                color: "#fff",
+                fontSize: "9px",
+              }}
+              data-testid="vcg-regime-badge"
+            >
+              {sig.regime}
+            </span>
+            {/* RISK-OFF */}
+            {sig.ro === 1 && (
+              <span
+                className="pill"
+                style={{
+                  background: "var(--fault, var(--negative))",
+                  color: "#fff",
+                  fontSize: "9px",
+                }}
+                data-testid="vcg-ro-badge"
+              >
+                <AlertTriangle size={10} style={{ marginRight: "3px" }} />
+                RISK-OFF
+              </span>
+            )}
+            {/* EDR (only when not already RISK-OFF) */}
+            {sig.edr === 1 && sig.ro !== 1 && (
+              <span
+                className="pill"
+                style={{
+                  background: "var(--warning)",
+                  color: "#000",
+                  fontSize: "9px",
+                  fontWeight: 700,
+                }}
+                data-testid="vcg-edr-badge"
+              >
+                EDR
+              </span>
+            )}
+            {/* Tier badge */}
+            {sig.tier != null && (
+              <span
+                className="pill"
+                style={{
+                  background: tierColor(sig.tier),
+                  color: "#fff",
+                  fontSize: "9px",
+                }}
+                data-testid="vcg-tier-badge"
+              >
+                T{sig.tier}
+              </span>
+            )}
+            {/* Bounce */}
+            {sig.bounce === 1 && (
+              <span
+                className="pill"
+                style={{
+                  background: "var(--signal-core, var(--positive))",
+                  color: "#000",
+                  fontSize: "9px",
+                  fontWeight: 700,
+                }}
+                data-testid="vcg-bounce-badge"
+              >
+                <TrendingUp size={10} style={{ marginRight: "3px" }} />
+                BOUNCE
+              </span>
+            )}
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "9px",
+                color: "var(--text-muted)",
+              }}
+              data-testid="vcg-proxy"
+            >
+              {data.credit_proxy}
+            </span>
+            {lastSync && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "9px",
+                  color: "var(--text-muted)",
+                }}
+              >
+                {new Date(lastSync).toLocaleTimeString("en-US", {
+                  hour: "numeric",
+                  minute: "2-digit",
+                })}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="metrics-grid">
+          <div className="metric-card">
+            <div className="metric-label">VCG Z-Score</div>
+            <div
+              className="metric-value"
+              style={{ color: interpColor }}
+              data-testid="vcg-z-score"
+            >
+              {fmtZ(sig.vcg)}
+            </div>
+            <div className="metric-change" style={{ color: interpColor }}>
+              {interpretationLabel(sig.interpretation)}
+            </div>
+          </div>
+          <div className="metric-card">
+            <div className="metric-label">VCG Adj (Panic-Adj)</div>
+            <div className="metric-value">{fmtZ(sig.vcg_adj)}</div>
+            <div className="metric-change neutral">
+              {sig.pi_panic > 0
+                ? `π = ${sig.pi_panic.toFixed(2)} SUPPRESSED`
+                : "NO SUPPRESSION"}
+            </div>
+          </div>
+          <div className="metric-card">
+            <div className="metric-label">Credit 5d Return</div>
+            <div
+              className={`metric-value ${
+                sig.credit_5d_return_pct >= 0 ? "positive" : "negative"
+              }`}
+            >
+              {fmtPct(sig.credit_5d_return_pct)}
+            </div>
+            <div className="metric-change neutral">
+              {data.credit_proxy} @ ${fmtNum(sig.credit_price)}
+            </div>
+          </div>
+          <div className="metric-card">
+            <div className="metric-label">Residual</div>
+            <div className="metric-value">
+              {sig.residual != null ? sig.residual.toFixed(6) : "---"}
+            </div>
+            <div className="metric-change neutral">MODEL ε</div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Signal Detail + Attribution ─────────────────────── */}
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">
+            <Zap size={14} />
+            Signal Detail
+            <InfoTooltip text="Severity tier (1=critical, 2=high, 3=elevated), VVIX amplifier, and bounce conditions. Tier activates when ro=1 (Tier 1/2) or edr=1 (Tier 3)." />
+          </div>
+          <span
+            className="pill"
+            style={{
+              background: interpColor,
+              color:
+                sig.interpretation === "NORMAL" ||
+                sig.interpretation === "BOUNCE"
+                  ? "#000"
+                  : "#fff",
+              fontSize: "9px",
+            }}
+            data-testid="vcg-interpretation-pill"
+          >
+            {interpretationLabel(sig.interpretation)}
+          </span>
+        </div>
+
+        <div
+          className="metrics-grid"
+          style={{ gridTemplateColumns: "1fr 1fr" }}
+        >
+          {/* Left: Tier + VVIX severity + EDR/Bounce */}
+          <div className="metric-card" style={{ padding: "12px 16px" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                paddingBottom: "8px",
+                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "10px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "var(--text-muted)",
+                }}
+              >
+                Severity Tier
+              </span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  color: tierColor(sig.tier),
+                  background:
+                    sig.tier != null
+                      ? `${tierColor(sig.tier)}18`
+                      : "transparent",
+                  padding: "2px 8px",
+                  borderRadius: "999px",
+                  border:
+                    sig.tier != null
+                      ? `1px solid ${tierColor(sig.tier)}40`
+                      : "none",
+                }}
+                data-testid="vcg-tier-label"
+              >
+                {tierLabel(sig.tier)}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "8px 0",
+                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
+              }}
+            >
+              <div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "10px",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  VVIX Severity
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "9px",
+                    color: "var(--text-muted)",
+                    marginTop: "2px",
+                  }}
+                >
+                  {vvixSeverityDesc(sig.vvix_severity)}
+                </div>
+              </div>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  color: vvixSeverityColor(sig.vvix_severity),
+                  textTransform: "uppercase",
+                  marginLeft: "12px",
+                  flexShrink: 0,
+                }}
+                data-testid="vcg-vvix-severity"
+              >
+                {sig.vvix_severity}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "8px 0",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "10px",
+                  color: "var(--text-muted)",
+                }}
+              >
+                EDR
+              </span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  color: sig.edr === 1 ? "var(--warning)" : "var(--text-muted)",
+                }}
+                data-testid="vcg-edr-state"
+              >
+                {sig.edr === 1 ? "ACTIVE" : "INACTIVE"}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                paddingTop: "0",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "10px",
+                  color: "var(--text-muted)",
+                }}
+              >
+                Bounce
+              </span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  color:
+                    sig.bounce === 1
+                      ? "var(--signal-core, var(--positive))"
+                      : "var(--text-muted)",
+                }}
+                data-testid="vcg-bounce-state"
+              >
+                {sig.bounce === 1 ? "DETECTED" : "—"}
+              </span>
+            </div>
+          </div>
+
+          {/* Right: Attribution bars */}
+          <div className="metric-card" style={{ padding: "12px 16px" }}>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "10px",
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                color: "var(--text-muted)",
+                marginBottom: "8px",
+              }}
+            >
+              Attribution
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                marginBottom: "8px",
+              }}
+            >
+              <div
+                style={{
+                  flex: 1,
+                  height: "6px",
+                  borderRadius: "3px",
+                  background: "var(--bg-panel-raised, var(--bg-panel))",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    width: `${clampPct(attr.vvix_pct)}%`,
+                    height: "100%",
+                    background: "var(--extreme, var(--negative))",
+                    borderRadius: "3px",
+                  }}
+                  data-testid="vcg-attr-vvix-bar"
+                />
+              </div>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  color: "var(--text-primary)",
+                  minWidth: "60px",
+                }}
+              >
+                VVIX {clampPct(attr.vvix_pct).toFixed(0)}%
+              </span>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                marginBottom: "12px",
+              }}
+            >
+              <div
+                style={{
+                  flex: 1,
+                  height: "6px",
+                  borderRadius: "3px",
+                  background: "var(--bg-panel-raised, var(--bg-panel))",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    width: `${clampPct(attr.vix_pct)}%`,
+                    height: "100%",
+                    background: "var(--signal-core, var(--positive))",
+                    borderRadius: "3px",
+                  }}
+                  data-testid="vcg-attr-vix-bar"
+                />
+              </div>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  color: "var(--text-primary)",
+                  minWidth: "60px",
+                }}
+              >
+                VIX {clampPct(attr.vix_pct).toFixed(0)}%
+              </span>
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "10px",
+                color: "var(--text-muted)",
+                borderTop: "1px solid var(--border-dim, var(--line-grid))",
+                paddingTop: "8px",
+              }}
+            >
+              β₁(VVIX) = {fmtNum(sig.beta1_vvix, 6)} | β₂(VIX) ={" "}
+              {fmtNum(sig.beta2_vix, 6)}
+              {sig.sign_suppressed && (
+                <span style={{ color: "var(--warning)", marginLeft: "8px" }}>
+                  SIGN REVERSED
+                </span>
+              )}
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "10px",
+                color: "var(--text-muted)",
+                marginTop: "6px",
+              }}
+            >
+              VVIX {fmtNum(sig.vvix)} · VIX {fmtNum(sig.vix)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── History table (sortable) ────────────────────────── */}
+      <div className="section">
+        <div className="section-header">
+          <div className="section-title">VCG History (20d)</div>
+        </div>
+        <div className="section-body table-wrap">
+          <table data-testid="vcg-history-table">
+            <thead>
+              <tr>
+                {(
+                  [
+                    ["date", "Date", false],
+                    ["vcg", "VCG", true],
+                    ["vcg_adj", "VCG Adj", true],
+                    ["residual", "Residual", true],
+                    ["beta1", "β₁ (VVIX)", true],
+                    ["beta2", "β₂ (VIX)", true],
+                    ["vix", "VIX", true],
+                    ["vvix", "VVIX", true],
+                    ["credit", data.credit_proxy, true],
+                  ] as [VcgSortCol, string, boolean][]
+                ).map(([col, label, isRight]) => (
+                  <th
+                    key={col}
+                    className={`${isRight ? "right" : ""} sortable-th`}
+                    onClick={() => handleSort(col)}
+                    style={{
+                      cursor: "pointer",
+                      userSelect: "none",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {label}
+                    {sortIndicator(col, sortCol, sortDir)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sortHistory(history, sortCol, sortDir).map(
+                (h: VcgHistoryEntry) => (
+                  <tr key={h.date}>
+                    <td>{h.date}</td>
+                    <td
+                      className="right"
+                      style={{
+                        color:
+                          (h.vcg ?? 0) > 2
+                            ? "var(--fault, var(--negative))"
+                            : (h.vcg ?? 0) < -2
+                              ? "var(--warning)"
+                              : "var(--text-primary)",
+                      }}
+                    >
+                      {fmtZ(h.vcg)}
+                    </td>
+                    <td className="right">{fmtZ(h.vcg_adj)}</td>
+                    <td className="right">
+                      {h.residual != null ? h.residual.toFixed(6) : "---"}
+                    </td>
+                    <td className="right">
+                      {h.beta1 != null ? h.beta1.toFixed(6) : "---"}
+                    </td>
+                    <td className="right">
+                      {h.beta2 != null ? h.beta2.toFixed(6) : "---"}
+                    </td>
+                    <td className="right">{h.vix.toFixed(2)}</td>
+                    <td className="right">{h.vvix.toFixed(2)}</td>
+                    <td className="right">{h.credit.toFixed(2)}</td>
+                  </tr>
+                ),
+              )}
+              {history.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={9}
+                    style={{ textAlign: "center", color: "var(--text-muted)" }}
+                  >
+                    No history data
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VcgSubTab() {
+  const { data, syncing, syncNow } = useVcg();
+  return <VcgSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
+}

--- a/web/components/regime/VolBackdropStrip.tsx
+++ b/web/components/regime/VolBackdropStrip.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { fmtDecimal } from "@/lib/formatters";
+import {
+  useVolBackdrop,
+  type VolBackdropData,
+} from "@/lib/regime/useVolBackdrop";
+
+const SYMBOLS = ["VIX", "VIX3M", "VVIX", "COR1M"] as const;
+
+const labels: Record<(typeof SYMBOLS)[number], string> = {
+  VIX: "VIX",
+  VIX3M: "VIX3M",
+  VVIX: "VVIX",
+  COR1M: "COR1M",
+};
+
+const tooltips: Record<(typeof SYMBOLS)[number], string> = {
+  VIX: "S&P 500 30-day implied vol",
+  VIX3M: "S&P 500 3-month implied vol",
+  VVIX: "Vol-of-vol (VIX of VIX)",
+  COR1M: "1-month implied correlation among S&P components",
+};
+
+function lastClose(points: { close: number }[] | undefined): number | null {
+  if (!points || !points.length) return null;
+  return points[points.length - 1].close;
+}
+
+function pctChange(points: { close: number }[] | undefined): number | null {
+  if (!points || points.length < 2) return null;
+  const prev = points[points.length - 2].close;
+  const last = points[points.length - 1].close;
+  if (!prev) return null;
+  return ((last - prev) / prev) * 100;
+}
+
+export function VolBackdropStripView({
+  data,
+}: {
+  data: VolBackdropData | null;
+}) {
+  if (!data) return null;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${SYMBOLS.length + 1}, 1fr)`,
+        gap: 8,
+        padding: "12px 16px",
+        borderTop: "1px solid var(--border-dim)",
+        borderBottom: "1px solid var(--border-dim)",
+        background: "var(--bg-panel)",
+      }}
+    >
+      {SYMBOLS.map((s) => {
+        const close = lastClose(data.series[s]);
+        const chg = pctChange(data.series[s]);
+        return (
+          <div key={s} title={tooltips[s]}>
+            <div
+              style={{
+                fontSize: 10,
+                letterSpacing: "0.15em",
+                color: "var(--text-muted)",
+                textTransform: "uppercase",
+              }}
+            >
+              {labels[s]}
+            </div>
+            <div
+              style={{
+                fontSize: 18,
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {close != null ? fmtDecimal(close, 2) : "—"}
+            </div>
+            <div
+              style={{
+                fontSize: 11,
+                color:
+                  chg == null
+                    ? "var(--text-muted)"
+                    : chg >= 0
+                      ? "var(--positive)"
+                      : "var(--negative)",
+              }}
+            >
+              {chg != null
+                ? `${chg >= 0 ? "+" : ""}${fmtDecimal(chg, 2)}%`
+                : "—"}
+            </div>
+          </div>
+        );
+      })}
+
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.15em",
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+          }}
+        >
+          Term Structure
+        </div>
+        <div
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            fontFamily: "var(--font-mono)",
+            color:
+              data.term_structure_state === "backwardation"
+                ? "var(--warning)"
+                : "var(--text-primary)",
+          }}
+        >
+          {data.term_structure_ratio != null
+            ? fmtDecimal(data.term_structure_ratio, 3)
+            : "—"}
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color:
+              data.term_structure_state === "backwardation"
+                ? "var(--warning)"
+                : "var(--text-secondary)",
+          }}
+        >
+          {data.term_structure_state ?? "—"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VolBackdropStrip() {
+  const { data } = useVolBackdrop();
+  return <VolBackdropStripView data={data ?? null} />;
+}

--- a/web/components/regime/charts/ChartLegend.tsx
+++ b/web/components/regime/charts/ChartLegend.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ChartLegendItem } from "@/lib/regime/chartSystem";
+import { chartSeriesColor } from "@/lib/regime/chartSystem";
+
+type ChartLegendProps = {
+  items: ChartLegendItem[];
+  className?: string;
+};
+
+export default function ChartLegend({ items, className }: ChartLegendProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className={`chart-legend ${className ?? ""}`.trim()}>
+      {items.map((item) => (
+        <span
+          key={`${item.label}-${item.role ?? item.color ?? "custom"}`}
+          className="chart-legend-item"
+        >
+          <span
+            className="chart-legend-swatch"
+            style={{
+              background:
+                item.color ?? chartSeriesColor(item.role ?? "primary"),
+            }}
+          />
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/components/regime/charts/ChartPanel.tsx
+++ b/web/components/regime/charts/ChartPanel.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { ChartFamily, ChartLegendItem } from "@/lib/regime/chartSystem";
+import { chartFamilyLabel } from "@/lib/regime/chartSystem";
+import ChartLegend from "./ChartLegend";
+
+type ChartPanelProps = {
+  family: ChartFamily;
+  title: ReactNode;
+  icon?: ReactNode;
+  badge?: ReactNode;
+  legend?: ChartLegendItem[];
+  children: ReactNode;
+  className?: string;
+  bodyClassName?: string;
+  contentClassName?: string;
+  dataTestId?: string;
+  footer?: ReactNode;
+};
+
+export default function ChartPanel({
+  family,
+  title,
+  icon,
+  badge,
+  legend = [],
+  children,
+  className,
+  bodyClassName,
+  contentClassName,
+  dataTestId,
+  footer,
+}: ChartPanelProps) {
+  const chartFamily = chartFamilyLabel(family);
+
+  return (
+    <div
+      className={`section chart-panel ${className ?? ""}`.trim()}
+      data-testid={dataTestId}
+      data-chart-family={chartFamily}
+    >
+      <div className="section-header chart-panel-header">
+        <div className="chart-panel-heading">
+          <div className="chart-panel-kicker" data-chart-family={chartFamily}>
+            <span>{chartFamily}</span>
+          </div>
+          <div className="section-title chart-panel-title">
+            {icon ? (
+              <span className="chart-panel-icon" aria-hidden="true">
+                {icon}
+              </span>
+            ) : null}
+            <span>{title}</span>
+          </div>
+        </div>
+        {badge ? <div className="chart-panel-badge">{badge}</div> : null}
+      </div>
+      <div
+        className={`section-body chart-panel-body ${bodyClassName ?? ""}`.trim()}
+      >
+        {legend.length > 0 ? (
+          <ChartLegend items={legend} className="chart-panel-legend" />
+        ) : null}
+        <div className={`chart-panel-content ${contentClassName ?? ""}`.trim()}>
+          {children}
+        </div>
+        {footer ? <div className="chart-panel-footer">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/web/components/regime/ui/MetricCard.tsx
+++ b/web/components/regime/ui/MetricCard.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { ReactNode } from "react";
+import InfoTooltip from "../InfoTooltip";
+
+/**
+ * Shared metric card used by the GEX tab and the UW Analyze detail panel.
+ *
+ * Visuals are driven by the `.gex-metric-card` / `.gex-metric-label`
+ * stack in `web/app/globals.css`. Consumers place one or more of these
+ * inside a `.gex-metrics-row` wrapper.
+ */
+export function MetricCard({
+  label,
+  value,
+  sub,
+  color,
+  badge,
+  tooltip,
+}: {
+  label: string;
+  value: string;
+  sub?: ReactNode;
+  color?: string;
+  badge?: ReactNode;
+  tooltip?: string;
+}) {
+  return (
+    <div className="gex-metric-card">
+      <div
+        className="gex-metric-label"
+        style={{ display: "flex", alignItems: "center", gap: 4 }}
+      >
+        {label}
+        {tooltip && <InfoTooltip text={tooltip} />}
+        {badge}
+      </div>
+      <div
+        className="gex-metric-value"
+        style={{ color: color || "var(--text-primary)" }}
+      >
+        {value}
+      </div>
+      {sub != null && sub !== "" && <div className="gex-metric-sub">{sub}</div>}
+    </div>
+  );
+}
+
+/**
+ * Small colour-coded badge tagging the provenance of a metric.
+ * Kept here so both `GexPanel` and the UW Analyze detail panel can share
+ * the same visual without a re-export intermediate.
+ */
+export function SourceBadge({ source }: { source: "uw" | "mq" | "both" }) {
+  const styles: Record<string, React.CSSProperties> = {
+    uw: {
+      background: "rgba(15,110,86,0.18)",
+      color: "var(--signal-core)",
+      border: "0.5px solid rgba(15,110,86,0.4)",
+    },
+    mq: {
+      background: "rgba(56,138,221,0.15)",
+      color: "#85b7eb",
+      border: "0.5px solid rgba(56,138,221,0.35)",
+    },
+    both: {
+      background: "rgba(93,202,165,0.12)",
+      color: "var(--signal-core)",
+      border: "0.5px solid rgba(93,202,165,0.3)",
+    },
+  };
+  const labels = { uw: "UW", mq: "MQ", both: "UW+MQ" };
+  return (
+    <span
+      style={{
+        ...styles[source],
+        fontSize: 9,
+        fontWeight: 500,
+        padding: "1px 5px",
+        borderRadius: 2,
+        letterSpacing: "0.06em",
+      }}
+    >
+      {labels[source]}
+    </span>
+  );
+}

--- a/web/components/shared/Sidebar.tsx
+++ b/web/components/shared/Sidebar.tsx
@@ -1,13 +1,14 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, Radar, ScanLine } from "lucide-react";
+import { Activity, LayoutDashboard, Radar, ScanLine } from "lucide-react";
 import { HealthPanel } from "./HealthPanel";
 
 const NAV = [
   { href: "/", label: "Dashboard", icon: LayoutDashboard },
   { href: "/scanner", label: "Scanner", icon: ScanLine },
   { href: "/cockpit/SPY", label: "Cockpit", icon: Radar },
+  { href: "/regime", label: "Regime", icon: Activity },
 ];
 
 export function Sidebar() {

--- a/web/components/stock/panels/GexLevelTiles.tsx
+++ b/web/components/stock/panels/GexLevelTiles.tsx
@@ -2,7 +2,7 @@ import type { components } from "@/lib/types";
 import { toNum } from "@/lib/formatters";
 
 type Report = components["schemas"]["SingleStockReport"];
-type Level = components["schemas"]["GexLevel"];
+type Level = components["schemas"]["uw_scan__models__GexLevel"];
 
 const tileStyle: React.CSSProperties = {
   background: "var(--bg-panel)",

--- a/web/lib/regime/api.ts
+++ b/web/lib/regime/api.ts
@@ -9,4 +9,5 @@ export const regimeApi = {
     `${API}/api/regime/gex?ticker=${encodeURIComponent(ticker)}`,
   gex_scan: (ticker: string) =>
     `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
+  vol_backdrop: () => `${API}/api/regime/vol-backdrop`,
 } as const;

--- a/web/lib/regime/api.ts
+++ b/web/lib/regime/api.ts
@@ -1,0 +1,12 @@
+const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8400";
+
+export const regimeApi = {
+  cri: () => `${API}/api/regime`,
+  cri_scan: () => `${API}/api/regime/scan`,
+  vcg: () => `${API}/api/regime/vcg`,
+  vcg_scan: () => `${API}/api/regime/vcg/scan`,
+  gex: (ticker: string) =>
+    `${API}/api/regime/gex?ticker=${encodeURIComponent(ticker)}`,
+  gex_scan: (ticker: string) =>
+    `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
+} as const;

--- a/web/lib/regime/chart-system-spec.json
+++ b/web/lib/regime/chart-system-spec.json
@@ -1,0 +1,92 @@
+{
+  "version": "2026-03-11",
+  "surface": {
+    "backgroundVar": "--bg-panel",
+    "borderVar": "--border-dim",
+    "radiusPx": 4,
+    "paddingPx": 16,
+    "headerHeightPx": 32
+  },
+  "axis": {
+    "fontFamily": "IBM Plex Mono, monospace",
+    "fontSizePx": 10,
+    "trackingEm": 0.04,
+    "gridVar": "--chart-grid",
+    "axisVar": "--chart-axis",
+    "labelVar": "--chart-axis-muted"
+  },
+  "tooltip": {
+    "backgroundVar": "--chart-tooltip-bg",
+    "borderVar": "--chart-tooltip-border",
+    "shadow": "none"
+  },
+  "seriesRoles": {
+    "primary": {
+      "cssVar": "--signal-core",
+      "fallback": "#05AD98",
+      "description": "Primary structural signal"
+    },
+    "comparison": {
+      "cssVar": "--chart-series-comparison",
+      "fallback": "rgba(148, 163, 184, 0.72)",
+      "description": "Benchmark or baseline comparison"
+    },
+    "caution": {
+      "cssVar": "--warning",
+      "fallback": "#F5A623",
+      "description": "Caution or elevated risk"
+    },
+    "dislocation": {
+      "cssVar": "--dislocation",
+      "fallback": "#D946A8",
+      "description": "Structural dislocation"
+    },
+    "extreme": {
+      "cssVar": "--extreme",
+      "fallback": "#8B5CF6",
+      "description": "Extreme regime or rare state"
+    },
+    "fault": {
+      "cssVar": "--negative",
+      "fallback": "#E85D6C",
+      "description": "Operational fault or explicit downside exception"
+    },
+    "neutral": {
+      "cssVar": "--neutral",
+      "fallback": "#94A3B8",
+      "description": "Neutral supporting context"
+    }
+  },
+  "families": {
+    "live-trace": {
+      "label": "Live Trace",
+      "renderer": "canvas-adapter",
+      "interaction": "scrub",
+      "requiresAxes": false
+    },
+    "analytical-time-series": {
+      "label": "Analytical Time Series",
+      "renderer": "svg",
+      "interaction": "inspect",
+      "requiresAxes": true
+    },
+    "distribution-bar": {
+      "label": "Distribution Bar",
+      "renderer": "html-css-or-svg",
+      "interaction": "static",
+      "requiresAxes": false
+    },
+    "matrix-heatmap": {
+      "label": "Matrix Heatmap",
+      "renderer": "html-css-or-svg",
+      "interaction": "static",
+      "requiresAxes": false
+    }
+  },
+  "sanctionedRenderers": {
+    "canvas-adapter": "Allowed for high-frequency interactive traces where the interaction model is the main product value.",
+    "svg": "Default for operator charts that need shared frame, axis, and legend control.",
+    "d3-svg": "Allowed only when scale logic or interaction complexity materially exceeds the shared SVG primitives.",
+    "html-css-or-svg": "Allowed for compact bars, gauges, tables, and matrix layouts where DOM density is clearer than a plotted chart."
+  }
+}

--- a/web/lib/regime/chartSystem.ts
+++ b/web/lib/regime/chartSystem.ts
@@ -1,0 +1,43 @@
+import chartSystemSpec from "./chart-system-spec.json";
+
+export const REGIME_CHART_SYSTEM = chartSystemSpec;
+
+export type ChartSeriesRole = keyof typeof chartSystemSpec.seriesRoles;
+export type ChartFamily = keyof typeof chartSystemSpec.families;
+
+export type ChartLegendItem = {
+  label: string;
+  role?: ChartSeriesRole;
+  color?: string;
+};
+
+export function chartSeriesColor(role: ChartSeriesRole): string {
+  const series = chartSystemSpec.seriesRoles[role];
+  return `var(${series.cssVar}, ${series.fallback})`;
+}
+
+export function chartSeriesFallback(role: ChartSeriesRole): string {
+  return chartSystemSpec.seriesRoles[role].fallback;
+}
+
+export function resolveChartSeriesColor(
+  role: ChartSeriesRole,
+  root?: Element | null,
+): string {
+  const series = chartSystemSpec.seriesRoles[role];
+  const target =
+    root ?? (typeof document !== "undefined" ? document.documentElement : null);
+
+  if (!target || typeof getComputedStyle !== "function") {
+    return series.fallback;
+  }
+
+  const resolved = getComputedStyle(target)
+    .getPropertyValue(series.cssVar)
+    .trim();
+  return resolved || series.fallback;
+}
+
+export function chartFamilyLabel(family: ChartFamily): string {
+  return chartSystemSpec.families[family].label;
+}

--- a/web/lib/regime/pricesProtocol.ts
+++ b/web/lib/regime/pricesProtocol.ts
@@ -1,0 +1,207 @@
+export type PriceData = {
+  symbol: string;
+  last: number | null;
+  lastIsCalculated: boolean;
+  bid: number | null;
+  ask: number | null;
+  bidSize: number | null;
+  askSize: number | null;
+  volume: number | null;
+  high: number | null;
+  low: number | null;
+  open: number | null;
+  close: number | null;
+  // Misc Stats (generic tick 165)
+  week52High: number | null;
+  week52Low: number | null;
+  avgVolume: number | null;
+  delta: number | null;
+  gamma: number | null;
+  theta: number | null;
+  vega: number | null;
+  impliedVol: number | null;
+  undPrice: number | null;
+  timestamp: string;
+};
+
+
+export type FundamentalsData = {
+  symbol: string;
+  peRatio: number | null;
+  eps: number | null;
+  dividendYield: number | null;
+  week52High: number | null;
+  week52Low: number | null;
+  priceBookRatio: number | null;
+  roe: number | null;
+  revenue: number | null;
+  timestamp: string;
+};
+
+export type WSPriceMessage = {
+  type: "price";
+  symbol: string;
+  data: PriceData;
+};
+
+export type WSSubscribedMessage = {
+  type: "subscribed";
+  symbols: string[];
+};
+
+export type WSUnsubscribedMessage = {
+  type: "unsubscribed";
+  symbols: string[];
+};
+
+export type WSSnapshotMessage = {
+  type: "snapshot";
+  symbol: string;
+  data: PriceData;
+};
+
+export type WSFundamentalsMessage = {
+  type: "fundamentals";
+  symbol: string;
+  data: FundamentalsData;
+};
+
+export type WSErrorMessage = {
+  type: "error";
+  message: string;
+};
+
+export type WSPingMessage = {
+  type: "ping";
+};
+
+export type WSPongMessage = {
+  type: "pong";
+};
+
+export type WSStatusMessage = {
+  type: "status";
+  ib_connected: boolean;
+  ib_issue: string | null;
+  ib_status_message: string | null;
+  subscriptions: string[];
+};
+
+export type WSBatchMessage = {
+  type: "batch";
+  updates: Record<string, PriceData>;
+};
+
+export type WSMessage =
+  | WSPriceMessage
+  | WSFundamentalsMessage
+  | WSSubscribedMessage
+  | WSUnsubscribedMessage
+  | WSSnapshotMessage
+  | WSBatchMessage
+  | WSErrorMessage
+  | WSPingMessage
+  | WSPongMessage
+  | WSStatusMessage;
+
+/* ─── Option contract types & helpers ─────────────────── */
+
+export type OptionContract = {
+  symbol: string;
+  expiry: string; // YYYYMMDD
+  strike: number;
+  right: "C" | "P";
+};
+
+export function normalizeOptionExpiry(expiry: string): string | null {
+  const compact = expiry.trim().replace(/-/g, "");
+  return compact.length === 8 ? compact : null;
+}
+
+export function normalizeOptionContract(contract: OptionContract): OptionContract | null {
+  const symbol = contract.symbol.trim().toUpperCase();
+  const expiry = normalizeOptionExpiry(contract.expiry);
+  if (!symbol || !expiry || !Number.isFinite(contract.strike) || contract.strike <= 0) {
+    return null;
+  }
+  return {
+    symbol,
+    expiry,
+    strike: contract.strike,
+    right: contract.right,
+  };
+}
+
+/** Build composite key for an option contract: SYMBOL_YYYYMMDD_STRIKE_RIGHT */
+export function optionKey(c: OptionContract): string {
+  const normalized = normalizeOptionContract(c);
+  if (normalized) {
+    return `${normalized.symbol}_${normalized.expiry}_${normalized.strike}_${normalized.right}`;
+  }
+  return `${c.symbol.trim().toUpperCase()}_${c.expiry.trim()}_${c.strike}_${c.right}`;
+}
+
+export function uniqueOptionContracts(contracts: OptionContract[]): OptionContract[] {
+  const seen = new Set<string>();
+  const normalizedContracts: OptionContract[] = [];
+  for (const contract of contracts) {
+    const normalized = normalizeOptionContract(contract);
+    if (!normalized) continue;
+    const key = optionKey(normalized);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalizedContracts.push(normalized);
+  }
+  return normalizedContracts;
+}
+
+/** Stable hash for a list of option contracts (for memoization change detection) */
+export function contractsKey(contracts: OptionContract[]): string {
+  return uniqueOptionContracts(contracts)
+    .map(optionKey)
+    .sort()
+    .join(",");
+}
+
+/**
+ * Convert a portfolio leg into an IB-ready OptionContract descriptor.
+ * Returns null for Stock legs, null/0 strikes, or missing data.
+ */
+export function portfolioLegToContract(
+  ticker: string,
+  expiry: string,
+  leg: { type: string; strike: number | null },
+): OptionContract | null {
+  if (leg.type === "Stock") return null;
+  if (leg.strike == null || leg.strike === 0) return null;
+  if (!expiry || expiry === "N/A") return null;
+
+  const right = leg.type === "Call" ? "C" : leg.type === "Put" ? "P" : null;
+  if (!right) return null;
+
+  return normalizeOptionContract({
+    symbol: ticker.toUpperCase(),
+    expiry,
+    strike: leg.strike,
+    right,
+  });
+}
+
+/* ─── Index contract types ────────────────────────────── */
+
+export type IndexContract = {
+  symbol: string;
+  exchange: string; // e.g. "CBOE"
+};
+
+/* ─── Symbol helpers ──────────────────────────────────── */
+
+export function normalizeSymbolList(symbols: string[]): string[] {
+  return [...symbols]
+    .map((symbol) => symbol.trim().toUpperCase())
+    .filter((symbol) => symbol.length > 0);
+}
+
+export function symbolKey(symbols: string[]): string {
+  return normalizeSymbolList(symbols).sort().join(",");
+}

--- a/web/lib/regime/types.ts
+++ b/web/lib/regime/types.ts
@@ -13,6 +13,3 @@ export type MqLevels = components["schemas"]["GexMqLevels"];
 export type SourceDelta = components["schemas"]["GexSourceDelta"];
 export type SourceDeltaEntry = components["schemas"]["GexSourceDeltaEntry"];
 export type IvData = components["schemas"]["GexIvData"];
-
-export type RegimePendingResponse =
-  components["schemas"]["RegimePendingResponse"];

--- a/web/lib/regime/types.ts
+++ b/web/lib/regime/types.ts
@@ -1,0 +1,18 @@
+import type { components } from "@/lib/types";
+
+export type GexData = components["schemas"]["GexResponse"];
+export type GexLevel =
+  | components["schemas"]["uw_scan__api__schemas__GexLevel"]
+  | null;
+export type GexLevels = components["schemas"]["GexLevels"];
+export type GexBucket = components["schemas"]["GexBucket"];
+export type GexBias = components["schemas"]["GexBias"];
+export type GexHistoryEntry = components["schemas"]["GexHistoryEntry"];
+export type GexExpectedRange = components["schemas"]["GexExpectedRange"];
+export type MqLevels = components["schemas"]["GexMqLevels"];
+export type SourceDelta = components["schemas"]["GexSourceDelta"];
+export type SourceDeltaEntry = components["schemas"]["GexSourceDeltaEntry"];
+export type IvData = components["schemas"]["GexIvData"];
+
+export type RegimePendingResponse =
+  components["schemas"]["RegimePendingResponse"];

--- a/web/lib/regime/useCri.ts
+++ b/web/lib/regime/useCri.ts
@@ -15,6 +15,8 @@ export function useCri(): UseSyncReturn<CriResponse> {
   return useSyncHook<CriResponse>(
     {
       endpoint: regimeApi.cri(),
+      // GET reads from /api/regime; manual Sync Now must hit /api/regime/scan.
+      postEndpoint: regimeApi.cri_scan(),
       interval: 3_600_000, // 1h — CRI inputs (vol indices + SPY OHLC) update daily
       hasPost: true,
       extractTimestamp: (d) => d.scan_time || null,

--- a/web/lib/regime/useCri.ts
+++ b/web/lib/regime/useCri.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type CriResponse = components["schemas"]["CriResponse"];
+export type CriBlock = components["schemas"]["CriBlock"];
+export type CriComponents = components["schemas"]["CriComponents"];
+export type CtaBlock = components["schemas"]["CtaBlock"];
+export type CrashTriggerBlock = components["schemas"]["CrashTriggerBlock"];
+export type CriHistoryEntry = components["schemas"]["CriHistoryEntry"];
+
+export function useCri(): UseSyncReturn<CriResponse> {
+  return useSyncHook<CriResponse>(
+    {
+      endpoint: regimeApi.cri(),
+      interval: 3_600_000, // 1h — CRI inputs (vol indices + SPY OHLC) update daily
+      hasPost: true,
+      extractTimestamp: (d) => d.scan_time || null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "POST",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useGex.ts
+++ b/web/lib/regime/useGex.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import { regimeApi } from "./api";
+import { MarketState } from "./useMarketHours";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+/* ─── GEX types (mirror xenon's gex_scan.py JSON output) ─────── */
+
+export type GexLevel = {
+  strike: number;
+  gamma: number;
+  distance: number;
+  distance_pct: number;
+} | null;
+
+export type GexBucket = {
+  strike: number;
+  call_gex: number;
+  put_gex: number;
+  net_gex: number;
+  pct_from_spot: number;
+  tag: string | null;
+};
+
+export type GexBias = {
+  direction: "BULL" | "CAUTIOUS_BULL" | "NEUTRAL" | "CAUTIOUS_BEAR" | "BEAR";
+  reasons: string[];
+  days_above_flip: number;
+  flip_migration: { date: string; flip: number }[];
+};
+
+export type GexHistoryEntry = {
+  date: string;
+  net_gex: number;
+  net_dex: number;
+  gex_flip: number | null;
+  spot: number;
+  atm_iv: number | null;
+  vol_pc: number | null;
+  bias: string | null;
+};
+
+export type MqLevels = {
+  source_date: string | null;
+  spot: number | null;
+  hvl: number | null;
+  call_resistance_all: number | null;
+  call_resistance_0dte: number | null;
+  put_support_all: number | null;
+  put_support_0dte: number | null;
+  expected_high: number | null;
+  expected_low: number | null;
+  distance_to_hvl_pct: string | null;
+  iv30d: number | null;
+  hv30: number | null;
+  iv_rank: string | null;
+  top_gex_strikes: number[];
+};
+
+export type SourceDeltaEntry = { uw: number; mq: number; delta: number };
+export type SourceDelta = {
+  flip_vs_hvl?: SourceDeltaEntry;
+  put_wall_vs_support_all?: SourceDeltaEntry;
+  put_wall_vs_support_0dte?: SourceDeltaEntry;
+  call_wall_vs_resistance_all?: SourceDeltaEntry;
+  call_wall_vs_resistance_0dte?: SourceDeltaEntry;
+};
+
+export type IvData = {
+  iv30d: number | null;
+  iv_rank: number | null;
+  hv30: number | null;
+  mq_iv30d: number | null;
+  mq_iv_rank: string | null;
+  source: "uw" | "mq" | "both" | null;
+};
+
+export type GexData = {
+  scan_time: string;
+  market_open: boolean;
+  ticker: string;
+  spot: number;
+  close: number | null;
+  day_change: number | null;
+  day_change_pct: number | null;
+  data_date: string;
+  net_gex: number;
+  net_dex: number;
+  atm_iv: number | null;
+  vol_pc: number | null;
+  levels: {
+    gex_flip: GexLevel;
+    max_magnet: GexLevel;
+    second_magnet: GexLevel;
+    max_accelerator: GexLevel;
+    put_wall: GexLevel;
+    call_wall: GexLevel;
+  };
+  profile: GexBucket[];
+  expected_range: {
+    low: number | null;
+    high: number | null;
+    iv_1d: number | null;
+  };
+  bias: GexBias;
+  history: GexHistoryEntry[];
+  iv: IvData | null;
+  mq: MqLevels | null;
+  source_delta: SourceDelta | null;
+};
+
+/* ─── Staleness check ────────────────────────────────────────── */
+
+function todayET(): string {
+  return new Date().toLocaleDateString("sv", {
+    timeZone: "America/New_York",
+  });
+}
+
+function needsGexRetry(data: GexData | null | undefined): boolean {
+  if (!data?.scan_time) return true;
+  try {
+    const scanDate = new Date(data.scan_time).toLocaleDateString("sv", {
+      timeZone: "America/New_York",
+    });
+    return scanDate !== todayET();
+  } catch {
+    return true;
+  }
+}
+
+/* ─── Hook ───────────────────────────────────────────────────── */
+
+export function useGex(
+  marketState: MarketState | null = null,
+  ticker: string = "SPX",
+): UseSyncReturn<GexData> {
+  let active: boolean;
+  if (
+    marketState === MarketState.OPEN ||
+    marketState === MarketState.EXTENDED
+  ) {
+    active = true;
+  } else if (marketState === MarketState.CLOSED) {
+    active = false;
+  } else {
+    active = true;
+  }
+
+  const config = {
+    endpoint: regimeApi.gex(ticker),
+    interval: marketState === MarketState.EXTENDED ? 300_000 : 60_000,
+    hasPost: false,
+    extractTimestamp: (d: GexData) => d.scan_time || null,
+    shouldRetry: (d: GexData) => needsGexRetry(d),
+    retryIntervalMs: 5000,
+    retryMethod: "GET" as const,
+  };
+
+  return useSyncHook<GexData>(config, active);
+}

--- a/web/lib/regime/useGex.ts
+++ b/web/lib/regime/useGex.ts
@@ -81,6 +81,10 @@ export type GexData = {
   ticker: string;
   spot: number;
   close: number | null;
+  prev_close: number | null;
+  market_time: string | null;
+  tape_time: string | null;
+  spot_source: string | null;
   day_change: number | null;
   day_change_pct: number | null;
   data_date: string;

--- a/web/lib/regime/useMarketHours.ts
+++ b/web/lib/regime/useMarketHours.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * Market state enum representing different trading time periods in ET.
+ * - OPEN: Regular trading hours (9:30 AM - 4:00 PM ET)
+ * - EXTENDED: Extended hours (4:00 AM - 9:30 AM OR 4:00 PM - 8:00 PM ET)
+ * - CLOSED: Market closed (weekends or 8:00 PM - 4:00 AM ET)
+ *
+ * Note: This does NOT account for US market holidays. Holidays are rare (~10/year)
+ * and not handling them does not introduce resource waste at the target scale.
+ */
+export enum MarketState {
+  OPEN = "open",
+  EXTENDED = "extended",
+  CLOSED = "closed",
+}
+
+/**
+ * Hook that returns the current market state based on Eastern Time.
+ * Updates every minute (sufficient for market hour boundaries).
+ *
+ * @returns Current MarketState (OPEN, EXTENDED, or CLOSED)
+ */
+export function useMarketHours(): MarketState {
+  const [state, setState] = useState<MarketState>(MarketState.CLOSED);
+
+  useEffect(() => {
+    /**
+     * Compute current market state based on ET time.
+     */
+    const check = () => {
+      const now = new Date();
+      const et = new Date(
+        now.toLocaleString("en-US", { timeZone: "America/New_York" }),
+      );
+      const day = et.getDay(); // 0=Sun, 6=Sat
+
+      // CLOSED on weekends (Saturdays and Sundays)
+      if (day === 0 || day === 6) {
+        setState(MarketState.CLOSED);
+        return;
+      }
+
+      const minutes = et.getHours() * 60 + et.getMinutes();
+
+      // Regular trading hours: 9:30 AM - 4:00 PM ET, half-open interval.
+      // IMPORTANT: `< 16*60` (not `<=`) so that at exactly 16:00 we agree
+      // with the Python backend's `is_market_open()` which uses the same
+      // half-open definition. Without this, frontend and backend disagree
+      // for a 60-second window at close and the UI ends up polling a gated
+      // backend. See silly-humming-tide.md §4 + Codex issue C4.
+      if (minutes >= 9 * 60 + 30 && minutes < 16 * 60) {
+        setState(MarketState.OPEN);
+      }
+      // Extended hours: Premarket (4:00 AM - 9:30 AM) or After Hours
+      // (4:00 PM - 8:00 PM). 16:00 now falls into EXTENDED, not OPEN.
+      else if (
+        (minutes >= 4 * 60 && minutes < 9 * 60 + 30) ||
+        (minutes >= 16 * 60 && minutes <= 20 * 60)
+      ) {
+        setState(MarketState.EXTENDED);
+      }
+      // Overnight: 8:00 PM - 4:00 AM
+      else {
+        setState(MarketState.CLOSED);
+      }
+    };
+
+    // Check immediately on mount
+    check();
+
+    // Re-check every minute (sufficient for market hour boundaries)
+    const interval = setInterval(check, 60_000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return state;
+}

--- a/web/lib/regime/useSyncHook.ts
+++ b/web/lib/regime/useSyncHook.ts
@@ -14,6 +14,11 @@ const _syncCache = new Map<string, SyncCacheEntry>();
 
 type UseSyncConfig<T> = {
   endpoint: string;
+  // Optional POST target. When the GET / sync paths differ (e.g. CRI
+  // reads `/api/regime` but the scan path is `/api/regime/scan`), set
+  // this to the scan path so the manual Sync Now button actually fires.
+  // Defaults to `endpoint`.
+  postEndpoint?: string;
   interval?: number;
   hasPost?: boolean; // default true; false = GET-only polling
   extractTimestamp?: (data: T) => string | null;
@@ -38,6 +43,7 @@ export function useSyncHook<T>(
 ): UseSyncReturn<T> {
   const {
     endpoint,
+    postEndpoint,
     interval = DEFAULT_INTERVAL_MS,
     hasPost = true,
     extractTimestamp,
@@ -46,6 +52,7 @@ export function useSyncHook<T>(
     retryMethod = "POST",
     showBackgroundError = false,
   } = config;
+  const resolvedPostEndpoint = postEndpoint ?? endpoint;
 
   // Re-hydrate from the per-endpoint module-level cache so re-mounts
   // (e.g. user navigates away from /flow-analysis and back) display the
@@ -65,6 +72,12 @@ export function useSyncHook<T>(
   const didInitialSync = useRef(false);
   const didInitialRead = useRef(false);
   const initialLoadKeyRef = useRef<string | null>(null);
+  // Monotonic id for race-protection. Each call to executeRequest claims
+  // the next id (and overwrites latestRequestIdRef); when the awaited
+  // fetch resolves, we only commit state if no newer request has started
+  // in the meantime — prevents a slow background tick from clobbering a
+  // fresher manual Sync Now result.
+  const latestRequestIdRef = useRef(0);
   const requestRef = useRef<
     (method: RetryMethod, background?: boolean) => Promise<void>
   >(async () => {});
@@ -81,15 +94,34 @@ export function useSyncHook<T>(
       if (!background && method === "POST") {
         setSyncing(true);
       }
+      const myId = ++latestRequestIdRef.current;
       try {
-        const res = await fetch(endpoint, { method });
+        const url = method === "POST" ? resolvedPostEndpoint : endpoint;
+        const res = await fetch(url, { method });
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
           throw new Error(
             (body as { error?: string }).error ?? `Sync failed (${res.status})`,
           );
         }
-        const json = (await res.json()) as T;
+        // When the POST target differs from the GET endpoint, the POST
+        // response is a scan-status payload (e.g. {status, row_id}) — NOT the
+        // GET shape. Don't stuff that into `data`. Re-fetch the GET endpoint
+        // instead so the UI always renders against the persisted snapshot.
+        let json: T;
+        if (method === "POST" && resolvedPostEndpoint !== endpoint) {
+          await res.json().catch(() => ({}));
+          const refresh = await fetch(endpoint, { method: "GET" });
+          if (!refresh.ok) {
+            throw new Error(`Refresh after scan failed (${refresh.status})`);
+          }
+          json = (await refresh.json()) as T;
+        } else {
+          json = (await res.json()) as T;
+        }
+        // Drop the result if a newer request has already started — prevents
+        // a slow background tick from clobbering a fresher manual sync.
+        if (myId !== latestRequestIdRef.current) return;
         const stamp = extractTimestamp
           ? extractTimestamp(json)
           : new Date().toISOString();
@@ -105,6 +137,9 @@ export function useSyncHook<T>(
           }, retryIntervalMs);
         }
       } catch (err) {
+        // Same race guard for the error path — a superseded request shouldn't
+        // overwrite a fresher one's error/data state either.
+        if (myId !== latestRequestIdRef.current) return;
         // Only show error if we don't already have valid cached data —
         // unless the caller explicitly wants the stale view marked as degraded.
         setData((prev) => {
@@ -123,6 +158,7 @@ export function useSyncHook<T>(
       active,
       clearRetry,
       endpoint,
+      resolvedPostEndpoint,
       extractTimestamp,
       retryIntervalMs,
       retryMethod,

--- a/web/lib/regime/useSyncHook.ts
+++ b/web/lib/regime/useSyncHook.ts
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+type RetryMethod = "GET" | "POST";
+
+// Module-level per-endpoint cache. Survives unmount/remount of any
+// component that uses this hook within the same browser session, so
+// navigating away from /flow-analysis (etc.) and coming back paints the
+// last known data immediately while a background revalidation runs.
+type SyncCacheEntry = { data: unknown; lastSync: string | null };
+const _syncCache = new Map<string, SyncCacheEntry>();
+
+type UseSyncConfig<T> = {
+  endpoint: string;
+  interval?: number;
+  hasPost?: boolean; // default true; false = GET-only polling
+  extractTimestamp?: (data: T) => string | null;
+  shouldRetry?: (data: T) => boolean;
+  retryIntervalMs?: number;
+  retryMethod?: RetryMethod;
+  showBackgroundError?: boolean;
+};
+
+export type UseSyncReturn<T> = {
+  data: T | null;
+  loading: boolean;
+  syncing: boolean;
+  error: string | null;
+  lastSync: string | null;
+  syncNow: () => void;
+};
+
+export function useSyncHook<T>(
+  config: UseSyncConfig<T>,
+  active: boolean,
+): UseSyncReturn<T> {
+  const {
+    endpoint,
+    interval = DEFAULT_INTERVAL_MS,
+    hasPost = true,
+    extractTimestamp,
+    shouldRetry,
+    retryIntervalMs = 0,
+    retryMethod = "POST",
+    showBackgroundError = false,
+  } = config;
+
+  // Re-hydrate from the per-endpoint module-level cache so re-mounts
+  // (e.g. user navigates away from /flow-analysis and back) display the
+  // last known data immediately. Background revalidation still runs.
+  const cachedEntry = _syncCache.get(endpoint);
+  const [data, setData] = useState<T | null>(
+    (cachedEntry?.data as T | undefined) ?? null,
+  );
+  const [loading, setLoading] = useState(cachedEntry == null);
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastSync, setLastSync] = useState<string | null>(
+    cachedEntry?.lastSync ?? null,
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const didInitialSync = useRef(false);
+  const didInitialRead = useRef(false);
+  const initialLoadKeyRef = useRef<string | null>(null);
+  const requestRef = useRef<
+    (method: RetryMethod, background?: boolean) => Promise<void>
+  >(async () => {});
+
+  const clearRetry = useCallback(() => {
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const executeRequest = useCallback(
+    async (method: RetryMethod, background = false) => {
+      if (!background && method === "POST") {
+        setSyncing(true);
+      }
+      try {
+        const res = await fetch(endpoint, { method });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            (body as { error?: string }).error ?? `Sync failed (${res.status})`,
+          );
+        }
+        const json = (await res.json()) as T;
+        const stamp = extractTimestamp
+          ? extractTimestamp(json)
+          : new Date().toISOString();
+        setData(json);
+        setLastSync(stamp);
+        setError(null);
+        _syncCache.set(endpoint, { data: json, lastSync: stamp });
+
+        clearRetry();
+        if (shouldRetry?.(json) && retryIntervalMs > 0) {
+          retryTimeoutRef.current = setTimeout(() => {
+            void requestRef.current(retryMethod, true);
+          }, retryIntervalMs);
+        }
+      } catch (err) {
+        // Only show error if we don't already have valid cached data —
+        // unless the caller explicitly wants the stale view marked as degraded.
+        setData((prev) => {
+          if (!prev || showBackgroundError) {
+            setError(err instanceof Error ? err.message : "Sync failed");
+          }
+          return prev;
+        });
+      } finally {
+        if (!background && method === "POST") {
+          setSyncing(false);
+        }
+      }
+    },
+    [
+      active,
+      clearRetry,
+      endpoint,
+      extractTimestamp,
+      retryIntervalMs,
+      retryMethod,
+      shouldRetry,
+      showBackgroundError,
+    ],
+  );
+
+  requestRef.current = executeRequest;
+
+  const triggerSync = useCallback(async () => {
+    const method = hasPost ? "POST" : "GET";
+    await executeRequest(method, false);
+  }, [executeRequest, hasPost]);
+
+  // Initial fetch — always read the cached file once when the hook mounts.
+  // `active=false` should disable polling and background sync, not blank the page.
+  useEffect(() => {
+    if (initialLoadKeyRef.current === endpoint) return;
+    initialLoadKeyRef.current = endpoint;
+
+    const init = async () => {
+      try {
+        const res = await fetch(endpoint, { method: "GET" });
+        if (!res.ok) throw new Error("Failed to fetch cached data");
+        const json = (await res.json()) as T;
+        const stamp = extractTimestamp ? extractTimestamp(json) : null;
+        setData(json);
+        setLastSync(stamp);
+        setError(null);
+        setLoading(false);
+        didInitialRead.current = true;
+        _syncCache.set(endpoint, { data: json, lastSync: stamp });
+
+        clearRetry();
+        if (shouldRetry?.(json) && retryIntervalMs > 0) {
+          retryTimeoutRef.current = setTimeout(() => {
+            void requestRef.current(retryMethod, true);
+          }, retryIntervalMs);
+        }
+
+        // Auto-sync on first load when the hook is active.
+        if (active && !didInitialSync.current) {
+          didInitialSync.current = true;
+          void triggerSync();
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+        setLoading(false);
+        didInitialRead.current = true;
+        if (active && !didInitialSync.current) {
+          didInitialSync.current = true;
+          void triggerSync();
+        }
+      }
+    };
+
+    void init();
+  }, [
+    active,
+    clearRetry,
+    endpoint,
+    triggerSync,
+    extractTimestamp,
+    retryIntervalMs,
+    retryMethod,
+    shouldRetry,
+  ]);
+
+  // If the hook mounted while inactive, issue the first sync when it later becomes active.
+  useEffect(() => {
+    if (!active || !didInitialRead.current || didInitialSync.current) return;
+    didInitialSync.current = true;
+    void triggerSync();
+  }, [active, triggerSync]);
+
+  // Auto-sync interval (only when active)
+  useEffect(() => {
+    if (!active || interval <= 0) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      void triggerSync();
+    }, interval);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [active, clearRetry, interval, triggerSync]);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      clearRetry();
+    };
+  }, [clearRetry]);
+
+  const syncNow = useCallback(() => {
+    void triggerSync();
+  }, [triggerSync]);
+
+  return { data, loading, syncing, error, lastSync, syncNow };
+}

--- a/web/lib/regime/useVcg.ts
+++ b/web/lib/regime/useVcg.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type VcgResponse = components["schemas"]["VcgResponse"];
+export type VcgSignal = components["schemas"]["VcgSignal"];
+export type VcgHistoryEntry = components["schemas"]["VcgHistoryEntry"];
+export type VcgAttribution = components["schemas"]["VcgAttribution"];
+
+export function useVcg(): UseSyncReturn<VcgResponse> {
+  return useSyncHook<VcgResponse>(
+    {
+      endpoint: regimeApi.vcg(),
+      // GET reads /api/regime/vcg; Sync Now must hit /api/regime/vcg/scan.
+      postEndpoint: regimeApi.vcg_scan(),
+      interval: 3_600_000, // 1h — VCG inputs (VIX / VVIX / credit OHLC) are daily
+      hasPost: true,
+      extractTimestamp: (d) => d.scan_time || null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "POST",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useVolBackdrop.ts
+++ b/web/lib/regime/useVolBackdrop.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type VolBackdropPoint = { date: string; close: number };
+
+export type VolBackdropData = {
+  series: Record<"VIX" | "VIX3M" | "VVIX" | "COR1M", VolBackdropPoint[]>;
+  term_structure_ratio: number | null;
+  term_structure_state: "contango" | "backwardation" | null;
+  as_of: string | null;
+};
+
+export function useVolBackdrop(): UseSyncReturn<VolBackdropData> {
+  return useSyncHook<VolBackdropData>(
+    {
+      endpoint: regimeApi.vol_backdrop(),
+      interval: 3_600_000, // 1h — slow data
+      hasPost: false,
+      extractTimestamp: (d) => d.as_of,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "GET",
+    },
+    true,
+  );
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -520,7 +520,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Trigger Cri Scan */
+        /**
+         * Trigger Cri Scan
+         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
+         */
         post: operations["trigger_cri_scan_api_regime_scan_post"];
         delete?: never;
         options?: never;
@@ -870,6 +873,194 @@ export interface components {
             market_date: string;
             /** Points */
             points?: components["schemas"]["CockpitVrpPoint"][];
+        };
+        /** CrashTriggerBlock */
+        CrashTriggerBlock: {
+            /**
+             * Fired
+             * @default false
+             */
+            fired: boolean;
+            /**
+             * Triggered
+             * @default false
+             */
+            triggered: boolean;
+            conditions?: components["schemas"]["CrashTriggerConditions"];
+            values?: components["schemas"]["CrashTriggerValues"];
+        };
+        /** CrashTriggerConditions */
+        CrashTriggerConditions: {
+            /**
+             * Spx Below 100D Ma
+             * @default false
+             */
+            spx_below_100d_ma: boolean;
+            /**
+             * Realized Vol Gt 25
+             * @default false
+             */
+            realized_vol_gt_25: boolean;
+            /**
+             * Cor1M Gt 60
+             * @default false
+             */
+            cor1m_gt_60: boolean;
+        };
+        /** CrashTriggerValues */
+        CrashTriggerValues: {
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+        };
+        /** CriBlock */
+        CriBlock: {
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
+            /**
+             * Level
+             * @default LOW
+             * @enum {string}
+             */
+            level: "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
+            components?: components["schemas"]["CriComponents"];
+        };
+        /**
+         * CriComponents
+         * @description Four 0-25 component scores summed into the composite 0-100.
+         */
+        CriComponents: {
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
+            /**
+             * Correlation
+             * @default 0
+             */
+            correlation: number;
+            /**
+             * Momentum
+             * @default 0
+             */
+            momentum: number;
+        };
+        /** CriHistoryEntry */
+        CriHistoryEntry: {
+            /** Date */
+            date: string;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Spx Vs Ma Pct */
+            spx_vs_ma_pct?: number | null;
+            /** Vix 5D Roc */
+            vix_5d_roc?: number | null;
+        };
+        /**
+         * CriResponse
+         * @description Crash Risk Indicator snapshot (latest scan).
+         */
+        CriResponse: {
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Date */
+            date?: string | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Vix 5D Roc */
+            vix_5d_roc?: number | null;
+            /** Vvix Vix Ratio */
+            vvix_vix_ratio?: number | null;
+            /** Spx 100D Ma */
+            spx_100d_ma?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Spy Closes */
+            spy_closes?: number[];
+        };
+        /**
+         * CriScanResponse
+         * @description Response body for POST /api/regime/scan.
+         */
+        CriScanResponse: {
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
+            /**
+             * Scanner
+             * @default cri
+             * @constant
+             */
+            scanner: "cri";
+            /** Row Id */
+            row_id?: number | null;
+            /** Reason */
+            reason?: string | null;
+        };
+        /** CtaBlock */
+        CtaBlock: {
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Exposure Pct */
+            exposure_pct?: number | null;
+            /** Forced Reduction Pct */
+            forced_reduction_pct?: number | null;
+            /**
+             * Forced Reduction
+             * @default false
+             */
+            forced_reduction: boolean;
+            /** Est Selling Bn */
+            est_selling_bn?: number | null;
+            /** Selling Usd B */
+            selling_usd_b?: number | null;
         };
         /** DivergencePoint */
         DivergencePoint: {
@@ -4216,7 +4407,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RegimePendingResponse"];
+                    "application/json": components["schemas"]["CriResponse"];
                 };
             };
         };
@@ -4236,7 +4427,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RegimePendingResponse"];
+                    "application/json": components["schemas"]["CriScanResponse"];
                 };
             };
         };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -477,6 +477,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/regime/vol-backdrop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vol Backdrop */
+        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/regime": {
         parameters: {
             query?: never;
@@ -2901,6 +2918,32 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /** VolBackdropPoint */
+        VolBackdropPoint: {
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Close */
+            close: number;
+        };
+        /**
+         * VolBackdropResponse
+         * @description Vol-complex time series + VIX term-structure (regime page header strip).
+         */
+        VolBackdropResponse: {
+            /** Series */
+            series?: {
+                [key: string]: components["schemas"]["VolBackdropPoint"][];
+            };
+            /** Term Structure Ratio */
+            term_structure_ratio?: number | null;
+            /** Term Structure State */
+            term_structure_state?: string | null;
+            /** As Of */
+            as_of?: string | null;
+        };
         /** VolHeaderBlock */
         VolHeaderBlock: {
             /** Iv */
@@ -4114,6 +4157,37 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vol_backdrop_api_regime_vol_backdrop_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolBackdropResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1117,6 +1117,14 @@ export interface components {
             spot?: number | null;
             /** Close */
             close?: number | null;
+            /** Prev Close */
+            prev_close?: number | null;
+            /** Market Time */
+            market_time?: string | null;
+            /** Tape Time */
+            tape_time?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
             /** Day Change */
             day_change?: number | null;
             /** Day Change Pct */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4,6 +4,91 @@
  */
 
 export interface paths {
+    "/api/cockpit/{ticker}/dealer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Dealer */
+        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/flow-im": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Flow Im */
+        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit State */
+        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/surface": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Surface */
+        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/vrp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Vrp */
+        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -21,25 +106,143 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist": {
+    "/api/jobs/{job_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Watchlist */
-        get: operations["get_watchlist_api_watchlist_get"];
+        /** Get Job */
+        get: operations["get_job_api_jobs__job_id__get"];
         put?: never;
-        /** Post Watchlist */
-        post: operations["post_watchlist_api_watchlist_post"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist/{ticker}": {
+    "/api/ohlc/{ticker}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Ohlc */
+        get: operations["get_ohlc_api_ohlc__ticker__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Endpoints */
+        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Requests */
+        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Summary */
+        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/tickers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Tickers */
+        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime */
+        get: operations["get_regime_api_regime_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gex */
+        get: operations["get_gex_api_regime_gex_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex/scan": {
         parameters: {
             query?: never;
             header?: never;
@@ -48,13 +251,89 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post?: never;
-        /** Delete Watchlist */
-        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
+        /**
+         * Trigger Gex Scan
+         * @description Run a GEX scan synchronously against UW and persist.
+         */
+        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        delete?: never;
         options?: never;
         head?: never;
-        /** Patch Watchlist */
-        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Cri Scan
+         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_cri_scan_api_regime_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg */
+        get: operations["get_vcg_api_regime_vcg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Vcg Scan
+         * @description Run a VCG scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vol-backdrop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vol Backdrop */
+        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/stock/{ticker}": {
@@ -131,247 +410,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/ohlc/{ticker}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ohlc */
-        get: operations["get_ohlc_api_ohlc__ticker__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit State */
-        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/dealer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Dealer */
-        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/surface": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Surface */
-        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/flow-im": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Flow Im */
-        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/vrp": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Vrp */
-        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/{ticker}/rescan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Enqueue Rescan */
-        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/rescan-all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enqueue Rescan All
-         * @description Enqueue a rescan job for every active watchlist ticker.
-         */
-        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Job */
-        get: operations["get_job_api_jobs__job_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/stock/{ticker}/volatility/series": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Volatility Series */
-        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Summary */
-        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/endpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Endpoints */
-        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/tickers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Tickers */
-        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/requests": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Requests */
-        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/stock/{ticker}/trade-insights": {
         parameters: {
             query?: never;
@@ -440,15 +478,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex": {
+    "/api/stock/{ticker}/volatility/series": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Gex */
-        get: operations["get_gex_api_regime_gex_get"];
+        /** Get Volatility Series */
+        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -457,7 +495,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex/scan": {
+    "/api/watchlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Watchlist */
+        get: operations["get_watchlist_api_watchlist_get"];
+        put?: never;
+        /** Post Watchlist */
+        post: operations["post_watchlist_api_watchlist_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist/rescan-all": {
         parameters: {
             query?: never;
             header?: never;
@@ -467,51 +523,17 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Trigger Gex Scan
-         * @description Run a GEX scan synchronously against UW and persist.
+         * Enqueue Rescan All
+         * @description Enqueue a rescan job for every active watchlist ticker.
          */
-        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/regime/vol-backdrop": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vol Backdrop */
-        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Regime */
-        get: operations["get_regime_api_regime_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/scan": {
+    "/api/watchlist/{ticker}": {
         parameters: {
             query?: never;
             header?: never;
@@ -520,35 +542,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Trigger Cri Scan
-         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
-         */
-        post: operations["trigger_cri_scan_api_regime_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg */
-        get: operations["get_vcg_api_regime_vcg_get"];
-        put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Watchlist */
+        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Patch Watchlist */
+        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
         trace?: never;
     };
-    "/api/regime/vcg/scan": {
+    "/api/watchlist/{ticker}/rescan": {
         parameters: {
             query?: never;
             header?: never;
@@ -557,8 +560,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Trigger Vcg Scan */
-        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
+        /** Enqueue Rescan */
+        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -571,72 +574,65 @@ export interface components {
     schemas: {
         /** CandidateStructure */
         CandidateStructure: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Thesis */
-            thesis: string;
-            /** Expression Type */
-            expression_type: string;
-            /**
-             * Legs
-             * @default []
-             */
-            legs: components["schemas"]["InsightLeg"][];
-            /** Net Credit Debit */
-            net_credit_debit?: string | null;
-            /** Max Profit */
-            max_profit?: string | null;
-            /** Max Loss */
-            max_loss?: string | null;
             /**
              * Breakevens
              * @default []
              */
             breakevens: string[];
             /**
-             * Profit Zone
-             * @default
-             */
-            profit_zone: string;
-            /**
              * Edge Source
              * @default
              */
             edge_source: string;
+            /** Expression Type */
+            expression_type: string;
+            /** Idea Id */
+            idea_id: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["InsightLeg"][];
+            /** Max Loss */
+            max_loss?: string | null;
+            /** Max Profit */
+            max_profit?: string | null;
+            /** Net Credit Debit */
+            net_credit_debit?: string | null;
+            /**
+             * Profit Zone
+             * @default
+             */
+            profit_zone: string;
+            /** Rank */
+            rank: number;
             /**
              * Risk Flags
              * @default []
              */
             risk_flags: string[];
-            /** Rank */
-            rank: number;
             /**
              * Status
              * @default candidate
              */
             status: string;
+            /** Structure */
+            structure: string;
+            /** Thesis */
+            thesis: string;
         };
         /** ChainFlowReadRow */
         ChainFlowReadRow: {
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
             /** Call Open Interest */
             call_open_interest?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
             /** Call Put Volume Ratio */
             call_put_volume_ratio?: string | null;
-            /**
-             * Volume Oi Note
-             * @default
-             */
-            volume_oi_note: string;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
             /**
              * Read
              * @default
@@ -647,78 +643,83 @@ export interface components {
              * @default false
              */
             requires_t1_oi_confirmation: boolean;
+            /** Strike */
+            strike: string;
+            /**
+             * Volume Oi Note
+             * @default
+             */
+            volume_oi_note: string;
         };
         /** CockpitDealerMetrics */
         CockpitDealerMetrics: {
-            /** Pin Candidate Strike */
-            pin_candidate_strike?: string | null;
-            /** Pin Candidate Expiry */
-            pin_candidate_expiry?: string | null;
-            /** Pin Source Date */
-            pin_source_date?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
-            /** Pin Regime Flag */
-            pin_regime_flag?: boolean | null;
-            /** Dealer Net Vanna Proxy */
-            dealer_net_vanna_proxy?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
+            /** Charm Stress Override */
+            charm_stress_override?: boolean | null;
             /** Dealer Net Charm Proxy */
             dealer_net_charm_proxy?: string | null;
+            /** Dealer Net Vanna Proxy */
+            dealer_net_vanna_proxy?: string | null;
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /** Flow Call Premium 3D */
+            flow_call_premium_3d?: string | null;
             /** Flow Color Lookback 3D */
             flow_color_lookback_3d?: ("put_heavy" | "call_heavy" | "neutral") | null;
             /** Flow Put Premium 3D */
             flow_put_premium_3d?: string | null;
-            /** Flow Call Premium 3D */
-            flow_call_premium_3d?: string | null;
+            /** Gamma Regime */
+            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
             /** Iv 30D Delta 5D */
             iv_30d_delta_5d?: string | null;
             /** Net Gamma */
             net_gamma?: string | null;
             /** Net Gamma Sign */
             net_gamma_sign?: ("positive" | "negative" | "neutral") | null;
-            /** Gamma Regime */
-            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
+            /** Pin Candidate Expiry */
+            pin_candidate_expiry?: string | null;
+            /** Pin Candidate Strike */
+            pin_candidate_strike?: string | null;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Pin Regime Flag */
+            pin_regime_flag?: boolean | null;
+            /** Pin Source Date */
+            pin_source_date?: string | null;
             /** Vanna Conditional Reading */
             vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
             /** Vanna Oi Change Bias */
             vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /** Charm Stress Override */
-            charm_stress_override?: boolean | null;
         };
         /** CockpitDealerPoint */
         CockpitDealerPoint: {
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Vanna */
-            call_vanna?: string | null;
-            /** Put Vanna */
-            put_vanna?: string | null;
-            /** Call Charm */
-            call_charm?: string | null;
-            /** Put Charm */
-            put_charm?: string | null;
-            /** Exposure Call Vanna */
-            exposure_call_vanna?: string | null;
-            /** Exposure Put Vanna */
-            exposure_put_vanna?: string | null;
             /** Exposure Call Charm */
             exposure_call_charm?: string | null;
+            /** Exposure Call Vanna */
+            exposure_call_vanna?: string | null;
             /** Exposure Put Charm */
             exposure_put_charm?: string | null;
+            /** Exposure Put Vanna */
+            exposure_put_vanna?: string | null;
+            /** Put Charm */
+            put_charm?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** CockpitDealerResponse */
         CockpitDealerResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -727,99 +728,99 @@ export interface components {
             metrics?: components["schemas"]["CockpitDealerMetrics"];
             /** Points */
             points?: components["schemas"]["CockpitDealerPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitFlowAlert */
         CockpitFlowAlert: {
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
             /** Alert Id */
             alert_id: string;
-            /** Option Chain */
-            option_chain?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Option Type */
-            option_type?: string | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Option Type */
+            option_type?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Volume */
+            volume?: number | null;
         };
         /** CockpitFlowImResponse */
         CockpitFlowImResponse: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
             /** Alerts */
             alerts?: components["schemas"]["CockpitFlowAlert"][];
             /** Implied Moves */
             implied_moves?: components["schemas"]["CockpitImPoint"][];
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitImPoint */
         CockpitImPoint: {
+            /** Days */
+            days: number;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Days */
-            days: number;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
             /** Percentile */
             percentile?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitSkewPoint */
         CockpitSkewPoint: {
+            /** Expiry */
+            expiry?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Expiry */
-            expiry?: string | null;
             /** Risk Reversal */
             risk_reversal?: string | null;
         };
         /** CockpitStateResponse */
         CockpitStateResponse: {
-            state: components["schemas"]["MatrixState"];
             freshness: components["schemas"]["MatrixSourceFreshness"];
+            state: components["schemas"]["MatrixState"];
         };
         /** CockpitSurfaceResponse */
         CockpitSurfaceResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -829,43 +830,43 @@ export interface components {
             skew?: components["schemas"]["CockpitSkewPoint"][];
             /** Term */
             term?: components["schemas"]["CockpitTermPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitTermPoint */
         CockpitTermPoint: {
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
             /** Implied Move Expected Abs */
             implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitVrpPoint */
         CockpitVrpPoint: {
+            /** Iv */
+            iv?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Iv */
-            iv?: string | null;
             /** Rv */
             rv?: string | null;
             /** Vrp */
             vrp?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
         };
         /** CockpitVrpResponse */
         CockpitVrpResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -873,9 +874,12 @@ export interface components {
             market_date: string;
             /** Points */
             points?: components["schemas"]["CockpitVrpPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CrashTriggerBlock */
         CrashTriggerBlock: {
+            conditions?: components["schemas"]["CrashTriggerConditions"];
             /**
              * Fired
              * @default false
@@ -886,64 +890,53 @@ export interface components {
              * @default false
              */
             triggered: boolean;
-            conditions?: components["schemas"]["CrashTriggerConditions"];
             values?: components["schemas"]["CrashTriggerValues"];
         };
         /** CrashTriggerConditions */
         CrashTriggerConditions: {
             /**
-             * Spx Below 100D Ma
+             * Cor1M Gt 60
              * @default false
              */
-            spx_below_100d_ma: boolean;
+            cor1m_gt_60: boolean;
             /**
              * Realized Vol Gt 25
              * @default false
              */
             realized_vol_gt_25: boolean;
             /**
-             * Cor1M Gt 60
+             * Spx Below 100D Ma
              * @default false
              */
-            cor1m_gt_60: boolean;
+            spx_below_100d_ma: boolean;
         };
         /** CrashTriggerValues */
         CrashTriggerValues: {
-            /** Realized Vol */
-            realized_vol?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
         };
         /** CriBlock */
         CriBlock: {
-            /**
-             * Score
-             * @default 0
-             */
-            score: number;
+            components?: components["schemas"]["CriComponents"];
             /**
              * Level
              * @default LOW
              * @enum {string}
              */
             level: "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
-            components?: components["schemas"]["CriComponents"];
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
         };
         /**
          * CriComponents
          * @description Four 0-25 component scores summed into the composite 0-100.
          */
         CriComponents: {
-            /**
-             * Vix
-             * @default 0
-             */
-            vix: number;
-            /**
-             * Vvix
-             * @default 0
-             */
-            vvix: number;
             /**
              * Correlation
              * @default 0
@@ -954,111 +947,121 @@ export interface components {
              * @default 0
              */
             momentum: number;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
         };
         /** CriHistoryEntry */
         CriHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Date */
+            date: string;
             /** Realized Vol */
             realized_vol?: number | null;
             /** Spx Vs Ma Pct */
             spx_vs_ma_pct?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Vix */
+            vix?: number | null;
             /** Vix 5D Roc */
             vix_5d_roc?: number | null;
+            /** Vvix */
+            vvix?: number | null;
         };
         /**
          * CriResponse
          * @description Crash Risk Indicator snapshot (latest scan).
          */
         CriResponse: {
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Spx 100D Ma */
+            spx_100d_ma?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Spy Closes */
+            spy_closes?: number[];
             /**
              * Status
              * @default empty
              * @enum {string}
              */
             status: "ok" | "empty";
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Date */
-            date?: string | null;
             /** Vix */
             vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
             /** Vix 5D Roc */
             vix_5d_roc?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix Vix Ratio */
             vvix_vix_ratio?: number | null;
-            /** Spx 100D Ma */
-            spx_100d_ma?: number | null;
-            /** Spx Distance Pct */
-            spx_distance_pct?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
-            /** Cor1M Previous Close */
-            cor1m_previous_close?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Realized Vol */
-            realized_vol?: number | null;
-            cri?: components["schemas"]["CriBlock"];
-            cta?: components["schemas"]["CtaBlock"];
-            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
-            /** History */
-            history?: components["schemas"]["CriHistoryEntry"][];
-            /** Spy Closes */
-            spy_closes?: number[];
         };
         /**
          * CriScanResponse
          * @description Response body for POST /api/regime/scan.
          */
         CriScanResponse: {
-            /**
-             * Status
-             * @default ok
-             * @enum {string}
-             */
-            status: "ok" | "skipped";
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default cri
              * @constant
              */
             scanner: "cri";
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
         };
         /** CtaBlock */
         CtaBlock: {
-            /** Realized Vol */
-            realized_vol?: number | null;
+            /** Est Selling Bn */
+            est_selling_bn?: number | null;
             /** Exposure Pct */
             exposure_pct?: number | null;
-            /** Forced Reduction Pct */
-            forced_reduction_pct?: number | null;
             /**
              * Forced Reduction
              * @default false
              */
             forced_reduction: boolean;
-            /** Est Selling Bn */
-            est_selling_bn?: number | null;
+            /** Forced Reduction Pct */
+            forced_reduction_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
             /** Selling Usd B */
             selling_usd_b?: number | null;
         };
@@ -1076,97 +1079,97 @@ export interface components {
         };
         /** FlowAlert */
         FlowAlert: {
-            /** Id */
-            id: string;
-            /** Ticker */
-            ticker: string;
-            /** Option Chain */
-            option_chain?: string | null;
-            /** Type */
-            type?: string | null;
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Price */
-            price?: string | null;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            /** Total Size */
-            total_size?: number | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Volume Oi Ratio */
-            volume_oi_ratio?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Iv Start */
-            iv_start?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Id */
+            id: string;
+            /** Issue Type */
+            issue_type?: string | null;
             /** Iv End */
             iv_end?: string | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
+            /** Iv Start */
+            iv_start?: string | null;
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Price */
+            price?: string | null;
             /** Rule Id */
             rule_id?: string | null;
             /** Sector */
             sector?: string | null;
-            /** Issue Type */
-            issue_type?: string | null;
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Ticker */
+            ticker: string;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Total Size */
+            total_size?: number | null;
+            /** Type */
+            type?: string | null;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            /** Volume */
+            volume?: number | null;
+            /** Volume Oi Ratio */
+            volume_oi_ratio?: string | null;
         };
         /** FlowSnapshot */
         FlowSnapshot: {
-            /** Ticker */
-            ticker: string;
+            /** Ask Side Premium */
+            ask_side_premium: string;
+            /** Bear Premium */
+            bear_premium: string;
+            /** Bid Side Premium */
+            bid_side_premium: string;
+            /** Bull Premium */
+            bull_premium: string;
             /** Flow Count */
             flow_count: number;
-            /**
-             * Flow Count Is Limited
-             * @default false
-             */
-            flow_count_is_limited: boolean;
             /** Flow Count 30D Avg */
             flow_count_30d_avg?: string | null;
-            /** Flow Count Vs 30D Avg */
-            flow_count_vs_30d_avg?: string | null;
             /**
              * Flow Count 30D Days
              * @default 0
              */
             flow_count_30d_days: number;
-            /** Top Alert Rule */
-            top_alert_rule?: string | null;
+            /**
+             * Flow Count Is Limited
+             * @default false
+             */
+            flow_count_is_limited: boolean;
+            /** Flow Count Vs 30D Avg */
+            flow_count_vs_30d_avg?: string | null;
             /** Net Premium */
             net_premium: string;
-            /** Bull Premium */
-            bull_premium: string;
-            /** Bear Premium */
-            bear_premium: string;
-            /** Ask Side Premium */
-            ask_side_premium: string;
-            /** Bid Side Premium */
-            bid_side_premium: string;
+            /** Ticker */
+            ticker: string;
+            /** Top Alert Rule */
+            top_alert_rule?: string | null;
             /**
              * Top Alerts
              * @default []
@@ -1175,53 +1178,53 @@ export interface components {
         };
         /** GammaBlock */
         GammaBlock: {
+            /** Expiring Date */
+            expiring_date?: string | null;
+            /** Expiring Pct */
+            expiring_pct?: string | null;
             /** Flip Distance */
             flip_distance?: string | null;
             /** Flip Price */
             flip_price?: string | null;
-            /** Per 1Pct Move */
-            per_1pct_move?: string | null;
             /** Max Strike */
             max_strike?: string | null;
-            /** Expiring Pct */
-            expiring_pct?: string | null;
-            /** Expiring Date */
-            expiring_date?: string | null;
+            /** Per 1Pct Move */
+            per_1pct_move?: string | null;
         };
         /** GexBias */
         GexBias: {
-            /** Direction */
-            direction?: string | null;
-            /** Reasons */
-            reasons?: string[];
             /** Days Above Flip */
             days_above_flip?: number | null;
+            /** Direction */
+            direction?: string | null;
             /** Flip Migration */
             flip_migration?: components["schemas"]["GexFlipMigrationEntry"][];
+            /** Reasons */
+            reasons?: string[];
         };
         /** GexBucket */
         GexBucket: {
-            /** Strike */
-            strike?: number | null;
             /** Call Gex */
             call_gex?: number | null;
-            /** Put Gex */
-            put_gex?: number | null;
             /** Net Gex */
             net_gex?: number | null;
             /** Pct From Spot */
             pct_from_spot?: number | null;
+            /** Put Gex */
+            put_gex?: number | null;
+            /** Strike */
+            strike?: number | null;
             /** Tag */
             tag?: string | null;
         };
         /** GexExpectedRange */
         GexExpectedRange: {
-            /** Low */
-            low?: number | null;
             /** High */
             high?: number | null;
             /** Iv 1D */
             iv_1d?: number | null;
+            /** Low */
+            low?: number | null;
         };
         /** GexFlipMigrationEntry */
         GexFlipMigrationEntry: {
@@ -1232,31 +1235,31 @@ export interface components {
         };
         /** GexHistoryEntry */
         GexHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Gex Flip */
-            gex_flip?: number | null;
-            /** Spot */
-            spot?: number | null;
             /** Atm Iv */
             atm_iv?: number | null;
-            /** Vol Pc */
-            vol_pc?: number | null;
             /** Bias */
             bias?: string | null;
+            /** Date */
+            date: string;
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Spot */
+            spot?: number | null;
+            /** Vol Pc */
+            vol_pc?: number | null;
         };
         /** GexIvData */
         GexIvData: {
+            /** Hv30 */
+            hv30?: number | null;
             /** Iv30D */
             iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: number | null;
-            /** Hv30 */
-            hv30?: number | null;
             /** Mq Iv30D */
             mq_iv30d?: number | null;
             /** Mq Iv Rank */
@@ -1266,114 +1269,114 @@ export interface components {
         };
         /** GexLevels */
         GexLevels: {
-            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
         };
         /** GexMqLevels */
         GexMqLevels: {
-            /** Source Date */
-            source_date?: string | null;
-            /** Spot */
-            spot?: number | null;
-            /** Hvl */
-            hvl?: number | null;
-            /** Call Resistance All */
-            call_resistance_all?: number | null;
             /** Call Resistance 0Dte */
             call_resistance_0dte?: number | null;
-            /** Put Support All */
-            put_support_all?: number | null;
-            /** Put Support 0Dte */
-            put_support_0dte?: number | null;
+            /** Call Resistance All */
+            call_resistance_all?: number | null;
+            /** Distance To Hvl Pct */
+            distance_to_hvl_pct?: string | null;
             /** Expected High */
             expected_high?: number | null;
             /** Expected Low */
             expected_low?: number | null;
-            /** Distance To Hvl Pct */
-            distance_to_hvl_pct?: string | null;
-            /** Iv30D */
-            iv30d?: number | null;
             /** Hv30 */
             hv30?: number | null;
+            /** Hvl */
+            hvl?: number | null;
+            /** Iv30D */
+            iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: string | null;
+            /** Put Support 0Dte */
+            put_support_0dte?: number | null;
+            /** Put Support All */
+            put_support_all?: number | null;
+            /** Source Date */
+            source_date?: string | null;
+            /** Spot */
+            spot?: number | null;
             /** Top Gex Strikes */
             top_gex_strikes?: number[];
         };
         /** GexResponse */
         GexResponse: {
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
+            /** Atm Iv */
+            atm_iv?: number | null;
+            bias?: components["schemas"]["GexBias"];
+            /** Close */
+            close?: number | null;
+            /** Data Date */
+            data_date?: string | null;
+            /** Day Change */
+            day_change?: number | null;
+            /** Day Change Pct */
+            day_change_pct?: number | null;
+            expected_range?: components["schemas"]["GexExpectedRange"];
+            /** History */
+            history?: components["schemas"]["GexHistoryEntry"][];
+            iv?: components["schemas"]["GexIvData"] | null;
+            levels?: components["schemas"]["GexLevels"];
             /**
              * Market Open
              * @default false
              */
             market_open: boolean;
+            /** Market Time */
+            market_time?: string | null;
+            mq?: components["schemas"]["GexMqLevels"] | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Prev Close */
+            prev_close?: number | null;
+            /** Profile */
+            profile?: components["schemas"]["GexBucket"][];
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            source_delta?: components["schemas"]["GexSourceDelta"] | null;
+            /** Spot */
+            spot?: number | null;
+            /** Spot Source */
+            spot_source?: string | null;
+            /** Tape Time */
+            tape_time?: string | null;
             /**
              * Ticker
              * @default SPX
              */
             ticker: string;
-            /** Spot */
-            spot?: number | null;
-            /** Close */
-            close?: number | null;
-            /** Prev Close */
-            prev_close?: number | null;
-            /** Market Time */
-            market_time?: string | null;
-            /** Tape Time */
-            tape_time?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /** Day Change */
-            day_change?: number | null;
-            /** Day Change Pct */
-            day_change_pct?: number | null;
-            /** Data Date */
-            data_date?: string | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Atm Iv */
-            atm_iv?: number | null;
             /** Vol Pc */
             vol_pc?: number | null;
-            levels?: components["schemas"]["GexLevels"];
-            /** Profile */
-            profile?: components["schemas"]["GexBucket"][];
-            expected_range?: components["schemas"]["GexExpectedRange"];
-            bias?: components["schemas"]["GexBias"];
-            /** History */
-            history?: components["schemas"]["GexHistoryEntry"][];
-            iv?: components["schemas"]["GexIvData"] | null;
-            mq?: components["schemas"]["GexMqLevels"] | null;
-            source_delta?: components["schemas"]["GexSourceDelta"] | null;
         };
         /** GexSourceDelta */
         GexSourceDelta: {
-            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
             call_wall_vs_resistance_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
         };
         /** GexSourceDeltaEntry */
         GexSourceDeltaEntry: {
-            /** Uw */
-            uw?: number | null;
-            /** Mq */
-            mq?: number | null;
             /** Delta */
             delta?: number | null;
+            /** Mq */
+            mq?: number | null;
+            /** Uw */
+            uw?: number | null;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -1382,68 +1385,68 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
-            /** Ok */
-            ok: boolean;
+            /** Avg Scan Duration Seconds */
+            avg_scan_duration_seconds?: number | null;
+            /** Cache Hit Pct */
+            cache_hit_pct?: number | null;
             /** Db */
             db: string;
-            /** Scheduler Lag Seconds */
-            scheduler_lag_seconds?: number | null;
+            /** Http 2Xx */
+            http_2xx?: number | null;
+            /** Http 429 */
+            http_429?: number | null;
+            /** Http 4Xx */
+            http_4xx?: number | null;
+            /** Http 5Xx */
+            http_5xx?: number | null;
             /** Last Full Scan At */
             last_full_scan_at?: string | null;
-            /** Reason */
-            reason?: string | null;
-            /** Worker Lag Seconds */
-            worker_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Name */
-            scheduler_heartbeat_name?: string | null;
-            /** Rescan Heartbeat Lag Seconds */
-            rescan_heartbeat_lag_seconds?: number | null;
-            /** Spot Refresh Heartbeat Lag Seconds */
-            spot_refresh_heartbeat_lag_seconds?: number | null;
-            /** Spot Quote Lag Seconds */
-            spot_quote_lag_seconds?: number | null;
+            /** Latency P95 Ms */
+            latency_p95_ms?: number | null;
             /** Latest Spot Quote At */
             latest_spot_quote_at?: string | null;
             /** Latest Spot Quote Fetched At */
             latest_spot_quote_fetched_at?: string | null;
-            /** Watchlist Size */
-            watchlist_size?: number | null;
+            /** Ok */
+            ok: boolean;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
+            /** Reason */
+            reason?: string | null;
+            /** Record Health */
+            record_health?: components["schemas"]["RecordHealthCheck"][];
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
+            /** Rescan Heartbeat Lag Seconds */
+            rescan_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Name */
+            scheduler_heartbeat_name?: string | null;
+            /** Scheduler Lag Seconds */
+            scheduler_lag_seconds?: number | null;
             /**
              * Source
              * @default UnusualWhales
              */
             source: string;
-            /** Latency P95 Ms */
-            latency_p95_ms?: number | null;
-            /** Http 2Xx */
-            http_2xx?: number | null;
-            /** Http 4Xx */
-            http_4xx?: number | null;
-            /** Http 5Xx */
-            http_5xx?: number | null;
-            /** Uw Today */
-            uw_today?: number | null;
-            /** Cache Hit Pct */
-            cache_hit_pct?: number | null;
+            /** Spot Quote Lag Seconds */
+            spot_quote_lag_seconds?: number | null;
+            /** Spot Refresh Heartbeat Lag Seconds */
+            spot_refresh_heartbeat_lag_seconds?: number | null;
             /**
              * Throughput Window Minutes
              * @default 0
              */
             throughput_window_minutes: number;
-            /** Requests Per Minute */
-            requests_per_minute?: number | null;
-            /** Http 429 */
-            http_429?: number | null;
-            /** Avg Scan Duration Seconds */
-            avg_scan_duration_seconds?: number | null;
-            /** Queue Drain Rate Per Minute */
-            queue_drain_rate_per_minute?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
-            /** Record Health */
-            record_health?: components["schemas"]["RecordHealthCheck"][];
+            /** Uw Today */
+            uw_today?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
+            /** Worker Lag Seconds */
+            worker_lag_seconds?: number | null;
             /** Workers */
             workers?: components["schemas"]["WorkerHealth"][];
         };
@@ -1461,41 +1464,48 @@ export interface components {
         };
         /** InsightLeg */
         InsightLeg: {
-            /** Side */
-            side: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Option Right */
-            option_right: string;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
             /** Mid */
             mid?: string | null;
+            /** Option Right */
+            option_right: string;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** InsightSignalRow */
         InsightSignalRow: {
-            /** Lens */
-            lens: string;
-            /** Read */
-            read: string;
-            /**
-             * Evidence
-             * @default []
-             */
-            evidence: string[];
             /**
              * Conflicts
              * @default []
              */
             conflicts: string[];
+            /**
+             * Evidence
+             * @default []
+             */
+            evidence: string[];
+            /** Lens */
+            lens: string;
+            /** Read */
+            read: string;
         };
         /** InsightsSynthesis */
         InsightsSynthesis: {
+            /**
+             * Avoid
+             * @default []
+             */
+            avoid: string[];
+            /** Best Risk Reward Idea Id */
+            best_risk_reward_idea_id?: string | null;
             /**
              * Dominant Story
              * @default
@@ -1503,13 +1513,6 @@ export interface components {
             dominant_story: string;
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
-            /** Best Risk Reward Idea Id */
-            best_risk_reward_idea_id?: string | null;
-            /**
-             * Avoid
-             * @default []
-             */
-            avoid: string[];
             /**
              * Required Before Sizing
              * @default []
@@ -1518,12 +1521,12 @@ export interface components {
         };
         /** IvHistogramBin */
         IvHistogramBin: {
-            /** Lo */
-            lo: string;
-            /** Hi */
-            hi: string;
             /** Count */
             count: number;
+            /** Hi */
+            hi: string;
+            /** Lo */
+            lo: string;
         };
         /** IvHvPoint */
         IvHvPoint: {
@@ -1563,23 +1566,23 @@ export interface components {
         };
         /** JobStatus */
         JobStatus: {
-            /** Job Id */
-            job_id: string;
-            /** Status */
-            status: string;
-            /** Run Id */
-            run_id?: number | null;
             /** Error */
             error?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Job Id */
+            job_id: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
+            /** Run Id */
+            run_id?: number | null;
             /** Started At */
             started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
+            /** Status */
+            status: string;
         };
         /**
          * MarketAggregates
@@ -1589,51 +1592,43 @@ export interface components {
          *     sub-models. Feeds the watchlist card POSITIONING and SKEW blocks.
          */
         MarketAggregates: {
+            /** Aum */
+            aum?: string | null;
             /** Call Oi Total */
             call_oi_total?: number | null;
-            /** Put Oi Total */
-            put_oi_total?: number | null;
-            /** Call Volume Total */
-            call_volume_total?: number | null;
-            /** Put Volume Total */
-            put_volume_total?: number | null;
             /** Call Volume Ask Side */
             call_volume_ask_side?: number | null;
             /** Call Volume Bid Side */
             call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Pcr Oi */
-            pcr_oi?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
+            /** Call Volume Total */
+            call_volume_total?: number | null;
             /** Iv30D */
             iv30d?: string | null;
             /** Market Cap */
             market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
+            /** Pcr Oi */
+            pcr_oi?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Put Oi Total */
+            put_oi_total?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
+            /** Put Volume Total */
+            put_volume_total?: number | null;
         };
         /** MarketStructure */
         MarketStructure: {
-            /** Spot */
-            spot?: string | null;
-            /** Nearest Expiry */
-            nearest_expiry?: string | null;
-            /** Total Call Gex */
-            total_call_gex?: string | null;
-            /** Total Put Gex */
-            total_put_gex?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Total Call Dex Oi */
-            total_call_dex_oi?: string | null;
-            /** Total Put Dex Oi */
-            total_put_dex_oi?: string | null;
             /** Max Pain */
             max_pain?: string | null;
+            /** Nearest Expiry */
+            nearest_expiry?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Spot */
+            spot?: string | null;
             /**
              * Top Call Oi Strikes
              * @default []
@@ -1644,6 +1639,14 @@ export interface components {
              * @default []
              */
             top_put_oi_strikes: string[];
+            /** Total Call Dex Oi */
+            total_call_dex_oi?: string | null;
+            /** Total Call Gex */
+            total_call_gex?: string | null;
+            /** Total Put Dex Oi */
+            total_put_dex_oi?: string | null;
+            /** Total Put Gex */
+            total_put_gex?: string | null;
         };
         /**
          * MarketStructureLevels
@@ -1658,152 +1661,154 @@ export interface components {
          *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
          */
         MarketStructureLevels: {
-            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             max_accel?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
         };
         /** MatrixSourceFreshness */
         MatrixSourceFreshness: {
-            /** Vanna Charm */
-            vanna_charm?: string | null;
+            /** Im Vrp */
+            im_vrp?: string | null;
+            /** Oi */
+            oi?: string | null;
             /** Skew */
             skew?: string | null;
             /** Term */
             term?: string | null;
-            /** Im Vrp */
-            im_vrp?: string | null;
+            /** Vanna Charm */
+            vanna_charm?: string | null;
             /** Vrp Rv */
             vrp_rv?: string | null;
-            /** Oi */
-            oi?: string | null;
         };
         /** MatrixState */
         MatrixState: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /**
-             * Threshold Version
-             * @default 1
-             */
-            threshold_version: number;
-            /**
-             * Vanna State
-             * @enum {string}
-             */
-            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Atm Straddle Mid */
+            atm_straddle_mid?: string | null;
+            /** Back Iv */
+            back_iv?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
             /**
              * Charm State
              * @enum {string}
              */
             charm_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
+             * Charm Stress Override
+             * @default false
+             */
+            charm_stress_override: boolean;
+            /** Cluster Coverage Ok */
+            cluster_coverage_ok: boolean;
+            /**
+             * Consistency Tier
+             * @enum {string}
+             */
+            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /**
+             * Flow State
+             * @enum {string}
+             */
+            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Front Back Spread */
+            front_back_spread?: string | null;
+            /** Front Iv */
+            front_iv?: string | null;
+            /** Full Curve Slope Pct */
+            full_curve_slope_pct?: string | null;
+            /**
+             * Im State
+             * @enum {string}
+             */
+            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Implied Move Event Percentile */
+            implied_move_event_percentile?: string | null;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Pct */
+            implied_move_pct?: string | null;
+            /** Iv Atm 30D */
+            iv_atm_30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Rv 30D */
+            rv_30d?: string | null;
+            /** Single Point Bump Pct */
+            single_point_bump_pct?: string | null;
+            /** Skew 25D 5D Change */
+            skew_25d_5d_change?: string | null;
+            /** Skew 25D Zscore 180D */
+            skew_25d_zscore_180d?: string | null;
+            /** Skew Regime */
+            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
+            /**
              * Skew State
              * @enum {string}
              */
             skew_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Skew Term Structure */
+            skew_term_structure?: string | null;
+            /** Term Classification */
+            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
+            /** Term Johnson Slope Pc1 */
+            term_johnson_slope_pc1?: string | null;
             /**
              * Term State
              * @enum {string}
              */
             term_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
-             * Im State
-             * @enum {string}
+             * Threshold Version
+             * @default 1
              */
-            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            threshold_version: number;
+            /** Ticker */
+            ticker: string;
+            /** Vanna Conditional Reading */
+            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
+            /** Vanna Oi Change Bias */
+            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
             /**
-             * Flow State
+             * Vanna State
              * @enum {string}
              */
-            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Vrp State
-             * @enum {string}
-             */
-            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Consistency Tier
-             * @enum {string}
-             */
-            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
-            /** Cluster Coverage Ok */
-            cluster_coverage_ok: boolean;
-            /** Term Classification */
-            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
-            /** Skew 25D Zscore 180D */
-            skew_25d_zscore_180d?: string | null;
-            /** Iv Atm 30D */
-            iv_atm_30d?: string | null;
-            /** Rv 30D */
-            rv_30d?: string | null;
+            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp */
             vrp?: string | null;
-            /** Vrp Zscore 60D */
-            vrp_zscore_60d?: string | null;
-            /** Implied Move Pct */
-            implied_move_pct?: string | null;
-            /** Front Iv */
-            front_iv?: string | null;
-            /** Back Iv */
-            back_iv?: string | null;
-            /** Front Back Spread */
-            front_back_spread?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
+            /**
+             * Vrp Sign Flip Aligned Days
+             * @default 0
+             */
+            vrp_sign_flip_aligned_days: number;
             /**
              * Vrp Sign Flip Status
              * @default insufficient_history
              */
             vrp_sign_flip_status: boolean | "insufficient_history";
             /**
-             * Vrp Sign Flip Aligned Days
-             * @default 0
+             * Vrp State
+             * @enum {string}
              */
-            vrp_sign_flip_aligned_days: number;
-            /** Vanna Conditional Reading */
-            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
-            /** Vanna Oi Change Bias */
-            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /**
-             * Charm Stress Override
-             * @default false
-             */
-            charm_stress_override: boolean;
-            /** Skew 25D 5D Change */
-            skew_25d_5d_change?: string | null;
-            /** Skew Regime */
-            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
-            /** Skew Term Structure */
-            skew_term_structure?: string | null;
-            /** Single Point Bump Pct */
-            single_point_bump_pct?: string | null;
-            /** Full Curve Slope Pct */
-            full_curve_slope_pct?: string | null;
-            /** Term Johnson Slope Pc1 */
-            term_johnson_slope_pc1?: string | null;
-            /** Atm Straddle Mid */
-            atm_straddle_mid?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
-            /** Implied Move Event Percentile */
-            implied_move_event_percentile?: string | null;
+            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp Zscore 252D */
             vrp_zscore_252d?: string | null;
+            /** Vrp Zscore 60D */
+            vrp_zscore_60d?: string | null;
         };
         /** MaxPainRow */
         MaxPainRow: {
+            /** Close */
+            close?: string | null;
             /**
              * Expiry
              * Format: date
@@ -1811,93 +1816,91 @@ export interface components {
             expiry: string;
             /** Max Pain */
             max_pain?: string | null;
-            /** Close */
-            close?: string | null;
-            /** Open */
-            open?: string | null;
-            /** Next Upper Strike */
-            next_upper_strike?: string | null;
             /** Next Lower Strike */
             next_lower_strike?: string | null;
+            /** Next Upper Strike */
+            next_upper_strike?: string | null;
+            /** Open */
+            open?: string | null;
         };
         /** OhlcRow */
         OhlcRow: {
+            /** Close */
+            close: string;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Open */
-            open?: string | null;
             /** High */
             high?: string | null;
             /** Low */
             low?: string | null;
-            /** Close */
-            close: string;
+            /** Open */
+            open?: string | null;
             /** Volume */
             volume?: number | null;
         };
         /** OiChangeRow */
         OiChangeRow: {
-            /** Underlying Symbol */
-            underlying_symbol: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Curr Date */
-            curr_date?: string | null;
-            /** Last Date */
-            last_date?: string | null;
-            /** Curr Oi */
-            curr_oi?: number | null;
-            /** Last Oi */
-            last_oi?: number | null;
-            /** Oi Diff Plain */
-            oi_diff_plain?: number | null;
-            /** Oi Change */
-            oi_change?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Trades */
-            trades?: number | null;
+            /** Ask Volume */
+            ask_volume?: number | null;
             /** Avg Price */
             avg_price?: string | null;
-            /** Last Fill */
-            last_fill?: string | null;
+            /** Bid Volume */
+            bid_volume?: number | null;
+            /** Curr Date */
+            curr_date?: string | null;
+            /** Curr Oi */
+            curr_oi?: number | null;
             /** Days Of Oi Increases */
             days_of_oi_increases?: number | null;
             /** Days Of Vol Greater Than Oi */
             days_of_vol_greater_than_oi?: number | null;
+            /** Last Ask */
+            last_ask?: string | null;
+            /** Last Bid */
+            last_bid?: string | null;
+            /** Last Date */
+            last_date?: string | null;
+            /** Last Fill */
+            last_fill?: string | null;
+            /** Last Oi */
+            last_oi?: number | null;
+            /** Mid Volume */
+            mid_volume?: number | null;
+            /** No Side Volume */
+            no_side_volume?: number | null;
+            /** Oi Change */
+            oi_change?: string | null;
+            /** Oi Diff Plain */
+            oi_diff_plain?: number | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Percentage Of Total */
             percentage_of_total?: string | null;
-            /** Rnk */
-            rnk?: number | null;
             /** Prev Ask Volume */
             prev_ask_volume?: number | null;
             /** Prev Bid Volume */
             prev_bid_volume?: number | null;
             /** Prev Mid Volume */
             prev_mid_volume?: number | null;
-            /** Prev Neutral Volume */
-            prev_neutral_volume?: number | null;
             /** Prev Multi Leg Volume */
             prev_multi_leg_volume?: number | null;
+            /** Prev Neutral Volume */
+            prev_neutral_volume?: number | null;
             /** Prev Stock Multi Leg Volume */
             prev_stock_multi_leg_volume?: number | null;
             /** Prev Total Premium */
             prev_total_premium?: string | null;
-            /** Last Ask */
-            last_ask?: string | null;
-            /** Last Bid */
-            last_bid?: string | null;
-            /** Ask Volume */
-            ask_volume?: number | null;
-            /** Bid Volume */
-            bid_volume?: number | null;
-            /** Mid Volume */
-            mid_volume?: number | null;
-            /** No Side Volume */
-            no_side_volume?: number | null;
+            /** Rnk */
+            rnk?: number | null;
+            /** Trades */
+            trades?: number | null;
+            /** Underlying Symbol */
+            underlying_symbol: string;
+            /** Volume */
+            volume?: number | null;
         };
         /**
          * OptionChainPerStrikeRow
@@ -1906,21 +1909,21 @@ export interface components {
          *     Backs both strike-profile charts (Volume and OI variants).
          */
         OptionChainPerStrikeRow: {
+            /** Call Oi */
+            call_oi?: number | null;
+            /** Call Volume */
+            call_volume?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Oi */
-            call_oi?: number | null;
             /** Put Oi */
             put_oi?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * OptionsDailyRow
@@ -1930,39 +1933,10 @@ export interface components {
          *     alert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot.
          */
         OptionsDailyRow: {
-            /**
-             * Date
-             * Format: date
-             */
-            date: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Volume Ask Side */
-            call_volume_ask_side?: number | null;
-            /** Call Volume Bid Side */
-            call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Call Premium */
-            call_premium?: string | null;
-            /** Put Premium */
-            put_premium?: string | null;
-            /** Net Call Premium */
-            net_call_premium?: string | null;
-            /** Net Put Premium */
-            net_put_premium?: string | null;
-            /** Bullish Premium */
-            bullish_premium?: string | null;
-            /** Bearish Premium */
-            bearish_premium?: string | null;
-            /** Call Open Interest */
-            call_open_interest?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
+            /** Avg 30 Day Call Volume */
+            avg_30_day_call_volume?: string | null;
+            /** Avg 30 Day Put Volume */
+            avg_30_day_put_volume?: string | null;
             /** Avg 3 Day Call Volume */
             avg_3_day_call_volume?: string | null;
             /** Avg 3 Day Put Volume */
@@ -1971,45 +1945,70 @@ export interface components {
             avg_7_day_call_volume?: string | null;
             /** Avg 7 Day Put Volume */
             avg_7_day_put_volume?: string | null;
-            /** Avg 30 Day Call Volume */
-            avg_30_day_call_volume?: string | null;
-            /** Avg 30 Day Put Volume */
-            avg_30_day_put_volume?: string | null;
+            /** Bearish Premium */
+            bearish_premium?: string | null;
+            /** Bullish Premium */
+            bullish_premium?: string | null;
+            /** Call Open Interest */
+            call_open_interest?: number | null;
+            /** Call Premium */
+            call_premium?: string | null;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Call Volume Ask Side */
+            call_volume_ask_side?: number | null;
+            /** Call Volume Bid Side */
+            call_volume_bid_side?: number | null;
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Net Call Premium */
+            net_call_premium?: string | null;
+            /** Net Put Premium */
+            net_put_premium?: string | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Premium */
+            put_premium?: string | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
         };
         /** PositioningBlock */
         PositioningBlock: {
             /** Call Oi */
             call_oi?: number | null;
-            /** Put Oi */
-            put_oi?: number | null;
+            /** Pcr Delta 30D */
+            pcr_delta_30d?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
             pcr_vol?: string | null;
-            /** Pcr Delta 30D */
-            pcr_delta_30d?: string | null;
+            /** Put Oi */
+            put_oi?: number | null;
         };
         /** ProviderUsageBreakdownResponse */
         ProviderUsageBreakdownResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageBreakdownRow"][];
         };
         /** ProviderUsageBreakdownRow */
         ProviderUsageBreakdownRow: {
-            /** Key */
-            key: string | null;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -2018,53 +2017,29 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
+            /** Key */
+            key: string | null;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
         };
         /** ProviderUsageRequestRow */
         ProviderUsageRequestRow: {
-            /** Request Id */
-            request_id: number;
-            /** Provider */
-            provider: string;
-            /** Endpoint Key */
-            endpoint_key: string;
-            /** Method */
-            method: string;
-            /** Path */
-            path: string;
-            /** Ticker */
-            ticker: string | null;
-            /** Params */
-            params: {
-                [key: string]: unknown;
-            };
-            /** Status Code */
-            status_code: number | null;
-            /** Status Family */
-            status_family: string;
-            /**
-             * Request Started At
-             * Format: date-time
-             */
-            request_started_at: string;
-            /**
-             * Request Finished At
-             * Format: date-time
-             */
-            request_finished_at: string;
-            /** Latency Ms */
-            latency_ms: number;
             /** Attempt */
             attempt: number;
-            /** Run Id */
-            run_id: number | null;
+            /** Endpoint Key */
+            endpoint_key: string;
+            /** Error Message */
+            error_message: string | null;
             /** Job Name */
             job_name: string | null;
-            /** Provider Request Id */
-            provider_request_id: string | null;
+            /** Latency Ms */
+            latency_ms: number;
+            /** Method */
+            method: string;
             /** Official Daily Count */
             official_daily_count: number | null;
             /** Official Daily Limit */
@@ -2073,40 +2048,56 @@ export interface components {
             official_minute_remaining: number | null;
             /** Official Minute Reset */
             official_minute_reset: string | null;
-            /** Error Message */
-            error_message: string | null;
+            /** Params */
+            params: {
+                [key: string]: unknown;
+            };
+            /** Path */
+            path: string;
+            /** Provider */
+            provider: string;
+            /** Provider Request Id */
+            provider_request_id: string | null;
+            /**
+             * Request Finished At
+             * Format: date-time
+             */
+            request_finished_at: string;
+            /** Request Id */
+            request_id: number;
+            /**
+             * Request Started At
+             * Format: date-time
+             */
+            request_started_at: string;
+            /** Run Id */
+            run_id: number | null;
+            /** Status Code */
+            status_code: number | null;
+            /** Status Family */
+            status_family: string;
+            /** Ticker */
+            ticker: string | null;
         };
         /** ProviderUsageRequestsResponse */
         ProviderUsageRequestsResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
+            /** Limit */
+            limit: number;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
-            /** Limit */
-            limit: number;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageRequestRow"][];
         };
         /** ProviderUsageSummaryResponse */
         ProviderUsageSummaryResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
-            /**
-             * Provider Day End
-             * Format: date-time
-             */
-            provider_day_end: string;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -2115,10 +2106,22 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
             /** Uw Latest Daily Count */
             uw_latest_daily_count: number | null;
             /** Uw Latest Daily Limit */
@@ -2128,8 +2131,6 @@ export interface components {
         QueueStatus: {
             /** Job Id */
             job_id: string;
-            /** Status */
-            status: string;
             /** Queue Position */
             queue_position: number;
             /**
@@ -2139,14 +2140,13 @@ export interface components {
             requested_at: string;
             /** Started At */
             started_at?: string | null;
+            /** Status */
+            status: string;
         };
         /** QueueSummary */
         QueueSummary: {
-            /**
-             * Total
-             * @default 0
-             */
-            total: number;
+            /** Oldest Requested At */
+            oldest_requested_at?: string | null;
             /**
              * Queued
              * @default 0
@@ -2157,11 +2157,28 @@ export interface components {
              * @default 0
              */
             running: number;
-            /** Oldest Requested At */
-            oldest_requested_at?: string | null;
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
         };
         /** RecordHealthCheck */
         RecordHealthCheck: {
+            /** Actual Rows */
+            actual_rows: number;
+            /** Actual Tickers */
+            actual_tickers: number;
+            /** Expected Min Rows */
+            expected_min_rows: number;
+            /** Expected Min Tickers */
+            expected_min_tickers: number;
+            /** Expected Tickers */
+            expected_tickers: number;
+            /** Latest At */
+            latest_at?: string | null;
+            /** Ok */
+            ok: boolean;
             /** Table */
             table: string;
             /**
@@ -2169,59 +2186,17 @@ export interface components {
              * Format: date-time
              */
             window_start: string;
-            /** Expected Tickers */
-            expected_tickers: number;
-            /** Expected Min Tickers */
-            expected_min_tickers: number;
-            /** Actual Tickers */
-            actual_tickers: number;
-            /** Expected Min Rows */
-            expected_min_rows: number;
-            /** Actual Rows */
-            actual_rows: number;
-            /** Latest At */
-            latest_at?: string | null;
-            /** Ok */
-            ok: boolean;
-        };
-        /**
-         * RegimePendingResponse
-         * @description Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands.
-         */
-        RegimePendingResponse: {
-            /**
-             * Status
-             * @default pending
-             * @constant
-             */
-            status: "pending";
-            /**
-             * Scanner
-             * @enum {string}
-             */
-            scanner: "cri" | "vcg";
-            /**
-             * Reason
-             * @default ib_via_r2_not_wired
-             * @constant
-             */
-            reason: "ib_via_r2_not_wired";
-            /**
-             * Message
-             * @default Data source pending. CRI/VCG require VIX/VVIX/COR1M from the IB-via-R2 reader (separate project).
-             */
-            message: string;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
+            /** Cutoff Corr */
+            cutoff_corr?: string | null;
+            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
             /**
              * Points
              * @default []
              */
             points: components["schemas"]["RegimeQuadrantPoint"][];
-            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
-            /** Cutoff Corr */
-            cutoff_corr?: string | null;
         };
         /** RegimeQuadrantLatest */
         RegimeQuadrantLatest: {
@@ -2268,10 +2243,10 @@ export interface components {
         ReturnsBlock: {
             /** D1 */
             d1?: string | null;
-            /** W1 */
-            w1?: string | null;
             /** D30 */
             d30?: string | null;
+            /** W1 */
+            w1?: string | null;
         };
         /** RvCorrPoint */
         RvCorrPoint: {
@@ -2287,41 +2262,49 @@ export interface components {
         };
         /** SetupBlock */
         SetupBlock: {
-            /** Type */
-            type?: string | null;
             /** Direction */
             direction?: string | null;
             /** Score */
             score?: string | null;
+            /** Type */
+            type?: string | null;
         };
         /** SetupClassification */
         SetupClassification: {
-            /** Setup Type */
-            setup_type: string;
-            /** Label */
-            label: string;
-            /** Direction */
-            direction: string;
-            /** Score */
-            score: string;
             /**
              * Confirmations
              * @default []
              */
             confirmations: string[];
-            /**
-             * Warnings
-             * @default []
-             */
-            warnings: string[];
+            /** Direction */
+            direction: string;
+            /** Label */
+            label: string;
             /**
              * Notes
              * @default
              */
             notes: string;
+            /** Score */
+            score: string;
+            /** Setup Type */
+            setup_type: string;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: string[];
         };
         /** ShortDataRow */
         ShortDataRow: {
+            /** Fee Rate */
+            fee_rate?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Rebate Rate */
+            rebate_rate?: string | null;
+            /** Short Shares Available */
+            short_shares_available?: number | null;
             /** Symbol */
             symbol: string;
             /**
@@ -2329,41 +2312,10 @@ export interface components {
              * Format: date-time
              */
             timestamp: string;
-            /** Name */
-            name?: string | null;
-            /** Short Shares Available */
-            short_shares_available?: number | null;
-            /** Fee Rate */
-            fee_rate?: string | null;
-            /** Rebate Rate */
-            rebate_rate?: string | null;
         };
         /** SingleStockReport */
         SingleStockReport: {
-            /** Run Id */
-            run_id: number;
-            /** Ticker */
-            ticker: string;
-            /**
-             * Generated At
-             * Format: date-time
-             */
-            generated_at: string;
-            /** Spot Quoted At */
-            spot_quoted_at?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /**
-             * Short Int Note
-             * @default n/a (UW endpoint does not expose %)
-             */
-            short_int_note: string;
-            market_structure: components["schemas"]["MarketStructure"];
-            volatility: components["schemas"]["VolatilityProfile"];
-            flow: components["schemas"]["FlowSnapshot"];
-            vrp: components["schemas"]["VRPAssessment"];
-            setup?: components["schemas"]["SetupClassification"] | null;
-            trade_plan?: components["schemas"]["TradePlan"] | null;
+            aggregates?: components["schemas"]["MarketAggregates"] | null;
             /** Dark Pool Notional */
             dark_pool_notional?: string | null;
             /**
@@ -2371,36 +2323,59 @@ export interface components {
              * @default 0
              */
             dark_pool_print_count: number;
-            short_data?: components["schemas"]["ShortDataRow"] | null;
+            flow: components["schemas"]["FlowSnapshot"];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            market_structure: components["schemas"]["MarketStructure"];
+            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
             /**
              * Max Pain Rows
              * @default []
              */
             max_pain_rows: components["schemas"]["MaxPainRow"][];
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
             /**
              * Oi Change Top
              * @default []
              */
             oi_change_top: components["schemas"]["OiChangeRow"][];
-            aggregates?: components["schemas"]["MarketAggregates"] | null;
-            /**
-             * Strike Gex Curve
-             * @default []
-             */
-            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
-            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
-            /**
-             * Options Timeline
-             * @default []
-             */
-            options_timeline: components["schemas"]["OptionsDailyRow"][];
             /**
              * Option Chain Per Strike
              * @default []
              */
             option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
+            /**
+             * Options Timeline
+             * @default []
+             */
+            options_timeline: components["schemas"]["OptionsDailyRow"][];
+            /** Run Id */
+            run_id: number;
+            setup?: components["schemas"]["SetupClassification"] | null;
+            short_data?: components["schemas"]["ShortDataRow"] | null;
+            /**
+             * Short Int Note
+             * @default n/a (UW endpoint does not expose %)
+             */
+            short_int_note: string;
+            /** Spot Quoted At */
+            spot_quoted_at?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
+            /**
+             * Strike Gex Curve
+             * @default []
+             */
+            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
+            /** Ticker */
+            ticker: string;
+            trade_plan?: components["schemas"]["TradePlan"] | null;
+            volatility: components["schemas"]["VolatilityProfile"];
+            vrp: components["schemas"]["VRPAssessment"];
         };
         /** SkewBlock */
         SkewBlock: {
@@ -2422,18 +2397,18 @@ export interface components {
         };
         /** SmilePoint */
         SmilePoint: {
-            /** Strike */
-            strike: string;
             /** Iv */
             iv?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** SourceReconciliation */
         SourceReconciliation: {
             /**
-             * Status
-             * @default UNKNOWN
+             * Decision
+             * @default Use deterministic data only where source agreement is understood.
              */
-            status: string;
+            decision: string;
             /**
              * Headline
              * @default Source reconciliation unavailable
@@ -2449,48 +2424,48 @@ export interface components {
              */
             rows: components["schemas"]["SourceReconciliationRow"][];
             /**
-             * Decision
-             * @default Use deterministic data only where source agreement is understood.
+             * Status
+             * @default UNKNOWN
              */
-            decision: string;
+            status: string;
         };
         /** SourceReconciliationRow */
         SourceReconciliationRow: {
-            /** Source Pair */
-            source_pair: string;
             /**
-             * Price Agreement
+             * Decision
              * @default
              */
-            price_agreement: string;
+            decision: string;
             /**
              * Iv Agreement
              * @default
              */
             iv_agreement: string;
+            /** Iv Diff */
+            iv_diff?: string | null;
             /**
-             * Decision
+             * Price Agreement
              * @default
              */
-            decision: string;
-            /** Strike */
-            strike?: string | null;
+            price_agreement: string;
             /** Source A Call Iv */
             source_a_call_iv?: string | null;
             /** Source B Call Iv */
             source_b_call_iv?: string | null;
-            /** Iv Diff */
-            iv_diff?: string | null;
+            /** Source Pair */
+            source_pair: string;
+            /** Strike */
+            strike?: string | null;
         };
         /** StockHistoryResponse */
         StockHistoryResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Rows
              * @default []
              */
             rows: components["schemas"]["StockHistoryRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /**
          * StockHistoryRow
@@ -2502,35 +2477,35 @@ export interface components {
          */
         StockHistoryRow: {
             /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /** Spot */
-            spot?: string | null;
-            /** Gex Flip */
-            gex_flip?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Net Dex */
-            net_dex?: string | null;
-            /** Iv30D */
-            iv30d?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
-            /**
              * Bias
              * @default NEUTRAL
              */
             bias: string;
+            /** Gex Flip */
+            gex_flip?: string | null;
+            /** Iv30D */
+            iv30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Net Dex */
+            net_dex?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Spot */
+            spot?: string | null;
         };
         /**
          * StrikeGexBucket
          * @description One row of the per-strike, per-expiry GEX curve persisted on each scan run.
          */
         StrikeGexBucket: {
-            /** Strike */
-            strike: string;
+            /** Call Gex */
+            call_gex?: string | null;
             /**
              * Expiry
              * Format: date
@@ -2538,26 +2513,26 @@ export interface components {
             expiry: string;
             /** Net Gex */
             net_gex?: string | null;
-            /** Call Gex */
-            call_gex?: string | null;
             /** Put Gex */
             put_gex?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** TermMoveRow */
         TermMoveRow: {
+            /** Atm Straddle */
+            atm_straddle?: string | null;
+            /** Daily Implied Move Perc */
+            daily_implied_move_perc?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Atm Straddle */
-            atm_straddle?: string | null;
             /** Implied Move Perc */
             implied_move_perc?: string | null;
-            /** Daily Implied Move Perc */
-            daily_implied_move_perc?: string | null;
             /**
              * Read
              * @default
@@ -2567,19 +2542,19 @@ export interface components {
         /** TermStructureExpiryRow */
         TermStructureExpiryRow: {
             /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /**
              * By Strike
              * @default {}
              */
             by_strike: {
                 [key: string]: string;
             };
+            /** Dte */
+            dte?: number | null;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
             /**
              * Strikes
              * @default {}
@@ -2603,104 +2578,101 @@ export interface components {
              * Format: uuid
              */
             analysis_id: string;
-            /** Ticker */
-            ticker: string;
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
-            /** Model */
-            model: string;
-            /** Prompt Version */
-            prompt_version: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "succeeded" | "failed";
-            /** Produced At */
-            produced_at?: string | null;
-            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
-            /** Markdown */
-            markdown?: string | null;
             /** Error Message */
             error_message?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Markdown */
+            markdown?: string | null;
+            /** Model */
+            model: string;
+            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
+            /** Produced At */
+            produced_at?: string | null;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
-            /** Started At */
-            started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
             /**
              * Reused
              * @default false
              */
             reused: boolean;
+            /** Run Id */
+            run_id: number;
+            /** Started At */
+            started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Ticker */
+            ticker: string;
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /** TradeInsightAiBestExpression */
         TradeInsightAiBestExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Role */
-            role: string;
-            /** Why */
-            why: string;
             /** Caveats */
             caveats?: string[];
-            /** Status Observed */
-            status_observed: string;
+            /** Idea Id */
+            idea_id: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Role */
+            role: string;
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiConflict */
         TradeInsightAiConflict: {
+            /** Affected Idea Ids */
+            affected_idea_ids?: string[];
+            /** Description */
+            description: string;
             /** Lens */
             lens: string;
             /** Severity */
             severity: string;
-            /** Description */
-            description: string;
-            /** Affected Idea Ids */
-            affected_idea_ids?: string[];
         };
         /** TradeInsightAiDominantRead */
         TradeInsightAiDominantRead: {
-            /** Headline */
-            headline: string;
-            /** Summary */
-            summary: string;
             /** Confidence Commentary */
             confidence_commentary: string;
             /** Data Quality Commentary */
             data_quality_commentary: string;
+            /** Headline */
+            headline: string;
+            /** Summary */
+            summary: string;
         };
         /** TradeInsightAiGuardrails */
         TradeInsightAiGuardrails: {
-            /** Statuses Preserved */
-            statuses_preserved: boolean;
-            /** Risk Flags Preserved */
-            risk_flags_preserved: boolean;
             /** No Executable Recommendations */
             no_executable_recommendations: boolean;
+            /** Risk Flags Preserved */
+            risk_flags_preserved: boolean;
+            /** Statuses Preserved */
+            statuses_preserved: boolean;
         };
         /** TradeInsightAiHeadline */
         TradeInsightAiHeadline: {
-            /** Title */
-            title: string;
-            /**
-             * Stance
-             * @enum {string}
-             */
-            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
-            /** Stance Label */
-            stance_label: string;
+            /** Conviction */
+            conviction: string;
+            /** Conviction Label */
+            conviction_label: string;
+            /** Primary Risk */
+            primary_risk: string;
             /** Score */
             score: number;
             /**
@@ -2708,14 +2680,17 @@ export interface components {
              * @default 100
              */
             score_scale: number;
-            /** Conviction */
-            conviction: string;
-            /** Conviction Label */
-            conviction_label: string;
+            /**
+             * Stance
+             * @enum {string}
+             */
+            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
+            /** Stance Label */
+            stance_label: string;
+            /** Title */
+            title: string;
             /** Top Reason */
             top_reason: string;
-            /** Primary Risk */
-            primary_risk: string;
             /** Watch Trigger */
             watch_trigger: string;
         };
@@ -2723,163 +2698,163 @@ export interface components {
         TradeInsightAiHighlight: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiLevel */
         TradeInsightAiLevel: {
-            /** Price */
-            price: string;
-            /** Kind */
-            kind: string;
-            /** Value */
-            value: string;
             /**
              * Importance
              * @default normal
              */
             importance: string;
-            /** Source Path */
-            source_path?: string | null;
+            /** Kind */
+            kind: string;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Price */
+            price: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiMetricCard */
         TradeInsightAiMetricCard: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /**
-             * Tone
-             * @default neutral
-             */
-            tone: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /**
+             * Tone
+             * @default neutral
+             */
+            tone: string;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiOutcome */
         TradeInsightAiOutcome: {
-            /** Schema Version */
-            schema_version: string;
             /**
              * Analysis Produced At
              * Format: date-time
              */
             analysis_produced_at: string;
-            /** Ticker */
-            ticker: string;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
-            headline: components["schemas"]["TradeInsightAiHeadline"];
-            /** Metric Cards */
-            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
-            /** Scenario Cards */
-            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
-            /** Score Breakdown */
-            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
-            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
-            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
-            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
-            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
             /** Best Expressions */
             best_expressions?: components["schemas"]["TradeInsightAiBestExpression"][];
             /** Conflicts */
             conflicts?: components["schemas"]["TradeInsightAiConflict"][];
-            /** Required Checks */
-            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
-            /** Rejected Ideas */
-            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
+            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
+            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            headline: components["schemas"]["TradeInsightAiHeadline"];
+            /** Metric Cards */
+            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Missing Data */
             missing_data?: string[];
+            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
+            /** Rejected Ideas */
+            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
             rendering: components["schemas"]["TradeInsightAiRendering"];
-            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            /** Required Checks */
+            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
+            /** Scenario Cards */
+            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
+            /** Schema Version */
+            schema_version: string;
+            /** Score Breakdown */
+            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
+            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
+            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
+            /** Ticker */
+            ticker: string;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
         };
         /** TradeInsightAiPreferredExpression */
         TradeInsightAiPreferredExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Title */
-            title: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
             /**
              * Estimated Entry
              * @default
              */
             estimated_entry: string;
-            /**
-             * Max Profit Observed
-             * @default
-             */
-            max_profit_observed: string;
+            /** Idea Id */
+            idea_id: string;
+            /** Management Notes */
+            management_notes?: string[];
             /**
              * Max Loss Observed
              * @default
              */
             max_loss_observed: string;
             /**
+             * Max Profit Observed
+             * @default
+             */
+            max_profit_observed: string;
+            /**
              * Reward Risk
              * @default
              */
             reward_risk: string;
-            /** Why */
-            why: string;
-            /** Management Notes */
-            management_notes?: string[];
-            /** Status Observed */
-            status_observed: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /** Title */
+            title: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiRejectedIdea */
         TradeInsightAiRejectedIdea: {
             /** Idea Id */
             idea_id: string;
-            /** Structure */
-            structure: string;
             /** Reason */
             reason: string;
+            /** Structure */
+            structure: string;
         };
         /** TradeInsightAiRendering */
         TradeInsightAiRendering: {
-            /** Disclaimer */
-            disclaimer: string;
             /** Card Order */
             card_order?: string[];
+            /** Disclaimer */
+            disclaimer: string;
         };
         /** TradeInsightAiRequiredCheck */
         TradeInsightAiRequiredCheck: {
-            /** Check */
-            check: string;
-            /** Reason */
-            reason: string;
             /**
              * Blocks Sizing
              * @default true
              */
             blocks_sizing: boolean;
+            /** Check */
+            check: string;
+            /** Reason */
+            reason: string;
             /**
              * Source
              * @default
@@ -2890,59 +2865,55 @@ export interface components {
         TradeInsightAiScenarioCard: {
             /** Case */
             case: ("upside" | "base" | "downside") | string;
+            /** Description */
+            description: string;
+            /** Title */
+            title: string;
             /**
              * Tone
              * @default neutral
              */
             tone: string;
-            /** Title */
-            title: string;
-            /** Description */
-            description: string;
         };
         /** TradeInsightAiScoreBreakdown */
         TradeInsightAiScoreBreakdown: {
-            /** Section */
-            section: string;
-            /** Score */
-            score: number;
             /** Max Score */
             max_score: number;
+            /** Score */
+            score: number;
+            /** Section */
+            section: string;
             /** Summary */
             summary: string;
         };
         /** TradeInsightAiSectionCard */
         TradeInsightAiSectionCard: {
-            /** Title */
-            title: string;
-            /** Score */
-            score?: number | null;
-            /** Max Score */
-            max_score?: number | null;
-            /** Summary */
-            summary: string;
-            /** Highlights */
-            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
-            /** Levels */
-            levels?: components["schemas"]["TradeInsightAiLevel"][];
             /**
              * Data Quality
              * @default unknown
              */
             data_quality: string;
+            /** Highlights */
+            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
+            /** Levels */
+            levels?: components["schemas"]["TradeInsightAiLevel"][];
+            /** Max Score */
+            max_score?: number | null;
+            /** Score */
+            score?: number | null;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightAiSectionCards */
         TradeInsightAiSectionCards: {
+            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
             market_structure: components["schemas"]["TradeInsightAiSectionCard"];
             volatility: components["schemas"]["TradeInsightAiSectionCard"];
-            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
         };
         /** TradeInsightAiSnapshotMeta */
         TradeInsightAiSnapshotMeta: {
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
             /** Data As Of */
@@ -2952,34 +2923,33 @@ export interface components {
              * @default unknown
              */
             freshness_label: string;
+            /** Run Id */
+            run_id: number;
             /** Source Notes */
             source_notes?: string[];
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /** TradeInsightAiVrpAssessment */
         TradeInsightAiVrpAssessment: {
-            /** Signal */
-            signal: string;
-            /** Title */
-            title: string;
-            /** Summary */
-            summary: string;
             /** Metrics */
             metrics?: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Reason */
             reason: string;
+            /** Signal */
+            signal: string;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightsHeader */
         TradeInsightsHeader: {
             /**
-             * Dominant Bias
-             * @default NEUTRAL
+             * Badges
+             * @default []
              */
-            dominant_bias: string;
-            /**
-             * Primary Setup
-             * @default NO_CLEAR_SETUP
-             */
-            primary_setup: string;
+            badges: components["schemas"]["InsightBadge"][];
             /**
              * Confidence Label
              * @default LOW
@@ -2991,6 +2961,11 @@ export interface components {
              */
             data_quality_label: string;
             /**
+             * Dominant Bias
+             * @default NEUTRAL
+             */
+            dominant_bias: string;
+            /**
              * Idea Count
              * @default 0
              */
@@ -2998,65 +2973,63 @@ export interface components {
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
             /**
-             * Badges
-             * @default []
+             * Primary Setup
+             * @default NO_CLEAR_SETUP
              */
-            badges: components["schemas"]["InsightBadge"][];
+            primary_setup: string;
         };
         /** TradeInsightsResponse */
         TradeInsightsResponse: {
-            /** Ticker */
-            ticker: string;
             /** As Of */
             as_of?: string | null;
-            /**
-             * Mode
-             * @default research
-             */
-            mode: string;
-            header: components["schemas"]["TradeInsightsHeader"];
-            /**
-             * @default {
-             *       "status": "UNKNOWN",
-             *       "headline": "Source reconciliation unavailable",
-             *       "rows": [],
-             *       "decision": "Use deterministic data only where source agreement is understood."
-             *     }
-             */
-            source_reconciliation: components["schemas"]["SourceReconciliation"];
-            /**
-             * Signal Stack
-             * @default []
-             */
-            signal_stack: components["schemas"]["InsightSignalRow"][];
-            /**
-             * Flow Table
-             * @default []
-             */
-            flow_table: components["schemas"]["ChainFlowReadRow"][];
-            /**
-             * Term Structure Table
-             * @default []
-             */
-            term_structure_table: components["schemas"]["TermMoveRow"][];
             /**
              * Candidate Structures
              * @default []
              */
             candidate_structures: components["schemas"]["CandidateStructure"][];
             /**
+             * Flow Table
+             * @default []
+             */
+            flow_table: components["schemas"]["ChainFlowReadRow"][];
+            header: components["schemas"]["TradeInsightsHeader"];
+            /**
+             * Mode
+             * @default research
+             */
+            mode: string;
+            /**
+             * Signal Stack
+             * @default []
+             */
+            signal_stack: components["schemas"]["InsightSignalRow"][];
+            /**
              * @default {
-             *       "dominant_story": "",
+             *       "decision": "Use deterministic data only where source agreement is understood.",
+             *       "headline": "Source reconciliation unavailable",
+             *       "rows": [],
+             *       "status": "UNKNOWN"
+             *     }
+             */
+            source_reconciliation: components["schemas"]["SourceReconciliation"];
+            /**
+             * @default {
              *       "avoid": [],
+             *       "dominant_story": "",
              *       "required_before_sizing": []
              *     }
              */
             synthesis: components["schemas"]["InsightsSynthesis"];
+            /**
+             * Term Structure Table
+             * @default []
+             */
+            term_structure_table: components["schemas"]["TermMoveRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /** TradePlan */
         TradePlan: {
-            /** Structure */
-            structure: string;
             /** Direction */
             direction: string;
             /**
@@ -3064,21 +3037,17 @@ export interface components {
              * @default []
              */
             legs: components["schemas"]["TradePlanLeg"][];
-            /** Rationale */
-            rationale: string;
             /** Max Loss */
             max_loss?: string | null;
             /** Max Profit */
             max_profit?: string | null;
+            /** Rationale */
+            rationale: string;
+            /** Structure */
+            structure: string;
         };
         /** TradePlanLeg */
         TradePlanLeg: {
-            /** Option Symbol */
-            option_symbol: string;
-            /** Side */
-            side: string;
-            /** Strike */
-            strike: string;
             /**
              * Expiry
              * Format: date
@@ -3086,44 +3055,267 @@ export interface components {
             expiry: string;
             /** Mid */
             mid?: string | null;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** VRPAssessment */
         VRPAssessment: {
-            /** Vrp */
-            vrp?: string | null;
-            /** Signal */
-            signal: string;
             /** Note */
             note: string;
+            /** Signal */
+            signal: string;
+            /** Vrp */
+            vrp?: string | null;
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
+        };
+        /** VcgAttribution */
+        VcgAttribution: {
+            /**
+             * Model Implied
+             * @default 0
+             */
+            model_implied: number;
+            /**
+             * Vix Component
+             * @default 0
+             */
+            vix_component: number;
+            /**
+             * Vix Pct
+             * @default 0
+             */
+            vix_pct: number;
+            /**
+             * Vvix Component
+             * @default 0
+             */
+            vvix_component: number;
+            /**
+             * Vvix Pct
+             * @default 0
+             */
+            vvix_pct: number;
+        };
+        /** VcgHistoryEntry */
+        VcgHistoryEntry: {
+            /** Beta1 */
+            beta1?: number | null;
+            /** Beta2 */
+            beta2?: number | null;
+            /**
+             * Bounce
+             * @default 0
+             */
+            bounce: number;
+            /**
+             * Credit
+             * @default 0
+             */
+            credit: number;
+            /** Date */
+            date: string;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /** Residual */
+            residual?: number | null;
+            /**
+             * Ro
+             * @default 0
+             */
+            ro: number;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
+        };
+        /**
+         * VcgResponse
+         * @description Volatility-Credit Gap snapshot (latest scan).
+         */
+        VcgResponse: {
+            /**
+             * Credit Proxy
+             * @default HYG
+             */
+            credit_proxy: string;
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["VcgHistoryEntry"][];
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            signal?: components["schemas"]["VcgSignal"];
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
+        };
+        /**
+         * VcgScanResponse
+         * @description Response body for POST /api/regime/vcg/scan.
+         */
+        VcgScanResponse: {
+            /**
+             * Proxy
+             * @default HYG
+             */
+            proxy: string;
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
+            /**
+             * Scanner
+             * @default vcg
+             * @constant
+             */
+            scanner: "vcg";
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
+        };
+        /** VcgSignal */
+        VcgSignal: {
+            /** Alpha */
+            alpha?: number | null;
+            attribution?: components["schemas"]["VcgAttribution"];
+            /** Beta1 Vvix */
+            beta1_vvix?: number | null;
+            /** Beta2 Vix */
+            beta2_vix?: number | null;
+            /**
+             * Bounce
+             * @default 0
+             */
+            bounce: number;
+            /**
+             * Credit 5D Return Pct
+             * @default 0
+             */
+            credit_5d_return_pct: number;
+            /**
+             * Credit Price
+             * @default 0
+             */
+            credit_price: number;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /**
+             * Interpretation
+             * @default NORMAL
+             * @enum {string}
+             */
+            interpretation: "RISK_OFF" | "EDR" | "WATCH" | "BOUNCE" | "NORMAL" | "SUPPRESSED" | "PANIC" | "INSUFFICIENT_DATA";
+            /**
+             * Pi Panic
+             * @default 0
+             */
+            pi_panic: number;
+            /**
+             * Regime
+             * @default DIVERGENCE
+             * @enum {string}
+             */
+            regime: "PANIC" | "TRANSITION" | "DIVERGENCE";
+            /** Residual */
+            residual?: number | null;
+            /**
+             * Ro
+             * @default 0
+             */
+            ro: number;
+            /**
+             * Sign Ok
+             * @default true
+             */
+            sign_ok: boolean;
+            /**
+             * Sign Suppressed
+             * @default false
+             */
+            sign_suppressed: boolean;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
+            /**
+             * Vvix Severity
+             * @default moderate
+             * @enum {string}
+             */
+            vvix_severity: "extreme" | "elevated" | "moderate";
         };
         /** VolBackdropPoint */
         VolBackdropPoint: {
+            /** Close */
+            close: number;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Close */
-            close: number;
         };
         /**
          * VolBackdropResponse
          * @description Vol-complex time series + VIX term-structure (regime page header strip).
          */
         VolBackdropResponse: {
+            /** As Of */
+            as_of?: string | null;
             /** Series */
             series?: {
                 [key: string]: components["schemas"]["VolBackdropPoint"][];
@@ -3132,68 +3324,66 @@ export interface components {
             term_structure_ratio?: number | null;
             /** Term Structure State */
             term_structure_state?: string | null;
-            /** As Of */
-            as_of?: string | null;
         };
         /** VolHeaderBlock */
         VolHeaderBlock: {
+            /** Implied Move 30D Perc */
+            implied_move_30d_perc?: string | null;
             /** Iv */
             iv?: string | null;
-            /** Rv */
-            rv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
             /** Iv Rank */
             iv_rank?: string | null;
             /** Iv Rank 1Y */
             iv_rank_1y?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
+            /** Rv */
+            rv?: string | null;
             /** Rv High 52W */
             rv_high_52w?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
-            /** Implied Move 30D Perc */
-            implied_move_30d_perc?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /** Vrp */
             vrp?: string | null;
             /**
-             * Vrp Signal
-             * @default
-             */
-            vrp_signal: string;
-            /**
              * Vrp Note
              * @default
              */
             vrp_note: string;
+            /**
+             * Vrp Signal
+             * @default
+             */
+            vrp_signal: string;
         };
         /** VolatilityProfile */
         VolatilityProfile: {
-            /** Iv */
-            iv?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv */
-            rv?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
-            /** Rv High 52W */
-            rv_high_52w?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
             /** Implied Move 30D Perc */
             implied_move_30d_perc?: string | null;
+            /** Iv */
+            iv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
+            /** Rv */
+            rv?: string | null;
+            /** Rv High 52W */
+            rv_high_52w?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /**
@@ -3207,8 +3397,6 @@ export interface components {
         };
         /** VolatilitySeriesResponse */
         VolatilitySeriesResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * As Of
              * Format: date
@@ -3216,44 +3404,6 @@ export interface components {
             as_of: string;
             /** Backfill Status */
             backfill_status: string;
-            header: components["schemas"]["VolHeaderBlock"];
-            /**
-             * Term Structure
-             * @default []
-             */
-            term_structure: components["schemas"]["TermStructureExpiryRow"][];
-            /**
-             * Smile
-             * @default []
-             */
-            smile: components["schemas"]["SmileExpiryCurve"][];
-            /**
-             * Hv Iv History
-             * @default []
-             */
-            hv_iv_history: components["schemas"]["IvHvPoint"][];
-            /**
-             * @default {
-             *       "bins": []
-             *     }
-             */
-            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
-            /**
-             * Iv Of Iv
-             * @default []
-             */
-            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
-            /**
-             * Rv Spy Corr
-             * @default []
-             */
-            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
-            /**
-             * @default {
-             *       "points": []
-             *     }
-             */
-            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
             /**
              * Divergence
              * @default []
@@ -3264,6 +3414,48 @@ export interface components {
              * @default
              */
             divergence_headline: string;
+            header: components["schemas"]["VolHeaderBlock"];
+            /**
+             * Hv Iv History
+             * @default []
+             */
+            hv_iv_history: components["schemas"]["IvHvPoint"][];
+            /**
+             * Iv Of Iv
+             * @default []
+             */
+            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
+            /**
+             * @default {
+             *       "bins": []
+             *     }
+             */
+            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
+            /**
+             * @default {
+             *       "points": []
+             *     }
+             */
+            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
+            /**
+             * Rv Spy Corr
+             * @default []
+             */
+            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
+            /**
+             * Smile
+             * @default []
+             */
+            smile: components["schemas"]["SmileExpiryCurve"][];
+            /** Spot */
+            spot?: string | null;
+            /**
+             * Term Structure
+             * @default []
+             */
+            term_structure: components["schemas"]["TermStructureExpiryRow"][];
+            /** Ticker */
+            ticker: string;
             /**
              * Vrp Spread
              * @default []
@@ -3274,8 +3466,6 @@ export interface components {
              * @default
              */
             vrp_spread_headline: string;
-            /** Spot */
-            spot?: string | null;
         };
         /** VrpDailyPoint */
         VrpDailyPoint: {
@@ -3291,12 +3481,28 @@ export interface components {
         };
         /** WatchlistCard */
         WatchlistCard: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
+            /** Aggression Pct */
+            aggression_pct?: string | null;
+            /** Aum */
+            aum?: string | null;
+            gamma: components["schemas"]["GammaBlock"];
+            /** Iv Atm */
+            iv_atm?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Market Cap */
+            market_cap?: string | null;
             /** Pinned */
             pinned: boolean;
+            positioning: components["schemas"]["PositioningBlock"];
+            queue?: components["schemas"]["QueueStatus"] | null;
+            returns: components["schemas"]["ReturnsBlock"];
+            /** Scanned At */
+            scanned_at?: string | null;
+            /** Sector */
+            sector: string;
+            setup: components["schemas"]["SetupBlock"];
+            skew: components["schemas"]["SkewBlock"];
             /** Sort Rank */
             sort_rank: number;
             /** Spot */
@@ -3305,31 +3511,11 @@ export interface components {
             spot_quoted_at?: string | null;
             /** Spot Source */
             spot_source?: string | null;
-            /** Scanned At */
-            scanned_at?: string | null;
-            /** Iv Atm */
-            iv_atm?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Market Cap */
-            market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
-            setup: components["schemas"]["SetupBlock"];
-            /** Aggression Pct */
-            aggression_pct?: string | null;
-            returns: components["schemas"]["ReturnsBlock"];
-            gamma: components["schemas"]["GammaBlock"];
-            skew: components["schemas"]["SkewBlock"];
-            positioning: components["schemas"]["PositioningBlock"];
-            queue?: components["schemas"]["QueueStatus"] | null;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistMutation */
         WatchlistMutation: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
             /** Notes */
             notes?: string | null;
             /**
@@ -3337,63 +3523,67 @@ export interface components {
              * @default false
              */
             pinned: boolean;
+            /** Sector */
+            sector: string;
             /**
              * Sort Rank
              * @default 0
              */
             sort_rank: number;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistPatch */
         WatchlistPatch: {
-            /** Sector */
-            sector?: string | null;
             /** Notes */
             notes?: string | null;
             /** Pinned */
             pinned?: boolean | null;
+            /** Sector */
+            sector?: string | null;
             /** Sort Rank */
             sort_rank?: number | null;
         };
         /** WatchlistResponse */
         WatchlistResponse: {
-            /** Scanned At Min */
-            scanned_at_min?: string | null;
+            queue?: components["schemas"]["QueueSummary"];
             /** Scanned At Max */
             scanned_at_max?: string | null;
+            /** Scanned At Min */
+            scanned_at_min?: string | null;
             /** Scheduler Lag Seconds */
             scheduler_lag_seconds?: number | null;
-            queue?: components["schemas"]["QueueSummary"];
             /** Tickers */
             tickers: components["schemas"]["WatchlistCard"][];
         };
         /** WorkerHealth */
         WorkerHealth: {
+            /** Heartbeat Name */
+            heartbeat_name: string;
+            /** Index */
+            index: number;
             /** Label */
             label: string;
+            /** Lag Seconds */
+            lag_seconds?: number | null;
+            /** Last Beat At */
+            last_beat_at?: string | null;
             /**
              * Role
              * @enum {string}
              */
             role: "uw" | "massive";
-            /** Index */
-            index: number;
-            /** Heartbeat Name */
-            heartbeat_name: string;
-            /** Lag Seconds */
-            lag_seconds?: number | null;
-            /** Last Beat At */
-            last_beat_at?: string | null;
         };
         /** GexLevel */
         uw_scan__api__schemas__GexLevel: {
-            /** Strike */
-            strike?: number | null;
-            /** Gamma */
-            gamma?: number | null;
             /** Distance */
             distance?: number | null;
             /** Distance Pct */
             distance_pct?: number | null;
+            /** Gamma */
+            gamma?: number | null;
+            /** Strike */
+            strike?: number | null;
         };
         /**
          * GexLevel
@@ -3403,14 +3593,14 @@ export interface components {
          *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
          */
         uw_scan__models__GexLevel: {
-            /** Strike */
-            strike: string;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
             /** Net Gex */
             net_gex?: string | null;
             /** Pct From Spot */
             pct_from_spot?: string | null;
-            /** Gamma Per Dollar */
-            gamma_per_dollar?: string | null;
+            /** Strike */
+            strike: string;
         };
     };
     responses: never;
@@ -3421,6 +3611,171 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitDealerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitFlowImResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_state_api_cockpit__ticker__state_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_surface_api_cockpit__ticker__surface_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitVrpResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     health_api_health_get: {
         parameters: {
             query?: {
@@ -3455,16 +3810,46 @@ export interface operations {
             };
         };
     };
-    get_watchlist_api_watchlist_get: {
+    get_job_api_jobs__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ohlc_api_ohlc__ticker__get: {
         parameters: {
             query?: {
-                sector?: string | null;
-                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
-                setup?: string | null;
-                fresh_within_minutes?: number | null;
+                days?: number;
             };
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -3475,7 +3860,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WatchlistResponse"];
+                    "application/json": components["schemas"]["OhlcRow"][];
                 };
             };
             /** @description Validation Error */
@@ -3489,21 +3874,197 @@ export interface operations {
             };
         };
     };
-    post_watchlist_api_watchlist_post: {
+    provider_usage_endpoints_api_provider_usage_endpoints_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_requests_api_provider_usage_requests_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+                ticker?: string | null;
+                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_summary_api_provider_usage_summary_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_tickers_api_provider_usage_tickers_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_regime_api_regime_get: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistMutation"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
-            201: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriResponse"];
+                };
+            };
+        };
+    };
+    get_gex_api_regime_gex_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_gex_scan_api_regime_gex_scan_post: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3524,23 +4085,45 @@ export interface operations {
             };
         };
     };
-    delete_watchlist_api_watchlist__ticker__delete: {
+    trigger_cri_scan_api_regime_scan_post: {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                ticker: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            204: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["CriScanResponse"];
+                };
+            };
+        };
+    };
+    get_vcg_api_regime_vcg_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgResponse"];
+                };
             };
             /** @description Validation Error */
             422: {
@@ -3553,20 +4136,47 @@ export interface operations {
             };
         };
     };
-    patch_watchlist_api_watchlist__ticker__patch: {
+    trigger_vcg_scan_api_regime_vcg_scan_post: {
         parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
+            query?: {
+                proxy?: string;
             };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistPatch"];
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgScanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
             };
         };
+    };
+    get_vol_backdrop_api_regime_vol_backdrop_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -3574,9 +4184,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["VolBackdropResponse"];
                 };
             };
             /** @description Validation Error */
@@ -3704,457 +4312,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SingleStockReport"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_ohlc_api_ohlc__ticker__get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OhlcRow"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_state_api_cockpit__ticker__state_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitStateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitDealerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_surface_api_cockpit__ticker__surface_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitFlowImResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitVrpResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_api_watchlist__ticker__rescan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_all_api_watchlist_rescan_all_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RescanAllRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_job_api_jobs__job_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_volatility_series_api_stock__ticker__volatility_series_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_summary_api_provider_usage_summary_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_endpoints_api_provider_usage_endpoints_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_tickers_api_provider_usage_tickers_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_requests_api_provider_usage_requests_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-                ticker?: string | null;
-                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -4297,13 +4454,13 @@ export interface operations {
             };
         };
     };
-    get_gex_api_regime_gex_get: {
+    get_volatility_series_api_stock__ticker__volatility_series_get: {
         parameters: {
-            query?: {
-                ticker?: string;
-            };
+            query?: never;
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -4314,7 +4471,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GexResponse"];
+                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
                 };
             };
             /** @description Validation Error */
@@ -4328,10 +4485,13 @@ export interface operations {
             };
         };
     };
-    trigger_gex_scan_api_regime_gex_scan_post: {
+    get_watchlist_api_watchlist_get: {
         parameters: {
             query?: {
-                ticker?: string;
+                sector?: string | null;
+                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
+                setup?: string | null;
+                fresh_within_minutes?: number | null;
             };
             header?: never;
             path?: never;
@@ -4340,7 +4500,40 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            202: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_watchlist_api_watchlist_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistMutation"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4361,24 +4554,26 @@ export interface operations {
             };
         };
     };
-    get_vol_backdrop_api_regime_vol_backdrop_get: {
+    enqueue_rescan_all_api_watchlist_rescan_all_post: {
         parameters: {
-            query?: {
-                days?: number;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RescanAllRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
-            200: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["VolBackdropResponse"];
+                    "application/json": components["schemas"]["JobStatus"][];
                 };
             };
             /** @description Validation Error */
@@ -4392,14 +4587,49 @@ export interface operations {
             };
         };
     };
-    get_regime_api_regime_get: {
+    delete_watchlist_api_watchlist__ticker__delete: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_watchlist_api_watchlist__ticker__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistPatch"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -4407,16 +4637,29 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriResponse"];
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
     };
-    trigger_cri_scan_api_regime_scan_post: {
+    enqueue_rescan_api_watchlist__ticker__rescan_post: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -4427,47 +4670,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriScanResponse"];
+                    "application/json": components["schemas"]["JobStatus"];
                 };
             };
-        };
-    };
-    get_vcg_api_regime_vcg_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
+            /** @description Validation Error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RegimePendingResponse"];
-                };
-            };
-        };
-    };
-    trigger_vcg_scan_api_regime_vcg_scan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RegimePendingResponse"];
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -440,6 +440,111 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/regime/gex": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gex */
+        get: operations["get_gex_api_regime_gex_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Gex Scan
+         * @description Run a GEX scan synchronously against UW and persist.
+         */
+        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime */
+        get: operations["get_regime_api_regime_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger Cri Scan */
+        post: operations["trigger_cri_scan_api_regime_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg */
+        get: operations["get_vcg_api_regime_vcg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger Vcg Scan */
+        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -875,22 +980,184 @@ export interface components {
             /** Expiring Date */
             expiring_date?: string | null;
         };
-        /**
-         * GexLevel
-         * @description One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).
-         *
-         *     `gamma_per_dollar` is the per-strike net_gex used as the "$N per $1" sensitivity
-         *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
-         */
-        GexLevel: {
+        /** GexBias */
+        GexBias: {
+            /** Direction */
+            direction?: string | null;
+            /** Reasons */
+            reasons?: string[];
+            /** Days Above Flip */
+            days_above_flip?: number | null;
+            /** Flip Migration */
+            flip_migration?: components["schemas"]["GexFlipMigrationEntry"][];
+        };
+        /** GexBucket */
+        GexBucket: {
             /** Strike */
-            strike: string;
+            strike?: number | null;
+            /** Call Gex */
+            call_gex?: number | null;
+            /** Put Gex */
+            put_gex?: number | null;
             /** Net Gex */
-            net_gex?: string | null;
+            net_gex?: number | null;
             /** Pct From Spot */
-            pct_from_spot?: string | null;
-            /** Gamma Per Dollar */
-            gamma_per_dollar?: string | null;
+            pct_from_spot?: number | null;
+            /** Tag */
+            tag?: string | null;
+        };
+        /** GexExpectedRange */
+        GexExpectedRange: {
+            /** Low */
+            low?: number | null;
+            /** High */
+            high?: number | null;
+            /** Iv 1D */
+            iv_1d?: number | null;
+        };
+        /** GexFlipMigrationEntry */
+        GexFlipMigrationEntry: {
+            /** Date */
+            date: string;
+            /** Flip */
+            flip?: number | null;
+        };
+        /** GexHistoryEntry */
+        GexHistoryEntry: {
+            /** Date */
+            date: string;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Spot */
+            spot?: number | null;
+            /** Atm Iv */
+            atm_iv?: number | null;
+            /** Vol Pc */
+            vol_pc?: number | null;
+            /** Bias */
+            bias?: string | null;
+        };
+        /** GexIvData */
+        GexIvData: {
+            /** Iv30D */
+            iv30d?: number | null;
+            /** Iv Rank */
+            iv_rank?: number | null;
+            /** Hv30 */
+            hv30?: number | null;
+            /** Mq Iv30D */
+            mq_iv30d?: number | null;
+            /** Mq Iv Rank */
+            mq_iv_rank?: string | null;
+            /** Source */
+            source?: string | null;
+        };
+        /** GexLevels */
+        GexLevels: {
+            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            call_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+        };
+        /** GexMqLevels */
+        GexMqLevels: {
+            /** Source Date */
+            source_date?: string | null;
+            /** Spot */
+            spot?: number | null;
+            /** Hvl */
+            hvl?: number | null;
+            /** Call Resistance All */
+            call_resistance_all?: number | null;
+            /** Call Resistance 0Dte */
+            call_resistance_0dte?: number | null;
+            /** Put Support All */
+            put_support_all?: number | null;
+            /** Put Support 0Dte */
+            put_support_0dte?: number | null;
+            /** Expected High */
+            expected_high?: number | null;
+            /** Expected Low */
+            expected_low?: number | null;
+            /** Distance To Hvl Pct */
+            distance_to_hvl_pct?: string | null;
+            /** Iv30D */
+            iv30d?: number | null;
+            /** Hv30 */
+            hv30?: number | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Top Gex Strikes */
+            top_gex_strikes?: number[];
+        };
+        /** GexResponse */
+        GexResponse: {
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /**
+             * Market Open
+             * @default false
+             */
+            market_open: boolean;
+            /**
+             * Ticker
+             * @default SPX
+             */
+            ticker: string;
+            /** Spot */
+            spot?: number | null;
+            /** Close */
+            close?: number | null;
+            /** Day Change */
+            day_change?: number | null;
+            /** Day Change Pct */
+            day_change_pct?: number | null;
+            /** Data Date */
+            data_date?: string | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Atm Iv */
+            atm_iv?: number | null;
+            /** Vol Pc */
+            vol_pc?: number | null;
+            levels?: components["schemas"]["GexLevels"];
+            /** Profile */
+            profile?: components["schemas"]["GexBucket"][];
+            expected_range?: components["schemas"]["GexExpectedRange"];
+            bias?: components["schemas"]["GexBias"];
+            /** History */
+            history?: components["schemas"]["GexHistoryEntry"][];
+            iv?: components["schemas"]["GexIvData"] | null;
+            mq?: components["schemas"]["GexMqLevels"] | null;
+            source_delta?: components["schemas"]["GexSourceDelta"] | null;
+        };
+        /** GexSourceDelta */
+        GexSourceDelta: {
+            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            call_wall_vs_resistance_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+        };
+        /** GexSourceDeltaEntry */
+        GexSourceDeltaEntry: {
+            /** Uw */
+            uw?: number | null;
+            /** Mq */
+            mq?: number | null;
+            /** Delta */
+            delta?: number | null;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -1175,12 +1442,12 @@ export interface components {
          *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
          */
         MarketStructureLevels: {
-            gex_flip?: components["schemas"]["GexLevel"] | null;
-            call_wall?: components["schemas"]["GexLevel"] | null;
-            put_wall?: components["schemas"]["GexLevel"] | null;
-            max_magnet?: components["schemas"]["GexLevel"] | null;
-            second_magnet?: components["schemas"]["GexLevel"] | null;
-            max_accel?: components["schemas"]["GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            call_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            max_accel?: components["schemas"]["uw_scan__models__GexLevel"] | null;
         };
         /** MatrixSourceFreshness */
         MatrixSourceFreshness: {
@@ -1700,6 +1967,34 @@ export interface components {
             latest_at?: string | null;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * RegimePendingResponse
+         * @description Sentinel for CRI/VCG endpoints until IB-via-R2 reader lands.
+         */
+        RegimePendingResponse: {
+            /**
+             * Status
+             * @default pending
+             * @constant
+             */
+            status: "pending";
+            /**
+             * Scanner
+             * @enum {string}
+             */
+            scanner: "cri" | "vcg";
+            /**
+             * Reason
+             * @default ib_via_r2_not_wired
+             * @constant
+             */
+            reason: "ib_via_r2_not_wired";
+            /**
+             * Message
+             * @default Data source pending. CRI/VCG require VIX/VVIX/COR1M from the IB-via-R2 reader (separate project).
+             */
+            message: string;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
@@ -2847,6 +3142,34 @@ export interface components {
             /** Last Beat At */
             last_beat_at?: string | null;
         };
+        /** GexLevel */
+        uw_scan__api__schemas__GexLevel: {
+            /** Strike */
+            strike?: number | null;
+            /** Gamma */
+            gamma?: number | null;
+            /** Distance */
+            distance?: number | null;
+            /** Distance Pct */
+            distance_pct?: number | null;
+        };
+        /**
+         * GexLevel
+         * @description One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).
+         *
+         *     `gamma_per_dollar` is the per-strike net_gex used as the "$N per $1" sensitivity
+         *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
+         */
+        uw_scan__models__GexLevel: {
+            /** Strike */
+            strike: string;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pct From Spot */
+            pct_from_spot?: string | null;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
+        };
     };
     responses: never;
     parameters: never;
@@ -3728,6 +4051,150 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gex_api_regime_gex_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_gex_scan_api_regime_gex_scan_post: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_regime_api_regime_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimePendingResponse"];
+                };
+            };
+        };
+    };
+    trigger_cri_scan_api_regime_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimePendingResponse"];
+                };
+            };
+        };
+    };
+    get_vcg_api_regime_vcg_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimePendingResponse"];
+                };
+            };
+        };
+    };
+    trigger_vcg_scan_api_regime_vcg_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimePendingResponse"];
                 };
             };
         };

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fontsource/inter": "^5.2.7",
+        "@types/d3": "^7.4.3",
+        "d3": "^7.9.0",
         "lucide-react": "^0.544.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
@@ -1901,6 +1903,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1913,6 +2168,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3468,6 +3729,416 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3609,6 +4280,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -4899,7 +5579,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4971,6 +5650,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7132,6 +7820,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
@@ -7196,6 +7890,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -7266,7 +7966,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "@fontsource/inter": "^5.2.7",
+    "@types/d3": "^7.4.3",
+    "d3": "^7.9.0",
     "lucide-react": "^0.544.0",
     "next": "^16.1.6",
     "react": "^19.2.4",

--- a/web/playwright.worktree.config.ts
+++ b/web/playwright.worktree.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+// Worktree e2e config — uses servers I started manually on 3003/8403.
+// Skips webServer so playwright doesn't try to spin up additional ports.
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://127.0.0.1:3003",
+    screenshot: "only-on-failure",
+  },
+});

--- a/web/tests/e2e/regime-page.spec.ts
+++ b/web/tests/e2e/regime-page.spec.ts
@@ -20,6 +20,16 @@ test("CRI tab renders subtab — either empty state or populated cards", async (
   ).toBeVisible({ timeout: 15_000 });
 });
 
+test("VCG tab renders subtab — either empty state or populated cards", async ({
+  page,
+}) => {
+  await page.goto("/regime");
+  await page.getByTestId("regime-tab-vcg").click();
+  await expect(
+    page.getByTestId("vcg-subtab").or(page.getByTestId("vcg-empty-state")),
+  ).toBeVisible({ timeout: 15_000 });
+});
+
 test("vol backdrop strip renders with four vol tiles + term structure", async ({
   page,
 }) => {

--- a/web/tests/e2e/regime-page.spec.ts
+++ b/web/tests/e2e/regime-page.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test("/regime renders with three tabs and GEX default", async ({ page }) => {
+  await page.goto("/regime");
+  await expect(page.getByRole("heading", { name: "Regime" })).toBeVisible();
+  await expect(page.getByTestId("regime-tab-cri")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-vcg")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-gex")).toBeVisible();
+  await expect(page.getByTestId("regime-tab-gex")).toHaveClass(/active/);
+});
+
+test("CRI tab shows pending placeholder", async ({ page }) => {
+  await page.goto("/regime");
+  await page.getByTestId("regime-tab-cri").click();
+  await expect(page.getByText(/coming soon/i)).toBeVisible();
+});

--- a/web/tests/e2e/regime-page.spec.ts
+++ b/web/tests/e2e/regime-page.spec.ts
@@ -9,10 +9,15 @@ test("/regime renders with three tabs and GEX default", async ({ page }) => {
   await expect(page.getByTestId("regime-tab-gex")).toHaveClass(/active/);
 });
 
-test("CRI tab shows pending placeholder", async ({ page }) => {
+test("CRI tab renders subtab — either empty state or populated cards", async ({
+  page,
+}) => {
   await page.goto("/regime");
   await page.getByTestId("regime-tab-cri").click();
-  await expect(page.getByText(/coming soon/i)).toBeVisible();
+  // After click, either CriSubTab loads (data path) or the empty placeholder appears.
+  await expect(
+    page.getByTestId("cri-subtab").or(page.getByTestId("cri-empty-state")),
+  ).toBeVisible({ timeout: 15_000 });
 });
 
 test("vol backdrop strip renders with four vol tiles + term structure", async ({

--- a/web/tests/e2e/regime-page.spec.ts
+++ b/web/tests/e2e/regime-page.spec.ts
@@ -14,3 +14,33 @@ test("CRI tab shows pending placeholder", async ({ page }) => {
   await page.getByTestId("regime-tab-cri").click();
   await expect(page.getByText(/coming soon/i)).toBeVisible();
 });
+
+test("vol backdrop strip renders with four vol tiles + term structure", async ({
+  page,
+}) => {
+  await page.goto("/regime");
+  // Strip is a client component that polls; wait for it to hydrate.
+  await expect(page.getByText("VIX", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("VIX3M")).toBeVisible();
+  await expect(page.getByText("VVIX")).toBeVisible();
+  await expect(page.getByText("COR1M")).toBeVisible();
+  await expect(page.getByText(/term structure/i)).toBeVisible();
+  // Either contango or backwardation should appear once data loads.
+  await expect(page.getByText(/contango|backwardation/i)).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test("history chart renders inside GEX tab for SPX", async ({ page }) => {
+  await page.goto("/regime");
+  await expect(page.getByTestId("regime-tab-gex")).toHaveClass(/active/);
+  // The HistoryChart renders an SVG with aria-label "<ticker> 90-day GEX history".
+  // SPX is the default ticker; without history the empty-state copy appears instead.
+  await expect(
+    page
+      .getByRole("img", { name: /90-day gex history/i })
+      .or(page.getByText(/no history available/i)),
+  ).toBeVisible({ timeout: 15_000 });
+});

--- a/web/tests/unit/CriSubTab.test.tsx
+++ b/web/tests/unit/CriSubTab.test.tsx
@@ -166,4 +166,13 @@ describe("CriSubTabView", () => {
       screen.getByTestId("regime-history-chart-rvol-cor1m"),
     ).not.toBeNull();
   });
+
+  it("renders the sortable history table beneath the charts", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    const table = screen.getByTestId("cri-history-table");
+    expect(table).not.toBeNull();
+    // Header row + 2 data rows from POPULATED.history
+    expect(table.querySelectorAll("tbody tr").length).toBe(2);
+    expect(screen.getByTestId("cri-history-table-toggle")).not.toBeNull();
+  });
 });

--- a/web/tests/unit/CriSubTab.test.tsx
+++ b/web/tests/unit/CriSubTab.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 import { CriSubTabView } from "@/components/regime/CriSubTab";
 import type { CriResponse } from "@/lib/regime/useCri";
@@ -15,6 +15,11 @@ const POPULATED: CriResponse = {
   cor1m: 10.8,
   spx_distance_pct: -2.5,
   realized_vol: 14.2,
+  vix_5d_roc: 2.5,
+  vvix_vix_ratio: 5.04,
+  spx_100d_ma: 605.0,
+  cor1m_previous_close: 10.5,
+  cor1m_5d_change: 0.6,
   cri: {
     score: 33.4,
     level: "ELEVATED",
@@ -82,6 +87,22 @@ const FIRED_TRIGGER: CriResponse = {
   },
 };
 
+// jsdom doesn't have ResizeObserver — stub one so CriHistoryChart can mount.
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("CriSubTabView", () => {
   it("renders empty placeholder when data is null", () => {
     render(<CriSubTabView data={null} />);
@@ -97,42 +118,52 @@ describe("CriSubTabView", () => {
     expect(screen.getByTestId("cri-empty-state")).not.toBeNull();
   });
 
-  it("renders score and level for populated data", () => {
+  it("renders hero score (no decimals) and level badge", () => {
     render(<CriSubTabView data={POPULATED} />);
-    expect(screen.getByTestId("cri-score").textContent).toContain("33.4");
+    // 33.4 → .toFixed(0) → "33"
+    expect(screen.getByTestId("cri-score").textContent).toBe("33");
     expect(screen.getByTestId("cri-level").textContent).toBe("ELEVATED");
   });
 
-  it("renders the four component bars", () => {
+  it("renders all four component bars (VIX/VVIX/CORRELATION/MOMENTUM)", () => {
     render(<CriSubTabView data={POPULATED} />);
-    expect(screen.getByText(/component scores/i)).not.toBeNull();
-    expect(screen.getByText("VIX")).not.toBeNull();
-    expect(screen.getByText("VVIX")).not.toBeNull();
-    expect(screen.getByText("COR1M")).not.toBeNull();
-    expect(screen.getByText("SPX MOM")).not.toBeNull();
+    expect(screen.getByText("CRI COMPONENTS")).not.toBeNull();
+    // Each component label is rendered inside the bar
+    expect(screen.getAllByText("VIX").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("VVIX").length).toBeGreaterThan(0);
+    expect(screen.getByText("CORRELATION")).not.toBeNull();
+    expect(screen.getByText("MOMENTUM")).not.toBeNull();
   });
 
-  it("renders SILENT crash trigger when not fired", () => {
+  it("renders INACTIVE crash trigger when not triggered", () => {
     render(<CriSubTabView data={POPULATED} />);
     expect(screen.getByTestId("crash-trigger-state").textContent).toBe(
-      "SILENT",
+      "INACTIVE",
     );
   });
 
-  it("renders FIRED crash trigger when triggered", () => {
+  it("renders TRIGGERED crash trigger when all three conditions fire", () => {
     render(<CriSubTabView data={FIRED_TRIGGER} />);
-    expect(screen.getByTestId("crash-trigger-state").textContent).toBe("FIRED");
+    expect(screen.getByTestId("crash-trigger-state").textContent).toBe(
+      "TRIGGERED",
+    );
   });
 
-  it("renders mini history chart when history rows exist", () => {
+  it("renders the 5-cell ticker strip", () => {
     render(<CriSubTabView data={POPULATED} />);
-    expect(screen.getByTestId("cri-mini-history")).not.toBeNull();
+    expect(screen.getByTestId("strip-vix")).not.toBeNull();
+    expect(screen.getByTestId("strip-vvix")).not.toBeNull();
+    expect(screen.getByTestId("strip-spy")).not.toBeNull();
+    expect(screen.getByTestId("strip-rvol")).not.toBeNull();
+    expect(screen.getByTestId("strip-cor1m")).not.toBeNull();
   });
 
-  it("renders CTA exposure card", () => {
+  it("renders the side-by-side 20-session history grid", () => {
     render(<CriSubTabView data={POPULATED} />);
-    expect(screen.getByText(/cta vol-target model/i)).not.toBeNull();
-    // 70.4 → fmtDecimal(_, 0) → "70%"
-    expect(screen.getByText("70%")).not.toBeNull();
+    expect(screen.getByTestId("regime-history-grid")).not.toBeNull();
+    expect(screen.getByTestId("regime-history-chart-vix-vvix")).not.toBeNull();
+    expect(
+      screen.getByTestId("regime-history-chart-rvol-cor1m"),
+    ).not.toBeNull();
   });
 });

--- a/web/tests/unit/CriSubTab.test.tsx
+++ b/web/tests/unit/CriSubTab.test.tsx
@@ -1,0 +1,138 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CriSubTabView } from "@/components/regime/CriSubTab";
+import type { CriResponse } from "@/lib/regime/useCri";
+
+const POPULATED: CriResponse = {
+  status: "ok",
+  scan_time: "2026-05-15T20:30:00+00:00",
+  date: "2026-05-15",
+  vix: 18.43,
+  vvix: 92.9,
+  spy: 588.12,
+  cor1m: 10.8,
+  spx_distance_pct: -2.5,
+  realized_vol: 14.2,
+  cri: {
+    score: 33.4,
+    level: "ELEVATED",
+    components: { vix: 8.0, vvix: 12.0, correlation: 6.4, momentum: 7.0 },
+  },
+  cta: {
+    realized_vol: 14.2,
+    exposure_pct: 70.4,
+    forced_reduction_pct: 29.6,
+    forced_reduction: true,
+    est_selling_bn: 103.6,
+    selling_usd_b: 103.6,
+  },
+  crash_trigger: {
+    fired: false,
+    triggered: false,
+    conditions: {
+      spx_below_100d_ma: true,
+      realized_vol_gt_25: false,
+      cor1m_gt_60: false,
+    },
+    values: { realized_vol: 14.2, cor1m: 10.8 },
+  },
+  history: [
+    {
+      date: "2026-05-13",
+      vix: 17.8,
+      vvix: 91.0,
+      spy: 585.0,
+      cor1m: 10.2,
+      realized_vol: 13.9,
+      spx_vs_ma_pct: -2.1,
+      vix_5d_roc: 2.5,
+    },
+    {
+      date: "2026-05-14",
+      vix: 18.1,
+      vvix: 92.2,
+      spy: 586.3,
+      cor1m: 10.5,
+      realized_vol: 14.0,
+      spx_vs_ma_pct: -2.3,
+      vix_5d_roc: 3.0,
+    },
+  ],
+  spy_closes: [],
+};
+
+const FIRED_TRIGGER: CriResponse = {
+  ...POPULATED,
+  cri: {
+    score: 82.0,
+    level: "CRITICAL",
+    components: { vix: 22.0, vvix: 20.0, correlation: 20.0, momentum: 20.0 },
+  },
+  crash_trigger: {
+    fired: true,
+    triggered: true,
+    conditions: {
+      spx_below_100d_ma: true,
+      realized_vol_gt_25: true,
+      cor1m_gt_60: true,
+    },
+    values: { realized_vol: 30.0, cor1m: 70.0 },
+  },
+};
+
+describe("CriSubTabView", () => {
+  it("renders empty placeholder when data is null", () => {
+    render(<CriSubTabView data={null} />);
+    expect(screen.getByTestId("cri-empty-state")).not.toBeNull();
+  });
+
+  it("renders empty placeholder when status is empty", () => {
+    render(
+      <CriSubTabView
+        data={{ ...POPULATED, status: "empty", cri: undefined }}
+      />,
+    );
+    expect(screen.getByTestId("cri-empty-state")).not.toBeNull();
+  });
+
+  it("renders score and level for populated data", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    expect(screen.getByTestId("cri-score").textContent).toContain("33.4");
+    expect(screen.getByTestId("cri-level").textContent).toBe("ELEVATED");
+  });
+
+  it("renders the four component bars", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    expect(screen.getByText(/component scores/i)).not.toBeNull();
+    expect(screen.getByText("VIX")).not.toBeNull();
+    expect(screen.getByText("VVIX")).not.toBeNull();
+    expect(screen.getByText("COR1M")).not.toBeNull();
+    expect(screen.getByText("SPX MOM")).not.toBeNull();
+  });
+
+  it("renders SILENT crash trigger when not fired", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    expect(screen.getByTestId("crash-trigger-state").textContent).toBe(
+      "SILENT",
+    );
+  });
+
+  it("renders FIRED crash trigger when triggered", () => {
+    render(<CriSubTabView data={FIRED_TRIGGER} />);
+    expect(screen.getByTestId("crash-trigger-state").textContent).toBe("FIRED");
+  });
+
+  it("renders mini history chart when history rows exist", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    expect(screen.getByTestId("cri-mini-history")).not.toBeNull();
+  });
+
+  it("renders CTA exposure card", () => {
+    render(<CriSubTabView data={POPULATED} />);
+    expect(screen.getByText(/cta vol-target model/i)).not.toBeNull();
+    // 70.4 → fmtDecimal(_, 0) → "70%"
+    expect(screen.getByText("70%")).not.toBeNull();
+  });
+});

--- a/web/tests/unit/VcgSubTab.test.tsx
+++ b/web/tests/unit/VcgSubTab.test.tsx
@@ -1,0 +1,191 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VcgSubTabView } from "@/components/regime/VcgSubTab";
+import type { VcgResponse } from "@/lib/regime/useVcg";
+
+const NORMAL: VcgResponse = {
+  status: "ok",
+  scan_time: "2026-05-15T20:30:00+00:00",
+  date: "2026-05-15",
+  credit_proxy: "HYG",
+  signal: {
+    vcg: -0.83,
+    vcg_adj: -0.83,
+    residual: -0.001987,
+    beta1_vvix: 0.005,
+    beta2_vix: -0.036,
+    alpha: 0.0001,
+    vix: 18.43,
+    vvix: 92.94,
+    credit_price: 79.46,
+    credit_5d_return_pct: 0.42,
+    ro: 0,
+    edr: 0,
+    tier: null,
+    bounce: 0,
+    vvix_severity: "moderate",
+    sign_ok: false,
+    sign_suppressed: true,
+    pi_panic: 0,
+    regime: "DIVERGENCE",
+    interpretation: "SUPPRESSED",
+    attribution: {
+      vvix_pct: 12.0,
+      vix_pct: 88.0,
+      vvix_component: -0.0001,
+      vix_component: -0.0007,
+      model_implied: -0.0008,
+    },
+  },
+  history: [
+    {
+      date: "2026-05-13",
+      residual: -0.0009,
+      vcg: -0.5,
+      vcg_adj: -0.5,
+      beta1: 0.001,
+      beta2: -0.03,
+      vix: 17.8,
+      vvix: 91.0,
+      credit: 79.7,
+      ro: 0,
+      edr: 0,
+      tier: null,
+      bounce: 0,
+    },
+    {
+      date: "2026-05-14",
+      residual: -0.0015,
+      vcg: -0.7,
+      vcg_adj: -0.7,
+      beta1: 0.002,
+      beta2: -0.035,
+      vix: 18.1,
+      vvix: 92.2,
+      credit: 79.6,
+      ro: 0,
+      edr: 0,
+      tier: null,
+      bounce: 0,
+    },
+  ],
+};
+
+const RISK_OFF: VcgResponse = {
+  ...NORMAL,
+  signal: {
+    ...NORMAL.signal!,
+    vcg: 3.1,
+    vcg_adj: 3.1,
+    vix: 32.0,
+    vvix: 130.0,
+    credit_price: 75.5,
+    credit_5d_return_pct: -2.5,
+    ro: 1,
+    edr: 1,
+    tier: 1,
+    bounce: 0,
+    vvix_severity: "extreme",
+    sign_ok: true,
+    sign_suppressed: false,
+    regime: "DIVERGENCE",
+    interpretation: "RISK_OFF",
+  },
+};
+
+const BOUNCE: VcgResponse = {
+  ...NORMAL,
+  signal: {
+    ...NORMAL.signal!,
+    vcg: -4.2,
+    vcg_adj: -4.2,
+    bounce: 1,
+    interpretation: "BOUNCE",
+    sign_ok: true,
+    sign_suppressed: false,
+  },
+};
+
+describe("VcgSubTabView", () => {
+  it("renders empty placeholder when data is null", () => {
+    render(<VcgSubTabView data={null} />);
+    expect(screen.getByTestId("vcg-empty-state")).not.toBeNull();
+  });
+
+  it("renders empty placeholder when status is empty", () => {
+    const empty: VcgResponse = {
+      ...NORMAL,
+      status: "empty",
+      signal: { ...NORMAL.signal!, vcg: null },
+    };
+    render(<VcgSubTabView data={empty} />);
+    expect(screen.getByTestId("vcg-empty-state")).not.toBeNull();
+  });
+
+  it("renders the four metric cards (VCG, VCG Adj, Credit 5d, Residual)", () => {
+    render(<VcgSubTabView data={NORMAL} />);
+    expect(screen.getByText("VCG Z-Score")).not.toBeNull();
+    expect(screen.getByText("VCG Adj (Panic-Adj)")).not.toBeNull();
+    expect(screen.getByText("Credit 5d Return")).not.toBeNull();
+    // "Residual" appears in both the metric card label and the table header;
+    // assert at least one match rather than a unique element.
+    expect(screen.getAllByText("Residual").length).toBeGreaterThanOrEqual(1);
+    // VCG is rendered via fmtZ → "-0.83"
+    expect(screen.getByTestId("vcg-z-score").textContent).toBe("-0.83");
+  });
+
+  it("shows SUPPRESSED interpretation when sign discipline fails", () => {
+    render(<VcgSubTabView data={NORMAL} />);
+    expect(screen.getByTestId("vcg-interpretation-pill").textContent).toBe(
+      "SUPPRESSED",
+    );
+  });
+
+  it("shows RISK-OFF + Tier 1 + EDR badges when ro=1 / tier=1 / edr=1", () => {
+    render(<VcgSubTabView data={RISK_OFF} />);
+    expect(screen.getByTestId("vcg-ro-badge")).not.toBeNull();
+    expect(screen.getByTestId("vcg-tier-badge")).not.toBeNull();
+    // EDR is suppressed when RO is active (xenon convention)
+    expect(screen.queryByTestId("vcg-edr-badge")).toBeNull();
+    expect(screen.getByTestId("vcg-tier-label").textContent).toContain(
+      "TIER 1",
+    );
+    expect(screen.getByTestId("vcg-edr-state").textContent).toBe("ACTIVE");
+  });
+
+  it("shows BOUNCE badge when bounce=1", () => {
+    render(<VcgSubTabView data={BOUNCE} />);
+    expect(screen.getByTestId("vcg-bounce-badge")).not.toBeNull();
+    expect(screen.getByTestId("vcg-bounce-state").textContent).toBe("DETECTED");
+  });
+
+  it("renders attribution bars + β coefficients", () => {
+    render(<VcgSubTabView data={NORMAL} />);
+    expect(screen.getByTestId("vcg-attr-vvix-bar")).not.toBeNull();
+    expect(screen.getByTestId("vcg-attr-vix-bar")).not.toBeNull();
+  });
+
+  it("renders the sortable history table with header + data rows", () => {
+    render(<VcgSubTabView data={NORMAL} />);
+    const table = screen.getByTestId("vcg-history-table");
+    expect(table).not.toBeNull();
+    // 2 data rows from NORMAL.history
+    expect(table.querySelectorAll("tbody tr").length).toBe(2);
+    // 9 columns
+    expect(table.querySelectorAll("thead th").length).toBe(9);
+  });
+
+  it("sorts the history table when a header is clicked", () => {
+    render(<VcgSubTabView data={NORMAL} />);
+    const table = screen.getByTestId("vcg-history-table");
+    const vcgHeader = Array.from(table.querySelectorAll("thead th")).find(
+      (th) => (th.textContent ?? "").startsWith("VCG"),
+    );
+    expect(vcgHeader).toBeDefined();
+    fireEvent.click(vcgHeader!);
+    // After click on VCG header, both rows still render
+    expect(table.querySelectorAll("tbody tr").length).toBe(2);
+  });
+});

--- a/web/tests/unit/historyChart.test.tsx
+++ b/web/tests/unit/historyChart.test.tsx
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HistoryChart } from "@/components/regime/HistoryChart";
+import type { GexHistoryEntry } from "@/lib/regime/useGex";
+
+const sample: GexHistoryEntry[] = [
+  {
+    date: "2026-05-01",
+    net_gex: 1e9,
+    net_dex: 1e8,
+    gex_flip: 7395,
+    spot: 7400,
+    atm_iv: null,
+    vol_pc: null,
+    bias: null,
+  },
+  {
+    date: "2026-05-02",
+    net_gex: 1.1e9,
+    net_dex: 1.1e8,
+    gex_flip: 7398,
+    spot: 7430,
+    atm_iv: null,
+    vol_pc: null,
+    bias: null,
+  },
+  {
+    date: "2026-05-03",
+    net_gex: 0.9e9,
+    net_dex: 0.9e8,
+    gex_flip: 7402,
+    spot: 7408,
+    atm_iv: null,
+    vol_pc: null,
+    bias: null,
+  },
+];
+
+describe("HistoryChart", () => {
+  it("renders an SVG with the right title", () => {
+    render(<HistoryChart history={sample} ticker="SPX" />);
+    expect(screen.getByRole("img", { name: /history/i })).toBeTruthy();
+  });
+
+  it("renders empty state for no history", () => {
+    render(<HistoryChart history={[]} ticker="SPX" />);
+    expect(screen.getByText(/no history/i)).toBeTruthy();
+  });
+
+  it("plots net_gex and gex_flip paths", () => {
+    const { container } = render(
+      <HistoryChart history={sample} ticker="SPX" />,
+    );
+    const paths = container.querySelectorAll("path");
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/web/tests/unit/regime-page.test.tsx
+++ b/web/tests/unit/regime-page.test.tsx
@@ -4,9 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RegimePanel from "@/components/regime/RegimePanel";
 
-// Stub GexSubTab so this test doesn't depend on d3 / fetch internals.
+// Stub GexSubTab / CriSubTab so this test doesn't depend on chart / fetch internals.
 vi.mock("@/components/regime/GexSubTab", () => ({
   default: () => <div data-testid="gex-subtab-stub">GEX subtab</div>,
+}));
+vi.mock("@/components/regime/CriSubTab", () => ({
+  default: () => <div data-testid="cri-subtab-stub">CRI subtab</div>,
 }));
 
 beforeEach(() => {
@@ -29,11 +32,10 @@ describe("RegimePanel", () => {
     expect(screen.queryByTestId("gex-subtab-stub")).not.toBeNull();
   });
 
-  it("shows pending placeholder on CRI tab", () => {
+  it("renders CRI subtab when CRI tab clicked", () => {
     render(<RegimePanel />);
     fireEvent.click(screen.getByTestId("regime-tab-cri"));
-    expect(screen.queryByTestId("regime-pending-cri")).not.toBeNull();
-    expect(screen.queryByText(/coming soon/i)).not.toBeNull();
+    expect(screen.queryByTestId("cri-subtab-stub")).not.toBeNull();
   });
 
   it("shows pending placeholder on VCG tab", () => {

--- a/web/tests/unit/regime-page.test.tsx
+++ b/web/tests/unit/regime-page.test.tsx
@@ -4,12 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RegimePanel from "@/components/regime/RegimePanel";
 
-// Stub GexSubTab / CriSubTab so this test doesn't depend on chart / fetch internals.
+// Stub the sub-tabs so this test doesn't depend on chart / fetch internals.
 vi.mock("@/components/regime/GexSubTab", () => ({
   default: () => <div data-testid="gex-subtab-stub">GEX subtab</div>,
 }));
 vi.mock("@/components/regime/CriSubTab", () => ({
   default: () => <div data-testid="cri-subtab-stub">CRI subtab</div>,
+}));
+vi.mock("@/components/regime/VcgSubTab", () => ({
+  default: () => <div data-testid="vcg-subtab-stub">VCG subtab</div>,
 }));
 
 beforeEach(() => {
@@ -38,9 +41,9 @@ describe("RegimePanel", () => {
     expect(screen.queryByTestId("cri-subtab-stub")).not.toBeNull();
   });
 
-  it("shows pending placeholder on VCG tab", () => {
+  it("renders VCG subtab when VCG tab clicked", () => {
     render(<RegimePanel />);
     fireEvent.click(screen.getByTestId("regime-tab-vcg"));
-    expect(screen.queryByTestId("regime-pending-vcg")).not.toBeNull();
+    expect(screen.queryByTestId("vcg-subtab-stub")).not.toBeNull();
   });
 });

--- a/web/tests/unit/regime-page.test.tsx
+++ b/web/tests/unit/regime-page.test.tsx
@@ -1,0 +1,44 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RegimePanel from "@/components/regime/RegimePanel";
+
+// Stub GexSubTab so this test doesn't depend on d3 / fetch internals.
+vi.mock("@/components/regime/GexSubTab", () => ({
+  default: () => <div data-testid="gex-subtab-stub">GEX subtab</div>,
+}));
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }),
+  );
+});
+
+describe("RegimePanel", () => {
+  it("renders three sub-tab buttons with GEX active by default", () => {
+    render(<RegimePanel />);
+    expect(screen.getByTestId("regime-tab-cri").textContent).toBe("CRI");
+    expect(screen.getByTestId("regime-tab-vcg").textContent).toBe("VCG");
+    expect(screen.getByTestId("regime-tab-gex").textContent).toBe("GEX");
+    expect(screen.getByTestId("regime-tab-gex").className).toMatch(/active/);
+    expect(screen.queryByTestId("gex-subtab-stub")).not.toBeNull();
+  });
+
+  it("shows pending placeholder on CRI tab", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-cri"));
+    expect(screen.queryByTestId("regime-pending-cri")).not.toBeNull();
+    expect(screen.queryByText(/coming soon/i)).not.toBeNull();
+  });
+
+  it("shows pending placeholder on VCG tab", () => {
+    render(<RegimePanel />);
+    fireEvent.click(screen.getByTestId("regime-tab-vcg"));
+    expect(screen.queryByTestId("regime-pending-vcg")).not.toBeNull();
+  });
+});

--- a/web/tests/unit/spotFreshnessPill.test.tsx
+++ b/web/tests/unit/spotFreshnessPill.test.tsx
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SpotFreshnessPill } from "@/components/regime/GexSubTab";
+
+const NOW_MS = Date.parse("2026-05-17T13:30:00Z");
+
+describe("SpotFreshnessPill", () => {
+  it("renders nothing when tapeTime is null", () => {
+    const { container } = render(
+      <SpotFreshnessPill tapeTime={null} nowMs={NOW_MS} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when tapeTime is invalid ISO", () => {
+    const { container } = render(
+      <SpotFreshnessPill tapeTime="not-a-date" nowMs={NOW_MS} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows LIVE when tape is ≤ 2 minutes old", () => {
+    render(
+      <SpotFreshnessPill tapeTime="2026-05-17T13:28:30Z" nowMs={NOW_MS} />,
+    );
+    const pill = screen.getByTestId("spot-freshness-pill");
+    expect(pill.textContent).toBe("LIVE");
+  });
+
+  it("shows Xm ago in warning color for 3-15 minutes old", () => {
+    render(
+      <SpotFreshnessPill tapeTime="2026-05-17T13:18:00Z" nowMs={NOW_MS} />,
+    );
+    const pill = screen.getByTestId("spot-freshness-pill");
+    expect(pill.textContent).toBe("12m ago");
+    expect(pill.style.color).toContain("--warning");
+  });
+
+  it("shows Xm ago in muted color for 16-59 minutes old", () => {
+    render(
+      <SpotFreshnessPill tapeTime="2026-05-17T13:00:00Z" nowMs={NOW_MS} />,
+    );
+    const pill = screen.getByTestId("spot-freshness-pill");
+    expect(pill.textContent).toBe("30m ago");
+    expect(pill.style.color).toContain("--text-secondary");
+  });
+
+  it("shows Xh ago when over an hour old", () => {
+    // 5 hours 30 min ago → "5h ago"
+    render(
+      <SpotFreshnessPill tapeTime="2026-05-17T08:00:00Z" nowMs={NOW_MS} />,
+    );
+    const pill = screen.getByTestId("spot-freshness-pill");
+    expect(pill.textContent).toBe("5h ago");
+  });
+
+  it("shows Xd ago when over a day old", () => {
+    // 2 days ago
+    render(
+      <SpotFreshnessPill tapeTime="2026-05-15T13:30:00Z" nowMs={NOW_MS} />,
+    );
+    const pill = screen.getByTestId("spot-freshness-pill");
+    expect(pill.textContent).toBe("2d ago");
+  });
+});

--- a/web/tests/unit/useCri.test.tsx
+++ b/web/tests/unit/useCri.test.tsx
@@ -61,8 +61,8 @@ describe("useCri", () => {
     await waitFor(() => {
       expect(result.current.data).not.toBeNull();
     });
-    expect(result.current.data?.cri.level).toBe("ELEVATED");
-    expect(result.current.data?.cri.score).toBe(33.4);
+    expect(result.current.data?.cri?.level).toBe("ELEVATED");
+    expect(result.current.data?.cri?.score).toBe(33.4);
     expect(result.current.lastSync).toBe("2026-05-15T20:30:00+00:00");
   });
 

--- a/web/tests/unit/useCri.test.tsx
+++ b/web/tests/unit/useCri.test.tsx
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCri } from "@/lib/regime/useCri";
+
+const SAMPLE_RESPONSE = {
+  status: "ok",
+  scan_time: "2026-05-15T20:30:00+00:00",
+  date: "2026-05-15",
+  vix: 18.43,
+  vvix: 92.9,
+  spy: 588.12,
+  cor1m: 10.8,
+  spx_distance_pct: -2.5,
+  realized_vol: 14.2,
+  cri: {
+    score: 33.4,
+    level: "ELEVATED",
+    components: { vix: 8.0, vvix: 12.0, correlation: 6.4, momentum: 7.0 },
+  },
+  cta: {
+    realized_vol: 14.2,
+    exposure_pct: 70.4,
+    forced_reduction_pct: 29.6,
+    forced_reduction: true,
+    est_selling_bn: 103.6,
+    selling_usd_b: 103.6,
+  },
+  crash_trigger: {
+    fired: false,
+    triggered: false,
+    conditions: {
+      spx_below_100d_ma: true,
+      realized_vol_gt_25: false,
+      cor1m_gt_60: false,
+    },
+    values: { realized_vol: 14.2, cor1m: 10.8 },
+  },
+  history: [],
+  spy_closes: [],
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_RESPONSE,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useCri", () => {
+  it("fetches and exposes the latest snapshot", async () => {
+    const { result } = renderHook(() => useCri());
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+    expect(result.current.data?.cri.level).toBe("ELEVATED");
+    expect(result.current.data?.cri.score).toBe(33.4);
+    expect(result.current.lastSync).toBe("2026-05-15T20:30:00+00:00");
+  });
+
+  it("calls POST when syncNow is invoked", async () => {
+    const fetchSpy = global.fetch as ReturnType<typeof vi.fn>;
+    const { result } = renderHook(() => useCri());
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+    act(() => {
+      result.current.syncNow();
+    });
+    await waitFor(() => {
+      // initial GET + auto-POST on first load + manual syncNow = at least one POST observed
+      const methods = fetchSpy.mock.calls.map((c) => c[1]?.method);
+      expect(methods).toContain("POST");
+    });
+  });
+});

--- a/web/tests/unit/useVcg.test.tsx
+++ b/web/tests/unit/useVcg.test.tsx
@@ -1,0 +1,89 @@
+/* @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useVcg } from "@/lib/regime/useVcg";
+
+const SAMPLE_RESPONSE = {
+  status: "ok",
+  scan_time: "2026-05-15T20:30:00+00:00",
+  date: "2026-05-15",
+  credit_proxy: "HYG",
+  signal: {
+    vcg: 2.85,
+    vcg_adj: 2.85,
+    residual: -0.0012,
+    beta1_vvix: -0.05,
+    beta2_vix: -0.03,
+    alpha: 0.0001,
+    vix: 30.2,
+    vvix: 125.0,
+    credit_price: 78.4,
+    credit_5d_return_pct: -1.2,
+    ro: 1,
+    edr: 1,
+    tier: 1,
+    bounce: 0,
+    vvix_severity: "extreme",
+    sign_ok: true,
+    sign_suppressed: false,
+    pi_panic: 0.0,
+    regime: "DIVERGENCE",
+    interpretation: "RISK_OFF",
+    attribution: {
+      vvix_pct: 60.0,
+      vix_pct: 40.0,
+      vvix_component: -0.001,
+      vix_component: -0.0006,
+      model_implied: -0.00159,
+    },
+  },
+  history: [],
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE_RESPONSE,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useVcg", () => {
+  it("fetches and exposes the latest snapshot", async () => {
+    const { result } = renderHook(() => useVcg());
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+    expect(result.current.data?.signal?.interpretation).toBe("RISK_OFF");
+    expect(result.current.data?.signal?.vcg).toBe(2.85);
+    expect(result.current.data?.credit_proxy).toBe("HYG");
+    expect(result.current.lastSync).toBe("2026-05-15T20:30:00+00:00");
+  });
+
+  it("calls POST against the /vcg/scan URL when syncNow is invoked", async () => {
+    const fetchSpy = global.fetch as ReturnType<typeof vi.fn>;
+    const { result } = renderHook(() => useVcg());
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+    act(() => {
+      result.current.syncNow();
+    });
+    await waitFor(() => {
+      const posts = fetchSpy.mock.calls.filter((c) => c[1]?.method === "POST");
+      expect(posts.length).toBeGreaterThan(0);
+      // POSTs must target the scan path, not the GET URL — protects against
+      // a 405 silent-fail regression.
+      for (const [url] of posts) {
+        expect(String(url)).toMatch(/\/api\/regime\/vcg\/scan$/);
+      }
+    });
+  });
+});

--- a/web/tests/unit/volBackdropStrip.test.tsx
+++ b/web/tests/unit/volBackdropStrip.test.tsx
@@ -1,0 +1,49 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VolBackdropStripView } from "@/components/regime/VolBackdropStrip";
+
+const sample = {
+  series: {
+    VIX: [
+      { date: "2026-05-14", close: 18.1 },
+      { date: "2026-05-15", close: 18.4 },
+    ],
+    VIX3M: [
+      { date: "2026-05-14", close: 21.0 },
+      { date: "2026-05-15", close: 21.4 },
+    ],
+    VVIX: [
+      { date: "2026-05-14", close: 92.1 },
+      { date: "2026-05-15", close: 92.9 },
+    ],
+    COR1M: [
+      { date: "2026-05-14", close: 10.5 },
+      { date: "2026-05-15", close: 10.8 },
+    ],
+  },
+  term_structure_ratio: 0.86,
+  term_structure_state: "contango" as const,
+  as_of: "2026-05-15",
+};
+
+describe("VolBackdropStripView", () => {
+  it("renders all four tiles", () => {
+    render(<VolBackdropStripView data={sample} />);
+    expect(screen.getByText("VIX")).toBeTruthy();
+    expect(screen.getByText("VIX3M")).toBeTruthy();
+    expect(screen.getByText("VVIX")).toBeTruthy();
+    expect(screen.getByText("COR1M")).toBeTruthy();
+  });
+
+  it("shows term-structure state badge", () => {
+    render(<VolBackdropStripView data={sample} />);
+    expect(screen.getByText(/contango/i)).toBeTruthy();
+  });
+
+  it("renders nothing when data is null", () => {
+    const { container } = render(<VolBackdropStripView data={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/regime` page with 3 sub-tabs (CRI / VCG / GEX), default GEX
- GEX renders live UW data end-to-end: UW → APScheduler scanner (5min) → Postgres `gex_snapshots` → `/api/regime/gex` → React `GexSubTab` via d3-using `GexProfileChart`
- **CRI and VCG are now live** (no longer placeholders) — both read from the parquet-lake-backed `vol_index_daily` table; CRI scans hourly, VCG scans at :25
- Sidebar gains a Regime nav entry
- Tribunal-reviewed (`/codex-review --diff`) before final commit; 12 consensus issues fixed in this push

## Architecture
**Data flow (GEX only)**: UW client → `gex_scanner.run(ticker)` (worker, 5-min cadence, primary-uw shard, weekday-only) → `repo.upsert_gex_snapshot()` → `gex_snapshots` table → `GET /api/regime/gex` → `useGex` hook polling.

**Data flow (CRI)**: parquet lake (CBOE vol complex) → `vol_index_lake_sync` nightly → `vol_index_daily` table → `cri_scanner.run()` hourly → `cri_snapshots` → `GET /api/regime` → `useCri`.

**Data flow (VCG)**: equity-asset lake (HYG/JNK/LQD) → `credit_etf_lake_sync` nightly (03:20 ET) → `vol_index_daily` → `vcg_scanner.run(proxy="HYG")` at :25 → `vcg_snapshots` (JSONB + generated columns) → `GET /api/regime/vcg` → `useVcg`.

**No IB, no Yahoo.** UW + the local parquet lake are the only data sources.

## Out of scope (follow-up plans)
- MenthorQ key levels in GEX — Playwright dep, skipped for v1 (`mq: null`, `source_delta: null`)
- Postgres → R2 backup

## CLAUDE.md deviations (documented)
- **d3 + @types/d3 added** to `web/package.json`. Scoped to `web/components/regime/*` for the 1:1 visual port of xenon's `GexProfileChart`. Other charts in this repo remain hand-rolled SVG per CLAUDE.md. User-approved 2026-05-16.

---

## VCG ship (2026-05-17, 3 new commits)

Three focused commits stack the full VCG port:

- `feat(vcg): scanner math, persistence, scheduler` — pure OLS in `cards/vcg_scoring.py`, scanner orchestrator in `scanners/vcg.py`, `vcg_snapshot_repository.py` (own file, not extending `repository.py`), migrations 041 + 042, `credit_etf_lake_sync` job, env-overridable lake roots
- `feat(vcg): API routes, schemas, type regen` — `GET/POST /api/regime/vcg[/scan]`, Pydantic Literal-enum schemas, deleted dead `RegimePendingResponse`, regenerated OpenAPI snapshot + `web/lib/types.ts`
- `feat(vcg): UI subtab, useVcg hook, sync hook race guard` — 1:1 mirror of xenon's `VcgPanel`, attribution bar `clampPct` defense, Sync Now button on both empty states (also fixes pre-existing CRI promise), monotonic `latestRequestIdRef` in `useSyncHook` so background ticks can't clobber fresh manual-sync results

### Tribunal review applied

`/codex-review --diff` before final commits. 12 consensus issues identified by Codex + Gemini + Claude; all fixed:

| Severity | Issue | Resolution |
|---|---|---|
| CRITICAL | Panic overlay didn't gate `ro`/`tier` flags → PANIC + RISK-OFF could render simultaneously | `_signal_for_index` compares against `vcg_adj` (panic-damped) |
| IMPORTANT | Credit ETF used unadjusted `close` — ex-div drops looked like credit stress | `_load_series` reads `adj_close` for the proxy, `close` for VIX/VVIX |
| IMPORTANT | `bounce` ignored sign discipline | gated on `sign_ok` |
| IMPORTANT | Tier-3 gap for `vcg ∈ (2.0, 2.5]` | dropped redundant secondary threshold |
| IMPORTANT | `np.linalg.lstsq` rank not checked — collinear windows silently produced meaningless betas | capture rank, skip rank-deficient + non-finite windows |
| IMPORTANT | Lake roots + credit symbols not env-overridable | wired `LAKE_VOL_INDEX_ROOT`, `LAKE_CREDIT_ETF_ROOT`, `CREDIT_ETF_SYMBOLS` in `from_env()` |
| IMPORTANT | `RegimePendingResponse` dead code | deleted + dropped orphan test |
| MINOR | Sync Now copy referenced nonexistent button | added button to both subtabs |
| MINOR | `log_returns` accepted 0 / neg / NaN / Inf | maps bad inputs to NaN so they propagate cleanly |
| MINOR | `fetch_latest(proxy=)` lacked matching index + tie-breaker | migration 042: `(credit_proxy, scanned_at DESC, id DESC)` + `id DESC` in repository ORDER BY |
| MINOR | `useSyncHook` POST → GET race window | monotonic `latestRequestIdRef` guard |
| MINOR | Attribution bars only lower-clamped (NaN / Inf / >100 not handled) | `clampPct` helper used in width + label |

## Test plan
- [x] `uv run pytest tests/unit/test_regime_schemas.py tests/integration/test_gex_repository.py tests/integration/test_gex_scanner.py tests/integration/api/test_regime_router.py` — 17 passed (initial GEX slice)
- [x] `uv run pytest` — 266 passed (full repo sweep after VCG ship)
- [x] `cd web && npm run test` — 175 vitest passed
- [x] `cd web && npx tsc --noEmit` — clean
- [x] `bash scripts/migrate.sh` — applied 041 + 042 idempotently
- [x] Live UW smoke: `gex_scanner.run(...)` against SPX → 60 profile buckets, real spot, NEUTRAL bias
- [x] Live VCG smoke: `vcg_scanner.run(proxy="HYG")` persists snapshot with correct sign-discipline behaviour (SUPPRESSED interpretation, all flags zero)
- [ ] Manual: `/regime` route in browser — all three tabs (defer to reviewer)
- [ ] `cd web && npx playwright test regime-page` (defer to CI)
- [ ] Panic-gate fix is dormant until VIX > 48; logic is straightforward (uses `vcg_adj` field already produced) and covered by integration test structure
- [ ] Optional: one-off historical rescan over the lookback window so older residuals re-evaluate under the new `adj_close` semantic
