### PR TITLE
fix(worker): correct APScheduler weekday crons

### DIFF
--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -71,8 +71,8 @@ class Settings(BaseModel):
     base_url: str = "https://api.unusualwhales.com"
     # Scheduler — consumed by uw_scan.worker.scheduler and uw_scan.api.routers.health
     spot_refresh_seconds: int = 300
-    full_scan_cron: str = "0 5-16 * * 1-5"
-    ohlc_pull_cron: str = "30 17 * * 1-5"
+    full_scan_cron: str = "0 5-16 * * 0-4"
+    ohlc_pull_cron: str = "30 17 * * 0-4"
     rth_tz: str = "America/New_York"
     worker_role: str = "all"
     worker_index: int = 0
@@ -94,7 +94,7 @@ class Settings(BaseModel):
     trade_insights_ai_poll_seconds: int = 3
     # Cockpit (6-dim matrix) — see docs/superpowers/research/six-dimension-matrix/
     cockpit_tickers: list[str] = ["SPX", "SPY", "QQQ", "IWM"]
-    cockpit_snapshot_cron: str = "30 16 * * 1-5"
+    cockpit_snapshot_cron: str = "30 16 * * 0-4"
     cockpit_target_dtes: list[int] = [0, 14, 30, 90]
     cockpit_oi_band_pct: Decimal = Decimal("0.10")
     cockpit_oi_max_dte: int = 7
@@ -183,8 +183,8 @@ class Settings(BaseModel):
             spot_refresh_seconds=int(
                 os.environ.get("UW_SCAN_SPOT_REFRESH_SECONDS", "300")
             ),
-            full_scan_cron=os.environ.get("UW_SCAN_FULL_SCAN_CRON", "0 5-16 * * 1-5"),
-            ohlc_pull_cron=os.environ.get("UW_SCAN_OHLC_PULL_CRON", "30 17 * * 1-5"),
+            full_scan_cron=os.environ.get("UW_SCAN_FULL_SCAN_CRON", "0 5-16 * * 0-4"),
+            ohlc_pull_cron=os.environ.get("UW_SCAN_OHLC_PULL_CRON", "30 17 * * 0-4"),
             rth_tz=os.environ.get("UW_SCAN_RTH_TZ", "America/New_York"),
             worker_role=os.environ.get("UW_SCAN_WORKER_ROLE", "all"),
             worker_index=int(os.environ.get("UW_SCAN_WORKER_INDEX", "0")),
