### PR TITLE
feat(health): collapsible HealthPanel, collapsed by default

### DIFF
--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -231,6 +231,12 @@ export function HealthPanel() {
   const massiveWorkers = workerRows.filter(
     (worker) => worker.role === "massive",
   );
+  // AI workers ship in a sibling PR that widens WorkerHealth.role to include
+  // "ai". Cast through string so this compiles regardless of merge order;
+  // once the role enum widens, this filter returns the real AI worker rows.
+  const aiWorkers = workerRows.filter(
+    (worker) => (worker.role as string) === "ai",
+  );
   const recordsStatus = recordHealthStatus(h?.record_health_ok);
   const summary = worstStatus(
     workerRows.length > 0
@@ -239,6 +245,10 @@ export function HealthPanel() {
           schedulerStatus,
           workerGroupStatus(uwWorkers),
           workerGroupStatus(massiveWorkers),
+          // Only include AI workers in the worst-status summary when they
+          // exist — otherwise workerGroupStatus([]) returns "UNKNOWN" and
+          // would tip the collapsed dot to warning unnecessarily.
+          ...(aiWorkers.length > 0 ? [workerGroupStatus(aiWorkers)] : []),
           recordsStatus,
         ]
       : [

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -12,6 +12,7 @@ const HEARTBEAT_HEALTHY_LAG_S = 5;
 const SPOT_REFRESH_HEALTHY_LAG_S = 660;
 const RECORD_WINDOW_HOURS = 8;
 const RECORD_MIN_COVERAGE = 0.9;
+const COLLAPSED_STORAGE_KEY = "uw_health_collapsed";
 
 const rowStyle: React.CSSProperties = {
   display: "flex",
@@ -54,7 +55,9 @@ function dash(v: number | string | null | undefined, suffix = ""): string {
 function fmtSidebarDateTime(iso: string | null | undefined): string {
   const full = fmtDateTimeWithZone(iso);
   if (full === "—") return full;
-  const match = full.match(/^\d{4}\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):\d{2} (.+)$/);
+  const match = full.match(
+    /^\d{4}\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):\d{2} (.+)$/,
+  );
   if (!match) return full;
   const [, month, day, hour, minute, zone] = match;
   return `${month}/${day} ${hour}:${minute} ${zone}`;
@@ -71,19 +74,26 @@ function heartbeatStatus(
   return { label: "STALE", color: "var(--warning)" };
 }
 
-function recordHealthStatus(
-  ok: boolean | null | undefined,
-): { label: "OK" | "ALERT" | "UNKNOWN"; color: string } {
+function recordHealthStatus(ok: boolean | null | undefined): {
+  label: "OK" | "ALERT" | "UNKNOWN";
+  color: string;
+} {
   if (ok == null) return { label: "UNKNOWN", color: "var(--warning)" };
   if (ok) return { label: "OK", color: "var(--positive)" };
   return { label: "ALERT", color: "var(--negative)" };
 }
 
-function workerGroupStatus(workers: WorkerHealth[]): { label: string; color: string } {
-  if (workers.length === 0) return { label: "UNKNOWN", color: "var(--warning)" };
+function workerGroupStatus(workers: WorkerHealth[]): {
+  label: string;
+  color: string;
+} {
+  if (workers.length === 0)
+    return { label: "UNKNOWN", color: "var(--warning)" };
   const online = workers.filter((worker) => {
     const healthyLag =
-      worker.role === "massive" ? SPOT_REFRESH_HEALTHY_LAG_S : HEARTBEAT_HEALTHY_LAG_S;
+      worker.role === "massive"
+        ? SPOT_REFRESH_HEALTHY_LAG_S
+        : HEARTBEAT_HEALTHY_LAG_S;
     return heartbeatStatus(worker.lag_seconds, healthyLag).label === "ONLINE";
   }).length;
   if (online === workers.length) {
@@ -135,9 +145,55 @@ function StatusRow({
   );
 }
 
+// Worst-color summary for the collapsed header dot. Severity order matches
+// the var() palette: --negative > --warning > --positive. UNKNOWN states
+// are mapped to --warning by their producers, which is the behaviour we
+// want here too.
+function worstStatus(statuses: { color: string }[]): {
+  label: "OK" | "WARN" | "ALERT";
+  color: string;
+} {
+  const colors = statuses.map((s) => s.color);
+  if (colors.includes("var(--negative)"))
+    return { label: "ALERT", color: "var(--negative)" };
+  if (colors.includes("var(--warning)"))
+    return { label: "WARN", color: "var(--warning)" };
+  return { label: "OK", color: "var(--positive)" };
+}
+
+function readStoredCollapsed(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = window.localStorage?.getItem(COLLAPSED_STORAGE_KEY);
+    if (stored == null) return true;
+    return stored === "1";
+  } catch {
+    return true;
+  }
+}
+
+function writeStoredCollapsed(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage?.setItem(COLLAPSED_STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    // Quota exceeded / disabled storage — fall through and keep in-memory only.
+  }
+}
+
 export function HealthPanel() {
   const [h, setH] = useState<Health | null>(null);
   const [source, setSource] = useState<ProviderSource>("uw");
+  // Always start collapsed on server + first client render to avoid a
+  // hydration mismatch; the real localStorage value is read in an effect.
+  const [collapsed, setCollapsed] = useState<boolean>(true);
+
+  useEffect(() => {
+    // Syncing with localStorage requires a post-mount read; a lazy useState
+    // initializer would still see SSR's undefined window and skip hydration.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCollapsed(readStoredCollapsed());
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -172,99 +228,177 @@ export function HealthPanel() {
   );
   const workerRows = h?.workers ?? [];
   const uwWorkers = workerRows.filter((worker) => worker.role === "uw");
-  const massiveWorkers = workerRows.filter((worker) => worker.role === "massive");
+  const massiveWorkers = workerRows.filter(
+    (worker) => worker.role === "massive",
+  );
   const recordsStatus = recordHealthStatus(h?.record_health_ok);
+  const summary = worstStatus(
+    workerRows.length > 0
+      ? [
+          apiStatus,
+          schedulerStatus,
+          workerGroupStatus(uwWorkers),
+          workerGroupStatus(massiveWorkers),
+          recordsStatus,
+        ]
+      : [
+          apiStatus,
+          schedulerStatus,
+          rescanStatus,
+          spotRefreshStatus,
+          recordsStatus,
+        ],
+  );
+
+  const toggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      writeStoredCollapsed(next);
+      return next;
+    });
+  };
 
   return (
-    <div
-      style={{
-        borderTop: "1px solid var(--border-dim)",
-        padding: "12px 16px",
-      }}
-    >
-      <StatusRow label="API" status={apiStatus} />
-      <StatusRow label="Scheduler" status={schedulerStatus} />
-      {workerRows.length > 0 ? (
-        <>
-          <StatusRow label="UW Workers" status={workerGroupStatus(uwWorkers)} />
-          <StatusRow label="Massive Workers" status={workerGroupStatus(massiveWorkers)} />
-        </>
-      ) : (
-        <>
-          <StatusRow label="UW Worker" status={rescanStatus} />
-          <StatusRow label="Massive Worker" status={spotRefreshStatus} />
-        </>
-      )}
-      <StatusRow label="Query Coverage" status={recordsStatus} />
-      <div style={rowStyle}>
-        <span style={labelStyle}>Last spot</span>
-        <span
-          style={valStyle}
-          title={`Quote ${fmtDateTimeWithZone(h?.latest_spot_quote_at)} / fetched ${fmtDateTimeWithZone(h?.latest_spot_quote_fetched_at)}`}
-        >
-          {fmtDuration(h?.spot_quote_lag_seconds)}
-        </span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Last Scan</span>
-        <span style={valStyle} title={fmtDateTimeWithZone(h?.last_full_scan_at)}>
-          {fmtSidebarDateTime(h?.last_full_scan_at)}
-        </span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Source</span>
-        <select
-          aria-label="Source"
-          value={source}
-          onChange={(event) => setSource(event.target.value as ProviderSource)}
-          style={sourceSelectStyle}
-        >
-          <option value="uw">UnusualWhales</option>
-          <option value="massive">Massive.com</option>
-        </select>
-      </div>
-      <div
+    <div style={{ borderTop: "1px solid var(--border-dim)" }}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-controls="health-panel-body"
+        title={`Status: ${summary.label}. Click to ${collapsed ? "expand" : "collapse"}.`}
         style={{
-          borderTop: "1px solid var(--border-dim)",
-          margin: "8px 0",
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          padding: "10px 16px",
+          background: "transparent",
+          border: "none",
+          color: "var(--text-secondary)",
+          cursor: "pointer",
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          letterSpacing: 1.5,
+          textTransform: "uppercase",
         }}
-      />
-      <div style={rowStyle}>
-        <span style={labelStyle}>Watchlist</span>
-        <span style={valStyle}>{dash(h?.watchlist_size)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Latency p95</span>
-        <span style={valStyle}>{dash(h?.latency_p95_ms, "ms")}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Req avg/min</span>
-        <span style={valStyle}>{fmtRate(h?.requests_per_minute)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>429</span>
-        <span style={valStyle}>{dash(h?.http_429)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Scan avg</span>
-        <span style={valStyle}>{fmtDuration(h?.avg_scan_duration_seconds)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>Queue avg/min</span>
-        <span style={valStyle}>{fmtRate(h?.queue_drain_rate_per_minute)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>2xx</span>
-        <span style={valStyle}>{dash(h?.http_2xx)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>4xx</span>
-        <span style={valStyle}>{dash(h?.http_4xx)}</span>
-      </div>
-      <div style={rowStyle}>
-        <span style={labelStyle}>5xx</span>
-        <span style={valStyle}>{dash(h?.http_5xx)}</span>
-      </div>
+      >
+        <span style={statusStyle}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              background: summary.color,
+              display: "inline-block",
+            }}
+          />
+          <span style={{ color: "var(--text-muted)" }}>Status</span>
+          <span style={valStyle}>{summary.label}</span>
+        </span>
+        <span aria-hidden="true">{collapsed ? "▸" : "▾"}</span>
+      </button>
+      {!collapsed && (
+        <div id="health-panel-body" style={{ padding: "0 16px 12px 16px" }}>
+          <StatusRow label="API" status={apiStatus} />
+          <StatusRow label="Scheduler" status={schedulerStatus} />
+          {workerRows.length > 0 ? (
+            <>
+              <StatusRow
+                label="UW Workers"
+                status={workerGroupStatus(uwWorkers)}
+              />
+              <StatusRow
+                label="Massive Workers"
+                status={workerGroupStatus(massiveWorkers)}
+              />
+            </>
+          ) : (
+            <>
+              <StatusRow label="UW Worker" status={rescanStatus} />
+              <StatusRow label="Massive Worker" status={spotRefreshStatus} />
+            </>
+          )}
+          <StatusRow label="Query Coverage" status={recordsStatus} />
+          <div style={rowStyle}>
+            <span style={labelStyle}>Last spot</span>
+            <span
+              style={valStyle}
+              title={`Quote ${fmtDateTimeWithZone(h?.latest_spot_quote_at)} / fetched ${fmtDateTimeWithZone(h?.latest_spot_quote_fetched_at)}`}
+            >
+              {fmtDuration(h?.spot_quote_lag_seconds)}
+            </span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Last Scan</span>
+            <span
+              style={valStyle}
+              title={fmtDateTimeWithZone(h?.last_full_scan_at)}
+            >
+              {fmtSidebarDateTime(h?.last_full_scan_at)}
+            </span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Source</span>
+            <select
+              aria-label="Source"
+              value={source}
+              onChange={(event) =>
+                setSource(event.target.value as ProviderSource)
+              }
+              style={sourceSelectStyle}
+            >
+              <option value="uw">UnusualWhales</option>
+              <option value="massive">Massive.com</option>
+            </select>
+          </div>
+          <div
+            style={{
+              borderTop: "1px solid var(--border-dim)",
+              margin: "8px 0",
+            }}
+          />
+          <div style={rowStyle}>
+            <span style={labelStyle}>Watchlist</span>
+            <span style={valStyle}>{dash(h?.watchlist_size)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Latency p95</span>
+            <span style={valStyle}>{dash(h?.latency_p95_ms, "ms")}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Req avg/min</span>
+            <span style={valStyle}>{fmtRate(h?.requests_per_minute)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>429</span>
+            <span style={valStyle}>{dash(h?.http_429)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Scan avg</span>
+            <span style={valStyle}>
+              {fmtDuration(h?.avg_scan_duration_seconds)}
+            </span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>Queue avg/min</span>
+            <span style={valStyle}>
+              {fmtRate(h?.queue_drain_rate_per_minute)}
+            </span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>2xx</span>
+            <span style={valStyle}>{dash(h?.http_2xx)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>4xx</span>
+            <span style={valStyle}>{dash(h?.http_4xx)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={labelStyle}>5xx</span>
+            <span style={valStyle}>{dash(h?.http_5xx)}</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -1,5 +1,11 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HealthPanel } from "@/components/shared/HealthPanel";
 import { api } from "@/lib/api";
@@ -10,10 +16,38 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
+// The panel ships collapsed by default; existing assertions cover the
+// expanded surface, so we click open before each check.
+async function expandPanel() {
+  const toggle = await screen.findByRole("button", { name: /status/i });
+  fireEvent.click(toggle);
+}
+
 describe("HealthPanel", () => {
+  // jsdom in this toolchain ships an empty Storage prototype; stub a
+  // Map-backed shim so the panel's localStorage reads + writes work.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    });
+  });
+
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("renders provider usage stats from health", async () => {
@@ -83,6 +117,7 @@ describe("HealthPanel", () => {
     });
 
     render(<HealthPanel />);
+    await expandPanel();
 
     await waitFor(() => expect(screen.getByText("API")).toBeTruthy());
     expect(screen.getByText("Scheduler")).toBeTruthy();
@@ -144,8 +179,11 @@ describe("HealthPanel", () => {
     });
 
     render(<HealthPanel />);
+    await expandPanel();
 
-    await waitFor(() => expect(screen.getAllByText("UNKNOWN").length).toBeGreaterThanOrEqual(2));
+    await waitFor(() =>
+      expect(screen.getAllByText("UNKNOWN").length).toBeGreaterThanOrEqual(2),
+    );
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(5);
   });
 
@@ -205,6 +243,7 @@ describe("HealthPanel", () => {
       });
 
     render(<HealthPanel />);
+    await expandPanel();
 
     await waitFor(() =>
       expect(api.health).toHaveBeenCalledWith("uw", {
@@ -269,8 +308,65 @@ describe("HealthPanel", () => {
     });
 
     render(<HealthPanel />);
+    await expandPanel();
 
-    await waitFor(() => expect(screen.getByText("Query Coverage")).toBeTruthy());
-    expect(screen.getByText("ALERT")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByText("Query Coverage")).toBeTruthy(),
+    );
+    // ALERT appears twice when records are unhealthy: once in the always-on
+    // summary chip at the top, once on the Query Coverage row.
+    expect(screen.getAllByText("ALERT").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("starts collapsed, hides the body, and toggles on click", async () => {
+    vi.mocked(api.health).mockResolvedValue({
+      ok: true,
+      db: "up",
+      scheduler_lag_seconds: 1,
+      last_full_scan_at: "2026-05-14T14:20:42Z",
+      reason: null,
+      worker_lag_seconds: 1,
+      scheduler_heartbeat_lag_seconds: 1,
+      scheduler_heartbeat_name: "worker",
+      rescan_heartbeat_lag_seconds: 1,
+      spot_refresh_heartbeat_lag_seconds: 1,
+      spot_quote_lag_seconds: 60,
+      latest_spot_quote_at: "2026-05-14T14:19:42Z",
+      latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
+      watchlist_size: 97,
+      source: "UnusualWhales",
+      latency_p95_ms: 88,
+      http_2xx: 120,
+      http_4xx: 0,
+      http_5xx: 0,
+      uw_today: 40,
+      cache_hit_pct: null,
+      throughput_window_minutes: 15,
+      record_health_ok: true,
+      record_health: [],
+      workers: [],
+    });
+
+    render(<HealthPanel />);
+
+    // Collapsed by default — header button visible, body hidden.
+    const toggle = await screen.findByRole("button", { name: /status/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Query Coverage")).toBeNull();
+    expect(screen.queryByText("Watchlist")).toBeNull();
+
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(screen.getByText("Query Coverage")).toBeTruthy(),
+    );
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    // Click again to collapse; localStorage persists the choice.
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(screen.queryByText("Query Coverage")).toBeNull(),
+    );
+    expect(window.localStorage.getItem("uw_health_collapsed")).toBe("1");
   });
 });


### PR DESCRIPTION
## Summary

- The HealthPanel grew to ~20 rows and was always-on, taking up sidebar real estate the operator doesn't need most of the time. Wrap the body in a collapsible container so the default state is "out of the way" with a single colored dot summarising overall health for at-a-glance triage.
- Default = collapsed; click anywhere on the header bar to expand. The choice is persisted to `localStorage['uw_health_collapsed']` so it sticks across reloads (and across tabs once they reload).
- Summary chip dot color = worst of `API / Scheduler / worker groups / Query Coverage` (severity: `--negative > --warning > --positive`). If anything is alerting, the dot turns red even when collapsed — operator never loses visibility on outages.

## Implementation notes

- SSR-safe: `useState(true)` for the initial render (server + first client both emit collapsed) avoids React hydration mismatch. A post-mount `useEffect` reads `localStorage` and re-renders if the user previously chose "expanded."
- Defensive storage access — `try/catch` + optional chaining around `localStorage.getItem/setItem` so private-browsing and Storage-disabled environments don't crash the panel.
- Used `eslint-disable-next-line react-hooks/set-state-in-effect` with a comment on the unavoidable `setCollapsed(readStoredCollapsed())` in `useEffect` — the alternative (`useSyncExternalStore` + a custom subscribe shim for same-tab updates) was overkill for one boolean.

## Test plan

- [x] `npm run test -- --run tests/unit/healthPanel.test.tsx` (5 tests, including a new round-trip toggle test that asserts `aria-expanded` flips and the persisted value)
- [x] `npm run test -- --run` full sweep (222 passing)
- [x] `npm run typecheck`
- [x] `npm run lint` — HealthPanel clean
- [ ] Manual: open the dashboard, confirm panel is collapsed on first load, expand, reload — should remain expanded; click to collapse, reload — should remain collapsed
- [ ] CI green

## Note on test-only stub

`jsdom` in this toolchain ships an empty `Storage` prototype — `window.localStorage.getItem` exists as a property but isn't a function — so the test file installs a Map-backed stub via `vi.stubGlobal("localStorage", …)`. This is scoped to the file's `beforeEach/afterEach`; no other tests are affected.