### PR TITLE
fix(scanner): anchor relative-time labels to prevent SSR hydration mismatch

### DIFF
--- a/web/app/scanner/page.tsx
+++ b/web/app/scanner/page.tsx
@@ -66,6 +66,10 @@ export default async function ScannerPage({
   ]);
 
   const grouped = groupByBias(data.candidates);
+  // Single render-time anchor so server-render and client-hydrate produce
+  // identical relative-time labels (avoids hydration mismatch — minute-rounded
+  // labels can differ across the few ms between SSR and hydration).
+  const nowMs = Date.now();
 
   return (
     <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
@@ -135,7 +139,7 @@ export default async function ScannerPage({
             }}
           >
             {discover.candidates.map((c) => (
-              <DiscoveredCard key={c.ticker} candidate={c} />
+              <DiscoveredCard key={c.ticker} candidate={c} nowMs={nowMs} />
             ))}
           </div>
         </section>
@@ -184,7 +188,7 @@ export default async function ScannerPage({
                 }}
               >
                 {section.map((c) => (
-                  <CandidateCard key={c.ticker} candidate={c} />
+                  <CandidateCard key={c.ticker} candidate={c} nowMs={nowMs} />
                 ))}
               </div>
             </section>

--- a/web/components/scanner/CandidateCard.tsx
+++ b/web/components/scanner/CandidateCard.tsx
@@ -65,10 +65,10 @@ function setupTooltip(setup: Setup, reason: string | null | undefined): string {
   }
 }
 
-function freshnessLabel(scannedAt: string): string {
+function freshnessLabel(scannedAt: string, nowMs: number): string {
   const minutes = Math.max(
     0,
-    Math.round((Date.now() - new Date(scannedAt).getTime()) / 60_000),
+    Math.round((nowMs - new Date(scannedAt).getTime()) / 60_000),
   );
   if (minutes < 1) return "just now";
   if (minutes < 60) return `${minutes}m`;
@@ -138,10 +138,19 @@ function SetupPill({
   );
 }
 
-export function CandidateCard({ candidate }: { candidate: Candidate }) {
+export function CandidateCard({
+  candidate,
+  nowMs,
+}: {
+  candidate: Candidate;
+  // Optional only so jsdom unit tests can omit it. The /scanner RSC always
+  // passes this so SSR + client hydration agree on the relative-time label.
+  nowMs?: number;
+}) {
+  const anchor = nowMs ?? Date.now();
   const fresh = bucketFreshness(
     candidate.scanned_at,
-    new Date(),
+    new Date(anchor),
     SCANNER_FRESHNESS_THRESHOLDS,
   );
   const tickerColor = BIAS_COLOR[candidate.bias];
@@ -259,7 +268,7 @@ export function CandidateCard({ candidate }: { candidate: Candidate }) {
           color: "var(--text-muted)",
         }}
       >
-        <span>scanned {freshnessLabel(candidate.scanned_at)} ago</span>
+        <span>scanned {freshnessLabel(candidate.scanned_at, anchor)} ago</span>
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <RescanButton ticker={candidate.ticker} initialJob={null} />
           <Link

--- a/web/components/scanner/DiscoveredCard.tsx
+++ b/web/components/scanner/DiscoveredCard.tsx
@@ -57,11 +57,11 @@ function BiasBadge({
   );
 }
 
-function freshnessLabel(iso: string | null | undefined): string {
+function freshnessLabel(iso: string | null | undefined, nowMs: number): string {
   if (!iso) return "unknown";
   const minutes = Math.max(
     0,
-    Math.round((Date.now() - new Date(iso).getTime()) / 60_000),
+    Math.round((nowMs - new Date(iso).getTime()) / 60_000),
   );
   if (minutes < 1) return "just now";
   if (minutes < 60) return `${minutes}m`;
@@ -69,7 +69,16 @@ function freshnessLabel(iso: string | null | undefined): string {
   return `${hours}h`;
 }
 
-export function DiscoveredCard({ candidate }: { candidate: Discovered }) {
+export function DiscoveredCard({
+  candidate,
+  nowMs,
+}: {
+  candidate: Discovered;
+  // Optional only so jsdom unit tests can omit it. The /scanner RSC always
+  // passes this so SSR + client hydration agree on the relative-time label.
+  nowMs?: number;
+}) {
+  const anchor = nowMs ?? Date.now();
   const router = useRouter();
   const [add, setAdd] = useState<AddState>("idle");
   const tickerColor = BIAS_COLOR[candidate.bias];
@@ -207,7 +216,7 @@ export function DiscoveredCard({ candidate }: { candidate: Discovered }) {
       >
         <span>
           {candidate.alert_count} alerts · last{" "}
-          {freshnessLabel(candidate.latest_alert_at)} ago
+          {freshnessLabel(candidate.latest_alert_at, anchor)} ago
         </span>
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <button


### PR DESCRIPTION
## Summary
- CandidateCard / DiscoveredCard computed \"scanned Xh ago\" with \`Date.now()\` at render time. The \`/scanner\` RSC SSRs these client components, so server-render and client-hydrate produced different minute-rounded values near hour boundaries (reported: 35h server vs 36h client on an RKLB card).
- Fix passes a single \`nowMs\` anchor from the RSC down to every card, so SSR and hydration share one timestamp. The prop is optional only so the existing jsdom unit tests can omit it (no SSR there); the page always passes it explicitly in production.

## Test plan
- [x] \`npx vitest run tests/unit/scannerPage.test.tsx tests/unit/discoveredCard.test.tsx\` — 26/26 pass
- [x] \`npx tsc --noEmit\` — clean
- [ ] Reload \`/scanner\` in browser after merge — hydration warning gone