### PR TITLE
docs: refresh routes, storage split, and gold sources/research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,16 @@ Environment:
 |---|---|
 | Active specs / plans | `docs/superpowers/specs/`, `docs/superpowers/plans/` |
 | API surface | `src/uw_scan/api/server.py` + `routers/*` |
-| Persistence | `src/uw_scan/storage/repository.py` (one method per query) |
+| Persistence — legacy mono-module | `src/uw_scan/storage/repository.py` (one method per query; 4,900+ lines; do not extend — split per [feedback_repository_split_threshold](.) ) |
+| Persistence — new leaf modules | `src/uw_scan/storage/{signals,cri_snapshot,vcg_snapshot,vol_index,greek_exposure,gold_etf,flow,health,jobs,market_data,scan_outputs,audit,provider_usage}_repository.py` (or `.py`). New domains go here, never appended to `repository.py` |
 | Scheduled jobs | `src/uw_scan/worker/scheduler.py` |
 | UW endpoints (integrated) | `src/uw_scan/api/endpoints.py` + `sources/uw.py` |
 | UW API reference (full surface) | `docs/uw-samples/unusual_whales_api.md` (human-readable) + `docs/uw-samples/unusual_whales_api_spec.yaml` (OpenAPI) — consult before adding any new UW fetcher |
 | UW sample payloads | `docs/uw-samples/*.json` — real responses for each integrated endpoint, with `_shape-summary.md` |
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
+| Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
+| Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
+| Gold Compass | `api/routers/gold.py` + `storage/gold_etf.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,8 @@ Environment:
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
 | Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
 | Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
-| Gold Compass | `api/routers/gold.py` + `storage/gold_etf.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Gold Compass — code | `api/routers/gold.py` + `storage/gold_etf.py` + `worker/jobs/gold_jobs.py` + `sources/{fred,gpr,lbma,comex,etf_holdings,uw_gold_options,cftc_cot,wgc_etf,wgc_cb}.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ Environment:
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
 | Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
 | Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
-| Gold Compass | `api/routers/gold.py` + `storage/gold_etf.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Gold Compass — code | `api/routers/gold.py` + `storage/gold_etf.py` + `worker/jobs/gold_jobs.py` + `sources/{fred,gpr,lbma,comex,etf_holdings,uw_gold_options,cftc_cot,wgc_etf,wgc_cb}.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ Environment:
 - **Data source priority**: IB → UW → FMP → massive (OHLC). Yahoo is banned
 - **No secrets to local Codex subprocesses** — do not pass UW/FMP/Massive keys, DB credentials, or unrelated app secrets to `codex exec`
 - **Never commit without an explicit user request.** Draft first, wait
+- **Big projects use milestone commits** — when the user has explicitly requested commits for a large project/task, commit each closed milestone after its relevant verification before continuing
 - **Always open a PR before merging to main.** `git push origin main` is forbidden
+- **Branch names** default to type prefixes: `feat/` for features, `fix/` for bug fixes, `chore/` for maintenance, and `misc/` for other work. Do not default to a `codex/` prefix
 - **Never add `Co-Authored-By: Claude` trailers** to commits
 - **Migrations are idempotent** (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`). No tracking table — re-running is a no-op
 - **Live API tests** are marked `live` and need `UW_SCAN_API_KEY`; default `pytest` excludes them
@@ -64,11 +66,16 @@ Environment:
 |---|---|
 | Active specs / plans | `docs/superpowers/specs/`, `docs/superpowers/plans/` |
 | API surface | `src/uw_scan/api/server.py` + `routers/*` |