@@ -230,7 +230,7 @@ class Settings(BaseModel):
                 "COCKPIT_TICKERS", default=["SPX", "SPY", "QQQ", "IWM"]
             ),
             cockpit_snapshot_cron=os.environ.get(
-                "COCKPIT_SNAPSHOT_CRON", "30 16 * * 1-5"
+                "COCKPIT_SNAPSHOT_CRON", "30 16 * * 0-4"
             ),
             cockpit_target_dtes=_parse_int_csv_env(
                 "COCKPIT_TARGET_DTES", default=[0, 14, 30, 90]

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -26,11 +26,11 @@ Set `UW_SCAN_WORKER_ROLE=uw|massive|all`, `UW_SCAN_WORKER_INDEX`, and
 | Job | Trigger | Default |
 |---|---|---|
 | `spot_refresh` | interval | `UW_SCAN_SPOT_REFRESH_SECONDS` (default 300s) |
-| `full_scan` | cron | `0 5-16 * * 1-5`; scans only missing cards or cards older than 8h |
-| `ohlc_pull` | cron | `30 17 * * 1-5` |
+| `full_scan` | cron | `0 5-16 * * 0-4`; scans only missing cards or cards older than 8h |
+| `ohlc_pull` | cron | `30 17 * * 0-4` |
 | `rescan_tick` | interval | 1s; user-requested rescans bypass the 8h freshness guard |
-| `daily_spy_ohlc_refresh` | cron | `30 16 * * 1-5` |
-| `nightly_vol_analytics_rollup` | cron | `0 18 * * 1-5` |
+| `daily_spy_ohlc_refresh` | cron | `30 16 * * 0-4` |
+| `nightly_vol_analytics_rollup` | cron | `0 18 * * 0-4` |
 
 ## Rules
 
@@ -38,6 +38,7 @@ Set `UW_SCAN_WORKER_ROLE=uw|massive|all`, `UW_SCAN_WORKER_INDEX`, and
 - **MASSIVE_API_KEY can be unset.** Jobs that need it should no-op + warn (see `_spy_ohlc_refresh`). Never crash the scheduler.
 - **No duplicated provider work.** If a worker role can run in more than one process, loops over watchlist tickers must either use stable shard ownership or atomically claim queued work.
 - **ET timezone everywhere.** `CronTrigger.from_crontab(..., timezone=settings.rth_tz)`. Don't use UTC for trading-hour crons.
+- **APScheduler weekdays are Monday=0.** Use `0-4` for Monday-Friday crons.
 - **Automatic UW scan freshness guard.** Full scan only queries tickers with no persisted card data or card data older than 8 hours. User-requested rescans always run.
 - **UW flow refresh window is weekdays 5:00am-7:59pm ET.** Flow-tab refresh skips outside that window.
 - **Idempotent.** A job that runs twice in a minute (e.g., after a restart) must produce the same DB state.

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -490,13 +490,13 @@ def main() -> int:
             # Volatility tab v2 jobs — ET-anchored via from_crontab (review I9).
             sched.add_job(
                 _spy_ohlc_refresh,
-                CronTrigger.from_crontab("30 16 * * 1-5", timezone=settings.rth_tz),
+                CronTrigger.from_crontab("30 16 * * 0-4", timezone=settings.rth_tz),
                 id="daily_spy_ohlc_refresh",
                 name="Daily SPY OHLC refresh",
             )
             sched.add_job(
                 _vol_analytics_rollup,
-                CronTrigger.from_crontab("0 18 * * 1-5", timezone=settings.rth_tz),
+                CronTrigger.from_crontab("0 18 * * 0-4", timezone=settings.rth_tz),
                 id="nightly_vol_analytics_rollup",
                 name="Nightly vol analytics rollup",
             )
@@ -517,7 +517,7 @@ def main() -> int:
         )
         sched.add_job(
             _flow_data_refresh,
-            CronTrigger.from_crontab("15 18 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("15 18 * * 0-4", timezone=settings.rth_tz),
             id="nightly_flow_data_refresh",
             name="Nightly Flow tab data refresh",
         )
@@ -602,49 +602,49 @@ def main() -> int:
         # this group) avoids duplicate UW spend.
         sched.add_job(
             _gold_fred_ingest,
-            CronTrigger.from_crontab("0 17 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("0 17 * * 0-4", timezone=settings.rth_tz),
             id="gold_fred_ingest",
             name="Gold: FRED daily refresh",
         )
         sched.add_job(
             _gold_spot_ingest,
-            CronTrigger.from_crontab("5 17 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("5 17 * * 0-4", timezone=settings.rth_tz),
             id="gold_spot_ingest",
             name="Gold: spot price (GLD daily bars via massive)",
         )
         sched.add_job(
             _gold_uw_options_ingest,
-            CronTrigger.from_crontab("15 17 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("15 17 * * 0-4", timezone=settings.rth_tz),
             id="gold_uw_options_ingest",
             name="Gold: UW options snapshot (GLD/GDX/IAU)",
         )
         sched.add_job(
             _gold_comex_vault_ingest,
-            CronTrigger.from_crontab("30 17 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("30 17 * * 0-4", timezone=settings.rth_tz),
             id="gold_comex_vault_ingest",
             name="Gold: COMEX vault daily",
         )
         sched.add_job(
             _gold_etf_holdings_ingest,
-            CronTrigger.from_crontab("30 18 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("30 18 * * 0-4", timezone=settings.rth_tz),
             id="gold_etf_holdings_ingest",
             name="Gold: ETF holdings daily (GLD/IAU/GLDM/PHYS)",
         )
         sched.add_job(
             _gold_gpr_ingest,
-            CronTrigger.from_crontab("0 20 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("0 20 * * 0-4", timezone=settings.rth_tz),
             id="gold_gpr_ingest",
             name="Gold: GPR daily refresh",
         )
         sched.add_job(
             _gold_posture_compute,
-            CronTrigger.from_crontab("0 21 * * 1-5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("0 21 * * 0-4", timezone=settings.rth_tz),
             id="gold_posture_compute",
             name="Gold: posture row compute (post-ingest)",
         )
         sched.add_job(
             _gold_cftc_cot_ingest,
-            CronTrigger.from_crontab("0 17 * * 5", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("0 17 * * 4", timezone=settings.rth_tz),
             id="gold_cftc_cot_ingest",
             name="Gold: CFTC COT weekly (Fridays)",
         )

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from apscheduler.triggers.cron import CronTrigger
 from pydantic import SecretStr
 
 from uw_scan.config import Settings
@@ -121,3 +123,36 @@ def test_ohlc_provider_uses_configured_request_timeout(monkeypatch) -> None:
 
 def test_rescan_worker_concurrency_is_two() -> None:
     assert RESCAN_WORKER_CONCURRENCY == 2
+
+
+def test_default_weekday_crons_include_monday_et() -> None:
+    settings = Settings(api_key="uw")
+    monday_et = datetime(2026, 5, 18, 13, 50, tzinfo=ZoneInfo(settings.rth_tz))
+
+    for expr in (
+        settings.full_scan_cron,
+        settings.ohlc_pull_cron,
+        settings.cockpit_snapshot_cron,
+    ):
+        trigger = CronTrigger.from_crontab(expr, timezone=settings.rth_tz)
+        next_fire = trigger.get_next_fire_time(None, monday_et)
+
+        assert next_fire is not None
+        assert next_fire.weekday() == 0
+        assert next_fire.date() == monday_et.date()
+
+
+def test_scheduler_cron_literals_do_not_use_apscheduler_tuesday_to_saturday_range() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    production_sources = (
+        repo_root / "src/uw_scan/config.py",
+        repo_root / "src/uw_scan/worker/scheduler.py",
+    )
+
+    offenders = [
+        str(path.relative_to(repo_root))
+        for path in production_sources
+        if "* * 1-5" in path.read_text()
+    ]
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- change APScheduler weekday crons from `1-5` to `0-4` so Monday-Friday jobs actually include Monday and exclude Saturday
- correct the weekly CFTC schedule from APScheduler Saturday to Friday
- add regression coverage for Monday ET cron behavior and stale `1-5` production literals
- document APScheduler weekday numbering in the worker guide

## Verification
- `uv run pytest tests/unit/worker/test_scheduler.py -q`
- `UW_SCAN_TEST_DB_NAME=option_wizard_test uv run pytest tests/integration/api/test_health.py -q`

## Operational note
- restart the running worker processes after merge so the scheduler reloads the corrected cron expressions
