### PR TITLE
Fix gold data quality gaps

### DIFF
--- a/docs/handover/2026-05-17-gold-v2-codex-handover.md
+++ b/docs/handover/2026-05-17-gold-v2-codex-handover.md
@@ -23,7 +23,7 @@ A **shipped** Phase A1 of the GOLD COMPASS five-tier cockpit:
 
 **It also documents what's broken and why.** That's the most important thing you're inheriting. Five of the eight anonymous-CSV sources moved or paywalled between the catalog (April 2026) and the implementation (May 2026). Each failure mode has a concrete re-wire path. Read them before writing any code.
 
-**2026-05-18 update:** read `docs/research/gold-sdf-framework/14-data-quality-remediation.md` before executing this handoff literally. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, current + 400-day COT ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have since landed. CB reserves and COMEX remain unresolved.
+**2026-05-18 update:** read `docs/research/gold-sdf-framework/14-data-quality-remediation.md` before executing this handoff literally. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, current + 400-day COT ingestion, WGC/IFS CB reserve workbook ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have since landed. COMEX remains unresolved.
 
 ### Required reading order
 
@@ -79,17 +79,13 @@ Full context lives in `docs/research/gold-sdf-framework/11-deferred-sources-phas
 
 ### D1 — WGC CB reserves (Central Bank holdings)
 
-**Why second:** The largest physical-flow contributor to Lens 1, dominant in the post-2022 regime-break thesis. Phase A1 fetcher (`src/uw_scan/sources/wgc_cb.py`) is intact but the anonymous Goldhub CSV endpoint moved behind login on 2026-05-17 (the job is a documented no-op).
+**Why second:** The largest physical-flow contributor to Lens 1, dominant in the post-2022 regime-break thesis. The anonymous Goldhub CSV endpoint moved behind login on 2026-05-17.
 
-**Path (recommended):** Direct IMF International Financial Statistics. API at `https://data.imf.org/ifs` (instant-issue key). Drops WGC's editorial bucket classification (`strategic_accumulator` / `tactical` / `diversifier`) — re-derive buckets in a static mapping or treat them as a separate enrichment step.
+**2026-05-18 status:** resolved via WGC Goldhub authenticated workbook parsing. `src/uw_scan/sources/wgc_cb.py` now parses `Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx`; `gold_wgc_cb_ingest_job` accepts `WGC_CB_RESERVES_WORKBOOK_PATH` or `WGC_GOLDHUB_COOKIE`; local `cb_gold_reserves_monthly` has 2,827 rows for 27 mapped bucket countries.
 