-| Persistence | `src/uw_scan/storage/repository.py` (one method per query) |
+| Persistence — legacy mono-module | `src/uw_scan/storage/repository.py` (one method per query; 4,900+ lines; do not extend — split per [feedback_repository_split_threshold](.) ) |
+| Persistence — new leaf modules | `src/uw_scan/storage/{signals,cri_snapshot,vcg_snapshot,vol_index,greek_exposure,gold_etf,flow,health,jobs,market_data,scan_outputs,audit,provider_usage}_repository.py` (or `.py`). New domains go here, never appended to `repository.py` |
 | Scheduled jobs | `src/uw_scan/worker/scheduler.py` |
 | UW endpoints (integrated) | `src/uw_scan/api/endpoints.py` + `sources/uw.py` |
 | UW API reference (full surface) | `docs/uw-samples/unusual_whales_api.md` (human-readable) + `docs/uw-samples/unusual_whales_api_spec.yaml` (OpenAPI) — consult before adding any new UW fetcher |
 | UW sample payloads | `docs/uw-samples/*.json` — real responses for each integrated endpoint, with `_shape-summary.md` |
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
+| Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
+| Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
+| Gold Compass | `api/routers/gold.py` + `storage/gold_etf.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
+| Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ A backfill kicks automatically the first time you open the tab for a ticker; sub
 
 ---
 
+## Other views
+
+| Route | What it is |
+|---|---|
+| `/scanner` | Detector-driven candidate list (DCF, Dark Pool, EIC, GEX) ranked by bias. Splits into **watchlist candidates** (full detector suite) and **discovered** tickers from the market-wide flow-alerts feed (DCF-only). |
+| `/regime` | Market-wide indicators ported from xenon — CRI (Crash Risk), VCG (Vol-Curve Gauge), and SPX GEX with profile chart. Vol-backdrop strip across the top. |
+| `/gold` | GOLD COMPASS five-tier cockpit on the gold complex (GLD, IAU, GDX, etc.) — physical/ETF/miner posture from WGC + ETF flow + dealer positioning. Has a `/gold/replay/<YYYY-MM-DD>` history view. |
+| `/cockpit/<TICKER>` | Index-only dealer-state research view (SPX / SPY / QQQ / IWM). Tabs: state, dealer, surface, flow-IM, VRP. Optional `?asof=YYYY-MM-DD` for historical snapshots. |
+| `/admin` | Health + scheduler controls. |
+
+---
+
 ## Run it
 
 ```bash

--- a/docs/research/gold-sdf-framework/CLAUDE.md
+++ b/docs/research/gold-sdf-framework/CLAUDE.md
@@ -1,0 +1,51 @@
+# docs/research/gold-sdf-framework — Gold SDF research
+
+Pre-spec research for the `/gold` GOLD COMPASS endpoint. **Read [`README.md`](./README.md) first** — it's the entry point and reading map for the 14 sub-documents in this directory.
+
+## What this directory is
+
+A research foundation, not an implementation. It cross-validates the SDF-based gold framework (viviennaBTC article + Andrew Ang Ch. 11) against primary sources and synthesizes a three-lens model:
+
+- **Lens 1 — Structural flow** *(dominant 2022-present)*: central-bank reserves, ETF holdings, exchange vaults, FX, COT, UW options stress
+- **Lens 2 — Cyclical** *(gated by regime)*: real yields, inflation breakevens, DXY, the article's two-force model
+- **Lens 3 — Valuation overlay** *(always-on tail-risk flag; never a sizing input)*: Erb-Harvey real-price percentile
+
+Lenses share variance — they are complementary, **not orthogonal**. Position sizing must assume correlated signals until variance accounting proves otherwise.
+
+## What this directory is NOT
+
+- **Not the implementation spec.** Specs live under `docs/superpowers/specs/` once the research lands.
+- **Not a backtest.** No model has been fit to data; all claims come from academic primaries, industry research, and direct review of the article.
+- **Not complete.** Open questions are tracked in [`10-open-research-questions.md`](./10-open-research-questions.md).
+
+## Status vs. shipped code (2026-05-17)
+
+| Lens | Sub-document | Code path | Status |
+|---|---|---|---|
+| 1 | `05-structural-flow-factors.md` | `sources/etf_holdings.py`, `sources/comex.py`, `sources/lbma.py`, `sources/cftc_cot.py`, `sources/wgc_etf.py`, `sources/uw_gold_options.py` | Mostly live (Phase A1); `wgc_cb.py` deferred |
+| 2 | `06-cyclical-factors.md` | `sources/fred.py`, `sources/gpr.py` | Live (FRED + GPR) |
+| 3 | `07-valuation-overlay.md` | computed in `worker/jobs/gold_jobs.py::gold_posture_compute_job` | Live |
+
+Routing into the cockpit: `api/routers/gold.py` → `storage/gold_etf.py` (+ other gold repositories) → `web/app/gold/` and `web/components/gold/` (lens1/lens2/lens3 component groups mirror the research lenses).
+
+## Deferred sources (Phase A1 → v2)
+
+Five of the eight anonymous-CSV sources designed for v1 had moved or paywalled by 2026-05-17 implementation time. Tracking + re-wire plan: [`11-deferred-sources-phase-a1.md`](./11-deferred-sources-phase-a1.md). Most-likely fixes lean on official APIs (Socrata, IMF IFS, SEC N-PORT) rather than scraping issuer pages.
+
+The provider files for deferred sources (e.g., `wgc_cb.py`) stay in the tree so re-wiring is a one-source change, not a structural refactor. Until that lands, the structural-lens CB tiles and the corresponding tables (`cb_gold_reserves_monthly`) stay empty by design.
+
+## When working in this directory
+
+- **Cite primary sources, not the article.** Every empirical claim must trace back to Ang/Cochrane/Erb-Harvey/Baur-Lucey/WGC/FRED rather than to the SDF article itself. The article's directional claims are correct; its specific numbers are not always (see [`02-empirical-claims-validation.md`](./02-empirical-claims-validation.md)).
+- **Regime gating is load-bearing.** The article's framework operates only in pre-2022 regimes (gold ↔ real-yield correlation ≈ -0.84). Post-2022 the correlation collapsed (~ 0). Code that consumes Lens 2 must gate on the regime gauge, not assume the relationship is always on.
+- **Cost rule:** All required series are free or already paid for. Roughly $0 in new external-data costs — the bottleneck is engineering time, not data subscriptions.
+- **Spec promotion path.** When a finding here is ready to ship, draft a spec under `docs/superpowers/specs/` referencing the specific sub-document. Don't grow research files into specs — keep these focused on *what's true*, not *what to build*.
+- **Updates over rewrites.** Each finding lives in its own sub-document so the body of work can grow without any single file becoming unwieldy. New findings either extend an existing file or land as a new numbered file with a README link.
+
+## Provider-level conventions
+
+Gold-source rules are documented at the implementation layer: [`src/uw_scan/sources/CLAUDE.md`](../../../src/uw_scan/sources/CLAUDE.md). Highlights that touch research:
+
+- **Backtest lag for COT:** lag to `release_date + 3 trading days`, never `obs_date` (look-ahead).
+- **Audit-first persistence:** raw payload + audit row land before normalisation, so a mid-pipeline crash still leaves a trace and we can reconstruct issuer payloads after schema drift.
+- **Source-workbook lineage** is preserved for revised monthly workbooks (WGC ETF) — revisions don't overwrite history.

