### PR TITLE
perf: batch storage writes and memoize hot chart derivations

### DIFF
--- a/docs/plans/2026-05-19-complexity-hotspots-optimization.md
+++ b/docs/plans/2026-05-19-complexity-hotspots-optimization.md
@@ -1,0 +1,562 @@
+# Complexity Hotspots Optimization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Reduce measured latency on the highest-confidence complexity hotspots without changing API contracts, persisted data shape, or UI behavior.
+
+**Architecture:** Keep the optimization local to existing storage mixins, API routers, worker jobs, and chart components. Prefer batching and memoized derived data over broad rewrites. Add narrow behavioral tests first, then add a lightweight measurement script so before/after claims have evidence.
+
+**Tech Stack:** Python via `uv` with project support for 3.11+, FastAPI, psycopg 3, pytest, Next.js 16, React 19, TypeScript, Vitest.
+
+---
+
+## Scope Guardrails
+
+- Do not change table schemas, migrations, API response schemas, OpenAPI component names, or visible UI copy unless a test proves the change is required.
+- Keep `src/uw_scan/storage/repository.py` thin; add or modify domain mixins only.
+- Preserve all `ON CONFLICT` behavior and return counts from repository insert/upsert methods.
+- Preserve row ordering in chart paths and API responses.
+- Do not claim percentage or multiplier performance gains unless a live Postgres before/after benchmark ran in the same environment. If live DB benchmarking is unavailable, describe the win structurally as fewer round trips.
+- Use milestone commits after each verified task.
+- Run `git diff --check` before each commit.
+
+## Baseline Commands
+
+Run from the worktree root:
+
+```bash
+uv run pytest tests/integration/test_repository_real_pg.py tests/integration/api/test_health.py -q
+cd web && npm run test
+cd web && npm run typecheck
+```
+
+Expected: pass, or document pre-existing failures before touching implementation.
+
+---
+
+### Task 0: Capture Pre-Change Performance Baseline
+
+**Files:**
+- No code changes required.
+- Optional scratch output only; do not commit environment-specific benchmark logs.
+
+**Step 1: Record current hotspot inventory**
+
+Run:
+
+```bash
+python3 /Users/chenxi/.codex/skills/complexity-optimizer/scripts/analyze_complexity.py /Users/chenxi/projects/unusual-whales/.claude/worktrees/chore+complexity-hotspots-plan --format json --exclude .venv --max-findings 1000
+```
+
+Expected: scanner still reports the storage write, health heartbeat, gold ingest, and chart render-derived-work hotspots this plan targets.
+
+**Step 2: Run pre-change live DB benchmark if a disposable/local DB is available**
+
+Run only when `UW_SCAN_DATABASE_URL` points to a database where temporary benchmark tables are acceptable:
+
+```bash
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 1000 --legacy-only
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 10000 --legacy-only
+```
+
+Expected: benchmark prints single-row execute timing for the current implementation path. Capture the output for PR notes, but do not commit it.
+
+If `scripts/bench_storage_batch_writes.py` does not exist yet, perform this baseline immediately after Task 1 creates the harness and before Task 2 changes repository writers.
+
+**Step 3: Fallback when live DB benchmark is unavailable**
+
+Document in the PR notes:
+
+```text
+Live Postgres benchmark unavailable in this environment; performance evidence is structural only: converted N per-row client/server calls to one executemany call per batch, with integration tests preserving DB behavior.
+```
+
+Do not include estimated percentage or multiplier gains in the PR unless Step 2 ran.
+
+---
+
+### Task 1: Add Measurement Harness For Batch Writes
+
+**Files:**
+- Create: `scripts/bench_storage_batch_writes.py`
+- Test: `tests/unit/storage/test_batch_write_params.py`
+
+**Step 1: Write the failing test**
+
+Create a unit test that imports the parameter builders added in the next step and verifies they preserve row order and exact tuple values for a small set of model rows.
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_batch_write_params.py -q
+```
+
+Expected: fail because the parameter builder module/function does not exist.
+
+**Step 2: Add pure parameter builders**
+
+Add small pure helpers near the target storage mixins, not in `repository.py`. Start with the largest repeated writers:
+
+- `src/uw_scan/storage/options.py`
+  - `_iv_term_params`
+  - `_greek_exposure_params`
+  - `_greeks_params`
+  - `_option_contract_params`
+- `src/uw_scan/storage/volatility_raw.py`
+  - `_iv_rank_params`
+  - `_volatility_stats_params`
+  - `_realized_vol_params`
+  - `_skew_params`
+- `src/uw_scan/storage/flow.py`
+  - `_flow_event_params`
+
+Keep helpers private and deterministic. They should return `list[tuple[...]]` in input order.
+
+**Step 3: Add benchmark script**
+
+Create `scripts/bench_storage_batch_writes.py` with two modes:
+
+- `--mode params-only` measures Python tuple-building overhead without a database.
+- `--mode live-postgres` optionally runs against `UW_SCAN_DATABASE_URL` and compares single-row execute vs `executemany` on a temporary table.
+- `--legacy-only` measures only the current single-row execute path so it can be used as a pre-change baseline before Task 2.
+
+The script must not require secrets or run by default in CI.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_batch_write_params.py -q
+uv run python scripts/bench_storage_batch_writes.py --mode params-only --rows 10000
+```
+
+Expected: tests pass and script prints rows/sec for tuple construction.
+
+If `UW_SCAN_DATABASE_URL` is available, also run:
+
+```bash
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 1000 --legacy-only
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 10000 --legacy-only
+```
+
+Expected: script prints current single-row execute timings for PR comparison.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/bench_storage_batch_writes.py tests/unit/storage/test_batch_write_params.py src/uw_scan/storage/options.py src/uw_scan/storage/volatility_raw.py src/uw_scan/storage/flow.py
+git commit -m "test(storage): add batch write measurement harness"
+```
+
+---
+
+### Task 2: Convert Hot Repository Writers To `executemany`
+
+**Files:**
+- Modify: `src/uw_scan/storage/options.py`
+- Modify: `src/uw_scan/storage/volatility_raw.py`
+- Modify: `src/uw_scan/storage/flow.py`
+- Test: `tests/unit/storage/test_batch_write_params.py`
+- Existing integration tests:
+  - `tests/integration/cards/test_matrix_state_db.py`
+  - `tests/integration/api/test_cockpit_endpoint.py`
+  - `tests/integration/test_repository_real_pg.py`
+
+**Step 1: Add failing call-shape tests**
+
+Extend the unit tests with a fake cursor/connection and assert the target methods call `cur.executemany(sql, params)` once for multi-row inputs and never call per-row `execute`.
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_batch_write_params.py -q
+```
+
+Expected: fail because current code loops over `cur.execute`.
+
+**Step 2: Add real DB behavior tests**
+
+Add or extend integration tests so each converted method is covered by real Postgres behavior, not only fake cursor call shape. Cover:
+
+- empty input returns `0` and performs no write
+- first insert persists the expected rows
+- duplicate rerun preserves `ON CONFLICT` semantics and does not create duplicates
+- returned count remains compatible with the existing method contract
+- persisted row values are identical to the pre-batch behavior, including ordering where callers observe it
+
+Use existing integration suites where possible:
+
+- `tests/integration/cards/test_matrix_state_db.py`
+- `tests/integration/api/test_cockpit_endpoint.py`
+- `tests/integration/test_repository_real_pg.py`
+- `tests/integration/test_pipeline_e2e.py` for flow events if needed
+
+Run the targeted test before implementation and confirm it fails for the new batching-specific assertions where appropriate.
+
+**Step 3: Replace per-row execute loops**
+
+For each hot writer, build `params = _*_params(...)`, return `0` when empty, then call `cur.executemany(sql, params)`. Preserve the exact SQL and conflict behavior.
+
+Target first:
+
+- `insert_iv_term_rows`
+- `insert_greek_exposure_rows`
+- `insert_greeks_rows`
+- `insert_option_contract_rows`
+- `upsert_iv_rank_rows`
+- `upsert_volatility_stats_rows`
+- `upsert_realized_vol_rows`
+- `upsert_skew_rows`
+- `insert_flow_events`
+
+Defer low-volume one-row or tiny-list methods unless benchmark data says they matter.
+
+**Step 4: Verify behavior**
+
+Run:
+
+```bash
+uv run pytest tests/unit/storage/test_batch_write_params.py -q
+uv run pytest tests/integration/cards/test_matrix_state_db.py tests/integration/api/test_cockpit_endpoint.py tests/integration/test_repository_real_pg.py tests/integration/test_pipeline_e2e.py -q
+uv run python scripts/bench_storage_batch_writes.py --mode params-only --rows 10000
+git diff --check
+```
+
+Expected: tests pass; benchmark output captured for PR evidence.
+
+If `UW_SCAN_DATABASE_URL` is available, also run:
+
+```bash
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 1000
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 10000
+```
+
+Expected: script prints single-row execute vs `executemany` timings from the same environment. Use these numbers for any percentage or multiplier claim.
+
+**Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/options.py src/uw_scan/storage/volatility_raw.py src/uw_scan/storage/flow.py tests/unit/storage/test_batch_write_params.py
+git commit -m "perf(storage): batch high-volume repository writes"
+```
+
+---
+
+### Task 3: Bulk Fetch Worker Heartbeats In Health API
+
+**Files:**
+- Modify: `src/uw_scan/storage/health.py`
+- Modify: `src/uw_scan/api/routers/health.py`
+- Test: `tests/integration/api/test_health.py`
+
+**Step 1: Write failing test**
+
+Add a test that inserts several `worker_heartbeat` rows, calls a new `repo.get_heartbeats([...])`, and asserts it returns a `dict[str, datetime]` with missing names omitted.
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_health.py -q
+```
+
+Expected: fail because `get_heartbeats` does not exist.
+
+**Step 2: Implement bulk repository method**
+
+Add:
+
+```python
+def get_heartbeats(self, job_names: Iterable[str]) -> dict[str, datetime]:
+    ...
+```
+
+Use one SQL query with `WHERE job_name = ANY(%s)` or an equivalent psycopg-safe array/list parameter. Return `{}` for an empty input list.
+
+**Step 3: Update API router**
+
+In `_worker_health_rows`, precompute all expected heartbeat names, fetch once, and populate rows from the returned mapping. Preserve labels, roles, indices, and lag calculation.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+uv run pytest tests/integration/api/test_health.py -q
+uv run pytest tests/unit/api/test_stock_router.py -q
+git diff --check
+```
+
+Expected: health tests pass and response shape remains stable.
+
+**Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/health.py src/uw_scan/api/routers/health.py tests/integration/api/test_health.py
+git commit -m "perf(health): fetch worker heartbeats in bulk"
+```
+
+---
+
+### Task 4: Batch Gold Ingest Persistence Loops
+
+**Files:**
+- Modify: `src/uw_scan/storage/gold.py`
+- Modify: `src/uw_scan/storage/gold_etf.py`
+- Modify: `src/uw_scan/worker/jobs/gold_jobs.py`
+- Test: `tests/integration/worker/test_gold_daily_jobs.py`
+- Test: `tests/integration/worker/test_gold_periodic_jobs.py`
+
+**Step 1: Write failing tests**
+
+Add real DB persistence tests for the new bulk methods and job paths before implementation. Existing tests already verify persisted rows; extend them so they also verify rerun/idempotency behavior for:
+
+- FRED daily macro rows
+- GPR daily macro rows
+- monthly macro rows
+- ETF holdings daily rows
+- ETF flows daily rows
+- WGC monthly rows
+
+Use mocks only where the behavior is about provider failure isolation or call boundaries, not as the primary proof of persistence correctness.
+
+Run:
+
+```bash
+uv run pytest tests/integration/worker/test_gold_daily_jobs.py tests/integration/worker/test_gold_periodic_jobs.py -q
+```
+
+Expected: fail for assertions that depend on the new bulk methods or new idempotency coverage.
+
+**Step 2: Add bulk repository methods**
+
+Use the existing `insert_wgc_etf_monthly_rows` style in `src/uw_scan/storage/gold_etf.py` as the template.
+
+Add only methods needed by the jobs:
+
+- daily macro series rows
+- monthly macro series rows
+- ETF holdings daily rows
+- ETF flows daily rows
+
+Each method should take an iterable of row dicts or typed source rows plus shared metadata like `as_of` and `source`, build params once, and call `executemany`.
+
+**Step 3: Update worker jobs**
+
+Buffer provider output into lists per source/ticker, then call the new bulk repository method. Preserve existing exception boundaries so one provider/ticker failure does not abort unrelated work.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+uv run pytest tests/integration/worker/test_gold_daily_jobs.py tests/integration/worker/test_gold_periodic_jobs.py -q
+uv run pytest tests/integration/api/test_gold_router_state.py tests/integration/api/test_gold_router_replay.py -q
+git diff --check
+```
+
+Expected: tests pass, with no schema/API changes. Real DB assertions, not mocks alone, must prove persisted values and idempotency.
+
+**Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/gold.py src/uw_scan/storage/gold_etf.py src/uw_scan/worker/jobs/gold_jobs.py tests/integration/worker/test_gold_daily_jobs.py tests/integration/worker/test_gold_periodic_jobs.py
+git commit -m "perf(gold): batch ingest persistence writes"
+```
+
+---
+
+### Task 5: Memoize High-Cost Gold And Cockpit Chart Derivations
+
+**Files:**
+- Modify: `web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx`
+- Modify: `web/app/cockpit/[ticker]/CockpitChart.tsx`
+- Modify: `web/app/cockpit/[ticker]/CockpitDealerTab.tsx`
+- Test: existing web test suite, add focused tests only if current harness covers these components cleanly
+
+**Step 1: Confirm current behavior**
+
+Run:
+
+```bash
+cd web && npm run test
+cd web && npm run typecheck
+```
+
+Expected: pass before edits.
+
+**Step 2: Memoize Gold chart data**
+
+In `GoldHoldingsVsPriceChart.tsx`, use `useMemo` for:
+
+- selected country set
+- visible countries
+- country color map
+- flattened central-bank history points
+- all date/domain arrays
+- chart points and ticks
+
+Replace repeated `colorForCountry(countryIso3, cbCountryHistory)` linear scans with `countryColorByIso3.get(countryIso3)`.
+
+**Step 3: Memoize Cockpit chart data**
+
+In `CockpitDealerTab.tsx`, precompute vanna/charm series arrays with `useMemo`. In `CockpitChart.tsx`, either document that callers must pass sorted points or add an `assumeSorted?: boolean` option and use it only where the caller already sorted by strike/date.
+
+**Step 4: Verify**
+
+Run:
+
+```bash
+cd web && npm run test
+cd web && npm run typecheck
+cd web && npm run lint
+git diff --check
+```
+
+Then run browser verification on a non-default port and check Gold plus Cockpit pages with Playwright or the Browser plugin:
+
+```bash
+cd web && npm run dev -- --port 3011
+```
+
+Expected:
+
+- Gold page renders the holdings/central-bank chart after toggling Strategic, All, None, and one individual country.
+- Cockpit page renders dealer vanna/charm charts with non-empty SVG paths.
+- No console errors are introduced.
+
+**Step 5: Commit**
+
+```bash
+git add web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx web/app/cockpit/[ticker]/CockpitChart.tsx web/app/cockpit/[ticker]/CockpitDealerTab.tsx
+git commit -m "perf(web): memoize chart derivations"
+```
+
+---
+
+### Task 6: Final Verification And PR Evidence
+
+**Files:**
+- Modify only if needed: `docs/plans/2026-05-19-complexity-hotspots-optimization.md`
+
+**Step 1: Run full relevant backend checks**
+
+```bash
+uv run ruff check src/uw_scan tests scripts
+uv run pytest
+```
+
+Expected: all non-live tests pass.
+
+**Step 2: Run full relevant web checks**
+
+```bash
+cd web && npm run test
+cd web && npm run typecheck
+cd web && npm run lint
+```
+
+Expected: pass.
+
+**Step 3: Capture benchmark evidence**
+
+```bash
+uv run python scripts/bench_storage_batch_writes.py --mode params-only --rows 10000
+```
+
+If `UW_SCAN_DATABASE_URL` is configured for a disposable/local database:
+
+```bash
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 1000
+uv run python scripts/bench_storage_batch_writes.py --mode live-postgres --rows 10000
+```
+
+Record before/after numbers in the PR body. Do not commit environment-specific benchmark output.
+
+Only state numeric speedups when live Postgres benchmark numbers exist for both pre-change and post-change paths. Otherwise, state the measured structural change: per-row `execute` calls were replaced with one `executemany` call per batch and behavior was verified through integration tests.
+
+**Step 4: Self-review**
+
+Check:
+
+- No API schema diff unless intentionally documented.
+- No ordering changes in charts or response lists.
+- No new writes to `repository.py`.
+- Batch methods preserve conflict clauses and transaction behavior.
+- Gold ingest still isolates provider/ticker failures.
+- Worktree has no unrelated files.
+
+**Step 5: Commit final doc/evidence updates if any**
+
+```bash
+git add docs/plans/2026-05-19-complexity-hotspots-optimization.md
+git commit -m "docs(perf): record complexity optimization verification"
+```
+
+Skip this commit if the plan document was not changed during execution.
+
+---
+
+## PR Guidance
+
+PR title:
+
+```text
+perf: batch storage writes and memoize hot chart derivations
+```
+
+PR body must include:
+
+- Top hotspots addressed.
+- Exact tests run.
+- Benchmark command and output summary.
+- Statement that API contracts and OpenAPI output were not intentionally changed.
+- Residual risk: batching changes Postgres call shape, so integration tests are the merge gate.
+
+---
+
+## Execution Evidence
+
+Implemented on branch `chore/complexity-hotspots-plan` in worktree
+`.claude/worktrees/chore+complexity-hotspots-plan`.
+
+Milestone commits:
+
+- `62bd997` — `test(storage): add batch write measurement harness`
+- `553a7fa` — `perf(storage): batch high-volume repository writes`
+- `22fcf74` — `perf(health): fetch worker heartbeats in bulk`
+- `ab6c0c8` — `perf(gold): batch ingest persistence writes`
+- `f5f864e` — `perf(web): memoize chart derivations`
+
+Verification run from the worktree:
+
+- `uv run ruff check src/uw_scan tests scripts` — passed, `All checks passed!`
+- `uv run pytest` — passed, `666 passed, 5 skipped in 355.90s`
+- `cd web && npm run test` — passed, `36 passed (36)`, `221 passed (221)`
+- `cd web && npm run typecheck` — passed
+- `cd web && npx eslint 'components/gold/lens1/GoldHoldingsVsPriceChart.tsx' 'app/cockpit/[ticker]/CockpitChart.tsx' 'app/cockpit/[ticker]/CockpitDealerTab.tsx'` — passed
+- `cd web && npm run lint` — failed on unrelated pre-existing scanner/regime files:
+  `web/app/scanner/page.tsx`, `web/components/regime/CriSubTab.tsx`,
+  `web/components/regime/GexSubTab.tsx`,
+  `web/components/scanner/CandidateCard.tsx`, and
+  `web/components/scanner/DiscoveredCard.tsx`. The changed chart files pass
+  targeted ESLint.
+- `uv run python scripts/bench_storage_batch_writes.py --mode params-only --rows 10000`
+  — `best=0.000717s`, `median=0.000765s`, `rows_per_sec=13066925`.
+- Live Postgres benchmark was skipped because `UW_SCAN_DATABASE_URL` was not set.
+  No numeric DB speedup claim should be made from this run.
+- Playwright browser check on `http://localhost:3011`:
+  Gold chart rendered `24` non-empty SVG paths after Strategic/All/None/country
+  toggles; Cockpit dealer rendered `6` non-empty chart polylines. Known health
+  CORS noise appeared because the non-default web origin `3011` calls the API on
+  `127.0.0.1:8400`; no unexpected chart/page errors were observed.
+
+Complexity optimizer after-scan:
+
+- Total scanner findings dropped from `552` baseline to `536`.
+- `io-or-query-in-loop` dropped from `23` baseline to `15`.
+- Targeted storage hits after scan:
+  `storage/volatility_raw.py=0`, `storage/flow.py=0`,
+  `worker/jobs/gold_jobs.py=1`.
+- Remaining scanner findings are still leads rather than proof; this PR only
+  claims structural reductions where tests verify behavior.