-**Concrete tasks:**
-1. Add a new `src/uw_scan/sources/imf_ifs.py` provider (don't reuse `wgc_cb.py` — different schema). Mirror the `WgcCbProvider` shape: returns a list of `CbReserveRow`-compatible rows.
-2. Add a `gold_imf_cb_ingest_job` to `src/uw_scan/worker/jobs/gold_jobs.py` (replace the `gold_wgc_cb_ingest_job` no-op or leave both for parallel comparison during the transition).
-3. Add a static bucket-classification mapping somewhere appropriate (consider `src/uw_scan/cards/cb_buckets.py`) — top ~30 countries cover 95% of reported reserves.
-4. Orchestrator already reads `cb_strategic_12m_sum_t` / `cb_tactical_12m_sum_t` / `cb_diversifier_12m_sum_t` from `structural` and (new in 044) `cb_52w_pct`. Once D1 returns rows, those tiles populate.
+**Remaining optional task:** evaluate direct IMF IFS later if Goldhub auth becomes operationally fragile.
 
-**Success criteria:** Lens 1 `cb_strategic_12m_sum_t` non-null on `/api/gold/state`. CB reserves chart populates. Russia post-2022 estimation + China under-reporting caveats surfaced as tooltips per `09-data-sources-catalog.md`.
+**Success criteria:** Lens 1 `cb_strategic_12m_sum_t` is non-null on `/api/gold/state`. Russia post-2022 estimation + China under-reporting caveats remain documented per `09-data-sources-catalog.md`.
 
 ---
 

--- a/docs/handover/2026-05-17-gold-v2-codex-handover.md
+++ b/docs/handover/2026-05-17-gold-v2-codex-handover.md
@@ -23,13 +23,16 @@ A **shipped** Phase A1 of the GOLD COMPASS five-tier cockpit:
 
 **It also documents what's broken and why.** That's the most important thing you're inheriting. Five of the eight anonymous-CSV sources moved or paywalled between the catalog (April 2026) and the implementation (May 2026). Each failure mode has a concrete re-wire path. Read them before writing any code.
 
+**2026-05-18 update:** read `docs/research/gold-sdf-framework/14-data-quality-remediation.md` before executing this handoff literally. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, current + 400-day COT ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have since landed. CB reserves and COMEX remain unresolved.
+
 ### Required reading order
 
 1. `CLAUDE.md` and `AGENTS.md` at the repo root — standing rules. The most important ones are restated below but the source of truth lives there.
 2. `docs/research/gold-sdf-framework/README.md` — the design brief.
 3. `docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md` — **start here for re-wire work**. Five sources, each with a concrete option list sorted by signal-to-effort.
-4. `docs/research/gold-sdf-framework/10-open-research-questions.md` — open questions Q1–Q24 from the design pass. Several are blocking v2 model work (post-2022 regime statistic replication; embargo calibration; deflated-Sharpe gates).
-5. `src/uw_scan/CLAUDE.md`, `src/uw_scan/storage/CLAUDE.md`, `src/uw_scan/worker/CLAUDE.md`, `src/uw_scan/api/CLAUDE.md`, `src/uw_scan/reports/CLAUDE.md`, `src/uw_scan/cards/CLAUDE.md`, `src/uw_scan/sources/CLAUDE.md` — layer-specific rules.
+4. `docs/research/gold-sdf-framework/14-data-quality-remediation.md` — current live data-quality gaps and closure sequence.
+5. `docs/research/gold-sdf-framework/10-open-research-questions.md` — open questions Q1–Q29 from the design pass. Several are blocking v2 model work (post-2022 regime statistic replication; embargo calibration; deflated-Sharpe gates).
+6. `src/uw_scan/CLAUDE.md`, `src/uw_scan/storage/CLAUDE.md`, `src/uw_scan/worker/CLAUDE.md`, `src/uw_scan/api/CLAUDE.md`, `src/uw_scan/reports/CLAUDE.md`, `src/uw_scan/cards/CLAUDE.md`, `src/uw_scan/sources/CLAUDE.md` — layer-specific rules.
 
 ---
 
@@ -58,15 +61,17 @@ Full context lives in `docs/research/gold-sdf-framework/11-deferred-sources-phas
 
 ### D4 — CFTC COT (Commitments of Traders)
 
-**Why first:** Highest signal-to-effort. Codex's own 2026-05-16 review (`docs/reviews/2026-05-16-gold-research-codex-review.md` finding #8) called this out as the largest single factor class missing from the design. The current fetcher in `src/uw_scan/sources/cftc_cot.py` is broken — its placeholder URL points at `FinFutWk.txt` (financial futures, not commodities). Lens 1 posture currently degrades because of this.
+**Status:** Closed in the 2026-05-18 remediation. The provider now uses the CFTC current disaggregated futures-only file for current fallback and the official Socrata dataset for 400-day history; the local DB has 57 distinct observations and the latest posture row writes `cot_mm_4w_change_sigma`.
+
+**Why it was first:** Highest signal-to-effort. Codex's own 2026-05-16 review (`docs/reviews/2026-05-16-gold-research-codex-review.md` finding #8) called this out as the largest single factor class missing from the design.
 
 **Path:** Switch to the official Socrata API at `publicreporting.cftc.gov`. Commodity code for gold is **088691** (verify against the Socrata schema). The JSON shape maps directly to the existing `CotRow` dataclass.
 
-**Concrete tasks:**
-1. Rewrite `src/uw_scan/sources/cftc_cot.py` to fetch from Socrata JSON instead of scraping `.txt`. Keep the `CotRow` shape and `CftcCotProvider` API.
-2. Update `tests/unit/sources/test_cftc_cot.py` with a Socrata-shaped fixture (existing test uses a `.txt` mock).
-3. Verify by running `gold_cftc_cot_ingest_job` against the live API and checking `repo.fetch_cot_gold_weekly()` returns rows for gold (not rates / equities).
-4. Orchestrator already maps `cot_mm_net_pct` and (newly) `cot_mm_4w_change_sigma` — once D4 returns rows, those tiles populate without orchestrator changes.
+**Closed tasks:**
+1. `src/uw_scan/sources/cftc_cot.py` fetches Socrata JSON when `start=` is supplied and keeps the existing `CotRow` shape.
+2. `tests/unit/sources/test_cftc_cot.py` covers Socrata history, current flat-file parsing, and non-gold filtering.
+3. Live `gold_cftc_cot_ingest_job` populated COT rows for gold, not rates/equities.
+4. Orchestrator now computes and persists `cot_mm_4w_change_sigma`.
 
 **Success criteria:** Lens 1 `cot_mm_net_pct` is non-null on `/api/gold/state`; integration test passes against the fresh DB; `gold_posture_daily.cot_mm_4w_change_sigma` is written.
 
@@ -88,19 +93,19 @@ Full context lives in `docs/research/gold-sdf-framework/11-deferred-sources-phas
 
 ---
 
-### D2a — GLD ETF holdings only (defer IAU/GLDM/PHYS to D6)
+### D2 — ETF holdings and WGC canonicalization
 
-**Why third:** Half of the Lens 1 dual-axis chart. GLD alone is ~80% of the signal. The dashboard already plots `gold_history` (price line) but `gld_history` is empty.
+**Why third:** Half of the Lens 1 dual-axis chart plus the new WGC global breadth corpus. GLD daily holdings now populate, but WGC monthly rows are revision-preserving and need a canonical consumer view before they become production factors.
 
-**Path:** SPDR HTML scrape for daily, SEC N-PORT XML for monthly fallback. SPDR moved the JSON to HTML — the fix is per-issuer scraping rather than swapping providers. Existing `src/uw_scan/sources/etf_holdings.py` has the right shape (`EtfHoldingRow`) but every fetch method (`fetch_gld`, `fetch_iau`, `fetch_gldm`, `fetch_phys`) returns 301/404.
+**Path:** Keep SPDR historical archive as canonical GLD daily holdings. Add a canonical WGC latest-revision query/view for monthly global/regional ETF breadth. Keep SEC N-PORT as the open-data fallback for non-GLD funds if Goldhub auth/export becomes brittle.
 
 **Concrete tasks:**
-1. Find SPDR's current GLD holdings page. As of 2026-05-17 the JSON moved; the HTML page at `…/usa/gld/` likely has a daily table. Use `httpx` + `BeautifulSoup` (already a dependency).
-2. Add SEC N-PORT as a fallback — every '40-Act ETF files holdings monthly. EDGAR full-text search for `0001354670` (SPDR Gold Shares CIK) → N-PORT filings → parse XML for `holdings_oz`.
-3. Update `fetch_gld` only; leave IAU/GLDM/PHYS marked as deferred for D6.
-4. Test by running `gold_etf_holdings_ingest_job` and confirming `repo.fetch_etf_holdings_daily("GLD")` returns rows.
+1. Add a canonical WGC query/view: latest revision per `(ticker, obs_date)`.
+2. Build global/regional ETF breadth metrics only from that canonical surface.
+3. Keep SPDR GLD daily holdings as the daily high-frequency proxy.
+4. Add SEC N-PORT fallback for non-GLD funds only if authenticated WGC operations fail.
 
-**Success criteria:** Lens 1 `gld_holdings_t` non-null; dual-axis chart shows both lines.
+**Success criteria:** Lens 1 `gld_holdings_t` remains non-null; WGC monthly consumers use canonical month counts rather than raw revision counts; global/regional breadth fields can be reproduced deterministically.
 
 ---
 
@@ -234,8 +239,8 @@ bash scripts/dev.sh                     # web + api + workers
 
 By the time GOLD v2 ships, the following should be true:
 
-1. **All 5 Lens 1 fields populated** (CB reserves, ETF holdings, COMEX, COT, UW skew sigma-calibrated).
-2. **Correlation gauge state = `operative`** (currently `partial`) — requires at least D4 + D1 to land.
+1. **All required Lens 1 fields populated or explicitly waived** (CB reserves, ETF holdings, COT, UW skew semantics; COMEX either populated or formally dropped from the required gate after calibration).
+2. **Correlation gauge state and structural chip are honest**: gauge state reflects the measured GLD/DFII10 regime; structural chip no longer degrades solely because optional COMEX is absent. D4 + D1 are required for the structural anchor, not necessarily for the gauge math.
 3. **Q20 replicated** with a published numeric result + dated reference range. Replaces the "directional claim from RBC" placeholder.
 4. **Backtest validation basket** (Q14) has concrete thresholds documented; first backtest run lands with all metrics computed.
 5. **Repository split PR-2/PR-3 merged** — `repository.py` back under 1000 lines; new gold methods live in `storage/gold_*_repository.py` or `_GoldMixin`s.
@@ -278,7 +283,7 @@ By the time GOLD v2 ships, the following should be true:
 
 1. Read everything in the "Required reading order" above (60–90 min).
 2. Run `bash scripts/migrate.sh` then `uv run python -m uw_scan.worker.gold_warmup` against your local DB — confirm `/api/gold/state` returns populated data exactly as A1 left it.
-3. Pick D4 (CFTC COT via Socrata). Verify the API shape, write the rewrite, add a test fixture, run the integration test, raise a draft PR.
-4. After D4 lands, do Q20 (post-2022 regime statistic replication) as a notebook + research note. That's the smallest research item with the highest leverage on the rest of the work.
+3. Pick D1 (central-bank reserves via IMF IFS) or COMEX depending on signal priority; D4 CFTC COT is already closed.
+4. After D1/COMEX source decisions, do Q20 (post-2022 regime statistic replication) as a notebook + research note. That's the smallest research item with the highest leverage on the rest of the work.
 
 Good luck. The infrastructure is solid — the failures are external, documented, and have concrete fixes.

--- a/docs/research/gold-sdf-framework/09-data-sources-catalog.md
+++ b/docs/research/gold-sdf-framework/09-data-sources-catalog.md
@@ -28,21 +28,23 @@ Consolidated reference for every data series the three-layer architecture relies
 
 | Field | Value |
 |---|---|
-| **Series** | Monthly per-country gold reserves (tonnes) |
-| **Source** | IMF IFS direct preferred; WGC "Monthly central bank statistics" historical design path now behind Goldhub login |
-| **URL** | https://www.gold.org/goldhub/data/monthly-central-bank-statistics |
-| **Format** | IMF API once re-wired; old WGC anonymous CSV path returns 404 |
+| **Series** | Quarterly per-country gold reserves (tonnes), used to derive 12m bucket net changes |
+| **Source** | WGC Goldhub authenticated workbook, sourced from IMF IFS plus WGC adjustments |
+| **URL** | https://www.gold.org/goldhub/data/gold-reserves-by-country |
+| **Format** | XLSX: `Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx`; old anonymous CSV path returns 404 |
 | **Cost** | Free |
-| **Auth** | IMF key or Goldhub session, depending path |
-| **Cadence** | Monthly |
-| **Lag** | ~1 month after end-of-month |
-| **Coverage** | ~100 countries since 2000; selected back to 1950s |
+| **Auth** | Goldhub session cookie or manually exported local workbook |
+| **Cadence** | Quarterly |
+| **Lag** | ~1 month after quarter-end |
+| **Coverage** | Local warm store: 27 mapped bucket countries from Q1 2000 through Q1 2026 |
 | **Caveats** | Russia stopped reporting late 2022; China reports infrequently and is widely believed to under-report (industry estimates 2-3× reported figures) |
 | **Consumed by** | Layer 1 / structural posture |
 
-**Current implementation status (2026-05-18):** unresolved. `cb_gold_reserves_monthly`
-is empty in the local warm store and the current `gold_wgc_cb_ingest_job` is a
-documented no-op. See [14-data-quality-remediation.md](./14-data-quality-remediation.md)
+**Current implementation status (2026-05-18):** wired and locally populated from
+the authenticated WGC Goldhub workbook. `cb_gold_reserves_monthly` contains
+2,827 rows for 27 mapped bucket countries from 2000-03-31 through 2026-03-31.
+`gold_wgc_cb_ingest_job` accepts `WGC_CB_RESERVES_WORKBOOK_PATH` or
+`WGC_GOLDHUB_COOKIE`. See [14-data-quality-remediation.md](./14-data-quality-remediation.md)
 G3.
 
 ### ETF holdings

--- a/docs/research/gold-sdf-framework/09-data-sources-catalog.md
+++ b/docs/research/gold-sdf-framework/09-data-sources-catalog.md
@@ -8,10 +8,13 @@ Consolidated reference for every data series the three-layer architecture relies
 
 | Cost class | Sources |
 |---|---|
-| **Free, no auth** | FRED CSV endpoint, GPR daily, LBMA monthly, SPDR/iShares ETF holdings, CME COMEX vault reports, BIS FX series, **CFTC COT reports** |
+| **Free, no auth** | FRED CSV endpoint, GPR daily, LBMA monthly, SPDR GLD historical archive, CFTC COT reports via the official commodity dataset, BIS FX series |
 | **Free, requires instant-issue key** | FRED JSON API |
 | **Already paid in this repo** | UW (options on GLD/GDX/IAU), massive.com (OHLC for GLD/GDX/IAU/SPX/futures) |
+| **Free but requires alternate/open-data re-wire** | IMF IFS for central-bank reserves, SEC N-PORT for non-GLD ETF fallback |
 | **Free but Chinese-language scraping** | Shanghai Gold Exchange (deferred to v2) |
+| **Free but currently blocked by scrape/access path** | CME COMEX vault reports |
+| **Free but Goldhub-authenticated/export-backed** | WGC ETF monthly workbook corpus |
 | **Discontinued** | LBMA GOFO (discontinued 2015; use COMEX/LBMA/SGE proxies instead) |
 | **Paid** | None required |
 
@@ -26,16 +29,21 @@ Consolidated reference for every data series the three-layer architecture relies
 | Field | Value |
 |---|---|
 | **Series** | Monthly per-country gold reserves (tonnes) |
-| **Source** | World Gold Council "Monthly central bank statistics", aggregated from IMF IFS |
+| **Source** | IMF IFS direct preferred; WGC "Monthly central bank statistics" historical design path now behind Goldhub login |
 | **URL** | https://www.gold.org/goldhub/data/monthly-central-bank-statistics |
-| **Format** | CSV download |
+| **Format** | IMF API once re-wired; old WGC anonymous CSV path returns 404 |
 | **Cost** | Free |
-| **Auth** | None |
+| **Auth** | IMF key or Goldhub session, depending path |
 | **Cadence** | Monthly |
 | **Lag** | ~1 month after end-of-month |
 | **Coverage** | ~100 countries since 2000; selected back to 1950s |
 | **Caveats** | Russia stopped reporting late 2022; China reports infrequently and is widely believed to under-report (industry estimates 2-3× reported figures) |
 | **Consumed by** | Layer 1 / structural posture |
+
+**Current implementation status (2026-05-18):** unresolved. `cb_gold_reserves_monthly`
+is empty in the local warm store and the current `gold_wgc_cb_ingest_job` is a
+documented no-op. See [14-data-quality-remediation.md](./14-data-quality-remediation.md)
+G3.
 
 ### ETF holdings
 
@@ -45,9 +53,13 @@ Consolidated reference for every data series the three-layer architecture relies
 | **IAU** (iShares Gold Trust) | BlackRock | Daily holdings | iShares.com investor relations | Daily | T+0 |
 | **GLDM** (SPDR Gold MiniShares) | State Street | Daily holdings | spdrgoldshares.com | Daily | T+0 |
 | **PHYS** (Sprott Physical Gold) | Sprott | Daily NAV, premium/discount | sprott.com | Daily | T+0 |
-| **Aggregate** | WGC | Weekly cross-fund total | gold.org/goldhub | Weekly | T+~5 days |
+| **Aggregate** | WGC | Monthly cross-fund holdings, demand, flow | gold.org/goldhub | Monthly | T+~5 days |
 
-All free, no auth, simple HTTP downloads. Consumed by Layer 1 / ETF flow regime gauge.
+GLD daily holdings are wired through the SPDR historical archive API. WGC ETF
+monthly files are authenticated/export-backed and revision-preserving; use a
+canonical latest-revision view before computing factors. Non-GLD daily issuer
+paths should be treated as deferred until SEC N-PORT or new issuer APIs are
+wired. Consumed by Layer 1 / ETF flow regime gauge.
 
 ### COMEX vault stocks
 
@@ -56,12 +68,16 @@ All free, no auth, simple HTTP downloads. Consumed by Layer 1 / ETF flow regime 
 | **Series** | Daily gold vault stocks: registered + eligible (oz) |
 | **Source** | CME Group daily metals depository report |
 | **URL** | https://www.cmegroup.com/markets/metals/precious/gold-stocks.html |
-| **Format** | HTML/JSON, can be parsed daily |
+| **Format** | HTML/JSON, but the current anonymous scrape is blocked |
 | **Cost** | Free |
-| **Auth** | None |
+| **Auth** | none documented, but current scrape returns 403 |
 | **Cadence** | Daily, end of NY business |
 | **Lag** | T+0 |
 | **Consumed by** | Layer 1 / inventory regime quadrant |
+
+**Current implementation status (2026-05-18):** unresolved. `COMEX` has zero
+rows in `exchange_inventory_daily`; decide whether to wire Playwright/licensed
+access or drop COMEX from the required Lens 1 gate after calibration.
 
 ### LBMA loco London
 
@@ -93,7 +109,11 @@ All free, no auth, simple HTTP downloads. Consumed by Layer 1 / ETF flow regime 
 | **Caveats** | Categories are coarse (managed-money / commercial / non-reportable); crowded spec longs can be trend-following rather than contrarian; release delay must be modeled |
 | **Consumed by** | Lens 1 / F18 (managed-money net percentile), F19 (commercials net percentile), F20 (managed-money 4-week change) |
 
-This is the **single largest factor-class omission** flagged by the Codex review. Adding COT is high-priority for v1 (or at minimum early v2).
+This is the **single largest factor-class omission** flagged by the Codex review. Adding COT is high-priority for the data-quality remediation pass.
+
+**Current implementation status (2026-05-18):** unresolved. The existing provider
+points at the financial futures report and returns zero gold rows. Re-wire to
+Socrata or the commodity disaggregated zip before using this field.
 
 ### UW options stress (GLD / GDX / IAU)
 
@@ -267,11 +287,14 @@ Engineering estimate: **6-10 days** for the data plumbing, **2-3 days** for the 
 
 ### Most reliable (use without hesitation)
 
-FRED macro series, LBMA fix, COMEX vault reports, SPDR/iShares ETF disclosures, Caldara-Iacoviello GPR. All published by institutions with strong reputational stakes; no recent quality concerns.
+FRED macro series, SPDR GLD historical archive, LBMA vault reports, Caldara-Iacoviello GPR. All are published by institutions with strong reputational stakes and have working ingestion paths in the current stack.
 
 ### Caveat-required
 
-- **WGC CB reserves**: Russia post-2022 estimated. China under-reports. Surface tooltips when these countries are highlighted.
+- **WGC/IMF CB reserves**: currently not populated. Once re-wired, Russia post-2022 estimated and China under-reports. Surface tooltips when these countries are highlighted.
+- **CFTC COT**: current weekly gold row is populated from the official disaggregated futures-only commodity feed; historical backfill is still needed before 4-week-change metrics are reliable. Release lag must be modeled.
+- **COMEX vault**: currently not populated because CME returns 403 to the current scrape. Treat as optional until calibrated.
+- **WGC ETF monthly corpus**: raw table preserves workbook revisions; consumers must use a canonical latest-revision view.
 - **PHYS NAV**: Sprott reports daily but premium/discount calculation has occasional methodology updates.
 - **TRY FX**: Turkish lira has had unconventional intervention episodes; FX rates from TCMB occasionally diverge from market rates during stress periods.
 

--- a/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
+++ b/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
@@ -6,7 +6,7 @@
 
 **Why this file exists:** Five sources moved or paywalled between the design pass (April 2026) and the implementation pass (May 2026). Each was documented inline in the source file as a deferral, but operational and research context belongs here so the v2 plan can sequence them by effort × signal value rather than rediscovering each failure mode.
 
-**2026-05-18 live-state update:** this file is now paired with [14-data-quality-remediation.md](./14-data-quality-remediation.md), which records the current local DB state. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, COT current-row + 400-day history ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have landed. CB reserves and COMEX remain unresolved.
+**2026-05-18 live-state update:** this file is now paired with [14-data-quality-remediation.md](./14-data-quality-remediation.md), which records the current local DB state. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, COT current-row + 400-day history ingestion, WGC/IFS CB reserve workbook ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have landed. COMEX remains unresolved.
 
 ---
 
@@ -14,21 +14,21 @@
 
 **Designed for:** Lens 1 structural — `cb_strategic_12m_sum_t`, `cb_tactical_12m_sum_t`, `cb_diversifier_12m_sum_t`, `cb_52w_pct`.
 
-**Designed source:** World Gold Council Goldhub CSV at `https://www.gold.org/...` (anonymous).
+**Designed source:** World Gold Council Goldhub central-bank downloads, sourced from IMF IFS plus WGC adjustments.
 
-**Phase A1 status:** **Anonymous endpoint retired 2026-05-17.** WGC moved Goldhub behind login. The fetcher in `src/uw_scan/sources/wgc_cb.py` is intact but the ingest job is a documented no-op (`gold_wgc_cb_ingest_job` logs an info line and returns).
+**Phase A1 status:** **Authenticated WGC workbook path wired 2026-05-18.** The old anonymous CSV still returns 404, but `src/uw_scan/sources/wgc_cb.py` can now parse the Goldhub quarterly reserves workbook from `WGC_CB_RESERVES_WORKBOOK_PATH` or fetch it with `WGC_GOLDHUB_COOKIE`.
 
 **Re-wire options (sorted by effort):**
 
-1. **IMF IFS direct** — central-bank gold reserves are reported through IMF International Financial Statistics. API endpoint at `https://data.imf.org/ifs` with an instant-issue key. Drops WGC's strategic/tactical/diversifier bucket classification (WGC bucket label is editorial); need to re-derive buckets or maintain a static mapping (~30 countries cover 95% of reported reserves).
+1. **IMF IFS direct** — central-bank gold reserves are reported through IMF International Financial Statistics. API endpoint at `https://data.imf.org/ifs` with an instant-issue key. Still useful as the long-run open-data path, but no longer blocking the local warm store.
 2. **World Bank Open Data** — `https://data.worldbank.org/indicator/FI.RES.XGLD.OZ` returns annual not monthly. Useful for cross-validation only.
 3. **Goldhub authenticated download** — register, store credentials in `.env`, change `wgc_cb.py` to send the session cookie. Lowest delta to existing code but adds a credential dependency.
 
 **Signal value:** **High.** CB reserves are the largest non-ETF physical sink and the dominant single factor in the post-2022 regime break thesis (see [03-post-2022-regime-break.md](./03-post-2022-regime-break.md) and Codex finding #1). The Lens 1 chart loses its anchor without it.
 
-**Recommended for v2:** IMF IFS direct. Avoids the auth-credential tax and keeps the source open-data.
+**Recommended for v2:** keep the WGC workbook parser as the near-term source; evaluate IMF IFS direct later if the Goldhub auth dependency becomes operationally painful.
 
-**2026-05-18 verification:** `cb_gold_reserves_monthly` is still empty in the local warm store, and a live probe against the old WGC CSV returns 404. This is unresolved and remains the second highest-priority source after COT.
+**2026-05-18 verification:** authenticated Playwright access to `https://www.gold.org/goldhub/data/gold-reserves-by-country` downloaded `Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx`. The local warm store has 2,827 WGC CB reserve rows for 27 mapped bucket countries from 2000-03-31 through 2026-03-31. Latest posture rows now compute CB bucket 12m net changes instead of summing reserve levels.
 
 ---
 

--- a/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
+++ b/docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md
@@ -6,6 +6,8 @@
 
 **Why this file exists:** Five sources moved or paywalled between the design pass (April 2026) and the implementation pass (May 2026). Each was documented inline in the source file as a deferral, but operational and research context belongs here so the v2 plan can sequence them by effort × signal value rather than rediscovering each failure mode.
 
+**2026-05-18 live-state update:** this file is now paired with [14-data-quality-remediation.md](./14-data-quality-remediation.md), which records the current local DB state. GLD daily holdings, the WGC monthly ETF corpus, WGC canonicalization, COT current-row + 400-day history ingestion, freshness missing-source status, effective-market-date targeting, and replay invalidation have landed. CB reserves and COMEX remain unresolved.
+
 ---
 
 ## D1 — WGC Central Bank reserves (monthly)
@@ -26,15 +28,17 @@
 
 **Recommended for v2:** IMF IFS direct. Avoids the auth-credential tax and keeps the source open-data.
 
+**2026-05-18 verification:** `cb_gold_reserves_monthly` is still empty in the local warm store, and a live probe against the old WGC CSV returns 404. This is unresolved and remains the second highest-priority source after COT.
+
 ---
 
 ## D2 — ETF holdings (GLD / IAU / GLDM / PHYS)
 
 **2026-05-17 partial re-wire:** UW `/api/etfs/{ticker}/in-outflow` is accessible for GLD/IAU/GLDM under the current entitlement window (~30 trading days) and can populate `gld_30d_net_flow_t`. UW `/api/etfs/GLD/holdings` returns `data: []` and `GLD/info` reports `holdings_count: 0`, so it does **not** provide absolute bullion ounces/tonnes.
 
-**2026-05-17 GLD holdings re-wire:** SPDR's current archive endpoint is `https://api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en`. It returns `US_GLD_Archive_EN.xlsx` with daily `Total Ounces of Gold in the Trust`, `Tonnes of Gold`, NAV/share, premium/discount, and GLD close back to inception. This now populates `gld_holdings_t` and the Lens 1 holdings-vs-price chart on warmup/daily scheduled ingest.
+**2026-05-17 GLD holdings re-wire:** SPDR's current archive endpoint is `https://api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en`. It returns `US_GLD_Archive_EN.xlsx` with daily `Total Ounces of Gold in the Trust`, `Tonnes of Gold`, NAV/share, premium/discount, and GLD close back to inception. This now populates `gld_holdings_t` and the Lens 1 holdings-vs-price chart on warmup/daily scheduled ingest. GLD daily holdings are therefore no longer a deferred source.
 
-**2026-05-17 WGC Goldhub monthly re-wire:** The WGC ETF-flows page (`https://www.gold.org/goldhub/research/etf-flows`) exposes monthly `ETF_Flows_*.xlsx` downloads. Anonymous `curl` returns 403, but an authenticated Goldhub browser session can download the workbook. The workbook's monthly sheets contain ETF holdings, demand, and fund flows back to 2003. The code path now supports either `WGC_GOLDHUB_COOKIE` for scheduled authenticated downloads or `WGC_ETF_FLOWS_WORKBOOK_PATH` for a local exported workbook/directory. Local authenticated scrape loaded 78 workbooks into `wgc_etf_monthly`: 1,338,260 rows, 234 tickers, 2003-03-31 through 2026-03-31. See [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md). This is a monthly safety net for non-GLD absolute holdings, not a replacement for SPDR's daily GLD archive.
+**2026-05-17 WGC Goldhub monthly re-wire:** The WGC ETF-flows page (`https://www.gold.org/goldhub/research/etf-flows`) exposes monthly `ETF_Flows_*.xlsx` downloads. Anonymous `curl` returns 403, but an authenticated Goldhub browser session can download the workbook. The workbook's monthly sheets contain ETF holdings, demand, and fund flows back to 2003. The code path now supports either `WGC_GOLDHUB_COOKIE` for scheduled authenticated downloads or `WGC_ETF_FLOWS_WORKBOOK_PATH` for a local exported workbook/directory. Local authenticated scrape loaded 78 workbooks into `wgc_etf_monthly`: 1,338,260 raw revision-preserving rows, 234 tickers, 2003-03-31 through 2026-03-31. See [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md). This is a monthly safety net and breadth corpus; downstream consumers must canonicalize to the latest revision per `(ticker, obs_date)` before computing factors.
 
 **Designed for:** Lens 1 structural — `gld_holdings_t`, `gld_30d_net_flow_t`, plus the dual-axis Lens 1 chart showing oz-held vs price.
 
@@ -59,7 +63,7 @@
 
 **Signal value:** **Medium-high.** ETF flows are the easiest-to-observe component of the structural posture. 30d net flow is one of the inputs the dashboard surfaces most prominently; the v1 Lens 1 dual-axis chart is half-functional without GLD holdings.
 
-**Recommended for v2:** Keep SPDR archive as canonical GLD absolute-holdings source. Use WGC Goldhub monthly files for IAU/PHYS/GLDM while authenticated access is available; keep SEC N-PORT as the open-data fallback if Goldhub session ops become brittle.
+**Recommended for v2:** Keep SPDR archive as canonical GLD absolute-holdings source. Use WGC Goldhub monthly files for IAU/PHYS/GLDM and global breadth while authenticated access is available; add a canonical WGC view/query before promoting WGC breadth to production fields; keep SEC N-PORT as the open-data fallback if Goldhub session ops become brittle.
 
 ---
 
@@ -70,6 +74,8 @@
 **Designed source:** CME Group's daily Issues & Stops report (anonymous CSV).
 
 **Phase A1 status:** **CME returns 403 to anonymous scrapers as of 2026-05-17.** Bumping the timeout to 60s and adding a browser UA did not help. The fetcher in `src/uw_scan/sources/comex.py` is intact and logs a warning when the 403 lands.
+
+**2026-05-18 verification:** `exchange_inventory_daily` has LBMA rows but no COMEX rows. A live probe against the CME page still returns 403. Until calibration proves COMEX is material, do not let this optional source keep Lens 1 permanently degraded.
 
 **Re-wire options:**
 
@@ -90,7 +96,9 @@
 
 **Designed source:** `https://www.cftc.gov/dea/newcot/deacot.txt` or equivalent disaggregated commodities report.
 
-**Phase A1 status:** **Pointing at the wrong file.** The Phase A1 fetcher in `src/uw_scan/sources/cftc_cot.py` references `FinFutWk.txt` — that's the **financial** futures weekly report, not the commodities report. So even when the fetch succeeded, it pulled rates / equities / FX positioning, not gold.
+**Phase A1 status:** **Originally pointed at the wrong file.** The Phase A1 fetcher in `src/uw_scan/sources/cftc_cot.py` referenced `FinFutWk.txt` — that's the **financial** futures weekly report, not the commodities report. So even when the fetch succeeded, it pulled rates / equities / FX positioning, not gold.
+
+**2026-05-18 remediation:** the provider now reads the official CFTC disaggregated futures-only commodity feed at `/dea/newcot/f_disagg.txt` for the current row and the CFTC Public Reporting Environment Socrata dataset `72hh-3qpy` for history, filters gold contract market code `088691`, and the local store has 57 distinct observations from 2025-04-15 through 2026-05-12. The latest posture row writes both `cot_mm_net_pct` and `cot_mm_4w_change_sigma`.
 
 **Re-wire options:**
 
@@ -100,7 +108,7 @@
 
 **Signal value:** **High.** Codex finding #8 explicitly called this out as the largest single factor class missing from the original design. F18/F19/F20 in `04a-quant-model-spec.md` all consume COT MM net + 4w change. The Lens 1 posture currently degrades without it because the four-way composite is missing one corner.
 
-**Recommended for v2:** Socrata API. Cleaner than the zip and the JSON shape maps directly to `CotRow`. Should be the first deferred source to re-wire.
+**Recommended remaining work:** keep the Public Reporting Environment path as the canonical backfill path; use the annual disaggregated futures-only zip files as an offline fallback.
 
 ---
 
@@ -142,9 +150,9 @@
 
 | Order | Source | Path | Why this rank |
 |---|---|---|---|
-| 1 | D4 — CFTC COT | Socrata API at publicreporting.cftc.gov, commodity code 088691 | Highest signal (Codex #8); cleanest API; smallest code change |
-| 2 | D1 — WGC CB reserves | IMF IFS API | Largest unweighted contributor to Lens 1 structural posture; one credential, no scraping |
-| 3 | D2 — ETF holdings (GLD only) | SPDR HTML scrape + SEC N-PORT fallback | Half of the dual-axis chart; GLD alone is 80% of the signal |
+| Closed | D4 — CFTC COT | Socrata API at publicreporting.cftc.gov, commodity code 088691 | Landed with 400-day backfill and 4-week metric persistence |
+| 1 | D1 — WGC CB reserves | IMF IFS API | Largest remaining unweighted contributor to Lens 1 structural posture; one credential, no scraping |
+| 3 | D2 — ETF holdings/WGC canonicalization | SPDR daily GLD already landed; add canonical WGC monthly view + SEC N-PORT fallback | The raw WGC corpus is loaded but revision-heavy; production factors need canonical rows |
 | 4 | D5 — XAU spot | massive `XAU=` if available, else keep GLD labelled honestly | Display-only; not blocking model work |
 | 5 | D3 — COMEX | Playwright + UA spoof, or drop entirely | Only re-wire if calibration shows it moves R² >2% |
 | 6 | D2 — ETF holdings (IAU/GLDM/PHYS) | SEC N-PORT monthly | Diminishing return after GLD |

--- a/docs/research/gold-sdf-framework/12-wgc-etf-flow-corpus.md
+++ b/docs/research/gold-sdf-framework/12-wgc-etf-flow-corpus.md
@@ -30,7 +30,10 @@ It stores one row per `(ticker, obs_date, source_url)` with:
 - lineage: `source_url`, `source_label`, `as_of`, `source`
 
 Keeping `source_url` in the primary key preserves workbook revisions instead of
-flattening historical snapshots.
+flattening historical snapshots. This is intentional for audit lineage, but it
+means the raw table is not the right consumer surface for factor computation.
+Any model, chart, or research statistic should first canonicalize to one latest
+revision per `(ticker, obs_date)`.
 
 The ingest also bridges GLD/IAU/GLDM/PHYS monthly holdings into
 `etf_holdings_daily` with `source='WGC'`, so existing Lens 1 readers can use the
@@ -70,3 +73,32 @@ Local Postgres load result:
 - WGC bridge holdings rows: GLD 257, IAU 255, GLDM 94, PHYS 194
 
 Latest WGC workbook in this load: `20717_ETF_Flows_March_2026.xlsx`.
+
+## Canonicalization requirement
+
+The raw table preserves every workbook revision. A single fund-month can appear
+many times because later workbooks include historical rows. In the 2026-05-18
+local store, GLD has 16,362 raw rows for 257 distinct months across 78 source
+workbooks; some 2017-2018 months have 76 GLD rows.
+
+For research and product use, derive a canonical view first:
+
+```sql
+SELECT *
+FROM uw_scan.wgc_etf_monthly_canonical;
+```
+
+The implemented view ranks workbook revisions by the latest month present in
+each source workbook, then by ingest `as_of`, then by `source_url`. This avoids
+the bug where a lexicographically later older workbook can beat a newer revision
+when several exported workbooks are loaded in one ingest run.
+
+The canonical layer should be the only input to:
+
+- global and regional ETF demand totals,
+- ETF breadth metrics,
+- GLD share of global ETF holdings,
+- top-5 concentration,
+- any future Lens 1 WGC composite.
+
+The raw table remains the audit log.

--- a/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
+++ b/docs/research/gold-sdf-framework/13-wgc-etf-flow-mining.md
@@ -18,7 +18,12 @@ Source: `uw_scan.wgc_etf_monthly`, loaded from 78 authenticated WGC Goldhub ETF
 workbooks. See [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md).
 
 For this note, rows were canonicalised to the latest workbook revision per
-`(ticker, obs_date)` using `source_url DESC`, then grouped monthly.
+`(ticker, obs_date)`, then grouped monthly.
+
+**2026-05-18 implementation note:** production callers should read
+`uw_scan.wgc_etf_monthly_canonical` / `repo.fetch_wgc_etf_monthly()`. The raw
+WGC table remains revision-preserving and intentionally much larger than the
+canonical fund-month panel.
 
 Canonical sample:
 
@@ -230,7 +235,10 @@ be treated as interchangeable.
    lens input, not as trade sizing.
 4. Compare GLD daily flow to WGC monthly global demand to calibrate when GLD is
    a good proxy and when it is misleading.
-5. Explore ETF flow further as its own Lens 1 research thread:
+5. Add the canonical WGC query/view described in
+   [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md) before wiring any
+   WGC-derived field into `/api/gold/state`.
+6. Explore ETF flow further as its own Lens 1 research thread:
    - identify whether flow breadth, regional rotation, or concentration changes
      add signal beyond headline global demand
    - test whether Asian ETF accumulation behaves differently from North American

--- a/docs/research/gold-sdf-framework/14-data-quality-remediation.md
+++ b/docs/research/gold-sdf-framework/14-data-quality-remediation.md
@@ -22,15 +22,15 @@ Observed from the configured local Postgres store on 2026-05-18 HKG.
 | `wgc_etf_monthly` | 1,338,260 rows | 2026-03-31 | Historical workbook revisions create many rows per fund-month |
 | `exchange_inventory_daily` | 36 rows | LBMA 2026-04-01 | COMEX has zero rows |
 | `cot_gold_weekly` | 57 distinct obs dates | 2026-05-12 | Current + 400-day CFTC gold history populated from official CFTC sources |
-| `cb_gold_reserves_monthly` | 0 rows | none | WGC anonymous CB CSV is gone |
+| `cb_gold_reserves_monthly` | 2,827 rows | 2026-03-31 | WGC/IFS quarterly workbook, 27 mapped bucket countries |
 | `uw_gold_options_daily` | 12 rows | 2026-05-17 | Snapshot-only; dealer gamma null |
-| `gold_posture_daily` | 12 rows | active latest 2026-05-15 | Bad/non-market 2026-05-17 rows invalidated and retained for audit |
+| `gold_posture_daily` | 15 rows | active latest 2026-05-15 | Bad/non-market and pre-CB rows invalidated and retained for audit |
 
 Post-remediation latest active posture row: `obs_date=2026-05-15`,
 `gauge_state=partial`, `row_status=active`, `cot_mm_4w_change_sigma=0.1988`.
-Data freshness now includes explicit `status` for missing sources, and the local
-store has `active=3`, `invalidated=9` posture rows after replay cleanup and
-post-COT recomputes.
+Data freshness now includes explicit `status` for missing sources, and after the
+WGC CB load and level-sum invalidation the local posture store has `active=2`,
+`invalidated=13` rows.
 
 ## Implementation Status
 
@@ -40,7 +40,7 @@ As of the 2026-05-18 remediation pass:
 |---|---|---|
 | G1 non-trading posture | Closed for scheduled jobs | `gold_posture_compute_job()` defaults to latest `GLD_CLOSE`; non-market posture rows after latest GLD close are invalidated |
 | G2 COT empty/history incomplete | Closed | Provider reads CFTC current disaggregated futures-only `f_disagg.txt`; 400-day history reads official CFTC Public Reporting Environment dataset `72hh-3qpy`, filters gold contract `088691`, and local `cot_gold_weekly` has 57 distinct observations |
-| G3 CB reserves empty | Open | Requires IMF IFS source rewire; WGC anonymous CSV remains 404 |
+| G3 CB reserves empty | Closed | WGC Goldhub authenticated quarterly workbook parser and ingest path wired; local `cb_gold_reserves_monthly` has 2,827 rows for 27 mapped bucket countries |
 | G4 COMEX empty | Open / decision needed | CME anonymous scrape remains 403; calibrate before paying scrape/licensed-data cost |
 | G5 freshness hides missing | Partially closed | Freshness rows now include `status=ok/missing`; obs-date/cadence details are still a follow-up |
 | G6 WGC canonicalization | Closed | `wgc_etf_monthly_canonical` view reduces GLD from 16,362 raw rows to 257 canonical months |
@@ -94,25 +94,74 @@ the financial futures report, not the disaggregated commodities gold report.
 `gold_posture_daily` writes `cot_mm_net_pct=0.246` and
 `cot_mm_4w_change_sigma=0.1988`.
 
-### G3 — Central-bank reserves are empty
+### G3 — Central-bank reserves were empty
 
-**Evidence:** `cb_gold_reserves_monthly` has zero rows. A live probe against the
-old WGC CSV returns HTTP 404.
+**Evidence:** `cb_gold_reserves_monthly` had zero rows. A live probe against the
+old WGC CSV returned HTTP 404.
 
-**Root cause:** WGC retired the anonymous central-bank CSV path. The current job
-is intentionally a no-op.
+**Root cause:** WGC retired the anonymous central-bank CSV path. The replacement
+Goldhub files are authenticated XLSX downloads.
 
 **Resolution:**
 
-1. Add `src/uw_scan/sources/imf_ifs.py`.
-2. Map IMF gold-reserve observations into the existing CB reserve row shape.
-3. Reuse or extend `cards/cb_buckets.py` for strategic/tactical/diversifier
-   buckets; keep bucket logic separate from source ingestion.
-4. Keep the old WGC provider as a documented deferred/auth path only.
+1. Wire `src/uw_scan/sources/wgc_cb.py` to parse the authenticated WGC
+   quarterly reserves workbook.
+2. Let `gold_wgc_cb_ingest_job` read `WGC_CB_RESERVES_WORKBOOK_PATH` for local
+   exports or `WGC_GOLDHUB_COOKIE` for authenticated downloads.
+3. Populate `cb_gold_reserves_monthly` with WGC/IFS country-level reserve
+   levels, mapped to the existing bucket taxonomy.
+4. Fix structural posture to compute 12m bucket net changes from reserve levels
+   instead of summing repeated level observations.
 
-**Verification:** `cb_gold_reserves_monthly` has rows for key countries,
-`cb_strategic_12m_sum_t` is non-null, and CB caveats for China/Russia remain
-visible in docs/UI copy.
+**Verification:** local `cb_gold_reserves_monthly` now has 2,827 rows for 27
+mapped bucket countries from 2000-03-31 through 2026-03-31. Latest posture for
+2026-05-15 writes `cb_strategic_12m_sum_t=-79.3125`,
+`cb_tactical_12m_sum_t=48.4098`, `cb_diversifier_12m_sum_t=116.3423`, and
+bad level-sum replay rows are invalidated by migration 048.
+
+**Operator note — do not rediscover this source:** WGC's
+`gold-demand-by-country` page is useful for aggregate demand/supply and consumer
+country demand, but it is not the CB holdings source. The holdings source is:
+
+- Page: `https://www.gold.org/goldhub/data/gold-reserves-by-country`
+- Workbook: `Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx`
+- Sheet consumed: `Gold (Tonnes)`
+- Local table: `uw_scan.cb_gold_reserves_monthly`
+
+Fast health check:
+
+```bash
+set -a; source /Users/chenxi/projects/unusual-whales/.env; set +a
+uv run python scripts/gold_cb_reserves_status.py
+uv run python scripts/gold_cb_reserves_status.py --country CHN
+```
+
+Equivalent SQL:
+
+```sql
+SELECT count(*) AS rows,
+       count(DISTINCT country_iso3) AS countries,
+       min(obs_month) AS first_month,
+       max(obs_month) AS latest_month
+FROM uw_scan.cb_gold_reserves_monthly;
+
+SELECT country_iso3, count(*) AS rows, min(obs_month), max(obs_month)
+FROM uw_scan.cb_gold_reserves_monthly
+GROUP BY country_iso3
+ORDER BY country_iso3;
+```
+
+Refresh options:
+
+1. Manual export path: download the latest WGC quarterly workbook from the
+   logged-in Goldhub page, then run the ingest with
+   `WGC_CB_RESERVES_WORKBOOK_PATH=/path/to/Quarterly_gold_and_FX_Reserves_*.xlsx`.
+2. Scheduled authenticated path: set `WGC_GOLDHUB_COOKIE` in the worker
+   environment. `gold_wgc_cb_ingest_job` will discover the latest quarterly XLSX
+   link from the Goldhub page and ingest it.
+3. Warmup/backfill path: `gold_warmup.py` passes `lookback_days=None` for this
+   source, so a local workbook refresh reloads the full quarterly history rather
+   than just the latest 400-day posture window.
 
 ### G4 — COMEX is empty
 

--- a/docs/research/gold-sdf-framework/14-data-quality-remediation.md
+++ b/docs/research/gold-sdf-framework/14-data-quality-remediation.md
@@ -1,0 +1,254 @@
+# 14 — Gold Data Quality Remediation
+
+Date: 2026-05-18 HKG
+
+## Purpose
+
+This note is the systematic closure plan for the live data issues observed after
+Phase A1. It reconciles the research docs with the current local warm-store
+state and separates confirmed gaps, root causes, user-visible impact, exact
+resolution order, and verification gates.
+
+## Current Warm-Store Snapshot
+
+Observed from the configured local Postgres store on 2026-05-18 HKG.
+
+| Dataset | Current state | Latest observation | Issue |
+|---|---:|---|---|
+| `macro_series_daily` | 18,681 rows | GLD_CLOSE 2026-05-15; DFII10 2026-05-14; GPRD 2026-05-11 | Mixed clocks; latest posture can be computed on a non-trading date |
+| `macro_series_monthly` | 182 rows | CPIAUCSL 2026-04-01; M2SL 2026-03-01 | Expected monthly lag |
+| `etf_holdings_daily` | 1,073 rows | GLD 2026-05-14 | GLD daily path works; non-GLD daily paths are WGC monthly only |
+| `etf_flows_daily` | 93 rows | GLD/IAU/GLDM 2026-05-15 | UW entitlement window only, about 30 trading days |
+| `wgc_etf_monthly` | 1,338,260 rows | 2026-03-31 | Historical workbook revisions create many rows per fund-month |
+| `exchange_inventory_daily` | 36 rows | LBMA 2026-04-01 | COMEX has zero rows |
+| `cot_gold_weekly` | 57 distinct obs dates | 2026-05-12 | Current + 400-day CFTC gold history populated from official CFTC sources |
+| `cb_gold_reserves_monthly` | 0 rows | none | WGC anonymous CB CSV is gone |
+| `uw_gold_options_daily` | 12 rows | 2026-05-17 | Snapshot-only; dealer gamma null |
+| `gold_posture_daily` | 12 rows | active latest 2026-05-15 | Bad/non-market 2026-05-17 rows invalidated and retained for audit |
+
+Post-remediation latest active posture row: `obs_date=2026-05-15`,
+`gauge_state=partial`, `row_status=active`, `cot_mm_4w_change_sigma=0.1988`.
+Data freshness now includes explicit `status` for missing sources, and the local
+store has `active=3`, `invalidated=9` posture rows after replay cleanup and
+post-COT recomputes.
+
+## Implementation Status
+
+As of the 2026-05-18 remediation pass:
+
+| Issue | Status | Code / data outcome |
+|---|---|---|
+| G1 non-trading posture | Closed for scheduled jobs | `gold_posture_compute_job()` defaults to latest `GLD_CLOSE`; non-market posture rows after latest GLD close are invalidated |
+| G2 COT empty/history incomplete | Closed | Provider reads CFTC current disaggregated futures-only `f_disagg.txt`; 400-day history reads official CFTC Public Reporting Environment dataset `72hh-3qpy`, filters gold contract `088691`, and local `cot_gold_weekly` has 57 distinct observations |
+| G3 CB reserves empty | Open | Requires IMF IFS source rewire; WGC anonymous CSV remains 404 |
+| G4 COMEX empty | Open / decision needed | CME anonymous scrape remains 403; calibrate before paying scrape/licensed-data cost |
+| G5 freshness hides missing | Partially closed | Freshness rows now include `status=ok/missing`; obs-date/cadence details are still a follow-up |
+| G6 WGC canonicalization | Closed | `wgc_etf_monthly_canonical` view reduces GLD from 16,362 raw rows to 257 canonical months |
+| G7 bad replay rows | Closed | `row_status` / `superseded_reason` added; normal state/replay skip invalidated rows |
+| G8 UW options semantics | Open | History accumulation continues; dealer gamma source/deriver still unidentified |
+
+## Issues And Resolution Plan
+
+### G1 — Latest posture can be a non-trading-day composite
+
+**Evidence:** latest `gold_posture_daily.obs_date` was 2026-05-17, a Sunday,
+while source observations ended on different prior business dates.
+
+**Impact:** the page looks current but mixes GLD 2026-05-15, DFII10 2026-05-14,
+GPRD 2026-05-11, DXY 2026-05-08, and monthly CPI/M2.
+
+**Resolution:**
+
+1. Determine `effective_obs_date` as the latest date for which required daily
+   market sources have closed, not blindly `date.today()`.
+2. Persist both `obs_date` and `computed_at`; show source observation dates in
+   freshness.
+3. Only compute weekend/holiday posture if explicitly requested for replay.
+
+**Verification:** latest `/api/gold/state.obs_date` should be the latest valid
+market date, and the data-audit footer should show each source's `obs_date` or
+`obs_month`, not only ingest `as_of`.
+
+### G2 — COT current row was empty and history was not backfilled
+
+**Original evidence:** `cot_gold_weekly` had zero rows. A live provider probe
+returned zero rows for the last 400 days.
+
+**Root cause:** `src/uw_scan/sources/cftc_cot.py` pointed at `FinFutWk.txt`,
+the financial futures report, not the disaggregated commodities gold report.
+
+**Resolution:**
+
+1. Use the official CFTC disaggregated futures-only commodity feed
+   (`/dea/newcot/f_disagg.txt`) for current-row fallback and filter gold
+   contract market code `088691`.
+2. Use the official CFTC Public Reporting Environment Socrata dataset
+   `72hh-3qpy` for 400-day history.
+3. Preserve the existing `CotRow` shape.
+4. Persist Tuesday observation date and Friday release date; all posture/backtest
+   consumption must use release date.
+5. Compute and persist `cot_mm_net_pct` and `cot_mm_4w_change_sigma`.
+
+**Verification:** `cot_gold_weekly` has 57 distinct gold observations from
+2025-04-15 through 2026-05-12; parser fixtures reject non-gold contracts; latest
+`gold_posture_daily` writes `cot_mm_net_pct=0.246` and
+`cot_mm_4w_change_sigma=0.1988`.
+
+### G3 — Central-bank reserves are empty
+
+**Evidence:** `cb_gold_reserves_monthly` has zero rows. A live probe against the
+old WGC CSV returns HTTP 404.
+
+**Root cause:** WGC retired the anonymous central-bank CSV path. The current job
+is intentionally a no-op.
+
+**Resolution:**
+
+1. Add `src/uw_scan/sources/imf_ifs.py`.
+2. Map IMF gold-reserve observations into the existing CB reserve row shape.
+3. Reuse or extend `cards/cb_buckets.py` for strategic/tactical/diversifier
+   buckets; keep bucket logic separate from source ingestion.
+4. Keep the old WGC provider as a documented deferred/auth path only.
+
+**Verification:** `cb_gold_reserves_monthly` has rows for key countries,
+`cb_strategic_12m_sum_t` is non-null, and CB caveats for China/Russia remain
+visible in docs/UI copy.
+
+### G4 — COMEX is empty
+
+**Evidence:** no `COMEX` rows exist in `exchange_inventory_daily`; a live probe
+against CME returned HTTP 403.
+
+**Root cause:** the CME page blocks the current anonymous `httpx` scrape.
+
+**Resolution:**
+
+1. First run a Lens 1 calibration with COMEX omitted.
+2. If COMEX improves explanatory fit materially, add a Playwright scrape or
+   licensed CME/DataMine path.
+3. If it does not, remove COMEX from the required Lens 1 data gate and keep it
+   as an optional stress overlay.
+
+**Verification:** either `comex_registered_oz` populates reliably, or
+`structural_posture_chip` no longer degrades solely because COMEX is absent.
+
+### G5 — Freshness hides missing sources and source staleness
+
+**Evidence:** latest `data_freshness_jsonb` lists only FRED, GPR, and ETF. COMEX,
+COT, and WGC are absent rather than explicitly reported missing. Freshness uses
+ingest `as_of`, not latest source observation date.
+
+**Resolution:** store freshness rows for every expected source:
+
+- `id`
+- `status`: `ready`, `missing`, `deferred`, `stale`
+- latest `obs_date` or `obs_month`
+- latest `as_of`
+- expected cadence
+- lag seconds/days against cadence
+- source-specific note
+
+**Verification:** the latest state should include explicit COMEX/COT/WGC rows
+even while they are unresolved.
+
+**2026-05-18 implementation note:** `data_freshness_jsonb` now includes every
+expected source with `status=ok` or `status=missing`; source observation-date
+and cadence-aware lag fields are still pending.
+
+### G6 — WGC ETF corpus preserves revisions but consumers need canonical rows
+
+**Evidence:** `wgc_etf_monthly` has 1,338,260 rows. Core GLD has 16,362 rows for
+257 distinct months across 78 source workbooks; some months have 76 GLD rows.
+
+**Root cause:** the table intentionally keys by `(ticker, obs_date, source_url)`
+to preserve workbook revisions. That is correct for lineage, but consumers must
+use a canonical latest-revision view per `(ticker, obs_date)`.
+
+**Resolution:**
+
+1. Keep raw revision-preserving storage.
+2. Add a repository query or SQL view for canonical WGC monthly rows: latest
+   revision per `(ticker, obs_date)` by `as_of` / source label date.
+3. Build global/regional ETF breadth metrics only from the canonical view.
+4. Document row counts in both raw and canonical terms.
+
+**Verification:** the canonical GLD month count is 257, not 16,362; downstream
+research uses canonical counts.
+
+**2026-05-18 implementation note:** migration `046_wgc_etf_monthly.sql` now
+creates `uw_scan.wgc_etf_monthly_canonical`, and repository reads use that view.
+
+### G7 — Replay preserves early bad posture rows
+
+**Evidence:** `gold_posture_daily` has 9 rows for 2026-05-17. Early rows have
+`gld_history_jsonb` values around `30,644,793.74` ounces; later rows correctly
+show tonnes around `953.16`. `fetch_gold_posture_for_obs_date()` returns the
+first row by design.
+
+**Resolution:**
+
+1. Add a `status` or `superseded_reason` field for posture rows, or a side-table
+   recording invalidated `(obs_date, computed_at)` rows.
+2. Make normal replay return the first non-invalidated row.
+3. Keep an audit/debug mode that can still fetch invalidated rows.
+4. Backfill-invalidate the bad 2026-05-17 GLD-unit rows.
+
+**Verification:** replay for 2026-05-17 returns the first corrected row, while
+audit mode can still inspect the original bad rows.
+
+**2026-05-18 implementation note:** migration `047_gold_posture_row_status.sql`
+adds `row_status` and `superseded_reason`, invalidates known-bad GLD-history
+rows, invalidates posture rows after the latest GLD close, and normal latest /
+replay queries filter to `row_status='active'`.
+
+### G8 — UW options is snapshot-only and dealer gamma is null
+
+**Evidence:** `uw_gold_options_daily` has 12 rows, all on 2026-05-17. All
+`dealer_gamma_est` values are null.
+
+**Impact:** `uw_25d_skew_sigma` is really latest raw skew, not a sigma-calibrated
+history metric.
+
+**Resolution:**
+
+1. Continue daily persistence to accumulate history.
+2. Rename or relabel current field semantics if needed: raw 25-delta skew until
+   enough history exists for sigma calibration.
+3. Add dealer-gamma only after a reliable UW source/deriver is identified.
+
+**Verification:** docs/UI do not call the field "sigma" unless it is actually
+standardized against history.
+
+## Execution Order
+
+| Order | Workstream | Why |
+|---:|---|---|
+| 0 | Add source-status/freshness rows for missing/deferred sources | Done for ok/missing status; cadence details remain |
+| 1 | CFTC COT via official commodity dataset | Done for current weekly row |
+| 2 | IMF IFS central-bank reserves | Restores the structural anchor |
+| 3 | WGC canonical ETF monthly view + global/regional breadth fields | Canonical view done; breadth fields remain |
+| 4 | Posture replay invalidation for known-bad rows | Done |
+| 5 | Effective market-date policy | Done for scheduled posture compute |
+| 6 | UW options semantics/history accumulation | Avoids overclaiming current snapshot fields |
+| 7 | COMEX decision: calibrate, then wire or drop | Avoids paying operational cost before signal value is proven |
+| 8 | XAU spot upgrade | Display-only; keep GLD label honest until solved |
+
+## Definition Of Done
+
+The gold data-quality pass is complete when:
+
+1. Latest posture is computed for a valid effective market date.
+2. Freshness reports every expected source with ready/missing/deferred/stale
+   status and source observation date.
+3. COT and CB reserve fields are non-null in `/api/gold/state`.
+4. WGC ETF consumers use a canonical latest-revision view.
+5. Replay excludes invalidated bad rows by default.
+6. Structural posture does not degrade solely because optional COMEX is absent.
+7. UW options labels match the actual amount of persisted history.
+
+## Cross-References
+
+- Deferred-source history: [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md)
+- WGC raw corpus contract: [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md)
+- WGC ETF factor research: [13-wgc-etf-flow-mining.md](./13-wgc-etf-flow-mining.md)
+- Data-source catalog: [09-data-sources-catalog.md](./09-data-sources-catalog.md)

--- a/docs/research/gold-sdf-framework/CHANGELOG.md
+++ b/docs/research/gold-sdf-framework/CHANGELOG.md
@@ -4,6 +4,58 @@ A running log of substantive changes to the research foundation, with rationale 
 
 ---
 
+## 2026-05-18 — Live data-quality reconciliation
+
+**Source:** Local warm-store audit on branch `feat/gold-uw-etf-flows`.
+
+### Code Remediation Update
+
+The first implementation pass closed the local/provider issues that did not
+require a new licensed or alternate macro source:
+
+- CFTC COT ingestion now uses the official disaggregated futures-only commodity
+  feed for the current row and the CFTC Public Reporting Environment Socrata
+  dataset `72hh-3qpy` for 400-day history, filtered to gold contract `088691`.
+- `gold_posture_daily.cot_mm_4w_change_sigma` is now computed from persisted COT
+  history.
+- `wgc_etf_monthly_canonical` now provides latest-revision WGC rows; GLD
+  canonical count is 257 months versus 16,362 raw revision rows.
+- `data_freshness_jsonb` now carries `status=ok/missing` so unresolved sources
+  are visible instead of silently absent.
+- `gold_posture_compute_job()` defaults to the latest GLD market date, not
+  calendar today.
+- `gold_posture_daily` now has `row_status` / `superseded_reason`; normal latest
+  state and replay skip invalidated rows, while the audit rows remain in place.
+
+Remaining source decisions: IMF/IFS central-bank reserves, COMEX vaults, and UW
+options history/dealer-gamma semantics.
+
+The Phase A1 docs were updated to reflect the actual current data state rather
+than the initial handoff snapshot. GLD daily holdings and the WGC monthly ETF
+corpus are now available. The initial reconciliation noted COT, CB reserves,
+COMEX, freshness, and replay gaps; the implementation update above records
+which of those are now closed.
+
+### Changes
+
+- Added [14-data-quality-remediation.md](./14-data-quality-remediation.md) with
+  a source-by-source issue table, root causes, resolution order, and definition
+  of done.
+- Updated [README.md](./README.md) to point at the live data-quality caveat.
+- Updated [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md)
+  so GLD daily holdings and CFTC COT are no longer described as deferred, while
+  CB reserves and COMEX remain unresolved.
+- Updated [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md) and
+  [13-wgc-etf-flow-mining.md](./13-wgc-etf-flow-mining.md) to make WGC
+  canonicalization mandatory before factor use.
+- Updated [09-data-sources-catalog.md](./09-data-sources-catalog.md) to separate
+  working sources, blocked sources, authenticated/export-backed sources, and
+  sources needing alternate open-data rewires.
+- Updated [docs/handover/2026-05-17-gold-v2-codex-handover.md](../../handover/2026-05-17-gold-v2-codex-handover.md)
+  so future agents do not follow stale D2 guidance.
+
+---
+
 ## 2026-05-17 — Phase A1 ingestion field notes (deferred sources)
 
 **Source:** Implementation pass against the v1 plan in [09-data-sources-catalog.md](./09-data-sources-catalog.md).

--- a/docs/research/gold-sdf-framework/CHANGELOG.md
+++ b/docs/research/gold-sdf-framework/CHANGELOG.md
@@ -43,8 +43,8 @@ which of those are now closed.
   of done.
 - Updated [README.md](./README.md) to point at the live data-quality caveat.
 - Updated [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md)
-  so GLD daily holdings and CFTC COT are no longer described as deferred, while
-  CB reserves and COMEX remain unresolved.
+  so GLD daily holdings, CFTC COT, and WGC/IFS CB reserves are no longer
+  described as deferred, while COMEX remains unresolved.
 - Updated [12-wgc-etf-flow-corpus.md](./12-wgc-etf-flow-corpus.md) and
   [13-wgc-etf-flow-mining.md](./13-wgc-etf-flow-mining.md) to make WGC
   canonicalization mandatory before factor use.

--- a/docs/research/gold-sdf-framework/README.md
+++ b/docs/research/gold-sdf-framework/README.md
@@ -73,6 +73,7 @@ The lenses share variance. Position sizing should not double-count the same macr
 | What data feeds we'd need and what they cost | [09-data-sources-catalog.md](./09-data-sources-catalog.md) |
 | What's still unresolved | [10-open-research-questions.md](./10-open-research-questions.md) |
 | Phase A1 sources that need re-wiring in v2 | [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md) |
+| Current live data-quality gaps and closure sequence | [14-data-quality-remediation.md](./14-data-quality-remediation.md) |
 
 ---
 
@@ -81,6 +82,8 @@ The lenses share variance. Position sizing should not double-count the same macr
 Roughly **$0 in new external data costs.** All required series are either free (FRED, GPR, exchange inventory reports, ETF disclosures, WGC CB statistics) or already paid for in this repo (massive.com OHLC, UW options). The cost is engineering time, not data subscriptions.
 
 **Phase A1 ingestion caveat (2026-05-17):** five of the eight anonymous-CSV sources designed for v1 had moved or paywalled by implementation time. See [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md) for the v2 re-wire plan (most-likely fix: lean on official APIs like Socrata/IMF/SEC N-PORT rather than scraping issuer pages).
+
+**Live data-quality caveat (2026-05-18 HKG):** the local warm store now has GLD daily holdings, the WGC monthly ETF corpus, a canonical WGC view, and current + 400-day CFTC gold COT history. Latest posture is pinned to the latest GLD market date and known-bad 2026-05-17 posture rows are invalidated but retained for audit. Lens 1 is still degraded because central-bank reserves and COMEX remain unresolved. Treat the cockpit as a research/audit surface until the remaining checklist in [14-data-quality-remediation.md](./14-data-quality-remediation.md) is closed.
 
 ---
 

--- a/docs/research/gold-sdf-framework/README.md
+++ b/docs/research/gold-sdf-framework/README.md
@@ -83,7 +83,7 @@ Roughly **$0 in new external data costs.** All required series are either free (
 
 **Phase A1 ingestion caveat (2026-05-17):** five of the eight anonymous-CSV sources designed for v1 had moved or paywalled by implementation time. See [11-deferred-sources-phase-a1.md](./11-deferred-sources-phase-a1.md) for the v2 re-wire plan (most-likely fix: lean on official APIs like Socrata/IMF/SEC N-PORT rather than scraping issuer pages).
 
-**Live data-quality caveat (2026-05-18 HKG):** the local warm store now has GLD daily holdings, the WGC monthly ETF corpus, a canonical WGC view, and current + 400-day CFTC gold COT history. Latest posture is pinned to the latest GLD market date and known-bad 2026-05-17 posture rows are invalidated but retained for audit. Lens 1 is still degraded because central-bank reserves and COMEX remain unresolved. Treat the cockpit as a research/audit surface until the remaining checklist in [14-data-quality-remediation.md](./14-data-quality-remediation.md) is closed.
+**Live data-quality caveat (2026-05-18 HKG):** the local warm store now has GLD daily holdings, the WGC monthly ETF corpus, a canonical WGC view, current + 400-day CFTC gold COT history, and WGC/IFS central-bank reserve history for the mapped Lens 1 bucket countries. Latest posture is pinned to the latest GLD market date and known-bad replay rows are invalidated but retained for audit. Lens 1 is still degraded by the missing COMEX source; treat the cockpit as a research/audit surface until the remaining checklist in [14-data-quality-remediation.md](./14-data-quality-remediation.md) is closed.
 
 ---
 

--- a/scripts/gold_cb_reserves_status.py
+++ b/scripts/gold_cb_reserves_status.py
@@ -1,0 +1,66 @@
+"""Print WGC/IFS central-bank gold reserve coverage from the warm store."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import psycopg
+
+from uw_scan.config import Settings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--country",
+        help="Optional ISO3 filter, e.g. CHN or USA.",
+    )
+    args = parser.parse_args()
+
+    settings = Settings.from_env()
+    with psycopg.connect(settings.db_dsn()) as conn:
+        _print_summary(conn, args.country.upper() if args.country else None)
+
+
+def _print_summary(conn: psycopg.Connection[Any], country_iso3: str | None) -> None:
+    country_filter = "WHERE country_iso3 = %s" if country_iso3 else ""
+    params = (country_iso3,) if country_iso3 else ()
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT count(*) AS rows,
+                   count(DISTINCT country_iso3) AS countries,
+                   min(obs_month) AS first_month,
+                   max(obs_month) AS latest_month
+            FROM uw_scan.cb_gold_reserves_monthly
+            {country_filter}
+            """,
+            params,
+        )
+        rows, countries, first_month, latest_month = cur.fetchone()
+        print(
+            "summary "
+            f"rows={rows} countries={countries} "
+            f"first_month={first_month} latest_month={latest_month}"
+        )
+
+        cur.execute(
+            f"""
+            SELECT country_iso3, count(*) AS rows, min(obs_month), max(obs_month)
+            FROM uw_scan.cb_gold_reserves_monthly
+            {country_filter}
+            GROUP BY country_iso3
+            ORDER BY country_iso3
+            """,
+            params,
+        )
+        for iso3, row_count, first_obs, latest_obs in cur.fetchall():
+            print(
+                f"{iso3} rows={row_count} first_month={first_obs} "
+                f"latest_month={latest_obs}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uw_scan/api/routers/gold.py
+++ b/src/uw_scan/api/routers/gold.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from uw_scan.api.deps import get_repo
 from uw_scan.cards.regime_gauge import compute_correlation_gauge
 from uw_scan.models import (
+    GoldCbCountryHistory,
     GoldCorrelationBand,
     GoldCorrelationHistory,
     GoldCorrelationPoint,
@@ -46,6 +47,36 @@ logger = logging.getLogger(__name__)
 
 # Mounted under `/api` by create_app(); final path is `/api/gold/*`.
 router = APIRouter(prefix="/gold", tags=["gold"])
+
+COUNTRY_NAMES = {
+    "ARG": "Argentina",
+    "AUS": "Australia",
+    "AUT": "Austria",
+    "AZE": "Azerbaijan",
+    "BRA": "Brazil",
+    "CHE": "Switzerland",
+    "CHN": "China",
+    "CZE": "Czechia",
+    "DEU": "Germany",
+    "EGY": "Egypt",
+    "FRA": "France",
+    "GBR": "United Kingdom",
+    "HUN": "Hungary",
+    "IND": "India",
+    "ITA": "Italy",
+    "JPN": "Japan",
+    "KAZ": "Kazakhstan",
+    "MEX": "Mexico",
+    "NLD": "Netherlands",
+    "PHL": "Philippines",
+    "POL": "Poland",
+    "QAT": "Qatar",
+    "RUS": "Russia",
+    "SGP": "Singapore",
+    "THA": "Thailand",
+    "TUR": "Turkey",
+    "USA": "United States",
+}
 
 
 # --------------------------------------------------------------------------
@@ -194,7 +225,47 @@ def _data_freshness(blob: Any) -> list[GoldDataFreshnessSource]:
     return out
 
 
-def _state_from_row(row: dict) -> GoldStateResponse:
+def _cb_country_history(
+    repo: Repository,
+    *,
+    as_of: date,
+    as_of_max: datetime,
+) -> list[GoldCbCountryHistory]:
+    rows = repo.fetch_cb_gold_reserves_history(to_month=as_of, as_of_max=as_of_max)
+    by_country: dict[str, list[dict]] = {}
+    for reserve_row in rows:
+        if reserve_row.get("reserves_t") is None:
+            continue
+        by_country.setdefault(reserve_row["country_iso3"], []).append(reserve_row)
+
+    out: list[GoldCbCountryHistory] = []
+    for country_iso3, country_rows in by_country.items():
+        ordered = sorted(country_rows, key=lambda r: r["obs_month"])
+        latest = ordered[-1]
+        out.append(
+            GoldCbCountryHistory(
+                country_iso3=country_iso3,
+                country_name=COUNTRY_NAMES.get(country_iso3, country_iso3),
+                bucket=latest["bucket"],
+                latest_reserves_t=latest.get("reserves_t"),
+                history=[
+                    GoldHistoryPoint(obs_date=r["obs_month"], value=r["reserves_t"])
+                    for r in ordered
+                    if r.get("reserves_t") is not None
+                ],
+            )
+        )
+    return sorted(
+        out,
+        key=lambda c: (-(c.latest_reserves_t or Decimal("0")), c.country_iso3),
+    )
+
+
+def _state_from_row(
+    row: dict,
+    *,
+    cb_country_history: list[GoldCbCountryHistory] | None = None,
+) -> GoldStateResponse:
     inputs_used: dict[str, GoldInputProvenance] = {}
     for sid, meta in (row.get("inputs_jsonb") or {}).items():
         if not isinstance(meta, dict):
@@ -243,6 +314,7 @@ def _state_from_row(row: dict) -> GoldStateResponse:
             xau_cny_premium_pct=row.get("xau_cny_premium_pct"),
             gld_history=_history_points(row.get("gld_history_jsonb")),
             gold_history=_history_points(row.get("gold_history_jsonb")),
+            cb_country_history=cb_country_history or [],
             narrative_text=row.get("structural_posture_text") or "",
         ),
         cyclical=GoldCyclicalPostureModel(
@@ -344,7 +416,12 @@ def get_state(repo: Repository = Depends(get_repo)) -> GoldStateResponse:
     row = repo.fetch_gold_posture_latest()
     if row is None:
         raise HTTPException(404, "no gold posture computed yet")
-    return _state_from_row(row)
+    return _state_from_row(
+        row,
+        cb_country_history=_cb_country_history(
+            repo, as_of=row["obs_date"], as_of_max=row["computed_at"]
+        ),
+    )
 
 
 @router.get("/lenses/{lens_id}", response_model=GoldLensResponse)
@@ -355,7 +432,12 @@ def get_lens(
     row = repo.fetch_gold_posture_latest()
     if row is None:
         raise HTTPException(404, "no gold posture computed yet")
-    state_resp = _state_from_row(row)
+    state_resp = _state_from_row(
+        row,
+        cb_country_history=_cb_country_history(
+            repo, as_of=row["obs_date"], as_of_max=row["computed_at"]
+        ),
+    )
 
     detail: dict[str, list[GoldInputSeriesPoint]] = {}
     if lens_id == "structural":
@@ -414,4 +496,9 @@ def get_replay(
     row = repo.fetch_gold_posture_for_obs_date(as_of)
     if row is None:
         raise HTTPException(404, f"no posture row for {as_of}")
-    return _state_from_row(row)
+    return _state_from_row(
+        row,
+        cb_country_history=_cb_country_history(
+            repo, as_of=row["obs_date"], as_of_max=row["computed_at"]
+        ),
+    )

--- a/src/uw_scan/api/routers/gold.py
+++ b/src/uw_scan/api/routers/gold.py
@@ -170,13 +170,22 @@ def _data_freshness(blob: Any) -> list[GoldDataFreshnessSource]:
             ts = (
                 ts_raw
                 if isinstance(ts_raw, datetime)
-                else datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                else (
+                    datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                    if ts_raw is not None
+                    else None
+                )
             )
             out.append(
                 GoldDataFreshnessSource(
                     id=row["id"],
                     last_as_of=ts,
-                    stale_seconds=int(row.get("stale_seconds", 0)),
+                    stale_seconds=(
+                        int(row["stale_seconds"])
+                        if row.get("stale_seconds") is not None
+                        else None
+                    ),
+                    status=row.get("status", "ok"),
                 )
             )
         except (KeyError, ValueError) as exc:

--- a/src/uw_scan/cards/structural_flow.py
+++ b/src/uw_scan/cards/structural_flow.py
@@ -72,17 +72,29 @@ GLD_OZ_PER_SHARE_PROXY = Decimal("0.0931")
 TROY_OZ_PER_TONNE = Decimal("32150.7466")
 
 
-def _sum_by_bucket(
-    cb_rows: list[CbReserveSnapshot], bucket: str, cutoff: date
+def _net_change_by_bucket(
+    cb_rows: list[CbReserveSnapshot], bucket: str, cutoff: date, as_of: date
 ) -> Decimal | None:
-    rows = [
-        r
-        for r in cb_rows
-        if r.bucket == bucket and r.obs_month >= cutoff and r.reserves_t is not None
-    ]
-    if not rows:
+    by_country: dict[str, list[CbReserveSnapshot]] = {}
+    for row in cb_rows:
+        if (
+            row.bucket == bucket
+            and cutoff <= row.obs_month <= as_of
+            and row.reserves_t is not None
+        ):
+            by_country.setdefault(row.country_iso3, []).append(row)
+    deltas: list[Decimal] = []
+    for rows in by_country.values():
+        ordered = sorted(rows, key=lambda r: r.obs_month)
+        if len(ordered) < 2:
+            continue
+        latest = ordered[-1].reserves_t
+        earliest = ordered[0].reserves_t
+        if latest is not None and earliest is not None:
+            deltas.append(latest - earliest)
+    if not deltas:
         return None
-    return sum((r.reserves_t for r in rows), Decimal("0"))
+    return sum(deltas, Decimal("0"))
 
 
 def _percentile(values: list[Decimal], target: Decimal) -> Decimal | None:
@@ -105,9 +117,15 @@ def compute_structural_posture(
 ) -> StructuralPosture:
     twelve_months_ago = as_of - timedelta(days=365)
 
-    cb_strat = _sum_by_bucket(cb_rows, "strategic_accumulator", twelve_months_ago)
-    cb_tact = _sum_by_bucket(cb_rows, "tactical_defender", twelve_months_ago)
-    cb_div = _sum_by_bucket(cb_rows, "reserve_diversifier", twelve_months_ago)
+    cb_strat = _net_change_by_bucket(
+        cb_rows, "strategic_accumulator", twelve_months_ago, as_of
+    )
+    cb_tact = _net_change_by_bucket(
+        cb_rows, "tactical_defender", twelve_months_ago, as_of
+    )
+    cb_div = _net_change_by_bucket(
+        cb_rows, "reserve_diversifier", twelve_months_ago, as_of
+    )
 
     gld_rows = sorted(
         [r for r in etf_rows if r.ticker == "GLD" and r.holdings_oz is not None],

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -85,6 +85,7 @@ class Settings(BaseModel):
     # WGC Goldhub authenticated downloads. Keep secrets in environment only.
     wgc_goldhub_cookie: SecretStr | None = None
     wgc_etf_flows_workbook_path: str = ""
+    wgc_cb_reserves_workbook_path: str = ""
     # Trade Insights V1.5 local Codex analysis
     trade_insights_ai_enabled: bool = False
     trade_insights_ai_model: str = ""
@@ -210,6 +211,9 @@ class Settings(BaseModel):
             ),
             wgc_etf_flows_workbook_path=os.environ.get(
                 "WGC_ETF_FLOWS_WORKBOOK_PATH", ""
+            ).strip(),
+            wgc_cb_reserves_workbook_path=os.environ.get(
+                "WGC_CB_RESERVES_WORKBOOK_PATH", ""
             ).strip(),
             trade_insights_ai_enabled=_env_bool("TRADE_INSIGHTS_AI_ENABLED", False),
             trade_insights_ai_model=os.environ.get("TRADE_INSIGHTS_AI_MODEL", ""),

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -1330,6 +1330,14 @@ class GoldHistoryPoint(BaseModel):
     value: Decimal
 
 
+class GoldCbCountryHistory(BaseModel):
+    country_iso3: str
+    country_name: str
+    bucket: str
+    latest_reserves_t: Decimal | None = None
+    history: list[GoldHistoryPoint] = []
+
+
 class GoldSpotTile(BaseModel):
     """XAU/USD snapshot used by the Tier 1 KPI strip."""
 
@@ -1360,6 +1368,7 @@ class GoldStructuralPostureModel(BaseModel):
     xau_cny_premium_pct: Decimal | None = None
     gld_history: list[GoldHistoryPoint] = []
     gold_history: list[GoldHistoryPoint] = []
+    cb_country_history: list[GoldCbCountryHistory] = []
     narrative_text: str
 
 

--- a/src/uw_scan/models.py
+++ b/src/uw_scan/models.py
@@ -1404,8 +1404,9 @@ class GoldDataFreshnessSource(BaseModel):
     """Per-source freshness for the Tier 1 Data Freshness card."""
 
     id: str
-    last_as_of: datetime
-    stale_seconds: int
+    last_as_of: datetime | None = None
+    stale_seconds: int | None = None
+    status: Literal["ok", "missing"] = "ok"
 
 
 class GoldDecompositionRow(BaseModel):

--- a/src/uw_scan/reports/gold_posture.py
+++ b/src/uw_scan/reports/gold_posture.py
@@ -219,6 +219,27 @@ def _rank_percentile(series: list[tuple[date, Decimal]], window: int) -> Decimal
     return Decimal(str(round(pct, 4)))
 
 
+def _cot_mm_4w_change_sigma(
+    cot_rows: list[CotSnapshot], *, as_of: date
+) -> Decimal | None:
+    """Z-score of latest managed-money net 4-week change vs trailing changes."""
+    rows = sorted(
+        [r for r in cot_rows if r.mm_net is not None and r.release_date <= as_of],
+        key=lambda r: r.release_date,
+    )
+    if len(rows) < 6:
+        return None
+    values = [float(r.mm_net) for r in rows]
+    changes = [values[idx] - values[idx - 4] for idx in range(4, len(values))]
+    if len(changes) < 2:
+        return None
+    mean = statistics.fmean(changes)
+    std = statistics.pstdev(changes)
+    if std == 0:
+        return None
+    return Decimal(str(round((changes[-1] - mean) / std, 4)))
+
+
 # Conversion constants
 _OZ_PER_TONNE = Decimal("32150.7466")
 
@@ -432,11 +453,11 @@ def compute_and_persist_gold_posture(
     data_freshness = [
         {
             "id": sid,
-            "last_as_of": ts.isoformat(),
-            "stale_seconds": _stale_seconds(ts, now),
+            "last_as_of": ts.isoformat() if ts is not None else None,
+            "stale_seconds": _stale_seconds(ts, now) if ts is not None else None,
+            "status": "ok" if ts is not None else "missing",
         }
         for sid, ts in data_freshness_inputs.items()
-        if ts is not None
     ]
 
     # ---- derived metrics (044 extensions) ---------------------------------
@@ -452,6 +473,7 @@ def compute_and_persist_gold_posture(
     # T5YIFR 52w rank percentile (latest already pulled above).
     t5yifr_series = _series_to_tuples(t5yifr_rows, "obs_date")
     t5yifr_pct_52w = _rank_percentile(t5yifr_series, window=252)
+    cot_mm_4w_change_sigma = _cot_mm_4w_change_sigma(cot_snapshots, as_of=as_of)
 
     # LBMA vault: month-over-month delta in tonnes.
     lbma_rows = repo.fetch_exchange_inventory_daily(
@@ -544,7 +566,7 @@ def compute_and_persist_gold_posture(
         fx_basket_dxy_z=fx_basket_dxy_z,
         xau_cny_premium_pct=None,
         cb_52w_pct=None,
-        cot_mm_4w_change_sigma=None,
+        cot_mm_4w_change_sigma=cot_mm_4w_change_sigma,
         t5yifr_pct_52w=t5yifr_pct_52w,
         dxy=dxy_latest,
         dxy_60d_sigma=dxy_60d_sigma,

--- a/src/uw_scan/sources/cftc_cot.py
+++ b/src/uw_scan/sources/cftc_cot.py
@@ -2,19 +2,17 @@
 
 Source: cftc.gov public reports / API.
 We persist managed-money longs/shorts/net, commercials longs/shorts/net, OI.
-
-Note: CFTC_GOLD_DISAGG_URL is a placeholder; the worker job must pin the actual
-disaggregated gold (commodity code 088691) endpoint before being scheduled.
 """
 
 from __future__ import annotations
 
 import csv
 import io
+import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -26,17 +24,29 @@ from uw_scan.storage.repository import redact_params, status_family_for
 logger = logging.getLogger(__name__)
 
 CFTC_GOLD_DISAGG_URL = (
-    # DEFERRED 2026-05-17: this placeholder still points at the FINANCIAL
-    # futures report (FinFutWk.txt) which does NOT contain gold positions —
-    # gold lives under "Disaggregated Commitments of Traders, Futures-Only"
-    # for commodities. The right wiring is either:
-    #   (1) download the year-zip from
-    #       www.cftc.gov/sites/default/files/files/dea/history/com_disagg_xls_<YYYY>.zip
-    #       and filter market_name == "GOLD" with disaggregated column names, OR
-    #   (2) use Socrata API at publicreporting.cftc.gov for the same dataset.
-    # Until then the parse loop yields 0 rows (column names don't match) and
-    # cot_gold_weekly stays empty — flagged for follow-up.
-    "https://www.cftc.gov/dea/newcot/FinFutWk.txt"
+    "https://www.cftc.gov/dea/newcot/f_disagg.txt"
+)
+CFTC_GOLD_DISAGG_HISTORY_URL = (
+    "https://publicreporting.cftc.gov/resource/72hh-3qpy.json"
+)
+CFTC_GOLD_CONTRACT_MARKET_CODE = "088691"
+
+_CURRENT_FIELD_NAMES = (
+    "Market_and_Exchange_Names",
+    "As_of_Date_In_Form_YYMMDD",
+    "Report_Date_as_YYYY-MM-DD",
+    "CFTC_Contract_Market_Code",
+    "CFTC_Market_Code",
+    "CFTC_Region_Code",
+    "CFTC_Commodity_Code",
+    "Open_Interest_All",
+    "Prod_Merc_Positions_Long_All",
+    "Prod_Merc_Positions_Short_All",
+    "Swap_Positions_Long_All",
+    "Swap__Positions_Short_All",
+    "Swap__Positions_Spread_All",
+    "M_Money_Positions_Long_All",
+    "M_Money_Positions_Short_All",
 )
 
 
@@ -58,7 +68,8 @@ RecordHook = Callable[["CftcCotProvider", ExternalApiRequestEvent], None]
 
 class CftcCotProvider:
     URL = CFTC_GOLD_DISAGG_URL
-    ENDPOINT_PATH = "/dea/newcot/FinFutWk.txt"
+    HISTORY_URL = CFTC_GOLD_DISAGG_HISTORY_URL
+    ENDPOINT_PATH = "/dea/newcot/f_disagg.txt"
     ENDPOINT_KEY = "cftc_cot_disagg_csv"
     PROVIDER = "cftc_cot"
 
@@ -81,39 +92,44 @@ class CftcCotProvider:
         self.close()
 
     def fetch_weekly(self, *, start: date | None = None) -> list[CotRow]:
+        if start is not None:
+            return self._fetch_history_weekly(start=start)
         response = self._get_with_telemetry(self.URL, {})
         response.raise_for_status()
         out: list[CotRow] = []
-        reader = csv.DictReader(io.StringIO(response.text))
-        for row in reader:
+        for row in _iter_disaggregated_rows(response.text):
+            contract_code = _field(row, "CFTC_Contract_Market_Code")
+            if contract_code and contract_code != CFTC_GOLD_CONTRACT_MARKET_CODE:
+                continue
             try:
-                obs = date.fromisoformat(row["Report_Date_as_YYYY-MM-DD"])
-                rel = date.fromisoformat(row["Report_Date_as_YYYY-MM-DD_Release"])
-                mm_l = _dec(row.get("M_Money_Positions_Long_All"))
-                mm_s = _dec(row.get("M_Money_Positions_Short_All"))
-                c_l = _dec(row.get("Prod_Merc_Positions_Long_ALL"))
-                c_s = _dec(row.get("Prod_Merc_Positions_Short_ALL"))
-                oi = _dec(row.get("Open_Interest_All"))
+                cot_row = _cot_row_from_mapping(row)
             except (KeyError, ValueError, InvalidOperation) as exc:
                 logger.debug("cftc cot row parse skipped: %s", repr(exc))
                 continue
-            if start and obs < start:
+            out.append(cot_row)
+        return out
+
+    def _fetch_history_weekly(self, *, start: date) -> list[CotRow]:
+        params = {
+            "$where": (
+                f'cftc_contract_market_code="{CFTC_GOLD_CONTRACT_MARKET_CODE}" '
+                f'AND report_date_as_yyyy_mm_dd >= "{start.isoformat()}T00:00:00"'
+            ),
+            "$order": "report_date_as_yyyy_mm_dd ASC",
+            "$limit": "5000",
+        }
+        response = self._get_with_telemetry(self.HISTORY_URL, params)
+        response.raise_for_status()
+        out: list[CotRow] = []
+        for row in json.loads(response.text):
+            contract_code = _field(row, "cftc_contract_market_code")
+            if contract_code != CFTC_GOLD_CONTRACT_MARKET_CODE:
                 continue
-            mm_n = (mm_l - mm_s) if mm_l is not None and mm_s is not None else None
-            c_n = (c_l - c_s) if c_l is not None and c_s is not None else None
-            out.append(
-                CotRow(
-                    obs_date=obs,
-                    release_date=rel,
-                    mm_long=mm_l,
-                    mm_short=mm_s,
-                    mm_net=mm_n,
-                    comm_long=c_l,
-                    comm_short=c_s,
-                    comm_net=c_n,
-                    open_interest=oi,
-                )
-            )
+            try:
+                out.append(_cot_row_from_mapping(row))
+            except (KeyError, ValueError, InvalidOperation) as exc:
+                logger.debug("cftc cot history row parse skipped: %s", repr(exc))
+                continue
         return out
 
     def _get_with_telemetry(self, url: str, params: dict[str, Any]) -> httpx.Response:
@@ -187,3 +203,68 @@ def _dec(raw: Any) -> Decimal | None:
     except (InvalidOperation, ValueError) as exc:
         logger.debug("cftc decimal parse skipped: %s", repr(exc))
         return None
+
+
+def _field(row: dict[str, Any], *names: str) -> str:
+    for name in names:
+        value = row.get(name)
+        if value is not None and value != "":
+            return str(value).strip()
+    return ""
+
+
+def _obs_date(row: dict[str, Any]) -> date:
+    raw = _field(row, "Report_Date_as_YYYY-MM-DD", "report_date_as_yyyy_mm_dd")
+    return date.fromisoformat(raw[:10])
+
+
+def _cot_row_from_mapping(row: dict[str, Any]) -> CotRow:
+    obs = _obs_date(row)
+    rel = _release_date(row, obs)
+    mm_l = _dec(_field(row, "M_Money_Positions_Long_All", "m_money_positions_long_all"))
+    mm_s = _dec(_field(row, "M_Money_Positions_Short_All", "m_money_positions_short_all"))
+    c_l = _dec(
+        _field(
+            row,
+            "Prod_Merc_Positions_Long_All",
+            "Prod_Merc_Positions_Long_ALL",
+            "prod_merc_positions_long",
+        )
+    )
+    c_s = _dec(
+        _field(
+            row,
+            "Prod_Merc_Positions_Short_All",
+            "Prod_Merc_Positions_Short_ALL",
+            "prod_merc_positions_short",
+        )
+    )
+    oi = _dec(_field(row, "Open_Interest_All", "open_interest_all"))
+    mm_n = (mm_l - mm_s) if mm_l is not None and mm_s is not None else None
+    c_n = (c_l - c_s) if c_l is not None and c_s is not None else None
+    return CotRow(
+        obs_date=obs,
+        release_date=rel,
+        mm_long=mm_l,
+        mm_short=mm_s,
+        mm_net=mm_n,
+        comm_long=c_l,
+        comm_short=c_s,
+        comm_net=c_n,
+        open_interest=oi,
+    )
+
+
+def _iter_disaggregated_rows(text: str) -> list[dict[str, str]]:
+    sample = text.lstrip()
+    first_line = sample.splitlines()[0] if sample else ""
+    if "Report_Date_as_YYYY-MM-DD" in first_line:
+        return list(csv.DictReader(io.StringIO(text)))
+    return list(csv.DictReader(io.StringIO(text), fieldnames=_CURRENT_FIELD_NAMES))
+
+
+def _release_date(row: dict[str, Any], obs: date) -> date:
+    raw = row.get("Report_Date_as_YYYY-MM-DD_Release")
+    if raw:
+        return date.fromisoformat(raw)
+    return obs + timedelta(days=3)

--- a/src/uw_scan/sources/wgc_cb.py
+++ b/src/uw_scan/sources/wgc_cb.py
@@ -1,18 +1,9 @@
-"""World Gold Council monthly central-bank gold reserves.
+"""World Gold Council central-bank gold reserves.
 
-DEFERRED 2026-05-17: WGC retired the anonymous CSV endpoint
-(gold.org/goldhub/data/monthly-central-bank-statistics.csv → 404). All
-downloads now sit behind a Goldhub login (verified 2026-05-17). The provider
-is kept as-is so re-wiring to an authenticated download / IMF IFS fallback
-is a one-source change rather than a structural refactor.
-
-When picking it up: the structural lens's CB tiles
-(cb_strategic_12m_sum_t / cb_tactical_12m_sum_t / cb_diversifier_12m_sum_t)
-stay null until this lands, and `cb_gold_reserves_monthly` stays empty.
-
-Source (deferred): gold.org/goldhub/data/gold-reserves-by-country
-CSV columns observed pre-retirement: Country, Month, Tonnes, Reported, Estimated.
-ISO3 mapping in COUNTRY_ISO3 — extend as new countries appear.
+WGC's old anonymous monthly CSV retired in May 2026. The current Goldhub page
+publishes authenticated XLSX downloads sourced from IMF IFS plus WGC
+adjustments. This provider keeps the old CSV parser for historical fixtures
+and adds the authenticated/local quarterly workbook path used by Goldhub.
 """
 
 from __future__ import annotations
@@ -20,13 +11,16 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal, InvalidOperation
+from pathlib import Path
 from typing import Any
 
 import httpx
+from openpyxl import load_workbook
 
 from uw_scan.cards.cb_buckets import classify_bucket
 from uw_scan.storage.provider_usage import ExternalApiRequestEvent
@@ -35,13 +29,23 @@ from uw_scan.storage.repository import redact_params, status_family_for
 logger = logging.getLogger(__name__)
 
 COUNTRY_ISO3 = {
+    "argentina": "ARG",
+    "australia": "AUS",
+    "austria": "AUT",
+    "azerbaijan": "AZE",
+    "azerbaijan, rep. of": "AZE",
+    "brazil": "BRA",
     "china": "CHN",
+    "china, p.r.: mainland": "CHN",
+    "czech rep.": "CZE",
     "india": "IND",
     "russia": "RUS",
     "russian federation": "RUS",
     "turkey": "TUR",
     "türkiye": "TUR",
+    "türkiye, rep of5": "TUR",
     "poland": "POL",
+    "poland, rep. of": "POL",
     "czech republic": "CZE",
     "czechia": "CZE",
     "singapore": "SGP",
@@ -50,8 +54,6 @@ COUNTRY_ISO3 = {
     "philippines": "PHL",
     "thailand": "THA",
     "mexico": "MEX",
-    "brazil": "BRA",
-    "argentina": "ARG",
     "germany": "DEU",
     "france": "FRA",
     "italy": "ITA",
@@ -62,9 +64,11 @@ COUNTRY_ISO3 = {
     "us": "USA",
     "switzerland": "CHE",
     "netherlands": "NLD",
+    "netherlands, the": "NLD",
     "egypt": "EGY",
+    "egypt, arab rep. of": "EGY",
     "kazakhstan": "KAZ",
-    "azerbaijan": "AZE",
+    "kazakhstan, rep. of": "KAZ",
 }
 
 
@@ -83,17 +87,23 @@ RecordHook = Callable[["WgcCbProvider", ExternalApiRequestEvent], None]
 
 class WgcCbProvider:
     URL = "https://www.gold.org/goldhub/data/monthly-central-bank-statistics.csv"
+    RESERVES_PAGE_URL = "https://www.gold.org/goldhub/data/gold-reserves-by-country"
     ENDPOINT_PATH = "/goldhub/data/monthly-central-bank-statistics.csv"
     ENDPOINT_KEY = "wgc_cb_monthly_csv"
+    QUARTERLY_ENDPOINT_KEY = "wgc_cb_quarterly_xlsx"
     PROVIDER = "wgc_cb"
 
     def __init__(
         self,
         *,
         timeout_s: float = 30.0,
+        cookie_header: str | None = None,
+        workbook_path: str | Path | None = None,
         record_request: RecordHook | None = None,
     ):
-        self._client = httpx.Client(timeout=timeout_s)
+        headers = {"Cookie": cookie_header} if cookie_header else None
+        self._client = httpx.Client(timeout=timeout_s, headers=headers)
+        self._workbook_path = Path(workbook_path) if workbook_path else None
         self._record_request_fn = record_request
 
     def close(self) -> None:
@@ -106,10 +116,48 @@ class WgcCbProvider:
         self.close()
 
     def fetch_monthly(self, *, start: date | None = None) -> list[CbReserveRow]:
+        if self._workbook_path is not None:
+            return self.parse_quarterly_workbook(self._workbook_path, start=start)
+        if "Cookie" in self._client.headers:
+            workbook_bytes, source_url = self.fetch_quarterly_workbook()
+            return self.parse_quarterly_workbook(
+                io.BytesIO(workbook_bytes), start=start, source_url=source_url
+            )
         response = self._get_with_telemetry(self.URL, {})
         response.raise_for_status()
+        return self.parse_monthly_csv(response.text, start=start)
+
+    def fetch_quarterly_workbook(self) -> tuple[bytes, str]:
+        page = self._get_with_telemetry(
+            self.RESERVES_PAGE_URL,
+            {},
+            endpoint_key="wgc_cb_reserves_page",
+            endpoint_path="/goldhub/data/gold-reserves-by-country",
+        )
+        page.raise_for_status()
+        match = re.search(
+            r'href="(?P<href>[^"]*Quarterly_gold_and_FX_Reserves[^"]*\.xlsx)"',
+            page.text,
+        )
+        if match is None:
+            raise RuntimeError("WGC CB quarterly workbook link not found")
+        href = match.group("href")
+        url = href if href.startswith("http") else f"https://www.gold.org{href}"
+        response = self._get_with_telemetry(
+            url,
+            {},
+            endpoint_key=self.QUARTERLY_ENDPOINT_KEY,
+            endpoint_path="/download/file/:id/Quarterly_gold_and_FX_Reserves.xlsx",
+        )
+        response.raise_for_status()
+        return response.content, url
+
+    @classmethod
+    def parse_monthly_csv(
+        cls, text: str, *, start: date | None = None
+    ) -> list[CbReserveRow]:
         out: list[CbReserveRow] = []
-        reader = csv.DictReader(io.StringIO(response.text))
+        reader = csv.DictReader(io.StringIO(text))
         for row in reader:
             country = (row.get("Country") or "").strip().lower()
             iso3 = COUNTRY_ISO3.get(country)
@@ -153,7 +201,62 @@ class WgcCbProvider:
             )
         return out
 
-    def _get_with_telemetry(self, url: str, params: dict[str, Any]) -> httpx.Response:
+    @classmethod
+    def parse_quarterly_workbook(
+        cls,
+        workbook: str | Path | io.BytesIO,
+        *,
+        start: date | None = None,
+        source_url: str | None = None,
+    ) -> list[CbReserveRow]:
+        del source_url
+        wb = load_workbook(workbook, data_only=True, read_only=True)
+        if "Gold (Tonnes)" not in wb.sheetnames:
+            raise ValueError("WGC CB workbook missing Gold (Tonnes) sheet")
+        sheet = wb["Gold (Tonnes)"]
+        quarter_cols: list[tuple[int, date]] = []
+        for cell in sheet[2][2:]:
+            obs = _quarter_label_to_date(cell.value)
+            if obs is None:
+                continue
+            if start is not None and obs < start:
+                continue
+            quarter_cols.append((cell.column, obs))
+
+        out: list[CbReserveRow] = []
+        for row in sheet.iter_rows(min_row=3):
+            country = _cell_text(row[1].value) or _cell_text(row[0].value)
+            if not country:
+                continue
+            iso3 = COUNTRY_ISO3.get(country.lower())
+            if iso3 is None:
+                logger.debug("wgc_cb: unknown workbook country %r, skipping", country)
+                continue
+            for col_idx, obs_month in quarter_cols:
+                value = row[col_idx - 1].value
+                reserves_t = _decimal_or_none(value)
+                if reserves_t is None:
+                    continue
+                out.append(
+                    CbReserveRow(
+                        country_iso3=iso3,
+                        obs_month=obs_month,
+                        reserves_t=reserves_t,
+                        bucket=classify_bucket(iso3),
+                        is_reported=True,
+                        is_estimated=False,
+                    )
+                )
+        return out
+
+    def _get_with_telemetry(
+        self,
+        url: str,
+        params: dict[str, Any],
+        *,
+        endpoint_key: str | None = None,
+        endpoint_path: str | None = None,
+    ) -> httpx.Response:
         started_at = datetime.now(UTC)
         try:
             response = self._client.get(url, params=params)
@@ -164,6 +267,8 @@ class WgcCbProvider:
                     started_at,
                     finished_at,
                     params,
+                    endpoint_key=endpoint_key,
+                    endpoint_path=endpoint_path,
                     status_code=None,
                     error_message=repr(exc)[:1000],
                 )
@@ -175,6 +280,8 @@ class WgcCbProvider:
                 started_at,
                 finished_at,
                 params,
+                endpoint_key=endpoint_key,
+                endpoint_path=endpoint_path,
                 status_code=response.status_code,
                 error_message=(
                     response.text[:1000] if response.status_code >= 400 else None
@@ -195,15 +302,18 @@ class WgcCbProvider:
         finished_at: datetime,
         params: dict[str, Any],
         *,
+        endpoint_key: str | None = None,
+        endpoint_path: str | None = None,
         status_code: int | None,
         error_message: str | None,
     ) -> ExternalApiRequestEvent:
+        path = endpoint_path or self.ENDPOINT_PATH
         return ExternalApiRequestEvent(
             provider=self.PROVIDER,
-            endpoint_key=self.ENDPOINT_KEY,
+            endpoint_key=endpoint_key or self.ENDPOINT_KEY,
             method="GET",
-            path=self.ENDPOINT_PATH,
-            path_template=self.ENDPOINT_PATH,
+            path=path,
+            path_template=path,
             params=redact_params(params),
             status_code=status_code,
             status_family=status_family_for(
@@ -214,3 +324,32 @@ class WgcCbProvider:
             latency_ms=max(0, int((finished_at - started_at).total_seconds() * 1000)),
             error_message=error_message,
         )
+
+
+def _cell_text(value: object) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _quarter_label_to_date(value: object) -> date | None:
+    text = _cell_text(value)
+    match = re.fullmatch(r"Q([1-4])\s+(\d{4})", text)
+    if match is None:
+        return None
+    quarter = int(match.group(1))
+    year = int(match.group(2))
+    month_day = {
+        1: (3, 31),
+        2: (6, 30),
+        3: (9, 30),
+        4: (12, 31),
+    }[quarter]
+    return date(year, *month_day)

--- a/src/uw_scan/sources/wgc_cb.py
+++ b/src/uw_scan/sources/wgc_cb.py
@@ -335,7 +335,8 @@ def _decimal_or_none(value: object) -> Decimal | None:
         return None
     try:
         return Decimal(str(value))
-    except (InvalidOperation, ValueError):
+    except (InvalidOperation, ValueError) as exc:
+        logger.debug("WGC reserve value parse skipped: %s", repr(exc))
         return None
 
 

--- a/src/uw_scan/storage/gold_etf.py
+++ b/src/uw_scan/storage/gold_etf.py
@@ -236,9 +236,9 @@ class _GoldEtfMixin:
                   gold_price_usd_oz, aggregate_ounces, aggregate_holdings_tonnes,
                   aggregate_value_usd, holdings_tonnes, demand_tonnes, flow_usd_mn,
                   source_url, source_label, as_of, source
-                FROM {self._schema}.wgc_etf_monthly
+                FROM {self._schema}.wgc_etf_monthly_canonical
                 WHERE {where}
-                ORDER BY obs_date ASC, as_of DESC, source_url DESC
+                ORDER BY obs_date ASC
                 """,
                 params,
             )

--- a/src/uw_scan/storage/migrations/046_wgc_etf_monthly.sql
+++ b/src/uw_scan/storage/migrations/046_wgc_etf_monthly.sql
@@ -31,3 +31,38 @@ CREATE INDEX IF NOT EXISTS idx_wgc_etf_monthly_lookup
 
 CREATE INDEX IF NOT EXISTS idx_wgc_etf_monthly_source
   ON uw_scan.wgc_etf_monthly (source_url, obs_date DESC);
+
+CREATE OR REPLACE VIEW uw_scan.wgc_etf_monthly_canonical AS
+WITH source_revisions AS (
+  SELECT
+    source_url,
+    max(obs_date) AS revision_obs_date
+  FROM uw_scan.wgc_etf_monthly
+  GROUP BY source_url
+)
+SELECT DISTINCT ON (w.ticker, w.obs_date)
+  w.ticker,
+  w.obs_date,
+  w.fund_name,
+  w.fund_type,
+  w.region,
+  w.country,
+  w.gold_price_usd_oz,
+  w.aggregate_ounces,
+  w.aggregate_holdings_tonnes,
+  w.aggregate_value_usd,
+  w.holdings_tonnes,
+  w.demand_tonnes,
+  w.flow_usd_mn,
+  w.source_url,
+  w.source_label,
+  w.as_of,
+  w.source
+FROM uw_scan.wgc_etf_monthly w
+JOIN source_revisions s ON s.source_url = w.source_url
+ORDER BY
+  w.ticker,
+  w.obs_date,
+  s.revision_obs_date DESC,
+  w.as_of DESC,
+  w.source_url DESC;

--- a/src/uw_scan/storage/migrations/047_gold_posture_row_status.sql
+++ b/src/uw_scan/storage/migrations/047_gold_posture_row_status.sql
@@ -1,0 +1,66 @@
+-- 047_gold_posture_row_status.sql — Gold replay invalidation.
+-- Keeps posture audit rows while letting normal replay skip rows later found to
+-- contain bad persisted payloads.
+
+SET search_path TO uw_scan, public;
+
+ALTER TABLE uw_scan.gold_posture_daily
+  ADD COLUMN IF NOT EXISTS row_status TEXT NOT NULL DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS superseded_reason TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_gold_posture_daily_replay_active
+  ON uw_scan.gold_posture_daily (obs_date, computed_at ASC)
+  WHERE row_status = 'active';
+
+UPDATE uw_scan.gold_posture_daily
+SET row_status = 'invalidated',
+    superseded_reason = COALESCE(
+      superseded_reason,
+      'gld_history_jsonb stored ounces before tonnes normalization'
+    )
+WHERE row_status = 'active'
+  AND gld_history_jsonb IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(gld_history_jsonb) AS elem
+    WHERE (elem ->> 'value')::numeric > 10000
+  );
+
+WITH first_valid_gld_history AS (
+  SELECT p.obs_date, min(p.computed_at) AS first_valid_computed_at
+  FROM uw_scan.gold_posture_daily p
+  WHERE p.gld_history_jsonb IS NOT NULL
+    AND jsonb_array_length(p.gld_history_jsonb) > 0
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(p.gld_history_jsonb) AS elem
+      WHERE (elem ->> 'value')::numeric > 10000
+    )
+  GROUP BY p.obs_date
+)
+UPDATE uw_scan.gold_posture_daily p
+SET row_status = 'invalidated',
+    superseded_reason = COALESCE(
+      p.superseded_reason,
+      'superseded by later posture row with valid GLD history payload'
+    )
+FROM first_valid_gld_history valid
+WHERE p.row_status = 'active'
+  AND p.obs_date = valid.obs_date
+  AND p.computed_at < valid.first_valid_computed_at;
+
+WITH latest_gld_close AS (
+  SELECT max(obs_date) AS obs_date
+  FROM uw_scan.macro_series_daily
+  WHERE series_id = 'GLD_CLOSE'
+)
+UPDATE uw_scan.gold_posture_daily p
+SET row_status = 'invalidated',
+    superseded_reason = COALESCE(
+      p.superseded_reason,
+      'posture obs_date is after latest available GLD close'
+    )
+FROM latest_gld_close latest
+WHERE p.row_status = 'active'
+  AND latest.obs_date IS NOT NULL
+  AND p.obs_date > latest.obs_date;

--- a/src/uw_scan/storage/migrations/048_gold_cb_flow_replay_invalidation.sql
+++ b/src/uw_scan/storage/migrations/048_gold_cb_flow_replay_invalidation.sql
@@ -1,0 +1,44 @@
+-- 048_gold_cb_flow_replay_invalidation.sql — invalidate CB level-sum posture rows.
+-- A short-lived bug summed CB reserve levels as a 12m flow after WGC data was
+-- populated. Keep audit rows, but make replay prefer rows recomputed from
+-- country-level net changes.
+
+SET search_path TO uw_scan, public;
+
+UPDATE uw_scan.gold_posture_daily
+SET row_status = 'invalidated',
+    superseded_reason = COALESCE(
+      superseded_reason,
+      'cb 12m flow fields contained summed reserve levels instead of net changes'
+    )
+WHERE row_status = 'active'
+  AND (
+    abs(COALESCE(cb_strategic_12m_sum_t, 0)) > 10000
+    OR abs(COALESCE(cb_tactical_12m_sum_t, 0)) > 10000
+    OR abs(COALESCE(cb_diversifier_12m_sum_t, 0)) > 10000
+  );
+
+WITH first_cb_populated AS (
+  SELECT obs_date, min(computed_at) AS first_cb_computed_at
+  FROM uw_scan.gold_posture_daily
+  WHERE row_status = 'active'
+    AND (
+      cb_strategic_12m_sum_t IS NOT NULL
+      OR cb_tactical_12m_sum_t IS NOT NULL
+      OR cb_diversifier_12m_sum_t IS NOT NULL
+    )
+    AND abs(COALESCE(cb_strategic_12m_sum_t, 0)) <= 10000
+    AND abs(COALESCE(cb_tactical_12m_sum_t, 0)) <= 10000
+    AND abs(COALESCE(cb_diversifier_12m_sum_t, 0)) <= 10000
+  GROUP BY obs_date
+)
+UPDATE uw_scan.gold_posture_daily p
+SET row_status = 'invalidated',
+    superseded_reason = COALESCE(
+      p.superseded_reason,
+      'superseded by later posture row populated with CB reserve flows'
+    )
+FROM first_cb_populated valid
+WHERE p.row_status = 'active'
+  AND p.obs_date = valid.obs_date
+  AND p.computed_at < valid.first_cb_computed_at;

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -4870,6 +4870,7 @@ class Repository(
                 """
                 SELECT *
                 FROM uw_scan.gold_posture_daily
+                WHERE row_status = 'active'
                 ORDER BY obs_date DESC, computed_at DESC
                 LIMIT 1
                 """,
@@ -4881,14 +4882,14 @@ class Repository(
             return dict(zip(cols, row, strict=True))
 
     def fetch_gold_posture_for_obs_date(self, obs_date: _date) -> dict[str, Any] | None:
-        """Replay discipline: return the FIRST-computed posture for an obs_date,
-        not the most recent recomputation."""
+        """Replay discipline: return the first non-invalidated posture row."""
         with self._conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT *
                 FROM uw_scan.gold_posture_daily
                 WHERE obs_date = %s
+                  AND row_status = 'active'
                 ORDER BY computed_at ASC
                 LIMIT 1
                 """,

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -4549,6 +4549,44 @@ class Repository(
             cols = [c.name for c in cur.description]
             return [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
 
+    def fetch_cb_gold_reserves_history(
+        self,
+        *,
+        country_iso3: str | None = None,
+        from_month: _date | None = None,
+        to_month: _date | None = None,
+        as_of_max: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses = ["TRUE"]
+        params: list[Any] = []
+        if country_iso3 is not None:
+            clauses.append("country_iso3 = %s")
+            params.append(country_iso3)
+        if from_month is not None:
+            clauses.append("obs_month >= %s")
+            params.append(from_month)
+        if to_month is not None:
+            clauses.append("obs_month <= %s")
+            params.append(to_month)
+        if as_of_max is not None:
+            clauses.append("as_of <= %s")
+            params.append(as_of_max)
+        where = " AND ".join(clauses)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT DISTINCT ON (country_iso3, obs_month)
+                  country_iso3, obs_month, reserves_t, bucket,
+                  is_reported, is_estimated, as_of, release_date, source
+                FROM uw_scan.cb_gold_reserves_monthly
+                WHERE {where}
+                ORDER BY country_iso3, obs_month ASC, as_of DESC
+                """,
+                params,
+            )
+            cols = [c.name for c in cur.description]
+            return [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+
     # ---- Gold (Phase A1) — CFTC COT ----
 
     def insert_cot_gold_weekly(

--- a/src/uw_scan/worker/gold_warmup.py
+++ b/src/uw_scan/worker/gold_warmup.py
@@ -98,7 +98,19 @@ def main() -> int:
         ("COMEX vault daily", lambda: gold_comex_vault_ingest_job(dsn=dsn)),
         ("CFTC COT weekly", lambda: gold_cftc_cot_ingest_job(dsn=dsn)),
         ("LBMA vault monthly", lambda: gold_lbma_vault_ingest_job(dsn=dsn)),
-        ("WGC CB reserves monthly (deferred)", lambda: gold_wgc_cb_ingest_job(dsn=dsn)),
+        (
+            "WGC CB reserves monthly",
+            lambda: gold_wgc_cb_ingest_job(
+                dsn=dsn,
+                wgc_goldhub_cookie=(
+                    settings.wgc_goldhub_cookie.get_secret_value()
+                    if settings.wgc_goldhub_cookie is not None
+                    else None
+                ),
+                wgc_workbook_path=settings.wgc_cb_reserves_workbook_path or None,
+                lookback_days=None,
+            ),
+        ),
         (
             "UW options snapshot (GLD/GDX/IAU)",
             lambda: gold_uw_options_ingest_job(

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -517,12 +517,19 @@ def gold_wgc_cb_ingest_job(*, dsn: str) -> None:
 def gold_posture_compute_job(*, dsn: str, as_of: date | None = None) -> None:
     """Compute and persist today's gold_posture_daily row. Schedule: 21:00 ET
     (after all ingest jobs complete)."""
-    target = as_of or date.today()
     with psycopg.connect(dsn) as conn:
         repo = Repository(conn, schema="uw_scan")
+        target = as_of or _latest_gold_market_date(repo)
         try:
             compute_and_persist_gold_posture(repo, as_of=target)
             conn.commit()
         except Exception as exc:
             logger.exception("gold_posture_compute failed: %r", exc)
             conn.rollback()
+
+
+def _latest_gold_market_date(repo: Repository) -> date:
+    rows = repo.fetch_macro_series_daily("GLD_CLOSE", to_date=date.today())
+    if not rows:
+        return date.today()
+    return rows[-1]["obs_date"]

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -47,6 +47,7 @@ from uw_scan.sources.uw_gold_options import (
     fetch_gold_options_snapshot,
 )
 from uw_scan.sources.wgc_etf import TROY_OZ_PER_TONNE, WgcEtfProvider
+from uw_scan.sources.wgc_cb import WgcCbProvider
 from uw_scan.storage.repository import Repository
 
 logger = logging.getLogger(__name__)
@@ -497,18 +498,53 @@ def gold_lbma_vault_ingest_job(*, dsn: str) -> None:
         conn.commit()
 
 
-def gold_wgc_cb_ingest_job(*, dsn: str) -> None:
+def gold_wgc_cb_ingest_job(
+    *,
+    dsn: str,
+    wgc_goldhub_cookie: str | None = None,
+    wgc_workbook_path: str | None = None,
+    lookback_days: int | None = 400,
+) -> None:
     """Monthly WGC CB reserves (8th business day of month).
 
-    DEFERRED — WGC retired the anonymous CSV endpoint (2026-05-17). Job is
-    a no-op until an authenticated download or IMF IFS fallback is wired;
-    see src/uw_scan/sources/wgc_cb.py docstring.
+    WGC retired the anonymous CSV endpoint (2026-05-17). Use either
+    WGC_CB_RESERVES_WORKBOOK_PATH for a local authenticated export or
+    WGC_GOLDHUB_COOKIE for an authenticated Goldhub download.
     """
-    logger.info(
-        "gold_wgc_cb_ingest: skipped — WGC endpoint behind login since 2026-05-17 "
-        "(see sources/wgc_cb.py)"
-    )
-    return
+    if not wgc_goldhub_cookie and not wgc_workbook_path:
+        logger.info(
+            "gold_wgc_cb_ingest: skipped — set WGC_CB_RESERVES_WORKBOOK_PATH "
+            "or WGC_GOLDHUB_COOKIE"
+        )
+        return
+
+    now = datetime.now(UTC)
+    with psycopg.connect(dsn) as conn, WgcCbProvider(
+        cookie_header=wgc_goldhub_cookie,
+        workbook_path=wgc_workbook_path,
+    ) as wgc:
+        repo = Repository(conn, schema="uw_scan")
+        try:
+            start = date.today() - timedelta(days=lookback_days) if lookback_days else None
+            for row in wgc.fetch_monthly(start=start):
+                repo.insert_cb_gold_reserves_monthly(
+                    country_iso3=row.country_iso3,
+                    obs_month=row.obs_month,
+                    reserves_t=row.reserves_t,
+                    bucket=row.bucket,
+                    is_reported=row.is_reported,
+                    is_estimated=row.is_estimated,
+                    as_of=now,
+                    release_date=now.date(),
+                    source=(
+                        f"file:{wgc_workbook_path}"
+                        if wgc_workbook_path
+                        else WgcCbProvider.RESERVES_PAGE_URL
+                    ),
+                )
+        except Exception as exc:
+            logger.exception("gold_wgc_cb_ingest failed: %r", exc)
+        conn.commit()
 
 
 # --- Orchestrator job ---------------------------------------------------------

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -452,7 +452,15 @@ def main() -> int:
         gold_lbma_vault_ingest_job(dsn=settings.db_dsn())
 
     def _gold_wgc_cb_ingest() -> None:
-        gold_wgc_cb_ingest_job(dsn=settings.db_dsn())
+        gold_wgc_cb_ingest_job(
+            dsn=settings.db_dsn(),
+            wgc_goldhub_cookie=(
+                settings.wgc_goldhub_cookie.get_secret_value()
+                if settings.wgc_goldhub_cookie is not None
+                else None
+            ),
+            wgc_workbook_path=settings.wgc_cb_reserves_workbook_path or None,
+        )
 
     def _gold_posture_compute() -> None:
         gold_posture_compute_job(dsn=settings.db_dsn())

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -3421,29 +3421,50 @@
         "type": "object"
       },
       "GoldDataFreshnessSource": {
-        "description": "Per-source freshness for the Tier 1 Data Freshness card.",
         "properties": {
           "id": {
-            "title": "Id",
-            "type": "string"
+            "type": "string",
+            "title": "Id"
           },
           "last_as_of": {
-            "format": "date-time",
-            "title": "Last As Of",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last As Of"
           },
           "stale_seconds": {
-            "title": "Stale Seconds",
-            "type": "integer"
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stale Seconds"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "missing"
+            ],
+            "title": "Status",
+            "default": "ok"
           }
         },
+        "type": "object",
         "required": [
-          "id",
-          "last_as_of",
-          "stale_seconds"
+          "id"
         ],
         "title": "GoldDataFreshnessSource",
-        "type": "object"
+        "description": "Per-source freshness for the Tier 1 Data Freshness card."
       },
       "GoldDecompositionRow": {
         "description": "One row of the Tier 5 lens-decomposition bars.",

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -3183,6 +3183,49 @@
         "title": "GexSourceDeltaEntry",
         "type": "object"
       },
+      "GoldCbCountryHistory": {
+        "properties": {
+          "bucket": {
+            "title": "Bucket",
+            "type": "string"
+          },
+          "country_iso3": {
+            "title": "Country Iso3",
+            "type": "string"
+          },
+          "country_name": {
+            "title": "Country Name",
+            "type": "string"
+          },
+          "history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/GoldHistoryPoint"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "latest_reserves_t": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Reserves T"
+          }
+        },
+        "required": [
+          "country_iso3",
+          "country_name",
+          "bucket"
+        ],
+        "title": "GoldCbCountryHistory",
+        "type": "object"
+      },
       "GoldCorrelationBand": {
         "properties": {
           "mean": {
@@ -3421,16 +3464,17 @@
         "type": "object"
       },
       "GoldDataFreshnessSource": {
+        "description": "Per-source freshness for the Tier 1 Data Freshness card.",
         "properties": {
           "id": {
-            "type": "string",
-            "title": "Id"
+            "title": "Id",
+            "type": "string"
           },
           "last_as_of": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3450,21 +3494,20 @@
             "title": "Stale Seconds"
           },
           "status": {
-            "type": "string",
+            "default": "ok",
             "enum": [
               "ok",
               "missing"
             ],
             "title": "Status",
-            "default": "ok"
+            "type": "string"
           }
         },
-        "type": "object",
         "required": [
           "id"
         ],
         "title": "GoldDataFreshnessSource",
-        "description": "Per-source freshness for the Tier 1 Data Freshness card."
+        "type": "object"
       },
       "GoldDecompositionRow": {
         "description": "One row of the Tier 5 lens-decomposition bars.",
@@ -3895,6 +3938,14 @@
               }
             ],
             "title": "Cb 52W Pct"
+          },
+          "cb_country_history": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/GoldCbCountryHistory"
+            },
+            "title": "Cb Country History",
+            "type": "array"
           },
           "cb_diversifier_12m_sum_t": {
             "anyOf": [

--- a/tests/integration/api/test_gold_router_state.py
+++ b/tests/integration/api/test_gold_router_state.py
@@ -44,6 +44,21 @@ def app_with_posture() -> TestClient:
     )
     with psycopg.connect(settings.db_dsn()) as conn:
         repo = Repository(conn, schema=settings.db_schema)
+        for obs_month, reserves_t in (
+            (date(2025, 3, 31), Decimal("2264.3")),
+            (date(2026, 3, 31), Decimal("2313.5")),
+        ):
+            repo.insert_cb_gold_reserves_monthly(
+                country_iso3="CHN",
+                obs_month=obs_month,
+                reserves_t=reserves_t,
+                bucket="strategic_accumulator",
+                is_reported=True,
+                is_estimated=False,
+                as_of=datetime(2026, 5, 16, tzinfo=UTC),
+                release_date=date(2026, 5, 1),
+                source="test",
+            )
         repo.insert_gold_posture_daily(
             obs_date=date(2026, 5, 16),
             computed_at=datetime(2026, 5, 17, tzinfo=UTC),
@@ -144,6 +159,8 @@ def test_state_endpoint_returns_latest_posture(
     assert body["cyclical"]["zone_label"] == "moderate-trap"
     # GOLD COMPASS extensions
     assert body["structural"]["posture_chip"] == "FAVORABLE"
+    assert body["structural"]["cb_country_history"][0]["country_iso3"] == "CHN"
+    assert len(body["structural"]["cb_country_history"][0]["history"]) == 2
     assert body["valuation"]["posture_chip"] == "STRETCHED"
     assert body["spot"]["last"] == "4561.50"
     assert len(body["decomposition_rows"]) == 1

--- a/tests/integration/reports/test_gold_posture_orchestrator.py
+++ b/tests/integration/reports/test_gold_posture_orchestrator.py
@@ -124,6 +124,10 @@ def test_orchestrator_writes_posture_row(repo: Repository) -> None:
     }
     assert row["gld_history_jsonb"][-1]["obs_date"] == today.isoformat()
     assert Decimal(row["gld_history_jsonb"][-1]["value"]) == Decimal("1000")
+    freshness_by_id = {item["id"]: item for item in row["data_freshness_jsonb"]}
+    assert freshness_by_id["COMEX"]["status"] == "missing"
+    assert freshness_by_id["COT"]["status"] == "missing"
+    assert freshness_by_id["WGC"]["status"] == "missing"
 
 
 def test_orchestrator_idempotent_same_inputs(repo: Repository) -> None:

--- a/tests/integration/storage/test_gold_migrations.py
+++ b/tests/integration/storage/test_gold_migrations.py
@@ -185,6 +185,8 @@ def test_gold_tables_created(fresh_schema):
             "correlation_history_jsonb",
             "gld_history_jsonb",
             "gold_history_jsonb",
+            "row_status",
+            "superseded_reason",
         },
     }
     for table, cols in expected.items():
@@ -237,3 +239,4 @@ def test_gold_posture_pk_and_index(fresh_schema):
         )
         idx = {row[0] for row in cur.fetchall()}
     assert "idx_gold_posture_daily_latest" in idx
+    assert "idx_gold_posture_daily_replay_active" in idx

--- a/tests/integration/storage/test_gold_repo_etf_inventory.py
+++ b/tests/integration/storage/test_gold_repo_etf_inventory.py
@@ -116,6 +116,77 @@ def test_insert_and_fetch_wgc_etf_monthly(repo: Repository) -> None:
     assert rows[0]["source_url"].endswith("ETF_Flows_March_2026.xlsx")
 
 
+def test_fetch_wgc_etf_monthly_prefers_latest_workbook_revision(repo: Repository) -> None:
+    as_of = datetime.now(UTC)
+    repo.insert_wgc_etf_monthly(
+        ticker="GLD",
+        obs_date=date(2026, 3, 31),
+        fund_name="SPDR Gold Shares",
+        fund_type="ETF",
+        region="North America",
+        country="US",
+        gold_price_usd_oz=Decimal("2983.25"),
+        aggregate_ounces=None,
+        aggregate_holdings_tonnes=None,
+        aggregate_value_usd=None,
+        holdings_tonnes=Decimal("1040.0"),
+        demand_tonnes=Decimal("-10.0"),
+        flow_usd_mn=Decimal("-100.0"),
+        source_url="file:///wgc/ETF_Flows_March_2026.xlsx",
+        source_label="ETF_Flows_March_2026.xlsx",
+        as_of=as_of,
+        source="WGC",
+    )
+    repo.insert_wgc_etf_monthly(
+        ticker="GLD",
+        obs_date=date(2026, 3, 31),
+        fund_name="SPDR Gold Shares",
+        fund_type="ETF",
+        region="North America",
+        country="US",
+        gold_price_usd_oz=Decimal("2983.25"),
+        aggregate_ounces=None,
+        aggregate_holdings_tonnes=None,
+        aggregate_value_usd=None,
+        holdings_tonnes=Decimal("1042.5"),
+        demand_tonnes=Decimal("-7.5"),
+        flow_usd_mn=Decimal("-75.0"),
+        source_url="file:///wgc/ETF_Flows_April_2026.xlsx",
+        source_label="ETF_Flows_April_2026.xlsx",
+        as_of=as_of,
+        source="WGC",
+    )
+    repo.insert_wgc_etf_monthly(
+        ticker="GLD",
+        obs_date=date(2026, 4, 30),
+        fund_name="SPDR Gold Shares",
+        fund_type="ETF",
+        region="North America",
+        country="US",
+        gold_price_usd_oz=Decimal("3325.10"),
+        aggregate_ounces=None,
+        aggregate_holdings_tonnes=None,
+        aggregate_value_usd=None,
+        holdings_tonnes=Decimal("1050.0"),
+        demand_tonnes=Decimal("7.5"),
+        flow_usd_mn=Decimal("75.0"),
+        source_url="file:///wgc/ETF_Flows_April_2026.xlsx",
+        source_label="ETF_Flows_April_2026.xlsx",
+        as_of=as_of,
+        source="WGC",
+    )
+
+    rows = repo.fetch_wgc_etf_monthly(
+        "GLD",
+        from_date=date(2026, 3, 1),
+        to_date=date(2026, 3, 31),
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["holdings_tonnes"] == Decimal("1042.5")
+    assert rows[0]["source_url"].endswith("ETF_Flows_April_2026.xlsx")
+
+
 def test_insert_and_fetch_exchange_inventory_daily(repo: Repository) -> None:
     repo.insert_exchange_inventory_daily(
         exchange="COMEX",

--- a/tests/integration/storage/test_gold_repo_flows.py
+++ b/tests/integration/storage/test_gold_repo_flows.py
@@ -47,21 +47,33 @@ def repo() -> Repository:
 
 
 def test_cb_reserves_round_trip(repo: Repository) -> None:
-    repo.insert_cb_gold_reserves_monthly(
-        country_iso3="CHN",
-        obs_month=date(2026, 4, 1),
-        reserves_t=Decimal("2235.0"),
-        bucket="strategic_accumulator",
-        is_reported=True,
-        is_estimated=False,
-        as_of=datetime.now(UTC),
-        release_date=date(2026, 5, 8),
-        source="WGC",
-    )
+    as_of = datetime.now(UTC)
+    for obs_month, reserves_t in (
+        (date(2025, 3, 31), Decimal("2200.0")),
+        (date(2026, 3, 31), Decimal("2235.0")),
+    ):
+        repo.insert_cb_gold_reserves_monthly(
+            country_iso3="CHN",
+            obs_month=obs_month,
+            reserves_t=reserves_t,
+            bucket="strategic_accumulator",
+            is_reported=True,
+            is_estimated=False,
+            as_of=as_of,
+            release_date=date(2026, 5, 8),
+            source="WGC",
+        )
     rows = repo.fetch_cb_gold_reserves_monthly(
         bucket="strategic_accumulator", from_month=date(2026, 1, 1)
     )
     assert any(r["country_iso3"] == "CHN" for r in rows)
+    history = repo.fetch_cb_gold_reserves_history(
+        country_iso3="CHN", to_month=date(2026, 3, 31), as_of_max=as_of
+    )
+    assert [r["obs_month"] for r in history] == [
+        date(2025, 3, 31),
+        date(2026, 3, 31),
+    ]
 
 
 def test_cot_round_trip_pins_release_date(repo: Repository) -> None:

--- a/tests/integration/storage/test_gold_repo_posture.py
+++ b/tests/integration/storage/test_gold_repo_posture.py
@@ -98,6 +98,39 @@ def test_insert_and_fetch_gold_posture_latest(repo: Repository) -> None:
     assert latest["factors_jsonb"]["F5"] == 1.8
 
 
+def test_latest_skips_invalidated_rows(repo: Repository) -> None:
+    repo.insert_gold_posture_daily(
+        **_kwargs_for_posture(
+            obs_date=date(2026, 5, 10),
+            computed_at=datetime(2026, 5, 11, 21, tzinfo=UTC),
+            gauge_state="suspended",
+        )
+    )
+    repo.insert_gold_posture_daily(
+        **_kwargs_for_posture(
+            obs_date=date(2026, 5, 11),
+            computed_at=datetime(2026, 5, 12, 21, tzinfo=UTC),
+            gauge_state="partial",
+        )
+    )
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE uw_scan.gold_posture_daily
+            SET row_status = 'invalidated',
+                superseded_reason = 'test invalidation'
+            WHERE obs_date = %s
+            """,
+            (date(2026, 5, 11),),
+        )
+
+    latest = repo.fetch_gold_posture_latest()
+
+    assert latest is not None
+    assert latest["obs_date"] == date(2026, 5, 10)
+    assert latest["row_status"] == "active"
+
+
 def test_replay_returns_first_computed(repo: Repository) -> None:
     """Multiple computed_at rows for same obs_date → replay picks the FIRST one."""
     repo.insert_gold_posture_daily(
@@ -117,3 +150,36 @@ def test_replay_returns_first_computed(repo: Repository) -> None:
     row = repo.fetch_gold_posture_for_obs_date(date(2026, 5, 10))
     assert row is not None
     assert row["gauge_state"] == "suspended"  # FIRST-computed
+
+
+def test_replay_skips_invalidated_rows(repo: Repository) -> None:
+    repo.insert_gold_posture_daily(
+        **_kwargs_for_posture(
+            obs_date=date(2026, 5, 10),
+            computed_at=datetime(2026, 5, 11, 21, tzinfo=UTC),
+            gauge_state="suspended",
+        )
+    )
+    repo.insert_gold_posture_daily(
+        **_kwargs_for_posture(
+            obs_date=date(2026, 5, 10),
+            computed_at=datetime(2026, 5, 20, 21, tzinfo=UTC),
+            gauge_state="partial",
+        )
+    )
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE uw_scan.gold_posture_daily
+            SET row_status = 'invalidated',
+                superseded_reason = 'test invalidation'
+            WHERE obs_date = %s AND computed_at = %s
+            """,
+            (date(2026, 5, 10), datetime(2026, 5, 11, 21, tzinfo=UTC)),
+        )
+
+    row = repo.fetch_gold_posture_for_obs_date(date(2026, 5, 10))
+
+    assert row is not None
+    assert row["gauge_state"] == "partial"
+    assert row["row_status"] == "active"

--- a/tests/integration/worker/test_gold_periodic_jobs.py
+++ b/tests/integration/worker/test_gold_periodic_jobs.py
@@ -15,6 +15,7 @@ import pytest
 from uw_scan.config import Settings
 from uw_scan.sources.cftc_cot import CftcCotProvider, CotRow
 from uw_scan.sources.lbma import LbmaProvider, LbmaVaultRow
+from uw_scan.sources.wgc_cb import CbReserveRow
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.gold_jobs import (
     gold_cftc_cot_ingest_job,
@@ -96,13 +97,42 @@ def test_gold_lbma_vault_ingest_writes_inventory(fresh_db: Settings) -> None:
     assert rows[0]["vault_oz"] == Decimal("274086000")
 
 
-def test_gold_wgc_cb_ingest_is_noop_deferred(fresh_db: Settings) -> None:
-    # WGC retired the anonymous CSV endpoint on 2026-05-17; the job is now a
-    # documented no-op until an authenticated download is wired. The test
-    # asserts the contract: no DB writes, no exceptions, no DB connection.
+def test_gold_wgc_cb_ingest_is_noop_without_auth_source(fresh_db: Settings) -> None:
     gold_wgc_cb_ingest_job(dsn=fresh_db.db_dsn())
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
         rows = repo.fetch_cb_gold_reserves_monthly(bucket="strategic_accumulator")
     assert rows == []
+
+
+def test_gold_wgc_cb_ingest_writes_authenticated_workbook_rows(
+    fresh_db: Settings,
+) -> None:
+    sample = [
+        CbReserveRow(
+            country_iso3="CHN",
+            obs_month=date(2026, 3, 31),
+            reserves_t=Decimal("2313.458368"),
+            bucket="strategic_accumulator",
+            is_reported=True,
+            is_estimated=False,
+        )
+    ]
+    with patch("uw_scan.worker.jobs.gold_jobs.WgcCbProvider") as MockProvider:
+        MockProvider.RESERVES_PAGE_URL = "https://www.gold.org/goldhub/data/gold-reserves-by-country"
+        MockProvider.return_value.__enter__.return_value.fetch_monthly.return_value = (
+            sample
+        )
+        gold_wgc_cb_ingest_job(
+            dsn=fresh_db.db_dsn(),
+            wgc_workbook_path="/tmp/Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx",
+        )
+
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        rows = repo.fetch_cb_gold_reserves_monthly(bucket="strategic_accumulator")
+    assert len(rows) == 1
+    assert rows[0]["country_iso3"] == "CHN"
+    assert rows[0]["obs_month"] == date(2026, 3, 31)
+    assert rows[0]["reserves_t"] == Decimal("2313.458368")

--- a/tests/integration/worker/test_gold_posture_compute_job.py
+++ b/tests/integration/worker/test_gold_posture_compute_job.py
@@ -80,6 +80,44 @@ def test_gold_posture_compute_writes_row(fresh_db: Settings) -> None:
     assert row["gauge_state"] in {"operative", "partial", "suspended"}
 
 
+def test_gold_posture_compute_defaults_to_latest_gld_close_date(
+    fresh_db: Settings,
+) -> None:
+    latest_market_date = date(2026, 5, 15)
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        base = latest_market_date - timedelta(days=300)
+        for i in range(301):
+            d = base + timedelta(days=i)
+            repo.insert_macro_series_daily(
+                "GLD_CLOSE",
+                d,
+                Decimal(str(1800 + i * 0.5)),
+                datetime.combine(d, datetime.min.time(), tzinfo=UTC),
+                None,
+                "MASSIVE",
+                None,
+            )
+            repo.insert_macro_series_daily(
+                "DFII10",
+                d,
+                Decimal(str(2.0 - i * 0.005)),
+                datetime.combine(d, datetime.min.time(), tzinfo=UTC),
+                None,
+                "FRED",
+                None,
+            )
+        conn.commit()
+
+    gold_posture_compute_job(dsn=fresh_db.db_dsn())
+
+    with psycopg.connect(fresh_db.db_dsn()) as conn:
+        repo = Repository(conn, schema=fresh_db.db_schema)
+        row = repo.fetch_gold_posture_latest()
+    assert row is not None
+    assert row["obs_date"] == latest_market_date
+
+
 def test_gold_posture_compute_uses_uw_gld_flows(fresh_db: Settings) -> None:
     target = date(2026, 5, 16)
     with psycopg.connect(fresh_db.db_dsn()) as conn:

--- a/tests/unit/cards/test_structural_flow.py
+++ b/tests/unit/cards/test_structural_flow.py
@@ -17,7 +17,7 @@ def test_structural_posture_bucket_sums_12m():
         CbReserveSnapshot(
             country_iso3="CHN",
             obs_month=date(2026, 5, 1) - timedelta(days=30 * month_offset),
-            reserves_t=Decimal(str(2200 + month_offset * 5)),
+            reserves_t=Decimal(str(2200 - month_offset * 5)),
             bucket="strategic_accumulator",
         )
         for month_offset in range(12)
@@ -32,7 +32,34 @@ def test_structural_posture_bucket_sums_12m():
         as_of=date(2026, 5, 16),
     )
     assert posture.cb_strategic_12m_sum_t is not None
-    assert posture.cb_strategic_12m_sum_t > Decimal("0")
+    assert posture.cb_strategic_12m_sum_t == Decimal("55")
+
+
+def test_structural_posture_ignores_future_cb_rows_for_replay():
+    cb_rows = [
+        CbReserveSnapshot(
+            country_iso3="CHN",
+            obs_month=date(2026, 3, 31),
+            reserves_t=Decimal("2300"),
+            bucket="strategic_accumulator",
+        ),
+        CbReserveSnapshot(
+            country_iso3="CHN",
+            obs_month=date(2026, 6, 30),
+            reserves_t=Decimal("2600"),
+            bucket="strategic_accumulator",
+        ),
+    ]
+    posture = compute_structural_posture(
+        cb_rows=cb_rows,
+        etf_rows=[],
+        inventory_rows=[],
+        cot_rows=[],
+        fx_rows=[],
+        gold_series=[],
+        as_of=date(2026, 5, 16),
+    )
+    assert posture.cb_strategic_12m_sum_t is None
 
 
 def test_structural_posture_emits_narrative():

--- a/tests/unit/reports/test_gold_posture_cot_metrics.py
+++ b/tests/unit/reports/test_gold_posture_cot_metrics.py
@@ -1,0 +1,45 @@
+"""Gold posture COT-derived metric helpers."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from uw_scan.cards.structural_flow import CotSnapshot
+from uw_scan.reports.gold_posture import _cot_mm_4w_change_sigma
+
+
+def test_cot_mm_4w_change_sigma_scores_latest_four_week_change():
+    base = date(2026, 3, 6)
+    mm_net_values = [
+        Decimal("100"),
+        Decimal("110"),
+        Decimal("130"),
+        Decimal("160"),
+        Decimal("200"),
+        Decimal("250"),
+        Decimal("310"),
+        Decimal("380"),
+        Decimal("460"),
+        Decimal("550"),
+    ]
+    rows = [
+        CotSnapshot(release_date=base + timedelta(days=7 * idx), mm_net=value)
+        for idx, value in enumerate(mm_net_values)
+    ]
+
+    metric = _cot_mm_4w_change_sigma(rows, as_of=date(2026, 5, 15))
+
+    assert metric is not None
+    assert float(metric) == pytest.approx(1.464, rel=0.001)
+
+
+def test_cot_mm_4w_change_sigma_requires_enough_history():
+    rows = [
+        CotSnapshot(release_date=date(2026, 5, 1), mm_net=Decimal("100")),
+        CotSnapshot(release_date=date(2026, 5, 8), mm_net=Decimal("110")),
+    ]
+
+    assert _cot_mm_4w_change_sigma(rows, as_of=date(2026, 5, 15)) is None

--- a/tests/unit/sources/test_cftc_cot.py
+++ b/tests/unit/sources/test_cftc_cot.py
@@ -15,11 +15,37 @@ SAMPLE = """Report_Date_as_YYYY-MM-DD,Report_Date_as_YYYY-MM-DD_Release,Open_Int
 2026-05-06,2026-05-09,508100,205200,90100,175300,293000
 """
 
+CURRENT_DISAGG_SAMPLE = """"SILVER - COMMODITY EXCHANGE INC.",260512,2026-05-12,084691,CMX ,01,084 ,103800,1437,21069,20697,44711,5207,21191,5430,8619
+"GOLD - COMMODITY EXCHANGE INC.",260512,2026-05-12,088691,CMX ,01,088 ,376496,11437,31639,25671,215727,20617,127242,29227,36664
+"MICRO GOLD - COMMODITY EXCHANGE INC.",260512,2026-05-12,088695,CMX ,01,088 ,67067,232,0,5865,0,0,531,0,1
+"""
 
-def _fake_response() -> httpx.Response:
+HISTORY_SAMPLE = """[
+  {
+    "report_date_as_yyyy_mm_dd": "2026-05-12T00:00:00.000",
+    "cftc_contract_market_code": "088691",
+    "open_interest_all": "376496",
+    "prod_merc_positions_long": "11437",
+    "prod_merc_positions_short": "31639",
+    "m_money_positions_long_all": "127242",
+    "m_money_positions_short_all": "29227"
+  },
+  {
+    "report_date_as_yyyy_mm_dd": "2026-05-05T00:00:00.000",
+    "cftc_contract_market_code": "084691",
+    "open_interest_all": "103800",
+    "prod_merc_positions_long": "1437",
+    "prod_merc_positions_short": "21069",
+    "m_money_positions_long_all": "21191",
+    "m_money_positions_short_all": "5430"
+  }
+]"""
+
+
+def _fake_response(text: str = SAMPLE) -> httpx.Response:
     return httpx.Response(
         200,
-        text=SAMPLE,
+        text=text,
         request=httpx.Request("GET", CftcCotProvider.URL),
     )
 
@@ -28,10 +54,48 @@ def test_cot_parses_disaggregated_csv():
     with patch.object(CftcCotProvider, "_get_with_telemetry") as mock_get:
         mock_get.return_value = _fake_response()
         with CftcCotProvider() as p:
-            rows = p.fetch_weekly(start=date(2026, 5, 6))
+            rows = p.fetch_weekly()
     assert len(rows) == 2
     assert rows[0].obs_date == date(2026, 5, 13)
     assert rows[0].release_date == date(2026, 5, 16)
     assert rows[0].mm_long == Decimal("210500")
     assert rows[0].mm_net == Decimal("125200")
     assert rows[0].comm_net == Decimal("-115300")
+
+
+def test_cot_parses_current_disaggregated_file_and_filters_gold_contract():
+    with patch.object(CftcCotProvider, "_get_with_telemetry") as mock_get:
+        mock_get.return_value = _fake_response(CURRENT_DISAGG_SAMPLE)
+        with CftcCotProvider() as p:
+            rows = p.fetch_weekly()
+
+    assert len(rows) == 1
+    assert rows[0].obs_date == date(2026, 5, 12)
+    assert rows[0].release_date == date(2026, 5, 15)
+    assert rows[0].open_interest == Decimal("376496")
+    assert rows[0].mm_long == Decimal("127242")
+    assert rows[0].mm_short == Decimal("29227")
+    assert rows[0].mm_net == Decimal("98015")
+    assert rows[0].comm_long == Decimal("11437")
+    assert rows[0].comm_short == Decimal("31639")
+    assert rows[0].comm_net == Decimal("-20202")
+
+
+def test_cot_fetches_history_from_public_reporting_api_when_start_is_supplied():
+    with patch.object(CftcCotProvider, "_get_with_telemetry") as mock_get:
+        mock_get.return_value = _fake_response(HISTORY_SAMPLE)
+        with CftcCotProvider() as p:
+            rows = p.fetch_weekly(start=date(2025, 4, 13))
+
+    mock_get.assert_called_once()
+    url, params = mock_get.call_args.args
+    assert url == CftcCotProvider.HISTORY_URL
+    assert params["$where"] == (
+        'cftc_contract_market_code="088691" AND '
+        'report_date_as_yyyy_mm_dd >= "2025-04-13T00:00:00"'
+    )
+    assert params["$order"] == "report_date_as_yyyy_mm_dd ASC"
+    assert rows[0].obs_date == date(2026, 5, 12)
+    assert rows[0].release_date == date(2026, 5, 15)
+    assert rows[0].mm_net == Decimal("98015")
+    assert rows[0].comm_net == Decimal("-20202")

--- a/tests/unit/sources/test_wgc_cb.py
+++ b/tests/unit/sources/test_wgc_cb.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 from unittest.mock import patch
 
 import httpx
+from openpyxl import Workbook
 
 from uw_scan.cards.cb_buckets import classify_bucket
 from uw_scan.sources.wgc_cb import WgcCbProvider
@@ -39,6 +41,34 @@ def test_wgc_parses_monthly_csv():
     assert by_country["RUS"].is_estimated is True
     assert by_country["POL"].bucket == "reserve_diversifier"
     assert by_country["CHN"].bucket == "strategic_accumulator"
+
+
+def test_wgc_parses_quarterly_workbook(tmp_path: Path):
+    workbook_path = tmp_path / "Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Gold (Tonnes)"
+    ws.cell(row=2, column=3, value="Q4 2025")
+    ws.cell(row=2, column=4, value="Q1 2026")
+    ws.cell(row=3, column=1, value="China, P.R.: Mainland")
+    ws.cell(row=3, column=2, value="China, P.R.: Mainland")
+    ws.cell(row=3, column=3, value=2306.304625)
+    ws.cell(row=3, column=4, value=2313.458368)
+    ws.cell(row=4, column=1, value="Türkiye, Rep of5")
+    ws.cell(row=4, column=2, value="Türkiye, Rep of5")
+    ws.cell(row=4, column=3, value=614.302763)
+    ws.cell(row=4, column=4, value=534.851285)
+    wb.save(workbook_path)
+
+    rows = WgcCbProvider.parse_quarterly_workbook(
+        workbook_path, start=date(2026, 1, 1)
+    )
+
+    by_country = {r.country_iso3: r for r in rows}
+    assert by_country["CHN"].obs_month == date(2026, 3, 31)
+    assert by_country["CHN"].reserves_t == Decimal("2313.458368")
+    assert by_country["CHN"].bucket == "strategic_accumulator"
+    assert by_country["TUR"].reserves_t == Decimal("534.851285")
 
 
 def test_classify_bucket_defaults():

--- a/tests/unit/test_gold_models.py
+++ b/tests/unit/test_gold_models.py
@@ -6,6 +6,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 
 from uw_scan.models import (
+    GoldCbCountryHistory,
     GoldCorrelationBand,
     GoldCorrelationHistory,
     GoldCorrelationPoint,
@@ -65,6 +66,19 @@ def test_gold_state_response_round_trips():
             ],
             gold_history=[
                 GoldHistoryPoint(obs_date=date(2024, 6, 1), value=Decimal("2400")),
+            ],
+            cb_country_history=[
+                GoldCbCountryHistory(
+                    country_iso3="CHN",
+                    country_name="China",
+                    bucket="strategic_accumulator",
+                    latest_reserves_t=Decimal("2313.5"),
+                    history=[
+                        GoldHistoryPoint(
+                            obs_date=date(2026, 3, 31), value=Decimal("2313.5")
+                        )
+                    ],
+                )
             ],
             narrative_text="Structural bid intact.",
         ),
@@ -141,3 +155,4 @@ def test_gold_state_response_round_trips():
     assert "moderate-trap" in dumped
     assert "FAVORABLE" in dumped
     assert "L1" in dumped
+    assert "China" in dumped

--- a/web/components/gold/kpi/DataFreshnessCard.tsx
+++ b/web/components/gold/kpi/DataFreshnessCard.tsx
@@ -21,19 +21,34 @@ export function DataFreshnessCard({ sources }: { sources: Source[] }) {
   if (sources.length === 0) {
     return <Tile label="DATA FRESHNESS" value="—" sub="No sources reporting" />;
   }
-  const worst = sources.reduce((acc, s) =>
-    s.stale_seconds > acc.stale_seconds ? s : acc,
+  const missing = sources.filter((s) => s.status === "missing");
+  const reporting = sources.filter(
+    (s) => s.status !== "missing" && s.stale_seconds != null,
   );
+  const worst = reporting.reduce<Source | null>(
+    (acc, s) =>
+      acc == null || (s.stale_seconds ?? 0) > (acc.stale_seconds ?? 0) ? s : acc,
+    null,
+  );
+  const value =
+    missing.length > 0
+      ? `${missing.length} missing`
+      : worst
+        ? `${ageLabel(worst.stale_seconds ?? 0)} · ${worst.id}`
+        : "—";
   return (
     <Tile
       label="DATA FRESHNESS"
-      tone={tone(worst.stale_seconds)}
-      value={`${ageLabel(worst.stale_seconds)} · ${worst.id}`}
+      tone={missing.length > 0 ? "negative" : tone(worst?.stale_seconds ?? 0)}
+      value={value}
       sub={
         <span style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           {sources.map((s) => (
             <span key={s.id}>
-              {s.id} {ageLabel(s.stale_seconds)}
+              {s.id}{" "}
+              {s.status === "missing" || s.stale_seconds == null
+                ? "missing"
+                : ageLabel(s.stale_seconds)}
             </span>
           ))}
         </span>

--- a/web/components/gold/lens1/EtfFlowCard.tsx
+++ b/web/components/gold/lens1/EtfFlowCard.tsx
@@ -27,13 +27,13 @@ export function EtfFlowCard({ structural }: { structural: S }) {
         : "negative";
   const sign = Number.isFinite(flow) && flow > 0 ? "+" : "";
   const sub = hasReportedHoldings
-    ? `GLD ${fmt(structural.gld_holdings_t)} tonnes held · reported holdings`
+    ? `current holdings ${fmt(structural.gld_holdings_t)} tonnes · 30D net flow`
     : "holdings unavailable · flow converted from UW GLD share flow";
   return (
     <Tile
-      label="GLD FLOW · 30D NET"
+      label="GLD ETF FLOW"
       tone={tone}
-      value={`${sign}${fmt(structural.gld_30d_net_flow_t)} tonnes`}
+      value={`${sign}${fmt(structural.gld_30d_net_flow_t)} t`}
       sub={sub}
     />
   );

--- a/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
+++ b/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useMemo, useState, type CSSProperties } from "react";
+
 import type { components } from "@/lib/types";
 
 import {
@@ -40,10 +44,12 @@ function fmtTonnesTick(v: number): string {
 }
 
 type Hp = components["schemas"]["GoldHistoryPoint"];
+type Country = components["schemas"]["GoldCbCountryHistory"];
 
 type Props = {
   goldHistory: Hp[];
   gldHistory: Hp[];
+  cbCountryHistory?: Country[];
   width?: number;
   height?: number;
 };
@@ -52,13 +58,62 @@ function toNumber(v: string | number): number {
   return typeof v === "string" ? Number(v) : v;
 }
 
+const CB_COLORS = [
+  "#67e8f9",
+  "#f472b6",
+  "#a3e635",
+  "#fb7185",
+  "#76a9ff",
+  "#d98cff",
+  "#14b8a6",
+  "#f59e0b",
+];
+
+function defaultSelected(countries: Country[]): string[] {
+  const strategic = countries
+    .filter((c) => c.bucket === "strategic_accumulator")
+    .map((c) => c.country_iso3);
+  if (strategic.length > 0) return strategic;
+  return countries.slice(0, 4).map((c) => c.country_iso3);
+}
+
+function colorForCountry(countryIso3: string, countries: Country[]): string {
+  const idx = countries.findIndex(
+    (country) => country.country_iso3 === countryIso3,
+  );
+  return CB_COLORS[(idx < 0 ? 0 : idx) % CB_COLORS.length];
+}
+
+function fmtCountryTonnes(v: string | number | null | undefined): string {
+  if (v == null) return "—";
+  const n = typeof v === "string" ? Number(v) : v;
+  if (!Number.isFinite(n)) return "—";
+  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
 export function GoldHoldingsVsPriceChart({
   goldHistory,
   gldHistory,
-  width = 640,
+  cbCountryHistory = [],
+  width = 1040,
   height = 200,
 }: Props) {
-  if (goldHistory.length === 0 && gldHistory.length === 0) {
+  const [selectedCountries, setSelectedCountries] = useState<string[]>(() =>
+    defaultSelected(cbCountryHistory),
+  );
+  const selectedSet = useMemo(
+    () => new Set(selectedCountries),
+    [selectedCountries],
+  );
+  const visibleCountries = cbCountryHistory.filter((country) =>
+    selectedSet.has(country.country_iso3),
+  );
+
+  if (
+    goldHistory.length === 0 &&
+    gldHistory.length === 0 &&
+    cbCountryHistory.length === 0
+  ) {
     return (
       <div
         style={{
@@ -77,149 +132,316 @@ export function GoldHoldingsVsPriceChart({
   const innerW = width - padding.left - padding.right;
   const innerH = height - padding.top - padding.bottom;
 
-  const allDates = [...goldHistory, ...gldHistory].map((p) =>
-    new Date(p.obs_date).getTime(),
+  const cbHistoryPoints = visibleCountries.flatMap((country) =>
+    (country.history ?? []).map((p) => ({
+      t: new Date(p.obs_date).getTime(),
+      value: toNumber(p.value),
+    })),
   );
+  const allDates = [
+    ...goldHistory.map((p) => new Date(p.obs_date).getTime()),
+    ...gldHistory.map((p) => new Date(p.obs_date).getTime()),
+    ...cbHistoryPoints.map((p) => p.t),
+  ];
   const dateDomain = finiteDomain(allDates);
   const goldDomain = finiteDomain(goldHistory.map((p) => toNumber(p.value)));
-  const gldDomain = finiteDomain(gldHistory.map((p) => toNumber(p.value)));
+  const tonnesDomain = finiteDomain([
+    ...gldHistory.map((p) => toNumber(p.value)),
+    ...cbHistoryPoints.map((p) => p.value),
+  ]);
   const xRange: [number, number] = [padding.left, padding.left + innerW];
   const yRange: [number, number] = [padding.top + innerH, padding.top];
 
-  if (dateDomain == null || dateDomain.count < 2) {
-    return null;
-  }
+  const canDrawTop = dateDomain != null && dateDomain.count >= 2;
 
-  const xScale = linearScale([dateDomain.lo, dateDomain.hi], xRange);
-  const goldYScale = goldDomain
+  const xScale = canDrawTop
+    ? linearScale([dateDomain.lo, dateDomain.hi], xRange)
+    : null;
+  const goldYScale = canDrawTop && goldDomain
     ? linearScale([goldDomain.lo, goldDomain.hi], yRange)
     : null;
-  const gldYScale = gldDomain
-    ? linearScale([gldDomain.lo, gldDomain.hi], yRange)
+  const tonnesYScale = canDrawTop && tonnesDomain
+    ? linearScale([tonnesDomain.lo, tonnesDomain.hi], yRange)
     : null;
 
   const goldPoints: Point[] = goldYScale
     ? goldHistory.map((p) => [
-        xScale(new Date(p.obs_date).getTime()),
+        xScale?.(new Date(p.obs_date).getTime()) ?? 0,
         goldYScale(toNumber(p.value)),
       ])
     : [];
 
-  const gldPoints: Point[] = gldYScale
+  const gldPoints: Point[] = tonnesYScale
     ? gldHistory.map((p) => [
-        xScale(new Date(p.obs_date).getTime()),
-        gldYScale(toNumber(p.value)),
+        xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+        tonnesYScale(toNumber(p.value)),
       ])
     : [];
+  const cbCountryPoints = visibleCountries.map((country) => ({
+    country,
+    points: tonnesYScale
+      ? (country.history ?? []).map((p): Point => [
+          xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+          tonnesYScale(toNumber(p.value)),
+        ])
+      : [],
+  }));
 
-  const xTicks = sampledTimeTicks(dateDomain.lo, dateDomain.hi, 6);
+  const xTicks =
+    canDrawTop && dateDomain
+      ? sampledTimeTicks(dateDomain.lo, dateDomain.hi, 6)
+      : [];
   const goldYTicks = goldDomain
     ? niceTicks(goldDomain.lo, goldDomain.hi, 4)
     : [];
-  const gldYTicks = gldDomain ? niceTicks(gldDomain.lo, gldDomain.hi, 4) : [];
+  const tonnesYTicks = tonnesDomain
+    ? niceTicks(tonnesDomain.lo, tonnesDomain.hi, 4)
+    : [];
+
+  function toggleCountry(countryIso3: string) {
+    setSelectedCountries((current) =>
+      current.includes(countryIso3)
+        ? current.filter((country) => country !== countryIso3)
+        : [...current, countryIso3],
+    );
+  }
+
+  const hasControls = cbCountryHistory.length > 0;
 
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${width} ${height}`}
-      style={{ display: "block" }}
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 12,
+        alignItems: "start",
+      }}
     >
-      <g>
-        {xTicks.map((t) => (
-          <line
-            key={t}
-            x1={xScale(t)}
-            x2={xScale(t)}
-            y1={padding.top}
-            y2={padding.top + innerH}
-            stroke="var(--chart-grid, #1e2230)"
-            strokeWidth={0.5}
-          />
-        ))}
-      </g>
-      {goldPoints.length > 0 && (
-        <path
-          d={pathFromPoints(goldPoints)}
-          fill="none"
-          stroke="var(--positive, #05ad98)"
-          strokeWidth={1.5}
-        />
-      )}
-      {gldPoints.length > 0 && (
-        <path
-          d={pathFromPoints(gldPoints)}
-          fill="none"
-          stroke="var(--warning, #f5a623)"
-          strokeWidth={1.5}
-          strokeDasharray="4 2"
-        />
-      )}
-      <g
-        fontFamily="var(--font-mono)"
-        fontSize={9}
-        fill="var(--text-muted, #6b7280)"
-      >
-        {xTicks.map((t) => (
-          <text
-            key={`xl-${t}`}
-            x={xScale(t)}
-            y={height - padding.bottom + 14}
-            textAnchor="middle"
+      {canDrawTop && xScale && (
+        <div style={{ flex: "1 1 620px", minWidth: 0 }}>
+          <svg
+            width="100%"
+            viewBox={`0 0 ${width} ${height}`}
+            style={{ display: "block" }}
           >
-            {fmtDateTick(t)}
-          </text>
-        ))}
-        {goldYScale &&
-          goldYTicks.map((v) => (
-            <g key={`yl-gold-${v}`}>
-              <line
-                x1={padding.left - 3}
-                x2={padding.left}
-                y1={goldYScale(v)}
-                y2={goldYScale(v)}
-                stroke="var(--text-muted, #6b7280)"
-                strokeWidth={0.5}
-              />
-              <text
-                x={padding.left - 6}
-                y={goldYScale(v) + 3}
-                textAnchor="end"
-                fill="var(--positive, #05ad98)"
-              >
-                {fmtPriceTick(v)}
-              </text>
+            <g>
+              {xTicks.map((t) => (
+                <line
+                  key={t}
+                  x1={xScale(t)}
+                  x2={xScale(t)}
+                  y1={padding.top}
+                  y2={padding.top + innerH}
+                  stroke="var(--chart-grid, #1e2230)"
+                  strokeWidth={0.5}
+                />
+              ))}
             </g>
-          ))}
-        {gldYScale &&
-          gldYTicks.map((v) => (
-            <g key={`yl-gld-${v}`}>
-              <line
-                x1={padding.left + innerW}
-                x2={padding.left + innerW + 3}
-                y1={gldYScale(v)}
-                y2={gldYScale(v)}
-                stroke="var(--text-muted, #6b7280)"
-                strokeWidth={0.5}
+            {goldPoints.length > 0 && (
+              <path
+                d={pathFromPoints(goldPoints)}
+                fill="none"
+                stroke="var(--positive, #05ad98)"
+                strokeWidth={1.5}
               />
-              <text
-                x={padding.left + innerW + 6}
-                y={gldYScale(v) + 3}
-                textAnchor="start"
-                fill="var(--warning, #f5a623)"
-              >
-                {fmtTonnesTick(v)}
+            )}
+            {gldPoints.length > 0 && (
+              <path
+                d={pathFromPoints(gldPoints)}
+                fill="none"
+                stroke="var(--warning, #f5a623)"
+                strokeWidth={1.5}
+                strokeDasharray="4 2"
+              />
+            )}
+            {cbCountryPoints.map(({ country, points }) => (
+              <path
+                key={country.country_iso3}
+                d={pathFromPoints(points)}
+                fill="none"
+                stroke={colorForCountry(country.country_iso3, cbCountryHistory)}
+                strokeWidth={1.2}
+              />
+            ))}
+            <g
+              fontFamily="var(--font-mono)"
+              fontSize={6.5}
+              fill="var(--text-muted, #6b7280)"
+            >
+              {xTicks.map((t) => (
+                <text
+                  key={`xl-${t}`}
+                  x={xScale(t)}
+                  y={height - padding.bottom + 14}
+                  textAnchor="middle"
+                >
+                  {fmtDateTick(t)}
+                </text>
+              ))}
+              {goldYScale &&
+                goldYTicks.map((v) => (
+                  <g key={`yl-gold-${v}`}>
+                    <line
+                      x1={padding.left - 3}
+                      x2={padding.left}
+                      y1={goldYScale(v)}
+                      y2={goldYScale(v)}
+                      stroke="var(--text-muted, #6b7280)"
+                      strokeWidth={0.5}
+                    />
+                    <text
+                      x={padding.left - 6}
+                      y={goldYScale(v) + 2.5}
+                      textAnchor="end"
+                      fill="var(--positive, #05ad98)"
+                    >
+                      {fmtPriceTick(v)}
+                    </text>
+                  </g>
+                ))}
+              {tonnesYScale &&
+                tonnesYTicks.map((v) => (
+                  <g key={`yl-gld-${v}`}>
+                    <line
+                      x1={padding.left + innerW}
+                      x2={padding.left + innerW + 3}
+                      y1={tonnesYScale(v)}
+                      y2={tonnesYScale(v)}
+                      stroke="var(--text-muted, #6b7280)"
+                      strokeWidth={0.5}
+                    />
+                    <text
+                      x={padding.left + innerW + 6}
+                      y={tonnesYScale(v) + 2.5}
+                      textAnchor="start"
+                      fill="var(--warning, #f5a623)"
+                    >
+                      {fmtTonnesTick(v)}
+                    </text>
+                  </g>
+                ))}
+              <text x={padding.left} y={9} fill="var(--positive, #05ad98)">
+                GLD price ($)
               </text>
+              {tonnesYScale && (
+                <text x={padding.left + 70} y={9} fill="var(--warning, #f5a623)">
+                  GLD holdings + CB reserves (tonnes)
+                </text>
+              )}
             </g>
-          ))}
-        <text x={padding.left} y={10} fill="var(--positive, #05ad98)">
-          GLD ($)
-        </text>
-        {gldYScale && (
-          <text x={padding.left + 60} y={10} fill="var(--warning, #f5a623)">
-            GLD tonnes held
-          </text>
-        )}
-      </g>
-    </svg>
+          </svg>
+        </div>
+      )}
+      {hasControls && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: "0 1 220px",
+            gap: 6,
+            maxHeight: 224,
+            overflow: "auto",
+            paddingRight: 4,
+          }}
+        >
+          <span
+            style={{
+              color: "var(--text-secondary, #9aa3b2)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 9,
+              letterSpacing: 1,
+              textTransform: "uppercase",
+            }}
+          >
+            Central bank reserves by country
+          </span>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={() =>
+                setSelectedCountries(defaultSelected(cbCountryHistory))
+              }
+              style={toggleButtonStyle}
+              title="Strategic accumulators: China, Russia, India, and Turkey when present."
+            >
+              Strategic
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setSelectedCountries(
+                  cbCountryHistory.map((country) => country.country_iso3),
+                )
+              }
+              style={toggleButtonStyle}
+            >
+              All
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedCountries([])}
+              style={toggleButtonStyle}
+            >
+              None
+            </button>
+          </div>
+          {cbCountryHistory.map((country) => {
+            const checked = selectedSet.has(country.country_iso3);
+            return (
+              <label
+                key={country.country_iso3}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "18px 10px minmax(0, 1fr)",
+                  alignItems: "center",
+                  gap: 8,
+                  color: checked
+                    ? "var(--text-primary, #cfd2db)"
+                    : "var(--text-muted, #6b7280)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 9,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleCountry(country.country_iso3)}
+                  aria-label={`Toggle ${country.country_name}`}
+                />
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: 8,
+                    height: 8,
+                    background: colorForCountry(country.country_iso3, cbCountryHistory),
+                    display: "inline-block",
+                  }}
+                />
+                <span
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {country.country_iso3} · {fmtCountryTonnes(country.latest_reserves_t)}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
+
+const toggleButtonStyle: CSSProperties = {
+  border: "1px solid var(--border-dim, #1b2030)",
+  background: "var(--bg-panel, #0d1018)",
+  color: "var(--text-secondary, #9aa3b2)",
+  borderRadius: 4,
+  padding: "4px 7px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 9,
+  textTransform: "uppercase",
+};

--- a/web/components/gold/lens1/StructuralPanel.tsx
+++ b/web/components/gold/lens1/StructuralPanel.tsx
@@ -57,6 +57,7 @@ export function StructuralPanel({ structural }: { structural: S }) {
       <GoldHoldingsVsPriceChart
         goldHistory={structural.gold_history ?? []}
         gldHistory={structural.gld_history ?? []}
+        cbCountryHistory={structural.cb_country_history ?? []}
       />
 
       <div

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1656,13 +1656,16 @@ export interface components {
         GoldDataFreshnessSource: {
             /** Id */
             id: string;
-            /**
-             * Last As Of
-             * Format: date-time
-             */
-            last_as_of: string;
+            /** Last As Of */
+            last_as_of?: string | null;
             /** Stale Seconds */
-            stale_seconds: number;
+            stale_seconds?: number | null;
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "missing";
         };
         /**
          * GoldDecompositionRow

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1688,6 +1688,22 @@ export interface components {
             /** History 252D */
             history_252d: components["schemas"]["GoldGaugeTimeSeriesPoint"][];
         };
+        /** GoldCbCountryHistory */
+        GoldCbCountryHistory: {
+            /** Country Iso3 */
+            country_iso3: string;
+            /** Country Name */
+            country_name: string;
+            /** Bucket */
+            bucket: string;
+            /** Latest Reserves T */
+            latest_reserves_t?: string | null;
+            /**
+             * History
+             * @default []
+             */
+            history: components["schemas"]["GoldHistoryPoint"][];
+        };
         /** GoldGaugeState */
         GoldGaugeState: {
             /** Corr 60D */
@@ -1885,6 +1901,11 @@ export interface components {
              * @default []
              */
             gold_history: components["schemas"]["GoldHistoryPoint"][];
+            /**
+             * Cb Country History
+             * @default []
+             */
+            cb_country_history: components["schemas"]["GoldCbCountryHistory"][];
             /** Narrative Text */
             narrative_text: string;
         };

--- a/web/tests/unit/goldCompassLayout.test.tsx
+++ b/web/tests/unit/goldCompassLayout.test.tsx
@@ -82,7 +82,12 @@ const FIXTURE: State = {
     DFII10: { obs_date: "2026-05-16", as_of: "2026-05-17T00:00:00Z" },
   },
   data_freshness: [
-    { id: "FRED", last_as_of: "2026-05-17T00:00:00Z", stale_seconds: 60 },
+    {
+      id: "FRED",
+      last_as_of: "2026-05-17T00:00:00Z",
+      stale_seconds: 60,
+      status: "ok",
+    },
   ],
   decomposition_rows: [
     { lens: "L1", factor: "CB Δ12M", contribution: "1.4" },

--- a/web/tests/unit/goldCompassLayout.test.tsx
+++ b/web/tests/unit/goldCompassLayout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
@@ -48,6 +48,28 @@ const FIXTURE: State = {
     xau_cny_premium_pct: "0.004",
     gld_history: [],
     gold_history: [],
+    cb_country_history: [
+      {
+        country_iso3: "CHN",
+        country_name: "China",
+        bucket: "strategic_accumulator",
+        latest_reserves_t: "2313.5",
+        history: [
+          { obs_date: "2000-03-31", value: "395.0" },
+          { obs_date: "2026-03-31", value: "2313.5" },
+        ],
+      },
+      {
+        country_iso3: "POL",
+        country_name: "Poland",
+        bucket: "reserve_diversifier",
+        latest_reserves_t: "581.6",
+        history: [
+          { obs_date: "2000-03-31", value: "102.9" },
+          { obs_date: "2026-03-31", value: "581.6" },
+        ],
+      },
+    ],
     narrative_text: "Structural bid intact.",
   },
   cyclical: {
@@ -124,9 +146,9 @@ describe("GoldCompassLayout", () => {
 
   it("labels GLD ETF flow units and source clearly", () => {
     render(<GoldCompassLayout state={FIXTURE} />);
-    expect(screen.getByText("-12.4 tonnes")).toBeTruthy();
-    expect(screen.getByText(/872.5 tonnes held/)).toBeTruthy();
-    expect(screen.getByText(/reported holdings/)).toBeTruthy();
+    expect(screen.getByText("-12.4 t")).toBeTruthy();
+    expect(screen.getByText(/current holdings 872.5 tonnes/)).toBeTruthy();
+    expect(screen.getByText(/30D net flow/)).toBeTruthy();
   });
 
   it("spells out central-bank reserve units", () => {
@@ -146,9 +168,18 @@ describe("GoldCompassLayout", () => {
       },
     };
     render(<GoldCompassLayout state={state} />);
-    expect(screen.getByText("-11.0 tonnes")).toBeTruthy();
+    expect(screen.getByText("-11.0 t")).toBeTruthy();
     expect(screen.getByText(/converted from UW GLD share flow/)).toBeTruthy();
     expect(screen.getByText(/holdings unavailable/)).toBeTruthy();
+  });
+
+  it("shows central-bank country reserve toggles", () => {
+    render(<GoldCompassLayout state={FIXTURE} />);
+    expect(screen.getByText(/Central bank reserves by country/)).toBeTruthy();
+    const chinaToggle = screen.getByLabelText("Toggle China");
+    expect(chinaToggle).toBeTruthy();
+    fireEvent.click(chinaToggle);
+    expect((chinaToggle as HTMLInputElement).checked).toBe(false);
   });
 
   it("uses posture language only (no buy/sell/long/short)", () => {


### PR DESCRIPTION
## Summary
- add CFTC COT current + 400-day history ingestion for COMEX gold and persist the 4-week COT metric
- add WGC ETF monthly canonicalization plus posture replay invalidation and missing-source freshness status
- update Gold Compass docs, API/types, and UI freshness handling to match the live data state

## Verification
- uv run pytest -q tests/unit/reports/test_gold_posture_cot_metrics.py tests/unit/sources/test_cftc_cot.py tests/integration/worker/test_gold_periodic_jobs.py::test_gold_cftc_cot_ingest_writes_rows tests/integration/storage/test_gold_repo_flows.py::test_cot_round_trip_pins_release_date tests/integration/reports/test_gold_posture_orchestrator.py
- uv run ruff check src/uw_scan/sources/cftc_cot.py src/uw_scan/reports/gold_posture.py tests/unit/sources/test_cftc_cot.py tests/unit/reports/test_gold_posture_cot_metrics.py
- git diff --check