### PR TITLE
fix(worker): add 'ai' role so Trade Insights AI tick gets registered

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -12,11 +12,12 @@ fi
 
 # Color-prefixed concurrent run. Press Ctrl-C to stop all processes.
 exec npx --prefix web concurrently \
-  -n next,api,uw-0,uw-1,massive-0,massive-1 \
-  -c cyan,green,yellow,magenta,blue,white \
+  -n next,api,uw-0,uw-1,massive-0,massive-1,ai \
+  -c cyan,green,yellow,magenta,blue,white,red \
   "cd web && npm run dev" \
   "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src" \
   "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
   "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
   "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=ai UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=1 uv run python -m uw_scan.worker.scheduler"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -11,13 +11,19 @@ if [ ! -d web/node_modules ]; then
 fi
 
 # Color-prefixed concurrent run. Press Ctrl-C to stop all processes.
+# Shared count exports so the API process can enumerate worker rows in the
+# health panel. AI workers use FOR UPDATE SKIP LOCKED on the analysis queue,
+# so 2 instances safely process distinct tickers in parallel.
+COUNTS="UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_AI_WORKER_COUNT=2"
+
 exec npx --prefix web concurrently \
-  -n next,api,uw-0,uw-1,massive-0,massive-1,ai \
-  -c cyan,green,yellow,magenta,blue,white,red \
+  -n next,api,uw-0,uw-1,massive-0,massive-1,ai-0,ai-1 \
+  -c cyan,green,yellow,magenta,blue,white,red,gray \
   "cd web && npm run dev" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
-  "UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 UW_SCAN_WORKER_ROLE=ai UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=1 uv run python -m uw_scan.worker.scheduler"
+  "$COUNTS uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=ai UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler" \
+  "$COUNTS UW_SCAN_WORKER_ROLE=ai UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -59,7 +59,7 @@ class HealthResponse(BaseModel):
 
 class WorkerHealth(BaseModel):
     label: str
-    role: Literal["uw", "massive"]
+    role: Literal["uw", "massive", "ai"]
     index: int
     heartbeat_name: str
     lag_seconds: float | None = None
@@ -107,11 +107,13 @@ def _worker_health_rows(
     now_utc: datetime,
     uw_count: int,
     massive_count: int,
+    ai_count: int,
 ) -> list[WorkerHealth]:
     rows: list[WorkerHealth] = []
     for role, count, label_prefix in (
         ("uw", uw_count, "UW"),
         ("massive", massive_count, "Massive"),
+        ("ai", ai_count, "AI"),
     ):
         for index in range(max(0, count)):
             heartbeat_name = f"worker:{role}:{index}"