--- a/docs/plans/2026-05-19-complexity-hotspots-optimization.md
+++ b/docs/plans/2026-05-19-complexity-hotspots-optimization.md
@@ -527,6 +527,8 @@ Milestone commits:
 - `22fcf74` — `perf(health): fetch worker heartbeats in bulk`
 - `ab6c0c8` — `perf(gold): batch ingest persistence writes`
 - `f5f864e` — `perf(web): memoize chart derivations`
+- `2637a30` — `docs(perf): record complexity optimization verification`
+- `36d052b` — `chore(perf): keep benchmark uv-invoked`
 
 Verification run from the worktree:
 

--- a/scripts/bench_storage_batch_writes.py
+++ b/scripts/bench_storage_batch_writes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Measure storage batch-write plumbing without requiring application secrets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+from collections.abc import Iterable
+
+
+def _build_params(rows: int) -> list[tuple[int, str, int]]:
+    return [(idx, f"ticker-{idx % 25}", idx * 10) for idx in range(rows)]
+
+
+def _time_call(fn, *, repeats: int) -> list[float]:
+    durations: list[float] = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        fn()
+        durations.append(time.perf_counter() - start)
+    return durations
+
+
+def _print_result(label: str, rows: int, durations: Iterable[float]) -> None:
+    samples = list(durations)
+    best = min(samples)
+    median = statistics.median(samples)
+    rows_per_second = rows / median if median else float("inf")
+    print(
+        f"{label}: rows={rows} best={best:.6f}s median={median:.6f}s "
+        f"rows_per_sec={rows_per_second:.0f}"
+    )
+
+
+def _run_params_only(rows: int, repeats: int) -> None:
+    durations = _time_call(lambda: _build_params(rows), repeats=repeats)
+    _print_result("params-only tuple build", rows, durations)
+
+
+def _run_live_postgres(rows: int, repeats: int, legacy_only: bool) -> None:
+    database_url = os.environ.get("UW_SCAN_DATABASE_URL")
+    if not database_url:
+        raise SystemExit(
+            "UW_SCAN_DATABASE_URL is required for --mode live-postgres; "
+            "use --mode params-only when a disposable DB is unavailable."
+        )
+
+    import psycopg
+
+    params = _build_params(rows)
+    create_sql = (
+        "CREATE TEMP TABLE bench_storage_batch_writes ("
+        "id integer PRIMARY KEY, ticker text NOT NULL, amount integer NOT NULL"
+        ") ON COMMIT PRESERVE ROWS"
+    )
+    insert_sql = (
+        "INSERT INTO bench_storage_batch_writes (id, ticker, amount) "
+        "VALUES (%s, %s, %s) "
+        "ON CONFLICT (id) DO UPDATE SET "
+        "ticker=EXCLUDED.ticker, amount=EXCLUDED.amount"
+    )
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS bench_storage_batch_writes")
+            cur.execute(create_sql)
+        conn.commit()
+
+        def clear_table() -> None:
+            with conn.cursor() as cur:
+                cur.execute("TRUNCATE bench_storage_batch_writes")
+            conn.commit()
+
+        def run_single_row_executes() -> None:
+            clear_table()
+            with conn.cursor() as cur:
+                for row in params:
+                    cur.execute(insert_sql, row)
+            conn.commit()
+
+        legacy_durations = _time_call(run_single_row_executes, repeats=repeats)
+        _print_result("live-postgres per-row execute", rows, legacy_durations)
+
+        if legacy_only:
+            return
+
+        def run_executemany() -> None:
+            clear_table()
+            with conn.cursor() as cur:
+                cur.executemany(insert_sql, params)
+            conn.commit()
+
+        batch_durations = _time_call(run_executemany, repeats=repeats)
+        _print_result("live-postgres executemany", rows, batch_durations)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["params-only", "live-postgres"], required=True)
+    parser.add_argument("--rows", type=int, default=10_000)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument(
+        "--legacy-only",
+        action="store_true",
+        help="Only measure the single-row execute path for pre-change baselines.",
+    )
+    args = parser.parse_args()
+
+    if args.rows <= 0:
+        raise SystemExit("--rows must be positive")
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be positive")
+    if args.legacy_only and args.mode != "live-postgres":
+        raise SystemExit("--legacy-only is only valid with --mode live-postgres")
+
+    if args.mode == "params-only":
+        _run_params_only(args.rows, args.repeats)
+    else:
+        _run_live_postgres(args.rows, args.repeats, args.legacy_only)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_storage_batch_writes.py
+++ b/scripts/bench_storage_batch_writes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Measure storage batch-write plumbing without requiring application secrets."""
 
 from __future__ import annotations

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -108,28 +108,37 @@ def _worker_health_rows(
     uw_count: int,
     massive_count: int,
 ) -> list[WorkerHealth]:
-    rows: list[WorkerHealth] = []
+    expected_workers: list[tuple[str, Literal["uw", "massive"], int, str]] = []
     for role, count, label_prefix in (
         ("uw", uw_count, "UW"),
         ("massive", massive_count, "Massive"),
     ):
         for index in range(max(0, count)):
-            heartbeat_name = f"worker:{role}:{index}"
-            last_beat_at = repo.get_heartbeat(heartbeat_name)
-            rows.append(
-                WorkerHealth(
-                    label=f"{label_prefix} {index + 1}",
-                    role=role,
-                    index=index,
-                    heartbeat_name=heartbeat_name,
-                    last_beat_at=last_beat_at,
-                    lag_seconds=(
-                        (now_utc - last_beat_at).total_seconds()
-                        if last_beat_at is not None
-                        else None
-                    ),
-                )
+            expected_workers.append(
+                (f"{label_prefix} {index + 1}", role, index, f"worker:{role}:{index}")
             )
+
+    heartbeats = repo.get_heartbeats(
+        heartbeat_name for _, _, _, heartbeat_name in expected_workers
+    )
+
+    rows: list[WorkerHealth] = []
+    for label, role, index, heartbeat_name in expected_workers:
+        last_beat_at = heartbeats.get(heartbeat_name)
+        rows.append(
+            WorkerHealth(
+                label=label,
+                role=role,
+                index=index,
+                heartbeat_name=heartbeat_name,
+                last_beat_at=last_beat_at,
+                lag_seconds=(
+                    (now_utc - last_beat_at).total_seconds()
+                    if last_beat_at is not None
+                    else None
+                ),
+            )
+        )
     return rows
 
 

--- a/src/uw_scan/storage/flow.py
+++ b/src/uw_scan/storage/flow.py
@@ -133,45 +133,9 @@ class _FlowMixin:
             "%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (run_id, alert_id) DO NOTHING"
         )
+        params = _flow_event_params(run_id, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        r.id,
-                        r.ticker,
-                        r.option_chain,
-                        r.expiry,
-                        r.strike,
-                        r.type,
-                        r.price,
-                        r.underlying_price,
-                        r.total_size,
-                        r.total_premium,
-                        r.total_ask_side_prem,
-                        r.total_bid_side_prem,
-                        r.volume,
-                        r.open_interest,
-                        r.volume_oi_ratio,
-                        r.has_sweep,
-                        r.has_floor,
-                        r.has_multileg,
-                        r.all_opening_trades,
-                        r.iv_start,
-                        r.iv_end,
-                        r.alert_rule,
-                        r.flow_footprint_label or _flow_footprint_label(r),
-                        r.aggressor_label_confidence
-                        if r.aggressor_label_confidence is not None
-                        else _aggressor_label_confidence(r),
-                        r.rule_id,
-                        r.sector,
-                        r.issue_type,
-                        r.next_earnings_date,
-                        r.created_at,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def upsert_flow_alerts_daily_rollup(

--- a/src/uw_scan/storage/flow.py
+++ b/src/uw_scan/storage/flow.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable
 from datetime import date as _date
 from datetime import datetime
 from decimal import Decimal
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import psycopg
@@ -65,6 +66,48 @@ def _flow_alert_trade_date(rows: list[models.FlowAlert]) -> _date:
             created_at = created_at.replace(tzinfo=market_tz)
         return created_at.astimezone(market_tz).date()
     return datetime.now(market_tz).date()
+
+
+def _flow_event_params(
+    run_id: int, rows: Iterable[models.FlowAlert]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            run_id,
+            r.id,
+            r.ticker,
+            r.option_chain,
+            r.expiry,
+            r.strike,
+            r.type,
+            r.price,
+            r.underlying_price,
+            r.total_size,
+            r.total_premium,
+            r.total_ask_side_prem,
+            r.total_bid_side_prem,
+            r.volume,
+            r.open_interest,
+            r.volume_oi_ratio,
+            r.has_sweep,
+            r.has_floor,
+            r.has_multileg,
+            r.all_opening_trades,
+            r.iv_start,
+            r.iv_end,
+            r.alert_rule,
+            r.flow_footprint_label or _flow_footprint_label(r),
+            r.aggressor_label_confidence
+            if r.aggressor_label_confidence is not None
+            else _aggressor_label_confidence(r),
+            r.rule_id,
+            r.sector,
+            r.issue_type,
+            r.next_earnings_date,
+            r.created_at,
+        )
+        for r in rows
+    ]
 
 
 class _FlowMixin:

--- a/src/uw_scan/storage/gold.py
+++ b/src/uw_scan/storage/gold.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import date as _date
 from datetime import datetime
 from decimal import Decimal
@@ -26,16 +27,52 @@ class _GoldMixin:
         source: str,
         source_url: str | None,
     ) -> None:
+        self.insert_macro_series_daily_rows(
+            [
+                {
+                    "series_id": series_id,
+                    "obs_date": obs_date,
+                    "value": value,
+                    "release_date": release_date,
+                    "source_url": source_url,
+                }
+            ],
+            as_of=as_of,
+            source=source,
+        )
+
+    def insert_macro_series_daily_rows(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        as_of: datetime,
+        source: str,
+    ) -> int:
+        values = [
+            (
+                row["series_id"],
+                row["obs_date"],
+                row["value"],
+                as_of,
+                row.get("release_date"),
+                source,
+                row.get("source_url"),
+            )
+            for row in rows
+        ]
+        if not values:
+            return 0
         with self._conn.cursor() as cur:
-            cur.execute(
+            cur.executemany(
                 """
                 INSERT INTO uw_scan.macro_series_daily
                   (series_id, obs_date, value, as_of, release_date, source, source_url)
                 VALUES (%s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (series_id, obs_date, as_of) DO NOTHING
                 """,
-                (series_id, obs_date, value, as_of, release_date, source, source_url),
+                values,
             )
+        return len(values)
 
     def insert_macro_series_monthly(
         self,
@@ -47,16 +84,52 @@ class _GoldMixin:
         source: str,
         source_url: str | None,
     ) -> None:
+        self.insert_macro_series_monthly_rows(
+            [
+                {
+                    "series_id": series_id,
+                    "obs_month": obs_month,
+                    "value": value,
+                    "release_date": release_date,
+                    "source_url": source_url,
+                }
+            ],
+            as_of=as_of,
+            source=source,
+        )
+
+    def insert_macro_series_monthly_rows(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        as_of: datetime,
+        source: str,
+    ) -> int:
+        values = [
+            (
+                row["series_id"],
+                row["obs_month"],
+                row["value"],
+                as_of,
+                row.get("release_date"),
+                source,
+                row.get("source_url"),
+            )
+            for row in rows
+        ]
+        if not values:
+            return 0
         with self._conn.cursor() as cur:
-            cur.execute(
+            cur.executemany(
                 """
                 INSERT INTO uw_scan.macro_series_monthly
                   (series_id, obs_month, value, as_of, release_date, source, source_url)
                 VALUES (%s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (series_id, obs_month, as_of) DO NOTHING
                 """,
-                (series_id, obs_month, value, as_of, release_date, source, source_url),
+                values,
             )
+        return len(values)
 
     def fetch_macro_series_daily(
         self,
@@ -159,8 +232,45 @@ class _GoldMixin:
         as_of: datetime,
         source: str,
     ) -> None:
+        self.insert_etf_holdings_daily_rows(
+            [
+                {
+                    "ticker": ticker,
+                    "obs_date": obs_date,
+                    "holdings_oz": holdings_oz,
+                    "shares_out": shares_out,
+                    "nav_per_share": nav_per_share,
+                    "premium_pct": premium_pct,
+                }
+            ],
+            as_of=as_of,
+            source=source,
+        )
+
+    def insert_etf_holdings_daily_rows(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        as_of: datetime,
+        source: str,
+    ) -> int:
+        values = [
+            (
+                row["ticker"],
+                row["obs_date"],
+                row.get("holdings_oz"),
+                row.get("shares_out"),
+                row.get("nav_per_share"),
+                row.get("premium_pct"),
+                as_of,
+                source,
+            )
+            for row in rows
+        ]
+        if not values:
+            return 0
         with self._conn.cursor() as cur:
-            cur.execute(
+            cur.executemany(
                 """
                 INSERT INTO uw_scan.etf_holdings_daily
                   (ticker, obs_date, holdings_oz, shares_out, nav_per_share,
@@ -168,17 +278,9 @@ class _GoldMixin:
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (ticker, obs_date, as_of) DO NOTHING
                 """,
-                (
-                    ticker,
-                    obs_date,
-                    holdings_oz,
-                    shares_out,
-                    nav_per_share,
-                    premium_pct,
-                    as_of,
-                    source,
-                ),
+                values,
             )
+        return len(values)
 
     def fetch_etf_holdings_daily(
         self,

--- a/src/uw_scan/storage/gold_etf.py
+++ b/src/uw_scan/storage/gold_etf.py
@@ -27,8 +27,45 @@ class _GoldEtfMixin:
         as_of: datetime,
         source: str,
     ) -> None:
+        self.insert_etf_flows_daily_rows(
+            [
+                {
+                    "ticker": ticker,
+                    "obs_date": obs_date,
+                    "share_change": share_change,
+                    "premium_change_usd": premium_change_usd,
+                    "close": close,
+                    "volume": volume,
+                }
+            ],
+            as_of=as_of,
+            source=source,
+        )
+
+    def insert_etf_flows_daily_rows(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        as_of: datetime,
+        source: str,
+    ) -> int:
+        values = [
+            (
+                row["ticker"].upper(),
+                row["obs_date"],
+                row.get("share_change"),
+                row.get("premium_change_usd"),
+                row.get("close"),
+                row.get("volume"),
+                as_of,
+                source,
+            )
+            for row in rows
+        ]
+        if not values:
+            return 0
         with self._conn.cursor() as cur:
-            cur.execute(
+            cur.executemany(
                 f"""
                 INSERT INTO {self._schema}.etf_flows_daily
                   (ticker, obs_date, share_change, premium_change_usd, close,
@@ -36,17 +73,9 @@ class _GoldEtfMixin:
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (ticker, obs_date, as_of) DO NOTHING
                 """,
-                (
-                    ticker.upper(),
-                    obs_date,
-                    share_change,
-                    premium_change_usd,
-                    close,
-                    volume,
-                    as_of,
-                    source,
-                ),
+                values,
             )
+        return len(values)
 
     def fetch_etf_flows_daily(
         self,

--- a/src/uw_scan/storage/health.py
+++ b/src/uw_scan/storage/health.py
@@ -217,6 +217,21 @@ class _HealthMixin:
             row = cur.fetchone()
         return row[0] if row else None
 
+    def get_heartbeats(self, job_names: Iterable[str]) -> dict[str, datetime]:
+        names = list(dict.fromkeys(job_names))
+        if not names:
+            return {}
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT job_name, last_beat_at
+                FROM {self._schema}.worker_heartbeat
+                WHERE job_name = ANY(%s)
+                """,
+                (names,),
+            )
+            return {row[0]: row[1] for row in cur.fetchall()}
+
     def get_latest_heartbeat(self) -> tuple[str, datetime] | None:
         with self._conn.cursor() as cur:
             cur.execute(

--- a/src/uw_scan/storage/options.py
+++ b/src/uw_scan/storage/options.py
@@ -136,21 +136,9 @@ class _OptionsMixin:
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (run_id, ticker, expiry) DO NOTHING"
         )
+        params = _iv_term_params(run_id, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        r.ticker,
-                        r.date,
-                        r.expiry,
-                        r.dte,
-                        r.volatility,
-                        r.implied_move,
-                        r.implied_move_perc,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def insert_interpolated_iv_rows(
@@ -195,27 +183,9 @@ class _OptionsMixin:
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (run_id, ticker, expiry, strike) DO NOTHING"
         )
+        params = _greek_exposure_params(run_id, ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        ticker,
-                        r.date,
-                        r.expiry,
-                        r.strike,
-                        r.dte,
-                        r.call_delta,
-                        r.put_delta,
-                        r.call_gex,
-                        r.put_gex,
-                        r.call_vanna,
-                        r.put_vanna,
-                        r.call_charm,
-                        r.put_charm,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def insert_greeks_rows(
@@ -236,36 +206,9 @@ class _OptionsMixin:
             "%s, %s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (run_id, ticker, expiry, strike) DO NOTHING"
         )
+        params = _greeks_params(run_id, ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        ticker,
-                        r.date,
-                        r.expiry,
-                        r.strike,
-                        r.call_delta,
-                        r.put_delta,
-                        r.call_gamma,
-                        r.put_gamma,
-                        r.call_vega,
-                        r.put_vega,
-                        r.call_theta,
-                        r.put_theta,
-                        r.call_rho,
-                        r.put_rho,
-                        r.call_vanna,
-                        r.put_vanna,
-                        r.call_charm,
-                        r.put_charm,
-                        r.call_volatility,
-                        r.put_volatility,
-                        r.call_option_symbol,
-                        r.put_option_symbol,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def upsert_oi_per_strike_rows(
@@ -564,35 +507,9 @@ class _OptionsMixin:
             "%s, %s, %s, %s, %s, %s, %s) "
             "ON CONFLICT (run_id, option_symbol) DO NOTHING"
         )
+        params = _option_contract_params(run_id, ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        run_id,
-                        ticker,
-                        r.option_symbol,
-                        r.last_price,
-                        r.nbbo_bid,
-                        r.nbbo_ask,
-                        r.implied_volatility,
-                        r.open_interest,
-                        r.prev_oi,
-                        r.volume,
-                        r.ask_volume,
-                        r.bid_volume,
-                        r.mid_volume,
-                        r.multi_leg_volume,
-                        r.stock_multi_leg_volume,
-                        r.floor_volume,
-                        r.sweep_volume,
-                        r.no_side_volume,
-                        r.avg_price,
-                        r.high_price,
-                        r.low_price,
-                        r.total_premium,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def insert_dark_pool_rows(

--- a/src/uw_scan/storage/options.py
+++ b/src/uw_scan/storage/options.py
@@ -12,6 +12,113 @@ import psycopg
 from .. import models
 
 
+def _iv_term_params(
+    run_id: int, rows: Iterable[models.TermStructureRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            run_id,
+            r.ticker,
+            r.date,
+            r.expiry,
+            r.dte,
+            r.volatility,
+            r.implied_move,
+            r.implied_move_perc,
+        )
+        for r in rows
+    ]
+
+
+def _greek_exposure_params(
+    run_id: int, ticker: str, rows: Iterable[models.GreekExposureRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            run_id,
+            ticker,
+            r.date,
+            r.expiry,
+            r.strike,
+            r.dte,
+            r.call_delta,
+            r.put_delta,
+            r.call_gex,
+            r.put_gex,
+            r.call_vanna,
+            r.put_vanna,
+            r.call_charm,
+            r.put_charm,
+        )
+        for r in rows
+    ]
+
+
+def _greeks_params(
+    run_id: int, ticker: str, rows: Iterable[models.GreeksRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            run_id,
+            ticker,
+            r.date,
+            r.expiry,
+            r.strike,
+            r.call_delta,
+            r.put_delta,
+            r.call_gamma,
+            r.put_gamma,
+            r.call_vega,
+            r.put_vega,
+            r.call_theta,
+            r.put_theta,
+            r.call_rho,
+            r.put_rho,
+            r.call_vanna,
+            r.put_vanna,
+            r.call_charm,
+            r.put_charm,
+            r.call_volatility,
+            r.put_volatility,
+            r.call_option_symbol,
+            r.put_option_symbol,
+        )
+        for r in rows
+    ]
+
+
+def _option_contract_params(
+    run_id: int, ticker: str, rows: Iterable[models.OptionContractRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            run_id,
+            ticker,
+            r.option_symbol,
+            r.last_price,
+            r.nbbo_bid,
+            r.nbbo_ask,
+            r.implied_volatility,
+            r.open_interest,
+            r.prev_oi,
+            r.volume,
+            r.ask_volume,
+            r.bid_volume,
+            r.mid_volume,
+            r.multi_leg_volume,
+            r.stock_multi_leg_volume,
+            r.floor_volume,
+            r.sweep_volume,
+            r.no_side_volume,
+            r.avg_price,
+            r.high_price,
+            r.low_price,
+            r.total_premium,
+        )
+        for r in rows
+    ]
+
+
 class _OptionsMixin:
     _conn: psycopg.Connection
     _schema: str

--- a/src/uw_scan/storage/volatility_raw.py
+++ b/src/uw_scan/storage/volatility_raw.py
@@ -77,12 +77,9 @@ class _VolatilityRawMixin:
             "close=EXCLUDED.close, volatility=EXCLUDED.volatility, "
             "iv_rank_1y=EXCLUDED.iv_rank_1y, updated_at_src=EXCLUDED.updated_at_src"
         )
+        params = _iv_rank_params(ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (ticker, r.date, r.close, r.volatility, r.iv_rank_1y, r.updated_at),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def upsert_volatility_stats_rows(self, rows: Iterable[models.VolStatsRow]) -> int:
@@ -98,22 +95,9 @@ class _VolatilityRawMixin:
             "iv_rank=EXCLUDED.iv_rank, rv=EXCLUDED.rv, rv_low=EXCLUDED.rv_low, "
             "rv_high=EXCLUDED.rv_high"
         )
+        params = _volatility_stats_params(rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        r.ticker,
-                        r.date,
-                        r.iv,
-                        r.iv_low,
-                        r.iv_high,
-                        r.iv_rank,
-                        r.rv,
-                        r.rv_low,
-                        r.rv_high,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def upsert_realized_vol_rows(
@@ -131,19 +115,9 @@ class _VolatilityRawMixin:
             "realized_volatility=EXCLUDED.realized_volatility, "
             "unshifted_rv_date=EXCLUDED.unshifted_rv_date"
         )
+        params = _realized_vol_params(ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (
-                        ticker,
-                        r.date,
-                        r.price,
-                        r.implied_volatility,
-                        r.realized_volatility,
-                        r.unshifted_rv_date,
-                    ),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     def upsert_skew_rows(self, ticker: str, rows: Iterable[models.SkewRow]) -> int:
@@ -157,12 +131,9 @@ class _VolatilityRawMixin:
             "ON CONFLICT (ticker, market_date, delta, expiry) DO UPDATE SET "
             "risk_reversal=EXCLUDED.risk_reversal"
         )
+        params = _skew_params(ticker, rows)
         with self._conn.cursor() as cur:
-            for r in rows:
-                cur.execute(
-                    sql,
-                    (ticker, r.date, r.delta, r.expiry, r.risk_reversal),
-                )
+            cur.executemany(sql, params)
         return len(rows)
 
     # ------------------------------------------------------------------

--- a/src/uw_scan/storage/volatility_raw.py
+++ b/src/uw_scan/storage/volatility_raw.py
@@ -3,10 +3,62 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import psycopg
 
 from .. import models
+
+
+def _iv_rank_params(
+    ticker: str, rows: Iterable[models.IvRankRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (ticker, r.date, r.close, r.volatility, r.iv_rank_1y, r.updated_at)
+        for r in rows
+    ]
+
+
+def _volatility_stats_params(
+    rows: Iterable[models.VolStatsRow],
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            r.ticker,
+            r.date,
+            r.iv,
+            r.iv_low,
+            r.iv_high,
+            r.iv_rank,
+            r.rv,
+            r.rv_low,
+            r.rv_high,
+        )
+        for r in rows
+    ]
+
+
+def _realized_vol_params(
+    ticker: str, rows: Iterable[models.RealizedVolRow]
+) -> list[tuple[Any, ...]]:
+    return [
+        (
+            ticker,
+            r.date,
+            r.price,
+            r.implied_volatility,
+            r.realized_volatility,
+            r.unshifted_rv_date,
+        )
+        for r in rows
+    ]
+
+
+def _skew_params(ticker: str, rows: Iterable[models.SkewRow]) -> list[tuple[Any, ...]]:
+    return [
+        (ticker, r.date, r.delta, r.expiry, r.risk_reversal)
+        for r in rows
+    ]
 
 
 class _VolatilityRawMixin:

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -104,34 +104,36 @@ def gold_fred_ingest_job(
         for sid in ids:
             stored_sid = FRED_SERIES_ALIASES.get(sid, sid)
             try:
-                for obs in fred.fetch_series(
-                    sid, start=date.today() - timedelta(days=lookback_days)
-                ):
-                    repo.insert_macro_series_daily(
-                        series_id=stored_sid,
-                        obs_date=obs.obs_date,
-                        value=obs.value,
-                        as_of=now,
-                        release_date=None,
-                        source="FRED",
-                        source_url=None,
+                rows = [
+                    {
+                        "series_id": stored_sid,
+                        "obs_date": obs.obs_date,
+                        "value": obs.value,
+                        "release_date": None,
+                        "source_url": None,
+                    }
+                    for obs in fred.fetch_series(
+                        sid, start=date.today() - timedelta(days=lookback_days)
                     )
+                ]
+                repo.insert_macro_series_daily_rows(rows, as_of=now, source="FRED")
             except Exception as exc:
                 logger.exception("gold_fred_ingest: series=%s failed: %r", sid, exc)
         for sid in monthly_ids:
             try:
-                for obs in fred.fetch_series(
-                    sid, start=date.today() - timedelta(days=monthly_lookback_days)
-                ):
-                    repo.insert_macro_series_monthly(
-                        series_id=obs.series_id,
-                        obs_month=date(obs.obs_date.year, obs.obs_date.month, 1),
-                        value=obs.value,
-                        as_of=now,
-                        release_date=None,
-                        source="FRED",
-                        source_url=None,
+                rows = [
+                    {
+                        "series_id": obs.series_id,
+                        "obs_month": date(obs.obs_date.year, obs.obs_date.month, 1),
+                        "value": obs.value,
+                        "release_date": None,
+                        "source_url": None,
+                    }
+                    for obs in fred.fetch_series(
+                        sid, start=date.today() - timedelta(days=monthly_lookback_days)
                     )
+                ]
+                repo.insert_macro_series_monthly_rows(rows, as_of=now, source="FRED")
             except Exception as exc:
                 logger.exception(
                     "gold_fred_ingest: monthly series=%s failed: %r", sid, exc
@@ -148,18 +150,19 @@ def gold_gpr_ingest_job(*, dsn: str, lookback_days: int = 45) -> None:
     with psycopg.connect(dsn) as conn, GprProvider() as gpr:
         repo = Repository(conn, schema="uw_scan")
         try:
-            for obs in gpr.fetch_daily(
-                start=date.today() - timedelta(days=lookback_days)
-            ):
-                repo.insert_macro_series_daily(
-                    series_id="GPRD",
-                    obs_date=obs.obs_date,
-                    value=obs.value,
-                    as_of=now,
-                    release_date=None,
-                    source="GPR",
-                    source_url="https://www.matteoiacoviello.com/gpr.htm",
+            rows = [
+                {
+                    "series_id": "GPRD",
+                    "obs_date": obs.obs_date,
+                    "value": obs.value,
+                    "release_date": None,
+                    "source_url": "https://www.matteoiacoviello.com/gpr.htm",
+                }
+                for obs in gpr.fetch_daily(
+                    start=date.today() - timedelta(days=lookback_days)
                 )
+            ]
+            repo.insert_macro_series_daily_rows(rows, as_of=now, source="GPR")
         except Exception as exc:
             logger.exception("gold_gpr_ingest failed: %r", exc)
         conn.commit()
@@ -192,17 +195,18 @@ def gold_etf_holdings_ingest_job(
             ("PHYS", etf.fetch_phys, "Sprott"),
         ]:
             try:
-                for row in fetch_fn(start=holdings_start):
-                    repo.insert_etf_holdings_daily(
-                        ticker=row.ticker,
-                        obs_date=row.obs_date,
-                        holdings_oz=row.holdings_oz,
-                        shares_out=row.shares_out,
-                        nav_per_share=row.nav_per_share,
-                        premium_pct=row.premium_pct,
-                        as_of=now,
-                        source=source,
-                    )
+                rows = [
+                    {
+                        "ticker": row.ticker,
+                        "obs_date": row.obs_date,
+                        "holdings_oz": row.holdings_oz,
+                        "shares_out": row.shares_out,
+                        "nav_per_share": row.nav_per_share,
+                        "premium_pct": row.premium_pct,
+                    }
+                    for row in fetch_fn(start=holdings_start)
+                ]
+                repo.insert_etf_holdings_daily_rows(rows, as_of=now, source=source)
             except Exception as exc:
                 logger.warning(
                     "gold_etf_holdings_ingest: %s skipped (%s)",
@@ -231,22 +235,27 @@ def gold_etf_holdings_ingest_job(
                             chunk, as_of=now, source="WGC"
                         )
                     holdings_rows = 0
+                    holdings_values = []
                     for row in monthly_rows:
                         if (
                             row.ticker in {"GLD", "IAU", "GLDM", "PHYS"}
                             and row.holdings_tonnes is not None
                         ):
-                            repo.insert_etf_holdings_daily(
-                                ticker=row.ticker,
-                                obs_date=row.obs_date,
-                                holdings_oz=row.holdings_tonnes * TROY_OZ_PER_TONNE,
-                                shares_out=None,
-                                nav_per_share=None,
-                                premium_pct=None,
-                                as_of=now,
-                                source="WGC",
+                            holdings_values.append(
+                                {
+                                    "ticker": row.ticker,
+                                    "obs_date": row.obs_date,
+                                    "holdings_oz": row.holdings_tonnes
+                                    * TROY_OZ_PER_TONNE,
+                                    "shares_out": None,
+                                    "nav_per_share": None,
+                                    "premium_pct": None,
+                                }
                             )
                             holdings_rows += 1
+                    repo.insert_etf_holdings_daily_rows(
+                        holdings_values, as_of=now, source="WGC"
+                    )
                     logger.info(
                         "gold_etf_holdings_ingest: %s WGC monthly rows, %s holdings rows",
                         corpus_rows,
@@ -270,24 +279,25 @@ def gold_etf_holdings_ingest_job(
                 )
                 for ticker in GOLD_ETF_FLOW_TICKERS:
                     try:
-                        for row in uw_sources.fetch_etf_in_outflow(
-                            client=client,
-                            repo=repo,
-                            run_id=run_id,
-                            ticker=ticker,
-                            start_date=start,
-                            end_date=end,
-                        ):
-                            repo.insert_etf_flows_daily(
-                                ticker=row.ticker,
-                                obs_date=row.date,
-                                share_change=row.change,
-                                premium_change_usd=row.change_prem,
-                                close=row.close,
-                                volume=row.volume,
-                                as_of=now,
-                                source="UW",
+                        rows = [
+                            {
+                                "ticker": row.ticker,
+                                "obs_date": row.date,
+                                "share_change": row.change,
+                                "premium_change_usd": row.change_prem,
+                                "close": row.close,
+                                "volume": row.volume,
+                            }
+                            for row in uw_sources.fetch_etf_in_outflow(
+                                client=client,
+                                repo=repo,
+                                run_id=run_id,
+                                ticker=ticker,
+                                start_date=start,
+                                end_date=end,
                             )
+                        ]
+                        repo.insert_etf_flows_daily_rows(rows, as_of=now, source="UW")
                     except Exception as exc:
                         logger.warning(
                             "gold_etf_in_outflow_ingest: %s skipped (%s)",
@@ -337,16 +347,20 @@ def gold_spot_ingest_job(
         repo = Repository(conn, schema="uw_scan")
         try:
             bars = ohlc.fetch_daily(ticker, start, end)
-            for bar in bars:
-                repo.insert_macro_series_daily(
-                    series_id=series_id,
-                    obs_date=bar.date,
-                    value=bar.close,
-                    as_of=now,
-                    release_date=None,
-                    source="MASSIVE",
-                    source_url=None,
-                )
+            repo.insert_macro_series_daily_rows(
+                [
+                    {
+                        "series_id": series_id,
+                        "obs_date": bar.date,
+                        "value": bar.close,
+                        "release_date": None,
+                        "source_url": None,
+                    }
+                    for bar in bars
+                ],
+                as_of=now,
+                source="MASSIVE",
+            )
             logger.info(
                 "gold_spot_ingest: %s bars persisted under series_id=%s",
                 len(bars),

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -96,6 +96,21 @@ def test_health_reports_expected_provider_workers(seeded_db_with_cards):
     assert workers["worker:massive:1"].label == "Massive 2"
 
 
+def test_repository_get_heartbeats_returns_mapping_for_present_names(
+    seeded_db_empty_cards,
+):
+    seeded_db_empty_cards.upsert_heartbeat("worker:uw:0")
+    seeded_db_empty_cards.upsert_heartbeat("worker:massive:1")
+
+    heartbeats = seeded_db_empty_cards.get_heartbeats(
+        ["worker:uw:0", "worker:uw:1", "worker:massive:1"]
+    )
+
+    assert set(heartbeats) == {"worker:uw:0", "worker:massive:1"}
+    assert heartbeats["worker:uw:0"].tzinfo is not None
+    assert seeded_db_empty_cards.get_heartbeats([]) == {}
+
+
 def test_health_includes_uw_provider_usage_stats(client, seeded_db_empty_cards):
     now = datetime.now(UTC)
     seeded_db_empty_cards.insert_external_api_request(

--- a/tests/integration/storage/test_gold_repo_etf_inventory.py
+++ b/tests/integration/storage/test_gold_repo_etf_inventory.py
@@ -62,6 +62,44 @@ def test_insert_and_fetch_etf_holdings_daily(repo: Repository) -> None:
     assert rows[0]["holdings_oz"] == Decimal("28047500.12")
 
 
+def test_insert_etf_holdings_daily_rows_is_empty_safe_and_idempotent(
+    repo: Repository,
+) -> None:
+    as_of = datetime(2026, 5, 19, 12, tzinfo=UTC)
+    rows = [
+        {
+            "ticker": "GLD",
+            "obs_date": date(2026, 5, 14),
+            "holdings_oz": Decimal("28047500.12"),
+            "shares_out": None,
+            "nav_per_share": Decimal("234.50"),
+            "premium_pct": None,
+        },
+        {
+            "ticker": "GLD",
+            "obs_date": date(2026, 5, 15),
+            "holdings_oz": Decimal("28048500.12"),
+            "shares_out": None,
+            "nav_per_share": Decimal("235.50"),
+            "premium_pct": None,
+        },
+    ]
+
+    assert repo.insert_etf_holdings_daily_rows([], as_of=as_of, source="SPDR") == 0
+    assert repo.insert_etf_holdings_daily_rows(rows, as_of=as_of, source="SPDR") == 2
+    assert repo.insert_etf_holdings_daily_rows(rows, as_of=as_of, source="SPDR") == 2
+
+    fetched = repo.fetch_etf_holdings_daily("GLD", from_date=date(2026, 5, 1))
+    assert [row["obs_date"] for row in fetched] == [
+        date(2026, 5, 14),
+        date(2026, 5, 15),
+    ]
+    assert [row["holdings_oz"] for row in fetched] == [
+        Decimal("28047500.12"),
+        Decimal("28048500.12"),
+    ]
+
+
 def test_insert_and_fetch_etf_flows_daily(repo: Repository) -> None:
     as_of = datetime.now(UTC)
     repo.insert_etf_flows_daily(
@@ -82,6 +120,44 @@ def test_insert_and_fetch_etf_flows_daily(repo: Repository) -> None:
     assert rows[0]["share_change"] == Decimal("-900000")
     assert rows[0]["premium_change_usd"] == Decimal("-375300000")
     assert rows[0]["source"] == "UW"
+
+
+def test_insert_etf_flows_daily_rows_is_empty_safe_and_idempotent(
+    repo: Repository,
+) -> None:
+    as_of = datetime(2026, 5, 19, 12, tzinfo=UTC)
+    rows = [
+        {
+            "ticker": "gld",
+            "obs_date": date(2026, 5, 15),
+            "share_change": Decimal("-900000"),
+            "premium_change_usd": Decimal("-375300000"),
+            "close": Decimal("417.29"),
+            "volume": Decimal("8801181"),
+        },
+        {
+            "ticker": "GLD",
+            "obs_date": date(2026, 5, 16),
+            "share_change": Decimal("100000"),
+            "premium_change_usd": Decimal("42100000"),
+            "close": Decimal("421.00"),
+            "volume": Decimal("7801181"),
+        },
+    ]
+
+    assert repo.insert_etf_flows_daily_rows([], as_of=as_of, source="UW") == 0
+    assert repo.insert_etf_flows_daily_rows(rows, as_of=as_of, source="UW") == 2
+    assert repo.insert_etf_flows_daily_rows(rows, as_of=as_of, source="UW") == 2
+
+    fetched = repo.fetch_etf_flows_daily("GLD", from_date=date(2026, 5, 1))
+    assert [row["obs_date"] for row in fetched] == [
+        date(2026, 5, 15),
+        date(2026, 5, 16),
+    ]
+    assert [row["share_change"] for row in fetched] == [
+        Decimal("-900000"),
+        Decimal("100000"),
+    ]
 
 
 def test_insert_and_fetch_wgc_etf_monthly(repo: Repository) -> None:

--- a/tests/integration/storage/test_gold_repo_macro_series.py
+++ b/tests/integration/storage/test_gold_repo_macro_series.py
@@ -62,6 +62,39 @@ def test_insert_and_fetch_macro_series_daily(repo: Repository) -> None:
     assert rows[0]["value"] == Decimal("1.97")
 
 
+def test_insert_macro_series_daily_rows_is_empty_safe_and_idempotent(
+    repo: Repository,
+) -> None:
+    as_of = datetime(2026, 5, 19, 12, tzinfo=UTC)
+    rows = [
+        {
+            "series_id": "DFII10",
+            "obs_date": date(2026, 5, 14),
+            "value": Decimal("1.97"),
+            "release_date": None,
+            "source_url": None,
+        },
+        {
+            "series_id": "DFII10",
+            "obs_date": date(2026, 5, 15),
+            "value": Decimal("2.01"),
+            "release_date": None,
+            "source_url": None,
+        },
+    ]
+
+    assert repo.insert_macro_series_daily_rows([], as_of=as_of, source="FRED") == 0
+    assert repo.insert_macro_series_daily_rows(rows, as_of=as_of, source="FRED") == 2
+    assert repo.insert_macro_series_daily_rows(rows, as_of=as_of, source="FRED") == 2
+
+    fetched = repo.fetch_macro_series_daily("DFII10", from_date=date(2026, 5, 1))
+    assert [row["obs_date"] for row in fetched] == [
+        date(2026, 5, 14),
+        date(2026, 5, 15),
+    ]
+    assert [row["value"] for row in fetched] == [Decimal("1.97"), Decimal("2.01")]
+
+
 def test_insert_macro_series_daily_keeps_vintages(repo: Repository) -> None:
     """Re-pulling a series writes a new vintage row, doesn't overwrite."""
     repo.insert_macro_series_daily(
@@ -127,3 +160,38 @@ def test_macro_series_monthly_round_trip(repo: Repository) -> None:
     rows = repo.fetch_macro_series_monthly("CPIAUCSL", from_month=date(2026, 1, 1))
     assert len(rows) == 1
     assert rows[0]["obs_month"] == date(2026, 4, 1)
+
+
+def test_insert_macro_series_monthly_rows_is_empty_safe_and_idempotent(
+    repo: Repository,
+) -> None:
+    as_of = datetime(2026, 5, 19, 12, tzinfo=UTC)
+    rows = [
+        {
+            "series_id": "CPIAUCSL",
+            "obs_month": date(2026, 3, 1),
+            "value": Decimal("309.7"),
+            "release_date": date(2026, 4, 10),
+            "source_url": None,
+        },
+        {
+            "series_id": "CPIAUCSL",
+            "obs_month": date(2026, 4, 1),
+            "value": Decimal("310.1"),
+            "release_date": date(2026, 5, 14),
+            "source_url": None,
+        },
+    ]
+
+    assert repo.insert_macro_series_monthly_rows([], as_of=as_of, source="FRED") == 0
+    assert repo.insert_macro_series_monthly_rows(rows, as_of=as_of, source="FRED") == 2
+    assert repo.insert_macro_series_monthly_rows(rows, as_of=as_of, source="FRED") == 2
+
+    fetched = repo.fetch_macro_series_monthly(
+        "CPIAUCSL", from_month=date(2026, 1, 1)
+    )
+    assert [row["obs_month"] for row in fetched] == [
+        date(2026, 3, 1),
+        date(2026, 4, 1),
+    ]
+    assert [row["value"] for row in fetched] == [Decimal("309.7"), Decimal("310.1")]

--- a/tests/integration/test_repository_real_pg.py
+++ b/tests/integration/test_repository_real_pg.py
@@ -194,6 +194,227 @@ def test_iv_rank_upsert_is_idempotent(repo: Repository):
     assert count == 2, "upsert duplicated rows"
 
 
+def test_batch_writer_methods_preserve_real_db_behavior(repo: Repository):
+    run_id = repo.insert_scan_run("TSLA")
+
+    assert repo.insert_iv_term_rows(run_id, []) == 0
+    assert repo.insert_greek_exposure_rows(run_id, "TSLA", []) == 0
+    assert repo.insert_greeks_rows(run_id, "TSLA", []) == 0
+    assert repo.insert_option_contract_rows(run_id, "TSLA", []) == 0
+    assert repo.upsert_iv_rank_rows("TSLA", []) == 0
+    assert repo.upsert_volatility_stats_rows([]) == 0
+    assert repo.upsert_realized_vol_rows("TSLA", []) == 0
+    assert repo.upsert_skew_rows("TSLA", []) == 0
+    assert repo.insert_flow_events(run_id, "TSLA", []) == 0
+
+    term_rows = [
+        models.TermStructureRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            dte=32,
+            volatility=Decimal("0.42"),
+        ),
+        models.TermStructureRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 7, 17),
+            dte=60,
+            volatility=Decimal("0.51"),
+        ),
+    ]
+    exposure_rows = [
+        models.GreekExposureRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            call_gex=Decimal("1000"),
+        ),
+        models.GreekExposureRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("460"),
+            call_gex=Decimal("1100"),
+        ),
+    ]
+    greeks_rows = [
+        models.GreeksRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            call_delta=Decimal("0.51"),
+        ),
+        models.GreeksRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("460"),
+            call_delta=Decimal("0.45"),
+        ),
+    ]
+    contract_rows = [
+        models.OptionContractRow(
+            option_symbol="TSLA260619C00450000",
+            last_price=Decimal("12.1"),
+            volume=300,
+        ),
+        models.OptionContractRow(
+            option_symbol="TSLA260619P00450000",
+            last_price=Decimal("10.2"),
+            volume=200,
+        ),
+    ]
+    iv_rank_rows = [
+        models.IvRankRow(date=date(2026, 5, 18), close=Decimal("450")),
+        models.IvRankRow(date=date(2026, 5, 19), close=Decimal("455")),
+    ]
+    vol_stats_rows = [
+        models.VolStatsRow(ticker="TSLA", date=date(2026, 5, 18), iv=Decimal("0.42")),
+        models.VolStatsRow(ticker="TSLA", date=date(2026, 5, 19), iv=Decimal("0.43")),
+    ]
+    realized_rows = [
+        models.RealizedVolRow(date=date(2026, 5, 18), price=Decimal("450")),
+        models.RealizedVolRow(date=date(2026, 5, 19), price=Decimal("455")),
+    ]
+    skew_rows = [
+        models.SkewRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            delta=25,
+            expiry=date(2026, 6, 19),
+            risk_reversal=Decimal("-0.04"),
+        ),
+        models.SkewRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            delta=25,
+            expiry=date(2026, 7, 17),
+            risk_reversal=Decimal("-0.05"),
+        ),
+    ]
+    flow_alerts = [
+        models.FlowAlert(
+            id="flow-1",
+            ticker="TSLA",
+            created_at=datetime(2026, 5, 18, 14, 30, tzinfo=UTC),
+            total_premium=Decimal("100"),
+        ),
+        models.FlowAlert(
+            id="flow-2",
+            ticker="TSLA",
+            created_at=datetime(2026, 5, 18, 14, 31, tzinfo=UTC),
+            total_premium=Decimal("200"),
+        ),
+    ]
+
+    writer_calls = [
+        lambda: repo.insert_iv_term_rows(run_id, term_rows),
+        lambda: repo.insert_greek_exposure_rows(run_id, "TSLA", exposure_rows),
+        lambda: repo.insert_greeks_rows(run_id, "TSLA", greeks_rows),
+        lambda: repo.insert_option_contract_rows(run_id, "TSLA", contract_rows),
+        lambda: repo.upsert_iv_rank_rows("TSLA", iv_rank_rows),
+        lambda: repo.upsert_volatility_stats_rows(vol_stats_rows),
+        lambda: repo.upsert_realized_vol_rows("TSLA", realized_rows),
+        lambda: repo.upsert_skew_rows("TSLA", skew_rows),
+        lambda: repo.insert_flow_events(run_id, "TSLA", flow_alerts),
+    ]
+    for call_writer in writer_calls:
+        assert call_writer() == 2
+        assert call_writer() == 2
+    repo.conn.commit()
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT expiry, volatility FROM uw_scan.iv_term_snapshots "
+            "WHERE run_id=%s ORDER BY expiry",
+            (run_id,),
+        )
+        assert cur.fetchall() == [
+            (date(2026, 6, 19), Decimal("0.42")),
+            (date(2026, 7, 17), Decimal("0.51")),
+        ]
+
+        cur.execute(
+            "SELECT strike, call_gex FROM uw_scan.exposures_by_expiry_strike "
+            "WHERE run_id=%s ORDER BY strike",
+            (run_id,),
+        )
+        assert cur.fetchall() == [
+            (Decimal("450"), Decimal("1000")),
+            (Decimal("460"), Decimal("1100")),
+        ]
+
+        cur.execute(
+            "SELECT strike, call_delta FROM uw_scan.greeks_by_expiry_strike "
+            "WHERE run_id=%s ORDER BY strike",
+            (run_id,),
+        )
+        assert cur.fetchall() == [
+            (Decimal("450"), Decimal("0.51")),
+            (Decimal("460"), Decimal("0.45")),
+        ]
+
+        cur.execute(
+            "SELECT option_symbol, last_price, volume "
+            "FROM uw_scan.option_contract_snapshots WHERE run_id=%s "
+            "ORDER BY option_symbol",
+            (run_id,),
+        )
+        assert cur.fetchall() == [
+            ("TSLA260619C00450000", Decimal("12.1"), 300),
+            ("TSLA260619P00450000", Decimal("10.2"), 200),
+        ]
+
+        cur.execute(
+            "SELECT market_date, close FROM uw_scan.iv_rank_history "
+            "WHERE ticker=%s ORDER BY market_date",
+            ("TSLA",),
+        )
+        assert cur.fetchall() == [
+            (date(2026, 5, 18), Decimal("450")),
+            (date(2026, 5, 19), Decimal("455")),
+        ]
+
+        cur.execute(
+            "SELECT market_date, iv FROM uw_scan.volatility_stats_history "
+            "WHERE ticker=%s ORDER BY market_date",
+            ("TSLA",),
+        )
+        assert cur.fetchall() == [
+            (date(2026, 5, 18), Decimal("0.42")),
+            (date(2026, 5, 19), Decimal("0.43")),
+        ]
+
+        cur.execute(
+            "SELECT market_date, price FROM uw_scan.realized_volatility_history "
+            "WHERE ticker=%s ORDER BY market_date",
+            ("TSLA",),
+        )
+        assert cur.fetchall() == [
+            (date(2026, 5, 18), Decimal("450")),
+            (date(2026, 5, 19), Decimal("455")),
+        ]
+
+        cur.execute(
+            "SELECT expiry, risk_reversal FROM uw_scan.risk_reversal_skew_history "
+            "WHERE ticker=%s ORDER BY expiry",
+            ("TSLA",),
+        )
+        assert cur.fetchall() == [
+            (date(2026, 6, 19), Decimal("-0.04")),
+            (date(2026, 7, 17), Decimal("-0.05")),
+        ]
+
+        cur.execute(
+            "SELECT alert_id, flow_footprint_label FROM uw_scan.flow_events "
+            "WHERE run_id=%s ORDER BY alert_id",
+            (run_id,),
+        )
+        assert cur.fetchall() == [
+            ("flow-1", "unclassified"),
+            ("flow-2", "unclassified"),
+        ]
+
+
 def test_opportunity_scores_persisted_with_text_array(repo: Repository):
     run_id = repo.insert_scan_run("TSLA")
     repo.insert_opportunity_score(

--- a/tests/integration/worker/test_gold_daily_jobs.py
+++ b/tests/integration/worker/test_gold_daily_jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
@@ -29,6 +29,12 @@ from uw_scan.worker.jobs.gold_jobs import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 5, 19, 12, 0, tzinfo=tz or UTC)
 
 
 def _write_wgc_etf_workbook(path: Path) -> None:
@@ -142,7 +148,9 @@ def test_gold_fred_ingest_writes_macro_series_daily(fresh_db: Settings) -> None:
     with patch("uw_scan.worker.jobs.gold_jobs.FredProvider") as MockProvider:
         instance = MockProvider.return_value.__enter__.return_value
         instance.fetch_series.return_value = sample
-        gold_fred_ingest_job(dsn=fresh_db.db_dsn(), series_ids=["DFII10"])
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_fred_ingest_job(dsn=fresh_db.db_dsn(), series_ids=["DFII10"])
+            gold_fred_ingest_job(dsn=fresh_db.db_dsn(), series_ids=["DFII10"])
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
@@ -155,7 +163,9 @@ def test_gold_gpr_ingest_writes_macro_series_daily(fresh_db: Settings) -> None:
     with patch("uw_scan.worker.jobs.gold_jobs.GprProvider") as MockProvider:
         instance = MockProvider.return_value.__enter__.return_value
         instance.fetch_daily.return_value = sample
-        gold_gpr_ingest_job(dsn=fresh_db.db_dsn())
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_gpr_ingest_job(dsn=fresh_db.db_dsn())
+            gold_gpr_ingest_job(dsn=fresh_db.db_dsn())
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
@@ -183,7 +193,9 @@ def test_gold_etf_holdings_ingest_writes_all_four_funds(
         instance.fetch_iau.return_value = one("IAU")
         instance.fetch_gldm.return_value = one("GLDM")
         instance.fetch_phys.return_value = one("PHYS")
-        gold_etf_holdings_ingest_job(dsn=fresh_db.db_dsn())
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_etf_holdings_ingest_job(dsn=fresh_db.db_dsn())
+            gold_etf_holdings_ingest_job(dsn=fresh_db.db_dsn())
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
@@ -221,10 +233,15 @@ def test_gold_etf_holdings_ingest_reads_wgc_monthly_workbook(
         instance.fetch_gldm.return_value = []
         instance.fetch_phys.return_value = []
 
-        gold_etf_holdings_ingest_job(
-            dsn=fresh_db.db_dsn(),
-            wgc_workbook_path=str(workbook_path),
-        )
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_etf_holdings_ingest_job(
+                dsn=fresh_db.db_dsn(),
+                wgc_workbook_path=str(workbook_path),
+            )
+            gold_etf_holdings_ingest_job(
+                dsn=fresh_db.db_dsn(),
+                wgc_workbook_path=str(workbook_path),
+            )
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
@@ -269,15 +286,19 @@ def test_gold_etf_holdings_ingest_writes_uw_etf_flows(
         instance.fetch_gldm.return_value = []
         instance.fetch_phys.return_value = []
 
-        gold_etf_holdings_ingest_job(
-            dsn=fresh_db.db_dsn(), uw_api_key="test-key", lookback_days=45
-        )
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_etf_holdings_ingest_job(
+                dsn=fresh_db.db_dsn(), uw_api_key="test-key", lookback_days=45
+            )
+            gold_etf_holdings_ingest_job(
+                dsn=fresh_db.db_dsn(), uw_api_key="test-key", lookback_days=45
+            )
 
     assert [call.kwargs["ticker"] for call in mock_fetch.call_args_list] == [
         "GLD",
         "IAU",
         "GLDM",
-    ]
+    ] * 2
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)
         rows = repo.fetch_etf_flows_daily("GLD")

--- a/tests/integration/worker/test_gold_periodic_jobs.py
+++ b/tests/integration/worker/test_gold_periodic_jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from datetime import date
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import patch
@@ -24,6 +24,12 @@ from uw_scan.worker.jobs.gold_jobs import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 5, 19, 12, 0, tzinfo=tz or UTC)
 
 
 def _test_settings() -> Settings:
@@ -124,10 +130,15 @@ def test_gold_wgc_cb_ingest_writes_authenticated_workbook_rows(
         MockProvider.return_value.__enter__.return_value.fetch_monthly.return_value = (
             sample
         )
-        gold_wgc_cb_ingest_job(
-            dsn=fresh_db.db_dsn(),
-            wgc_workbook_path="/tmp/Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx",
-        )
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _FixedDatetime):
+            gold_wgc_cb_ingest_job(
+                dsn=fresh_db.db_dsn(),
+                wgc_workbook_path="/tmp/Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx",
+            )
+            gold_wgc_cb_ingest_job(
+                dsn=fresh_db.db_dsn(),
+                wgc_workbook_path="/tmp/Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx",
+            )
 
     with psycopg.connect(fresh_db.db_dsn()) as conn:
         repo = Repository(conn, schema=fresh_db.db_schema)

--- a/tests/unit/storage/test_batch_write_params.py
+++ b/tests/unit/storage/test_batch_write_params.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from uw_scan import models
+from uw_scan.storage.flow import _flow_event_params
+from uw_scan.storage.options import (
+    _greek_exposure_params,
+    _greeks_params,
+    _iv_term_params,
+    _option_contract_params,
+)
+from uw_scan.storage.volatility_raw import (
+    _iv_rank_params,
+    _realized_vol_params,
+    _skew_params,
+    _volatility_stats_params,
+)
+
+
+def test_options_param_builders_preserve_order_and_values():
+    iv_rows = [
+        models.TermStructureRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            dte=32,
+            volatility=Decimal("0.42"),
+            implied_move=Decimal("12.3"),
+            implied_move_perc=Decimal("0.031"),
+        ),
+        models.TermStructureRow(
+            ticker="NVDA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 7, 17),
+            dte=60,
+            volatility=Decimal("0.51"),
+        ),
+    ]
+    assert _iv_term_params(77, iv_rows) == [
+        (
+            77,
+            "TSLA",
+            date(2026, 5, 18),
+            date(2026, 6, 19),
+            32,
+            Decimal("0.42"),
+            Decimal("12.3"),
+            Decimal("0.031"),
+        ),
+        (
+            77,
+            "NVDA",
+            date(2026, 5, 18),
+            date(2026, 7, 17),
+            60,
+            Decimal("0.51"),
+            None,
+            None,
+        ),
+    ]
+
+    exposure_rows = [
+        models.GreekExposureRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            dte=32,
+            call_delta=Decimal("0.51"),
+            put_delta=Decimal("-0.49"),
+            call_gex=Decimal("1000"),
+            put_gex=Decimal("-900"),
+            call_vanna=Decimal("12"),
+            put_vanna=Decimal("-11"),
+            call_charm=Decimal("5"),
+            put_charm=Decimal("-4"),
+        )
+    ]
+    assert _greek_exposure_params(78, "TSLA", exposure_rows) == [
+        (
+            78,
+            "TSLA",
+            date(2026, 5, 18),
+            date(2026, 6, 19),
+            Decimal("450"),
+            32,
+            Decimal("0.51"),
+            Decimal("-0.49"),
+            Decimal("1000"),
+            Decimal("-900"),
+            Decimal("12"),
+            Decimal("-11"),
+            Decimal("5"),
+            Decimal("-4"),
+        )
+    ]
+
+    greeks_rows = [
+        models.GreeksRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            call_delta=Decimal("0.51"),
+            put_delta=Decimal("-0.49"),
+            call_gamma=Decimal("0.02"),
+            put_gamma=Decimal("0.03"),
+            call_vega=Decimal("1.2"),
+            put_vega=Decimal("1.1"),
+            call_theta=Decimal("-0.1"),
+            put_theta=Decimal("-0.2"),
+            call_rho=Decimal("0.04"),
+            put_rho=Decimal("-0.03"),
+            call_vanna=Decimal("12"),
+            put_vanna=Decimal("-11"),
+            call_charm=Decimal("5"),
+            put_charm=Decimal("-4"),
+            call_volatility=Decimal("0.42"),
+            put_volatility=Decimal("0.44"),
+            call_option_symbol="TSLA260619C00450000",
+            put_option_symbol="TSLA260619P00450000",
+        )
+    ]
+    assert _greeks_params(79, "TSLA", greeks_rows) == [
+        (
+            79,
+            "TSLA",
+            date(2026, 5, 18),
+            date(2026, 6, 19),
+            Decimal("450"),
+            Decimal("0.51"),
+            Decimal("-0.49"),
+            Decimal("0.02"),
+            Decimal("0.03"),
+            Decimal("1.2"),
+            Decimal("1.1"),
+            Decimal("-0.1"),
+            Decimal("-0.2"),
+            Decimal("0.04"),
+            Decimal("-0.03"),
+            Decimal("12"),
+            Decimal("-11"),
+            Decimal("5"),
+            Decimal("-4"),
+            Decimal("0.42"),
+            Decimal("0.44"),
+            "TSLA260619C00450000",
+            "TSLA260619P00450000",
+        )
+    ]
+
+    contract_rows = [
+        models.OptionContractRow(
+            option_symbol="TSLA260619C00450000",
+            last_price=Decimal("12.1"),
+            nbbo_bid=Decimal("12"),
+            nbbo_ask=Decimal("12.2"),
+            implied_volatility=Decimal("0.42"),
+            open_interest=1000,
+            prev_oi=900,
+            volume=300,
+            ask_volume=200,
+            bid_volume=80,
+            mid_volume=20,
+            multi_leg_volume=10,
+            stock_multi_leg_volume=5,
+            floor_volume=2,
+            sweep_volume=7,
+            no_side_volume=1,
+            avg_price=Decimal("12.05"),
+            high_price=Decimal("12.5"),
+            low_price=Decimal("11.9"),
+            total_premium=Decimal("36150"),
+        )
+    ]
+    assert _option_contract_params(80, "TSLA", contract_rows) == [
+        (
+            80,
+            "TSLA",
+            "TSLA260619C00450000",
+            Decimal("12.1"),
+            Decimal("12"),
+            Decimal("12.2"),
+            Decimal("0.42"),
+            1000,
+            900,
+            300,
+            200,
+            80,
+            20,
+            10,
+            5,
+            2,
+            7,
+            1,
+            Decimal("12.05"),
+            Decimal("12.5"),
+            Decimal("11.9"),
+            Decimal("36150"),
+        )
+    ]
+
+
+def test_volatility_param_builders_preserve_order_and_values():
+    assert _iv_rank_params(
+        "TSLA",
+        [
+            models.IvRankRow(
+                date=date(2026, 5, 18),
+                close=Decimal("450"),
+                volatility=Decimal("0.42"),
+                iv_rank_1y=Decimal("69"),
+                updated_at=datetime(2026, 5, 18, 12, 0, tzinfo=UTC),
+            )
+        ],
+    ) == [
+        (
+            "TSLA",
+            date(2026, 5, 18),
+            Decimal("450"),
+            Decimal("0.42"),
+            Decimal("69"),
+            datetime(2026, 5, 18, 12, 0, tzinfo=UTC),
+        )
+    ]
+
+    assert _volatility_stats_params(
+        [
+            models.VolStatsRow(
+                ticker="TSLA",
+                date=date(2026, 5, 18),
+                iv=Decimal("0.42"),
+                iv_low=Decimal("0.20"),
+                iv_high=Decimal("0.80"),
+                iv_rank=Decimal("0.65"),
+                rv=Decimal("0.30"),
+                rv_low=Decimal("0.15"),
+                rv_high=Decimal("0.70"),
+            )
+        ]
+    ) == [
+        (
+            "TSLA",
+            date(2026, 5, 18),
+            Decimal("0.42"),
+            Decimal("0.20"),
+            Decimal("0.80"),
+            Decimal("0.65"),
+            Decimal("0.30"),
+            Decimal("0.15"),
+            Decimal("0.70"),
+        )
+    ]
+
+    assert _realized_vol_params(
+        "TSLA",
+        [
+            models.RealizedVolRow(
+                date=date(2026, 5, 18),
+                price=Decimal("450"),
+                implied_volatility=Decimal("0.42"),
+                realized_volatility=Decimal("0.31"),
+                unshifted_rv_date=date(2026, 5, 15),
+            )
+        ],
+    ) == [
+        (
+            "TSLA",
+            date(2026, 5, 18),
+            Decimal("450"),
+            Decimal("0.42"),
+            Decimal("0.31"),
+            date(2026, 5, 15),
+        )
+    ]
+
+    assert _skew_params(
+        "TSLA",
+        [
+            models.SkewRow(
+                ticker="TSLA",
+                date=date(2026, 5, 18),
+                delta=25,
+                expiry=date(2026, 6, 19),
+                risk_reversal=Decimal("-0.04"),
+            )
+        ],
+    ) == [
+        ("TSLA", date(2026, 5, 18), 25, date(2026, 6, 19), Decimal("-0.04"))
+    ]
+
+
+def test_flow_event_params_preserve_order_and_derived_values():
+    created_at = datetime(2026, 5, 18, 14, 30, tzinfo=UTC)
+    rows = [
+        models.FlowAlert(
+            id="flow-1",
+            ticker="TSLA",
+            option_chain="TSLA260619C00450000",
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            type="call",
+            price=Decimal("12.1"),
+            underlying_price=Decimal("451.2"),
+            total_size=10,
+            total_premium=Decimal("12100"),
+            total_ask_side_prem=Decimal("9000"),
+            total_bid_side_prem=Decimal("3100"),
+            volume=100,
+            open_interest=1000,
+            volume_oi_ratio=Decimal("0.10"),
+            has_sweep=True,
+            has_floor=False,
+            has_multileg=False,
+            all_opening_trades=True,
+            iv_start=Decimal("0.40"),
+            iv_end=Decimal("0.42"),
+            alert_rule="RepeatedHits",
+            rule_id="rule-1",
+            sector="Consumer Cyclical",
+            issue_type="Common Stock",
+            next_earnings_date=date(2026, 7, 24),
+            created_at=created_at,
+        )
+    ]
+
+    assert _flow_event_params(81, rows) == [
+        (
+            81,
+            "flow-1",
+            "TSLA",
+            "TSLA260619C00450000",
+            date(2026, 6, 19),
+            Decimal("450"),
+            "call",
+            Decimal("12.1"),
+            Decimal("451.2"),
+            10,
+            Decimal("12100"),
+            Decimal("9000"),
+            Decimal("3100"),
+            100,
+            1000,
+            Decimal("0.10"),
+            True,
+            False,
+            False,
+            True,
+            Decimal("0.40"),
+            Decimal("0.42"),
+            "RepeatedHits",
+            "directional_whale",
+            Decimal("0.74"),
+            "rule-1",
+            "Consumer Cyclical",
+            "Common Stock",
+            date(2026, 7, 24),
+            created_at,
+        )
+    ]

--- a/tests/unit/storage/test_batch_write_params.py
+++ b/tests/unit/storage/test_batch_write_params.py
@@ -5,13 +5,16 @@ from decimal import Decimal
 
 from uw_scan import models
 from uw_scan.storage.flow import _flow_event_params
+from uw_scan.storage.flow import _FlowMixin
 from uw_scan.storage.options import (
+    _OptionsMixin,
     _greek_exposure_params,
     _greeks_params,
     _iv_term_params,
     _option_contract_params,
 )
 from uw_scan.storage.volatility_raw import (
+    _VolatilityRawMixin,
     _iv_rank_params,
     _realized_vol_params,
     _skew_params,
@@ -199,6 +202,196 @@ def test_options_param_builders_preserve_order_and_values():
             Decimal("36150"),
         )
     ]
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, object | None]] = []
+        self.executemany_calls: list[tuple[str, list[tuple[object, ...]]]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def execute(self, sql: str, params: object | None = None) -> None:
+        self.execute_calls.append((sql, params))
+
+    def executemany(self, sql: str, params: list[tuple[object, ...]]) -> None:
+        self.executemany_calls.append((sql, params))
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+
+class _FakeRepository(_OptionsMixin, _VolatilityRawMixin, _FlowMixin):
+    def __init__(self) -> None:
+        self._conn = _FakeConnection()
+        self._schema = "uw_scan"
+
+    @property
+    def fake_cursor(self) -> _FakeCursor:
+        return self._conn.cursor_obj
+
+
+def _sample_iv_rows() -> list[models.TermStructureRow]:
+    return [
+        models.TermStructureRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            dte=32,
+            volatility=Decimal("0.42"),
+        ),
+        models.TermStructureRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            expiry=date(2026, 7, 17),
+            dte=60,
+            volatility=Decimal("0.51"),
+        ),
+    ]
+
+
+def _sample_exposure_rows() -> list[models.GreekExposureRow]:
+    return [
+        models.GreekExposureRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            dte=32,
+            call_gex=Decimal("1000"),
+        ),
+        models.GreekExposureRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("460"),
+            dte=32,
+            call_gex=Decimal("1100"),
+        ),
+    ]
+
+
+def _sample_greeks_rows() -> list[models.GreeksRow]:
+    return [
+        models.GreeksRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("450"),
+            call_delta=Decimal("0.51"),
+            put_delta=Decimal("-0.49"),
+        ),
+        models.GreeksRow(
+            date=date(2026, 5, 18),
+            expiry=date(2026, 6, 19),
+            strike=Decimal("460"),
+            call_delta=Decimal("0.45"),
+            put_delta=Decimal("-0.55"),
+        ),
+    ]
+
+
+def _sample_contract_rows() -> list[models.OptionContractRow]:
+    return [
+        models.OptionContractRow(
+            option_symbol="TSLA260619C00450000",
+            last_price=Decimal("12.1"),
+            volume=300,
+        ),
+        models.OptionContractRow(
+            option_symbol="TSLA260619P00450000",
+            last_price=Decimal("10.2"),
+            volume=200,
+        ),
+    ]
+
+
+def _sample_iv_rank_rows() -> list[models.IvRankRow]:
+    return [
+        models.IvRankRow(date=date(2026, 5, 18), close=Decimal("450")),
+        models.IvRankRow(date=date(2026, 5, 19), close=Decimal("455")),
+    ]
+
+
+def _sample_vol_stats_rows() -> list[models.VolStatsRow]:
+    return [
+        models.VolStatsRow(ticker="TSLA", date=date(2026, 5, 18), iv=Decimal("0.42")),
+        models.VolStatsRow(ticker="TSLA", date=date(2026, 5, 19), iv=Decimal("0.43")),
+    ]
+
+
+def _sample_realized_vol_rows() -> list[models.RealizedVolRow]:
+    return [
+        models.RealizedVolRow(date=date(2026, 5, 18), price=Decimal("450")),
+        models.RealizedVolRow(date=date(2026, 5, 19), price=Decimal("455")),
+    ]
+
+
+def _sample_skew_rows() -> list[models.SkewRow]:
+    return [
+        models.SkewRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            delta=25,
+            expiry=date(2026, 6, 19),
+            risk_reversal=Decimal("-0.04"),
+        ),
+        models.SkewRow(
+            ticker="TSLA",
+            date=date(2026, 5, 18),
+            delta=25,
+            expiry=date(2026, 7, 17),
+            risk_reversal=Decimal("-0.05"),
+        ),
+    ]
+
+
+def _sample_flow_alerts() -> list[models.FlowAlert]:
+    return [
+        models.FlowAlert(
+            id="flow-1",
+            ticker="TSLA",
+            created_at=datetime(2026, 5, 18, 14, 30, tzinfo=UTC),
+            total_premium=Decimal("100"),
+        ),
+        models.FlowAlert(
+            id="flow-2",
+            ticker="TSLA",
+            created_at=datetime(2026, 5, 18, 14, 31, tzinfo=UTC),
+            total_premium=Decimal("200"),
+        ),
+    ]
+
+
+def _assert_single_executemany(repo: _FakeRepository, expected_count: int) -> None:
+    assert len(repo.fake_cursor.executemany_calls) == 1
+    assert len(repo.fake_cursor.executemany_calls[0][1]) == expected_count
+    assert repo.fake_cursor.execute_calls == []
+
+
+def test_batch_writer_methods_use_one_executemany_call_for_multi_row_inputs():
+    cases = [
+        lambda repo: repo.insert_iv_term_rows(1, _sample_iv_rows()),
+        lambda repo: repo.insert_greek_exposure_rows(1, "TSLA", _sample_exposure_rows()),
+        lambda repo: repo.insert_greeks_rows(1, "TSLA", _sample_greeks_rows()),
+        lambda repo: repo.insert_option_contract_rows(1, "TSLA", _sample_contract_rows()),
+        lambda repo: repo.upsert_iv_rank_rows("TSLA", _sample_iv_rank_rows()),
+        lambda repo: repo.upsert_volatility_stats_rows(_sample_vol_stats_rows()),
+        lambda repo: repo.upsert_realized_vol_rows("TSLA", _sample_realized_vol_rows()),
+        lambda repo: repo.upsert_skew_rows("TSLA", _sample_skew_rows()),
+        lambda repo: repo.insert_flow_events(1, "TSLA", _sample_flow_alerts()),
+    ]
+
+    for call_method in cases:
+        repo = _FakeRepository()
+        assert call_method(repo) == 2
+        _assert_single_executemany(repo, expected_count=2)
 
 
 def test_volatility_param_builders_preserve_order_and_values():

--- a/web/app/cockpit/[ticker]/CockpitChart.tsx
+++ b/web/app/cockpit/[ticker]/CockpitChart.tsx
@@ -17,19 +17,27 @@ export function MultiLineChart({
   showZero = true,
   band,
   xLabel,
+  assumeSorted = false,
 }: {
   series: ChartSeries[];
   height?: number;
   showZero?: boolean;
   band?: { min: number; max: number; color: string };
   xLabel?: (x: number) => string;
+  assumeSorted?: boolean;
 }) {
   const cleanSeries = series.map((item) => ({
     ...item,
-    points: item.points
-      .filter((point) => Number.isFinite(point.x) && point.y != null)
-      .map((point) => ({ x: point.x, y: point.y as number }))
-      .sort((a, b) => a.x - b.x),
+    points: (
+      assumeSorted
+        ? item.points
+            .filter((point) => Number.isFinite(point.x) && point.y != null)
+            .map((point) => ({ x: point.x, y: point.y as number }))
+        : item.points
+            .filter((point) => Number.isFinite(point.x) && point.y != null)
+            .map((point) => ({ x: point.x, y: point.y as number }))
+            .sort((a, b) => a.x - b.x)
+    ),
   }));
   const all = cleanSeries.flatMap((item) => item.points);
   if (!all.length) {

--- a/web/app/cockpit/[ticker]/CockpitDealerTab.tsx
+++ b/web/app/cockpit/[ticker]/CockpitDealerTab.tsx
@@ -1,4 +1,5 @@
 import type { CockpitDealerResponse } from "@/lib/api";
+import { useMemo } from "react";
 import type React from "react";
 import { fmtDecimal, fmtMoney, fmtSigned, toNum } from "@/lib/formatters";
 import {
@@ -20,23 +21,85 @@ export function CockpitDealerTab({
   ticker: string;
   data: CockpitDealerResponse | null;
 }) {
-  if (!data) return <EmptyPanel ticker={ticker} />;
-
-  const points = data.points ?? [];
-  const metrics = data.metrics ?? {};
-  const groups = groupByExpiry(points).slice(0, 6);
+  const points = useMemo(() => data?.points ?? [], [data?.points]);
+  const metrics = useMemo(() => data?.metrics ?? {}, [data?.metrics]);
+  const groups = useMemo(() => groupByExpiry(points).slice(0, 6), [points]);
   const primaryGroup = groups[0] ?? null;
   const primaryExpiry = primaryGroup?.[0] ?? null;
-  const primaryPoints = primaryGroup?.[1] ?? [];
-  const primaryTotals = totals(primaryPoints);
-  const primaryPeaks = peaks(primaryPoints);
-  const expirySummaries = groups.map(([expiry, points]) => ({
-    expiry,
-    count: points.length,
-    ...totals(points),
-    ...peaks(points),
-  }));
-  const latest = points.slice(0, 12);
+  const primaryPoints = useMemo(() => primaryGroup?.[1] ?? [], [primaryGroup]);
+  const primaryTotals = useMemo(() => totals(primaryPoints), [primaryPoints]);
+  const primaryPeaks = useMemo(() => peaks(primaryPoints), [primaryPoints]);
+  const expirySummaries = useMemo(
+    () =>
+      groups.map(([expiry, points]) => ({
+        expiry,
+        count: points.length,
+        ...totals(points),
+        ...peaks(points),
+      })),
+    [groups],
+  );
+  const latest = useMemo(() => points.slice(0, 12), [points]);
+  const vannaSeries = useMemo(
+    () => [
+      {
+        label: "Call vanna",
+        color: "var(--accent-bg)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: exposureValue(point, "call", "vanna"),
+        })),
+      },
+      {
+        label: "Put vanna",
+        color: "var(--negative)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: exposureValue(point, "put", "vanna"),
+        })),
+      },
+      {
+        label: "Net vanna",
+        color: "var(--warning)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: netValue(point, "vanna"),
+        })),
+      },
+    ],
+    [primaryPoints],
+  );
+  const charmSeries = useMemo(
+    () => [
+      {
+        label: "Call charm",
+        color: "var(--accent-bg)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: exposureValue(point, "call", "charm"),
+        })),
+      },
+      {
+        label: "Put charm",
+        color: "var(--negative)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: exposureValue(point, "put", "charm"),
+        })),
+      },
+      {
+        label: "Net charm",
+        color: "var(--warning)",
+        points: primaryPoints.map((point) => ({
+          x: toNum(point.strike) ?? 0,
+          y: netValue(point, "charm"),
+        })),
+      },
+    ],
+    [primaryPoints],
+  );
+
+  if (!data) return <EmptyPanel ticker={ticker} />;
 
   return (
     <div style={{ display: "grid", gap: 16 }}>
@@ -77,64 +140,16 @@ export function CockpitDealerTab({
             <div style={miniTitleStyle}>Vanna by strike</div>
             <MultiLineChart
               height={230}
-              series={[
-                {
-                  label: "Call vanna",
-                  color: "var(--accent-bg)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: exposureValue(point, "call", "vanna"),
-                  })),
-                },
-                {
-                  label: "Put vanna",
-                  color: "var(--negative)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: exposureValue(point, "put", "vanna"),
-                  })),
-                },
-                {
-                  label: "Net vanna",
-                  color: "var(--warning)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: netValue(point, "vanna"),
-                  })),
-                },
-              ]}
+              series={vannaSeries}
+              assumeSorted
             />
           </div>
           <div style={miniPanelStyle}>
             <div style={miniTitleStyle}>Charm by strike</div>
             <MultiLineChart
               height={230}
