### PR TITLE
feat: add WGC ETF flow corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 
 # Playwright MCP artifacts
 .playwright-mcp/
+output/
 *.png
 !docs/screenshots/*.png
 .claude/

--- a/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
+++ b/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
@@ -30,6 +30,12 @@
 
 ## D2 — ETF holdings (GLD / IAU / GLDM / PHYS)
 
+**2026-05-17 partial re-wire:** UW `/api/etfs/{ticker}/in-outflow` is accessible for GLD/IAU/GLDM under the current entitlement window (~30 trading days) and can populate `gld_30d_net_flow_t`. UW `/api/etfs/GLD/holdings` returns `data: []` and `GLD/info` reports `holdings_count: 0`, so it does **not** provide absolute bullion ounces/tonnes.
+
+**2026-05-17 GLD holdings re-wire:** SPDR's current archive endpoint is `https://api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en`. It returns `US_GLD_Archive_EN.xlsx` with daily `Total Ounces of Gold in the Trust`, `Tonnes of Gold`, NAV/share, premium/discount, and GLD close back to inception. This now populates `gld_holdings_t` and the Lens 1 holdings-vs-price chart on warmup/daily scheduled ingest.
+
+**2026-05-17 WGC Goldhub monthly re-wire:** The WGC ETF-flows page (`https://www.gold.org/goldhub/research/etf-flows`) exposes monthly `ETF_Flows_*.xlsx` downloads. Anonymous `curl` returns 403, but an authenticated Goldhub browser session can download the workbook. The workbook's monthly sheets contain ETF holdings, demand, and fund flows back to 2003. The code path now supports either `WGC_GOLDHUB_COOKIE` for scheduled authenticated downloads or `WGC_ETF_FLOWS_WORKBOOK_PATH` for a local exported workbook/directory. Local authenticated scrape loaded 78 workbooks into `wgc_etf_monthly`: 1,338,260 rows, 234 tickers, 2003-03-31 through 2026-03-31. See [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md). This is a monthly safety net for non-GLD absolute holdings, not a replacement for SPDR's daily GLD archive.
+
 **Designed for:** Lens 1 structural — `gld_holdings_t`, `gld_30d_net_flow_t`, plus the dual-axis Lens 1 chart showing oz-held vs price.
 
 **Designed source:** Each fund manager's published holdings page (anonymous JSON / CSV).
@@ -45,14 +51,15 @@
 
 **Re-wire options:**
 
-1. **Per-manager re-discovery** — each issuer has a current download path under a refreshed CMS. SPDR's current path is HTML-scraped (their JSON moved). Lowest signal-to-effort because each one is brittle.
-2. **ETF.com / ETFDB scraping** — third-party aggregators publish daily holdings tables. Adds a dependency on a third party who can also rotate URLs.
-3. **Bloomberg / Refinitiv** — paid feed, deterministic. Not justified for one factor.
-4. **SEC N-PORT filings** — every '40-Act ETF files holdings monthly via N-PORT. The XML is parseable and the schedule is fixed. Lower granularity (monthly not daily) but the most durable.
+1. **SPDR historical archive API for GLD** — current path is `api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en`; daily XLSX archive, suitable for startup backfill and once-daily refresh. Landed for GLD on 2026-05-17.
+2. **WGC Goldhub ETF-flows workbook** — authenticated monthly XLSX with GLD/IAU/GLDM/PHYS holdings in tonnes and fund-flow panels. Landed as an authenticated/export-backed parser on 2026-05-17.
+3. **ETF.com / ETFDB scraping** — third-party aggregators publish daily holdings tables. Adds a dependency on a third party who can also rotate URLs.
+4. **Bloomberg / Refinitiv** — paid feed, deterministic. Not justified for one factor.
+5. **SEC N-PORT filings** — every '40-Act ETF files holdings monthly via N-PORT. The XML is parseable and the schedule is fixed. Lower granularity (monthly not daily) but the most durable.
 
 **Signal value:** **Medium-high.** ETF flows are the easiest-to-observe component of the structural posture. 30d net flow is one of the inputs the dashboard surfaces most prominently; the v1 Lens 1 dual-axis chart is half-functional without GLD holdings.
 
-**Recommended for v2:** SPDR scrape for GLD (highest AUM, highest signal) + SEC N-PORT for the rest as a monthly safety net. Per-manager re-discovery for IAU/PHYS/GLDM only if signal calibration shows they materially improve the structural composite.
+**Recommended for v2:** Keep SPDR archive as canonical GLD absolute-holdings source. Use WGC Goldhub monthly files for IAU/PHYS/GLDM while authenticated access is available; keep SEC N-PORT as the open-data fallback if Goldhub session ops become brittle.
 
 ---
 

--- a/docs/research/gold-sdf-framework/12-wgc-etf-flow-corpus.md
+++ b/docs/research/gold-sdf-framework/12-wgc-etf-flow-corpus.md
@@ -1,0 +1,72 @@
+# WGC ETF Flow Corpus
+
+Date: 2026-05-17
+
+## Source contract
+
+World Gold Council publishes the Goldhub ETF-flows archive at:
+
+`https://www.gold.org/goldhub/research/etf-flows`
+
+The listing pages are public and expose monthly XLSX download links under
+`/download/file/<id>/ETF...xlsx`. The XLSX files themselves are Goldhub-gated:
+anonymous HTTP requests return 403, while an authenticated browser session can
+download them.
+
+Do not commit cookies or session material. Supported operational modes:
+
+- `WGC_GOLDHUB_COOKIE`: environment-only cookie header for scheduled authenticated downloads.
+- `WGC_ETF_FLOWS_WORKBOOK_PATH`: local workbook file or directory of exported workbooks.
+
+## Persisted schema
+
+Migration `046_wgc_etf_monthly.sql` creates `uw_scan.wgc_etf_monthly`.
+
+It stores one row per `(ticker, obs_date, source_url)` with:
+
+- fund identity: `ticker`, `fund_name`, `fund_type`, `region`, `country`
+- market context: `gold_price_usd_oz`, aggregate ounces/tonnes/value
+- fund metrics: `holdings_tonnes`, `demand_tonnes`, `flow_usd_mn`
+- lineage: `source_url`, `source_label`, `as_of`, `source`
+
+Keeping `source_url` in the primary key preserves workbook revisions instead of
+flattening historical snapshots.
+
+The ingest also bridges GLD/IAU/GLDM/PHYS monthly holdings into
+`etf_holdings_daily` with `source='WGC'`, so existing Lens 1 readers can use the
+data without a new API surface.
+
+## Parser coverage
+
+Modern workbooks use:
+
+- `Holdings by month`
+- `Demand by month`
+- `Fund flows by month`
+
+Legacy workbooks use combinations of:
+
+- `All holdings by month`
+- `Delta tonnes by month`
+- `All flows US$ by month`
+- `All fund flows` / `All fund flows by fund`
+
+The fallback table parser captures current-month snapshot rows when a workbook
+lacks a full historical holdings sheet.
+
+## Local load result
+
+Authenticated scrape on 2026-05-17 downloaded 78 workbooks from Dec 2018 through
+Mar 2026 into `output/wgc_etf_workbooks/`.
+
+Local Postgres load result:
+
+- `wgc_etf_monthly`: 1,338,260 rows
+- distinct `source_url`: 78
+- distinct tickers: 234
+- date range: 2003-03-31 to 2026-03-31
+- rows with `demand_tonnes`: 678,265
+- rows with `flow_usd_mn`: 620,624
+- WGC bridge holdings rows: GLD 257, IAU 255, GLDM 94, PHYS 194
+
+Latest WGC workbook in this load: `20717_ETF_Flows_March_2026.xlsx`.

--- a/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
+++ b/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
@@ -230,3 +230,10 @@ be treated as interchangeable.
    lens input, not as trade sizing.
 4. Compare GLD daily flow to WGC monthly global demand to calibrate when GLD is
    a good proxy and when it is misleading.
+5. Explore ETF flow further as its own Lens 1 research thread:
+   - identify whether flow breadth, regional rotation, or concentration changes
+     add signal beyond headline global demand
+   - test whether Asian ETF accumulation behaves differently from North American
+     and European ETF flow in the post-2022 sample
+   - define which ETF-flow metrics should become persisted cockpit fields versus
+     research-only diagnostics

--- a/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
+++ b/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
@@ -1,0 +1,232 @@
+# WGC ETF Flow Mining: Breadth, Concentration, And Post-2022 Sensitivity
+
+Date: 2026-05-17
+
+## Question
+
+Now that the WGC ETF-flow corpus is persisted, should Lens 1 continue to treat
+GLD as a sufficient ETF-flow proxy, or should the gold cockpit use a broader
+global ETF breadth/flow composite?
+
+Short answer: GLD is still the largest single fund, but it is no longer enough
+as a standalone proxy. The global ETF market has become meaningfully less
+concentrated, and Asia's share has risen sharply since 2024.
+
+## Data
+
+Source: `uw_scan.wgc_etf_monthly`, loaded from 78 authenticated WGC Goldhub ETF
+workbooks. See [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md).
+
+For this note, rows were canonicalised to the latest workbook revision per
+`(ticker, obs_date)` using `source_url DESC`, then grouped monthly.
+
+Canonical sample:
+
+- Rows: 26,217 fund-month observations
+- Months: 277
+- Date range: 2003-03-31 through 2026-03-31
+- Latest month fund count: 182
+- Latest total gold ETF holdings: 4,087.8 tonnes
+
+Metrics:
+
+- `holdings_tonnes`: WGC fund-level gold holdings
+- `demand_tonnes`: monthly change in tonnes when available
+- `flow_usd_mn`: monthly fund flow in USD millions when available
+- `gold_price_usd_oz`: WGC workbook gold price context
+
+## Findings
+
+### 1. GLD is still largest, but no longer dominant enough
+
+Latest month: 2026-03-31.
+
+| Rank | Ticker | Fund | Region | Holdings |
+|---:|---|---|---|---:|
+| 1 | GLD | SPDR Gold Shares | North America | 1,046.9 tonnes |
+| 2 | IAU | iShares Gold Trust | North America | 476.0 tonnes |
+| 3 | IGLN LN EQUITY | iShares Physical Gold ETC | Europe | 247.1 tonnes |
+| 4 | GLDM | SPDR Gold MiniShares Trust | North America | 199.9 tonnes |
+| 5 | SGLD LN EQUITY | Invesco Physical Gold ETC | Europe | 198.6 tonnes |
+| 6 | 4GLD GR EQUITY | Xetra-Gold | Europe | 170.2 tonnes |
+| 7 | PHYS | Sprott Physical Gold Trust | North America | 114.7 tonnes |
+| 8 | 518880 CH EQUITY | Huaan Yifu Gold ETF | Asia | 111.2 tonnes |
+| 9 | GOLD FP EQUITY | Amundi Physical Gold ETC | Europe | 83.5 tonnes |
+| 10 | 1540 JT EQUITY | Japan Physical Gold ETF | Asia | 72.4 tonnes |
+
+GLD share of total WGC gold ETF holdings:
+
+- Pre-2022 average: 48.1%
+- Post-2022 average: 26.2%
+- Latest: 25.6%
+
+Top-5 concentration:
+
+- Pre-2022 average: 76.3%
+- Post-2022 average: 57.1%
+- Latest: 53.0%
+
+Interpretation: GLD remains the biggest single signal, but the ETF universe has
+spread out. A GLD-only proxy now misses too much regional and issuer breadth.
+
+### 2. Asia has become a real share of the ETF holdings base
+
+Selected year-end snapshots:
+
+| Year | Total Holdings | GLD Share | Top-5 Share | North America | Europe | Asia |
+|---:|---:|---:|---:|---:|---:|---:|
+| 2008 | 1,222.9t | 63.8% | 91.6% | 71.1% | 24.9% | 0.5% |
+| 2011 | 2,530.1t | 49.6% | 71.0% | 62.3% | 33.5% | 2.0% |
+| 2016 | 2,199.9t | 37.4% | 62.4% | 52.2% | 41.5% | 4.2% |
+| 2020 | 4,017.3t | 29.1% | 59.6% | 49.9% | 45.5% | 3.1% |
+| 2022 | 3,723.5t | 24.6% | 56.0% | 46.4% | 48.3% | 3.6% |
+| 2024 | 3,224.2t | 27.1% | 56.7% | 51.2% | 39.9% | 6.9% |
+| 2025 | 4,025.8t | 26.6% | 54.5% | 52.0% | 35.3% | 10.9% |
+| 2026 | 4,087.8t | 25.6% | 53.0% | 50.9% | 34.5% | 12.8% |
+
+Latest month regional holdings:
+
+- North America: 2,079.4 tonnes
+- Europe: 1,411.8 tonnes
+- Asia: 521.6 tonnes
+- Other: 74.9 tonnes
+
+Asia is still smaller than North America and Europe, but it is no longer a
+rounding error. The 2025-2026 rise is large enough that Lens 1 should track it
+explicitly.
+
+### 3. Latest month was Western outflow, Asian inflow
+
+Latest month demand, 2026-03-31:
+
+- North America: -87.0 tonnes
+- Europe: -7.3 tonnes
+- Asia: +9.9 tonnes
+- Other: -0.4 tonnes
+- Global total: -84.8 tonnes
+
+Trailing 12-month regional demand into 2026-03-31:
+
+- North America: +195.1 tonnes
+- Asia: +171.2 tonnes
+- Europe: +39.2 tonnes
+- Other: +5.8 tonnes
+
+Interpretation: the latest month was a Western de-risking/outflow month, but
+the 12-month picture shows Asia as a major net accumulator alongside North
+America.
+
+### 4. Flow-price sensitivity is stronger post-2022, not weaker
+
+Correlation of global monthly ETF demand with same-month gold return:
+
+- Full sample: +0.43
+- Pre-2022: +0.40
+- Post-2022: +0.56
+
+Correlation of global monthly USD flow with same-month gold return:
+
+- Full sample: +0.42
+- Pre-2022: +0.36
+- Post-2022: +0.60
+
+Regional demand correlations with same-month gold return:
+
+- North America: +0.44
+- Europe: +0.23
+- Asia: +0.22
+- Other: +0.23
+
+Interpretation: ETF flows remain price-sensitive, especially in North America.
+This does not prove ETF flows drive gold price; same-month correlation can also
+reflect momentum chasing, allocation response, or shared macro drivers.
+
+### 5. Breadth has softened slightly post-2022
+
+Monthly positive-demand breadth is:
+
+`positive-demand funds / funds with demand data`
+
+- Pre-2022 average breadth: 52.2%
+- Post-2022 average breadth: 48.8%
+
+This is not a dramatic break, but it argues for using breadth as a stabiliser:
+when gold rises on narrow GLD-only flow, Lens 1 should treat that differently
+from a month where the majority of global products are accumulating metal.
+
+### 6. Extreme ETF-flow months align with obvious stress/momentum regimes
+
+Largest monthly global ETF demand:
+
+| Month | Demand | Gold Return |
+|---|---:|---:|
+| 2022-03-31 | +230.9t | +4.9% |
+| 2016-02-29 | +210.9t | +9.5% |
+| 2020-04-30 | +192.6t | +5.7% |
+| 2020-07-31 | +181.4t | +6.4% |
+| 2020-03-31 | +179.9t | -0.3% |
+
+Largest monthly global ETF outflow:
+
+| Month | Demand | Gold Return |
+|---|---:|---:|
+| 2013-04-30 | -179.6t | -6.5% |
+| 2013-05-31 | -148.2t | -5.1% |
+| 2020-11-30 | -127.1t | -1.9% |
+| 2021-03-31 | -119.9t | -5.0% |
+| 2013-02-28 | -118.9t | -2.6% |
+
+This supports using ETF flow as a structural/momentum thermometer, not as a
+standalone directional forecast.
+
+## Product Implication
+
+Lens 1 should graduate from `gld_30d_net_flow_t` alone to a broader WGC-backed
+ETF flow composite:
+
+1. `global_etf_demand_1m_t`
+2. `global_etf_demand_3m_t`
+3. `regional_etf_demand_3m_t`: North America / Europe / Asia / Other
+4. `etf_positive_breadth_pct`
+5. `gld_share_of_global_etf_holdings_pct`
+6. `top5_etf_concentration_pct`
+
+GLD remains useful as the daily, high-frequency proxy. WGC should become the
+monthly breadth and global-composition anchor.
+
+## Proposed Lens 1 Use
+
+Use two layers:
+
+- Daily layer: SPDR GLD holdings and UW in/outflow for near-term movement.
+- Monthly layer: WGC global/regional/breadth composite for structural context.
+
+Example posture language:
+
+- "ETF flow broadening: Asia and North America both positive over 3 months."
+- "ETF flow narrow: GLD inflow positive, global breadth below median."
+- "ETF distribution risk: Western ETF outflows partly offset by Asian inflows."
+
+Keep this informational. Do not map it to sizing until Q14/Q23 validation is
+complete.
+
+## Caveats
+
+- This is same-month analysis, not a lead/lag test.
+- WGC workbooks are snapshots and can revise history. The DB preserves source
+workbook lineage, but this note uses the latest revision per `(ticker, month)`.
+- Some older 2018-2021 files lack the full modern sheet set. The parser captures
+available current-month rows and partial history where present.
+- WGC definitions distinguish demand tonnes from USD fund flow. They should not
+be treated as interchangeable.
+
+## Next Analysis
+
+1. Run lead/lag correlations:
+   - ETF demand at `t-1` versus gold return at `t`
+   - regional demand at `t-1` versus global ETF demand at `t`
+2. Add real-rate and DXY controls to separate ETF momentum from macro beta.
+3. Build a monthly ETF breadth factor and backtest it only as an explanatory
+   lens input, not as trade sizing.
+4. Compare GLD daily flow to WGC monthly global demand to calibrate when GLD is
+   a good proxy and when it is misleading.

--- a/src/uw_scan/api/endpoints.py
+++ b/src/uw_scan/api/endpoints.py
@@ -31,6 +31,7 @@ class EndpointSlug(StrEnum):
     SHORT_DATA = "short_data"
     BULK_SCREENER_STOCKS = "bulk_screener_stocks"
     ETF_INFO = "etf_info"
+    ETF_IN_OUTFLOW = "etf_in_outflow"
     OPTIONS_VOLUME_DAILY = "options_volume_daily"
 
 
@@ -106,6 +107,9 @@ REGISTRY: dict[EndpointSlug, Endpoint] = {
     ),
     EndpointSlug.ETF_INFO: Endpoint(
         EndpointSlug.ETF_INFO, "/api/etfs/{ticker}/info", ()
+    ),
+    EndpointSlug.ETF_IN_OUTFLOW: Endpoint(
+        EndpointSlug.ETF_IN_OUTFLOW, "/api/etfs/{ticker}/in-outflow", ()
     ),
     EndpointSlug.OPTIONS_VOLUME_DAILY: Endpoint(
         EndpointSlug.OPTIONS_VOLUME_DAILY,

--- a/src/uw_scan/cards/structural_flow.py
+++ b/src/uw_scan/cards/structural_flow.py
@@ -27,6 +27,13 @@ class EtfHoldingSnapshot:
 
 
 @dataclass(frozen=True)
+class EtfFlowSnapshot:
+    ticker: str
+    obs_date: date
+    share_change: Decimal | None
+
+
+@dataclass(frozen=True)
 class InventorySnapshot:
     exchange: str
     obs_date: date
@@ -61,6 +68,10 @@ class StructuralPosture:
     narrative_text: str
 
 
+GLD_OZ_PER_SHARE_PROXY = Decimal("0.0931")
+TROY_OZ_PER_TONNE = Decimal("32150.7466")
+
+
 def _sum_by_bucket(
     cb_rows: list[CbReserveSnapshot], bucket: str, cutoff: date
 ) -> Decimal | None:
@@ -90,6 +101,7 @@ def compute_structural_posture(
     fx_rows: list[FxSnapshot],
     gold_series: list[tuple[date, Decimal]],
     as_of: date,
+    etf_flow_rows: list[EtfFlowSnapshot] | None = None,
 ) -> StructuralPosture:
     twelve_months_ago = as_of - timedelta(days=365)
 
@@ -102,13 +114,27 @@ def compute_structural_posture(
         key=lambda r: r.obs_date,
     )
     gld_now = gld_rows[-1].holdings_oz if gld_rows else None
-    gld_holdings_t = gld_now / Decimal("32150.7") if gld_now is not None else None
+    gld_holdings_t = gld_now / TROY_OZ_PER_TONNE if gld_now is not None else None
 
     if len(gld_rows) >= 30:
         delta_30d = gld_rows[-1].holdings_oz - gld_rows[-30].holdings_oz
-        gld_30d_net_flow_t = delta_30d / Decimal("32150.7")
+        gld_30d_net_flow_t = delta_30d / TROY_OZ_PER_TONNE
     else:
-        gld_30d_net_flow_t = None
+        flow_cutoff = as_of - timedelta(days=30)
+        gld_flow_shares = [
+            r.share_change
+            for r in (etf_flow_rows or [])
+            if r.ticker == "GLD"
+            and r.obs_date >= flow_cutoff
+            and r.obs_date <= as_of
+            and r.share_change is not None
+        ]
+        if gld_flow_shares:
+            gld_30d_net_flow_t = (
+                sum(gld_flow_shares, Decimal("0")) * GLD_OZ_PER_SHARE_PROXY
+            ) / TROY_OZ_PER_TONNE
+        else:
+            gld_30d_net_flow_t = None
 
     comex_rows = sorted(
         [
@@ -196,9 +222,9 @@ def _narrate_structural(
     else:
         parts.append("Structural posture mixed.")
     if cb_strat is not None:
-        parts.append(f"CB strategic accumulators 12m sum: {cb_strat:.0f}t.")
+        parts.append(f"CB strategic accumulators 12m sum: {cb_strat:.0f} tonnes.")
     if gld_flow is not None:
-        parts.append(f"GLD 30d net flow: {gld_flow:+.1f}t.")
+        parts.append(f"GLD 30d net flow: {gld_flow:+.1f} tonnes.")
     if comex_roc is not None:
         parts.append(f"COMEX registered 20d ROC: {comex_roc * 100:+.1f}%.")
     if cot_pct is not None:

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -82,6 +82,9 @@ class Settings(BaseModel):
     # OHLC provider (massive.com)
     massive_api_key: SecretStr | None = None
     massive_base_url: str = "https://api.massive.com"
+    # WGC Goldhub authenticated downloads. Keep secrets in environment only.
+    wgc_goldhub_cookie: SecretStr | None = None
+    wgc_etf_flows_workbook_path: str = ""
     # Trade Insights V1.5 local Codex analysis
     trade_insights_ai_enabled: bool = False
     trade_insights_ai_model: str = ""
@@ -149,6 +152,14 @@ class Settings(BaseModel):
             massive_base_url=os.environ.get(
                 "MASSIVE_BASE_URL", "https://api.massive.com"
             ),
+            wgc_goldhub_cookie=(
+                SecretStr(_wgc_cookie)
+                if (_wgc_cookie := os.environ.get("WGC_GOLDHUB_COOKIE", "").strip())
+                else None
+            ),
+            wgc_etf_flows_workbook_path=os.environ.get(
+                "WGC_ETF_FLOWS_WORKBOOK_PATH", ""
+            ).strip(),
             trade_insights_ai_enabled=_env_bool("TRADE_INSIGHTS_AI_ENABLED", False),
             trade_insights_ai_model=os.environ.get("TRADE_INSIGHTS_AI_MODEL", ""),
             trade_insights_ai_timeout_seconds=float(

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -718,6 +718,17 @@ class EtfInfo(_UwBase):
     has_options: bool | None = None
 
 
+class EtfInOutflowRow(_UwBase):
+    ticker: str
+    date: _date
+    change: Decimal | None = None
+    change_prem: Decimal | None = None
+    close: Decimal | None = None
+    volume: Decimal | None = None
+    expiration_cycle: str | None = None
+    is_fomc: bool | None = None
+
+
 class ScanTickerResult(_UwBase):
     """One row in the Full Scan output. Ranked by `score` desc."""
 

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from .models import (
     BulkScreenerRow,
     DarkPoolPrint,
+    EtfInOutflowRow,
     EtfInfo,
     FlowAlert,
     GreekExposureRow,
@@ -195,6 +196,10 @@ def normalize_etf_info(payload: dict) -> EtfInfo:
             f"etf_info payload['data'] expected object, got {type(raw).__name__}"
         )
     return EtfInfo(**raw)
+
+
+def normalize_etf_in_outflow(payload: dict, *, ticker: str) -> list[EtfInOutflowRow]:
+    return [EtfInOutflowRow(ticker=ticker.upper(), **row) for row in _data_list(payload)]
 
 
 # ---------------------------------------------------------------------------

--- a/src/uw_scan/reports/gold_posture.py
+++ b/src/uw_scan/reports/gold_posture.py
@@ -22,6 +22,7 @@ from uw_scan.cards.regime_gauge import compute_correlation_gauge
 from uw_scan.cards.structural_flow import (
     CbReserveSnapshot,
     CotSnapshot,
+    EtfFlowSnapshot,
     EtfHoldingSnapshot,
     InventorySnapshot,
     compute_structural_posture,
@@ -268,6 +269,17 @@ def compute_and_persist_gold_posture(
         )
         for r in etf_db
     ]
+    etf_flow_db = repo.fetch_etf_flows_daily(
+        "GLD", from_date=as_of - timedelta(days=45), to_date=as_of
+    )
+    etf_flow_snapshots = [
+        EtfFlowSnapshot(
+            ticker="GLD",
+            obs_date=r["obs_date"],
+            share_change=r.get("share_change"),
+        )
+        for r in etf_flow_db
+    ]
     inv_db = repo.fetch_exchange_inventory_daily(
         "COMEX", from_date=as_of - timedelta(days=60)
     )
@@ -297,6 +309,7 @@ def compute_and_persist_gold_posture(
         fx_rows=[],
         gold_series=gold_series,
         as_of=as_of,
+        etf_flow_rows=etf_flow_snapshots,
     )
 
     cpi_rows = repo.fetch_macro_series_monthly(
@@ -461,7 +474,10 @@ def compute_and_persist_gold_posture(
         structural, cyclical, valuation
     )
     gld_history_rows = [
-        {"obs_date": r["obs_date"].isoformat(), "value": str(r["holdings_oz"])}
+        {
+            "obs_date": r["obs_date"].isoformat(),
+            "value": str(Decimal(str(r["holdings_oz"])) / _OZ_PER_TONNE),
+        }
         for r in etf_db
         if r["obs_date"] >= window5y_start and r.get("holdings_oz") is not None
     ]

--- a/src/uw_scan/sources/etf_holdings.py
+++ b/src/uw_scan/sources/etf_holdings.py
@@ -16,6 +16,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import httpx
+from openpyxl import load_workbook
 
 from uw_scan.storage.provider_usage import ExternalApiRequestEvent
 from uw_scan.storage.repository import redact_params, status_family_for
@@ -37,7 +38,8 @@ RecordHook = Callable[["EtfHoldingsProvider", ExternalApiRequestEvent], None]
 
 
 class EtfHoldingsProvider:
-    GLD_URL = "https://www.spdrgoldshares.com/usa/historical-data/"
+    GLD_URL = "https://api.spdrgoldshares.com/api/v1/historical-archive"
+    GLD_PARAMS = {"product": "gld", "exchange": "NYSE", "lang": "en"}
     GLDM_URL = "https://www.spdrgoldshares.com/usa/historical-data-gldm/"
     IAU_URL = "https://www.ishares.com/us/products/239561/iau-holdings.ajax"
     PHYS_URL = "https://sprott.com/api/v1/funds/phys/nav-history"
@@ -75,9 +77,11 @@ class EtfHoldingsProvider:
 
     def fetch_gld(self, *, start: date | None = None) -> list[EtfHoldingRow]:
         response = self._get_with_telemetry(
-            self.GLD_URL, {}, endpoint_key="spdr_gld_csv"
+            self.GLD_URL, self.GLD_PARAMS, endpoint_key="spdr_gld_archive"
         )
         response.raise_for_status()
+        if _looks_like_xlsx(response):
+            return self._parse_spdr_archive_xlsx("GLD", response.content, start)
         return self._parse_spdr_csv("GLD", response.text, start)
 
     def fetch_gldm(self, *, start: date | None = None) -> list[EtfHoldingRow]:
@@ -148,6 +152,47 @@ class EtfHoldingsProvider:
                     shares_out=None,
                     nav_per_share=_dec(row.get("NAV per Share (USD)")),
                     premium_pct=None,
+                )
+            )
+        return out
+
+    def _parse_spdr_archive_xlsx(
+        self, ticker: str, content: bytes, start: date | None
+    ) -> list[EtfHoldingRow]:
+        out: list[EtfHoldingRow] = []
+        workbook = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+        sheet_name = f"US {ticker} Historical Archive"
+        sheet = workbook[sheet_name] if sheet_name in workbook.sheetnames else None
+        if sheet is None:
+            logger.warning("spdr archive missing sheet %s", sheet_name)
+            return out
+
+        rows = sheet.iter_rows(values_only=True)
+        header = next(rows, None)
+        if header is None:
+            return out
+        columns = {str(value).strip(): idx for idx, value in enumerate(header) if value}
+        for row in rows:
+            d = _parse_date(_cell(row, columns, "Date"))
+            if d is None or (start and d < start):
+                continue
+            holdings_oz = _dec(_cell(row, columns, "Total Ounces of Gold in the Trust"))
+            if holdings_oz is None:
+                continue
+            out.append(
+                EtfHoldingRow(
+                    ticker=ticker,
+                    obs_date=d,
+                    holdings_oz=holdings_oz,
+                    shares_out=None,
+                    nav_per_share=_dec(_cell(row, columns, "NAV/Share at 10:30am NYT")),
+                    premium_pct=_dec(
+                        _cell(
+                            row,
+                            columns,
+                            "Premium/Discount of GLD Mid Point vs Indicative Value of GLD at 4:15pm NYT",
+                        )
+                    ),
                 )
             )
         return out
@@ -250,14 +295,33 @@ class EtfHoldingsProvider:
 def _parse_date(raw: str | None) -> date | None:
     if not raw:
         return None
-    raw = raw.strip()
-    for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    raw = str(raw).strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d-%b-%Y"):
         try:
             return datetime.strptime(raw, fmt).date()
         except ValueError as exc:
             logger.debug("etf date parse fmt=%s skipped: %s", fmt, repr(exc))
             continue
     return None
+
+
+def _looks_like_xlsx(response: httpx.Response) -> bool:
+    content_type = response.headers.get("content-type", "").lower()
+    return (
+        response.content.startswith(b"PK\x03\x04")
+        or "spreadsheetml.sheet" in content_type
+    )
+
+
+def _cell(row: tuple[Any, ...], columns: dict[str, int], name: str) -> Any:
+    idx = columns.get(name)
+    if idx is None or idx >= len(row):
+        return None
+    return row[idx]
 
 
 def _dec(raw: Any) -> Decimal | None:

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -16,6 +16,7 @@ from ..api.endpoints import EndpointSlug, build_path
 from ..models import (
     BulkScreenerRow,
     DarkPoolPrint,
+    EtfInOutflowRow,
     EtfInfo,
     FlowAlert,
     GreekExposureRow,
@@ -374,3 +375,23 @@ def fetch_etf_info(
 ) -> EtfInfo:
     body = _fetch_json(client, repo, run_id, EndpointSlug.ETF_INFO, ticker)
     return normalize.normalize_etf_info(body)
+
+
+def fetch_etf_in_outflow(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+    *,
+    start_date: str,
+    end_date: str,
+) -> list[EtfInOutflowRow]:
+    body = _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.ETF_IN_OUTFLOW,
+        ticker,
+        params={"start_date": start_date, "end_date": end_date},
+    )
+    return normalize.normalize_etf_in_outflow(body, ticker=ticker)

--- a/src/uw_scan/sources/wgc_etf.py
+++ b/src/uw_scan/sources/wgc_etf.py
@@ -1,0 +1,523 @@
+"""World Gold Council monthly gold ETF holdings workbook."""
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+from openpyxl import load_workbook
+
+from uw_scan.sources.etf_holdings import EtfHoldingRow
+from uw_scan.storage.provider_usage import ExternalApiRequestEvent
+from uw_scan.storage.repository import redact_params, status_family_for
+
+logger = logging.getLogger(__name__)
+
+TROY_OZ_PER_TONNE = Decimal("32150.7466")
+
+
+@dataclass(frozen=True)
+class WgcEtfDownload:
+    url: str
+    label: str
+
+
+@dataclass(frozen=True)
+class WgcEtfMonthlyRow:
+    ticker: str
+    obs_date: date
+    fund_name: str | None
+    fund_type: str | None
+    region: str | None
+    country: str | None
+    gold_price_usd_oz: Decimal | None
+    aggregate_ounces: Decimal | None
+    aggregate_holdings_tonnes: Decimal | None
+    aggregate_value_usd: Decimal | None
+    holdings_tonnes: Decimal | None
+    demand_tonnes: Decimal | None
+    flow_usd_mn: Decimal | None
+    source_url: str
+    source_label: str | None
+
+
+class WgcEtfProvider:
+    """Fetch and parse WGC's monthly ETF flows workbook.
+
+    The listing page is public, but the XLSX downloads are gated by Goldhub
+    login. Pass a cookie header only from local environment/config; never bake
+    it into source.
+    """
+
+    ETF_FLOWS_PAGE = "https://www.gold.org/goldhub/research/etf-flows"
+    PROVIDER = "wgc_etf"
+    ENDPOINT_KEY = "wgc_etf_flows_xlsx"
+    DEFAULT_TIMEOUT_S = 60.0
+    BROWSER_UA = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    )
+    DEFAULT_TICKERS = {
+        "gld us equity": "GLD",
+        "iau us equity": "IAU",
+        "gldm us equity": "GLDM",
+        "phys us equity": "PHYS",
+    }
+
+    def __init__(
+        self,
+        *,
+        cookie_header: str | None = None,
+        timeout_s: float | None = None,
+        record_request: Any | None = None,
+    ) -> None:
+        headers = {"User-Agent": self.BROWSER_UA}
+        if cookie_header:
+            headers["Cookie"] = cookie_header
+        self._client = httpx.Client(
+            timeout=timeout_s if timeout_s is not None else self.DEFAULT_TIMEOUT_S,
+            headers=headers,
+            follow_redirects=True,
+        )
+        self._record_request_fn = record_request
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "WgcEtfProvider":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def fetch_downloads(self, *, max_pages: int = 9) -> list[WgcEtfDownload]:
+        downloads: list[WgcEtfDownload] = []
+        seen: set[str] = set()
+        for page in range(max_pages):
+            url = self.ETF_FLOWS_PAGE if page == 0 else f"{self.ETF_FLOWS_PAGE}?page={page}"
+            page_downloads = self._fetch_downloads_page(url)
+            if not page_downloads:
+                break
+            for item in page_downloads:
+                if item.url in seen:
+                    continue
+                seen.add(item.url)
+                downloads.append(item)
+        return downloads
+
+    def _fetch_downloads_page(self, url: str) -> list[WgcEtfDownload]:
+        response = self._get(url, endpoint_key="wgc_etf_flows_page")
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        downloads: list[WgcEtfDownload] = []
+        for anchor in soup.select('a[href*="/download/file/"][href$=".xlsx"]'):
+            href = anchor.get("href")
+            if not href or "ETF" not in href.upper():
+                continue
+            downloads.append(
+                WgcEtfDownload(
+                    url=urljoin(self.ETF_FLOWS_PAGE, href),
+                    label=anchor.get_text(" ", strip=True) or Path(href).name,
+                )
+            )
+        return downloads
+
+    def fetch_monthly_rows(
+        self,
+        *,
+        start: date | None = None,
+        max_pages: int = 9,
+    ) -> list[WgcEtfMonthlyRow]:
+        out: list[WgcEtfMonthlyRow] = []
+        for download in self.fetch_downloads(max_pages=max_pages):
+            content = self.fetch_workbook(download.url)
+            out.extend(
+                self.parse_monthly_rows(
+                    content,
+                    source_url=download.url,
+                    source_label=download.label,
+                    start=start,
+                )
+            )
+        return out
+
+    def fetch_latest_holdings(
+        self,
+        *,
+        start: date | None = None,
+        tickers: Iterable[str] | None = None,
+    ) -> list[EtfHoldingRow]:
+        downloads = self.fetch_downloads()
+        if not downloads:
+            return []
+        content = self.fetch_workbook(downloads[0].url)
+        return self.parse_holdings(content, start=start, tickers=tickers)
+
+    def fetch_workbook(self, url: str) -> bytes:
+        response = self._get(url, endpoint_key=self.ENDPOINT_KEY)
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "").lower()
+        if not (
+            response.content.startswith(b"PK\x03\x04")
+            or "spreadsheetml.sheet" in content_type
+        ):
+            raise ValueError(f"WGC ETF response is not an XLSX workbook: {content_type}")
+        return response.content
+
+    def parse_holdings(
+        self,
+        content: bytes,
+        *,
+        start: date | None = None,
+        tickers: Iterable[str] | None = None,
+    ) -> list[EtfHoldingRow]:
+        wanted = {t.upper() for t in tickers} if tickers is not None else None
+        workbook = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+        sheet = _sheet_by_names(workbook, ["Holdings by month", "All holdings by month"])
+        if sheet is None:
+            logger.warning("WGC ETF workbook missing Holdings by month sheet")
+            return []
+        rows = list(sheet.iter_rows(values_only=True))
+        if len(rows) < 7:
+            return []
+
+        ticker_row = rows[0]
+        fund_row = rows[5]
+        columns: list[tuple[int, str]] = []
+        for idx, raw_ticker in enumerate(ticker_row):
+            ticker = self.DEFAULT_TICKERS.get(str(raw_ticker or "").strip().lower())
+            if ticker is None:
+                continue
+            if wanted is not None and ticker not in wanted:
+                continue
+            columns.append((idx, ticker))
+
+        out: list[EtfHoldingRow] = []
+        for row in rows[6:]:
+            obs_date = _parse_excel_date(row[0] if row else None)
+            if obs_date is None or (start and obs_date < start):
+                continue
+            for idx, ticker in columns:
+                tonnes = _dec(_cell(row, idx))
+                if tonnes is None:
+                    continue
+                out.append(
+                    EtfHoldingRow(
+                        ticker=ticker,
+                        obs_date=obs_date,
+                        holdings_oz=tonnes * TROY_OZ_PER_TONNE,
+                        shares_out=None,
+                        nav_per_share=None,
+                        premium_pct=None,
+                    )
+                )
+        logger.debug(
+            "parsed %s WGC ETF holdings rows from columns=%s",
+            len(out),
+            [fund_row[idx] for idx, _ticker in columns],
+        )
+        return out
+
+    def parse_monthly_rows(
+        self,
+        content: bytes,
+        *,
+        source_url: str,
+        source_label: str | None = None,
+        start: date | None = None,
+    ) -> list[WgcEtfMonthlyRow]:
+        workbook = load_workbook(io.BytesIO(content), read_only=True, data_only=True)
+        holdings_sheet = _sheet_by_names(
+            workbook, ["Holdings by month", "All holdings by month"]
+        )
+        if holdings_sheet is None:
+            fund_flow_sheet = _sheet_by_names(
+                workbook, ["All fund flows by fund", "All fund flows"]
+            )
+            if fund_flow_sheet is None:
+                logger.warning("WGC ETF workbook missing monthly holdings sheet")
+                return []
+            return _parse_current_fund_flow_rows(
+                list(fund_flow_sheet.iter_rows(values_only=True)),
+                source_url=source_url,
+                source_label=source_label,
+                start=start,
+            )
+        demand_sheet = _sheet_by_names(
+            workbook, ["Demand by month", "Delta tonnes by month"]
+        )
+        flow_sheet = _sheet_by_names(
+            workbook, ["Fund flows by month", "All flows US$ by month"]
+        )
+
+        holdings_rows = list(holdings_sheet.iter_rows(values_only=True))
+        if len(holdings_rows) < 7:
+            return []
+
+        columns = _monthly_columns(holdings_rows)
+        demand_by_date = (
+            _monthly_values_by_date(list(demand_sheet.iter_rows(values_only=True)))
+            if demand_sheet is not None
+            else {}
+        )
+        flows_by_date = (
+            _monthly_values_by_date(list(flow_sheet.iter_rows(values_only=True)))
+            if flow_sheet is not None
+            else {}
+        )
+
+        out: list[WgcEtfMonthlyRow] = []
+        for row in holdings_rows[6:]:
+            obs_date = _parse_excel_date(_cell(row, 0))
+            if obs_date is None or (start and obs_date < start):
+                continue
+            demand_for_date = demand_by_date.get(obs_date, {})
+            flows_for_date = flows_by_date.get(obs_date, {})
+            for idx, meta in columns.items():
+                holdings_tonnes = _dec(_cell(row, idx))
+                demand_tonnes = demand_for_date.get(idx)
+                flow_usd_mn = flows_for_date.get(idx)
+                if (
+                    holdings_tonnes is None
+                    and demand_tonnes is None
+                    and flow_usd_mn is None
+                ):
+                    continue
+                out.append(
+                    WgcEtfMonthlyRow(
+                        ticker=meta["ticker"],
+                        obs_date=obs_date,
+                        fund_name=meta["fund_name"],
+                        fund_type=meta["fund_type"],
+                        region=meta["region"],
+                        country=meta["country"],
+                        gold_price_usd_oz=_dec(_cell(row, 1)),
+                        aggregate_ounces=_dec(_cell(row, 2)),
+                        aggregate_holdings_tonnes=_dec(_cell(row, 3)),
+                        aggregate_value_usd=_dec(_cell(row, 4)),
+                        holdings_tonnes=holdings_tonnes,
+                        demand_tonnes=demand_tonnes,
+                        flow_usd_mn=flow_usd_mn,
+                        source_url=source_url,
+                        source_label=source_label,
+                    )
+                )
+        return out
+
+    def _get(self, url: str, *, endpoint_key: str) -> httpx.Response:
+        started_at = datetime.now(UTC)
+        try:
+            response = self._client.get(url)
+        except httpx.HTTPError as exc:
+            finished_at = datetime.now(UTC)
+            self._record_request(
+                self._build_event(
+                    url,
+                    endpoint_key,
+                    started_at,
+                    finished_at,
+                    status_code=None,
+                    error_message=repr(exc)[:1000],
+                )
+            )
+            raise
+        finished_at = datetime.now(UTC)
+        self._record_request(
+            self._build_event(
+                url,
+                endpoint_key,
+                started_at,
+                finished_at,
+                status_code=response.status_code,
+                error_message=(
+                    response.text[:1000] if response.status_code >= 400 else None
+                ),
+            )
+        )
+        return response
+
+    def _record_request(self, event: ExternalApiRequestEvent) -> None:
+        if self._record_request_fn is not None:
+            self._record_request_fn(self, event)
+        else:
+            logger.debug("wgc_etf telemetry %r", event)
+
+    def _build_event(
+        self,
+        url: str,
+        endpoint_key: str,
+        started_at: datetime,
+        finished_at: datetime,
+        *,
+        status_code: int | None,
+        error_message: str | None,
+    ) -> ExternalApiRequestEvent:
+        return ExternalApiRequestEvent(
+            provider=self.PROVIDER,
+            endpoint_key=endpoint_key,
+            method="GET",
+            path=url,
+            path_template=url,
+            params=redact_params({}),
+            status_code=status_code,
+            status_family=status_family_for(
+                status_code, transport_error=status_code is None
+            ),
+            started_at=started_at,
+            finished_at=finished_at,
+            latency_ms=max(0, int((finished_at - started_at).total_seconds() * 1000)),
+            error_message=error_message,
+        )
+
+
+def _cell(row: tuple[Any, ...], idx: int) -> Any:
+    if idx >= len(row):
+        return None
+    return row[idx]
+
+
+def _sheet_by_names(workbook: Any, names: list[str]) -> Any | None:
+    for name in names:
+        if name in workbook.sheetnames:
+            return workbook[name]
+    return None
+
+
+def _monthly_columns(rows: list[tuple[Any, ...]]) -> dict[int, dict[str, str | None]]:
+    tickers = rows[0]
+    fund_types = rows[2]
+    regions = rows[3]
+    countries = rows[4]
+    fund_names = rows[5]
+    columns: dict[int, dict[str, str | None]] = {}
+    for idx in range(5, len(tickers)):
+        raw_ticker = str(tickers[idx] or "").strip()
+        if not raw_ticker:
+            continue
+        columns[idx] = {
+            "ticker": _display_ticker(raw_ticker),
+            "fund_name": _str_or_none(_cell(fund_names, idx)),
+            "fund_type": _str_or_none(_cell(fund_types, idx)),
+            "region": _str_or_none(_cell(regions, idx)),
+            "country": _str_or_none(_cell(countries, idx)),
+        }
+    return columns
+
+
+def _monthly_values_by_date(rows: list[tuple[Any, ...]]) -> dict[date, dict[int, Decimal]]:
+    out: dict[date, dict[int, Decimal]] = {}
+    for row in rows[6:]:
+        obs_date = _parse_excel_date(_cell(row, 0))
+        if obs_date is None:
+            continue
+        values: dict[int, Decimal] = {}
+        for idx in range(5, len(row)):
+            value = _dec(_cell(row, idx))
+            if value is not None:
+                values[idx] = value
+        out[obs_date] = values
+    return out
+
+
+def _parse_current_fund_flow_rows(
+    rows: list[tuple[Any, ...]],
+    *,
+    source_url: str,
+    source_label: str | None,
+    start: date | None,
+) -> list[WgcEtfMonthlyRow]:
+    if len(rows) < 4:
+        return []
+    obs_date = _parse_as_of_date(_cell(rows[1], 1))
+    if obs_date is None or (start and obs_date < start):
+        return []
+    out: list[WgcEtfMonthlyRow] = []
+    current_region: str | None = None
+    for row in rows[3:]:
+        region = _str_or_none(_cell(row, 1))
+        if region is not None:
+            current_region = region
+        raw_ticker = _str_or_none(_cell(row, 3))
+        if raw_ticker is None:
+            continue
+        holdings_tonnes = _dec(_cell(row, 5))
+        demand_tonnes = _dec(_cell(row, 8))
+        flow_usd_mn = _dec(_cell(row, 9))
+        if holdings_tonnes is None and demand_tonnes is None and flow_usd_mn is None:
+            continue
+        out.append(
+            WgcEtfMonthlyRow(
+                ticker=_display_ticker(raw_ticker),
+                obs_date=obs_date,
+                fund_name=_str_or_none(_cell(row, 2)),
+                fund_type=None,
+                region=current_region,
+                country=_str_or_none(_cell(row, 4)),
+                gold_price_usd_oz=None,
+                aggregate_ounces=None,
+                aggregate_holdings_tonnes=None,
+                aggregate_value_usd=None,
+                holdings_tonnes=holdings_tonnes,
+                demand_tonnes=demand_tonnes,
+                flow_usd_mn=flow_usd_mn,
+                source_url=source_url,
+                source_label=source_label,
+            )
+        )
+    return out
+
+
+def _parse_as_of_date(raw: Any) -> date | None:
+    text = str(raw or "")
+    _, _, value = text.partition("As Of Date")
+    return _parse_excel_date(value.strip() or text.strip())
+
+
+def _display_ticker(raw: str) -> str:
+    mapped = WgcEtfProvider.DEFAULT_TICKERS.get(raw.strip().lower())
+    if mapped is not None:
+        return mapped
+    return raw.strip().upper()
+
+
+def _str_or_none(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _parse_excel_date(raw: Any) -> date | None:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, date):
+        return raw
+    text = str(raw).strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError as exc:
+            logger.debug("wgc etf date parse fmt=%s skipped: %s", fmt, repr(exc))
+            continue
+    return None
+
+
+def _dec(raw: Any) -> Decimal | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        return Decimal(str(raw).replace(",", "").strip())
+    except (InvalidOperation, ValueError) as exc:
+        logger.debug("wgc etf decimal parse skipped: %s", repr(exc))
+        return None

--- a/src/uw_scan/storage/gold_etf.py
+++ b/src/uw_scan/storage/gold_etf.py
@@ -1,0 +1,246 @@
+"""Gold ETF flow persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date as _date
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+
+class _GoldEtfMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_etf_flows_daily(
+        self,
+        *,
+        ticker: str,
+        obs_date: _date,
+        share_change: Decimal | None,
+        premium_change_usd: Decimal | None,
+        close: Decimal | None,
+        volume: Decimal | None,
+        as_of: datetime,
+        source: str,
+    ) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.etf_flows_daily
+                  (ticker, obs_date, share_change, premium_change_usd, close,
+                   volume, as_of, source)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (ticker, obs_date, as_of) DO NOTHING
+                """,
+                (
+                    ticker.upper(),
+                    obs_date,
+                    share_change,
+                    premium_change_usd,
+                    close,
+                    volume,
+                    as_of,
+                    source,
+                ),
+            )
+
+    def fetch_etf_flows_daily(
+        self,
+        ticker: str,
+        *,
+        from_date: _date | None = None,
+        to_date: _date | None = None,
+        as_of_max: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses = ["ticker = %s"]
+        params: list[Any] = [ticker.upper()]
+        if from_date is not None:
+            clauses.append("obs_date >= %s")
+            params.append(from_date)
+        if to_date is not None:
+            clauses.append("obs_date <= %s")
+            params.append(to_date)
+        if as_of_max is not None:
+            clauses.append("as_of <= %s")
+            params.append(as_of_max)
+        where = " AND ".join(clauses)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT DISTINCT ON (obs_date)
+                  obs_date, share_change, premium_change_usd, close, volume,
+                  as_of, source
+                FROM {self._schema}.etf_flows_daily
+                WHERE {where}
+                ORDER BY obs_date ASC, as_of DESC
+                """,
+                params,
+            )
+            cols = [c.name for c in cur.description]
+            return [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+
+    def insert_wgc_etf_monthly(
+        self,
+        *,
+        ticker: str,
+        obs_date: _date,
+        fund_name: str | None,
+        fund_type: str | None,
+        region: str | None,
+        country: str | None,
+        gold_price_usd_oz: Decimal | None,
+        aggregate_ounces: Decimal | None,
+        aggregate_holdings_tonnes: Decimal | None,
+        aggregate_value_usd: Decimal | None,
+        holdings_tonnes: Decimal | None,
+        demand_tonnes: Decimal | None,
+        flow_usd_mn: Decimal | None,
+        source_url: str,
+        source_label: str | None,
+        as_of: datetime,
+        source: str,
+    ) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.wgc_etf_monthly
+                  (ticker, obs_date, fund_name, fund_type, region, country,
+                   gold_price_usd_oz, aggregate_ounces, aggregate_holdings_tonnes,
+                   aggregate_value_usd, holdings_tonnes, demand_tonnes, flow_usd_mn,
+                   source_url, source_label, as_of, source)
+                VALUES
+                  (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (ticker, obs_date, source_url) DO UPDATE SET
+                  fund_name = EXCLUDED.fund_name,
+                  fund_type = EXCLUDED.fund_type,
+                  region = EXCLUDED.region,
+                  country = EXCLUDED.country,
+                  gold_price_usd_oz = EXCLUDED.gold_price_usd_oz,
+                  aggregate_ounces = EXCLUDED.aggregate_ounces,
+                  aggregate_holdings_tonnes = EXCLUDED.aggregate_holdings_tonnes,
+                  aggregate_value_usd = EXCLUDED.aggregate_value_usd,
+                  holdings_tonnes = EXCLUDED.holdings_tonnes,
+                  demand_tonnes = EXCLUDED.demand_tonnes,
+                  flow_usd_mn = EXCLUDED.flow_usd_mn,
+                  source_label = EXCLUDED.source_label,
+                  as_of = EXCLUDED.as_of,
+                  source = EXCLUDED.source
+                """,
+                (
+                    ticker.upper(),
+                    obs_date,
+                    fund_name,
+                    fund_type,
+                    region,
+                    country,
+                    gold_price_usd_oz,
+                    aggregate_ounces,
+                    aggregate_holdings_tonnes,
+                    aggregate_value_usd,
+                    holdings_tonnes,
+                    demand_tonnes,
+                    flow_usd_mn,
+                    source_url,
+                    source_label,
+                    as_of,
+                    source,
+                ),
+            )
+
+    def insert_wgc_etf_monthly_rows(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        as_of: datetime,
+        source: str,
+    ) -> int:
+        values = [
+            (
+                row["ticker"].upper(),
+                row["obs_date"],
+                row.get("fund_name"),
+                row.get("fund_type"),
+                row.get("region"),
+                row.get("country"),
+                row.get("gold_price_usd_oz"),
+                row.get("aggregate_ounces"),
+                row.get("aggregate_holdings_tonnes"),
+                row.get("aggregate_value_usd"),
+                row.get("holdings_tonnes"),
+                row.get("demand_tonnes"),
+                row.get("flow_usd_mn"),
+                row["source_url"],
+                row.get("source_label"),
+                as_of,
+                source,
+            )
+            for row in rows
+        ]
+        if not values:
+            return 0
+        with self._conn.cursor() as cur:
+            cur.executemany(
+                f"""
+                INSERT INTO {self._schema}.wgc_etf_monthly
+                  (ticker, obs_date, fund_name, fund_type, region, country,
+                   gold_price_usd_oz, aggregate_ounces, aggregate_holdings_tonnes,
+                   aggregate_value_usd, holdings_tonnes, demand_tonnes, flow_usd_mn,
+                   source_url, source_label, as_of, source)
+                VALUES
+                  (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (ticker, obs_date, source_url) DO UPDATE SET
+                  fund_name = EXCLUDED.fund_name,
+                  fund_type = EXCLUDED.fund_type,
+                  region = EXCLUDED.region,
+                  country = EXCLUDED.country,
+                  gold_price_usd_oz = EXCLUDED.gold_price_usd_oz,
+                  aggregate_ounces = EXCLUDED.aggregate_ounces,
+                  aggregate_holdings_tonnes = EXCLUDED.aggregate_holdings_tonnes,
+                  aggregate_value_usd = EXCLUDED.aggregate_value_usd,
+                  holdings_tonnes = EXCLUDED.holdings_tonnes,
+                  demand_tonnes = EXCLUDED.demand_tonnes,
+                  flow_usd_mn = EXCLUDED.flow_usd_mn,
+                  source_label = EXCLUDED.source_label,
+                  as_of = EXCLUDED.as_of,
+                  source = EXCLUDED.source
+                """,
+                values,
+            )
+        return len(values)
+
+    def fetch_wgc_etf_monthly(
+        self,
+        ticker: str,
+        *,
+        from_date: _date | None = None,
+        to_date: _date | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses = ["ticker = %s"]
+        params: list[Any] = [ticker.upper()]
+        if from_date is not None:
+            clauses.append("obs_date >= %s")
+            params.append(from_date)
+        if to_date is not None:
+            clauses.append("obs_date <= %s")
+            params.append(to_date)
+        where = " AND ".join(clauses)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT DISTINCT ON (obs_date)
+                  ticker, obs_date, fund_name, fund_type, region, country,
+                  gold_price_usd_oz, aggregate_ounces, aggregate_holdings_tonnes,
+                  aggregate_value_usd, holdings_tonnes, demand_tonnes, flow_usd_mn,
+                  source_url, source_label, as_of, source
+                FROM {self._schema}.wgc_etf_monthly
+                WHERE {where}
+                ORDER BY obs_date ASC, as_of DESC, source_url DESC
+                """,
+                params,
+            )
+            cols = [c.name for c in cur.description]
+            return [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]

--- a/src/uw_scan/storage/migrations/045_gold_etf_flows.sql
+++ b/src/uw_scan/storage/migrations/045_gold_etf_flows.sql
@@ -1,0 +1,21 @@
+-- 045_gold_etf_flows.sql — Gold v2 source re-wire.
+-- Daily UW ETF in/outflow rows. This is flow, not absolute bullion holdings:
+-- GLD/IAU/GLDM commodity trusts can have empty UW constituent holdings while
+-- still publishing share/premium flow rows through /api/etfs/{ticker}/in-outflow.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.etf_flows_daily (
+  ticker              TEXT        NOT NULL,
+  obs_date            DATE        NOT NULL,
+  share_change        NUMERIC     NULL,
+  premium_change_usd  NUMERIC     NULL,
+  close               NUMERIC     NULL,
+  volume              NUMERIC     NULL,
+  as_of               TIMESTAMPTZ NOT NULL,
+  source              TEXT        NOT NULL,
+  PRIMARY KEY (ticker, obs_date, as_of)
+);
+
+CREATE INDEX IF NOT EXISTS idx_etf_flows_daily_lookup
+  ON uw_scan.etf_flows_daily (ticker, obs_date DESC, as_of DESC);

--- a/src/uw_scan/storage/migrations/046_wgc_etf_monthly.sql
+++ b/src/uw_scan/storage/migrations/046_wgc_etf_monthly.sql
@@ -1,0 +1,33 @@
+-- 046_wgc_etf_monthly.sql — Gold v2 WGC ETF historical corpus.
+-- Monthly Goldhub ETF workbook rows. Stores per-fund holdings, demand, and
+-- fund-flow fields with source workbook lineage so revised workbooks are
+-- preserved rather than flattened away.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.wgc_etf_monthly (
+  ticker                     TEXT        NOT NULL,
+  obs_date                   DATE        NOT NULL,
+  fund_name                  TEXT        NULL,
+  fund_type                  TEXT        NULL,
+  region                     TEXT        NULL,
+  country                    TEXT        NULL,
+  gold_price_usd_oz          NUMERIC     NULL,
+  aggregate_ounces           NUMERIC     NULL,
+  aggregate_holdings_tonnes  NUMERIC     NULL,
+  aggregate_value_usd        NUMERIC     NULL,
+  holdings_tonnes            NUMERIC     NULL,
+  demand_tonnes              NUMERIC     NULL,
+  flow_usd_mn                NUMERIC     NULL,
+  source_url                 TEXT        NOT NULL,
+  source_label               TEXT        NULL,
+  as_of                      TIMESTAMPTZ NOT NULL,
+  source                     TEXT        NOT NULL,
+  PRIMARY KEY (ticker, obs_date, source_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wgc_etf_monthly_lookup
+  ON uw_scan.wgc_etf_monthly (ticker, obs_date DESC, as_of DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wgc_etf_monthly_source
+  ON uw_scan.wgc_etf_monthly (source_url, obs_date DESC);

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -39,6 +39,7 @@ from .flow import (
     _flow_footprint_label,  # noqa: F401
     _FlowMixin,
 )
+from .gold_etf import _GoldEtfMixin
 from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
@@ -290,6 +291,7 @@ logger = logging.getLogger(__name__)
 class Repository(
     _AuditMixin,
     _FlowMixin,
+    _GoldEtfMixin,
     _HealthMixin,
     _JobsMixin,
     _MarketDataMixin,

--- a/src/uw_scan/worker/gold_warmup.py
+++ b/src/uw_scan/worker/gold_warmup.py
@@ -44,9 +44,10 @@ def main() -> int:
     logger.info("gold_warmup: starting (db=%s)", settings.db_name)
 
     # Warmup pulls 5y of FRED/GPR history so correlations (60/126/252/504D)
-    # have enough overlap with GLD_CLOSE. Routine daily jobs stick with the
-    # 45-day default to keep ingest cheap.
+    # have enough overlap with GLD_CLOSE. WGC ETF workbooks preserve history
+    # back to 2003, so warmup uses a deeper holdings window than daily refresh.
     LONG_LOOKBACK_DAYS = 1825
+    ETF_HOLDINGS_FULL_HISTORY_DAYS = 365 * 30
 
     steps: list[tuple[str, Callable[[], None]]] = [
         (
@@ -91,6 +92,7 @@ def main() -> int:
                 ),
                 wgc_workbook_path=settings.wgc_etf_flows_workbook_path or None,
                 lookback_days=45,
+                holdings_lookback_days=ETF_HOLDINGS_FULL_HISTORY_DAYS,
             ),
         ),
         ("COMEX vault daily", lambda: gold_comex_vault_ingest_job(dsn=dsn)),

--- a/src/uw_scan/worker/gold_warmup.py
+++ b/src/uw_scan/worker/gold_warmup.py
@@ -81,7 +81,17 @@ def main() -> int:
         ),
         (
             "ETF holdings (GLD/IAU/GLDM/PHYS — best-effort)",
-            lambda: gold_etf_holdings_ingest_job(dsn=dsn),
+            lambda: gold_etf_holdings_ingest_job(
+                dsn=dsn,
+                uw_api_key=settings.api_key.get_secret_value(),
+                wgc_goldhub_cookie=(
+                    settings.wgc_goldhub_cookie.get_secret_value()
+                    if settings.wgc_goldhub_cookie is not None
+                    else None
+                ),
+                wgc_workbook_path=settings.wgc_etf_flows_workbook_path or None,
+                lookback_days=45,
+            ),
         ),
         ("COMEX vault daily", lambda: gold_comex_vault_ingest_job(dsn=dsn)),
         ("CFTC COT weekly", lambda: gold_cftc_cot_ingest_job(dsn=dsn)),

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -26,7 +26,9 @@ runs against that database, no scheduler required.
 from __future__ import annotations
 
 import logging
+from dataclasses import asdict
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 
 import psycopg
 
@@ -39,14 +41,18 @@ from uw_scan.sources.fred import FredProvider
 from uw_scan.sources.gpr import GprProvider
 from uw_scan.sources.lbma import LbmaProvider
 from uw_scan.sources.ohlc import MassiveOhlcProvider
+from uw_scan.sources import uw as uw_sources
 from uw_scan.sources.uw_gold_options import (
     GOLD_OPTIONS_TICKERS,
     fetch_gold_options_snapshot,
 )
+from uw_scan.sources.wgc_etf import TROY_OZ_PER_TONNE, WgcEtfProvider
 from uw_scan.storage.repository import Repository
 
 logger = logging.getLogger(__name__)
 
+
+GOLD_ETF_FLOW_TICKERS = ("GLD", "IAU", "GLDM")
 
 FRED_SERIES_DAILY = [
     "DFII10",
@@ -158,17 +164,24 @@ def gold_gpr_ingest_job(*, dsn: str, lookback_days: int = 45) -> None:
         conn.commit()
 
 
-def gold_etf_holdings_ingest_job(*, dsn: str) -> None:
+def gold_etf_holdings_ingest_job(
+    *,
+    dsn: str,
+    uw_api_key: str | None = None,
+    wgc_goldhub_cookie: str | None = None,
+    wgc_workbook_path: str | None = None,
+    lookback_days: int = 45,
+    holdings_lookback_days: int = 400,
+) -> None:
     """Daily ETF refresh (GLD/IAU/GLDM/PHYS). Schedule: 18:30 ET.
 
-    Best-effort: as of 2026-05-17 all four fund-manager scraping endpoints
-    return 301/404 (SPDR moved to /usa/gld/, BlackRock retired the .ajax
-    endpoint, Sprott changed their API path). Job runs and persists rows
-    for any ticker that still returns 200; other tickers fall through to
-    the per-ticker except. Re-wire each endpoint as the manager's site
-    stabilises — see sources/etf_holdings.py.
+    GLD uses SPDR's daily historical archive workbook. WGC Goldhub monthly
+    files backfill GLD/IAU/GLDM/PHYS when an authenticated cookie or exported
+    workbook path is provided. UW ETF in/outflow stays on a shorter lookback
+    because current entitlement only exposes recent history.
     """
     now = datetime.now(UTC)
+    holdings_start = date.today() - timedelta(days=holdings_lookback_days)
     with psycopg.connect(dsn) as conn, EtfHoldingsProvider() as etf:
         repo = Repository(conn, schema="uw_scan")
         for ticker, fetch_fn, source in [
@@ -178,7 +191,7 @@ def gold_etf_holdings_ingest_job(*, dsn: str) -> None:
             ("PHYS", etf.fetch_phys, "Sprott"),
         ]:
             try:
-                for row in fetch_fn(start=date.today() - timedelta(days=45)):
+                for row in fetch_fn(start=holdings_start):
                     repo.insert_etf_holdings_daily(
                         ticker=row.ticker,
                         obs_date=row.obs_date,
@@ -195,7 +208,105 @@ def gold_etf_holdings_ingest_job(*, dsn: str) -> None:
                     ticker,
                     repr(exc)[:200],
                 )
+        if wgc_goldhub_cookie or wgc_workbook_path:
+            try:
+                with WgcEtfProvider(cookie_header=wgc_goldhub_cookie) as wgc:
+                    if wgc_workbook_path:
+                        monthly_rows = []
+                        for workbook_path in _wgc_workbook_paths(wgc_workbook_path):
+                            monthly_rows.extend(
+                                wgc.parse_monthly_rows(
+                                    workbook_path.read_bytes(),
+                                    source_url=workbook_path.resolve().as_uri(),
+                                    source_label=workbook_path.name,
+                                    start=holdings_start,
+                                )
+                            )
+                    else:
+                        monthly_rows = wgc.fetch_monthly_rows(start=holdings_start)
+                    corpus_rows = 0
+                    for chunk in _chunks([asdict(row) for row in monthly_rows], 5000):
+                        corpus_rows += repo.insert_wgc_etf_monthly_rows(
+                            chunk, as_of=now, source="WGC"
+                        )
+                    holdings_rows = 0
+                    for row in monthly_rows:
+                        if (
+                            row.ticker in {"GLD", "IAU", "GLDM", "PHYS"}
+                            and row.holdings_tonnes is not None
+                        ):
+                            repo.insert_etf_holdings_daily(
+                                ticker=row.ticker,
+                                obs_date=row.obs_date,
+                                holdings_oz=row.holdings_tonnes * TROY_OZ_PER_TONNE,
+                                shares_out=None,
+                                nav_per_share=None,
+                                premium_pct=None,
+                                as_of=now,
+                                source="WGC",
+                            )
+                            holdings_rows += 1
+                    logger.info(
+                        "gold_etf_holdings_ingest: %s WGC monthly rows, %s holdings rows",
+                        corpus_rows,
+                        holdings_rows,
+                    )
+            except Exception as exc:
+                logger.warning("gold_etf_holdings_ingest: WGC skipped (%s)", repr(exc))
+        else:
+            logger.info("WGC Goldhub auth/export not provided; skipping WGC ETF ingest")
+        if uw_api_key:
+            start = (date.today() - timedelta(days=lookback_days)).isoformat()
+            end = date.today().isoformat()
+            with UwClient(
+                api_key=uw_api_key,
+                timeout=30.0,
+                job_name="gold_etf_in_outflow_ingest",
+            ) as client:
+                run_id = repo.insert_scan_run(
+                    ticker="GOLD",
+                    notes=f"gold_etf_in_outflow:{end}",
+                )
+                for ticker in GOLD_ETF_FLOW_TICKERS:
+                    try:
+                        for row in uw_sources.fetch_etf_in_outflow(
+                            client=client,
+                            repo=repo,
+                            run_id=run_id,
+                            ticker=ticker,
+                            start_date=start,
+                            end_date=end,
+                        ):
+                            repo.insert_etf_flows_daily(
+                                ticker=row.ticker,
+                                obs_date=row.date,
+                                share_change=row.change,
+                                premium_change_usd=row.change_prem,
+                                close=row.close,
+                                volume=row.volume,
+                                as_of=now,
+                                source="UW",
+                            )
+                    except Exception as exc:
+                        logger.warning(
+                            "gold_etf_in_outflow_ingest: %s skipped (%s)",
+                            ticker,
+                            repr(exc)[:200],
+                        )
+        else:
+            logger.info("UW API key not provided; skipping gold ETF in/outflow ingest")
         conn.commit()
+
+
+def _wgc_workbook_paths(raw_path: str) -> list[Path]:
+    path = Path(raw_path)
+    if path.is_dir():
+        return sorted(path.glob("*.xlsx"))
+    return [path]
+
+
+def _chunks(items: list[dict[str, object]], size: int) -> list[list[dict[str, object]]]:
+    return [items[idx : idx + size] for idx in range(0, len(items), size)]
 
 
 def gold_spot_ingest_job(

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -354,7 +354,16 @@ def main() -> int:
         gold_gpr_ingest_job(dsn=settings.db_dsn())
 
     def _gold_etf_holdings_ingest() -> None:
-        gold_etf_holdings_ingest_job(dsn=settings.db_dsn())
+        gold_etf_holdings_ingest_job(
+            dsn=settings.db_dsn(),
+            uw_api_key=settings.api_key.get_secret_value(),
+            wgc_goldhub_cookie=(
+                settings.wgc_goldhub_cookie.get_secret_value()
+                if settings.wgc_goldhub_cookie is not None
+                else None
+            ),
+            wgc_workbook_path=settings.wgc_etf_flows_workbook_path or None,
+        )
 
     def _gold_comex_vault_ingest() -> None:
         gold_comex_vault_ingest_job(dsn=settings.db_dsn())

--- a/tests/integration/reports/test_gold_posture_orchestrator.py
+++ b/tests/integration/reports/test_gold_posture_orchestrator.py
@@ -88,6 +88,16 @@ def _seed_minimum(repo: Repository, today: date) -> None:
         "FRED",
         None,
     )
+    repo.insert_etf_holdings_daily(
+        ticker="GLD",
+        obs_date=today,
+        holdings_oz=Decimal("32150746.6"),
+        shares_out=None,
+        nav_per_share=Decimal("420.50"),
+        premium_pct=Decimal("0.01"),
+        as_of=datetime.now(UTC),
+        source="SPDR",
+    )
 
 
 def test_orchestrator_writes_posture_row(repo: Repository) -> None:
@@ -112,6 +122,8 @@ def test_orchestrator_writes_posture_row(repo: Repository) -> None:
         "SUSPENDED",
         "DEGRADED",
     }
+    assert row["gld_history_jsonb"][-1]["obs_date"] == today.isoformat()
+    assert Decimal(row["gld_history_jsonb"][-1]["value"]) == Decimal("1000")
 
 
 def test_orchestrator_idempotent_same_inputs(repo: Repository) -> None:

--- a/tests/integration/storage/test_gold_repo_etf_inventory.py
+++ b/tests/integration/storage/test_gold_repo_etf_inventory.py
@@ -62,6 +62,60 @@ def test_insert_and_fetch_etf_holdings_daily(repo: Repository) -> None:
     assert rows[0]["holdings_oz"] == Decimal("28047500.12")
 
 
+def test_insert_and_fetch_etf_flows_daily(repo: Repository) -> None:
+    as_of = datetime.now(UTC)
+    repo.insert_etf_flows_daily(
+        ticker="GLD",
+        obs_date=date(2026, 5, 15),
+        share_change=Decimal("-900000"),
+        premium_change_usd=Decimal("-375300000"),
+        close=Decimal("417.29"),
+        volume=Decimal("8801181"),
+        as_of=as_of,
+        source="UW",
+    )
+
+    rows = repo.fetch_etf_flows_daily("GLD", from_date=date(2026, 5, 1))
+
+    assert len(rows) == 1
+    assert rows[0]["obs_date"] == date(2026, 5, 15)
+    assert rows[0]["share_change"] == Decimal("-900000")
+    assert rows[0]["premium_change_usd"] == Decimal("-375300000")
+    assert rows[0]["source"] == "UW"
+
+
+def test_insert_and_fetch_wgc_etf_monthly(repo: Repository) -> None:
+    as_of = datetime.now(UTC)
+    repo.insert_wgc_etf_monthly(
+        ticker="GLD",
+        obs_date=date(2026, 3, 31),
+        fund_name="SPDR Gold Shares",
+        fund_type="ETF",
+        region="North America",
+        country="US",
+        gold_price_usd_oz=Decimal("2983.25"),
+        aggregate_ounces=Decimal("131428333.123"),
+        aggregate_holdings_tonnes=Decimal("4087.79194987"),
+        aggregate_value_usd=Decimal("606500000000"),
+        holdings_tonnes=Decimal("1046.9009356"),
+        demand_tonnes=Decimal("-54.13175268"),
+        flow_usd_mn=Decimal("-8426.7817"),
+        source_url="https://www.gold.org/download/file/20717/ETF_Flows_March_2026.xlsx",
+        source_label="ETF_Flows_March_2026.xlsx",
+        as_of=as_of,
+        source="WGC",
+    )
+
+    rows = repo.fetch_wgc_etf_monthly("GLD", from_date=date(2026, 1, 1))
+
+    assert len(rows) == 1
+    assert rows[0]["fund_name"] == "SPDR Gold Shares"
+    assert rows[0]["holdings_tonnes"] == Decimal("1046.9009356")
+    assert rows[0]["demand_tonnes"] == Decimal("-54.13175268")
+    assert rows[0]["flow_usd_mn"] == Decimal("-8426.7817")
+    assert rows[0]["source_url"].endswith("ETF_Flows_March_2026.xlsx")
+
+
 def test_insert_and_fetch_exchange_inventory_daily(repo: Repository) -> None:
     repo.insert_exchange_inventory_daily(
         exchange="COMEX",

--- a/tests/integration/worker/test_gold_daily_jobs.py
+++ b/tests/integration/worker/test_gold_daily_jobs.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import os
 import subprocess
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
 import psycopg
 import pytest
+from openpyxl import Workbook
 
 from uw_scan.config import Settings
+from uw_scan.models import EtfInOutflowRow
 from uw_scan.sources.comex import ComexProvider, ComexVaultRow
 from uw_scan.sources.etf_holdings import EtfHoldingRow
 from uw_scan.sources.fred import FredObservation
@@ -26,6 +29,84 @@ from uw_scan.worker.jobs.gold_jobs import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write_wgc_etf_workbook(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Holdings by month"
+    ws.append(
+        [
+            "ticker",
+            "All units in tonnes unless otherwise specified",
+            None,
+            None,
+            None,
+            "gld us equity",
+            "iau us equity",
+            "gldm us equity",
+            "phys us equity",
+        ]
+    )
+    ws.append(["Active", None, None, None, None, "Active", "Active", "Active", "Active"])
+    ws.append(
+        ["Fund Type", None, None, None, None, "ETF", "ETF", "ETF", "Closed-End Fund"]
+    )
+    ws.append(
+        [
+            "Region",
+            None,
+            None,
+            None,
+            None,
+            "North America",
+            "North America",
+            "North America",
+            "North America",
+        ]
+    )
+    ws.append(["Country", None, None, None, None, "US", "US", "US", "US"])
+    ws.append(
+        [
+            "Date",
+            "Gold, US$/oz",
+            "Ounces",
+            "Tonnes",
+            "Value (USD)",
+            "SPDR Gold Shares",
+            "iShares Gold Trust",
+            "SPDR Gold MiniShares Trust",
+            "Sprott Physical Gold Trust",
+        ]
+    )
+    ws.append(
+        [
+            date(2026, 3, 31),
+            Decimal("2983.25"),
+            None,
+            None,
+            None,
+            Decimal("1046.9009356"),
+            Decimal("475.96149609"),
+            Decimal("199.89033267"),
+            Decimal("114.72237255"),
+        ]
+    )
+    demand = wb.copy_worksheet(ws)
+    demand.title = "Demand by month"
+    demand["F7"] = Decimal("-54.13175268")
+    demand["G7"] = Decimal("-23.26570443")
+    demand["H7"] = Decimal("-2.17337528")
+    demand["I7"] = Decimal("-2.98578583")
+    flows = wb.copy_worksheet(ws)
+    flows.title = "Fund flows by month"
+    flows["F7"] = Decimal("-8426.7817")
+    flows["G7"] = Decimal("-3677.5729")
+    flows["H7"] = Decimal("-360.4612")
+    flows["I7"] = Decimal("-466.74545549")
+    buf = BytesIO()
+    wb.save(buf)
+    path.write_bytes(buf.getvalue())
 
 
 def _test_settings() -> Settings:
@@ -108,6 +189,101 @@ def test_gold_etf_holdings_ingest_writes_all_four_funds(
         repo = Repository(conn, schema=fresh_db.db_schema)
         for t in ("GLD", "IAU", "GLDM", "PHYS"):
             assert len(repo.fetch_etf_holdings_daily(t)) == 1
+
+
+def test_gold_etf_holdings_ingest_uses_deep_holdings_lookback(
+    fresh_db: Settings,
+) -> None:
+    with patch("uw_scan.worker.jobs.gold_jobs.EtfHoldingsProvider") as MockProvider:
+        instance = MockProvider.return_value.__enter__.return_value
+        instance.fetch_gld.return_value = []
+        instance.fetch_iau.return_value = []
+        instance.fetch_gldm.return_value = []
+        instance.fetch_phys.return_value = []
+
+        gold_etf_holdings_ingest_job(dsn=fresh_db.db_dsn())
+
+    assert instance.fetch_gld.call_args.kwargs["start"] <= date.today() - timedelta(
+        days=400
+    )
+
+
+def test_gold_etf_holdings_ingest_reads_wgc_monthly_workbook(
+    fresh_db: Settings,
+    tmp_path: Path,
+) -> None:
+    workbook_path = tmp_path / "ETF_Flows_March_2026.xlsx"
+    _write_wgc_etf_workbook(workbook_path)
+    with patch("uw_scan.worker.jobs.gold_jobs.EtfHoldingsProvider") as MockProvider:
+        instance = MockProvider.return_value.__enter__.return_value
+        instance.fetch_gld.return_value = []
+        instance.fetch_iau.return_value = []
+        instance.fetch_gldm.return_value = []
+        instance.fetch_phys.return_value = []
+
+        gold_etf_holdings_ingest_job(
+            dsn=fresh_db.db_dsn(),
+            wgc_workbook_path=str(workbook_path),
+        )
+
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        gld = repo.fetch_etf_holdings_daily("GLD")
+        iau = repo.fetch_etf_holdings_daily("IAU")
+        phys = repo.fetch_etf_holdings_daily("PHYS")
+        wgc_gld = repo.fetch_wgc_etf_monthly("GLD")
+
+    assert gld[0]["obs_date"] == date(2026, 3, 31)
+    assert gld[0]["source"] == "WGC"
+    assert gld[0]["holdings_oz"] == Decimal("1046.9009356") * Decimal("32150.7466")
+    assert iau[0]["source"] == "WGC"
+    assert phys[0]["source"] == "WGC"
+    assert wgc_gld[0]["holdings_tonnes"] == Decimal("1046.9009356")
+    assert wgc_gld[0]["source_url"].startswith("file:")
+
+
+def test_gold_etf_holdings_ingest_writes_uw_etf_flows(
+    fresh_db: Settings,
+) -> None:
+    sample = [
+        EtfInOutflowRow(
+            ticker="GLD",
+            date=date(2026, 5, 15),
+            change=Decimal("-900000"),
+            change_prem=Decimal("-375300000"),
+            close=Decimal("417.29"),
+            volume=Decimal("8801181"),
+        )
+    ]
+    with (
+        patch("uw_scan.worker.jobs.gold_jobs.EtfHoldingsProvider") as MockProvider,
+        patch("uw_scan.worker.jobs.gold_jobs.UwClient"),
+        patch(
+            "uw_scan.worker.jobs.gold_jobs.uw_sources.fetch_etf_in_outflow",
+            return_value=sample,
+        ) as mock_fetch,
+    ):
+        instance = MockProvider.return_value.__enter__.return_value
+        instance.fetch_gld.return_value = []
+        instance.fetch_iau.return_value = []
+        instance.fetch_gldm.return_value = []
+        instance.fetch_phys.return_value = []
+
+        gold_etf_holdings_ingest_job(
+            dsn=fresh_db.db_dsn(), uw_api_key="test-key", lookback_days=45
+        )
+
+    assert [call.kwargs["ticker"] for call in mock_fetch.call_args_list] == [
+        "GLD",
+        "IAU",
+        "GLDM",
+    ]
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        rows = repo.fetch_etf_flows_daily("GLD")
+    assert len(rows) == 1
+    assert rows[0]["share_change"] == Decimal("-900000")
+    assert rows[0]["premium_change_usd"] == Decimal("-375300000")
 
 
 def test_gold_comex_vault_ingest_writes_inventory(fresh_db: Settings) -> None:

--- a/tests/integration/worker/test_gold_posture_compute_job.py
+++ b/tests/integration/worker/test_gold_posture_compute_job.py
@@ -78,3 +78,50 @@ def test_gold_posture_compute_writes_row(fresh_db: Settings) -> None:
     assert row is not None
     assert row["obs_date"] == target
     assert row["gauge_state"] in {"operative", "partial", "suspended"}
+
+
+def test_gold_posture_compute_uses_uw_gld_flows(fresh_db: Settings) -> None:
+    target = date(2026, 5, 16)
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        base = target - timedelta(days=300)
+        for i in range(301):
+            d = base + timedelta(days=i)
+            repo.insert_macro_series_daily(
+                "GLD_CLOSE",
+                d,
+                Decimal(str(1800 + i * 0.5)),
+                datetime.combine(d, datetime.min.time(), tzinfo=UTC),
+                None,
+                "MASSIVE",
+                None,
+            )
+            repo.insert_macro_series_daily(
+                "DFII10",
+                d,
+                Decimal(str(2.0 - i * 0.005)),
+                datetime.combine(d, datetime.min.time(), tzinfo=UTC),
+                None,
+                "FRED",
+                None,
+            )
+        repo.insert_etf_flows_daily(
+            ticker="GLD",
+            obs_date=date(2026, 5, 15),
+            share_change=Decimal("-900000"),
+            premium_change_usd=Decimal("-375300000"),
+            close=Decimal("417.29"),
+            volume=Decimal("8801181"),
+            as_of=datetime.now(UTC),
+            source="UW",
+        )
+        conn.commit()
+
+    gold_posture_compute_job(dsn=fresh_db.db_dsn(), as_of=target)
+
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        row = repo.fetch_gold_posture_latest()
+    assert row is not None
+    assert row["gld_holdings_t"] is None
+    assert row["gld_30d_net_flow_t"].quantize(Decimal("0.001")) == Decimal("-2.606")

--- a/tests/unit/cards/test_structural_flow.py
+++ b/tests/unit/cards/test_structural_flow.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from uw_scan.cards.structural_flow import (
     CbReserveSnapshot,
+    EtfFlowSnapshot,
     compute_structural_posture,
 )
 
@@ -46,3 +47,27 @@ def test_structural_posture_emits_narrative():
     )
     assert posture.narrative_text
     assert posture.structural_state_label == "structural-mixed"
+
+
+def test_structural_posture_uses_gld_share_flows_when_holdings_absent():
+    posture = compute_structural_posture(
+        cb_rows=[],
+        etf_rows=[],
+        inventory_rows=[],
+        cot_rows=[],
+        fx_rows=[],
+        gold_series=[],
+        as_of=date(2026, 5, 16),
+        etf_flow_rows=[
+            EtfFlowSnapshot(
+                ticker="GLD",
+                obs_date=date(2026, 5, 15),
+                share_change=Decimal("-900000"),
+            )
+        ],
+    )
+
+    assert posture.gld_holdings_t is None
+    assert posture.gld_30d_net_flow_t is not None
+    assert posture.gld_30d_net_flow_t.quantize(Decimal("0.001")) == Decimal("-2.606")
+    assert "GLD 30d net flow: -2.6 tonnes." in posture.narrative_text

--- a/tests/unit/sources/test_etf_holdings.py
+++ b/tests/unit/sources/test_etf_holdings.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from io import BytesIO
 from unittest.mock import patch
 
 import httpx
+from openpyxl import Workbook
 
 from uw_scan.sources.etf_holdings import EtfHoldingRow, EtfHoldingsProvider
 
@@ -20,6 +22,65 @@ def _fake_csv_response(text: str) -> httpx.Response:
     return httpx.Response(
         200,
         text=text,
+        request=httpx.Request("GET", EtfHoldingsProvider.GLD_URL),
+    )
+
+
+def _fake_xlsx_response() -> httpx.Response:
+    wb = Workbook()
+    disclaimer = wb.active
+    disclaimer.title = "Disclaimer"
+    sheet = wb.create_sheet("US GLD Historical Archive")
+    sheet.append(
+        [
+            "Date",
+            "Closing Price",
+            "Ounces of Gold per Share",
+            "NAV/Share at 10:30am NYT",
+            "Indicative Price per Share at 4:15pm NYT",
+            "Mid point of bid/ask spread at 4:15pm NYT",
+            "Premium/Discount of GLD Mid Point vs Indicative Value of GLD at 4:15pm NYT",
+            "Daily Share Volume",
+            "Total Ounces of Gold in the Trust",
+            "Tonnes of Gold",
+            "Total Net Asset Value in the Trust",
+        ]
+    )
+    sheet.append(
+        [
+            "13-May-2026",
+            Decimal("235.10"),
+            Decimal("0.0931"),
+            Decimal("234.90"),
+            Decimal("235.00"),
+            Decimal("235.10"),
+            Decimal("0.04"),
+            1_500_000,
+            Decimal("28063540.00"),
+            Decimal("872.87"),
+            Decimal("75500000000"),
+        ]
+    )
+    sheet.append(
+        [
+            "14-May-2026",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+            "US Holiday",
+        ]
+    )
+    buf = BytesIO()
+    wb.save(buf)
+    return httpx.Response(
+        200,
+        content=buf.getvalue(),
         request=httpx.Request("GET", EtfHoldingsProvider.GLD_URL),
     )
 
@@ -46,6 +107,28 @@ def test_etf_provider_parses_gld_csv():
         nav_per_share=Decimal("234.50"),
         premium_pct=None,
     )
+
+
+def test_etf_provider_parses_spdr_historical_archive_xlsx():
+    with patch.object(EtfHoldingsProvider, "_get_with_telemetry") as mock_get:
+        mock_get.return_value = _fake_xlsx_response()
+        with EtfHoldingsProvider() as p:
+            rows = p.fetch_gld(start=date(2026, 5, 12))
+    assert mock_get.call_args.args[1] == {
+        "product": "gld",
+        "exchange": "NYSE",
+        "lang": "en",
+    }
+    assert rows == [
+        EtfHoldingRow(
+            ticker="GLD",
+            obs_date=date(2026, 5, 13),
+            holdings_oz=Decimal("28063540.00"),
+            shares_out=None,
+            nav_per_share=Decimal("234.90"),
+            premium_pct=Decimal("0.04"),
+        )
+    ]
 
 
 def test_etf_provider_iau_uses_blackrock_endpoint():

--- a/tests/unit/sources/test_wgc_etf.py
+++ b/tests/unit/sources/test_wgc_etf.py
@@ -1,0 +1,208 @@
+"""WGC ETF monthly workbook provider."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+
+import httpx
+from openpyxl import Workbook
+
+from uw_scan.sources.wgc_etf import TROY_OZ_PER_TONNE, WgcEtfProvider
+
+
+def _workbook_bytes() -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Holdings by month"
+    ws.append(
+        [
+            "ticker",
+            "All units in tonnes unless otherwise specified",
+            None,
+            None,
+            None,
+            "gld us equity",
+            "iau us equity",
+            "gldm us equity",
+            "phys us equity",
+        ]
+    )
+    ws.append(["Active", None, None, None, None, "Active", "Active", "Active", "Active"])
+    ws.append(["Fund Type", None, None, None, None, "ETF", "ETF", "ETF", "Closed-End Fund"])
+    ws.append(["Region", None, None, None, None, "North America", "North America", "North America", "North America"])
+    ws.append(["Country", None, None, None, None, "US", "US", "US", "US"])
+    ws.append(
+        [
+            "Date",
+            "Gold, US$/oz",
+            "Ounces",
+            "Tonnes",
+            "Value (USD)",
+            "SPDR Gold Shares",
+            "iShares Gold Trust",
+            "SPDR Gold MiniShares Trust",
+            "Sprott Physical Gold Trust",
+        ]
+    )
+    ws.append(
+        [
+            date(2026, 2, 28),
+            Decimal("2894.725"),
+            None,
+            None,
+            None,
+            Decimal("1100.0"),
+            Decimal("450.0"),
+            Decimal("190.0"),
+            Decimal("100.0"),
+        ]
+    )
+    ws.append(
+        [
+            date(2026, 3, 31),
+            Decimal("2983.25"),
+            None,
+            None,
+            None,
+            Decimal("1046.9009356"),
+            Decimal("475.96149609"),
+            Decimal("199.89033267"),
+            Decimal("114.72237255"),
+        ]
+    )
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _full_monthly_workbook_bytes() -> bytes:
+    wb = Workbook()
+    for idx, title in enumerate(
+        ["Holdings by month", "Demand by month", "Fund flows by month"]
+    ):
+        ws = wb.active if idx == 0 else wb.create_sheet(title)
+        ws.title = title
+        ws.append(
+            [
+                "ticker",
+                "All units in tonnes unless otherwise specified",
+                None,
+                None,
+                None,
+                "gld us equity",
+                "iau us equity",
+            ]
+        )
+        ws.append(["Active", None, None, None, None, "Active", "Active"])
+        ws.append(["Fund Type", None, None, None, None, "ETF", "ETF"])
+        ws.append(["Region", None, None, None, None, "North America", "North America"])
+        ws.append(["Country", None, None, None, None, "US", "US"])
+        ws.append(
+            [
+                "Date",
+                "Gold, US$/oz",
+                "Ounces",
+                "Tonnes",
+                "Value (USD)",
+                "SPDR Gold Shares",
+                "iShares Gold Trust",
+            ]
+        )
+    wb["Holdings by month"].append(
+        [
+            date(2026, 3, 31),
+            Decimal("2983.25"),
+            Decimal("131428333.123"),
+            Decimal("4087.79194987"),
+            Decimal("606500000000"),
+            Decimal("1046.9009356"),
+            Decimal("475.96149609"),
+        ]
+    )
+    wb["Demand by month"].append(
+        [
+            date(2026, 3, 31),
+            Decimal("2983.25"),
+            Decimal("131428333.123"),
+            Decimal("4087.79194987"),
+            Decimal("606500000000"),
+            Decimal("-54.13175268"),
+            Decimal("-23.26570443"),
+        ]
+    )
+    wb["Fund flows by month"].append(
+        [
+            date(2026, 3, 31),
+            Decimal("2983.25"),
+            Decimal("131428333.123"),
+            Decimal("4087.79194987"),
+            Decimal("606500000000"),
+            Decimal("-8426.7817"),
+            Decimal("-3677.5729"),
+        ]
+    )
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def test_wgc_etf_provider_parses_monthly_holdings_for_gold_funds() -> None:
+    rows = WgcEtfProvider().parse_holdings(
+        _workbook_bytes(), start=date(2026, 3, 1)
+    )
+
+    assert [row.ticker for row in rows] == ["GLD", "IAU", "GLDM", "PHYS"]
+    assert rows[0].obs_date == date(2026, 3, 31)
+    assert rows[0].holdings_oz == Decimal("1046.9009356") * TROY_OZ_PER_TONNE
+    assert rows[1].holdings_oz == Decimal("475.96149609") * TROY_OZ_PER_TONNE
+
+
+def test_wgc_etf_provider_discovers_xlsx_downloads() -> None:
+    provider = WgcEtfProvider()
+    provider._client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                text="""
+                <a class="download xlsx private"
+                   href="/download/file/20717/ETF_Flows_March_2026.xlsx">Data</a>
+                <a href="/download/file/20718/Gold_ETF_Commentary_March_2026.pdf">PDF</a>
+                """,
+                request=request,
+            )
+        )
+    )
+    try:
+        downloads = provider.fetch_downloads()
+    finally:
+        provider.close()
+
+    assert len(downloads) == 1
+    assert downloads[0].url == (
+        "https://www.gold.org/download/file/20717/ETF_Flows_March_2026.xlsx"
+    )
+
+
+def test_wgc_etf_provider_parses_monthly_holdings_demand_and_flows() -> None:
+    rows = WgcEtfProvider().parse_monthly_rows(
+        _full_monthly_workbook_bytes(),
+        source_url="https://www.gold.org/download/file/20717/ETF_Flows_March_2026.xlsx",
+        source_label="ETF_Flows_March_2026.xlsx",
+        start=date(2026, 3, 1),
+    )
+
+    assert len(rows) == 2
+    assert rows[0].ticker == "GLD"
+    assert rows[0].obs_date == date(2026, 3, 31)
+    assert rows[0].fund_name == "SPDR Gold Shares"
+    assert rows[0].region == "North America"
+    assert rows[0].country == "US"
+    assert rows[0].gold_price_usd_oz == Decimal("2983.25")
+    assert rows[0].aggregate_holdings_tonnes == Decimal("4087.79194987")
+    assert rows[0].aggregate_value_usd == Decimal("606500000000")
+    assert rows[0].holdings_tonnes == Decimal("1046.9009356")
+    assert rows[0].demand_tonnes == Decimal("-54.13175268")
+    assert rows[0].flow_usd_mn == Decimal("-8426.7817")
+    assert rows[0].source_url.endswith("ETF_Flows_March_2026.xlsx")

--- a/tests/unit/test_uw_sources_bulk_screener_ticker.py
+++ b/tests/unit/test_uw_sources_bulk_screener_ticker.py
@@ -73,3 +73,45 @@ def test_fetch_etf_info_returns_aum():
     assert isinstance(row, EtfInfo)
     assert row.aum == Decimal("428887833900")
     assert mock_fetch.call_args.args[3] == uw_sources.EndpointSlug.ETF_INFO
+
+
+def test_fetch_etf_in_outflow_returns_recent_flow_rows():
+    client = MagicMock()
+    repo = MagicMock()
+    with patch.object(
+        uw_sources,
+        "_fetch_json",
+        return_value={
+            "data": [
+                {
+                    "date": "2026-05-15",
+                    "change": -900000,
+                    "change_prem": "-375300000",
+                    "close": "417.29",
+                    "volume": 8801181,
+                    "expiration_cycle": "monthly",
+                    "is_fomc": False,
+                }
+            ]
+        },
+    ) as mock_fetch:
+        rows = uw_sources.fetch_etf_in_outflow(
+            client,
+            repo,
+            run_id=42,
+            ticker="GLD",
+            start_date="2026-04-02",
+            end_date="2026-05-17",
+        )
+
+    assert len(rows) == 1
+    assert rows[0].ticker == "GLD"
+    assert rows[0].date.isoformat() == "2026-05-15"
+    assert rows[0].change == Decimal("-900000")
+    assert rows[0].change_prem == Decimal("-375300000")
+    assert rows[0].close == Decimal("417.29")
+    assert mock_fetch.call_args.args[3] == uw_sources.EndpointSlug.ETF_IN_OUTFLOW
+    assert mock_fetch.call_args.kwargs["params"] == {
+        "start_date": "2026-04-02",
+        "end_date": "2026-05-17",
+    }

--- a/tests/unit/worker/test_gold_warmup.py
+++ b/tests/unit/worker/test_gold_warmup.py
@@ -1,0 +1,44 @@
+"""Gold warmup CLI wiring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pydantic import SecretStr
+
+from uw_scan.worker import gold_warmup
+
+
+def test_gold_warmup_uses_full_history_etf_holdings_lookback(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    settings = SimpleNamespace(
+        api_key=SecretStr("test-uw-key"),
+        db_name="option_wizard_test",
+        massive_api_key=None,
+        massive_base_url="https://api.massive.com",
+        wgc_goldhub_cookie=None,
+        wgc_etf_flows_workbook_path="/tmp/wgc-workbooks",
+        base_url="https://api.unusualwhales.com",
+        request_timeout_seconds=30.0,
+        db_dsn=lambda: "dbname=option_wizard_test",
+    )
+
+    monkeypatch.setattr(gold_warmup.Settings, "from_env", lambda: settings)
+    monkeypatch.setattr(gold_warmup, "gold_fred_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_gpr_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_spot_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_comex_vault_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_cftc_cot_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_lbma_vault_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_wgc_cb_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_uw_options_ingest_job", lambda **_kwargs: None)
+    monkeypatch.setattr(gold_warmup, "gold_posture_compute_job", lambda **_kwargs: None)
+
+    def _capture_etf_holdings(**kwargs) -> None:
+        calls.update(kwargs)
+
+    monkeypatch.setattr(gold_warmup, "gold_etf_holdings_ingest_job", _capture_etf_holdings)
+
+    assert gold_warmup.main() == 0
+    assert calls["holdings_lookback_days"] >= 365 * 25
+

--- a/web/app/gold/page.tsx
+++ b/web/app/gold/page.tsx
@@ -7,7 +7,7 @@ async function fetchGoldState(): Promise<State | null> {
   const base = process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:8400";
   try {
     const res = await fetch(`${base}/api/gold/state`, {
-      next: { revalidate: 60 },
+      cache: "no-store",
     });
     if (!res.ok) return null;
     return (await res.json()) as State;

--- a/web/components/gold/lens1/CbReservesCard.tsx
+++ b/web/components/gold/lens1/CbReservesCard.tsx
@@ -18,12 +18,13 @@ export function CbReservesCard({ structural }: { structural: S }) {
   return (
     <Tile
       label="CB RESERVES · 12M ACCUM"
-      value={`${fmt(structural.cb_strategic_12m_sum_t)} T`}
+      value={`${fmt(structural.cb_strategic_12m_sum_t)} tonnes`}
       sub={
         <>
-          STRATEGIC {fmt(structural.cb_strategic_12m_sum_t)} · TACTICAL{" "}
-          {fmt(structural.cb_tactical_12m_sum_t)} · DIVERSIFIER{" "}
+          STRATEGIC {fmt(structural.cb_strategic_12m_sum_t)} tonnes · TACTICAL{" "}
+          {fmt(structural.cb_tactical_12m_sum_t)} tonnes · DIVERSIFIER{" "}
           {fmt(structural.cb_diversifier_12m_sum_t)}
+          {" tonnes"}
         </>
       }
     />

--- a/web/components/gold/lens1/EtfFlowCard.tsx
+++ b/web/components/gold/lens1/EtfFlowCard.tsx
@@ -16,6 +16,9 @@ function fmt(v: string | number | null | undefined, digits = 1): string {
 
 export function EtfFlowCard({ structural }: { structural: S }) {
   const flow = Number(structural.gld_30d_net_flow_t);
+  const holdings = Number(structural.gld_holdings_t);
+  const hasReportedHoldings =
+    structural.gld_holdings_t != null && Number.isFinite(holdings);
   const tone =
     !Number.isFinite(flow) || flow === 0
       ? "default"
@@ -23,12 +26,15 @@ export function EtfFlowCard({ structural }: { structural: S }) {
         ? "positive"
         : "negative";
   const sign = Number.isFinite(flow) && flow > 0 ? "+" : "";
+  const sub = hasReportedHoldings
+    ? `GLD ${fmt(structural.gld_holdings_t)} tonnes held · reported holdings`
+    : "holdings unavailable · flow converted from UW GLD share flow";
   return (
     <Tile
       label="GLD FLOW · 30D NET"
       tone={tone}
-      value={`${sign}${fmt(structural.gld_30d_net_flow_t)} T`}
-      sub={`GLD ${fmt(structural.gld_holdings_t)} T held`}
+      value={`${sign}${fmt(structural.gld_30d_net_flow_t)} tonnes`}
+      sub={sub}
     />
   );
 }

--- a/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
+++ b/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
@@ -33,10 +33,10 @@ function fmtPriceTick(v: number): string {
   return v.toFixed(2);
 }
 
-function fmtOzTick(v: number): string {
-  // GLD holdings_oz is a large number (oz). Show in millions with one decimal.
-  const m = v / 1_000_000;
-  return `${m.toFixed(1)}M`;
+function fmtTonnesTick(v: number): string {
+  return v.toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  });
 }
 
 type Hp = components["schemas"]["GoldHistoryPoint"];
@@ -207,7 +207,7 @@ export function GoldHoldingsVsPriceChart({
                 textAnchor="start"
                 fill="var(--warning, #f5a623)"
               >
-                {fmtOzTick(v)}
+                {fmtTonnesTick(v)}
               </text>
             </g>
           ))}
@@ -216,7 +216,7 @@ export function GoldHoldingsVsPriceChart({
         </text>
         {gldYScale && (
           <text x={padding.left + 60} y={10} fill="var(--warning, #f5a623)">
-            GLD (oz held)
+            GLD tonnes held
           </text>
         )}
       </g>

--- a/web/tests/unit/goldCompassLayout.test.tsx
+++ b/web/tests/unit/goldCompassLayout.test.tsx
@@ -117,6 +117,35 @@ describe("GoldCompassLayout", () => {
     expect(screen.getByText(/GOLD COMPASS/)).toBeTruthy();
   });
 
+  it("labels GLD ETF flow units and source clearly", () => {
+    render(<GoldCompassLayout state={FIXTURE} />);
+    expect(screen.getByText("-12.4 tonnes")).toBeTruthy();
+    expect(screen.getByText(/872.5 tonnes held/)).toBeTruthy();
+    expect(screen.getByText(/reported holdings/)).toBeTruthy();
+  });
+
+  it("spells out central-bank reserve units", () => {
+    render(<GoldCompassLayout state={FIXTURE} />);
+    expect(screen.getAllByText(/210 tonnes/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/TACTICAL 12 tonnes/)).toBeTruthy();
+    expect(screen.getByText(/DIVERSIFIER 34 tonnes/)).toBeTruthy();
+  });
+
+  it("labels converted UW flow clearly when holdings are unavailable", () => {
+    const state: State = {
+      ...FIXTURE,
+      structural: {
+        ...FIXTURE.structural,
+        gld_holdings_t: null,
+        gld_30d_net_flow_t: "-11.0038",
+      },
+    };
+    render(<GoldCompassLayout state={state} />);
+    expect(screen.getByText("-11.0 tonnes")).toBeTruthy();
+    expect(screen.getByText(/converted from UW GLD share flow/)).toBeTruthy();
+    expect(screen.getByText(/holdings unavailable/)).toBeTruthy();
+  });
+
   it("uses posture language only (no buy/sell/long/short)", () => {
     const { container } = render(<GoldCompassLayout state={FIXTURE} />);
     const text = (container.textContent ?? "").toLowerCase();


### PR DESCRIPTION
## Summary
- Add UW ETF in/outflow normalization plus SPDR GLD archive ingestion and WGC Goldhub workbook parsing.
- Persist WGC monthly ETF holdings/demand/flow rows and bridge core ETF holdings into the gold holdings store.
- Document the WGC corpus and first mining pass, including GLD concentration, regional holdings, breadth, and post-2022 flow sensitivity.

## Notes
- WGC workbook downloads require an authenticated `WGC_GOLDHUB_COOKIE` or a local `WGC_ETF_FLOWS_WORKBOOK_PATH`.
- Local downloaded WGC workbooks remain ignored under `output/`.
- Warmup now requests a 30-year ETF holdings window so WGC full-history workbook loads are preserved on fresh DBs.
- This PR keeps posture copy informational and does not add sizing language.

## Test Plan
- [x] `uv run pytest tests/unit/worker/test_gold_warmup.py -q`
- [x] `uv run pytest tests/unit/sources/test_wgc_etf.py tests/unit/sources/test_etf_holdings.py tests/unit/test_uw_sources_bulk_screener_ticker.py tests/unit/cards/test_structural_flow.py -q`
- [x] `uv run ruff check src/uw_scan/sources/wgc_etf.py src/uw_scan/sources/etf_holdings.py src/uw_scan/storage/gold_etf.py src/uw_scan/worker/jobs/gold_jobs.py src/uw_scan/reports/gold_posture.py tests/unit/sources/test_wgc_etf.py tests/integration/storage/test_gold_repo_etf_inventory.py tests/integration/worker/test_gold_daily_jobs.py`
- [x] `uv run pytest tests/integration/storage/test_gold_repo_etf_inventory.py tests/integration/worker/test_gold_daily_jobs.py tests/integration/reports/test_gold_posture_orchestrator.py tests/integration/worker/test_gold_posture_compute_job.py -q`
- [x] `git diff --check`