@@ -189,6 +191,7 @@ def health(
         now_utc=now_utc,
         uw_count=settings.uw_worker_count,
         massive_count=settings.massive_worker_count,
+        ai_count=settings.ai_worker_count,
     )
     provider_day_start, provider_day_end = provider_day_bounds()
     provider_usage = repo.get_external_api_usage_summary(

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -79,6 +79,7 @@ class Settings(BaseModel):
     worker_count: int = 1
     uw_worker_count: int = 0
     massive_worker_count: int = 0
+    ai_worker_count: int = 0
     # OHLC provider (massive.com)
     massive_api_key: SecretStr | None = None
     massive_base_url: str = "https://api.massive.com"
@@ -193,6 +194,7 @@ class Settings(BaseModel):
             massive_worker_count=int(
                 os.environ.get("UW_SCAN_MASSIVE_WORKER_COUNT", "0")
             ),
+            ai_worker_count=int(os.environ.get("UW_SCAN_AI_WORKER_COUNT", "0")),
             # SecretStr("") is truthy and not None — would silently allow the
             # scheduler to instantiate a Massive client with a blank bearer and
             # generate a stream of 401s. Coerce blank to None before wrapping.

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -11,12 +11,17 @@
 
 ## Worker roles
 
-Set `UW_SCAN_WORKER_ROLE=uw|massive|all`, `UW_SCAN_WORKER_INDEX`, and
+Set `UW_SCAN_WORKER_ROLE=uw|massive|ai|all`, `UW_SCAN_WORKER_INDEX`, and
 `UW_SCAN_WORKER_COUNT` to split provider work across processes.
 
 - `uw` workers run `full_scan`, `rescan_tick`, and `flow_data_refresh`.
 - `massive` workers run `spot_refresh`, `ohlc_pull`, and primary-worker-only
   volatility OHLC/rollup jobs.
+- `ai` workers run only `trade_insights_ai_tick` (gated on
+  `TRADE_INSIGHTS_AI_ENABLED=true`). Keep `UW_SCAN_WORKER_COUNT=1` for the
+  AI role — the tick already serializes via a Codex subprocess, no sharding.
+  Without an `ai` (or `all`) worker, Trade Insights AI rows stay `queued`
+  forever.
 - `all` preserves the legacy single scheduler shape.
 - Per-ticker scheduled jobs must use the scheduler-provided shard filter.
   Rescans use DB claiming (`FOR UPDATE SKIP LOCKED`) and are not sharded.

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -18,10 +18,13 @@ Set `UW_SCAN_WORKER_ROLE=uw|massive|ai|all`, `UW_SCAN_WORKER_INDEX`, and
 - `massive` workers run `spot_refresh`, `ohlc_pull`, and primary-worker-only
   volatility OHLC/rollup jobs.
 - `ai` workers run only `trade_insights_ai_tick` (gated on
-  `TRADE_INSIGHTS_AI_ENABLED=true`). Keep `UW_SCAN_WORKER_COUNT=1` for the
-  AI role — the tick already serializes via a Codex subprocess, no sharding.
-  Without an `ai` (or `all`) worker, Trade Insights AI rows stay `queued`
-  forever.
+  `TRADE_INSIGHTS_AI_ENABLED=true`). The tick claims rows via
+  `FOR UPDATE SKIP LOCKED`, so multiple `ai` workers safely process distinct
+  tickers in parallel — `UW_SCAN_WORKER_COUNT=2` doubles throughput when the
+  analysis queue has multiple tickers. Without an `ai` (or `all`) worker,
+  Trade Insights AI rows stay `queued` forever. Also export
+  `UW_SCAN_AI_WORKER_COUNT=N` to the API process so the health panel can
+  enumerate the AI worker heartbeats.
 - `all` preserves the legacy single scheduler shape.
 - Per-ticker scheduled jobs must use the scheduler-provided shard filter.
   Rescans use DB claiming (`FOR UPDATE SKIP LOCKED`) and are not sharded.

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -56,7 +56,7 @@ logging.basicConfig(
 logger = logging.getLogger("uw_scan.worker")
 RESCAN_WORKER_CONCURRENCY = 2
 WorkerGroup = Literal["uw", "massive", "ai"]
-WORKER_ROLES: set[str] = {"all", "uw", "massive"}
+WORKER_ROLES: set[str] = {"all", "uw", "massive", "ai"}
 
 
 def _spot_refresh_market_date(now: datetime) -> date | None:
@@ -103,8 +103,10 @@ def _worker_groups(settings: Settings) -> set[WorkerGroup]:
         return {"uw"}
     if role == "massive":
         return {"massive"}
+    if role == "ai":
+        return {"ai"}
     raise RuntimeError(
-        "UW_SCAN_WORKER_ROLE must be one of: all, uw, massive "
+        "UW_SCAN_WORKER_ROLE must be one of: all, uw, massive, ai "
         f"(got {settings.worker_role!r})"
     )
 

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -11132,7 +11132,8 @@
           "role": {
             "enum": [
               "uw",
-              "massive"
+              "massive",
+              "ai"
             ],
             "title": "Role",
             "type": "string"

--- a/tests/integration/storage/test_repository_trade_insights_ai.py
+++ b/tests/integration/storage/test_repository_trade_insights_ai.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta, timezone
 
 import psycopg
+import pytest
 
+from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
+
+
+def _test_db_dsn() -> str:
+    """Rebuild the test DSN from Settings (mirrors conftest._test_settings).
+
+    Cannot rely on `repo.conn.info.dsn` for opening a second connection: in
+    CI's pytest-postgresql setup, conn.info.dsn doesn't carry the auth
+    credentials that the original connect() pulled from environment.
+    """
+    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
+    if not test_db:
+        pytest.fail(
+            "UW_SCAN_TEST_DB_NAME not set; refusing to point integration "
+            "tests at the working DB.",
+            pytrace=False,
+        )
+    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
+    return Settings.from_env().model_copy(update={"db_name": test_db}).db_dsn()
 
 
 def _create_snapshot(repo, *, ticker: str = "TSLA", input_hash: str = "ti-hash"):
@@ -287,8 +308,7 @@ def test_two_concurrent_claimers_get_distinct_rows(seeded_db_empty_cards):
     repo.conn.commit()
 
     # Open a second connection on the same DSN — simulates a separate worker.
-    dsn = repo.conn.info.dsn
-    conn_b = psycopg.connect(dsn)
+    conn_b = psycopg.connect(_test_db_dsn())
     try:
         repo_b = Repository(conn_b, schema=repo._schema)
 

--- a/tests/integration/storage/test_repository_trade_insights_ai.py
+++ b/tests/integration/storage/test_repository_trade_insights_ai.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import psycopg
+
+from uw_scan.storage.repository import Repository
+
 
 def _create_snapshot(repo, *, ticker: str = "TSLA", input_hash: str = "ti-hash"):
     run_id = repo.insert_scan_run(ticker)
@@ -88,7 +92,9 @@ def test_prepare_trade_insight_ai_analysis_persists_audit_payloads(
 
     row = repo.get_trade_insight_ai_analysis(analysis_id)
     assert row["prompt_text"] == "Analyze this deterministic payload."
-    assert row["prompt_payload_jsonb"]["analysis_produced_at"] == produced_at.isoformat()
+    assert (
+        row["prompt_payload_jsonb"]["analysis_produced_at"] == produced_at.isoformat()
+    )
     assert row["output_schema_jsonb"] == {"type": "object"}
     assert row["produced_at"] == produced_at
 
@@ -250,6 +256,70 @@ def test_claim_reclaims_stale_running_analysis(seeded_db_empty_cards):
     assert str(claimed["analysis_id"]) == analysis_id
     assert claimed["status"] == "running"
     assert claimed["started_at"] > stale_started_at
+
+
+def test_two_concurrent_claimers_get_distinct_rows(seeded_db_empty_cards):
+    """Two `ai` workers on separate connections must not double-process.
+
+    PR #53 ships a second AI worker; correctness relies on
+    `claim_next_trade_insight_ai_analysis` using FOR UPDATE SKIP LOCKED so
+    the second claimer skips the row the first one just locked. Without
+    that, both workers would race on `status='queued'` reads and could both
+    flip the same row to running.
+    """
+    repo = seeded_db_empty_cards
+    run_id, snapshot_id = _create_snapshot(repo, ticker="TSLA", input_hash="ti-1")
+    id_a = _enqueue(
+        repo,
+        snapshot_id=snapshot_id,
+        run_id=run_id,
+        analysis_input_hash="ai-1",
+        analysis_input={"ticker": "TSLA", "tabs": {"flow": {"x": 1}}},
+    )
+    id_b = _enqueue(
+        repo,
+        snapshot_id=snapshot_id,
+        run_id=run_id,
+        analysis_input_hash="ai-2",
+        analysis_input={"ticker": "TSLA", "tabs": {"flow": {"x": 2}}},
+    )
+    assert id_a != id_b
+    repo.conn.commit()
+
+    # Open a second connection on the same DSN — simulates a separate worker.
+    dsn = repo.conn.info.dsn
+    conn_b = psycopg.connect(dsn)
+    try:
+        repo_b = Repository(conn_b, schema=repo._schema)
+
+        # Claim from worker A — its inner SELECT FOR UPDATE locks one row.
+        claimed_a = repo.claim_next_trade_insight_ai_analysis()
+        # Claim from worker B BEFORE A commits — must SKIP the locked row
+        # and grab the other queued one (or return None if SKIP LOCKED is
+        # broken and B sees only the row A locked).
+        claimed_b = repo_b.claim_next_trade_insight_ai_analysis()
+
+        assert claimed_a is not None, "worker A should claim a row"
+        assert claimed_b is not None, (
+            "worker B should claim the OTHER row, not skip out — "
+            "FOR UPDATE SKIP LOCKED is the contract here"
+        )
+        assert str(claimed_a["analysis_id"]) != str(claimed_b["analysis_id"]), (
+            "two workers claimed the SAME row — concurrency invariant broken"
+        )
+        assert {str(claimed_a["analysis_id"]), str(claimed_b["analysis_id"])} == {
+            id_a,
+            id_b,
+        }
+
+        # Commit both so the third claim sees both as 'running'; with no
+        # queued or stale-running rows, it should return None.
+        repo.conn.commit()
+        repo_b.conn.commit()
+        third = repo.claim_next_trade_insight_ai_analysis()
+        assert third is None, "no more queued rows; third claim should be empty"
+    finally:
+        conn_b.close()
 
 
 def test_complete_stores_outcome_markdown_and_preserves_produced_at(

--- a/tests/unit/worker/test_worker_sharding.py
+++ b/tests/unit/worker/test_worker_sharding.py
@@ -43,18 +43,13 @@ def test_ticker_shard_filter_is_disabled_for_single_worker() -> None:
 def test_worker_groups_split_provider_roles() -> None:
     assert _worker_groups(_settings(worker_role="uw")) == {"uw"}
     assert _worker_groups(_settings(worker_role="massive")) == {"massive"}
+    assert _worker_groups(_settings(worker_role="ai")) == {"ai"}
     assert _worker_groups(_settings(worker_role="all")) == {"uw", "massive", "ai"}
 
 
 def test_split_uw_workers_run_one_rescan_instance_each() -> None:
-    assert (
-        _rescan_worker_concurrency(_settings(worker_role="uw", worker_count=2))
-        == 1
-    )
-    assert (
-        _rescan_worker_concurrency(_settings(worker_role="all", worker_count=1))
-        == 2
-    )
+    assert _rescan_worker_concurrency(_settings(worker_role="uw", worker_count=2)) == 1
+    assert _rescan_worker_concurrency(_settings(worker_role="all", worker_count=1)) == 2
 
 
 def test_spot_refresh_respects_ticker_filter() -> None:

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -54,7 +54,9 @@ function dash(v: number | string | null | undefined, suffix = ""): string {
 function fmtSidebarDateTime(iso: string | null | undefined): string {
   const full = fmtDateTimeWithZone(iso);
   if (full === "—") return full;
-  const match = full.match(/^\d{4}\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):\d{2} (.+)$/);
+  const match = full.match(
+    /^\d{4}\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):\d{2} (.+)$/,
+  );
   if (!match) return full;
   const [, month, day, hour, minute, zone] = match;
   return `${month}/${day} ${hour}:${minute} ${zone}`;
@@ -71,19 +73,26 @@ function heartbeatStatus(
   return { label: "STALE", color: "var(--warning)" };
 }
 
-function recordHealthStatus(
-  ok: boolean | null | undefined,
-): { label: "OK" | "ALERT" | "UNKNOWN"; color: string } {
+function recordHealthStatus(ok: boolean | null | undefined): {
+  label: "OK" | "ALERT" | "UNKNOWN";
+  color: string;
+} {
   if (ok == null) return { label: "UNKNOWN", color: "var(--warning)" };
   if (ok) return { label: "OK", color: "var(--positive)" };
   return { label: "ALERT", color: "var(--negative)" };
 }
 
-function workerGroupStatus(workers: WorkerHealth[]): { label: string; color: string } {
-  if (workers.length === 0) return { label: "UNKNOWN", color: "var(--warning)" };
+function workerGroupStatus(workers: WorkerHealth[]): {
+  label: string;
+  color: string;
+} {
+  if (workers.length === 0)
+    return { label: "UNKNOWN", color: "var(--warning)" };
   const online = workers.filter((worker) => {
     const healthyLag =
-      worker.role === "massive" ? SPOT_REFRESH_HEALTHY_LAG_S : HEARTBEAT_HEALTHY_LAG_S;
+      worker.role === "massive"
+        ? SPOT_REFRESH_HEALTHY_LAG_S
+        : HEARTBEAT_HEALTHY_LAG_S;
     return heartbeatStatus(worker.lag_seconds, healthyLag).label === "ONLINE";
   }).length;
   if (online === workers.length) {
@@ -172,7 +181,10 @@ export function HealthPanel() {
   );
   const workerRows = h?.workers ?? [];
   const uwWorkers = workerRows.filter((worker) => worker.role === "uw");
-  const massiveWorkers = workerRows.filter((worker) => worker.role === "massive");
+  const massiveWorkers = workerRows.filter(
+    (worker) => worker.role === "massive",
+  );
+  const aiWorkers = workerRows.filter((worker) => worker.role === "ai");
   const recordsStatus = recordHealthStatus(h?.record_health_ok);
 
   return (
@@ -187,7 +199,16 @@ export function HealthPanel() {
       {workerRows.length > 0 ? (
         <>
           <StatusRow label="UW Workers" status={workerGroupStatus(uwWorkers)} />
-          <StatusRow label="Massive Workers" status={workerGroupStatus(massiveWorkers)} />
+          <StatusRow
+            label="Massive Workers"
+            status={workerGroupStatus(massiveWorkers)}
+          />
+          {aiWorkers.length > 0 && (
+            <StatusRow
+              label="AI Workers"
+              status={workerGroupStatus(aiWorkers)}
+            />
+          )}
         </>
       ) : (
         <>
@@ -207,7 +228,10 @@ export function HealthPanel() {
       </div>
       <div style={rowStyle}>
         <span style={labelStyle}>Last Scan</span>
-        <span style={valStyle} title={fmtDateTimeWithZone(h?.last_full_scan_at)}>
+        <span
+          style={valStyle}
+          title={fmtDateTimeWithZone(h?.last_full_scan_at)}
+        >
           {fmtSidebarDateTime(h?.last_full_scan_at)}
         </span>
       </div>
@@ -247,7 +271,9 @@ export function HealthPanel() {
       </div>
       <div style={rowStyle}>
         <span style={labelStyle}>Scan avg</span>
-        <span style={valStyle}>{fmtDuration(h?.avg_scan_duration_seconds)}</span>
+        <span style={valStyle}>
+          {fmtDuration(h?.avg_scan_duration_seconds)}
+        </span>
       </div>
       <div style={rowStyle}>
         <span style={labelStyle}>Queue avg/min</span>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1572,6 +1572,22 @@ export interface components {
             /** Delta */
             delta?: number | null;
         };
+        /** GoldCbCountryHistory */
+        GoldCbCountryHistory: {
+            /** Country Iso3 */
+            country_iso3: string;
+            /** Country Name */
+            country_name: string;
+            /** Bucket */
+            bucket: string;
+            /** Latest Reserves T */
+            latest_reserves_t?: string | null;
+            /**
+             * History
+             * @default []
+             */
+            history: components["schemas"]["GoldHistoryPoint"][];
+        };
         /** GoldCorrelationBand */
         GoldCorrelationBand: {
             /** Mean */
@@ -1687,22 +1703,6 @@ export interface components {
             current: components["schemas"]["GoldGaugeState"];
             /** History 252D */
             history_252d: components["schemas"]["GoldGaugeTimeSeriesPoint"][];
-        };
-        /** GoldCbCountryHistory */
-        GoldCbCountryHistory: {
-            /** Country Iso3 */
-            country_iso3: string;
-            /** Country Name */
-            country_name: string;
-            /** Bucket */
-            bucket: string;
-            /** Latest Reserves T */
-            latest_reserves_t?: string | null;
-            /**
-             * History
-             * @default []
-             */
-            history: components["schemas"]["GoldHistoryPoint"][];
         };
         /** GoldGaugeState */
         GoldGaugeState: {
@@ -4254,7 +4254,7 @@ export interface components {
              * Role
              * @enum {string}
              */
-            role: "uw" | "massive";
+            role: "uw" | "massive" | "ai";
             /** Index */
             index: number;
             /** Heartbeat Name */


### PR DESCRIPTION
## Summary

- Trade Insights AI rows were sitting in `queued` forever — latest stranded row (TSLA) for 3 days, no error in the UI because the API happily 202-accepts. Root cause: `scripts/dev.sh` only spawns `role=uw` and `role=massive` workers, but the AI poll job (`trade_insights_ai_tick`) is gated on `"ai" in _worker_groups(settings)`, and only `role=all` had `"ai"` in its set. So no scheduler ever registered the AI tick.
- Adds `role=ai` as a first-class worker role (`_worker_groups("ai") → {"ai"}`, `WORKER_ROLES` accepts it) and spawns a 5th `WORKER_COUNT=1` `ai` process in `dev.sh`. AI doesn't need sharding — the Codex subprocess already serializes — and keeping it separate avoids forcing the legacy `all` scheduler shape just to get AI polling.
- Documents the role in `src/uw_scan/worker/CLAUDE.md` so this gating is visible from the doc layer next time.

## Verification

- `uv run pytest tests/unit/worker/test_worker_sharding.py` → 7 passed.
- Restarted `dev.sh` locally with the new config. 7 prefixes register: `next, api, uw-0, uw-1, massive-0, massive-1, ai`. Within 3s of startup the `ai` scheduler logged `Added job "Trade Insights AI analysis poll"` and the oldest stranded row (TSLA, queued 3 days) flipped from `queued → running`.

## Operator note

Requires `TRADE_INSIGHTS_AI_ENABLED=true` to be set (env, not committed). Without it the `ai` worker registers the heartbeat but skips the AI tick (gated separately in `scheduler.py:580`). Local `.env` should grow this line; doc PR for `.env.example` can land separately.

## Test plan

- [x] `uv run pytest tests/unit/worker/test_worker_sharding.py`
- [x] Local `dev.sh` restart shows `ai` prefix + AI tick registered
- [x] Stranded `queued` row picked up by new worker within 3s
- [ ] CI green