-              series={[
-                {
-                  label: "Call charm",
-                  color: "var(--accent-bg)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: exposureValue(point, "call", "charm"),
-                  })),
-                },
-                {
-                  label: "Put charm",
-                  color: "var(--negative)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: exposureValue(point, "put", "charm"),
-                  })),
-                },
-                {
-                  label: "Net charm",
-                  color: "var(--warning)",
-                  points: primaryPoints.map((point) => ({
-                    x: toNum(point.strike) ?? 0,
-                    y: netValue(point, "charm"),
-                  })),
-                },
-              ]}
+              series={charmSeries}
+              assumeSorted
             />
           </div>
         </div>

--- a/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
+++ b/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
@@ -69,19 +69,14 @@ const CB_COLORS = [
   "#f59e0b",
 ];
 
+const CHART_PADDING = { top: 12, right: 56, bottom: 24, left: 48 } as const;
+
 function defaultSelected(countries: Country[]): string[] {
   const strategic = countries
     .filter((c) => c.bucket === "strategic_accumulator")
     .map((c) => c.country_iso3);
   if (strategic.length > 0) return strategic;
   return countries.slice(0, 4).map((c) => c.country_iso3);
-}
-
-function colorForCountry(countryIso3: string, countries: Country[]): string {
-  const idx = countries.findIndex(
-    (country) => country.country_iso3 === countryIso3,
-  );
-  return CB_COLORS[(idx < 0 ? 0 : idx) % CB_COLORS.length];
 }
 
 function fmtCountryTonnes(v: string | number | null | undefined): string {
@@ -105,8 +100,141 @@ export function GoldHoldingsVsPriceChart({
     () => new Set(selectedCountries),
     [selectedCountries],
   );
-  const visibleCountries = cbCountryHistory.filter((country) =>
-    selectedSet.has(country.country_iso3),
+  const visibleCountries = useMemo(
+    () =>
+      cbCountryHistory.filter((country) =>
+        selectedSet.has(country.country_iso3),
+      ),
+    [cbCountryHistory, selectedSet],
+  );
+  const countryColorByIso3 = useMemo(
+    () =>
+      new Map(
+        cbCountryHistory.map((country, index) => [
+          country.country_iso3,
+          CB_COLORS[index % CB_COLORS.length],
+        ]),
+      ),
+    [cbCountryHistory],
+  );
+
+  const padding = CHART_PADDING;
+  const innerW = width - padding.left - padding.right;
+  const innerH = height - padding.top - padding.bottom;
+
+  const cbHistoryPoints = useMemo(
+    () =>
+      visibleCountries.flatMap((country) =>
+        (country.history ?? []).map((p) => ({
+          t: new Date(p.obs_date).getTime(),
+          value: toNumber(p.value),
+        })),
+      ),
+    [visibleCountries],
+  );
+  const allDates = useMemo(
+    () => [
+      ...goldHistory.map((p) => new Date(p.obs_date).getTime()),
+      ...gldHistory.map((p) => new Date(p.obs_date).getTime()),
+      ...cbHistoryPoints.map((p) => p.t),
+    ],
+    [goldHistory, gldHistory, cbHistoryPoints],
+  );
+  const dateDomain = useMemo(() => finiteDomain(allDates), [allDates]);
+  const goldDomain = useMemo(
+    () => finiteDomain(goldHistory.map((p) => toNumber(p.value))),
+    [goldHistory],
+  );
+  const tonnesDomain = useMemo(
+    () =>
+      finiteDomain([
+        ...gldHistory.map((p) => toNumber(p.value)),
+        ...cbHistoryPoints.map((p) => p.value),
+      ]),
+    [gldHistory, cbHistoryPoints],
+  );
+  const xRange = useMemo<[number, number]>(
+    () => [padding.left, padding.left + innerW],
+    [innerW, padding.left],
+  );
+  const yRange = useMemo<[number, number]>(
+    () => [padding.top + innerH, padding.top],
+    [innerH, padding.top],
+  );
+
+  const canDrawTop = dateDomain != null && dateDomain.count >= 2;
+
+  const xScale = useMemo(
+    () =>
+      canDrawTop && dateDomain
+        ? linearScale([dateDomain.lo, dateDomain.hi], xRange)
+        : null,
+    [canDrawTop, dateDomain, xRange],
+  );
+  const goldYScale = useMemo(
+    () =>
+      canDrawTop && goldDomain
+        ? linearScale([goldDomain.lo, goldDomain.hi], yRange)
+        : null,
+    [canDrawTop, goldDomain, yRange],
+  );
+  const tonnesYScale = useMemo(
+    () =>
+      canDrawTop && tonnesDomain
+        ? linearScale([tonnesDomain.lo, tonnesDomain.hi], yRange)
+        : null,
+    [canDrawTop, tonnesDomain, yRange],
+  );
+
+  const goldPoints: Point[] = useMemo(
+    () =>
+      goldYScale
+        ? goldHistory.map((p) => [
+            xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+            goldYScale(toNumber(p.value)),
+          ])
+        : [],
+    [goldHistory, goldYScale, xScale],
+  );
+
+  const gldPoints: Point[] = useMemo(
+    () =>
+      tonnesYScale
+        ? gldHistory.map((p) => [
+            xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+            tonnesYScale(toNumber(p.value)),
+          ])
+        : [],
+    [gldHistory, tonnesYScale, xScale],
+  );
+  const cbCountryPoints = useMemo(
+    () =>
+      visibleCountries.map((country) => ({
+        country,
+        points: tonnesYScale
+          ? (country.history ?? []).map((p): Point => [
+              xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+              tonnesYScale(toNumber(p.value)),
+            ])
+          : [],
+      })),
+    [visibleCountries, tonnesYScale, xScale],
+  );
+
+  const xTicks = useMemo(
+    () =>
+      canDrawTop && dateDomain
+        ? sampledTimeTicks(dateDomain.lo, dateDomain.hi, 6)
+        : [],
+    [canDrawTop, dateDomain],
+  );
+  const goldYTicks = useMemo(
+    () => (goldDomain ? niceTicks(goldDomain.lo, goldDomain.hi, 4) : []),
+    [goldDomain],
+  );
+  const tonnesYTicks = useMemo(
+    () => (tonnesDomain ? niceTicks(tonnesDomain.lo, tonnesDomain.hi, 4) : []),
+    [tonnesDomain],
   );
 
   if (
@@ -127,76 +255,6 @@ export function GoldHoldingsVsPriceChart({
       </div>
     );
   }
-
-  const padding = { top: 12, right: 56, bottom: 24, left: 48 };
-  const innerW = width - padding.left - padding.right;
-  const innerH = height - padding.top - padding.bottom;
-
-  const cbHistoryPoints = visibleCountries.flatMap((country) =>
-    (country.history ?? []).map((p) => ({
-      t: new Date(p.obs_date).getTime(),
-      value: toNumber(p.value),
-    })),
-  );
-  const allDates = [
-    ...goldHistory.map((p) => new Date(p.obs_date).getTime()),
-    ...gldHistory.map((p) => new Date(p.obs_date).getTime()),
-    ...cbHistoryPoints.map((p) => p.t),
-  ];
-  const dateDomain = finiteDomain(allDates);
-  const goldDomain = finiteDomain(goldHistory.map((p) => toNumber(p.value)));
-  const tonnesDomain = finiteDomain([
-    ...gldHistory.map((p) => toNumber(p.value)),
-    ...cbHistoryPoints.map((p) => p.value),
-  ]);
-  const xRange: [number, number] = [padding.left, padding.left + innerW];
-  const yRange: [number, number] = [padding.top + innerH, padding.top];
-
-  const canDrawTop = dateDomain != null && dateDomain.count >= 2;
-
-  const xScale = canDrawTop
-    ? linearScale([dateDomain.lo, dateDomain.hi], xRange)
-    : null;
-  const goldYScale = canDrawTop && goldDomain
-    ? linearScale([goldDomain.lo, goldDomain.hi], yRange)
-    : null;
-  const tonnesYScale = canDrawTop && tonnesDomain
-    ? linearScale([tonnesDomain.lo, tonnesDomain.hi], yRange)
-    : null;
-
-  const goldPoints: Point[] = goldYScale
-    ? goldHistory.map((p) => [
-        xScale?.(new Date(p.obs_date).getTime()) ?? 0,
-        goldYScale(toNumber(p.value)),
-      ])
-    : [];
-
-  const gldPoints: Point[] = tonnesYScale
-    ? gldHistory.map((p) => [
-        xScale?.(new Date(p.obs_date).getTime()) ?? 0,
-        tonnesYScale(toNumber(p.value)),
-      ])
-    : [];
-  const cbCountryPoints = visibleCountries.map((country) => ({
-    country,
-    points: tonnesYScale
-      ? (country.history ?? []).map((p): Point => [
-          xScale?.(new Date(p.obs_date).getTime()) ?? 0,
-          tonnesYScale(toNumber(p.value)),
-        ])
-      : [],
-  }));
-
-  const xTicks =
-    canDrawTop && dateDomain
-      ? sampledTimeTicks(dateDomain.lo, dateDomain.hi, 6)
-      : [];
-  const goldYTicks = goldDomain
-    ? niceTicks(goldDomain.lo, goldDomain.hi, 4)
-    : [];
-  const tonnesYTicks = tonnesDomain
-    ? niceTicks(tonnesDomain.lo, tonnesDomain.hi, 4)
-    : [];
 
   function toggleCountry(countryIso3: string) {
     setSelectedCountries((current) =>
@@ -259,7 +317,9 @@ export function GoldHoldingsVsPriceChart({
                 key={country.country_iso3}
                 d={pathFromPoints(points)}
                 fill="none"
-                stroke={colorForCountry(country.country_iso3, cbCountryHistory)}
+                stroke={
+                  countryColorByIso3.get(country.country_iso3) ?? CB_COLORS[0]
+                }
                 strokeWidth={1.2}
               />
             ))}
@@ -413,7 +473,8 @@ export function GoldHoldingsVsPriceChart({
                   style={{
                     width: 8,
                     height: 8,
-                    background: colorForCountry(country.country_iso3, cbCountryHistory),
+                    background:
+                      countryColorByIso3.get(country.country_iso3) ?? CB_COLORS[0],
                     display: "inline-block",
                   }}
                 />


### PR DESCRIPTION
## Summary
- Batch high-volume repository writes in options, volatility, flow, and Gold ingest persistence paths with `executemany` while preserving existing SQL conflict behavior.
- Bulk-fetch worker heartbeat rows for health worker status instead of one query per expected worker.
- Memoize Gold holdings and Cockpit dealer chart derivations; add benchmark/test harness and execution evidence doc.

## Verification
- `uv run ruff check src/uw_scan tests scripts` — passed, `All checks passed!`
- `uv run pytest` — passed, `666 passed, 5 skipped in 355.90s`
- `cd web && npm run test` — passed, `36 passed (36)`, `221 passed (221)`
- `cd web && npm run typecheck` — passed
- `cd web && npx eslint 'components/gold/lens1/GoldHoldingsVsPriceChart.tsx' 'app/cockpit/[ticker]/CockpitChart.tsx' 'app/cockpit/[ticker]/CockpitDealerTab.tsx'` — passed
- `uv run python scripts/bench_storage_batch_writes.py --mode params-only --rows 10000` — `best=0.000717s`, `median=0.000765s`, `rows_per_sec=13066925`
- Playwright browser check on `http://localhost:3011`: Gold chart rendered 24 non-empty SVG paths after Strategic/All/None/country toggles; Cockpit dealer rendered 6 non-empty chart polylines.

## Complexity Evidence
- Complexity scanner findings dropped from `552` baseline to `536`.
- `io-or-query-in-loop` dropped from `23` baseline to `15`.
- Live Postgres benchmark was skipped because `UW_SCAN_DATABASE_URL` was not set, so this PR does not claim numeric DB speedups.

## Contract / Scope Notes
- No intentional API contract, OpenAPI, schema, migration, or generated type changes.
- No edits to `src/uw_scan/storage/repository.py`.
- Batch methods preserve existing `ON CONFLICT` clauses and same-`as_of` idempotency behavior.

## Known Caveat
- `cd web && npm run lint` still fails on unrelated pre-existing scanner/regime files (`Date.now` purity and a conditional hook in `CriSubTab`). The changed chart files pass targeted ESLint.
