### PR TITLE
feat(stock/flow): inline color legend on volume/OI timeline charts

### DIFF
--- a/web/components/stock/panels/FlowTimelinePanel.tsx
+++ b/web/components/stock/panels/FlowTimelinePanel.tsx
@@ -79,10 +79,8 @@ export function FlowTimelinePanel({
   const dateIndex = new Map(dates.map((d, i) => [d, i]));
 
   return (
-    <AnalyticalSeriesPanel
-      title={title}
-      subtitle={`${primary.label} · ${secondary.label} (right)`}
-    >
+    <AnalyticalSeriesPanel title={title}>
+      <Legend primary={primary} secondary={secondary} />
       <svg
         role="img"
         aria-label={`${title} timeline`}
@@ -123,5 +121,57 @@ export function FlowTimelinePanel({
         />
       </svg>
     </AnalyticalSeriesPanel>
+  );
+}
+
+function Legend({ primary, secondary }: { primary: Series; secondary: Series }) {
+  return (
+    <div
+      role="list"
+      aria-label="Series legend"
+      style={{
+        display: "flex",
+        gap: 14,
+        marginBottom: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: 1.5,
+        textTransform: "uppercase",
+        color: "var(--text-muted)",
+      }}
+    >
+      <LegendItem color={primary.color} label={primary.label} axis="left" />
+      <LegendItem color={secondary.color} label={secondary.label} axis="right" />
+    </div>
+  );
+}
+
+function LegendItem({
+  color,
+  label,
+  axis,
+}: {
+  color: string;
+  label: string;
+  axis: "left" | "right";
+}) {
+  return (
+    <div
+      role="listitem"
+      style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+    >
+      <span
+        aria-hidden
+        style={{
+          display: "inline-block",
+          width: 14,
+          height: 2,
+          background: color,
+        }}
+      />
+      <span>
+        {label} <span style={{ opacity: 0.65 }}>({axis})</span>
+      </span>
+    </div>
   );
 }

--- a/web/tests/unit/FlowTimelinePanel.test.tsx
+++ b/web/tests/unit/FlowTimelinePanel.test.tsx
@@ -50,6 +50,32 @@ describe("FlowTimelinePanel", () => {
     expect(markerLines.length).toBe(1);
   });
 
+  it("renders a legend with both series labels and axis markers", () => {
+    const { getByRole, getAllByRole } = render(
+      <FlowTimelinePanel
+        title="OPTIONS VOLUME"
+        primary={{
+          label: "Volume",
+          values: [1000, 1500, 2000, 1200],
+          color: "var(--accent-bg)",
+        }}
+        secondary={{
+          label: "P/C Vol",
+          values: [0.6, 0.8, 0.9, 0.7],
+          color: "var(--accent-warm)",
+        }}
+        dates={dates}
+      />,
+    );
+    const legend = getByRole("list", { name: /series legend/i });
+    const items = getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(legend.textContent).toMatch(/Volume/);
+    expect(legend.textContent).toMatch(/\(left\)/);
+    expect(legend.textContent).toMatch(/P\/C Vol/);
+    expect(legend.textContent).toMatch(/\(right\)/);
+  });
+
   it("renders NO DATA when fewer than 2 finite values are present", () => {
     const { container } = render(
       <FlowTimelinePanel


### PR DESCRIPTION
## Summary

The OPTIONS VOLUME and OPEN INTEREST panels on the Flow tab rendered two-axis line charts whose color → series mapping was only visible via the hover tooltip. Replaces the duplicate text subtitle with a small inline legend that carries the missing color information.

Before: `VOLUME · P/C VOL (RIGHT)` (text only — no color mapping)
After: `█ VOLUME (LEFT)   █ P/C VOL (RIGHT)` (color swatch + label + axis marker)

## Changes

- `FlowTimelinePanel.tsx` — drop the redundant `subtitle` prop on `AnalyticalSeriesPanel`; render a `Legend` row above the SVG with one `LegendItem` per series. Each item: 14×2 stroke swatch in the series color, label, dimmed axis marker.
- `FlowTimelinePanel.test.tsx` — new case: legend renders both labels and the `(left)` / `(right)` markers, accessible via `role="list"` / `role="listitem"`.

## Design notes

- Matches the Argon mono-label spec in `web/CLAUDE.md` (10 px, letter-spacing 1.5, uppercase, `var(--text-muted)`)
- Colors come from existing tokens — primary `var(--accent-bg)` (teal), secondary `var(--accent-warm)` (orange); both panels share the same `FlowTimelinePanel` so the legend applies to OPTIONS VOLUME and OPEN INTEREST automatically
- A11y: `role="list"` + `aria-label="Series legend"` on the wrapper; `aria-hidden` on the decorative swatches; the SVG's `<title>` element still encodes the full axis mapping for screen readers
- Axis markers rendered at 65% opacity so the series name stays the dominant token

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 241 / 241 pass (one new legend test)
- [ ] Manual: hit `/stock/<ticker>` Flow tab, confirm legend renders with correct color swatches on both panels