--- a/src/uw_scan/sources/CLAUDE.md
+++ b/src/uw_scan/sources/CLAUDE.md
@@ -2,10 +2,29 @@
 
 The only place that talks to the outside world.
 
-## Files
+## Per-ticker sources (UW + OHLC)
 
 - `uw.py` — Unusual Whales fetchers. Every fetcher: call UW → write audit row → persist raw compressed payload → normalize → return typed model.
 - `ohlc.py` — `MassiveOhlcProvider` (Polygon-shaped REST). Daily bars + intraday quote.
+- `lake.py` — Parquet reader for `~/market-warehouse/data-lake`. Used by the nightly `vol_index_lake_sync` job. Pure I/O, no business logic.
+
+## Gold complex (Phase A1 + v2 corpus)
+
+Feeds the `/gold` GOLD COMPASS cockpit (`web/app/gold/`, `api/routers/gold.py`). The three-lens model (structural-flow / cyclical / valuation overlay) is documented in [`docs/research/gold-sdf-framework/`](../../../docs/research/gold-sdf-framework/) — read its CLAUDE.md before touching gold ingestion.
+
+| Source file | What it pulls | Status |
+|---|---|---|
+| `fred.py` | FRED CSV provider for daily + monthly macro series (reference pattern for the other A1 sources). Persists to `macro_series_daily`. | Live |
+| `gpr.py` | Caldara-Iacoviello Geopolitical Risk Index (GPRD) from matteoiacoviello.com. Publisher switched daily file from CSV → `.xls` (BIFF8) in 2024 — the old `/gpr_files/gpr_daily_recent.csv` path 404s. | Live |
+| `lbma.py` | LBMA monthly loco-London vault holdings. LBMA moved from a stable .csv URL to monthly-named .xlsx at `cdn.lbma.org.uk/downloads/LBMA-London-Vault-Holdings-Data-<Month-Year>.xlsx` — we scrape the listing page each run to discover the current URL. Gold column is in thousand troy oz; we multiply by 1000 to keep `vault_oz` in oz (consistent with COMEX). | Live |
+| `comex.py` | COMEX daily gold-stocks scraper from `cmegroup.com/markets/metals/precious/gold-stocks.html`. URL is subject to CME publishing changes — sanity-check before deploy. | Live |
+| `etf_holdings.py` | Per-fund daily holdings for GLD (SPDR), IAU (BlackRock), GLDM (SPDR), PHYS (Sprott). Each fund has its own endpoint and payload shape; normalised to `EtfHoldingRow`. | Live |
+| `uw_gold_options.py` | Gold-options snapshot for GLD/GDX/IAU. Composes existing UW fetchers (`interpolated_iv`, `oi_per_strike`, `option_contracts`, `skew`) into one snapshot row per (ticker, obs_date). | Live (A1 persists; A2 will consume) |
+| `cftc_cot.py` | CFTC Commitments of Traders disaggregated weekly report (commodity code `088691`). Managed-money + commercials longs/shorts/net, OI. `obs_date` = Tuesday position date, `release_date` = Friday publication. **Backtests must lag to release+3 trading days, never to obs_date.** | Live |
+| `wgc_etf.py` | World Gold Council monthly gold-ETF holdings workbook (Goldhub `Gold_ETF_flows_*.xlsx`). Per-fund holdings, demand, fund-flow with source-workbook lineage preserved. See `migrations/046_wgc_etf_monthly.sql` and `docs/research/gold-sdf-framework/12-wgc-etf-flow-corpus.md`. | Live (PR #42) |
+| `wgc_cb.py` | World Gold Council monthly central-bank gold reserves. | **Deferred** — WGC retired the anonymous CSV; downloads now sit behind a Goldhub login (verified 2026-05-17). Structural-lens CB tiles stay null and `cb_gold_reserves_monthly` stays empty until re-wired. See `docs/research/gold-sdf-framework/11-deferred-sources-phase-a1.md`. |
+
+Related migrations: `storage/migrations/041_gold_cot.sql` (COT), `046_wgc_etf_monthly.sql` (WGC ETF corpus). Repository: `storage/gold_etf.py`. Scheduler jobs: `worker/jobs/gold_jobs.py` (`gold_fred_ingest_job`, `gold_gpr_ingest_job`, `gold_lbma_vault_ingest_job`, `gold_comex_vault_ingest_job`, `gold_etf_holdings_ingest_job`, `gold_spot_ingest_job`, `gold_uw_options_ingest_job`, `gold_cftc_cot_ingest_job`, `gold_wgc_cb_ingest_job`, `gold_posture_compute_job`).
 
 ## Rules
 
@@ -15,3 +34,5 @@ The only place that talks to the outside world.
 - **Massive can be absent.** If `MASSIVE_API_KEY` is missing the worker uses `_NoOhlc` (null object). Don't crash the scheduler on a missing key.
 - **No retry logic here.** Backoff/retry lives in `api/client.py` (UW) — sources stay thin.
 - **Never add a Yahoo Finance source.** Project-wide rule — yfinance is for radon/other projects, not this one.
+- **Telemetry hook.** Gold sources accept a `record_request` callable that emits `ExternalApiRequestEvent` rows via `ExternalApiRequestRecorder` (production wiring) — keep it injectable for tests.
+- **Backtest lag rule for COT.** Always lag inputs to CFTC `release_date + 3 trading days`. Using `obs_date` (Tuesday position date) leaks look-ahead because the report is published Friday.

--- a/web/app/CLAUDE.md
+++ b/web/app/CLAUDE.md
@@ -9,6 +9,11 @@ app/
 ├── stock/[ticker]/       # Per-ticker detail page
 │   ├── layout.tsx        # Header + TabBar
 │   └── page.tsx          # Tab router (Tables | Vol | Flow | TradePlan | Market Structure)
+├── scanner/              # /scanner — detector candidates + discovery (force-dynamic)
+├── regime/               # /regime — CRI + VCG + GEX (market-wide, ported from xenon)
+├── gold/                 # /gold — GOLD COMPASS five-tier cockpit
+│   └── replay/[date]/    # /gold/replay/<YYYY-MM-DD> — historical posture
+├── cockpit/[ticker]/     # /cockpit/<SPX|SPY|QQQ|IWM> — index dealer state research
 ├── watchlist/            # /watchlist (currently a thin variant of /)
 └── admin/                # /admin — health + scheduler controls
 ```


### PR DESCRIPTION
## Summary

The docs had drifted from shipped surface. This PR catches them up — code-only changes, no behavior.

- **README** — added an *Other views* table for `/scanner`, `/regime`, `/gold` (+ `/gold/replay/<date>`), `/cockpit/<TICKER>`, `/admin`. These pages all exist but only the dashboard and per-stock page were documented.
- **CLAUDE.md + AGENTS.md** — extended *Where to look first* with rows for Scanner (PR #45/#46), Regime indicators / CRI/GEX/VCG (PR #39), Gold Compass (PR #40), index dealer cockpit (PR #27), and the in-progress `storage/` split (PR #38). The legacy `repository.py` row now flags it as do-not-extend and points at the new leaf-module row.
- **CLAUDE.md sync** — ported two standing rules that had drifted into AGENTS.md only: milestone commits during big projects, and `feat/fix/chore/misc` branch prefixes (not `codex/`). The two files are byte-identical again.
- **web/app/CLAUDE.md** — added `scanner/`, `regime/`, `gold/` (+ `gold/replay/[date]/`), and `cockpit/[ticker]/` to the App Router routes tree.

Net diff: +29 / -2 across 4 files.

## Test plan

- [x] `diff CLAUDE.md AGENTS.md` returns exit 0 (sync rule satisfied)
- [ ] Skim the rendered README on the PR page — verify the new *Other views* table renders cleanly
- [ ] Skim the rendered CLAUDE.md table — verify new rows wrap reasonably on GitHub