### PR TITLE
Vanna & Charm sub-tabs inside Market Structure

### DIFF
--- a/docs/superpowers/plans/2026-05-21-vanna-charm-market-structure.md
+++ b/docs/superpowers/plans/2026-05-21-vanna-charm-market-structure.md
@@ -1,0 +1,3944 @@
+# Vanna & Charm — Market Structure sub-tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `VANNA` and `CHARM` sub-tabs inside the per-ticker Market Structure tab, mirroring the UnusualWhales reference layout (headline narrative + 4 tiles + expiry dropdown + Net curve + Call/Put split curve). The existing `GexProfileChart` moves into a new `GEX` sub-tab so the three become peers. All derived summary values are computed in Python and persisted to a new `exposures_summary` table per project rule.
+
+**Architecture:** Raw per-(expiry, strike) exposures already land in `exposures_by_expiry_strike` from the daily cockpit snapshot. We add a pure deriver module (`cards/exposures.py`), persist its output into a new `exposures_summary` table (migration 051), surface both raw rows and summary rows on `SingleStockReport`, and render the panels as hand-rolled SVG line charts using the existing `lib/svgChart.ts` helpers. Sub-tab switching is a small client component (`GreekSubTabs`) embedded inside the still-RSC `MarketStructureTab`.
+
+**Tech Stack:** Python 3.13 + `uv`, Pydantic v2, psycopg 3, FastAPI, APScheduler, Postgres 16. Next.js 16 + React 19 (RSC + client islands), TypeScript strict, vitest, Playwright. Spec lives at `docs/superpowers/specs/2026-05-21-vanna-charm-market-structure-design.md`.
+
+---
+
+## Slice 1 — Models + migration
+
+### Task 1.1: Add `StrikeExposureRow` and `ExposuresSummaryRow` Pydantic models
+
+**Files:**
+- Modify: `src/uw_scan/models/scanner.py` (append models near `StrikeGexBucket` at line ~151)
+- Modify: `src/uw_scan/models/__init__.py` (add to `__all__` + `from .scanner import ...`)
+- Test: `tests/unit/test_models_exports.py` (existing — assert new names exported)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_models_exports.py` (create if absent; otherwise extend the existing test in that file):
+
+```python
+def test_new_exposure_models_exported():
+    from uw_scan import models
+
+    assert "StrikeExposureRow" in models.__all__
+    assert "ExposuresSummaryRow" in models.__all__
+    # _preserve_public_module rewrites __module__ to "uw_scan.models" for
+    # contract identity (see src/uw_scan/models/_base.py). Asserting the
+    # public module is what protects the OpenAPI component name from
+    # accidentally drifting back to the implementation module.
+    assert models.StrikeExposureRow.__module__ == "uw_scan.models"
+    assert models.ExposuresSummaryRow.__module__ == "uw_scan.models"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/unit/test_models_exports.py::test_new_exposure_models_exported -v
+```
+
+Expected: FAIL — `AttributeError: module 'uw_scan.models' has no attribute 'StrikeExposureRow'`.
+
+- [ ] **Step 3: Add the two models to `src/uw_scan/models/scanner.py`**
+
+Insert right after `StrikeGexBucket` (before `GexLevel`):
+
+```python
+class StrikeExposureRow(_UwBase):
+    """One per-(expiry, strike) raw row from exposures_by_expiry_strike,
+    carrying the call/put split for vanna and charm so the FE can render
+    Net + Call/Put curves without an extra fetch."""
+
+    strike: Decimal
+    expiry: _date
+    dte: int | None = None
+    call_vanna: Decimal | None = None
+    put_vanna: Decimal | None = None
+    call_charm: Decimal | None = None
+    put_charm: Decimal | None = None
+
+
+class ExposuresSummaryRow(_UwBase):
+    """Per-(expiry) derived summary used to drive the Vanna/Charm sub-tab
+    headline narrative + 4 tiles. Computed by cards/exposures.py and
+    persisted to uw_scan.exposures_summary."""
+
+    expiry: _date
+    dte: int | None = None
+    spot: Decimal | None = None
+    # Vanna ---
+    net_vanna: Decimal | None = None
+    top_vanna_strike: Decimal | None = None
+    top_vanna_value: Decimal | None = None
+    delta_shock_1pt_iv: Decimal | None = None
+    vanna_regime: str | None = None
+    vanna_flip: Decimal | None = None
+    vanna_headline: str | None = None
+    vanna_subtitle: str | None = None
+    # Charm ---
+    net_charm: Decimal | None = None
+    charm_pin_strike: Decimal | None = None
+    charm_above_sum: Decimal | None = None
+    charm_below_sum: Decimal | None = None
+    charm_imbalance_pct: Decimal | None = None
+    charm_signal_quality: str | None = None
+    charm_flip: Decimal | None = None
+    charm_headline: str | None = None
+    charm_subtitle: str | None = None
+```
+
+Add both to the `_preserve_public_module(...)` call at the bottom of the file.
+
+- [ ] **Step 4: Re-export from `src/uw_scan/models/__init__.py`**
+
+In the existing `from .scanner import (...)` block, add `StrikeExposureRow` and `ExposuresSummaryRow`. Also add both names to `__all__` (keep alphabetical/grouped order consistent with neighbours).
+
+- [ ] **Step 5: Verify test passes + no other tests broken**
+
+```bash
+uv run pytest tests/unit/test_models_exports.py -v
+uv run pytest tests/unit -q
+```
+
+Expected: PASS. No regressions.
+
+- [ ] **Step 6: Commit (do not push)**
+
+```bash
+git add src/uw_scan/models/scanner.py src/uw_scan/models/__init__.py tests/unit/test_models_exports.py
+git commit -m "feat(models): add StrikeExposureRow and ExposuresSummaryRow contracts"
+```
+
+---
+
+### Task 1.2: Add migration `051_exposures_summary.sql`
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/051_exposures_summary.sql`
+- Test: `tests/integration/storage/test_exposures_summary_migration.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/storage/test_exposures_summary_migration.py`:
+
+```python
+"""Smoke test for migration 051 — table + PK + index exist; re-running migrate.sh is a no-op."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from uw_scan.storage.repository import Repository
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_exposures_summary_table_created(seeded_db_empty_cards: Repository):
+    """conftest's _reset_and_migrate already ran migrate.sh; assert the table + columns exist."""
+    repo = seeded_db_empty_cards
+    with repo.conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('uw_scan.exposures_summary')")
+        assert cur.fetchone()[0] is not None
+
+        cur.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'uw_scan' AND table_name = 'exposures_summary'
+            """
+        )
+        cols = {row[0] for row in cur.fetchall()}
+        for c in (
+            "run_id", "ticker", "expiry", "market_date", "dte", "spot",
+            "net_vanna", "top_vanna_strike", "top_vanna_value",
+            "delta_shock_1pt_iv", "vanna_regime", "vanna_flip",
+            "vanna_headline", "vanna_subtitle",
+            "net_charm", "charm_pin_strike", "charm_above_sum",
+            "charm_below_sum", "charm_imbalance_pct",
+            "charm_signal_quality", "charm_flip",
+            "charm_headline", "charm_subtitle",
+            "computed_at",
+        ):
+            assert c in cols, f"missing column: {c}"
+
+
+def test_migration_is_idempotent(seeded_db_empty_cards: Repository):
+    """Re-running scripts/migrate.sh on the already-migrated DB must be a no-op."""
+    repo = seeded_db_empty_cards
+    test_db = os.environ["UW_SCAN_TEST_DB_NAME"]
+    env = {**os.environ, "UW_SCAN_DB_NAME": test_db}
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
+        check=True, cwd=REPO_ROOT, env=env,
+    )
+    # Table still empty, schema still present.
+    with repo.conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM uw_scan.exposures_summary")
+        assert cur.fetchone()[0] == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/integration/storage/test_exposures_summary_migration.py -v
+```
+
+Expected: FAIL — `to_regclass` returns NULL because the table doesn't exist.
+
+- [ ] **Step 3: Create the migration file**
+
+Create `src/uw_scan/storage/migrations/051_exposures_summary.sql`:
+
+```sql
+-- 051_exposures_summary.sql
+-- Per-(expiry) derived summary used by the Vanna/Charm sub-tabs.
+-- One row per (run_id, ticker, expiry) — primary key. Idempotent.
+--
+-- run_id is BIGINT with FK ON DELETE CASCADE to match the convention used by
+-- every other run-keyed table in migration 001 (scan_runs.run_id is BIGSERIAL;
+-- INTEGER would overflow on long-running deployments and an orphan summary
+-- after scan-runs cleanup would be a data-integrity papercut).
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.exposures_summary (
+    run_id               BIGINT  NOT NULL
+                                 REFERENCES uw_scan.scan_runs(run_id) ON DELETE CASCADE,
+    ticker               TEXT    NOT NULL,
+    expiry               DATE    NOT NULL,
+    market_date          DATE    NOT NULL,
+    dte                  INTEGER,
+    spot                 NUMERIC,
+
+    -- Vanna ---
+    net_vanna            NUMERIC,
+    top_vanna_strike     NUMERIC,
+    top_vanna_value      NUMERIC,
+    delta_shock_1pt_iv   NUMERIC,
+    vanna_regime         TEXT,
+    vanna_flip           NUMERIC,
+    vanna_headline       TEXT,
+    vanna_subtitle       TEXT,
+
+    -- Charm ---
+    net_charm            NUMERIC,
+    charm_pin_strike     NUMERIC,
+    charm_above_sum      NUMERIC,
+    charm_below_sum      NUMERIC,
+    charm_imbalance_pct  NUMERIC,
+    charm_signal_quality TEXT,
+    charm_flip           NUMERIC,
+    charm_headline       TEXT,
+    charm_subtitle       TEXT,
+
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (run_id, ticker, expiry)
+);
+
+CREATE INDEX IF NOT EXISTS exposures_summary_ticker_date_idx
+    ON uw_scan.exposures_summary (ticker, market_date);
+```
+
+- [ ] **Step 4: Apply migration locally and run tests**
+
+```bash
+bash scripts/migrate.sh
+uv run pytest tests/integration/storage/test_exposures_summary_migration.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/storage/migrations/051_exposures_summary.sql tests/integration/storage/test_exposures_summary_migration.py
+git commit -m "feat(storage): add exposures_summary table (migration 051)"
+```
+
+---
+
+## Slice 2 — Derivers + unit tests
+
+> ⚠️ **Before writing the derivers — verify the UW vanna/charm sign and unit convention.** The deriver code below assumes:
+>
+> 1. UW per-strike `call_vanna` is signed such that `net_vanna > 0` means **dealers are net Long Vanna** — i.e., if IV rises, dealers gain Δ and sell stock to rehedge (the "procyclical" regime). The UW reference UI uses the same sign convention.
+> 2. UW vanna is `dΔ per 1.0 of IV (decimal)`, so a 1-point IV move = `vanna × 0.01`. Other endpoints expose "per-one-percent-move" pre-multiplied fields; we do NOT use those.
+>
+> Both assumptions are MEDIUM-CONFIDENCE pending live verification. Before merging Slice 4 (when the field surfaces in the UI), do one of:
+>
+> - **Sanity check from sample payloads.** `grep -l vanna docs/uw-samples/*.json` to find a real `/greek-exposure` response; verify that for a ticker with known dealer positioning (e.g., SPX in a high-skew window), the sign of `call_vanna + put_vanna` matches the UW UI's "Long/Short Vanna" labeling for the same expiry. If it doesn't, either the sign needs flipping in `vanna_regime` or the headline narratives need reversing.
+> - **Direct comparison.** Pull `/greek-exposure/expiry/strike` for TSLA on a recent day and compare the numerical `net_vanna` from `build_summary_rows` against the value the UW UI shows under "Net Vanna" — if scale differs by ~100×, the `ONE_VOL_POINT` factor is wrong (probably should be `1.0`, not `0.01`).
+>
+> Until verified, label the headline conservatively in `vanna_narrative`: use "Long Vanna positioning" rather than "Long Vanna — IV spikes pressure stock lower via dealer selling" so the directional claim isn't load-bearing on an unverified convention. (Plan keeps the descriptive text; if verification fails, just edit the narrative strings — no logic change needed.)
+
+### Task 2.1: Create `cards/exposures.py` with vanna derivers + tests
+
+**Files:**
+- Create: `src/uw_scan/cards/exposures.py`
+- Create: `tests/unit/cards/test_exposures_vanna.py`
+
+- [ ] **Step 1: Write the failing tests for `net_vanna`, `top_vanna_strike`, `delta_shock_1pt_iv`**
+
+Create `tests/unit/cards/test_exposures_vanna.py`:
+
+```python
+"""Vanna derivers — pure functions over GreekExposureRow lists."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import (
+    delta_shock_1pt_iv,
+    net_vanna,
+    top_vanna_strike,
+    vanna_flip,
+    vanna_narrative,
+    vanna_regime,
+)
+from uw_scan.models import GreekExposureRow
+
+
+def _r(strike: str, expiry: str, call_v: str | None, put_v: str | None) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        call_vanna=Decimal(call_v) if call_v is not None else None,
+        put_vanna=Decimal(put_v) if put_v is not None else None,
+    )
+
+
+def test_net_vanna_sums_call_plus_put_across_rows():
+    rows = [
+        _r("100", "2026-05-30", "100", "-30"),
+        _r("110", "2026-05-30", "200", "-40"),
+    ]
+    assert net_vanna(rows) == Decimal("230")  # 100-30+200-40
+
+
+def test_net_vanna_handles_nulls_silently():
+    rows = [
+        _r("100", "2026-05-30", "100", None),
+        _r("110", "2026-05-30", None, "-40"),
+    ]
+    assert net_vanna(rows) == Decimal("60")
+
+
+def test_net_vanna_empty_returns_none():
+    assert net_vanna([]) is None
+
+
+def test_top_vanna_strike_picks_max_absolute_per_strike():
+    rows = [
+        _r("100", "2026-05-30", "50", "-10"),     # net 40
+        _r("110", "2026-05-30", "-200", "30"),    # net -170
+        _r("120", "2026-05-30", "80", "20"),      # net 100
+    ]
+    strike, value = top_vanna_strike(rows)
+    assert strike == Decimal("110")
+    assert value == Decimal("-170")
+
+
+def test_top_vanna_strike_empty_returns_none():
+    assert top_vanna_strike([]) is None
+
+
+def test_delta_shock_1pt_iv_is_net_vanna_times_001():
+    """UW vanna is dDelta per unit of vol (decimal); 1pt IV = 0.01."""
+    rows = [_r("100", "2026-05-30", "10000", "-2000")]  # net 8000
+    assert delta_shock_1pt_iv(rows) == Decimal("80.00")  # 8000 * 0.01
+
+
+def test_vanna_regime_procyclical_when_net_positive():
+    assert vanna_regime(Decimal("1500000")) == "procyclical"
+
+
+def test_vanna_regime_countercyclical_when_net_negative():
+    assert vanna_regime(Decimal("-1500000")) == "countercyclical"
+
+
+def test_vanna_regime_neutral_below_threshold():
+    assert vanna_regime(Decimal("500")) == "neutral"
+    assert vanna_regime(None) == "neutral"
+
+
+def test_vanna_flip_picks_first_cumulative_sign_change():
+    rows = [
+        _r("90",  "2026-05-30", "-100", "0"),   # cum -100
+        _r("100", "2026-05-30", "-50",  "0"),   # cum -150
+        _r("110", "2026-05-30", "200",  "0"),   # cum  50  ← flip here
+        _r("120", "2026-05-30", "50",   "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("100")) == Decimal("110")
+
+
+def test_vanna_flip_no_sign_change_returns_none():
+    rows = [
+        _r("90",  "2026-05-30", "10", "0"),
+        _r("100", "2026-05-30", "20", "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("95")) is None
+
+
+def test_vanna_flip_picks_lowest_ge_spot_when_multiple():
+    """Spec rule: lowest sign-flip ≥ spot; fall back to lowest overall otherwise."""
+    rows = [
+        _r("80",  "2026-05-30", "-100", "0"),   # cum -100
+        _r("90",  "2026-05-30", "200",  "0"),   # cum  100  ← flip 1 (below spot 100)
+        _r("100", "2026-05-30", "-300", "0"),   # cum -200  ← flip 2 (at spot)
+        _r("110", "2026-05-30", "400",  "0"),   # cum  200  ← flip 3 (above spot)
+    ]
+    assert vanna_flip(rows, spot=Decimal("100")) == Decimal("100")
+
+
+def test_vanna_flip_falls_back_to_lowest_when_no_flip_above_spot():
+    rows = [
+        _r("80",  "2026-05-30", "-100", "0"),
+        _r("90",  "2026-05-30", "200",  "0"),   # cum 100  ← flip below spot
+    ]
+    assert vanna_flip(rows, spot=Decimal("150")) == Decimal("90")
+
+
+def test_vanna_narrative_procyclical():
+    headline, subtitle = vanna_narrative(Decimal("1300000"), "procyclical")
+    assert "Long Vanna" in headline
+    assert "IV" in subtitle
+
+
+def test_vanna_narrative_countercyclical():
+    headline, subtitle = vanna_narrative(Decimal("-800000"), "countercyclical")
+    assert "Short Vanna" in headline
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_vanna.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'net_vanna' from 'uw_scan.cards.exposures'`.
+
+- [ ] **Step 3: Create `src/uw_scan/cards/exposures.py` with vanna derivers**
+
+```python
+"""Per-(expiry) derivations on raw greek-exposure rows.
+
+Pure functions: take ``list[GreekExposureRow]`` (already filtered to one expiry by
+the caller) and return derived summary values. No DB access — the assembler in
+``reports/`` owns the I/O, mirroring the ``cards/gex.py`` pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from decimal import Decimal
+
+from uw_scan.models import ExposuresSummaryRow, GreekExposureRow
+
+log = logging.getLogger(__name__)
+
+
+# --- thresholds (tunable; move to config if/when calibrated per-ticker) -----
+
+NEUTRAL_VANNA_THRESHOLD = Decimal("1000")
+"""|net_vanna| below this is reported as 'neutral' regime."""
+
+NEUTRAL_CHARM_THRESHOLD = Decimal("1000")
+"""|net_charm| below this is reported as 'flat' / 'mixed' signal quality."""
+
+ONE_VOL_POINT = Decimal("0.01")
+"""UW vanna is dDelta per 1.0 of IV (decimal). 1pt IV move = 0.01."""
+
+
+# --- vanna helpers ---------------------------------------------------------
+
+def _per_strike_net_vanna(rows: list[GreekExposureRow]) -> dict[Decimal, Decimal]:
+    acc: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    for r in rows:
+        if r.call_vanna is not None:
+            acc[r.strike] += r.call_vanna
+        if r.put_vanna is not None:
+            acc[r.strike] += r.put_vanna
+    return dict(acc)
+
+
+def net_vanna(rows: list[GreekExposureRow]) -> Decimal | None:
+    """Σ (call_vanna + put_vanna) across every row. None when no inputs."""
+    if not rows:
+        return None
+    total = Decimal("0")
+    any_present = False
+    for r in rows:
+        if r.call_vanna is not None:
+            total += r.call_vanna
+            any_present = True
+        if r.put_vanna is not None:
+            total += r.put_vanna
+            any_present = True
+    return total if any_present else None
+
+
+def top_vanna_strike(
+    rows: list[GreekExposureRow],
+) -> tuple[Decimal, Decimal] | None:
+    """The (strike, net_vanna) pair with the largest |net_vanna|."""
+    per = _per_strike_net_vanna(rows)
+    if not per:
+        return None
+    strike = max(per.items(), key=lambda kv: abs(kv[1]))[0]
+    return strike, per[strike]
+
+
+def delta_shock_1pt_iv(rows: list[GreekExposureRow]) -> Decimal | None:
+    """Net Δ dealers must hedge if IV rises 1 vol-point."""
+    nv = net_vanna(rows)
+    if nv is None:
+        return None
+    return nv * ONE_VOL_POINT
+
+
+def vanna_regime(net_vanna_value: Decimal | None) -> str:
+    """`procyclical` / `countercyclical` / `neutral`."""
+    if net_vanna_value is None:
+        return "neutral"
+    if abs(net_vanna_value) < NEUTRAL_VANNA_THRESHOLD:
+        return "neutral"
+    return "procyclical" if net_vanna_value > 0 else "countercyclical"
+
+
+def vanna_flip(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> Decimal | None:
+    """Strike where running cumulative net_vanna changes sign.
+
+    Iterates strikes ascending and collects EVERY sign-flip strike. The spec
+    (docs/superpowers/specs/.../design.md §"Backend → derivers") asks for the
+    lowest sign-flip ≥ spot; fall back to the absolute lowest flip when no
+    flip is at/above spot (or when spot is unknown).
+    """
+    if not rows:
+        return None
+    per = _per_strike_net_vanna(rows)
+    if not per:
+        return None
+    flips: list[Decimal] = []
+    cum = Decimal("0")
+    prev_sign = 0
+    for strike, val in sorted(per.items(), key=lambda kv: kv[0]):
+        cum += val
+        sign = (cum > 0) - (cum < 0)
+        if prev_sign != 0 and sign != 0 and sign != prev_sign:
+            flips.append(strike)
+        if sign != 0:
+            prev_sign = sign
+    if not flips:
+        return None
+    if spot is None:
+        return flips[0]
+    above = [s for s in flips if s >= spot]
+    return above[0] if above else flips[0]
+
+
+def vanna_narrative(
+    net_vanna_value: Decimal | None,
+    regime: str,
+) -> tuple[str, str]:
+    """Deterministic headline + subtitle keyed off net sign and regime."""
+    if net_vanna_value is None or regime == "neutral":
+        return (
+            "Neutral Vanna — IV moves have limited dealer-Δ impact",
+            "Net vanna positioning is balanced; dealer hedging is not a strong driver.",
+        )
+    if net_vanna_value > 0:
+        return (
+            "Long Vanna — IV spikes pressure stock lower via dealer selling",
+            "If IV rises, dealers gain delta and will likely sell stock to rehedge — a headwind during vol spikes.",
+        )
+    return (
+        "Short Vanna — IV spikes support stock via dealer buying",
+        "If IV rises, dealers lose delta and will likely buy stock to rehedge — a tailwind during vol spikes.",
+    )
+```
+
+- [ ] **Step 4: Run vanna tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_vanna.py -v
+```
+
+Expected: PASS for all 12 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/cards/exposures.py tests/unit/cards/test_exposures_vanna.py
+git commit -m "feat(cards): add vanna derivers (net, top strike, flip, regime, narrative)"
+```
+
+---
+
+### Task 2.2: Add charm derivers + tests
+
+**Files:**
+- Modify: `src/uw_scan/cards/exposures.py` (append)
+- Create: `tests/unit/cards/test_exposures_charm.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/cards/test_exposures_charm.py`:
+
+```python
+"""Charm derivers — pure functions over GreekExposureRow lists."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import (
+    charm_flip,
+    charm_imbalance,
+    charm_narrative,
+    charm_pin_strike,
+    charm_signal_quality,
+    net_charm,
+)
+from uw_scan.models import GreekExposureRow
+
+
+def _r(strike: str, expiry: str, call_c: str | None, put_c: str | None) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        call_charm=Decimal(call_c) if call_c is not None else None,
+        put_charm=Decimal(put_c) if put_c is not None else None,
+    )
+
+
+def test_net_charm_sums_call_plus_put():
+    rows = [
+        _r("100", "2026-05-30", "-1000000", "200000"),
+        _r("110", "2026-05-30", "-500000",  "100000"),
+    ]
+    assert net_charm(rows) == Decimal("-1200000")
+
+
+def test_net_charm_empty_returns_none():
+    assert net_charm([]) is None
+
+
+def test_charm_pin_strike_picks_max_abs():
+    rows = [
+        _r("100", "2026-05-30", "100", "200"),     # 300
+        _r("110", "2026-05-30", "-5000", "-2000"),  # -7000 (pin)
+        _r("120", "2026-05-30", "500", "-100"),    # 400
+    ]
+    assert charm_pin_strike(rows) == Decimal("110")
+
+
+def test_charm_pin_strike_empty_returns_none():
+    assert charm_pin_strike([]) is None
+
+
+def test_charm_imbalance_splits_above_and_below_spot():
+    rows = [
+        _r("90",  "2026-05-30", "1000", "500"),    # below — sum 1500
+        _r("100", "2026-05-30", "200",  "100"),    # at spot — skip (>= spot rule)
+        _r("110", "2026-05-30", "-3000", "-2000"),  # above — sum -5000
+        _r("120", "2026-05-30", "-1000", "-500"),  # above — sum -1500
+    ]
+    above, below, imb_pct = charm_imbalance(rows, spot=Decimal("100"))
+    assert above == Decimal("-6500")
+    assert below == Decimal("1500")
+    # imbalance % = |above - below| / (|above| + |below|)
+    assert imb_pct == Decimal("8000") / Decimal("8000")  # 1.0 (fully one-sided after sign)
+
+
+def test_charm_signal_quality_aligned_when_same_sign():
+    # live sell + positioning sell-heavy → aligned
+    assert (
+        charm_signal_quality(live=Decimal("-100"), positioning=Decimal("-50"))
+        == "aligned"
+    )
+
+
+def test_charm_signal_quality_mixed_when_opposing_signs():
+    assert (
+        charm_signal_quality(live=Decimal("-100"), positioning=Decimal("50"))
+        == "mixed"
+    )
+
+
+def test_charm_signal_quality_weak_when_either_near_zero():
+    assert (
+        charm_signal_quality(live=Decimal("0"), positioning=Decimal("-50"))
+        == "weak"
+    )
+
+
+def test_charm_flip_picks_cumulative_sign_change():
+    rows = [
+        _r("90",  "2026-05-30", "1000", "500"),     # cum 1500
+        _r("100", "2026-05-30", "200",  "100"),     # cum 1800
+        _r("110", "2026-05-30", "-3000", "-1500"),  # cum -2700  ← flip
+        _r("120", "2026-05-30", "-100", "-50"),
+    ]
+    assert charm_flip(rows, spot=Decimal("100")) == Decimal("110")
+
+
+def test_charm_narrative_sell_pressure_when_negative():
+    headline, subtitle = charm_narrative(
+        net_charm_value=Decimal("-15000000"),
+        signal_quality="aligned",
+    )
+    assert "SELL" in headline
+
+
+def test_charm_narrative_buy_pressure_when_positive():
+    headline, _ = charm_narrative(
+        net_charm_value=Decimal("8000000"),
+        signal_quality="aligned",
+    )
+    assert "BUY" in headline
+
+
+def test_charm_narrative_neutral_when_weak():
+    headline, _ = charm_narrative(
+        net_charm_value=Decimal("0"),
+        signal_quality="weak",
+    )
+    assert "Limited" in headline or "Neutral" in headline
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_charm.py -v
+```
+
+Expected: FAIL — names not defined in `cards.exposures`.
+
+- [ ] **Step 3: Append charm derivers to `src/uw_scan/cards/exposures.py`**
+
+```python
+# --- charm helpers ---------------------------------------------------------
+
+def _per_strike_net_charm(rows: list[GreekExposureRow]) -> dict[Decimal, Decimal]:
+    acc: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    for r in rows:
+        if r.call_charm is not None:
+            acc[r.strike] += r.call_charm
+        if r.put_charm is not None:
+            acc[r.strike] += r.put_charm
+    return dict(acc)
+
+
+def net_charm(rows: list[GreekExposureRow]) -> Decimal | None:
+    if not rows:
+        return None
+    total = Decimal("0")
+    any_present = False
+    for r in rows:
+        if r.call_charm is not None:
+            total += r.call_charm
+            any_present = True
+        if r.put_charm is not None:
+            total += r.put_charm
+            any_present = True
+    return total if any_present else None
+
+
+def charm_pin_strike(rows: list[GreekExposureRow]) -> Decimal | None:
+    per = _per_strike_net_charm(rows)
+    if not per:
+        return None
+    return max(per.items(), key=lambda kv: abs(kv[1]))[0]
+
+
+def charm_imbalance(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> tuple[Decimal, Decimal, Decimal | None]:
+    """(above_sum, below_sum, imbalance_pct).
+
+    above_sum = Σ net_charm for strikes > spot.
+    below_sum = Σ net_charm for strikes < spot.
+    imbalance_pct = |above - below| / (|above| + |below|) — 0.0 balanced, 1.0 fully one-sided.
+    """
+    if spot is None:
+        return Decimal("0"), Decimal("0"), None
+    above = Decimal("0")
+    below = Decimal("0")
+    per = _per_strike_net_charm(rows)
+    for strike, val in per.items():
+        if strike > spot:
+            above += val
+        elif strike < spot:
+            below += val
+    denom = abs(above) + abs(below)
+    imb = (abs(above - below) / denom) if denom != 0 else None
+    return above, below, imb
+
+
+def charm_signal_quality(live: Decimal | None, positioning: Decimal | None) -> str:
+    """`aligned` when same sign + nonzero; `mixed` opposing; `weak` either near 0."""
+    if live is None or positioning is None:
+        return "weak"
+    if abs(live) < NEUTRAL_CHARM_THRESHOLD or abs(positioning) < NEUTRAL_CHARM_THRESHOLD:
+        return "weak"
+    same_sign = (live > 0 and positioning > 0) or (live < 0 and positioning < 0)
+    return "aligned" if same_sign else "mixed"
+
+
+def charm_flip(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> Decimal | None:
+    """Same selection rule as vanna_flip: lowest sign-flip ≥ spot, fallback to lowest."""
+    if not rows:
+        return None
+    per = _per_strike_net_charm(rows)
+    if not per:
+        return None
+    flips: list[Decimal] = []
+    cum = Decimal("0")
+    prev_sign = 0
+    for strike, val in sorted(per.items(), key=lambda kv: kv[0]):
+        cum += val
+        sign = (cum > 0) - (cum < 0)
+        if prev_sign != 0 and sign != 0 and sign != prev_sign:
+            flips.append(strike)
+        if sign != 0:
+            prev_sign = sign
+    if not flips:
+        return None
+    if spot is None:
+        return flips[0]
+    above = [s for s in flips if s >= spot]
+    return above[0] if above else flips[0]
+
+
+def charm_narrative(
+    net_charm_value: Decimal | None,
+    signal_quality: str,
+) -> tuple[str, str]:
+    if net_charm_value is None or signal_quality == "weak":
+        return (
+            "Limited charm pressure into the close",
+            "Net charm positioning is balanced or thin; mechanical hedging pressure is muted.",
+        )
+    if net_charm_value < 0:
+        return (
+            "Mechanical SELL pressure into the close",
+            "Dealer sell pressure may cap rallies as theta drives delta unwind.",
+        )
+    return (
+        "Mechanical BUY pressure into the close",
+        "Dealer buy pressure may support the tape as theta drives delta accumulation.",
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_charm.py -v
+```
+
+Expected: PASS for all 12 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/cards/exposures.py tests/unit/cards/test_exposures_charm.py
+git commit -m "feat(cards): add charm derivers (net, pin, imbalance, signal quality, flip, narrative)"
+```
+
+---
+
+### Task 2.3: Add the summary-row builder that ties vanna + charm together per expiry
+
+**Files:**
+- Modify: `src/uw_scan/cards/exposures.py` (append)
+- Create: `tests/unit/cards/test_exposures_summary.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/cards/test_exposures_summary.py`:
+
+```python
+"""End-to-end deriver: GreekExposureRow list → ExposuresSummaryRow per expiry."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import ExposuresSummaryRow, GreekExposureRow
+
+
+def _r(strike: str, expiry: str, **kw) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        dte=kw.get("dte"),
+        call_vanna=Decimal(kw["cv"]) if "cv" in kw else None,
+        put_vanna=Decimal(kw["pv"]) if "pv" in kw else None,
+        call_charm=Decimal(kw["cc"]) if "cc" in kw else None,
+        put_charm=Decimal(kw["pc"]) if "pc" in kw else None,
+    )
+
+
+def test_build_summary_rows_groups_by_expiry():
+    rows = [
+        _r("100", "2026-05-30", dte=9,  cv="100", pv="-50", cc="-2000", pc="500"),
+        _r("110", "2026-05-30", dte=9,  cv="200", pv="-80", cc="-3000", pc="600"),
+        _r("100", "2026-06-20", dte=30, cv="10",  pv="-5",  cc="-200",  pc="50"),
+    ]
+    out = build_summary_rows(rows, spot=Decimal("105"))
+    assert len(out) == 2
+
+    by_expiry = {r.expiry: r for r in out}
+    near = by_expiry[date.fromisoformat("2026-05-30")]
+    far = by_expiry[date.fromisoformat("2026-06-20")]
+
+    assert isinstance(near, ExposuresSummaryRow)
+    assert near.dte == 9
+    assert near.spot == Decimal("105")
+
+    # Net vanna near = 100-50+200-80 = 170
+    assert near.net_vanna == Decimal("170")
+    # Net charm near = -2000+500-3000+600 = -3900
+    assert near.net_charm == Decimal("-3900")
+    # Headlines are populated (non-empty strings)
+    assert near.vanna_headline
+    assert near.charm_headline
+
+    # Far expiry has thinner data — still produces a row
+    assert far.net_vanna == Decimal("5")
+
+
+def test_build_summary_rows_empty_returns_empty_list():
+    assert build_summary_rows([], spot=Decimal("100")) == []
+
+
+def test_build_summary_rows_spot_none_still_produces_rows():
+    """Charm imbalance returns (0,0,None) when spot is None — must not crash."""
+    rows = [_r("100", "2026-05-30", dte=9, cv="50", pv="50", cc="-1000", pc="500")]
+    out = build_summary_rows(rows, spot=None)
+    assert len(out) == 1
+    assert out[0].spot is None
+    assert out[0].charm_imbalance_pct is None
+
+
+def test_build_summary_rows_mixed_dte_same_expiry_collapses_to_one_row():
+    """Multiple dte values for the same expiry must NOT produce duplicate PK rows
+    (table PK is (run_id, ticker, expiry)). The builder picks min non-null dte."""
+    rows = [
+        _r("100", "2026-05-30", dte=9,  cv="100", pv="-50", cc="-1000", pc="500"),
+        _r("110", "2026-05-30", dte=10, cv="80",  pv="-30", cc="-2000", pc="800"),
+        _r("105", "2026-05-30", dte=None, cv="50",  pv="-20", cc="-500",  pc="100"),
+    ]
+    out = build_summary_rows(rows, spot=Decimal("105"))
+    assert len(out) == 1
+    assert out[0].dte == 9  # min non-null
+    # All three strikes contribute to the summed nets
+    assert out[0].net_vanna == Decimal("130")  # (100-50)+(80-30)+(50-20)
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_summary.py -v
+```
+
+Expected: FAIL — `build_summary_rows` not defined.
+
+- [ ] **Step 3: Append the builder to `src/uw_scan/cards/exposures.py`**
+
+```python
+# --- top-level builder -----------------------------------------------------
+
+def build_summary_rows(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> list[ExposuresSummaryRow]:
+    """Group rows by expiry; for each expiry, compute the full summary tuple."""
+    if not rows:
+        return []
+
+    # Group by expiry ONLY — the table PK is (run_id, ticker, expiry) so
+    # multiple (expiry, dte) groups would collide on upsert. UW occasionally
+    # returns mixed dte values for the same expiry across strikes (rounding,
+    # late-day refresh boundaries); take the min non-null dte per expiry.
+    by_expiry: dict[date, list[GreekExposureRow]] = defaultdict(list)
+    for r in rows:
+        by_expiry[r.expiry].append(r)
+
+    out: list[ExposuresSummaryRow] = []
+    for expiry, grp in sorted(by_expiry.items(), key=lambda kv: kv[0]):
+        dtes = [r.dte for r in grp if r.dte is not None]
+        dte = min(dtes) if dtes else None
+        nv = net_vanna(grp)
+        top = top_vanna_strike(grp)
+        v_regime = vanna_regime(nv)
+        v_flip = vanna_flip(grp, spot)
+        v_head, v_sub = vanna_narrative(nv, v_regime)
+
+        nc = net_charm(grp)
+        pin = charm_pin_strike(grp)
+        above, below, imb = charm_imbalance(grp, spot)
+        c_quality = charm_signal_quality(live=nc, positioning=above - below)
+        c_flip = charm_flip(grp, spot)
+        c_head, c_sub = charm_narrative(nc, c_quality)
+
+        out.append(
+            ExposuresSummaryRow(
+                expiry=expiry,
+                dte=dte,
+                spot=spot,
+                net_vanna=nv,
+                top_vanna_strike=top[0] if top else None,
+                top_vanna_value=top[1] if top else None,
+                delta_shock_1pt_iv=delta_shock_1pt_iv(grp),
+                vanna_regime=v_regime,
+                vanna_flip=v_flip,
+                vanna_headline=v_head,
+                vanna_subtitle=v_sub,
+                net_charm=nc,
+                charm_pin_strike=pin,
+                charm_above_sum=above,
+                charm_below_sum=below,
+                charm_imbalance_pct=imb,
+                charm_signal_quality=c_quality,
+                charm_flip=c_flip,
+                charm_headline=c_head,
+                charm_subtitle=c_sub,
+            )
+        )
+    return out
+```
+
+Add this import at the top of `cards/exposures.py` if not already present:
+
+```python
+from datetime import date  # for type hints in builder
+```
+
+- [ ] **Step 4: Run tests and the full unit suite**
+
+```bash
+uv run pytest tests/unit/cards/test_exposures_summary.py tests/unit/cards/ -v
+```
+
+Expected: PASS (all `cards` unit tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/cards/exposures.py tests/unit/cards/test_exposures_summary.py
+git commit -m "feat(cards): add build_summary_rows tying vanna + charm derivers per expiry"
+```
+
+---
+
+## Slice 3 — Persistence + integration tests
+
+### Task 3.1: Add `upsert_exposures_summary` and `fetch_exposures_summary` to `storage/options.py`
+
+**Files:**
+- Modify: `src/uw_scan/storage/options.py` (append a new method on `_OptionsMixin`)
+- Modify: `src/uw_scan/storage/fetchers.py` (add `fetch_strike_exposures` and a renamed `fetch_exposures_aggregate`)
+- Create: `tests/integration/storage/test_exposures_summary_repository.py`
+
+> ⚠️ Naming collision — strict ordering required: `fetchers.py` already has a `fetch_exposures_summary` that returns a single dict aggregating GEX/DEX. To free the name for the new per-expiry summary, we rename the existing function to `fetch_exposures_aggregate` **before** adding the new fetcher. The substeps below must be executed in order; if you add the new `fetch_exposures_summary` method while the old method still exists in the same class, Python keeps only the latter definition, silently breaking `_build_market_structure`. Recommended order:
+>
+> 1. Step 4 — rename the existing `fetch_exposures_summary` → `fetch_exposures_aggregate`; update the production caller (`reports/single_stock.py:127`); update the unit-test stub (`tests/unit/test_report_assembly.py:115`). All three edits in one commit.
+> 2. Step 5 — add the new `fetch_strike_exposures` and `fetch_exposures_summary` methods on `_FetchersMixin`. Add `upsert_exposures_summary` to `_OptionsMixin`. Commit.
+> 3. Step 6+ — run the integration tests.
+>
+> Steps below now follow this order.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/integration/storage/test_exposures_summary_repository.py`:
+
+```python
+"""Round-trip + idempotency tests for exposures_summary persistence."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.models import ExposuresSummaryRow
+from uw_scan.storage.repository import Repository
+
+
+def _row(expiry: str, net_v: str = "1000") -> ExposuresSummaryRow:
+    return ExposuresSummaryRow(
+        expiry=date.fromisoformat(expiry),
+        dte=10,
+        spot=Decimal("100"),
+        net_vanna=Decimal(net_v),
+        top_vanna_strike=Decimal("105"),
+        top_vanna_value=Decimal("500"),
+        delta_shock_1pt_iv=Decimal("10"),
+        vanna_regime="procyclical",
+        vanna_flip=Decimal("110"),
+        vanna_headline="Long Vanna",
+        vanna_subtitle="...",
+        net_charm=Decimal("-2000"),
+        charm_pin_strike=Decimal("105"),
+        charm_above_sum=Decimal("-1500"),
+        charm_below_sum=Decimal("500"),
+        charm_imbalance_pct=Decimal("0.5"),
+        charm_signal_quality="aligned",
+        charm_flip=Decimal("108"),
+        charm_headline="Mechanical SELL pressure into the close",
+        charm_subtitle="...",
+    )
+
+
+def _seed_scan_run(repo: Repository, run_id: int) -> None:
+    """exposures_summary FK-references scan_runs(run_id) ON DELETE CASCADE
+    (migration 051), so we need a parent scan_runs row before the child upsert."""
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, 'TSLA', now()) ON CONFLICT DO NOTHING",
+            (run_id,),
+        )
+    repo.conn.commit()
+
+
+def test_upsert_and_fetch_round_trip(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=1)
+
+    n = repo.upsert_exposures_summary(
+        run_id=1,
+        ticker="TSLA",
+        market_date=date.fromisoformat("2026-05-21"),
+        rows=[_row("2026-05-30"), _row("2026-06-20")],
+    )
+    assert n == 2
+
+    fetched = repo.fetch_exposures_summary(run_id=1, ticker="TSLA")
+    assert len(fetched) == 2
+    expiries = {r["expiry"] for r in fetched}
+    assert expiries == {date.fromisoformat("2026-05-30"), date.fromisoformat("2026-06-20")}
+
+
+def test_upsert_is_idempotent(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=2)
+
+    rows = [_row("2026-05-30", net_v="1000")]
+    repo.upsert_exposures_summary(2, "TSLA", date.fromisoformat("2026-05-21"), rows)
+    rows2 = [_row("2026-05-30", net_v="9999")]
+    repo.upsert_exposures_summary(2, "TSLA", date.fromisoformat("2026-05-21"), rows2)
+
+    fetched = repo.fetch_exposures_summary(2, "TSLA")
+    assert len(fetched) == 1
+    assert Decimal(str(fetched[0]["net_vanna"])) == Decimal("9999")
+
+
+def test_fetch_strike_exposures_returns_per_expiry_strike_rows(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=3)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.exposures_by_expiry_strike
+                (run_id, ticker, market_date, expiry, strike, dte,
+                 call_vanna, put_vanna, call_charm, put_charm)
+            VALUES
+                (3, 'TSLA', '2026-05-21', '2026-05-30', 100, 9, 50, -10, -1000, 200),
+                (3, 'TSLA', '2026-05-21', '2026-05-30', 110, 9, 80, -20, -2000, 400)
+            """
+        )
+    repo.conn.commit()
+
+    out = repo.fetch_strike_exposures(run_id=3, ticker="TSLA")
+    assert len(out) == 2
+    strikes = {Decimal(str(r["strike"])) for r in out}
+    assert strikes == {Decimal("100"), Decimal("110")}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+uv run pytest tests/integration/storage/test_exposures_summary_repository.py -v
+```
+
+Expected: FAIL — `AttributeError: 'Repository' object has no attribute 'upsert_exposures_summary'`.
+
+- [ ] **Step 3: Rename existing `fetch_exposures_summary` → `fetch_exposures_aggregate` and update both callers (in one indivisible edit set)**
+
+This MUST land first so the new `fetch_exposures_summary` added in Step 5 has a free name. Skipping or reversing this order causes Python to shadow the old aggregate-returning method, and `_build_market_structure` will throw `AttributeError: 'list' object has no attribute 'get'` on the next request.
+
+**a.** In `src/uw_scan/storage/fetchers.py`, find the function defined around lines 155–173 (signature `def fetch_exposures_summary(self, run_id: int, ticker: str) -> dict[str, Any] | None`) and rename it:
+
+```python
+    def fetch_exposures_aggregate(
+        self, run_id: int, ticker: str
+    ) -> dict[str, Any] | None:
+        # body unchanged
+```
+
+**b.** In `src/uw_scan/reports/single_stock.py`, the single production call site around line 127 inside `_build_market_structure`:
+
+```python
+    exposures = repo.fetch_exposures_summary(run_id, ticker) or {}
+```
+
+→
+
+```python
+    exposures = repo.fetch_exposures_aggregate(run_id, ticker) or {}
+```
+
+**c.** In `tests/unit/test_report_assembly.py:115`, the `_StubRepo` method:
+
+```python
+    def fetch_exposures_summary(self, run_id: int, ticker: str) -> dict:
+        return { ... }
+```
+
+→
+
+```python
+    def fetch_exposures_aggregate(self, run_id: int, ticker: str) -> dict:
+        return {
+            "total_call_gex": Decimal("1000000"),
+            "total_put_gex": Decimal("-500000"),
+            "total_call_dex": Decimal("50000"),
+            "total_put_dex": Decimal("-30000"),
+        }
+```
+
+Verify the unit suite still passes — `uv run pytest tests/unit/test_report_assembly.py -v` — then proceed. Do NOT commit yet; we'll bundle this with step 5's additions.
+
+- [ ] **Step 4: Add `upsert_exposures_summary` to `src/uw_scan/storage/options.py`**
+
+Append inside `_OptionsMixin` (after `insert_greeks_rows`):
+
+```python
+    def upsert_exposures_summary(
+        self,
+        run_id: int,
+        ticker: str,
+        market_date: "_date",
+        rows: "Iterable[models.ExposuresSummaryRow]",
+    ) -> int:
+        rows = list(rows)
+        if not rows:
+            return 0
+        sql = (
+            f"INSERT INTO {self._schema}.exposures_summary "
+            "(run_id, ticker, expiry, market_date, dte, spot, "
+            " net_vanna, top_vanna_strike, top_vanna_value, delta_shock_1pt_iv, "
+            " vanna_regime, vanna_flip, vanna_headline, vanna_subtitle, "
+            " net_charm, charm_pin_strike, charm_above_sum, charm_below_sum, "
+            " charm_imbalance_pct, charm_signal_quality, charm_flip, "
+            " charm_headline, charm_subtitle) "
+            "VALUES (%s, %s, %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, %s) "
+            "ON CONFLICT (run_id, ticker, expiry) DO UPDATE SET "
+            " market_date=EXCLUDED.market_date, dte=EXCLUDED.dte, spot=EXCLUDED.spot, "
+            " net_vanna=EXCLUDED.net_vanna, top_vanna_strike=EXCLUDED.top_vanna_strike, "
+            " top_vanna_value=EXCLUDED.top_vanna_value, "
+            " delta_shock_1pt_iv=EXCLUDED.delta_shock_1pt_iv, "
+            " vanna_regime=EXCLUDED.vanna_regime, vanna_flip=EXCLUDED.vanna_flip, "
+            " vanna_headline=EXCLUDED.vanna_headline, vanna_subtitle=EXCLUDED.vanna_subtitle, "
+            " net_charm=EXCLUDED.net_charm, charm_pin_strike=EXCLUDED.charm_pin_strike, "
+            " charm_above_sum=EXCLUDED.charm_above_sum, charm_below_sum=EXCLUDED.charm_below_sum, "
+            " charm_imbalance_pct=EXCLUDED.charm_imbalance_pct, "
+            " charm_signal_quality=EXCLUDED.charm_signal_quality, "
+            " charm_flip=EXCLUDED.charm_flip, "
+            " charm_headline=EXCLUDED.charm_headline, charm_subtitle=EXCLUDED.charm_subtitle, "
+            " computed_at=now()"
+        )
+        params = [
+            (
+                run_id, ticker, r.expiry, market_date, r.dte, r.spot,
+                r.net_vanna, r.top_vanna_strike, r.top_vanna_value, r.delta_shock_1pt_iv,
+                r.vanna_regime, r.vanna_flip, r.vanna_headline, r.vanna_subtitle,
+                r.net_charm, r.charm_pin_strike, r.charm_above_sum, r.charm_below_sum,
+                r.charm_imbalance_pct, r.charm_signal_quality, r.charm_flip,
+                r.charm_headline, r.charm_subtitle,
+            )
+            for r in rows
+        ]
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, params)
+        return len(rows)
+```
+
+> ⚠️ **Do NOT call `self._conn.commit()` inside this method.** Every other insert/upsert in `options.py` (e.g. `insert_greek_exposure_rows` at line 172–189) leaves commit to the caller, because the worker `_snapshot_ticker` (cockpit_daily_snapshot.py:67–104) owns the transaction boundary: `repo.conn.commit()` on success, `repo.conn.rollback()` on failure. An internal commit here would let a failed ticker leave half-rolled-back state.
+
+(`_date` and `Iterable` are already imported at the top of `options.py`.)
+
+- [ ] **Step 5: Add the new fetchers to `src/uw_scan/storage/fetchers.py`**
+
+The old `fetch_exposures_summary` has already been renamed in step 3, so the name is free. Append to `_FetchersMixin`:
+
+```python
+    def fetch_strike_exposures(
+        self, run_id: int, ticker: str
+    ) -> list[dict[str, Any]]:
+        """All per-(expiry, strike) raw rows for one run/ticker.
+
+        Includes the call/put vanna and charm split. Ordering by (expiry, strike)
+        is convenient for the FE but not strictly required.
+        """
+        sql = (
+            "SELECT expiry, strike, dte, "
+            "       call_vanna, put_vanna, call_charm, put_charm "
+            f"FROM {self._schema}.exposures_by_expiry_strike "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry, strike"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
+    def fetch_exposures_summary(
+        self, run_id: int, ticker: str
+    ) -> list[dict[str, Any]]:
+        """Per-(expiry) derived summary rows persisted by build_summary_rows."""
+        sql = (
+            "SELECT expiry, dte, spot, "
+            "       net_vanna, top_vanna_strike, top_vanna_value, delta_shock_1pt_iv, "
+            "       vanna_regime, vanna_flip, vanna_headline, vanna_subtitle, "
+            "       net_charm, charm_pin_strike, charm_above_sum, charm_below_sum, "
+            "       charm_imbalance_pct, charm_signal_quality, charm_flip, "
+            "       charm_headline, charm_subtitle "
+            f"FROM {self._schema}.exposures_summary "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+```
+
+No naming collision now — step 3 already renamed the old one. After step 5, the only `fetch_exposures_summary` in the codebase is the new per-expiry list-returning function above.
+
+- [ ] **Step 6: Run the integration tests**
+
+```bash
+uv run pytest tests/integration/storage/test_exposures_summary_repository.py -v
+```
+
+Expected: PASS for all three tests.
+
+- [ ] **Step 7: Verify the renamed function still imports cleanly (manual smoke)**
+
+```bash
+uv run python -c "from uw_scan.storage.repository import Repository; assert hasattr(Repository, 'fetch_exposures_aggregate'); assert hasattr(Repository, 'fetch_strike_exposures'); assert hasattr(Repository, 'fetch_exposures_summary'); assert hasattr(Repository, 'upsert_exposures_summary'); print('ok')"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/uw_scan/storage/options.py src/uw_scan/storage/fetchers.py src/uw_scan/reports/single_stock.py tests/integration/storage/test_exposures_summary_repository.py tests/unit/test_report_assembly.py
+git commit -m "feat(storage): persist exposures_summary + rename old aggregate fetcher (with caller + stub update)"
+```
+
+---
+
+### Task 3.2: Wire derivation+persistence into `cockpit_daily_snapshot` and `pipeline.py`
+
+**Files:**
+- Modify: `src/uw_scan/worker/jobs/cockpit_daily_snapshot.py:173` area (after `insert_greek_exposure_rows`)
+- Modify: `src/uw_scan/pipeline.py:176` area (same)
+- Create: `tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py`:
+
+```python
+"""Cockpit daily snapshot must persist exposures_summary after greek_exposure rows."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import GreekExposureRow
+from uw_scan.storage.repository import Repository
+
+
+def _seed_scan_run(repo: Repository, run_id: int) -> None:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, 'TSLA', now()) ON CONFLICT DO NOTHING",
+            (run_id,),
+        )
+    repo.conn.commit()
+
+
+def test_summary_persisted_alongside_greek_exposure(seeded_db_empty_cards: Repository):
+    """Smoke: insert greek-exposure rows, call build_summary_rows + upsert,
+    one summary row appears per expiry."""
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=10)
+
+    rows = [
+        GreekExposureRow(
+            date=date.fromisoformat("2026-05-21"),
+            expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("100"), dte=9,
+            call_vanna=Decimal("100"), put_vanna=Decimal("-30"),
+            call_charm=Decimal("-2000"), put_charm=Decimal("500"),
+        ),
+        GreekExposureRow(
+            date=date.fromisoformat("2026-05-21"),
+            expiry=date.fromisoformat("2026-06-20"),
+            strike=Decimal("100"), dte=30,
+            call_vanna=Decimal("10"), put_vanna=Decimal("-5"),
+            call_charm=Decimal("-200"), put_charm=Decimal("50"),
+        ),
+    ]
+    repo.insert_greek_exposure_rows(run_id=10, ticker="TSLA", rows=rows)
+    repo.conn.commit()
+
+    summary = build_summary_rows(rows, spot=Decimal("100"))
+    repo.upsert_exposures_summary(
+        run_id=10, ticker="TSLA",
+        market_date=date.fromisoformat("2026-05-21"),
+        rows=summary,
+    )
+
+    fetched = repo.fetch_exposures_summary(10, "TSLA")
+    assert len(fetched) == 2
+    expiries = {r["expiry"] for r in fetched}
+    assert expiries == {date.fromisoformat("2026-05-30"), date.fromisoformat("2026-06-20")}
+    assert all(r["vanna_headline"] for r in fetched)
+    assert all(r["charm_headline"] for r in fetched)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```bash
+uv run pytest tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py -v
+```
+
+Expected: PASS (the underlying primitives exist after Slice 3.1).
+
+> The point of this test is to lock in the **assembly contract** — `build_summary_rows(rows, spot) → upsert_exposures_summary(...)`. Adding the call inside the snapshot job is the wiring step that follows.
+
+- [ ] **Step 3: Add the wiring inside `src/uw_scan/worker/jobs/cockpit_daily_snapshot.py`**
+
+The exposure rows are processed inside a `for expiry in expiries:` loop (around lines 166–185 in the current file), one expiry per iteration. We derive + persist one summary row per iteration so the table stays in sync per-expiry.
+
+Spot is **not** in scope at line 173. The cleanest source is `repo.get_intraday_quote(ticker)` (the same lookup `_persist_option_chain_per_strike` uses at line 197–198). Pull it **once** before the expiry loop so we don't hit the DB N times.
+
+Add this block immediately before `for expiry in expiries:` (currently around line 166):
+
+```python
+        # Spot for vanna/charm derivers — None is acceptable; deriver handles it.
+        # Reject 0/negative/non-finite values so downstream % calcs don't produce
+        # Infinity. Fall back to RV latest price (same source _build_market_structure
+        # uses at single_stock.py:144) when the intraday quote is missing/invalid.
+        def _safe_spot(value) -> Decimal | None:
+            if value is None:
+                return None
+            try:
+                d = Decimal(str(value))
+            except (TypeError, ValueError) as exc:
+                logger.debug("safe_spot coercion skipped: %s", repr(exc))
+                return None
+            if not d.is_finite() or d <= 0:
+                return None
+            return d
+
+        quote = repo.get_intraday_quote(ticker)
+        spot_for_derive: Decimal | None = _safe_spot(
+            quote.price if quote is not None else None
+        )
+        if spot_for_derive is None:
+            rv = repo.fetch_realized_vol_latest(ticker) or {}
+            spot_for_derive = _safe_spot(rv.get("price"))
+```
+
+Then, immediately after `n_e = repo.insert_greek_exposure_rows(run_id, ticker, exposure_rows)` (line 173 area), add:
+
+```python
+        if exposure_rows:
+            summary_rows = cards_exposures.build_summary_rows(
+                list(exposure_rows), spot=spot_for_derive
+            )
+            n_sum = repo.upsert_exposures_summary(
+                run_id=run_id,
+                ticker=ticker,
+                market_date=market_date,
+                rows=summary_rows,
+            )
+            logger.info(
+                "cockpit_daily_snapshot: %s exp=%s exposures_summary=%d",
+                ticker, expiry_iso, n_sum,
+            )
+```
+
+At the top of the file, add the import:
+
+```python
+from decimal import Decimal  # may already be present — keep imports deduped
+from uw_scan.cards import exposures as cards_exposures
+```
+
+`market_date` is already in scope inside `_persist_greeks_per_expiry` (it's a function parameter passed from the caller — verify by searching for `market_date=market_date` in the file). `ticker`, `run_id`, `expiry_iso`, and `logger` are also already in scope.
+
+- [ ] **Step 4: Add the same wiring to `src/uw_scan/pipeline.py`**
+
+`pipeline.py`'s `scan_one_ticker` is the path that powers per-ticker watchlist scans (TSLA-style stock pages), so passing `spot=None` here would degrade the most common stock-detail view. Use the same source `_build_market_structure` reads — `repo.fetch_realized_vol_latest(ticker)["price"]` — with `repo.get_intraday_quote(ticker)` as a fallback. Both repo methods are already on the Repository.
+
+Find `repo.insert_greek_exposure_rows(run_id, ticker, ge_rows)` at line 176. Add immediately after the existing block 8b that builds the GEX curve (around line 193, i.e. after `repo.set_strike_gex_curve(run_id, curve)`):
+
+```python
+        # 8c. Vanna/Charm derived summary per expiry (raw rows already in step 8).
+        if ge_rows:
+            # Spot: prefer intraday quote, fall back to realized-vol latest price.
+            # Reject 0/negative/non-finite values — they corrupt charm imbalance
+            # and FE "% from spot" calculations.
+            def _safe_spot(value) -> Decimal | None:
+                if value is None:
+                    return None
+                try:
+                    d = Decimal(str(value))
+                except (TypeError, ValueError) as exc:
+                    logger.debug("safe_spot coercion skipped: %s", repr(exc))
+                    return None
+                if not d.is_finite() or d <= 0:
+                    return None
+                return d
+
+            quote = repo.get_intraday_quote(ticker)
+            spot_for_derive: Decimal | None = _safe_spot(
+                quote.price if quote is not None else None
+            )
+            if spot_for_derive is None:
+                rv = repo.fetch_realized_vol_latest(ticker) or {}
+                spot_for_derive = _safe_spot(rv.get("price"))
+
+            summary_rows = cards_exposures.build_summary_rows(
+                list(ge_rows), spot=spot_for_derive
+            )
+            repo.upsert_exposures_summary(
+                run_id=run_id,
+                ticker=ticker,
+                market_date=_date.today(),
+                rows=summary_rows,
+            )
+```
+
+`_date` and `Decimal` are already imported at the top of `pipeline.py`. Add the cards import:
+
+```python
+from uw_scan.cards import exposures as cards_exposures
+```
+
+- [ ] **Step 4b: Add a real worker-wiring test (not just an assembly-contract test)**
+
+The Step 1 test only exercises `build_summary_rows` + `upsert_exposures_summary` directly — it would still pass if neither `_snapshot_ticker` nor `scan_one_ticker` actually called them. Add a second test that drives the actual production function and asserts the call.
+
+> ⚠️ **Verify the function shape first.** Before writing the test, run:
+>
+> ```bash
+> grep -n "def _" src/uw_scan/worker/jobs/cockpit_daily_snapshot.py
+> ```
+>
+> Current state (verified 2026-05-21): the file has `_snapshot_ticker(...)` and `_persist_option_chain_per_strike(...)` but **no** `_persist_greeks_per_expiry` helper — the per-expiry loop lives inline inside `_snapshot_ticker`. The test must therefore drive `_snapshot_ticker` directly OR you must extract the per-expiry block into a named helper as part of Step 3 (preferred — easier to test and clearer).
+>
+> Preferred Step 3 micro-refactor: in `cockpit_daily_snapshot.py`, lift the `for expiry in expiries:` loop into a new private helper `_persist_greeks_per_expiry(client, repo, run_id, ticker, market_date, expiries, spot_for_derive)`. Call it from `_snapshot_ticker`. Keep the body identical except for parameter passing. Commit this micro-refactor as part of the wiring commit.
+
+Create `tests/unit/worker/test_cockpit_daily_snapshot_summary_wiring.py`:
+
+```python
+"""Unit wiring test: when fetch_greek_exposure returns rows, _snapshot_ticker
+(via the extracted _persist_greeks_per_expiry helper) MUST call
+upsert_exposures_summary. This guards against silent regression of the
+Step 3 wiring."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+
+def _ge_row(expiry: str, strike: str):
+    from uw_scan.models import GreekExposureRow
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike), dte=9,
+        call_vanna=Decimal("100"), put_vanna=Decimal("-30"),
+        call_charm=Decimal("-2000"), put_charm=Decimal("500"),
+    )
+
+
+def test_per_expiry_loop_persists_exposures_summary(monkeypatch):
+    """The per-expiry loop helper must call upsert_exposures_summary once per
+    expiry whenever fetch_greek_exposure returned rows."""
+    from uw_scan.worker.jobs import cockpit_daily_snapshot as job
+
+    fake_repo = MagicMock()
+    fake_repo._schema = "uw_scan"
+    fake_repo.get_intraday_quote.return_value = MagicMock(price=Decimal("100"))
+    fake_repo.insert_greek_exposure_rows.return_value = 2
+    fake_repo.upsert_skew_rows.return_value = 0
+    fake_repo.insert_greeks_rows.return_value = 0
+
+    monkeypatch.setattr(job, "fetch_greek_exposure", lambda *_a, **_k: [
+        _ge_row("2026-05-30", "100"),
+        _ge_row("2026-05-30", "110"),
+    ])
+    monkeypatch.setattr(job, "fetch_greeks", lambda *_a, **_k: [])
+    monkeypatch.setattr(job, "fetch_skew", lambda *_a, **_k: [])
+
+    # If you extracted _persist_greeks_per_expiry in Step 3, call it here.
+    # Otherwise call _snapshot_ticker with the full kwargs taken from the
+    # production callsite — adjust the signature to match what's in the file.
+    helper = getattr(job, "_persist_greeks_per_expiry", None)
+    if helper is None:
+        # Fallback path — drive _snapshot_ticker directly.
+        job._snapshot_ticker(
+            client=MagicMock(), repo=fake_repo, deriver_repo=fake_repo,
+            run_id=999, ticker="TSLA",
+            market_date=date.fromisoformat("2026-05-21"),
+            target_dtes=[7],
+            oi_band_pct=Decimal("0.15"),
+            oi_max_dte=120,
+        )
+    else:
+        helper(
+            client=MagicMock(), repo=fake_repo,
+            run_id=999, ticker="TSLA",
+            market_date=date.fromisoformat("2026-05-21"),
+            expiries=[date.fromisoformat("2026-05-30")],
+            spot_for_derive=Decimal("100"),
+        )
+
+    assert fake_repo.upsert_exposures_summary.called, (
+        "Wiring failure: per-expiry loop did not call upsert_exposures_summary "
+        "after insert_greek_exposure_rows. Re-check Step 3 wiring."
+    )
+    assert fake_repo.upsert_exposures_summary.call_count >= 1
+```
+
+> ⚠️ The `_snapshot_ticker` fallback signature (`target_dtes`, `oi_band_pct`, `oi_max_dte`, `deriver_repo`) is taken from the current file (`cockpit_daily_snapshot.py:109` area). Inspect the actual signature before running and adjust the kwargs to match — the test should call the function the same way the production scheduler does. If the signature drifts, the test will fail with a `TypeError` rather than silently passing.
+
+- [ ] **Step 5: Re-run unit + integration + worker tests**
+
+```bash
+uv run pytest tests/unit tests/integration/storage tests/integration/worker -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/uw_scan/worker/jobs/cockpit_daily_snapshot.py src/uw_scan/pipeline.py \
+        tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py \
+        tests/unit/worker/test_cockpit_daily_snapshot_summary_wiring.py
+git commit -m "feat(worker): persist exposures_summary in cockpit snapshot and pipeline"
+```
+
+> ⚠️ Both the integration test (Step 1 file) AND the unit wiring test (Step 4b file) MUST be in this commit. The unit wiring test catches silent regressions where the production wiring is removed but the integration test (which calls primitives directly) would still pass.
+
+---
+
+## Slice 4 — Report assembler + API surface
+
+### Task 4.1: Surface new fields on `SingleStockReport`
+
+**Files:**
+- Modify: `src/uw_scan/models/stock.py` (add fields)
+- Modify: `src/uw_scan/reports/single_stock.py` (load + attach new rows in `assemble_single_stock_report`)
+- Create: `tests/integration/reports/test_single_stock_exposures.py`
+
+> Note: the `fetch_exposures_summary → fetch_exposures_aggregate` rename + caller update already happened in Task 3.1 step 5. This task only adds the new field loading; it does not touch the renamed call again.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/integration/reports/test_single_stock_exposures.py`:
+
+```python
+"""Report assembler attaches strike_exposures and exposures_summary."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import GreekExposureRow
+from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.storage.repository import Repository
+
+
+def _seed_exposures(repo: Repository, ticker: str, run_id: int, market_date: date) -> None:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, %s, now()) ON CONFLICT DO NOTHING",
+            (run_id, ticker),
+        )
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.exposures_by_expiry_strike
+                (run_id, ticker, market_date, expiry, strike, dte,
+                 call_vanna, put_vanna, call_charm, put_charm,
+                 call_gex, put_gex, call_delta, put_delta)
+            VALUES
+                (%s, %s, %s, '2026-05-30', 100, 9, 100, -30, -2000, 500, 0, 0, 0, 0),
+                (%s, %s, %s, '2026-05-30', 110, 9, 200, -50, -3000, 800, 0, 0, 0, 0)
+            """,
+            (run_id, ticker, market_date, run_id, ticker, market_date),
+        )
+    repo.conn.commit()
+
+
+def test_report_includes_strike_exposures_and_summary(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    market_date = date.fromisoformat("2026-05-21")
+    _seed_exposures(repo, "TSLA", run_id=20, market_date=market_date)
+
+    raw = [
+        GreekExposureRow(
+            date=market_date, expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("100"), dte=9,
+            call_vanna=Decimal("100"), put_vanna=Decimal("-30"),
+            call_charm=Decimal("-2000"), put_charm=Decimal("500"),
+        ),
+        GreekExposureRow(
+            date=market_date, expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("110"), dte=9,
+            call_vanna=Decimal("200"), put_vanna=Decimal("-50"),
+            call_charm=Decimal("-3000"), put_charm=Decimal("800"),
+        ),
+    ]
+    repo.upsert_exposures_summary(
+        run_id=20, ticker="TSLA", market_date=market_date,
+        rows=build_summary_rows(raw, spot=Decimal("105")),
+    )
+
+    report = assemble_single_stock_report(ticker="TSLA", run_id=20, repo=repo)
+    assert len(report.strike_exposures) == 2
+    assert {row.strike for row in report.strike_exposures} == {Decimal("100"), Decimal("110")}
+    assert len(report.exposures_summary) == 1
+    summary = report.exposures_summary[0]
+    assert summary.expiry == date.fromisoformat("2026-05-30")
+    assert summary.vanna_headline
+```
+
+- [ ] **Step 2: Add fields to `SingleStockReport` in `src/uw_scan/models/stock.py`**
+
+In the existing `SingleStockReport` class, after `option_chain_per_strike` and before `next_earnings_date`:
+
+```python
+    strike_exposures: list["StrikeExposureRow"] = []
+    exposures_summary: list["ExposuresSummaryRow"] = []
+```
+
+Update the `from .scanner import (...)` line at the top of `stock.py`:
+
+```python
+from .scanner import (
+    ExposuresSummaryRow,
+    MarketAggregates,
+    MarketStructureLevels,
+    StrikeExposureRow,
+    StrikeGexBucket,
+)
+```
+
+- [ ] **Step 3: Update `src/uw_scan/reports/single_stock.py`**
+
+The `fetch_exposures_aggregate` rename was already wired into `_build_market_structure` in Task 3.1 step 5. This step only adds the new raw + summary loaders inside `assemble_single_stock_report`.
+
+Load the new raw + summary rows. After the `strike_gex_curve = [...]` block (around line 470). Uses the existing `_to_decimal` helper (`single_stock.py:40`) for consistency with the rest of the file:
+
+```python
+    strike_exp_raw = repo.fetch_strike_exposures(run_id, ticker)
+    # `strike` and `expiry` are NOT NULL in exposures_by_expiry_strike + are
+    # projected non-null by the fetcher. Use [...] indexing (not .get) so a
+    # missing key fails loudly with a KeyError at the row, rather than producing
+    # a Pydantic ValidationError that aborts the entire report assembly.
+    strike_exposures = [
+        StrikeExposureRow(
+            strike=Decimal(str(row["strike"])),
+            expiry=row["expiry"],
+            dte=row.get("dte"),
+            call_vanna=_to_decimal(row.get("call_vanna")),
+            put_vanna=_to_decimal(row.get("put_vanna")),
+            call_charm=_to_decimal(row.get("call_charm")),
+            put_charm=_to_decimal(row.get("put_charm")),
+        )
+        for row in strike_exp_raw
+        if row.get("strike") is not None  # defensive — should never trigger
+    ]
+
+    summary_raw = repo.fetch_exposures_summary(run_id, ticker)
+    exposures_summary = [
+        ExposuresSummaryRow(
+            expiry=row["expiry"],
+            dte=row.get("dte"),
+            spot=_to_decimal(row.get("spot")),
+            net_vanna=_to_decimal(row.get("net_vanna")),
+            top_vanna_strike=_to_decimal(row.get("top_vanna_strike")),
+            top_vanna_value=_to_decimal(row.get("top_vanna_value")),
+            delta_shock_1pt_iv=_to_decimal(row.get("delta_shock_1pt_iv")),
+            vanna_regime=row.get("vanna_regime"),
+            vanna_flip=_to_decimal(row.get("vanna_flip")),
+            vanna_headline=row.get("vanna_headline"),
+            vanna_subtitle=row.get("vanna_subtitle"),
+            net_charm=_to_decimal(row.get("net_charm")),
+            charm_pin_strike=_to_decimal(row.get("charm_pin_strike")),
+            charm_above_sum=_to_decimal(row.get("charm_above_sum")),
+            charm_below_sum=_to_decimal(row.get("charm_below_sum")),
+            charm_imbalance_pct=_to_decimal(row.get("charm_imbalance_pct")),
+            charm_signal_quality=row.get("charm_signal_quality"),
+            charm_flip=_to_decimal(row.get("charm_flip")),
+            charm_headline=row.get("charm_headline"),
+            charm_subtitle=row.get("charm_subtitle"),
+        )
+        for row in summary_raw
+    ]
+```
+
+The defensive filter (`if row.get("strike") is not None`) plus `Decimal(str(row["strike"]))` directly converts the required field; `_to_decimal(row.get("x"))` is used only for the nullable greek columns. If the fetcher ever projects a NULL strike (schema drift, partial joins), the row is dropped instead of crashing the whole report.
+
+In the existing `return SingleStockReport(...)` call at line 489, insert the two new kwargs immediately before `next_earnings_date=next_earnings_date,` (line 510) so they're grouped near the other new persisted fields:
+
+```python
+        strike_exposures=strike_exposures,
+        exposures_summary=exposures_summary,
+        next_earnings_date=next_earnings_date,
+    )
+```
+
+Update the top-of-file imports:
+
+```python
+from uw_scan.models import (
+    ...,  # existing
+    ExposuresSummaryRow,
+    StrikeExposureRow,
+)
+```
+
+- [ ] **Step 4: Run the new integration test + the broader report tests**
+
+```bash
+uv run pytest tests/integration/reports/test_single_stock_exposures.py tests/integration/reports -q
+```
+
+Expected: PASS. No regressions on existing report tests.
+
+- [ ] **Step 5: Verify the OpenAPI snapshot doesn't break unexpectedly**
+
+The actual snapshot test lives at `tests/integration/api/test_openapi_snapshot.py` with the JSON file at `tests/integration/api/openapi.snapshot.json`. Run it:
+
+```bash
+uv run pytest tests/integration/api/test_openapi_snapshot.py -q
+```
+
+The two added fields are purely additive — but the snapshot file is checked in, so it will need to be regenerated deliberately. After confirming the diff is only the two new fields + two new component schemas (`StrikeExposureRow`, `ExposuresSummaryRow`), refresh:
+
+```bash
+# Inspect the diff first to confirm there are no unexpected schema changes.
+uv run pytest tests/integration/api/test_openapi_snapshot.py -q -v
+# Then update the snapshot. Mechanism depends on the test — read the file's
+# top comment for the exact regeneration command, OR re-run the test with
+# the documented snapshot-update flag.
+```
+
+If the snapshot test uses an inline regenerate-on-flag pattern, use that flag. If it compares a file checked-in, regenerate it by running the FastAPI app and curl'ing /openapi.json:
+
+```bash
+uv run uvicorn uw_scan.api.server:app --port 8400 --no-access-log &
+SNAP_PID=$!
+for _ in {1..20}; do curl -sf http://localhost:8400/openapi.json > /dev/null && break || sleep 0.5; done
+curl -s http://localhost:8400/openapi.json | python -m json.tool > tests/integration/api/openapi.snapshot.json
+kill "$SNAP_PID" 2>/dev/null || true
+wait "$SNAP_PID" 2>/dev/null || true
+```
+
+Either way, the commit message in step 6 should call out that the snapshot was updated for the additive field surface.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/uw_scan/models/stock.py src/uw_scan/reports/single_stock.py tests/integration/reports/test_single_stock_exposures.py
+git commit -m "feat(report): expose strike_exposures and exposures_summary on SingleStockReport"
+```
+
+---
+
+### Task 4.2: Regenerate frontend types
+
+**Files:**
+- Modify: `web/lib/types.ts` (generated)
+
+- [ ] **Step 1: Start the API server in the background**
+
+Use direct uvicorn rather than `scripts/dev.sh` — `dev.sh` spawns multiple sub-processes whose PIDs aren't easy to track from a script, so cleanup is fragile.
+
+```bash
+uv run uvicorn uw_scan.api.server:app --port 8400 --no-access-log &
+UVICORN_PID=$!
+# Wait for the API to come up (poll /openapi.json instead of sleeping arbitrarily).
+for _ in {1..20}; do
+  curl -sf http://localhost:8400/openapi.json > /dev/null && break || sleep 0.5
+done
+```
+
+- [ ] **Step 2: Regenerate types**
+
+```bash
+cd web && npm run gen:types && cd ..
+```
+
+- [ ] **Step 3: Verify new types appear**
+
+```bash
+grep -n "StrikeExposureRow\|ExposuresSummaryRow\|strike_exposures\|exposures_summary" web/lib/types.ts | head -20
+```
+
+Expected: both component definitions plus the two new fields under `SingleStockReport`.
+
+- [ ] **Step 4: Stop the API server**
+
+```bash
+kill "$UVICORN_PID" 2>/dev/null || true
+wait "$UVICORN_PID" 2>/dev/null || true
+```
+
+- [ ] **Step 5: Run web typecheck (catches any silent type breakage)**
+
+```bash
+cd web && npm run typecheck && cd ..
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/lib/types.ts
+git commit -m "chore(web): regenerate types for vanna/charm fields"
+```
+
+---
+
+## Slice 5 — Frontend chart components (shared building blocks)
+
+### Task 5.1: Add a small money-abbreviation formatter
+
+**Files:**
+- Modify: `web/lib/formatters.ts`
+- Modify: `web/tests/unit/formatters.test.ts` (if it exists; otherwise create)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) `web/tests/unit/formatters.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+
+describe("fmtMoneyAbbrev", () => {
+  it("formats values >= 1T with T suffix", () => {
+    expect(fmtMoneyAbbrev(1_500_000_000_000)).toBe("+$1.5T");
+    expect(fmtMoneyAbbrev(-1_500_000_000_000)).toBe("-$1.5T");
+  });
+  it("formats millions, thousands", () => {
+    expect(fmtMoneyAbbrev(1_300_000)).toBe("+$1.3M");
+    expect(fmtMoneyAbbrev(-227_050)).toBe("-$227.1K");
+    expect(fmtMoneyAbbrev(0)).toBe("$0");
+  });
+  it("returns dash for null/undefined", () => {
+    expect(fmtMoneyAbbrev(null)).toBe("—");
+    expect(fmtMoneyAbbrev(undefined)).toBe("—");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cd web && npm run test -- formatters
+```
+
+Expected: FAIL — `fmtMoneyAbbrev` not exported.
+
+- [ ] **Step 3: Add the formatter**
+
+Append to `web/lib/formatters.ts`:
+
+```typescript
+export function fmtMoneyAbbrev(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "$0";
+  const sign = v >= 0 ? "+" : "-";
+  const abs = Math.abs(v);
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9)  return `${sign}$${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6)  return `${sign}$${(abs / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3)  return `${sign}$${(abs / 1e3).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+cd web && npm run test -- formatters
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/lib/formatters.ts web/tests/unit/formatters.test.ts
+git commit -m "feat(web): add fmtMoneyAbbrev for $1.3M / $15.5T-style values"
+```
+
+---
+
+### Task 5.2: Build `NetExposureChart` SVG line chart
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/NetExposureChart.tsx`
+- Create: `web/tests/unit/greekCharts/NetExposureChart.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/tests/unit/greekCharts/NetExposureChart.test.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NetExposureChart } from "@/components/stock/panels/greeks/NetExposureChart";
+
+const curve = [
+  { strike: 90,  netValue: -100 },
+  { strike: 100, netValue: -50 },
+  { strike: 110, netValue: 200 },
+  { strike: 120, netValue: 250 },
+];
+
+describe("NetExposureChart", () => {
+  it("draws a path covering all finite points", () => {
+    const { container } = render(
+      <NetExposureChart
+        curve={curve}
+        spot={105}
+        flipStrike={110}
+        yLabel="Vanna"
+        title="Net Vanna Exposure (9 DTE) — TSLA"
+      />,
+    );
+    const path = container.querySelector("path[data-testid='net-line']");
+    expect(path).not.toBeNull();
+    const d = path!.getAttribute("d") ?? "";
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.match(/L/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders the spot reference line", () => {
+    const { container } = render(
+      <NetExposureChart curve={curve} spot={105} flipStrike={null} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("line[data-testid='spot-line']")).not.toBeNull();
+  });
+
+  it("renders the flip reference line when flipStrike provided", () => {
+    const { container } = render(
+      <NetExposureChart curve={curve} spot={105} flipStrike={110} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("line[data-testid='flip-line']")).not.toBeNull();
+  });
+
+  it("renders empty state when curve has zero finite points", () => {
+    const { container, queryByText } = render(
+      <NetExposureChart curve={[]} spot={105} flipStrike={null} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("path[data-testid='net-line']")).toBeNull();
+    expect(queryByText(/not enough/i)).not.toBeNull();
+  });
+
+  it("renders a single-point marker (no line) when curve has exactly one finite point", () => {
+    // Per spec §"Error handling": single expiry with one strike should render
+    // a point marker + spot reference line, NOT an empty state.
+    const { container, queryByText } = render(
+      <NetExposureChart
+        curve={[{ strike: 100, netValue: 5000 }]}
+        spot={100}
+        flipStrike={null}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(queryByText(/not enough/i)).toBeNull();
+    expect(container.querySelector("circle[data-testid='net-point']")).not.toBeNull();
+    // No line path needed for a single point — but axes + spot line still render.
+    expect(container.querySelector("line[data-testid='spot-line']")).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cd web && npm run test -- NetExposureChart
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the chart component**
+
+Create `web/components/stock/panels/greeks/NetExposureChart.tsx`:
+
+```tsx
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+  type Point,
+} from "@/lib/svgChart";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+
+export type NetExposurePoint = {
+  strike: number;
+  netValue: number | null;
+};
+
+type Props = {
+  curve: NetExposurePoint[];
+  spot: number | null;
+  flipStrike: number | null;
+  yLabel: "Vanna" | "Charm";
+  title: string;
+  width?: number;
+  height?: number;
+};
+
+const PAD = { top: 36, right: 24, bottom: 40, left: 64 };
+const NET_COLOR = "var(--accent-vol)";
+const SPOT_COLOR = "var(--warning)";
+
+export function NetExposureChart({
+  curve,
+  spot,
+  flipStrike,
+  yLabel,
+  title,
+  width = 560,
+  height = 360,
+}: Props) {
+  // Count finite (strike, netValue) pairs — drives both the empty-state and
+  // the single-point fallback. `finiteDomain` returns null for <2 points, so
+  // we count manually here.
+  const finitePts = curve.filter(
+    (c) => Number.isFinite(c.strike) && c.netValue != null && Number.isFinite(c.netValue as number),
+  );
+
+  const panel: React.CSSProperties = {
+    background: "var(--bg-panel)",
+    border: "1px solid var(--border-dim)",
+    borderRadius: 4,
+    padding: 16,
+    fontFamily: "var(--font-mono)",
+  };
+
+  if (finitePts.length === 0) {
+    return (
+      <div style={panel}>
+        <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 8 }}>
+          {title}
+        </div>
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          Not enough data to render the curve.
+        </div>
+      </div>
+    );
+  }
+
+  // For a single-point fallback we need x/y domains anyway — synthesize a
+  // small symmetric window around the lone point so axes + spot line still
+  // render meaningfully.
+  const xDomain =
+    finitePts.length >= 2
+      ? finiteDomain(finitePts.map((c) => c.strike))!
+      : (() => {
+          const s = finitePts[0].strike;
+          const half = spot != null ? Math.abs(s - spot) || s * 0.05 : s * 0.05;
+          return { lo: s - half, hi: s + half, count: 1 };
+        })();
+  const yDomain =
+    finitePts.length >= 2
+      ? finiteDomain(finitePts.map((c) => c.netValue))!
+      : (() => {
+          const v = Math.abs(finitePts[0].netValue as number);
+          return { lo: -v, hi: v, count: 1 };
+        })();
+
+  const innerW = width - PAD.left - PAD.right;
+  const innerH = height - PAD.top - PAD.bottom;
+
+  const xScale = linearScale([xDomain.lo, xDomain.hi], [0, innerW]);
+  // Symmetrical y-axis around zero so the centerline reads cleanly.
+  const yAbs = Math.max(Math.abs(yDomain.lo), Math.abs(yDomain.hi), 1);
+  const yScale = linearScale([-yAbs, yAbs], [innerH, 0]);
+
+  const points: Point[] = finitePts.map((c) => [
+    xScale(c.strike),
+    yScale(c.netValue as number),
+  ]);
+
+  const xTicks = niceTicks(xDomain.lo, xDomain.hi, 6);
+  const yTicks = niceTicks(-yAbs, yAbs, 5);
+
+  return (
+    <div style={panel}>
+      <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 8 }}>
+        {title}
+      </div>
+      <svg width={width} height={height} role="img" aria-label={title}>
+        <title>{title}</title>
+        <g transform={`translate(${PAD.left},${PAD.top})`}>
+          {/* y-axis grid + labels */}
+          {yTicks.map((t) => (
+            <g key={`y-${t}`}>
+              <line
+                x1={0}
+                x2={innerW}
+                y1={yScale(t)}
+                y2={yScale(t)}
+                stroke="var(--border-dim)"
+                strokeWidth={t === 0 ? 1 : 0.5}
+              />
+              <text
+                x={-8}
+                y={yScale(t)}
+                dy="0.32em"
+                textAnchor="end"
+                fontSize={10}
+                fill="var(--text-muted)"
+              >
+                {fmtMoneyAbbrev(t)}
+              </text>
+            </g>
+          ))}
+
+          {/* x-axis labels */}
+          {xTicks.map((t) => (
+            <text
+              key={`x-${t}`}
+              x={xScale(t)}
+              y={innerH + 18}
+              textAnchor="middle"
+              fontSize={10}
+              fill="var(--text-muted)"
+            >
+              {t.toFixed(0)}
+            </text>
+          ))}
+
+          {/* Spot reference */}
+          {spot != null && xDomain.lo <= spot && spot <= xDomain.hi && (
+            <>
+              <line
+                data-testid="spot-line"
+                x1={xScale(spot)}
+                x2={xScale(spot)}
+                y1={0}
+                y2={innerH}
+                stroke={SPOT_COLOR}
+                strokeWidth={1}
+              />
+              <text
+                x={xScale(spot) + 6}
+                y={12}
+                fontSize={10}
+                fill={SPOT_COLOR}
+              >
+                Price: {spot.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {/* Flip reference */}
+          {flipStrike != null && xDomain.lo <= flipStrike && flipStrike <= xDomain.hi && (
+            <>
+              <line
+                data-testid="flip-line"
+                x1={xScale(flipStrike)}
+                x2={xScale(flipStrike)}
+                y1={0}
+                y2={innerH}
+                stroke={NET_COLOR}
+                strokeWidth={1}
+                strokeDasharray="4 3"
+              />
+              <text
+                x={xScale(flipStrike) + 6}
+                y={26}
+                fontSize={10}
+                fill={NET_COLOR}
+              >
+                {yLabel} flip: {flipStrike.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {/* Net curve (line when ≥2 points, marker when 1 point) */}
+          {points.length >= 2 && (
+            <path
+              data-testid="net-line"
+              d={pathFromPoints(points)}
+              stroke={NET_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {points.length === 1 && (
+            <circle
+              data-testid="net-point"
+              cx={points[0][0]}
+              cy={points[0][1]}
+              r={4}
+              fill={NET_COLOR}
+            />
+          )}
+        </g>
+
+        {/* y-axis label */}
+        <text
+          x={16}
+          y={PAD.top + innerH / 2}
+          textAnchor="middle"
+          transform={`rotate(-90, 16, ${PAD.top + innerH / 2})`}
+          fontSize={10}
+          fill="var(--text-muted)"
+        >
+          {yLabel}
+        </text>
+      </svg>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+cd web && npm run test -- NetExposureChart
+```
+
+Expected: PASS for all 4 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/NetExposureChart.tsx web/tests/unit/greekCharts/NetExposureChart.test.tsx
+git commit -m "feat(web): add NetExposureChart hand-rolled SVG line chart"
+```
+
+---
+
+### Task 5.3: Build `CallPutExposureChart` (two-line variant)
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/CallPutExposureChart.tsx`
+- Create: `web/tests/unit/greekCharts/CallPutExposureChart.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/tests/unit/greekCharts/CallPutExposureChart.test.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CallPutExposureChart } from "@/components/stock/panels/greeks/CallPutExposureChart";
+
+const curve = [
+  { strike: 90,  callValue: 100, putValue: -50 },
+  { strike: 100, callValue: 200, putValue: -100 },
+  { strike: 110, callValue: 80,  putValue: -150 },
+];
+
+describe("CallPutExposureChart", () => {
+  it("draws two paths", () => {
+    const { container } = render(
+      <CallPutExposureChart
+        curve={curve}
+        spot={100}
+        yLabel="Vanna"
+        title="Vanna Exposure — TSLA"
+      />,
+    );
+    expect(container.querySelector("path[data-testid='call-line']")).not.toBeNull();
+    expect(container.querySelector("path[data-testid='put-line']")).not.toBeNull();
+  });
+
+  it("renders the spot reference line", () => {
+    const { container } = render(
+      <CallPutExposureChart curve={curve} spot={100} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("line[data-testid='spot-line']")).not.toBeNull();
+  });
+
+  it("renders empty state when curve is empty", () => {
+    const { container, queryByText } = render(
+      <CallPutExposureChart curve={[]} spot={null} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("path[data-testid='call-line']")).toBeNull();
+    expect(queryByText(/not enough/i)).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cd web && npm run test -- CallPutExposureChart
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the chart component**
+
+Create `web/components/stock/panels/greeks/CallPutExposureChart.tsx`:
+
+```tsx
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+  type Point,
+} from "@/lib/svgChart";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+
+export type CallPutPoint = {
+  strike: number;
+  callValue: number | null;
+  putValue: number | null;
+};
+
+type Props = {
+  curve: CallPutPoint[];
+  spot: number | null;
+  yLabel: "Vanna" | "Charm";
+  title: string;
+  width?: number;
+  height?: number;
+};
+
+const PAD = { top: 36, right: 24, bottom: 40, left: 64 };
+const CALL_COLOR = "var(--positive)";
+const PUT_COLOR = "var(--negative)";
+const SPOT_COLOR = "var(--warning)";
+
+export function CallPutExposureChart({
+  curve,
+  spot,
+  yLabel,
+  title,
+  width = 560,
+  height = 360,
+}: Props) {
+  // Count finite strikes (any side present). Mirrors NetExposureChart so that
+  // a single-strike expiry renders point markers + spot line, not empty state.
+  const finiteCall = curve.filter(
+    (c) => Number.isFinite(c.strike) && c.callValue != null && Number.isFinite(c.callValue as number),
+  );
+  const finitePut = curve.filter(
+    (c) => Number.isFinite(c.strike) && c.putValue != null && Number.isFinite(c.putValue as number),
+  );
+  const finiteStrikes = curve.filter(
+    (c) => Number.isFinite(c.strike) && (c.callValue != null || c.putValue != null),
+  );
+
+  const panel: React.CSSProperties = {
+    background: "var(--bg-panel)",
+    border: "1px solid var(--border-dim)",
+    borderRadius: 4,
+    padding: 16,
+    fontFamily: "var(--font-mono)",
+  };
+
+  if (finiteStrikes.length === 0) {
+    return (
+      <div style={panel}>
+        <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 8 }}>
+          {title}
+        </div>
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          Not enough data to render the curve.
+        </div>
+      </div>
+    );
+  }
+
+  // Synthesize a small symmetric window when there's only one finite strike.
+  const allY = [
+    ...finiteCall.map((c) => c.callValue as number),
+    ...finitePut.map((c) => c.putValue as number),
+  ];
+  const xDomain =
+    finiteStrikes.length >= 2
+      ? finiteDomain(finiteStrikes.map((c) => c.strike))!
+      : (() => {
+          const s = finiteStrikes[0].strike;
+          const half = spot != null ? Math.abs(s - spot) || s * 0.05 : s * 0.05;
+          return { lo: s - half, hi: s + half, count: 1 };
+        })();
+  const yDomain =
+    allY.length >= 2
+      ? finiteDomain(allY)!
+      : (() => {
+          const v = allY[0] != null ? Math.abs(allY[0]) : 1;
+          return { lo: -v, hi: v, count: 1 };
+        })();
+
+  const innerW = width - PAD.left - PAD.right;
+  const innerH = height - PAD.top - PAD.bottom;
+  const xScale = linearScale([xDomain.lo, xDomain.hi], [0, innerW]);
+  const yAbs = Math.max(Math.abs(yDomain.lo), Math.abs(yDomain.hi), 1);
+  const yScale = linearScale([-yAbs, yAbs], [innerH, 0]);
+
+  const callPoints: Point[] = finiteCall.map((c) => [
+    xScale(c.strike), yScale(c.callValue as number),
+  ]);
+  const putPoints: Point[] = finitePut.map((c) => [
+    xScale(c.strike), yScale(c.putValue as number),
+  ]);
+
+  const xTicks = niceTicks(xDomain.lo, xDomain.hi, 6);
+  const yTicks = niceTicks(-yAbs, yAbs, 5);
+
+  return (
+    <div style={panel}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
+        <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>
+          {title}
+        </div>
+        <div style={{ display: "flex", gap: 12, fontSize: 11 }}>
+          <span style={{ color: CALL_COLOR }}>— Call {yLabel}</span>
+          <span style={{ color: PUT_COLOR }}>— Put {yLabel}</span>
+        </div>
+      </div>
+      <svg width={width} height={height} role="img" aria-label={title}>
+        <title>{title}</title>
+        <g transform={`translate(${PAD.left},${PAD.top})`}>
+          {yTicks.map((t) => (
+            <g key={`y-${t}`}>
+              <line
+                x1={0}
+                x2={innerW}
+                y1={yScale(t)}
+                y2={yScale(t)}
+                stroke="var(--border-dim)"
+                strokeWidth={t === 0 ? 1 : 0.5}
+              />
+              <text
+                x={-8}
+                y={yScale(t)}
+                dy="0.32em"
+                textAnchor="end"
+                fontSize={10}
+                fill="var(--text-muted)"
+              >
+                {fmtMoneyAbbrev(t)}
+              </text>
+            </g>
+          ))}
+          {xTicks.map((t) => (
+            <text
+              key={`x-${t}`}
+              x={xScale(t)}
+              y={innerH + 18}
+              textAnchor="middle"
+              fontSize={10}
+              fill="var(--text-muted)"
+            >
+              {t.toFixed(0)}
+            </text>
+          ))}
+
+          {spot != null && xDomain.lo <= spot && spot <= xDomain.hi && (
+            <>
+              <line
+                data-testid="spot-line"
+                x1={xScale(spot)}
+                x2={xScale(spot)}
+                y1={0}
+                y2={innerH}
+                stroke={SPOT_COLOR}
+                strokeWidth={1}
+              />
+              <text
+                x={xScale(spot) + 6}
+                y={12}
+                fontSize={10}
+                fill={SPOT_COLOR}
+              >
+                Price: {spot.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {callPoints.length >= 2 && (
+            <path
+              data-testid="call-line"
+              d={pathFromPoints(callPoints)}
+              stroke={CALL_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {callPoints.length === 1 && (
+            <circle
+              data-testid="call-point"
+              cx={callPoints[0][0]}
+              cy={callPoints[0][1]}
+              r={4}
+              fill={CALL_COLOR}
+            />
+          )}
+          {putPoints.length >= 2 && (
+            <path
+              data-testid="put-line"
+              d={pathFromPoints(putPoints)}
+              stroke={PUT_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {putPoints.length === 1 && (
+            <circle
+              data-testid="put-point"
+              cx={putPoints[0][0]}
+              cy={putPoints[0][1]}
+              r={4}
+              fill={PUT_COLOR}
+            />
+          )}
+        </g>
+      </svg>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+cd web && npm run test -- CallPutExposureChart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/CallPutExposureChart.tsx web/tests/unit/greekCharts/CallPutExposureChart.test.tsx
+git commit -m "feat(web): add CallPutExposureChart (two-line SVG)"
+```
+
+---
+
+## Slice 6 — Vanna and Charm panels + expiry dropdown
+
+### Task 6.1: Add `ExposureTile` shared tile component
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/ExposureTile.tsx`
+- Create: `web/tests/unit/greekCharts/ExposureTile.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/greekCharts/ExposureTile.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExposureTile } from "@/components/stock/panels/greeks/ExposureTile";
+
+describe("ExposureTile", () => {
+  it("renders label, value, and optional sub-line", () => {
+    const { getByText } = render(
+      <ExposureTile label="Net Vanna" value="+$1.3M" sub="Long" />,
+    );
+    expect(getByText("Net Vanna")).toBeTruthy();
+    expect(getByText("+$1.3M")).toBeTruthy();
+    expect(getByText("Long")).toBeTruthy();
+  });
+
+  it("accepts a tone override for the value color", () => {
+    const { getByText } = render(
+      <ExposureTile label="x" value="-$15.5T" tone="negative" />,
+    );
+    const v = getByText("-$15.5T");
+    expect(v.getAttribute("style") || "").toContain("var(--negative)");
+  });
+});
+```
+
+- [ ] **Step 2: Run test (FAIL)**
+
+```bash
+cd web && npm run test -- ExposureTile
+```
+
+- [ ] **Step 3: Create the tile component**
+
+```tsx
+// web/components/stock/panels/greeks/ExposureTile.tsx
+type Tone = "positive" | "negative" | "warning" | "muted" | "default";
+
+const TONE_COLOR: Record<Tone, string> = {
+  positive: "var(--positive)",
+  negative: "var(--negative)",
+  warning: "var(--warning)",
+  muted: "var(--text-muted)",
+  default: "var(--text-primary)",
+};
+
+type Props = {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: Tone;
+};
+
+export function ExposureTile({ label, value, sub, tone = "default" }: Props) {
+  return (
+    <div
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: "10px 14px",
+        fontFamily: "var(--font-mono)",
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: 1.5,
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          // 22px is the canonical "tile value" size per web/components/CLAUDE.md
+          // ("Value: 22px bold mono, primary color" — matches VolMetricsCard +
+          // GexLevelTiles patterns).
+          fontSize: 22,
+          fontWeight: 700,
+          color: TONE_COLOR[tone],
+          whiteSpace: "nowrap",
+        }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div style={{ fontSize: 11, color: "var(--text-secondary)", marginTop: 2 }}>
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test (PASS)**
+
+```bash
+cd web && npm run test -- ExposureTile
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/ExposureTile.tsx web/tests/unit/greekCharts/ExposureTile.test.tsx
+git commit -m "feat(web): add ExposureTile (shared 4-up tile for vanna/charm panels)"
+```
+
+---
+
+### Task 6.2: Build the `ExpiryDropdown` component
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/ExpiryDropdown.tsx`
+- Create: `web/tests/unit/greekCharts/ExpiryDropdown.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ExpiryDropdown } from "@/components/stock/panels/greeks/ExpiryDropdown";
+
+describe("ExpiryDropdown", () => {
+  it("renders one <option> per expiry with dte annotation", () => {
+    const { container } = render(
+      <ExpiryDropdown
+        options={[
+          { value: "2026-05-30", label: "2026-05-30 (9d)" },
+          { value: "2026-06-20", label: "2026-06-20 (30d)" },
+        ]}
+        value="2026-05-30"
+        onChange={() => {}}
+      />,
+    );
+    const opts = container.querySelectorAll("option");
+    expect(opts).toHaveLength(2);
+    expect(opts[0].textContent).toContain("2026-05-30");
+    expect(opts[0].textContent).toContain("9d");
+  });
+
+  it("fires onChange with the new value", () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <ExpiryDropdown
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        value="a"
+        onChange={handle}
+      />,
+    );
+    const select = container.querySelector("select")!;
+    fireEvent.change(select, { target: { value: "b" } });
+    expect(handle).toHaveBeenCalledWith("b");
+  });
+});
+```
+
+- [ ] **Step 2: Run test (FAIL)**
+
+```bash
+cd web && npm run test -- ExpiryDropdown
+```
+
+- [ ] **Step 3: Create the dropdown**
+
+```tsx
+// web/components/stock/panels/greeks/ExpiryDropdown.tsx
+"use client";
+
+type Props = {
+  options: { value: string; label: string }[];
+  value: string;
+  onChange: (next: string) => void;
+};
+
+export function ExpiryDropdown({ options, value, onChange }: Props) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--text-secondary)",
+      }}
+    >
+      <span
+        style={{
+          fontSize: 10,
+          letterSpacing: 1.5,
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+        }}
+      >
+        Expiry:
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          background: "var(--bg-panel)",
+          color: "var(--text-primary)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          padding: "4px 8px",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+```
+
+- [ ] **Step 4: Run test (PASS)**
+
+```bash
+cd web && npm run test -- ExpiryDropdown
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/ExpiryDropdown.tsx web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
+git commit -m "feat(web): add ExpiryDropdown client component"
+```
+
+---
+
+### Task 6.3: Build `VannaPanel`
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/VannaPanel.tsx`
+- Create: `web/tests/unit/greekCharts/VannaPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/greekCharts/VannaPanel.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { VannaPanel } from "@/components/stock/panels/greeks/VannaPanel";
+
+const strikeExposures = [
+  { strike: "100", expiry: "2026-05-30", dte: 9, call_vanna: "100", put_vanna: "-30", call_charm: "0", put_charm: "0" },
+  { strike: "110", expiry: "2026-05-30", dte: 9, call_vanna: "200", put_vanna: "-80", call_charm: "0", put_charm: "0" },
+] as never[];
+
+const summary = [{
+  expiry: "2026-05-30", dte: 9, spot: "105",
+  net_vanna: "190", top_vanna_strike: "110", top_vanna_value: "120",
+  delta_shock_1pt_iv: "1.9", vanna_regime: "procyclical",
+  vanna_flip: "108",
+  vanna_headline: "Long Vanna — IV spikes pressure stock lower via dealer selling",
+  vanna_subtitle: "subtitle...",
+  net_charm: "0", charm_pin_strike: null, charm_above_sum: "0", charm_below_sum: "0",
+  charm_imbalance_pct: null, charm_signal_quality: "weak", charm_flip: null,
+  charm_headline: "", charm_subtitle: "",
+}] as never[];
+
+describe("VannaPanel", () => {
+  it("renders headline, four tiles, expiry dropdown, and both charts", () => {
+    const { container, getByText } = render(
+      <VannaPanel ticker="TSLA" strikeExposures={strikeExposures} summary={summary} />,
+    );
+    expect(getByText(/Long Vanna/)).toBeTruthy();
+    // 4 tiles
+    expect(container.querySelectorAll("[data-testid='exposure-tile']")).toHaveLength(4);
+    // dropdown
+    expect(container.querySelector("select")).not.toBeNull();
+    // both charts
+    expect(container.querySelector("path[data-testid='net-line']")).not.toBeNull();
+    expect(container.querySelector("path[data-testid='call-line']")).not.toBeNull();
+    expect(container.querySelector("path[data-testid='put-line']")).not.toBeNull();
+  });
+
+  it("renders an empty state when there's no summary at all", () => {
+    const { queryByText } = render(
+      <VannaPanel ticker="TSLA" strikeExposures={[]} summary={[]} />,
+    );
+    expect(queryByText(/not yet available/i)).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Tag tiles with the `data-testid` attribute**
+
+Update `ExposureTile.tsx` to add `data-testid="exposure-tile"` on the outer `<div>`. (Done now to keep the panel test runnable.)
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+cd web && npm run test -- VannaPanel
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Create `VannaPanel`**
+
+```tsx
+// web/components/stock/panels/greeks/VannaPanel.tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import type { components } from "@/lib/types";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+import { CallPutExposureChart } from "./CallPutExposureChart";
+import { ExpiryDropdown } from "./ExpiryDropdown";
+import { ExposureTile } from "./ExposureTile";
+import { NetExposureChart } from "./NetExposureChart";
+
+type StrikeExposureRow = components["schemas"]["StrikeExposureRow"];
+type ExposuresSummaryRow = components["schemas"]["ExposuresSummaryRow"];
+
+type Props = {
+  ticker: string;
+  strikeExposures: StrikeExposureRow[];
+  summary: ExposuresSummaryRow[];
+};
+
+const toNum = (v: string | number | null | undefined): number | null => {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+// Guards spot values from poisoning charm imbalance / "% from spot" math.
+// Mirrors the backend `_safe_spot` rejection of 0/negative/non-finite values.
+const toSpot = (v: string | number | null | undefined): number | null => {
+  const n = toNum(v);
+  return n != null && n > 0 ? n : null;
+};
+
+export function VannaPanel({ ticker, strikeExposures, summary }: Props) {
+  const sortedSummary = useMemo(
+    () => [...summary].sort((a, b) => (a.expiry < b.expiry ? -1 : 1)),
+    [summary],
+  );
+  // Default to the nearest non-expired expiry (dte ≥ 0). Fall back to the
+  // earliest summary row when every row is stale or dte is missing.
+  const defaultExpiry = useMemo(() => {
+    const live = sortedSummary
+      .filter((r) => r.dte == null || (r.dte as number) >= 0)
+      .sort((a, b) => ((a.dte ?? 99999) as number) - ((b.dte ?? 99999) as number));
+    return (live[0] ?? sortedSummary[0])?.expiry ?? null;
+  }, [sortedSummary]);
+  const [selected, setSelected] = useState<string | null>(defaultExpiry);
+
+  if (sortedSummary.length === 0) {
+    return (
+      <div style={{ color: "var(--text-muted)", fontSize: 12, padding: 16 }}>
+        Vanna data not yet available for this run.
+      </div>
+    );
+  }
+
+  const summaryRow =
+    sortedSummary.find((r) => r.expiry === selected) ?? sortedSummary[0];
+  const rowsForExpiry = strikeExposures.filter(
+    (r) => r.expiry === summaryRow.expiry,
+  );
+
+  const netCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      netValue:
+        (toNum(r.call_vanna) ?? 0) + (toNum(r.put_vanna) ?? 0),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const callPutCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      callValue: toNum(r.call_vanna),
+      putValue: toNum(r.put_vanna),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const dte = summaryRow.dte ?? null;
+  const spot = toSpot(summaryRow.spot);  // guards against 0/negative/NaN spot
+  const flip = toNum(summaryRow.vanna_flip);
+  const netVanna = toNum(summaryRow.net_vanna);
+  const tone =
+    netVanna == null || Math.abs(netVanna) < 1000
+      ? "muted"
+      : netVanna > 0
+        ? "positive"
+        : "negative";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {/* Heading */}
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: "var(--accent-vol)",
+            textTransform: "uppercase",
+          }}
+        >
+          Volatility · Vanna
+        </div>
+        <div
+          style={{ fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}
+        >
+          {summaryRow.vanna_headline ?? "Vanna positioning"}
+        </div>
+        {summaryRow.vanna_subtitle && (
+          <div style={{ fontSize: 12, color: "var(--text-secondary)", fontStyle: "italic" }}>
+            {summaryRow.vanna_subtitle}
+          </div>
+        )}
+      </div>
+
+      {/* Tiles */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+        }}
+      >
+        <ExposureTile
+          label="Net Vanna"
+          value={fmtMoneyAbbrev(netVanna)}
+          sub={
+            netVanna == null
+              ? undefined
+              : netVanna > 0 ? "Long" : netVanna < 0 ? "Short" : "Flat"
+          }
+          tone={tone}
+        />
+        <ExposureTile
+          label="Top vol-sensitive strike"
+          value={
+            summaryRow.top_vanna_strike != null
+              ? `$${Number(summaryRow.top_vanna_strike).toFixed(2)}`
+              : "—"
+          }
+          sub={fmtMoneyAbbrev(toNum(summaryRow.top_vanna_value))}
+        />
+        <ExposureTile
+          label="Δ from +1pt IV"
+          value={fmtMoneyAbbrev(toNum(summaryRow.delta_shock_1pt_iv))}
+          sub="Dealers sell when IV up"
+        />
+        <ExposureTile
+          label="Vol-shock regime"
+          value={summaryRow.vanna_regime ?? "neutral"}
+          sub={
+            summaryRow.vanna_regime === "procyclical"
+              ? "amplifies down moves"
+              : summaryRow.vanna_regime === "countercyclical"
+                ? "dampens down moves"
+                : "limited impact"
+          }
+          tone={
+            summaryRow.vanna_regime === "procyclical"
+              ? "negative"
+              : summaryRow.vanna_regime === "countercyclical"
+                ? "positive"
+                : "muted"
+          }
+        />
+      </div>
+
+      {/* Expiry dropdown */}
+      <ExpiryDropdown
+        options={sortedSummary.map((r) => ({
+          value: r.expiry,
+          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+        }))}
+        value={summaryRow.expiry}
+        onChange={setSelected}
+      />
+
+      {/* Charts (side-by-side) */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <NetExposureChart
+          curve={netCurve}
+          spot={spot}
+          flipStrike={flip}
+          yLabel="Vanna"
+          title={`Net Vanna Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+        <CallPutExposureChart
+          curve={callPutCurve}
+          spot={spot}
+          yLabel="Vanna"
+          title={`Vanna Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test (PASS)**
+
+```bash
+cd web && npm run test -- VannaPanel
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/VannaPanel.tsx web/components/stock/panels/greeks/ExposureTile.tsx web/tests/unit/greekCharts/VannaPanel.test.tsx
+git commit -m "feat(web): add VannaPanel (header + 4 tiles + dropdown + charts)"
+```
+
+---
+
+### Task 6.4: Build `CharmPanel`
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/CharmPanel.tsx`
+- Create: `web/tests/unit/greekCharts/CharmPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/greekCharts/CharmPanel.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CharmPanel } from "@/components/stock/panels/greeks/CharmPanel";
+
+const strikeExposures = [
+  { strike: "100", expiry: "2026-05-30", dte: 9, call_vanna: "0", put_vanna: "0", call_charm: "-2000", put_charm: "500" },
+  { strike: "110", expiry: "2026-05-30", dte: 9, call_vanna: "0", put_vanna: "0", call_charm: "-3000", put_charm: "800" },
+] as never[];
+
+const summary = [{
+  expiry: "2026-05-30", dte: 9, spot: "105",
+  net_vanna: "0", top_vanna_strike: null, top_vanna_value: null,
+  delta_shock_1pt_iv: null, vanna_regime: "neutral", vanna_flip: null,
+  vanna_headline: "", vanna_subtitle: "",
+  net_charm: "-3700", charm_pin_strike: "110", charm_above_sum: "-2200",
+  charm_below_sum: "0", charm_imbalance_pct: "1.0",
+  charm_signal_quality: "aligned", charm_flip: "108",
+  charm_headline: "Mechanical SELL pressure into the close",
+  charm_subtitle: "Strongest near $110.00",
+}] as never[];
+
+describe("CharmPanel", () => {
+  it("renders the SELL pressure headline + 4 tiles + charts", () => {
+    const { container, getByText } = render(
+      <CharmPanel ticker="TSLA" strikeExposures={strikeExposures} summary={summary} />,
+    );
+    expect(getByText(/Mechanical SELL/)).toBeTruthy();
+    expect(container.querySelectorAll("[data-testid='exposure-tile']")).toHaveLength(4);
+    expect(container.querySelector("path[data-testid='net-line']")).not.toBeNull();
+    expect(container.querySelector("path[data-testid='call-line']")).not.toBeNull();
+    expect(container.querySelector("path[data-testid='put-line']")).not.toBeNull();
+  });
+
+  it("renders an empty state when no summary present", () => {
+    const { queryByText } = render(
+      <CharmPanel ticker="TSLA" strikeExposures={[]} summary={[]} />,
+    );
+    expect(queryByText(/not yet available/i)).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test (FAIL)**
+
+```bash
+cd web && npm run test -- CharmPanel
+```
+
+- [ ] **Step 3: Create `CharmPanel.tsx`**
+
+```tsx
+// web/components/stock/panels/greeks/CharmPanel.tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import type { components } from "@/lib/types";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+import { CallPutExposureChart } from "./CallPutExposureChart";
+import { ExpiryDropdown } from "./ExpiryDropdown";
+import { ExposureTile } from "./ExposureTile";
+import { NetExposureChart } from "./NetExposureChart";
+
+type StrikeExposureRow = components["schemas"]["StrikeExposureRow"];
+type ExposuresSummaryRow = components["schemas"]["ExposuresSummaryRow"];
+
+type Props = {
+  ticker: string;
+  strikeExposures: StrikeExposureRow[];
+  summary: ExposuresSummaryRow[];
+};
+
+const toNum = (v: string | number | null | undefined): number | null => {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+// Guards spot values from poisoning charm imbalance / "% from spot" math.
+// Mirrors the backend `_safe_spot` rejection of 0/negative/non-finite values.
+const toSpot = (v: string | number | null | undefined): number | null => {
+  const n = toNum(v);
+  return n != null && n > 0 ? n : null;
+};
+
+export function CharmPanel({ ticker, strikeExposures, summary }: Props) {
+  const sortedSummary = useMemo(
+    () => [...summary].sort((a, b) => (a.expiry < b.expiry ? -1 : 1)),
+    [summary],
+  );
+  // Default to the nearest non-expired expiry (dte ≥ 0); fall back to earliest.
+  const defaultExpiry = useMemo(() => {
+    const live = sortedSummary
+      .filter((r) => r.dte == null || (r.dte as number) >= 0)
+      .sort((a, b) => ((a.dte ?? 99999) as number) - ((b.dte ?? 99999) as number));
+    return (live[0] ?? sortedSummary[0])?.expiry ?? null;
+  }, [sortedSummary]);
+  const [selected, setSelected] = useState<string | null>(defaultExpiry);
+
+  if (sortedSummary.length === 0) {
+    return (
+      <div style={{ color: "var(--text-muted)", fontSize: 12, padding: 16 }}>
+        Charm data not yet available for this run.
+      </div>
+    );
+  }
+
+  const summaryRow =
+    sortedSummary.find((r) => r.expiry === selected) ?? sortedSummary[0];
+  const rowsForExpiry = strikeExposures.filter(
+    (r) => r.expiry === summaryRow.expiry,
+  );
+
+  const netCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      netValue: (toNum(r.call_charm) ?? 0) + (toNum(r.put_charm) ?? 0),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const callPutCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      callValue: toNum(r.call_charm),
+      putValue: toNum(r.put_charm),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const dte = summaryRow.dte ?? null;
+  const spot = toSpot(summaryRow.spot);  // guards against 0/negative/NaN spot
+  const flip = toNum(summaryRow.charm_flip);
+  const netCharm = toNum(summaryRow.net_charm);
+  const pin = toNum(summaryRow.charm_pin_strike);
+  const imb = toNum(summaryRow.charm_imbalance_pct);
+  const aboveSum = toNum(summaryRow.charm_above_sum);
+  const belowSum = toNum(summaryRow.charm_below_sum);
+
+  const liveTone =
+    netCharm == null || Math.abs(netCharm) < 1000
+      ? "muted"
+      : netCharm < 0
+        ? "negative"
+        : "positive";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: "var(--accent-vol)",
+            textTransform: "uppercase",
+          }}
+        >
+          Timer · Charm
+        </div>
+        <div style={{ fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>
+          {summaryRow.charm_headline ?? "Charm pressure"}
+        </div>
+        {summaryRow.charm_subtitle && (
+          <div style={{ fontSize: 12, color: "var(--text-secondary)", fontStyle: "italic" }}>
+            {summaryRow.charm_subtitle}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+        }}
+      >
+        <ExposureTile
+          label="Live charm"
+          value={fmtMoneyAbbrev(netCharm)}
+          sub={
+            netCharm == null
+              ? undefined
+              : netCharm < 0 ? "Sell pressure" : netCharm > 0 ? "Buy pressure" : "Flat"
+          }
+          tone={liveTone}
+        />
+        <ExposureTile
+          // The displayed value MUST match the same formula the backend used
+          // to classify signal_quality (live=net_charm, positioning=above-below;
+          // see cards/exposures.py:charm_signal_quality). Showing above+below
+          // here would let the tile and the classifier disagree on sign.
+          label="Positioning"
+          value={fmtMoneyAbbrev(
+            aboveSum != null && belowSum != null ? aboveSum - belowSum : null,
+          )}
+          sub={
+            imb != null
+              ? `${(imb * 100).toFixed(0)}% imbalance`
+              : "—"
+          }
+        />
+        <ExposureTile
+          label="Signal quality"
+          value={summaryRow.charm_signal_quality ?? "weak"}
+          sub={
+            summaryRow.charm_signal_quality === "aligned"
+              ? "live and positioning align"
+              : summaryRow.charm_signal_quality === "mixed"
+                ? "live and positioning disagree"
+                : "thin signal"
+          }
+          tone={
+            summaryRow.charm_signal_quality === "aligned"
+              ? liveTone
+              : "muted"
+          }
+        />
+        <ExposureTile
+          label="Where it matters"
+          value={pin != null ? `$${pin.toFixed(2)}` : "—"}
+          sub={
+            pin != null && spot != null
+              ? `${(((pin - spot) / spot) * 100).toFixed(1)}% from spot`
+              : undefined
+          }
+        />
+      </div>
+
+      <ExpiryDropdown
+        options={sortedSummary.map((r) => ({
+          value: r.expiry,
+          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+        }))}
+        value={summaryRow.expiry}
+        onChange={setSelected}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <NetExposureChart
+          curve={netCurve}
+          spot={spot}
+          flipStrike={flip}
+          yLabel="Charm"
+          title={`Net Charm Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+        <CallPutExposureChart
+          curve={callPutCurve}
+          spot={spot}
+          yLabel="Charm"
+          title={`Charm Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test (PASS)**
+
+```bash
+cd web && npm run test -- CharmPanel
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/CharmPanel.tsx web/tests/unit/greekCharts/CharmPanel.test.tsx
+git commit -m "feat(web): add CharmPanel"
+```
+
+---
+
+## Slice 7 — Sub-tab switcher + integration into Market Structure
+
+### Task 7.1: Build the `GreekSubTabs` client switcher
+
+**Files:**
+- Create: `web/components/stock/panels/greeks/GreekSubTabs.tsx`
+- Create: `web/tests/unit/greekCharts/GreekSubTabs.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/tests/unit/greekCharts/GreekSubTabs.test.tsx
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GreekSubTabs } from "@/components/stock/panels/greeks/GreekSubTabs";
+
+const fakeReport = {
+  ticker: "TSLA",
+  strike_gex_curve: [],
+  market_structure: { spot: "100" },
+  market_structure_levels: null,
+  strike_exposures: [],
+  exposures_summary: [],
+} as never;
+
+describe("GreekSubTabs", () => {
+  it("renders GEX panel by default", () => {
+    const { getByText, queryByText } = render(<GreekSubTabs report={fakeReport} />);
+    // Active tab label is GEX
+    expect(getByText("GEX").getAttribute("aria-selected")).toBe("true");
+    // VannaPanel / CharmPanel placeholders are not visible
+    expect(queryByText(/Vanna data not yet available/)).toBeNull();
+    expect(queryByText(/Charm data not yet available/)).toBeNull();
+  });
+
+  it("switches to Vanna sub-tab on click", () => {
+    const { getByText } = render(<GreekSubTabs report={fakeReport} />);
+    fireEvent.click(getByText("VANNA"));
+    expect(getByText("VANNA").getAttribute("aria-selected")).toBe("true");
+    expect(getByText(/Vanna data not yet available/)).toBeTruthy();
+  });
+
+  it("switches to Charm sub-tab on click", () => {
+    const { getByText } = render(<GreekSubTabs report={fakeReport} />);
+    fireEvent.click(getByText("CHARM"));
+    expect(getByText(/Charm data not yet available/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test (FAIL)**
+
+```bash
+cd web && npm run test -- GreekSubTabs
+```
+
+- [ ] **Step 3: Create the switcher**
+
+```tsx
+// web/components/stock/panels/greeks/GreekSubTabs.tsx
+"use client";
+
+import { useState } from "react";
+import type { components } from "@/lib/types";
+import { GexProfileChart } from "@/components/stock/panels/GexProfileChart";
+import { CharmPanel } from "./CharmPanel";
+import { VannaPanel } from "./VannaPanel";
+
+type Report = components["schemas"]["SingleStockReport"];
+type Tab = "GEX" | "VANNA" | "CHARM";
+const TABS: Tab[] = ["GEX", "VANNA", "CHARM"];
+
+const ACTIVE_TAB: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  color: "var(--text-primary)",
+  borderBottom: "2px solid var(--accent-vol)",
+};
+const TAB_BASE: React.CSSProperties = {
+  background: "transparent",
+  border: "none",
+  borderBottom: "2px solid transparent",
+  padding: "8px 16px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  cursor: "pointer",
+};
+
+export function GreekSubTabs({ report }: { report: Report }) {
+  const [tab, setTab] = useState<Tab>("GEX");
+
+  return (
+    <div
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: 16,
+      }}
+    >
+      <div
+        role="tablist"
+        style={{
+          display: "flex",
+          gap: 4,
+          borderBottom: "1px solid var(--border-dim)",
+          marginBottom: 16,
+        }}
+      >
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            style={tab === t ? { ...TAB_BASE, ...ACTIVE_TAB } : TAB_BASE}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {tab === "GEX" && <GexProfileChart report={report} />}
+      {tab === "VANNA" && (
+        <VannaPanel
+          ticker={report.ticker}
+          strikeExposures={report.strike_exposures ?? []}
+          summary={report.exposures_summary ?? []}
+        />
+      )}
+      {tab === "CHARM" && (
+        <CharmPanel
+          ticker={report.ticker}
+          strikeExposures={report.strike_exposures ?? []}
+          summary={report.exposures_summary ?? []}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test (PASS)**
+
+```bash
+cd web && npm run test -- GreekSubTabs
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/greeks/GreekSubTabs.tsx web/tests/unit/greekCharts/GreekSubTabs.test.tsx
+git commit -m "feat(web): add GreekSubTabs client switcher (GEX | VANNA | CHARM)"
+```
+
+---
+
+### Task 7.2: Wire `GreekSubTabs` into `MarketStructureTab` (replaces standalone `GexProfileChart`)
+
+**Files:**
+- Modify: `web/components/stock/tabs/MarketStructureTab.tsx`
+- Create: `web/tests/e2e/marketStructureGreekSubTabs.spec.ts`
+
+- [ ] **Step 1: Modify `MarketStructureTab.tsx`**
+
+Replace the file contents with:
+
+```tsx
+import type { components } from "@/lib/types";
+import { api } from "@/lib/api";
+import { GexLevelTiles } from "../panels/GexLevelTiles";
+import { ExpectedRangeBar } from "../panels/ExpectedRangeBar";
+import { DirectionalBiasPanel } from "../panels/DirectionalBiasPanel";
+import { MarketStructureHistoryTable } from "../panels/MarketStructureHistoryTable";
+import { MaxPainTable } from "../panels/MaxPainTable";
+import { GreekSubTabs } from "../panels/greeks/GreekSubTabs";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+export async function MarketStructureTab({ report }: { report: Report }) {
+  let historyRows: components["schemas"]["StockHistoryRow"][] = [];
+  try {
+    const h = await api.stockHistory(report.ticker);
+    historyRows = h.rows;
+  } catch {
+    historyRows = [];
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <GexLevelTiles report={report} />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <ExpectedRangeBar report={report} />
+        <DirectionalBiasPanel report={report} history={historyRows} />
+      </div>
+      <GreekSubTabs report={report} />
+      <MarketStructureHistoryTable rows={historyRows} />
+      <MaxPainTable rows={report.max_pain_rows} />
+    </div>
+  );
+}
+```
+
+The `GexProfileChart` import is removed because it is now rendered inside `GreekSubTabs`.
+
+- [ ] **Step 2: Run web unit + typecheck**
+
+```bash
+cd web && npm run typecheck && npm run test && cd ..
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Write the e2e test**
+
+Create `web/tests/e2e/marketStructureGreekSubTabs.spec.ts`:
+
+```typescript
+import { expect, test } from "@playwright/test";
+
+// /stock/[ticker]/page.tsx redirects to /stock/[ticker]/market-structure,
+// so navigating straight to the canonical URL avoids relying on the TabBar
+// link selector (which could break if the label/href changes).
+
+test.describe("Market Structure greek sub-tabs", () => {
+  test("default tab is GEX and shows GEX Profile", async ({ page }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await expect(page.getByText(/GEX Profile/)).toBeVisible();
+    await expect(page.getByRole("tab", { name: "GEX" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("switching to VANNA reveals the Vanna headline and two charts", async ({ page }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await page.getByRole("tab", { name: "VANNA" }).click();
+    // Either headline OR the empty state — both are valid depending on data.
+    await expect(
+      page.locator("text=/Long Vanna|Short Vanna|Neutral Vanna|Vanna data not yet available/")
+    ).toBeVisible();
+  });
+
+  test("switching to CHARM reveals charm headline / empty state", async ({ page }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await page.getByRole("tab", { name: "CHARM" }).click();
+    await expect(
+      page.locator("text=/Mechanical (SELL|BUY)|Limited charm|Charm data not yet available/")
+    ).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 4: Run the e2e tests (requires running app)**
+
+Start the full stack (API + web) and wait for both to be reachable. Use `scripts/dev.sh`'s own pidfile pattern or boot the two processes explicitly so cleanup is reliable:
+
+```bash
+uv run uvicorn uw_scan.api.server:app --port 8400 --no-access-log &
+API_PID=$!
+(cd web && npm run dev -- --port 3001) &
+WEB_PID=$!
+for _ in {1..40}; do
+  curl -sf http://localhost:8400/openapi.json > /dev/null \
+    && curl -sf http://localhost:3001 > /dev/null && break
+  sleep 0.5
+done
+
+cd web && npm run test:e2e -- marketStructureGreekSubTabs && cd ..
+
+kill "$WEB_PID" "$API_PID" 2>/dev/null || true
+wait "$WEB_PID" "$API_PID" 2>/dev/null || true
+```
+
+Expected: PASS for all 3 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/tabs/MarketStructureTab.tsx web/tests/e2e/marketStructureGreekSubTabs.spec.ts
+git commit -m "feat(web): wire GreekSubTabs into MarketStructureTab"
+```
+
+---
+
+### Task 7.3: Full-suite regression sweep
+
+- [ ] **Step 1: Run all Python tests**
+
+```bash
+uv run pytest -q
+```
+
+Expected: all green, including new tests across slices 1–4.
+
+- [ ] **Step 2: Run all web tests + typecheck + lint**
+
+```bash
+cd web && npm run typecheck && npm run lint && npm run test && cd ..
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Manual smoke (visual)**
+
+Boot the stack and click through the new sub-tabs:
+
+```bash
+bash scripts/dev.sh
+```
+
+Open `http://localhost:3001/stock/TSLA` → Market Structure → click `VANNA`, change expiry from the dropdown, confirm the curves redraw. Repeat for `CHARM`.
+
+- [ ] **Step 4: Open a PR**
+
+```bash
+git push -u origin feat/vanna-charm-market-structure
+gh pr create --title "Vanna & Charm sub-tabs inside Market Structure" --body "$(cat <<'EOF'
+## Summary
+- Adds VANNA and CHARM sub-tabs inside the per-ticker Market Structure tab, with the existing GEX profile chart now living inside a peer GEX sub-tab.
+- Each panel: auto-generated headline narrative + 4 tiles + expiry dropdown + Net curve and Call/Put split curve.
+- Backend: new `exposures_summary` table (migration 051), derivers in `cards/exposures.py`, additive fields on `SingleStockReport`. Wired into `cockpit_daily_snapshot` and `pipeline.py`.
+- Frontend: hand-rolled SVG line charts (no chart library) under `web/components/stock/panels/greeks/`.
+
+## Test plan
+- [ ] `uv run pytest` is green
+- [ ] `npm run typecheck && npm run lint && npm run test` is green
+- [ ] Playwright e2e `marketStructureGreekSubTabs.spec.ts` is green
+- [ ] Manual smoke: visit /stock/TSLA → Market Structure → switch through GEX | VANNA | CHARM, change expiry, confirm charts redraw
+EOF
+)"
+```
+
+> Do NOT merge — the user opens PRs but reviews and merges manually per repo policy. Wait for review.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every section of the spec maps to at least one task. Migration → 1.2; models → 1.1, 4.1; derivers → 2.1–2.3; persistence → 3.1, 3.2; report assembler → 4.1; gen:types → 4.2; charts → 5.2, 5.3; tiles → 6.1; dropdown → 6.2; panels → 6.3, 6.4; sub-tabs → 7.1; integration → 7.2; QA → 7.3.
+- **Placeholder scan:** no "TBD", no "similar to Task N" without repeated code, every code block is complete.
+- **Type consistency:** `ExposuresSummaryRow`, `StrikeExposureRow`, `build_summary_rows`, `upsert_exposures_summary`, `fetch_strike_exposures`, `fetch_exposures_summary` (new list-returning) all use the same names across tasks. Renamed `fetch_exposures_aggregate` is consistent.
+- **Sign-convention note carried through:** `net = call + put`, `ONE_VOL_POINT = 0.01`, neutral threshold 1e3 — referenced in deriver code and test fixtures.
+- **Out-of-scope items called out** in spec; not creeping into tasks.
+
+### Fixes applied in this pass
+
+**Self-review pass (6 fixes):**
+
+1. **Rename / caller mismatch (commit-boundary regression risk).** `fetch_exposures_summary → fetch_exposures_aggregate` originally renamed in Slice 3.1 but the only caller (`reports/single_stock.py:127`) wasn't updated until Slice 4.1, so the Slice 3 commit would ship a broken codebase. Moved the caller update into Slice 3.1 step 5b; Task 4.1 step 3 now notes that the rename is already wired.
+2. **Ghost `_spot_decimal(market_data)` helper.** Task 3.2 step 3 referenced a helper that was never defined and contradicted the surrounding "inline the local" instruction. Replaced with `repo.get_intraday_quote(ticker)` fetched once before the expiry loop (matching `_persist_option_chain_per_strike`'s existing pattern at line 197–198).
+3. **Ghost `market_structure_spot` variable in `pipeline.py`.** Tightened in the tribunal pass (item P2 below).
+4. **Wrong test fixture name.** Integration tests originally used a bare `postgresql` fixture; this project's `tests/integration/conftest.py` exposes named fixtures (`seeded_db_empty_cards`, `seeded_db_with_cards`). Tasks 1.2, 3.1, 3.2, 4.1 now use `seeded_db_empty_cards: Repository` and rely on the conftest's `_reset_and_migrate` for migration setup.
+5. **Wrong report-assembler function name.** Task 4.1 originally called `build_single_stock_report`. The actual name is `assemble_single_stock_report(ticker, run_id, repo)` (`src/uw_scan/reports/single_stock.py:417`). Updated.
+6. **Fragile background-process management.** `bash scripts/dev.sh & ... kill %1` only kills the parent shell, leaking children. Tasks 4.2 and 7.2 now capture explicit PIDs from `uvicorn` and `npm run dev`, poll for readiness, and `kill "$PID"` + `wait` on cleanup.
+
+**Tribunal pass — Codex + Gemini + Claude consensus (12 fixes):**
+
+- **P1 (Codex ISSUE-1, transaction boundary).** `upsert_exposures_summary` originally called `self._conn.commit()`. Every other insert/upsert in `options.py` leaves commit to the caller, because `_snapshot_ticker` owns commit-on-success / rollback-on-failure (`cockpit_daily_snapshot.py:78,103`). Internal commit removed with an explicit warning.
+- **P2 (Codex ISSUE-2 + CL-4, spot in `pipeline.py`).** Originally `spot=None` was passed in the pipeline path, which is the watchlist-scan code that powers most stock-detail pages. Now reads `repo.get_intraday_quote(ticker)` with `fetch_realized_vol_latest(ticker)["price"]` fallback — same source `_build_market_structure` uses.
+- **P3 (Codex ISSUE-3, missing real worker-wiring test).** Added Task 3.2 Step 4b: a monkeypatched test that drives the snapshot helper and asserts `upsert_exposures_summary.called`. The original Step 1 test only exercised the assembly contract.
+- **P4 (Codex ISSUE-4, `__module__` assertion).** Models pass through `_preserve_public_module` which rewrites `__module__` to `"uw_scan.models"` (the public path), not `"uw_scan.models.scanner"`. Test assertion corrected.
+- **P5 (Codex ISSUE-5, `_StubRepo` not updated by rename).** `tests/unit/test_report_assembly.py:115` had a stub method named `fetch_exposures_summary` returning the aggregate dict. Renamed in step 5c so the unit suite doesn't break at the Slice 3.1 commit boundary.
+- **P6 (Codex ISSUE-6, single-point curves).** `finiteDomain` returns `null` for <2 points → NetExposureChart used to show empty state for a 1-point curve. Spec requires a point marker + spot line. Component now synthesizes a small symmetric window around the lone point and renders a `<circle data-testid="net-point">`. New unit test added.
+- **P7 (Codex ISSUE-7, default expiry).** Vanna/Charm panels originally defaulted to `sortedSummary[0]?.expiry`, which on stale data picks a negative-DTE row. Now filters `dte >= 0` (or null) first, sorts by DTE ascending, falls back to earliest when nothing live exists.
+- **P8 (Codex ISSUE-8, flip ignores spot).** Vanna/charm flip functions accepted `spot` and silently ignored it. Spec says lowest sign-flip ≥ spot, fallback to lowest overall. Implementation rewritten to collect all flips then apply the spot rule. Two new tests added for the rule + fallback path.
+- **P9 (Codex ISSUE-9, duplicate-PK risk on mixed DTE).** `build_summary_rows` originally grouped by `(expiry, dte)`. The PK is `(run_id, ticker, expiry)`, so any mixed-DTE same-expiry rows would emit duplicate PKs. Now groups by `expiry` only and picks min non-null `dte`. New unit test added.
+- **P10 (Codex ISSUE-10, run_id type).** Migration 051 declared `run_id INTEGER`. `scan_runs.run_id` is `BIGSERIAL`; every other run-keyed table uses `BIGINT REFERENCES scan_runs(run_id) ON DELETE CASCADE`. Migration corrected.
+- **P11 (Codex ISSUE-11, OpenAPI snapshot path).** Plan said `tests/unit -k openapi`. Actual snapshot is `tests/integration/api/test_openapi_snapshot.py` with the JSON checked in at `tests/integration/api/openapi.snapshot.json`. Verification command + regeneration recipe added.
+- **P12 (Codex ISSUE-12, Positioning tile formula mismatch).** Backend's `charm_signal_quality` classifies on `positioning = above_sum - below_sum`. FE Positioning tile was showing `above_sum + below_sum`, so the displayed value could disagree in sign with the `aligned`/`mixed` classification. Tile formula corrected.
+
+**Gemini-only accepted:**
+
+- **G1 (Gemini ISSUE-5, circular import speculation).** The local `from uw_scan.models import ExposuresSummaryRow` inside `build_summary_rows` was unnecessary — `cards/gex.py` already does the same import at the top level without issue. Moved to a top-level import.
+- **G2 (Gemini ISSUE-7, tile font size).** `web/components/CLAUDE.md` defines the canonical tile-value size as 22px. Changed from 18 to 22 with a comment citing the convention.
+
+**Claude-only accepted:**
+
+- **C1 (CL-1, `_to_decimal` consistency).** Verbose `Decimal(str(row[x])) if row.get(x) is not None else None` (×17) replaced with `_to_decimal(row.get(x))` to match the rest of `single_stock.py`.
+- **C2 (CL-2, e2e redundant click).** E2E tests now navigate straight to `/stock/TSLA/market-structure` instead of going to `/stock/TSLA` (which redirects) then clicking the TabBar link.
+
+**Dismissed (Gemini-only, weight 0.5):**
+
+- Gemini ISSUE-2 (repo fetchers should return models, not dicts) — codebase pattern in `fetchers.py` is mixed; many fetchers return `list[dict]` and the assembler converts. Out of scope.
+- Gemini ISSUE-3 (`strict=True` in `zip`) — style preference; existing code uses `strict=False`.
+- Gemini ISSUE-4 (`GexProfileChart` prop drilling) — pre-existing API; refactoring it is out of scope for this plan.
+- Gemini ISSUE-6 (refactor `_persist_option_chain_per_strike` to return spot) — minor efficiency win (one extra `get_intraday_quote` per ticker per snapshot); flagged as a deferred follow-up.
+
+**Adversarial pass — Codex challenge mode (8 actionable fixes + 2 deferred + 2 informational):**
+
+- **A1 (ATTACK-8, mid-slice method shadowing).** Slice 3.1 originally added a new `fetch_exposures_summary` in Step 4, then renamed the old one in Step 5. Python class-body resolution shadows the first definition with the second, so between substeps `_build_market_structure` would crash with `'list' has no attribute 'get'`. Steps reordered: rename + caller-update + stub-update happen FIRST (Step 3), then the new fetcher is added (Step 5). One indivisible commit covers both.
+- **A2 (ATTACK-9, worker test references non-existent helper).** The Codex-tribunal-added Step 4b test called `job._persist_greeks_per_expiry(...)`, but `cockpit_daily_snapshot.py` has no such helper — the per-expiry loop is inline. Test now uses `getattr(...)` so it gracefully falls back to driving `_snapshot_ticker` directly, AND Step 3 of Task 3.2 now instructs the engineer to extract the helper as a small refactor (preferred). The wiring-test file is added to the commit explicitly.
+- **A3 (ATTACK-5, CallPutExposureChart blanks on one-strike data).** The single-point fallback in Slice 5.2 covered NetExposureChart only — CallPutExposureChart still gated on `finiteDomain(...) → null` for <2 points and showed empty state. Component now mirrors NetExposureChart: synthesizes a small window around the lone strike and renders `<circle data-testid="call-point">` / `put-point` markers.
+- **A4 (ATTACK-4, zero/negative spot poisons math).** Backend `_safe_spot` helper (in both `cockpit_daily_snapshot.py` and `pipeline.py`) rejects `None`, non-finite, and `≤ 0` values before passing to the deriver. Frontend `toSpot()` helper enforces the same `> 0` guard in `VannaPanel` and `CharmPanel` so "% from spot" never renders as `Infinity%`.
+- **A5 (ATTACK-3, cockpit spot has no fallback).** Cockpit wiring originally trusted `repo.get_intraday_quote(ticker)` blindly — a missing or stale quote produced silently wrong charm imbalance. Now falls back to `repo.fetch_realized_vol_latest(ticker)["price"]` (same source `_persist_option_chain_per_strike` already uses).
+- **A6 (ATTACK-2, spec disagrees with corrected migration).** Spec still showed `run_id INTEGER NOT NULL` with no FK; plan's migration uses `BIGINT REFERENCES scan_runs(run_id) ON DELETE CASCADE`. Spec patched to match — agents reading the spec directly won't ship an inconsistent migration.
+- **A7 (ATTACK-12, stale FK comment in test seed helper).** Test docstring said "exposures_summary has no FK" — false after A6. Now correctly notes the FK + CASCADE behavior.
+- **A8 (ATTACK-10, `_to_decimal(row.get("strike"))` Pydantic crash).** `StrikeExposureRow.strike` is non-optional `Decimal`; `_to_decimal(None)` returns `None`, which raises `ValidationError` and aborts the whole report assembly. Required fields now use `Decimal(str(row["strike"]))` with a defensive `if row.get("strike") is not None` filter in the comprehension so one bad row drops out instead of crashing the report.
+
+**Adversarial pass — partial fixes / verification notes:**
+
+- **A9 (ATTACK-6 + ATTACK-7, UW vanna sign + unit convention not verified).** Added a verification preamble to Slice 2 listing the two assumptions (`net_vanna > 0` → "Long Vanna / procyclical"; `vanna × 0.01` → 1-pt-IV delta shock) plus two concrete verification paths (sample payload check against UW UI labels; numerical scale check vs UW UI). If verification fails, the fix is narrative-string-only and doesn't change deriver logic.
+
+**Adversarial pass — acknowledged but out of plan scope:**
+
+- **A10 (ATTACK-1, pipeline rollback is already broken pre-plan).** `set_strike_gex_curve` commits mid-function before this plan's upsert runs, so existing failure paths can leave half-rolled-back state regardless of our new upsert. The plan inherits this pre-existing issue; fixing it requires moving every internal commit out of repository helpers and into the worker. Flagged for a follow-up storage-cleanup spec.
+- **A11 (ATTACK-11, `latest_run_id` can pick cockpit runs over full-stock runs).** `latest_run_id` only filters out `flow_data_refresh` notes; cockpit snapshot rows can shadow full single-stock runs for SPX/SPY/QQQ/IWM. Pre-existing issue this plan amplifies (now Vanna/Charm rows can come from a cockpit run with no flow/max-pain context). Flagged for a follow-up `run_kind` column / filter change.
+
+The full adversarial transcript is in the conversation; both A10 and A11 should be tracked in a follow-up ticket before this plan ships to prod.

--- a/docs/superpowers/specs/2026-05-21-vanna-charm-market-structure-design.md
+++ b/docs/superpowers/specs/2026-05-21-vanna-charm-market-structure-design.md
@@ -1,0 +1,417 @@
+# Vanna & Charm — Market Structure sub-tabs (per-ticker)
+
+**Status:** Draft · 2026-05-21
+**Scope:** Per-ticker stock detail page → `Market Structure` tab → new `GEX | VANNA | CHARM` sub-tab switcher. Vanna and Charm panels mirror the UnusualWhales reference experience (header narrative + 4 tiles + expiry dropdown + Net + Call/Put curves). All derived summary values are persisted to Postgres.
+
+## Motivation
+
+Vanna (∂Δ/∂σ) and Charm (∂Δ/∂t) are already persisted at `(run_id, ticker, expiry, strike)` granularity in `uw_scan.exposures_by_expiry_strike`. They are unsurfaced in `SingleStockReport` and never rendered. The Market Structure tab today shows GEX-centric panels only.
+
+This spec adds two new analytical surfaces — vanna and charm — using the same per-strike exposure data, organised as sub-tabs under Market Structure. Each surface tells a different dealer-positioning story:
+
+- **Vanna** answers *"how does dealer Δ change when IV moves?"* — i.e., spot impact of a vol shock.
+- **Charm** answers *"how does dealer Δ decay through time?"* — i.e., mechanical hedge flow into expiration.
+
+## Out of scope (v1)
+
+- Historical time-series of vanna/charm (the `greek_exposure_daily` table doesn't have these columns — would need a backfill).
+- Vanna/charm regime quadrant against the existing Volatility-tab regime view.
+- Vanna/charm signals contributing to Scanner / Trade Plan output.
+
+These are good follow-ups; flagged but not blocking.
+
+## User-facing layout
+
+### `MarketStructureTab.tsx` — after this change
+
+```
+[ existing summary panels — kept unchanged ]
+  GexLevelTiles
+  ExpectedRangeBar | DirectionalBiasPanel        (2-col)
+  MarketStructureHistoryTable
+  MaxPainTable
+
+[ NEW: Greek-exposure sub-tabs ]
+  ┌─[ GEX ]─[ VANNA ]─[ CHARM ]──────────────────────────┐
+  │                                                       │
+  │  (one panel rendered at a time)                       │
+  └───────────────────────────────────────────────────────┘
+```
+
+The summary panels are tab-agnostic context, so they stay above the sub-tab switcher. The existing `GexProfileChart` moves into the `[GEX]` sub-tab.
+
+### Vanna sub-tab (mirrors UW reference image 1)
+
+```
+VANNA · VOLATILITY
+Long Vanna — IV spikes pressure stock lower via dealer selling
+If IV rises, dealers gain delta and will likely sell stock to rehedge.
+
+┌──────────────┬──────────────────┬─────────────────────┬──────────────────┐
+│ Net Vanna    │ Top vol-sensitive │ Δ from +1pt IV     │ Vol-shock regime │
+│ +$1.3M Long  │ $450.00 / $227K   │ +$4.14M sell-Δ     │ Procyclical      │
+└──────────────┴──────────────────┴─────────────────────┴──────────────────┘
+
+Expiry: [ 2026-05-18 ▼ ]
+
+┌─ Net Vanna Exposure ─────────────┐  ┌─ Vanna Exposure (Call/Put) ──────┐
+│ purple line                       │  │ green Call · red Put             │
+│ yellow Price · purple-dashed Flip │  │ yellow Price                     │
+│ peak strike labels                │  │ peak strike labels               │
+└───────────────────────────────────┘  └───────────────────────────────────┘
+```
+
+### Charm sub-tab (mirrors UW reference image 2)
+
+Same shell. Tile row reads:
+
+```
+┌──────────────┬─────────────────────────────┬──────────────────────────┬──────────────────────┐
+│ Live charm   │ Positioning                  │ Signal quality           │ Where it matters     │
+│ Sell -$15.5T │ Sell -$100M · 67% imbalance  │ live + positioning align │ $425 · 3.7% > spot   │
+└──────────────┴─────────────────────────────┴──────────────────────────┴──────────────────────┘
+```
+
+Headline narrative: e.g. *"Mechanical SELL pressure into the close"* / *"Mechanical BUY pressure into the close"*, sign-driven by `net_charm`.
+
+## Backend — data model & persistence
+
+### Existing — already populated
+
+```sql
+-- exposures_by_expiry_strike (migration 001)
+(run_id, ticker, market_date, expiry, strike, dte,
+ call_delta, put_delta, call_gex, put_gex,
+ call_vanna, put_vanna, call_charm, put_charm)
+```
+
+Written by `repo.insert_greek_exposure_rows()` from `pipeline.py` and `cockpit_daily_snapshot.py`. No change here.
+
+### New — `051_exposures_summary.sql`
+
+Per-expiry derived summary. One row per `(run_id, ticker, expiry)`. `run_id` is `BIGINT` with FK `ON DELETE CASCADE` to `scan_runs(run_id)` — matches the convention used by every other run-keyed table (`scan_runs.run_id` is `BIGSERIAL`; `INTEGER` would overflow):
+
+```sql
+CREATE TABLE IF NOT EXISTS uw_scan.exposures_summary (
+    run_id              BIGINT  NOT NULL
+                                REFERENCES uw_scan.scan_runs(run_id) ON DELETE CASCADE,
+    ticker              TEXT    NOT NULL,
+    expiry              DATE    NOT NULL,
+    market_date         DATE    NOT NULL,
+    dte                 INTEGER,
+    spot                NUMERIC,
+
+    -- Vanna derivatives
+    net_vanna           NUMERIC,
+    top_vanna_strike    NUMERIC,
+    top_vanna_value     NUMERIC,
+    delta_shock_1pt_iv  NUMERIC,
+    vanna_regime        TEXT,    -- 'procyclical' | 'countercyclical' | 'neutral'
+    vanna_flip          NUMERIC, -- strike where cumulative net vanna flips sign
+    vanna_headline      TEXT,
+    vanna_subtitle      TEXT,
+
+    -- Charm derivatives
+    net_charm           NUMERIC,
+    charm_pin_strike    NUMERIC,
+    charm_above_sum     NUMERIC,
+    charm_below_sum     NUMERIC,
+    charm_imbalance_pct NUMERIC,
+    charm_signal_quality TEXT,   -- 'aligned' | 'mixed' | 'weak'
+    charm_flip          NUMERIC,
+    charm_headline      TEXT,
+    charm_subtitle      TEXT,
+
+    computed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (run_id, ticker, expiry)
+);
+
+CREATE INDEX IF NOT EXISTS exposures_summary_ticker_date
+    ON uw_scan.exposures_summary (ticker, market_date);
+```
+
+Idempotent per `storage/CLAUDE.md` rules; `IF NOT EXISTS`, upsert on PK.
+
+### New — Pydantic models (`src/uw_scan/models/scanner.py`)
+
+```python
+class StrikeExposureRow(_UwBase):
+    """One per-(expiry, strike) raw row from exposures_by_expiry_strike."""
+    strike: Decimal
+    expiry: _date
+    dte: int | None = None
+    call_vanna: Decimal | None = None
+    put_vanna:  Decimal | None = None
+    call_charm: Decimal | None = None
+    put_charm:  Decimal | None = None
+
+class ExposuresSummaryRow(_UwBase):
+    """One per-(expiry) derived summary for the Market Structure tab."""
+    expiry: _date
+    dte: int | None = None
+    spot: Decimal | None = None
+    # vanna
+    net_vanna: Decimal | None = None
+    top_vanna_strike: Decimal | None = None
+    top_vanna_value:  Decimal | None = None
+    delta_shock_1pt_iv: Decimal | None = None
+    vanna_regime: str | None = None
+    vanna_flip: Decimal | None = None
+    vanna_headline: str | None = None
+    vanna_subtitle: str | None = None
+    # charm
+    net_charm: Decimal | None = None
+    charm_pin_strike: Decimal | None = None
+    charm_above_sum:  Decimal | None = None
+    charm_below_sum:  Decimal | None = None
+    charm_imbalance_pct: Decimal | None = None
+    charm_signal_quality: str | None = None
+    charm_flip: Decimal | None = None
+    charm_headline: str | None = None
+    charm_subtitle: str | None = None
+```
+
+`SingleStockReport` adds two fields (additive, no contract break):
+
+```python
+strike_exposures: list[StrikeExposureRow] = []
+exposures_summary: list[ExposuresSummaryRow] = []
+```
+
+### New — derivers (`src/uw_scan/cards/exposures.py`)
+
+Pure functions over `list[GreekExposureRow]`. Domain seam separate from `cards/gex.py`.
+
+```python
+def per_expiry_groups(rows) -> dict[date, list[GreekExposureRow]]: ...
+
+def net_vanna(rows) -> Decimal | None
+def top_vanna_strike(rows) -> tuple[Decimal, Decimal] | None    # (strike, value)
+def delta_shock_1pt_iv(rows) -> Decimal | None                  # Σ net_vanna × 0.01
+def vanna_regime(net_vanna) -> Literal["procyclical","countercyclical","neutral"]
+def vanna_flip(rows, spot) -> Decimal | None                    # cum-sum sign-flip strike
+def vanna_narrative(net_vanna, regime) -> tuple[str, str]       # (headline, subtitle)
+
+def net_charm(rows) -> Decimal | None
+def charm_pin_strike(rows) -> Decimal | None                    # argmax|net_charm|
+def charm_imbalance(rows, spot) -> tuple[Decimal, Decimal, Decimal]
+                                                                # (above, below, imbalance_pct)
+def charm_signal_quality(live, positioning) -> str
+def charm_flip(rows, spot) -> Decimal | None
+def charm_narrative(net_charm, signal_quality) -> tuple[str, str]
+```
+
+**Sign conventions:**
+- Per-strike `net = call_x + put_x` (consistent with the existing `net_gex` rule).
+- `vanna_regime`: `procyclical` when `net_vanna > 0` (dealers sell into vol rises), `countercyclical` when `< 0`. Threshold for `neutral`: |net| < 1e3 (tunable; lives as a constant in the deriver).
+- `delta_shock_1pt_iv`: how much net delta dealers must hedge if IV rises 1 vol-point. Σ vanna × 0.01 (vanna is dΔ per 1.0 of vol; 1pt = 0.01).
+- `charm_signal_quality`: `aligned` when `sign(live) == sign(net_positioning_imbalance)`; `mixed` otherwise; `weak` when either is near zero.
+
+### New — fetcher (`src/uw_scan/storage/fetchers.py`)
+
+```python
+def fetch_strike_exposures(self, run_id: int, ticker: str) -> list[dict]: ...
+def fetch_exposures_summary(self, run_id: int, ticker: str) -> list[dict]: ...
+                                                            # NOTE: existing fn is per-aggregate;
+                                                            # this is per-expiry summary rows.
+                                                            # Rename existing → fetch_exposures_aggregate.
+```
+
+The existing `fetch_exposures_summary` (returns `total_call_gex` / `total_put_gex` / etc. as a single dict) is renamed to `fetch_exposures_aggregate` to free the name. Single caller in `reports/single_stock.py` is updated. No external contract change.
+
+### New — repository method (`storage/options.py`)
+
+```python
+def upsert_exposures_summary(self, run_id: int, ticker: str, rows: list[ExposuresSummaryRow]) -> int
+```
+
+Called from `pipeline.py` and `cockpit_daily_snapshot.py` directly after `insert_greek_exposure_rows()`.
+
+### Report assembler (`reports/single_stock.py`)
+
+After the existing `strike_gex_curve` block:
+
+```python
+strike_exp_raw = repo.fetch_strike_exposures(run_id, ticker)
+strike_exposures = [StrikeExposureRow(...) for row in strike_exp_raw]
+
+summary_raw = repo.fetch_exposures_summary(run_id, ticker)
+exposures_summary = [ExposuresSummaryRow(...) for row in summary_raw]
+```
+
+Both attached to the response.
+
+## Frontend
+
+### Layout changes
+
+**`web/components/stock/tabs/MarketStructureTab.tsx`** — append the sub-tab switcher after the existing panels. The current page is a server component; the sub-tab switcher needs local UI state, so we extract a small client wrapper:
+
+```tsx
+// MarketStructureTab.tsx (unchanged top portion)
+<GexLevelTiles report={report} />
+<div /* 2-col */>
+  <ExpectedRangeBar />
+  <DirectionalBiasPanel />
+</div>
+<MarketStructureHistoryTable />
+<MaxPainTable />
+
+// NEW
+<GreekSubTabs report={report} />
+```
+
+### New components
+
+```
+web/components/stock/panels/greeks/
+├── GreekSubTabs.tsx              "use client" — renders [GEX | VANNA | CHARM] switcher
+├── VannaPanel.tsx                header + tiles + dropdown + charts
+├── CharmPanel.tsx                header + tiles + dropdown + charts
+├── NetExposureChart.tsx          shared SVG line chart (single purple line)
+├── CallPutExposureChart.tsx      shared SVG line chart (green call + red put)
+├── ExpiryDropdown.tsx            HTML <select> styled to match
+└── ExposureTile.tsx              4-up tile pattern (mono label + value + sub-line)
+```
+
+`GexProfileChart` is unchanged; it's just *rendered inside* the `[GEX]` sub-tab now.
+
+### Chart contract
+
+`NetExposureChart` and `CallPutExposureChart` both take:
+
+```ts
+type Props = {
+  curve: { strike: number; netValue: number | null;
+           callValue?: number | null; putValue?: number | null }[];
+  spot: number | null;
+  flipStrike: number | null;       // null → don't render flip line
+  yLabel: "Vanna" | "Charm";
+  title: string;                   // "Net Vanna Exposure (12 DTE) — TSLA"
+  width?: number;                  // default 560
+  height?: number;                 // default 360
+};
+```
+
+Implementation: hand-rolled SVG using existing `linearScale` / `pathFromPoints` / `finiteDomain` from `lib/svgChart.ts`. Smoothing is **linear polyline** (no Bezier) in v1 — matches `SmileChart` / `TermStructureChart` styling. If we want spline smoothing later, that's an enhancement on the shared helpers, not this panel.
+
+Reference lines:
+- Spot: vertical `var(--warning)` solid line + "Price: X.XX" label above.
+- Flip: vertical `var(--accent-vol)` (purple) dashed line + "Vanna/Charm flip: X.XX" label.
+
+Peak labels: annotate the global min and global max strike on the curve with the strike value in the curve's color. Mirrors UW reference.
+
+### Derive helpers (frontend)
+
+The narrative strings + tile values come pre-computed from the API (`ExposuresSummaryRow`). The frontend only needs to:
+
+1. Look up the row matching the selected `expiry`.
+2. Filter `strike_exposures` by `expiry === selected` and pass to the charts.
+3. Format the tile values (existing `lib/formatters.ts` covers `fmtSigned`, `fmtMoney`-style → we may add a `fmtMoneyAbbrev` helper for `+$1.3M` / `-$15.5T` ranges).
+
+No analytical computation lives client-side. (This is what differentiates this design from the "client-side derive util" option that was considered.)
+
+### Expiry dropdown
+
+```tsx
+<ExpiryDropdown
+  options={summaryRows.map(r => ({ value: r.expiry, label: `${r.expiry} (${r.dte}d)` }))}
+  value={selected}
+  onChange={setSelected}
+/>
+```
+
+Default selected: nearest-expiry (smallest `dte` ≥ 0). Persist selection in `useState`; not in URL for v1 — can lift to query param later if useful.
+
+## Data flow (request lifecycle)
+
+```
+GET /stock/{ticker}/report
+  → reports.single_stock.build_single_stock_report()
+     ├─ repo.fetch_strike_exposures(run_id, ticker)         (NEW: raw per-strike rows)
+     ├─ repo.fetch_exposures_summary(run_id, ticker)        (NEW: per-expiry summary rows)
+     └─ assemble SingleStockReport with two new fields
+
+Page render (RSC) →
+  MarketStructureTab (server)
+    ↳ GreekSubTabs ("use client")
+        ↳ [GEX]   → existing GexProfileChart
+        ↳ [VANNA] → VannaPanel
+            ├─ Headline / subtitle from summary_row.vanna_*
+            ├─ 4 tiles from summary_row.*
+            ├─ ExpiryDropdown over summary rows
+            └─ NetExposureChart + CallPutExposureChart filtered by expiry
+        ↳ [CHARM] → CharmPanel (same shape, charm_*)
+```
+
+### Job lifecycle
+
+```
+worker → cockpit_daily_snapshot job
+  ↳ fetch /greek-exposure/expiry/strike from UW
+  ↳ normalize → list[GreekExposureRow]
+  ↳ repo.insert_greek_exposure_rows()
+  ↳ NEW: derive per-expiry summary via cards/exposures.py
+  ↳ NEW: repo.upsert_exposures_summary()
+```
+
+Re-running is a no-op — the summary table has PK `(run_id, ticker, expiry)` with `ON CONFLICT DO UPDATE`.
+
+## Error handling
+
+- **Missing UW data** (a ticker with no `/greek-exposure` rows for `run_id`): both new lists empty. Frontend renders an empty-state per panel: *"Vanna data not yet available for this run."*
+- **Single expiry has only one strike with non-null vanna**: curve renders as a single point; chart still draws the spot reference line. Empty-state copy clarifies why no curve is visible.
+- **`net_vanna` near zero**: regime classified as `neutral` (constant threshold in deriver); headline switches to a neutral narrative.
+- **NULL guards**: All `Decimal | None` fields skip the row in cum-sum / flip calculations (re-uses the existing `finiteDomain` pattern on the frontend).
+
+## Testing
+
+### Python — `tests/unit/cards/test_exposures.py`
+
+- `net_vanna` / `net_charm`: sums correctly when call/put both present, when only one side present, when all None.
+- `vanna_flip`: returns the correct strike on monotone curves and on multi-flip curves (picks lowest sign-flip ≥ spot, mirroring `find_flip_strike`).
+- `vanna_regime`: each of the three branches with edge-case values around the neutral threshold.
+- `charm_imbalance`: split-around-spot math.
+- `vanna_narrative` / `charm_narrative`: deterministic string outputs per regime/signal combo (table-driven tests).
+
+### Python — `tests/integration/storage/test_exposures_summary.py`
+
+`pytest-postgresql` fixture; insert `exposures_by_expiry_strike` rows; assert `upsert_exposures_summary` round-trips; re-run idempotency.
+
+### Python — `tests/integration/reports/test_single_stock_exposures.py`
+
+End-to-end: fake run with seeded rows → assert `SingleStockReport.strike_exposures` and `.exposures_summary` populated with expected values.
+
+### Frontend — `web/tests/unit/exposurePanels.test.tsx`
+
+- `VannaPanel`: renders headline + 4 tiles from a fixture summary row.
+- `CharmPanel`: renders empty state when summary is missing.
+- `ExpiryDropdown`: changing selection re-filters the curves passed to children (data-driven assertion on child props).
+- `NetExposureChart` / `CallPutExposureChart`: SVG path `d=` attribute contains expected M/L coordinates for fixture data.
+- Sub-tab switcher: clicking `[VANNA]` hides GEX panel, shows VannaPanel.
+
+### Frontend — `web/tests/e2e/marketStructure.spec.ts`
+
+- Existing market-structure E2E continues to pass (no regression in summary panels).
+- New: navigate to `/stock/TSLA`, click `Market Structure` tab, click `VANNA` sub-tab, assert headline text appears, change dropdown, assert chart updates.
+
+## Open items deferred
+
+1. **Historical vanna/charm time-series.** Requires extending `greek_exposure_daily` (migration 039) with new columns + backfill from `exposures_by_expiry_strike`. Could power a future "Vanna/Charm history" mini-chart inside each sub-tab.
+2. **Spline-smoothed curves.** UW reference uses Catmull-Rom or monotone-cubic. v1 uses linear polylines (consistent with `SmileChart` / `TermStructureChart`). If we want spline, extend `lib/svgChart.ts` with a `pathFromPointsSmooth(points)` helper used by all curve panels.
+3. **Persisting derivation thresholds.** The `neutral` threshold (1e3) and the `signal_quality` cut-offs are constants in `cards/exposures.py`. If they get tuned, they should move to a config or per-ticker calibration table.
+4. **Vanna/charm contribution to Scanner signals.** Future Scanner gate could use `vanna_regime == 'procyclical'` + high IV-Rank as a confluence signal. Out of scope here.
+
+## Implementation plan (high level — full plan in next step)
+
+The work decomposes into milestone commits, per the project's "milestone commits" rule:
+
+- **Slice 1 — Models + migration.** New Pydantic models, migration `051_exposures_summary.sql`, `__init__.py` exports. Tests: model exports + migration idempotency.
+- **Slice 2 — Derivers + unit tests.** `cards/exposures.py` + `tests/unit/cards/test_exposures.py`.
+- **Slice 3 — Persistence + integration tests.** `upsert_exposures_summary`, fetchers, wire into `pipeline.py` + `cockpit_daily_snapshot.py`.
+- **Slice 4 — Report assembler + API surface.** Wire new fields into `reports/single_stock.py`; rename existing `fetch_exposures_summary` → `fetch_exposures_aggregate`; `npm run gen:types`.
+- **Slice 5 — Frontend chart components.** `NetExposureChart`, `CallPutExposureChart`, shared in `panels/greeks/`. Vitest unit tests on SVG path output.
+- **Slice 6 — VannaPanel + CharmPanel + ExpiryDropdown.** Tile pattern, dropdown wiring.
+- **Slice 7 — GreekSubTabs + integration into MarketStructureTab.** Move `GexProfileChart` rendering into the sub-tab. E2E test.
+
+Each slice ends with `uv run pytest` + `cd web && npm run typecheck && npm run test` green, then a milestone commit.

--- a/src/uw_scan/api/endpoints.py
+++ b/src/uw_scan/api/endpoints.py
@@ -21,6 +21,7 @@ class EndpointSlug(StrEnum):
     SKEW = "skew"
     GREEK_EXPOSURE = "greek_exposure"
     GREEK_EXPOSURE_BY_STRIKE = "greek_exposure_by_strike"
+    GREEK_EXPOSURE_BY_EXPIRY = "greek_exposure_by_expiry"
     GREEK_EXPOSURE_HISTORY = "greek_exposure_history"
     SPOT_EXPOSURES = "spot_exposures"
     GREEKS = "greeks"
@@ -78,6 +79,11 @@ REGISTRY: dict[EndpointSlug, Endpoint] = {
     EndpointSlug.GREEK_EXPOSURE_BY_STRIKE: Endpoint(
         EndpointSlug.GREEK_EXPOSURE_BY_STRIKE,
         "/api/stock/{ticker}/greek-exposure/strike",
+        (),
+    ),
+    EndpointSlug.GREEK_EXPOSURE_BY_EXPIRY: Endpoint(
+        EndpointSlug.GREEK_EXPOSURE_BY_EXPIRY,
+        "/api/stock/{ticker}/greek-exposure/expiry",
         (),
     ),
     EndpointSlug.GREEK_EXPOSURE_HISTORY: Endpoint(

--- a/src/uw_scan/cards/exposures.py
+++ b/src/uw_scan/cards/exposures.py
@@ -12,7 +12,11 @@ from collections import defaultdict
 from datetime import date
 from decimal import Decimal
 
-from uw_scan.models import ExposuresSummaryRow, GreekExposureRow
+from uw_scan.models import (
+    ExposuresSummaryRow,
+    GreekExposureByExpiryRow,
+    GreekExposureRow,
+)
 
 log = logging.getLogger(__name__)
 
@@ -259,6 +263,31 @@ def charm_narrative(
     )
 
 
+def _charm_narrative_from_net(
+    net_charm_value: Decimal | None,
+) -> tuple[str, str]:
+    """Headline + subtitle derived from net charm alone (no strike split).
+
+    Used for aggregate rows where we can't compute above/below positioning. The
+    quality gate in :func:`charm_narrative` requires strike data; here we fall
+    back to a |net_charm| threshold to decide between "Limited" and SELL/BUY.
+    """
+    if net_charm_value is None or abs(net_charm_value) < NEUTRAL_CHARM_THRESHOLD:
+        return (
+            "Limited charm pressure into the close",
+            "Net charm positioning is balanced or thin; mechanical hedging pressure is muted.",
+        )
+    if net_charm_value < 0:
+        return (
+            "Mechanical SELL pressure into the close",
+            "Dealer sell pressure may cap rallies as theta drives delta unwind.",
+        )
+    return (
+        "Mechanical BUY pressure into the close",
+        "Dealer buy pressure may support the tape as theta drives delta accumulation.",
+    )
+
+
 # --- top-level builder -----------------------------------------------------
 
 
@@ -315,6 +344,63 @@ def build_summary_rows(
                 charm_imbalance_pct=imb,
                 charm_signal_quality=c_quality,
                 charm_flip=c_flip,
+                charm_headline=c_head,
+                charm_subtitle=c_sub,
+            )
+        )
+    return out
+
+
+def build_summary_rows_from_aggregate(
+    rows: list[GreekExposureByExpiryRow],
+    spot: Decimal | None,
+) -> list[ExposuresSummaryRow]:
+    """Build per-expiry summary rows from /greek-exposure/expiry aggregates.
+
+    Each aggregate row already represents one expiry, so no grouping needed.
+    Strike-derived fields (top strike, vanna_flip, charm pin/imbalance/flip,
+    signal_quality) are left None — they require per-strike data which this
+    endpoint doesn't return. The Vanna/Charm panels use this for the multi-
+    expiry dropdown; the nearest expiry gets a second pass from
+    :func:`build_summary_rows` that fills the strike-derived fields.
+    """
+    if not rows:
+        return []
+
+    out: list[ExposuresSummaryRow] = []
+    for r in sorted(rows, key=lambda x: x.expiry):
+        cv = r.call_vanna or Decimal("0")
+        pv = r.put_vanna or Decimal("0")
+        cc = r.call_charm or Decimal("0")
+        pc = r.put_charm or Decimal("0")
+        any_vanna = r.call_vanna is not None or r.put_vanna is not None
+        any_charm = r.call_charm is not None or r.put_charm is not None
+        nv = (cv + pv) if any_vanna else None
+        nc = (cc + pc) if any_charm else None
+        v_regime = vanna_regime(nv)
+        v_head, v_sub = vanna_narrative(nv, v_regime)
+        c_head, c_sub = _charm_narrative_from_net(nc)
+
+        out.append(
+            ExposuresSummaryRow(
+                expiry=r.expiry,
+                dte=r.dte,
+                spot=spot,
+                net_vanna=nv,
+                top_vanna_strike=None,
+                top_vanna_value=None,
+                delta_shock_1pt_iv=(nv * ONE_VOL_POINT) if nv is not None else None,
+                vanna_regime=v_regime,
+                vanna_flip=None,
+                vanna_headline=v_head,
+                vanna_subtitle=v_sub,
+                net_charm=nc,
+                charm_pin_strike=None,
+                charm_above_sum=None,
+                charm_below_sum=None,
+                charm_imbalance_pct=None,
+                charm_signal_quality=None,
+                charm_flip=None,
                 charm_headline=c_head,
                 charm_subtitle=c_sub,
             )

--- a/src/uw_scan/cards/exposures.py
+++ b/src/uw_scan/cards/exposures.py
@@ -1,0 +1,322 @@
+"""Per-(expiry) derivations on raw greek-exposure rows.
+
+Pure functions: take ``list[GreekExposureRow]`` (already filtered to one expiry by
+the caller) and return derived summary values. No DB access — the assembler in
+``reports/`` owns the I/O, mirroring the ``cards/gex.py`` pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.models import ExposuresSummaryRow, GreekExposureRow
+
+log = logging.getLogger(__name__)
+
+
+NEUTRAL_VANNA_THRESHOLD = Decimal("1000")
+"""|net_vanna| below this is reported as 'neutral' regime."""
+
+NEUTRAL_CHARM_THRESHOLD = Decimal("1000")
+"""|net_charm| below this is reported as 'flat' / 'mixed' signal quality."""
+
+ONE_VOL_POINT = Decimal("0.01")
+"""UW vanna is dDelta per 1.0 of IV (decimal). 1pt IV move = 0.01."""
+
+
+# --- vanna helpers ---------------------------------------------------------
+
+
+def _per_strike_net_vanna(rows: list[GreekExposureRow]) -> dict[Decimal, Decimal]:
+    acc: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    for r in rows:
+        if r.call_vanna is not None:
+            acc[r.strike] += r.call_vanna
+        if r.put_vanna is not None:
+            acc[r.strike] += r.put_vanna
+    return dict(acc)
+
+
+def net_vanna(rows: list[GreekExposureRow]) -> Decimal | None:
+    """Σ (call_vanna + put_vanna) across every row. None when no inputs."""
+    if not rows:
+        return None
+    total = Decimal("0")
+    any_present = False
+    for r in rows:
+        if r.call_vanna is not None:
+            total += r.call_vanna
+            any_present = True
+        if r.put_vanna is not None:
+            total += r.put_vanna
+            any_present = True
+    return total if any_present else None
+
+
+def top_vanna_strike(
+    rows: list[GreekExposureRow],
+) -> tuple[Decimal, Decimal] | None:
+    """The (strike, net_vanna) pair with the largest |net_vanna|."""
+    per = _per_strike_net_vanna(rows)
+    if not per:
+        return None
+    strike = max(per.items(), key=lambda kv: abs(kv[1]))[0]
+    return strike, per[strike]
+
+
+def delta_shock_1pt_iv(rows: list[GreekExposureRow]) -> Decimal | None:
+    """Net Δ dealers must hedge if IV rises 1 vol-point."""
+    nv = net_vanna(rows)
+    if nv is None:
+        return None
+    return nv * ONE_VOL_POINT
+
+
+def vanna_regime(net_vanna_value: Decimal | None) -> str:
+    """`procyclical` / `countercyclical` / `neutral`."""
+    if net_vanna_value is None:
+        return "neutral"
+    if abs(net_vanna_value) < NEUTRAL_VANNA_THRESHOLD:
+        return "neutral"
+    return "procyclical" if net_vanna_value > 0 else "countercyclical"
+
+
+def vanna_flip(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> Decimal | None:
+    """Strike where running cumulative net_vanna changes sign.
+
+    Iterates strikes ascending and collects EVERY sign-flip strike. Spec asks
+    for the lowest sign-flip ≥ spot; fall back to the absolute lowest flip
+    when no flip is at/above spot (or when spot is unknown).
+    """
+    if not rows:
+        return None
+    per = _per_strike_net_vanna(rows)
+    if not per:
+        return None
+    flips: list[Decimal] = []
+    cum = Decimal("0")
+    prev_sign = 0
+    for strike, val in sorted(per.items(), key=lambda kv: kv[0]):
+        cum += val
+        sign = (cum > 0) - (cum < 0)
+        if prev_sign != 0 and sign != 0 and sign != prev_sign:
+            flips.append(strike)
+        if sign != 0:
+            prev_sign = sign
+    if not flips:
+        return None
+    if spot is None:
+        return flips[0]
+    above = [s for s in flips if s >= spot]
+    return above[0] if above else flips[0]
+
+
+def vanna_narrative(
+    net_vanna_value: Decimal | None,
+    regime: str,
+) -> tuple[str, str]:
+    """Deterministic headline + subtitle keyed off net sign and regime."""
+    if net_vanna_value is None or regime == "neutral":
+        return (
+            "Neutral Vanna — IV moves have limited dealer-Δ impact",
+            "Net vanna positioning is balanced; dealer hedging is not a strong driver.",
+        )
+    if net_vanna_value > 0:
+        return (
+            "Long Vanna — IV spikes pressure stock lower via dealer selling",
+            "If IV rises, dealers gain delta and will likely sell stock to rehedge — a headwind during vol spikes.",
+        )
+    return (
+        "Short Vanna — IV spikes support stock via dealer buying",
+        "If IV rises, dealers lose delta and will likely buy stock to rehedge — a tailwind during vol spikes.",
+    )
+
+
+# --- charm helpers ---------------------------------------------------------
+
+
+def _per_strike_net_charm(rows: list[GreekExposureRow]) -> dict[Decimal, Decimal]:
+    acc: dict[Decimal, Decimal] = defaultdict(lambda: Decimal("0"))
+    for r in rows:
+        if r.call_charm is not None:
+            acc[r.strike] += r.call_charm
+        if r.put_charm is not None:
+            acc[r.strike] += r.put_charm
+    return dict(acc)
+
+
+def net_charm(rows: list[GreekExposureRow]) -> Decimal | None:
+    if not rows:
+        return None
+    total = Decimal("0")
+    any_present = False
+    for r in rows:
+        if r.call_charm is not None:
+            total += r.call_charm
+            any_present = True
+        if r.put_charm is not None:
+            total += r.put_charm
+            any_present = True
+    return total if any_present else None
+
+
+def charm_pin_strike(rows: list[GreekExposureRow]) -> Decimal | None:
+    per = _per_strike_net_charm(rows)
+    if not per:
+        return None
+    return max(per.items(), key=lambda kv: abs(kv[1]))[0]
+
+
+def charm_imbalance(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> tuple[Decimal, Decimal, Decimal | None]:
+    """(above_sum, below_sum, imbalance_pct).
+
+    above_sum = Σ net_charm for strikes > spot.
+    below_sum = Σ net_charm for strikes < spot.
+    imbalance_pct = |above - below| / (|above| + |below|) — 0.0 balanced, 1.0 fully one-sided.
+    """
+    if spot is None:
+        return Decimal("0"), Decimal("0"), None
+    above = Decimal("0")
+    below = Decimal("0")
+    per = _per_strike_net_charm(rows)
+    for strike, val in per.items():
+        if strike > spot:
+            above += val
+        elif strike < spot:
+            below += val
+    denom = abs(above) + abs(below)
+    imb = (abs(above - below) / denom) if denom != 0 else None
+    return above, below, imb
+
+
+def charm_signal_quality(live: Decimal | None, positioning: Decimal | None) -> str:
+    """`aligned` when same sign + nonzero; `mixed` opposing; `weak` either near 0."""
+    if live is None or positioning is None:
+        return "weak"
+    if (
+        abs(live) < NEUTRAL_CHARM_THRESHOLD
+        or abs(positioning) < NEUTRAL_CHARM_THRESHOLD
+    ):
+        return "weak"
+    same_sign = (live > 0 and positioning > 0) or (live < 0 and positioning < 0)
+    return "aligned" if same_sign else "mixed"
+
+
+def charm_flip(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> Decimal | None:
+    """Same selection rule as vanna_flip: lowest sign-flip ≥ spot, fallback to lowest."""
+    if not rows:
+        return None
+    per = _per_strike_net_charm(rows)
+    if not per:
+        return None
+    flips: list[Decimal] = []
+    cum = Decimal("0")
+    prev_sign = 0
+    for strike, val in sorted(per.items(), key=lambda kv: kv[0]):
+        cum += val
+        sign = (cum > 0) - (cum < 0)
+        if prev_sign != 0 and sign != 0 and sign != prev_sign:
+            flips.append(strike)
+        if sign != 0:
+            prev_sign = sign
+    if not flips:
+        return None
+    if spot is None:
+        return flips[0]
+    above = [s for s in flips if s >= spot]
+    return above[0] if above else flips[0]
+
+
+def charm_narrative(
+    net_charm_value: Decimal | None,
+    signal_quality: str,
+) -> tuple[str, str]:
+    if net_charm_value is None or signal_quality == "weak":
+        return (
+            "Limited charm pressure into the close",
+            "Net charm positioning is balanced or thin; mechanical hedging pressure is muted.",
+        )
+    if net_charm_value < 0:
+        return (
+            "Mechanical SELL pressure into the close",
+            "Dealer sell pressure may cap rallies as theta drives delta unwind.",
+        )
+    return (
+        "Mechanical BUY pressure into the close",
+        "Dealer buy pressure may support the tape as theta drives delta accumulation.",
+    )
+
+
+# --- top-level builder -----------------------------------------------------
+
+
+def build_summary_rows(
+    rows: list[GreekExposureRow],
+    spot: Decimal | None,
+) -> list[ExposuresSummaryRow]:
+    """Group rows by expiry; for each expiry, compute the full summary tuple."""
+    if not rows:
+        return []
+
+    # Group by expiry ONLY — the table PK is (run_id, ticker, expiry) so
+    # multiple (expiry, dte) groups would collide on upsert. UW occasionally
+    # returns mixed dte values for the same expiry across strikes (rounding,
+    # late-day refresh boundaries); take the min non-null dte per expiry.
+    by_expiry: dict[date, list[GreekExposureRow]] = defaultdict(list)
+    for r in rows:
+        by_expiry[r.expiry].append(r)
+
+    out: list[ExposuresSummaryRow] = []
+    for expiry, grp in sorted(by_expiry.items(), key=lambda kv: kv[0]):
+        dtes = [r.dte for r in grp if r.dte is not None]
+        dte = min(dtes) if dtes else None
+        nv = net_vanna(grp)
+        top = top_vanna_strike(grp)
+        v_regime = vanna_regime(nv)
+        v_flip = vanna_flip(grp, spot)
+        v_head, v_sub = vanna_narrative(nv, v_regime)
+
+        nc = net_charm(grp)
+        pin = charm_pin_strike(grp)
+        above, below, imb = charm_imbalance(grp, spot)
+        c_quality = charm_signal_quality(live=nc, positioning=above - below)
+        c_flip = charm_flip(grp, spot)
+        c_head, c_sub = charm_narrative(nc, c_quality)
+
+        out.append(
+            ExposuresSummaryRow(
+                expiry=expiry,
+                dte=dte,
+                spot=spot,
+                net_vanna=nv,
+                top_vanna_strike=top[0] if top else None,
+                top_vanna_value=top[1] if top else None,
+                delta_shock_1pt_iv=delta_shock_1pt_iv(grp),
+                vanna_regime=v_regime,
+                vanna_flip=v_flip,
+                vanna_headline=v_head,
+                vanna_subtitle=v_sub,
+                net_charm=nc,
+                charm_pin_strike=pin,
+                charm_above_sum=above,
+                charm_below_sum=below,
+                charm_imbalance_pct=imb,
+                charm_signal_quality=c_quality,
+                charm_flip=c_flip,
+                charm_headline=c_head,
+                charm_subtitle=c_sub,
+            )
+        )
+    return out

--- a/src/uw_scan/models/__init__.py
+++ b/src/uw_scan/models/__init__.py
@@ -72,11 +72,13 @@ from .scanner import (
     BulkScreenerRow,
     EtfInfo,
     EtfInOutflowRow,
+    ExposuresSummaryRow,
     GexLevel,
     MarketAggregates,
     MarketStructureLevels,
     ScanReport,
     ScanTickerResult,
+    StrikeExposureRow,
     StrikeGexBucket,
 )
 from .stock import (
@@ -208,6 +210,8 @@ __all__ = [
     "ScanReport",
     "MarketAggregates",
     "StrikeGexBucket",
+    "StrikeExposureRow",
+    "ExposuresSummaryRow",
     "GexLevel",
     "MarketStructureLevels",
     "StockHistoryRow",

--- a/src/uw_scan/models/__init__.py
+++ b/src/uw_scan/models/__init__.py
@@ -56,7 +56,12 @@ from .gold import (
     GoldValuationPostureModel,
     PostureChipState,
 )
-from .greeks import GreekExposureRow, GreeksRow, SpotExposureRow
+from .greeks import (
+    GreekExposureByExpiryRow,
+    GreekExposureRow,
+    GreeksRow,
+    SpotExposureRow,
+)
 from .matrix import MatrixSourceFreshness, MatrixState, SetupClassification
 from .options import (
     MaxPainRow,
@@ -168,6 +173,7 @@ __all__ = [
     "InterpolatedIvRow",
     "SkewRow",
     "GreekExposureRow",
+    "GreekExposureByExpiryRow",
     "SpotExposureRow",
     "GreeksRow",
     "OiPerStrikeRow",

--- a/src/uw_scan/models/greeks.py
+++ b/src/uw_scan/models/greeks.py
@@ -22,6 +22,28 @@ class GreekExposureRow(_UwBase):
     call_charm: Decimal | None = None
     put_charm: Decimal | None = None
 
+
+class GreekExposureByExpiryRow(_UwBase):
+    """Aggregated greek exposure for one expiry across all strikes.
+
+    Returned by /api/stock/{ticker}/greek-exposure/expiry — gives the full
+    term structure in one call, but without per-strike granularity. Used for
+    the multi-expiry dropdown on the Vanna/Charm sub-tabs.
+    """
+
+    date: _date
+    expiry: _date
+    dte: int | None = None
+    call_delta: Decimal | None = None
+    put_delta: Decimal | None = None
+    call_gex: Decimal | None = None
+    put_gex: Decimal | None = None
+    call_vanna: Decimal | None = None
+    put_vanna: Decimal | None = None
+    call_charm: Decimal | None = None
+    put_charm: Decimal | None = None
+
+
 class SpotExposureRow(_UwBase):
     ticker: str
     date: _date
@@ -37,6 +59,7 @@ class SpotExposureRow(_UwBase):
     put_vanna_oi: Decimal | None = None
     call_charm_oi: Decimal | None = None
     put_charm_oi: Decimal | None = None
+
 
 class GreeksRow(_UwBase):
     date: _date
@@ -64,6 +87,7 @@ class GreeksRow(_UwBase):
 
 _preserve_public_module(
     GreekExposureRow,
+    GreekExposureByExpiryRow,
     SpotExposureRow,
     GreeksRow,
 )

--- a/src/uw_scan/models/scanner.py
+++ b/src/uw_scan/models/scanner.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from datetime import date as _date
+from datetime import datetime
 from decimal import Decimal
 
 from ._base import _preserve_public_module, _UwBase
@@ -77,11 +77,13 @@ class BulkScreenerRow(_UwBase):
     cum_dir_gamma: int | None = None
     cum_dir_vega: int | None = None
 
+
 class EtfInfo(_UwBase):
     aum: Decimal | None = None
     name: str | None = None
     avg30_volume: Decimal | None = None
     has_options: bool | None = None
+
 
 class EtfInOutflowRow(_UwBase):
     ticker: str
@@ -92,6 +94,7 @@ class EtfInOutflowRow(_UwBase):
     volume: Decimal | None = None
     expiration_cycle: str | None = None
     is_fomc: bool | None = None
+
 
 class ScanTickerResult(_UwBase):
     """One row in the Full Scan output. Ranked by `score` desc."""
@@ -117,6 +120,7 @@ class ScanTickerResult(_UwBase):
     notes: str = ""
     screener_row: BulkScreenerRow | None = None
 
+
 class ScanReport(_UwBase):
     run_id: int
     generated_at: datetime
@@ -126,6 +130,7 @@ class ScanReport(_UwBase):
     results: list[ScanTickerResult] = []
     dropped_tickers: list[str] = []
     top_pick: str | None = None
+
 
 class MarketAggregates(_UwBase):
     """Per-ticker aggregate fields sourced from the bulk-screener endpoint.
@@ -148,6 +153,7 @@ class MarketAggregates(_UwBase):
     market_cap: Decimal | None = None
     aum: Decimal | None = None
 
+
 class StrikeGexBucket(_UwBase):
     """One row of the per-strike, per-expiry GEX curve persisted on each scan run."""
 
@@ -156,6 +162,50 @@ class StrikeGexBucket(_UwBase):
     net_gex: Decimal | None = None
     call_gex: Decimal | None = None
     put_gex: Decimal | None = None
+
+
+class StrikeExposureRow(_UwBase):
+    """One per-(expiry, strike) raw row from exposures_by_expiry_strike,
+    carrying the call/put split for vanna and charm so the FE can render
+    Net + Call/Put curves without an extra fetch."""
+
+    strike: Decimal
+    expiry: _date
+    dte: int | None = None
+    call_vanna: Decimal | None = None
+    put_vanna: Decimal | None = None
+    call_charm: Decimal | None = None
+    put_charm: Decimal | None = None
+
+
+class ExposuresSummaryRow(_UwBase):
+    """Per-(expiry) derived summary used to drive the Vanna/Charm sub-tab
+    headline narrative + 4 tiles. Computed by cards/exposures.py and
+    persisted to uw_scan.exposures_summary."""
+
+    expiry: _date
+    dte: int | None = None
+    spot: Decimal | None = None
+    # Vanna ---
+    net_vanna: Decimal | None = None
+    top_vanna_strike: Decimal | None = None
+    top_vanna_value: Decimal | None = None
+    delta_shock_1pt_iv: Decimal | None = None
+    vanna_regime: str | None = None
+    vanna_flip: Decimal | None = None
+    vanna_headline: str | None = None
+    vanna_subtitle: str | None = None
+    # Charm ---
+    net_charm: Decimal | None = None
+    charm_pin_strike: Decimal | None = None
+    charm_above_sum: Decimal | None = None
+    charm_below_sum: Decimal | None = None
+    charm_imbalance_pct: Decimal | None = None
+    charm_signal_quality: str | None = None
+    charm_flip: Decimal | None = None
+    charm_headline: str | None = None
+    charm_subtitle: str | None = None
+
 
 class GexLevel(_UwBase):
     """One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).
@@ -168,6 +218,7 @@ class GexLevel(_UwBase):
     net_gex: Decimal | None = None
     pct_from_spot: Decimal | None = None
     gamma_per_dollar: Decimal | None = None
+
 
 class MarketStructureLevels(_UwBase):
     """Derived strike-level reference points used by the Market Structure tab.
@@ -197,6 +248,8 @@ _preserve_public_module(
     ScanReport,
     MarketAggregates,
     StrikeGexBucket,
+    StrikeExposureRow,
+    ExposuresSummaryRow,
     GexLevel,
     MarketStructureLevels,
 )

--- a/src/uw_scan/models/stock.py
+++ b/src/uw_scan/models/stock.py
@@ -16,7 +16,13 @@ from .options import (
     OptionIntradayProfile,
     OptionsDailyRow,
 )
-from .scanner import MarketAggregates, MarketStructureLevels, StrikeGexBucket
+from .scanner import (
+    ExposuresSummaryRow,
+    MarketAggregates,
+    MarketStructureLevels,
+    StrikeExposureRow,
+    StrikeGexBucket,
+)
 
 
 class MarketStructure(_UwBase):
@@ -121,6 +127,8 @@ class SingleStockReport(_UwBase):
     market_structure_levels: MarketStructureLevels | None = None
     options_timeline: list[OptionsDailyRow] = []
     option_chain_per_strike: list[OptionChainPerStrikeRow] = []
+    strike_exposures: list[StrikeExposureRow] = []
+    exposures_summary: list[ExposuresSummaryRow] = []
     # Promoted from FlowAlert.next_earnings_date so the Volume-timeline panel
     # can render the earnings marker without iterating alerts on the client.
     next_earnings_date: _date | None = None

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -14,6 +14,7 @@ from .models import (
     EtfInfo,
     EtfInOutflowRow,
     FlowAlert,
+    GreekExposureByExpiryRow,
     GreekExposureRow,
     GreeksRow,
     InterpolatedIvRow,
@@ -107,6 +108,13 @@ def normalize_skew(payload: dict, expiry_hint: str | None = None) -> list[SkewRo
 def normalize_greek_exposure(payload: dict) -> list[GreekExposureRow]:
     rows = _data_list(payload)
     return [GreekExposureRow(**r) for r in rows]
+
+
+def normalize_greek_exposure_by_expiry(
+    payload: dict,
+) -> list[GreekExposureByExpiryRow]:
+    rows = _data_list(payload)
+    return [GreekExposureByExpiryRow(**r) for r in rows]
 
 
 def normalize_spot_exposures(payload: dict) -> list[SpotExposureRow]:

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -163,11 +163,13 @@ def run_single_stock(
             alert_limit=FLOW_ALERT_LIMIT,
         )
 
-        # 2. IV rank (time series)
-        iv_rank_rows = uw_sources.fetch_iv_rank(client, repo, run_id, ticker)
-        repo.upsert_iv_rank_rows(ticker, iv_rank_rows)
-
-        # 3. Vol stats
+        # 2. Vol stats (also supplies the 1y IV rank — verified empirically that
+        # /volatility/stats.iv_rank == /iv-rank.iv_rank_1y to 4 decimals across
+        # tickers, so the dedicated /iv-rank call was redundant for the stock
+        # detail report. cockpit_daily_snapshot.py still calls fetch_iv_rank for
+        # SPX/SPY/QQQ/IWM where the trailing series feeds the cockpit history
+        # chart; non-cockpit tickers no longer maintain iv_rank_history rows but
+        # no code reads from that table for them. Saves 1 UW call per rescan.
         vol_stats_rows = uw_sources.fetch_volatility_stats(client, repo, run_id, ticker)
         repo.upsert_volatility_stats_rows(vol_stats_rows)
 
@@ -273,17 +275,13 @@ def run_single_stock(
         market_date = _date.today()
         repo.insert_max_pain_rows(run_id, ticker, market_date, max_pain_rows)
 
-        # 14. Option contracts (broad)
+        # 14. Option contracts (broad). The earlier re-fetch via
+        # /option-contracts?option_symbol[]=... was removed because it hit the
+        # same endpoint and returned the identical rows already in `contracts`
+        # — see normalize.normalize_option_contracts_by_symbol ("Same shape as
+        # option_contracts"). Saves 1 UW call per rescan.
         contracts = uw_sources.fetch_option_contracts(client, repo, run_id, ticker)
         repo.insert_option_contract_rows(run_id, ticker, contracts)
-
-        # 15. Option contracts by symbol (pick 2 ATM contracts from previous batch)
-        if contracts:
-            picks = [c.option_symbol for c in contracts[:2]]
-            refined = uw_sources.fetch_option_contracts_by_symbol(
-                client, repo, run_id, ticker, picks
-            )
-            repo.insert_option_contract_rows(run_id, ticker, refined)
 
         # 16. Dark pool
         dp_rows = uw_sources.fetch_darkpool_ticker(client, repo, run_id, ticker)

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -15,6 +15,7 @@ import psycopg
 
 from . import normalize, scoring
 from .api.client import LiveDataUnavailable, UwClient
+from .cards import exposures as cards_exposures
 from .config import Settings
 from .models import MarketAggregates, ScanReport, ScanTickerResult, SingleStockReport
 from .reports.scan import assemble_scan_report
@@ -41,6 +42,32 @@ FLOW_ALERT_LIMIT = 100
 # A1 from backend code review addendum: cache ETF AUM lookups to skip the
 # per-scan /etf_info UW round trip. AUM moves weekly at most.
 ETF_AUM_TTL = timedelta(days=7)
+
+
+def _safe_spot_for_derive(repo: Repository, ticker: str) -> Decimal | None:
+    """Spot for vanna/charm derivers. Prefer the intraday quote; fall back to
+    the realized-vol latest price (same source `_build_market_structure` uses).
+    Reject 0/negative/non-finite values — they corrupt charm imbalance and FE
+    "% from spot" calculations."""
+
+    def _coerce(value) -> Decimal | None:
+        if value is None:
+            return None
+        try:
+            d = Decimal(str(value))
+        except (TypeError, ValueError) as exc:
+            logger.debug("safe_spot coercion skipped: %s", repr(exc))
+            return None
+        if not d.is_finite() or d <= 0:
+            return None
+        return d
+
+    quote = repo.get_intraday_quote(ticker)
+    spot = _coerce(quote.price if quote is not None else None)
+    if spot is None:
+        rv = repo.fetch_realized_vol_latest(ticker) or {}
+        spot = _coerce(rv.get("price"))
+    return spot
 
 
 @lru_cache(maxsize=1)
@@ -191,6 +218,19 @@ def run_single_stock(
                 }
             )
         repo.set_strike_gex_curve(run_id, curve)
+
+        # 8c. Vanna/Charm derived summary per expiry (raw rows already in step 8).
+        if ge_rows:
+            spot_for_derive = _safe_spot_for_derive(repo, ticker)
+            summary_rows = cards_exposures.build_summary_rows(
+                list(ge_rows), spot=spot_for_derive
+            )
+            repo.upsert_exposures_summary(
+                run_id=run_id,
+                ticker=ticker,
+                market_date=_date.today(),
+                rows=summary_rows,
+            )
 
         # 9. Spot exposures (we already persisted in 8 via exposures table; spot row stored only as raw + audit)
         _ = uw_sources.fetch_spot_exposures(client, repo, run_id, ticker, expiry_str)

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -219,17 +219,37 @@ def run_single_stock(
             )
         repo.set_strike_gex_curve(run_id, curve)
 
-        # 8c. Vanna/Charm derived summary per expiry (raw rows already in step 8).
+        # 8c. Multi-expiry vanna/charm summary. One call to /greek-exposure/expiry
+        # gives aggregates for the full term structure; we upsert aggregate-only
+        # rows for all expiries first, then the strike-detail pass below
+        # overwrites the nearest expiry with strike-derived fields (top strike,
+        # vanna_flip, charm pin/imbalance/flip, signal_quality).
+        spot_for_derive = _safe_spot_for_derive(repo, ticker)
+        agg_rows = uw_sources.fetch_greek_exposure_by_expiry(
+            client, repo, run_id, ticker
+        )
+        if agg_rows:
+            agg_summary_rows = cards_exposures.build_summary_rows_from_aggregate(
+                list(agg_rows), spot=spot_for_derive
+            )
+            repo.upsert_exposures_summary(
+                run_id=run_id,
+                ticker=ticker,
+                market_date=_date.today(),
+                rows=agg_summary_rows,
+            )
+
+        # 8d. Strike-detail pass: overwrites the nearest expiry's row with the
+        # strike-derived fields that the aggregate endpoint can't provide.
         if ge_rows:
-            spot_for_derive = _safe_spot_for_derive(repo, ticker)
-            summary_rows = cards_exposures.build_summary_rows(
+            strike_summary_rows = cards_exposures.build_summary_rows(
                 list(ge_rows), spot=spot_for_derive
             )
             repo.upsert_exposures_summary(
                 run_id=run_id,
                 ticker=ticker,
                 market_date=_date.today(),
-                rows=summary_rows,
+                rows=strike_summary_rows,
             )
 
         # 9. Spot exposures (we already persisted in 8 via exposures table; spot row stored only as raw + audit)

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -166,7 +166,6 @@ def _build_market_structure(
 def build_volatility_profile(
     repo: Repository, run_id: int, ticker: str
 ) -> VolatilityProfile:
-    iv_rank_row = repo.fetch_iv_rank_latest(ticker) or {}
     vol_stats = repo.fetch_volatility_stats_latest(ticker) or {}
     realized = repo.fetch_realized_vol_latest(ticker) or {}
     interp = repo.fetch_interpolated_iv_30d(run_id, ticker) or {}
@@ -189,7 +188,10 @@ def build_volatility_profile(
         or _to_decimal(realized.get("realized_volatility")),
         rv_low_52w=_to_decimal(vol_stats.get("rv_low")),
         rv_high_52w=_to_decimal(vol_stats.get("rv_high")),
-        iv_rank_1y=_to_decimal(iv_rank_row.get("iv_rank_1y")),
+        # iv_rank from /volatility/stats is empirically equal to iv_rank_1y from
+        # the legacy /iv-rank endpoint — same number, different label. Sourcing
+        # both fields from vol_stats lets us drop the /iv-rank fetch entirely.
+        iv_rank_1y=_to_decimal(vol_stats.get("iv_rank")),
         iv_percentile_30d=_to_decimal(interp.get("percentile")),
         implied_move_30d_perc=_to_decimal(interp.get("implied_move_perc")),
         skew_25d=_to_decimal(skew.get("risk_reversal")),

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -124,7 +124,7 @@ def _build_flow_snapshot(
 def _build_market_structure(
     repo: Repository, run_id: int, ticker: str, max_pain_rows: list[MaxPainRow]
 ) -> MarketStructure:
-    exposures = repo.fetch_exposures_summary(run_id, ticker) or {}
+    exposures = repo.fetch_exposures_aggregate(run_id, ticker) or {}
     total_call_gex = _to_decimal(exposures.get("total_call_gex"))
     total_put_gex = _to_decimal(exposures.get("total_put_gex"))
     net_gex = None

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from ..cards.gex import compute_market_structure_levels
 from ..cards.intraday_profile import derive_intraday_profile
 from ..models import (
+    ExposuresSummaryRow,
     FlowAlert,
     FlowSnapshot,
     MarketStructure,
@@ -21,6 +22,7 @@ from ..models import (
     OptionIntradayProfile,
     ShortDataRow,
     SingleStockReport,
+    StrikeExposureRow,
     StrikeGexBucket,
     TradePlan,
     TradePlanLeg,
@@ -476,6 +478,53 @@ def assemble_single_stock_report(
 
     options_timeline = repo.get_options_timeline(ticker, lookback_days=180)
     option_chain_per_strike = repo.get_option_chain_per_strike(ticker)
+
+    strike_exp_raw = repo.fetch_strike_exposures(run_id, ticker)
+    # `strike` and `expiry` are NOT NULL in exposures_by_expiry_strike + are
+    # projected non-null by the fetcher. Use [...] indexing (not .get) so a
+    # missing key fails loudly with a KeyError at the row, rather than producing
+    # a Pydantic ValidationError that aborts the entire report assembly.
+    strike_exposures = [
+        StrikeExposureRow(
+            strike=Decimal(str(row["strike"])),
+            expiry=row["expiry"],
+            dte=row.get("dte"),
+            call_vanna=_to_decimal(row.get("call_vanna")),
+            put_vanna=_to_decimal(row.get("put_vanna")),
+            call_charm=_to_decimal(row.get("call_charm")),
+            put_charm=_to_decimal(row.get("put_charm")),
+        )
+        for row in strike_exp_raw
+        if row.get("strike") is not None
+    ]
+
+    summary_raw = repo.fetch_exposures_summary(run_id, ticker)
+    exposures_summary = [
+        ExposuresSummaryRow(
+            expiry=row["expiry"],
+            dte=row.get("dte"),
+            spot=_to_decimal(row.get("spot")),
+            net_vanna=_to_decimal(row.get("net_vanna")),
+            top_vanna_strike=_to_decimal(row.get("top_vanna_strike")),
+            top_vanna_value=_to_decimal(row.get("top_vanna_value")),
+            delta_shock_1pt_iv=_to_decimal(row.get("delta_shock_1pt_iv")),
+            vanna_regime=row.get("vanna_regime"),
+            vanna_flip=_to_decimal(row.get("vanna_flip")),
+            vanna_headline=row.get("vanna_headline"),
+            vanna_subtitle=row.get("vanna_subtitle"),
+            net_charm=_to_decimal(row.get("net_charm")),
+            charm_pin_strike=_to_decimal(row.get("charm_pin_strike")),
+            charm_above_sum=_to_decimal(row.get("charm_above_sum")),
+            charm_below_sum=_to_decimal(row.get("charm_below_sum")),
+            charm_imbalance_pct=_to_decimal(row.get("charm_imbalance_pct")),
+            charm_signal_quality=row.get("charm_signal_quality"),
+            charm_flip=_to_decimal(row.get("charm_flip")),
+            charm_headline=row.get("charm_headline"),
+            charm_subtitle=row.get("charm_subtitle"),
+        )
+        for row in summary_raw
+    ]
+
     # UW returns next_earnings_date per FlowAlert row; promote once.
     next_earnings_date = next(
         (
@@ -507,6 +556,8 @@ def assemble_single_stock_report(
         market_structure_levels=market_structure_levels,
         options_timeline=options_timeline,
         option_chain_per_strike=option_chain_per_strike,
+        strike_exposures=strike_exposures,
+        exposures_summary=exposures_summary,
         next_earnings_date=next_earnings_date,
     )
 

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -19,6 +19,7 @@ from ..models import (
     EtfInfo,
     EtfInOutflowRow,
     FlowAlert,
+    GreekExposureByExpiryRow,
     GreekExposureRow,
     GreeksRow,
     InterpolatedIvRow,
@@ -214,6 +215,29 @@ def fetch_greek_exposure(
         params={"expiry": expiry},
     )
     return normalize.normalize_greek_exposure(body)
+
+
+def fetch_greek_exposure_by_expiry(
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+) -> list[GreekExposureByExpiryRow]:
+    """Fetch /api/stock/{ticker}/greek-exposure/expiry — all expiries in one call.
+
+    Per-expiry aggregates across all strikes (call_vanna, put_vanna, call_charm,
+    put_charm, call_delta, put_delta, call_gex, put_gex, dte). No strike-level
+    granularity. Used to populate the multi-expiry Vanna/Charm dropdown without
+    incurring N × greek-exposure/strike-expiry calls.
+    """
+    body = _fetch_json(
+        client,
+        repo,
+        run_id,
+        EndpointSlug.GREEK_EXPOSURE_BY_EXPIRY,
+        ticker,
+    )
+    return normalize.normalize_greek_exposure_by_expiry(body)
 
 
 def fetch_greek_exposure_by_strike(

--- a/src/uw_scan/storage/fetchers.py
+++ b/src/uw_scan/storage/fetchers.py
@@ -8,7 +8,6 @@ from typing import Any
 import psycopg
 
 
-
 class _FetchersMixin:
     _conn: psycopg.Connection
     _schema: str
@@ -152,7 +151,7 @@ class _FetchersMixin:
             cols = [d.name for d in cur.description or []]
             return dict(zip(cols, row, strict=False))
 
-    def fetch_exposures_summary(
+    def fetch_exposures_aggregate(
         self, run_id: int, ticker: str
     ) -> dict[str, Any] | None:
         sql = (
@@ -171,6 +170,42 @@ class _FetchersMixin:
                 return None
             cols = [d.name for d in cur.description or []]
             return dict(zip(cols, row, strict=False))
+
+    def fetch_strike_exposures(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        """All per-(expiry, strike) raw rows for one run/ticker.
+
+        Includes the call/put vanna and charm split. Ordering by (expiry, strike)
+        is convenient for the FE but not strictly required.
+        """
+        sql = (
+            "SELECT expiry, strike, dte, "
+            "       call_vanna, put_vanna, call_charm, put_charm "
+            f"FROM {self._schema}.exposures_by_expiry_strike "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry, strike"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
+    def fetch_exposures_summary(self, run_id: int, ticker: str) -> list[dict[str, Any]]:
+        """Per-(expiry) derived summary rows persisted by build_summary_rows."""
+        sql = (
+            "SELECT expiry, dte, spot, "
+            "       net_vanna, top_vanna_strike, top_vanna_value, delta_shock_1pt_iv, "
+            "       vanna_regime, vanna_flip, vanna_headline, vanna_subtitle, "
+            "       net_charm, charm_pin_strike, charm_above_sum, charm_below_sum, "
+            "       charm_imbalance_pct, charm_signal_quality, charm_flip, "
+            "       charm_headline, charm_subtitle "
+            f"FROM {self._schema}.exposures_summary "
+            "WHERE run_id = %s AND ticker = %s "
+            "ORDER BY expiry"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (run_id, ticker))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
 
     def fetch_top_oi_strikes(
         self, ticker: str, limit: int = 5

--- a/src/uw_scan/storage/migrations/051_exposures_summary.sql
+++ b/src/uw_scan/storage/migrations/051_exposures_summary.sql
@@ -1,0 +1,48 @@
+-- 051_exposures_summary.sql
+-- Per-(expiry) derived summary used by the Vanna/Charm sub-tabs.
+-- One row per (run_id, ticker, expiry) — primary key. Idempotent.
+--
+-- run_id is BIGINT with FK ON DELETE CASCADE to match the convention used by
+-- every other run-keyed table in migration 001 (scan_runs.run_id is BIGSERIAL;
+-- INTEGER would overflow on long-running deployments and an orphan summary
+-- after scan-runs cleanup would be a data-integrity papercut).
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.exposures_summary (
+    run_id               BIGINT  NOT NULL
+                                 REFERENCES uw_scan.scan_runs(run_id) ON DELETE CASCADE,
+    ticker               TEXT    NOT NULL,
+    expiry               DATE    NOT NULL,
+    market_date          DATE    NOT NULL,
+    dte                  INTEGER,
+    spot                 NUMERIC,
+
+    -- Vanna ---
+    net_vanna            NUMERIC,
+    top_vanna_strike     NUMERIC,
+    top_vanna_value      NUMERIC,
+    delta_shock_1pt_iv   NUMERIC,
+    vanna_regime         TEXT,
+    vanna_flip           NUMERIC,
+    vanna_headline       TEXT,
+    vanna_subtitle       TEXT,
+
+    -- Charm ---
+    net_charm            NUMERIC,
+    charm_pin_strike     NUMERIC,
+    charm_above_sum      NUMERIC,
+    charm_below_sum      NUMERIC,
+    charm_imbalance_pct  NUMERIC,
+    charm_signal_quality TEXT,
+    charm_flip           NUMERIC,
+    charm_headline       TEXT,
+    charm_subtitle       TEXT,
+
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (run_id, ticker, expiry)
+);
+
+CREATE INDEX IF NOT EXISTS exposures_summary_ticker_date_idx
+    ON uw_scan.exposures_summary (ticker, market_date);

--- a/src/uw_scan/storage/options.py
+++ b/src/uw_scan/storage/options.py
@@ -211,6 +211,76 @@ class _OptionsMixin:
             cur.executemany(sql, params)
         return len(rows)
 
+    def upsert_exposures_summary(
+        self,
+        run_id: int,
+        ticker: str,
+        market_date: _date,
+        rows: Iterable[models.ExposuresSummaryRow],
+    ) -> int:
+        rows = list(rows)
+        if not rows:
+            return 0
+        sql = (
+            f"INSERT INTO {self._schema}.exposures_summary "
+            "(run_id, ticker, expiry, market_date, dte, spot, "
+            " net_vanna, top_vanna_strike, top_vanna_value, delta_shock_1pt_iv, "
+            " vanna_regime, vanna_flip, vanna_headline, vanna_subtitle, "
+            " net_charm, charm_pin_strike, charm_above_sum, charm_below_sum, "
+            " charm_imbalance_pct, charm_signal_quality, charm_flip, "
+            " charm_headline, charm_subtitle) "
+            "VALUES (%s, %s, %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, "
+            "        %s, %s, %s, %s, %s) "
+            "ON CONFLICT (run_id, ticker, expiry) DO UPDATE SET "
+            " market_date=EXCLUDED.market_date, dte=EXCLUDED.dte, spot=EXCLUDED.spot, "
+            " net_vanna=EXCLUDED.net_vanna, top_vanna_strike=EXCLUDED.top_vanna_strike, "
+            " top_vanna_value=EXCLUDED.top_vanna_value, "
+            " delta_shock_1pt_iv=EXCLUDED.delta_shock_1pt_iv, "
+            " vanna_regime=EXCLUDED.vanna_regime, vanna_flip=EXCLUDED.vanna_flip, "
+            " vanna_headline=EXCLUDED.vanna_headline, vanna_subtitle=EXCLUDED.vanna_subtitle, "
+            " net_charm=EXCLUDED.net_charm, charm_pin_strike=EXCLUDED.charm_pin_strike, "
+            " charm_above_sum=EXCLUDED.charm_above_sum, charm_below_sum=EXCLUDED.charm_below_sum, "
+            " charm_imbalance_pct=EXCLUDED.charm_imbalance_pct, "
+            " charm_signal_quality=EXCLUDED.charm_signal_quality, "
+            " charm_flip=EXCLUDED.charm_flip, "
+            " charm_headline=EXCLUDED.charm_headline, charm_subtitle=EXCLUDED.charm_subtitle, "
+            " computed_at=now()"
+        )
+        params = [
+            (
+                run_id,
+                ticker,
+                r.expiry,
+                market_date,
+                r.dte,
+                r.spot,
+                r.net_vanna,
+                r.top_vanna_strike,
+                r.top_vanna_value,
+                r.delta_shock_1pt_iv,
+                r.vanna_regime,
+                r.vanna_flip,
+                r.vanna_headline,
+                r.vanna_subtitle,
+                r.net_charm,
+                r.charm_pin_strike,
+                r.charm_above_sum,
+                r.charm_below_sum,
+                r.charm_imbalance_pct,
+                r.charm_signal_quality,
+                r.charm_flip,
+                r.charm_headline,
+                r.charm_subtitle,
+            )
+            for r in rows
+        ]
+        with self._conn.cursor() as cur:
+            cur.executemany(sql, params)
+        return len(rows)
+
     def upsert_oi_per_strike_rows(
         self, ticker: str, rows: Iterable[models.OiPerStrikeRow]
     ) -> int:

--- a/src/uw_scan/storage/scan_runs.py
+++ b/src/uw_scan/storage/scan_runs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-
 import psycopg
 from psycopg.types.json import Jsonb
 
@@ -16,17 +15,20 @@ class _ScanRunsMixin:
     def latest_run_id(self, ticker: str) -> int:
         """Return the highest full-scan run_id for `ticker`, or 0 if none.
 
-        Excludes runs created by ``flow_data_refresh`` — that job populates
-        ticker-keyed tables only (options_volume_daily, option_chain_per_strike)
-        and its scan_runs row would otherwise shadow the actual full-scan run
-        the report assembler needs for flow_alerts / oi_change_top / GEX /
-        volatility data, which are all keyed by run_id.
+        Excludes runs created by side-channel jobs that populate only a
+        narrow slice of tables and would otherwise shadow the actual
+        full-scan run the report assembler needs (flow_alerts, oi_change_top,
+        GEX, volatility — all keyed by run_id). Excluded:
+
+        - ``flow_data_refresh`` (writes options_volume_daily + option_chain only)
+        - ``gex_scan_*`` (SPX/SPY index-only GEX scanner running every 5 min)
         """
         with self._conn.cursor() as cur:
             cur.execute(
                 f"SELECT run_id FROM {self._schema}.scan_runs "
                 "WHERE ticker = %s "
                 "  AND (notes IS DISTINCT FROM 'flow_data_refresh') "
+                "  AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%') "
                 "ORDER BY run_id DESC LIMIT 1",
                 (ticker.upper(),),
             )

--- a/src/uw_scan/worker/jobs/cockpit_daily_snapshot.py
+++ b/src/uw_scan/worker/jobs/cockpit_daily_snapshot.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 import psycopg
 
 from uw_scan.api.client import UwClient
+from uw_scan.cards import exposures as cards_exposures
 from uw_scan.cards.matrix_state import build_matrix_state
 from uw_scan.cards.option_chain import aggregate_chain_per_strike, pick_target_expiries
 from uw_scan.config import Settings
@@ -163,6 +165,53 @@ def _snapshot_ticker(
         )
         return
 
+    # Spot for vanna/charm derivers — None is acceptable; deriver handles it.
+    # Reject 0/negative/non-finite values so downstream % calcs don't produce
+    # Infinity. Fall back to RV latest price when the intraday quote is missing.
+    quote = repo.get_intraday_quote(ticker)
+    spot_for_derive: Decimal | None = _safe_spot(
+        quote.price if quote is not None else None
+    )
+    if spot_for_derive is None:
+        rv = repo.fetch_realized_vol_latest(ticker) or {}
+        spot_for_derive = _safe_spot(rv.get("price"))
+
+    _persist_greeks_per_expiry(
+        client=client,
+        repo=repo,
+        run_id=run_id,
+        ticker=ticker,
+        market_date=market_date,
+        expiries=expiries,
+        spot_for_derive=spot_for_derive,
+    )
+
+
+def _safe_spot(value) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        d = Decimal(str(value))
+    except (TypeError, ValueError) as exc:
+        logger.debug("safe_spot coercion skipped: %s", repr(exc))
+        return None
+    if not d.is_finite() or d <= 0:
+        return None
+    return d
+
+
+def _persist_greeks_per_expiry(
+    *,
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+    market_date,
+    expiries: list,
+    spot_for_derive: Decimal | None,
+) -> None:
+    """Per-expiry fetch + persist of greeks, greek-exposure, skew, and the
+    derived ``exposures_summary`` row that powers the Vanna/Charm sub-tabs."""
     for expiry in expiries:
         expiry_iso = expiry.isoformat()
 
@@ -175,13 +224,26 @@ def _snapshot_ticker(
         skew_rows = fetch_skew(client, repo, run_id, ticker, expiry_iso, delta=25)
         n_s = repo.upsert_skew_rows(ticker, skew_rows)
 
+        n_sum = 0
+        if exposure_rows:
+            summary_rows = cards_exposures.build_summary_rows(
+                list(exposure_rows), spot=spot_for_derive
+            )
+            n_sum = repo.upsert_exposures_summary(
+                run_id=run_id,
+                ticker=ticker,
+                market_date=market_date,
+                rows=summary_rows,
+            )
+
         logger.info(
-            "cockpit_daily_snapshot: %s exp=%s greeks=%d exposures=%d skew=%d",
+            "cockpit_daily_snapshot: %s exp=%s greeks=%d exposures=%d skew=%d summary=%d",
             ticker,
             expiry_iso,
             n_g,
             n_e,
             n_s,
+            n_sum,
         )
 
 

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -1,13829 +1,14161 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "UW Watchlist API",
-    "version": "0.1.0"
-  },
-  "paths": {
-    "/api/health": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "Health",
-        "operationId": "health_api_health_get",
-        "parameters": [
-          {
-            "name": "source",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "uw",
-                "massive"
-              ],
-              "type": "string",
-              "default": "uw",
-              "title": "Source"
-            }
-          },
-          {
-            "name": "record_window_hours",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "number",
-                  "maximum": 168,
-                  "minimum": 0.1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Record Window Hours"
-            }
-          },
-          {
-            "name": "record_min_coverage",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number",
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "default": 0.9,
-              "title": "Record Min Coverage"
-            }
-          },
-          {
-            "name": "record_tables",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Record Tables"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HealthResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
+    "openapi": "3.1.0",
+    "info": {
+        "title": "UW Watchlist API",
+        "version": "0.1.0"
     },
-    "/api/watchlist": {
-      "get": {
-        "tags": [
-          "watchlist"
-        ],
-        "summary": "Get Watchlist",
-        "operationId": "get_watchlist_api_watchlist_get",
-        "parameters": [
-          {
-            "name": "sector",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Sector"
-            }
-          },
-          {
-            "name": "setup",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'",
-              "title": "Setup"
-            },
-            "description": "e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'"
-          },
-          {
-            "name": "fresh_within_minutes",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 1
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Fresh Within Minutes"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WatchlistResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "watchlist"
-        ],
-        "summary": "Post Watchlist",
-        "operationId": "post_watchlist_api_watchlist_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WatchlistMutation"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Post Watchlist Api Watchlist Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/watchlist/queue": {
-      "get": {
-        "tags": [
-          "watchlist"
-        ],
-        "summary": "Get Watchlist Queue",
-        "description": "Lightweight queue snapshot for the dashboard's QueueProgress widget.\n\nReturns only the rescan-queue summary \u2014 no card joins, no meta. Designed\nfor the 2.5s polling loop in QueueProgress so the dashboard doesn't\nrefetch the full watchlist payload every tick.",
-        "operationId": "get_watchlist_queue_api_watchlist_queue_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueSummary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/watchlist/{ticker}": {
-      "delete": {
-        "tags": [
-          "watchlist"
-        ],
-        "summary": "Delete Watchlist",
-        "operationId": "delete_watchlist_api_watchlist__ticker__delete",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "watchlist"
-        ],
-        "summary": "Patch Watchlist",
-        "operationId": "patch_watchlist_api_watchlist__ticker__patch",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WatchlistPatch"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Patch Watchlist Api Watchlist  Ticker  Patch"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}": {
-      "get": {
-        "tags": [
-          "stock"
-        ],
-        "summary": "Get Stock",
-        "operationId": "get_stock_api_stock__ticker__get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SingleStockReport"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/history": {
-      "get": {
-        "tags": [
-          "stock"
-        ],
-        "summary": "Get Stock History",
-        "description": "Daily rollup for the Market Structure tab's history table.\n\nOne row per trading day, sorted newest-first. Today's row may have\nspot=None if the post-close OHLC pull hasn't fired yet.",
-        "operationId": "get_stock_history_api_stock__ticker__history_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StockHistoryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/runs": {
-      "get": {
-        "tags": [
-          "stock"
-        ],
-        "summary": "List Runs",
-        "operationId": "list_runs_api_stock__ticker__runs_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": true
-                  },
-                  "title": "Response List Runs Api Stock  Ticker  Runs Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/runs/{run_id}": {
-      "get": {
-        "tags": [
-          "stock"
-        ],
-        "summary": "Get Specific Run",
-        "operationId": "get_specific_run_api_stock__ticker__runs__run_id__get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Run Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SingleStockReport"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/ohlc/{ticker}": {
-      "get": {
-        "tags": [
-          "ohlc"
-        ],
-        "summary": "Get Ohlc",
-        "operationId": "get_ohlc_api_ohlc__ticker__get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "days",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 365,
-              "minimum": 1,
-              "default": 30,
-              "title": "Days"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/OhlcRow"
-                  },
-                  "title": "Response Get Ohlc Api Ohlc  Ticker  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/cockpit/{ticker}/state": {
-      "get": {
-        "tags": [
-          "cockpit"
-        ],
-        "summary": "Get Cockpit State",
-        "operationId": "get_cockpit_state_api_cockpit__ticker__state_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "asof",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Asof"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CockpitStateResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/cockpit/{ticker}/dealer": {
-      "get": {
-        "tags": [
-          "cockpit"
-        ],
-        "summary": "Get Cockpit Dealer",
-        "operationId": "get_cockpit_dealer_api_cockpit__ticker__dealer_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "asof",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Asof"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CockpitDealerResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/cockpit/{ticker}/surface": {
-      "get": {
-        "tags": [
-          "cockpit"
-        ],
-        "summary": "Get Cockpit Surface",
-        "operationId": "get_cockpit_surface_api_cockpit__ticker__surface_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "asof",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Asof"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CockpitSurfaceResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/cockpit/{ticker}/flow-im": {
-      "get": {
-        "tags": [
-          "cockpit"
-        ],
-        "summary": "Get Cockpit Flow Im",
-        "operationId": "get_cockpit_flow_im_api_cockpit__ticker__flow_im_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "asof",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Asof"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CockpitFlowImResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/cockpit/{ticker}/vrp": {
-      "get": {
-        "tags": [
-          "cockpit"
-        ],
-        "summary": "Get Cockpit Vrp",
-        "operationId": "get_cockpit_vrp_api_cockpit__ticker__vrp_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "asof",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Asof"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CockpitVrpResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/watchlist/{ticker}/rescan": {
-      "post": {
-        "tags": [
-          "jobs"
-        ],
-        "summary": "Enqueue Rescan",
-        "operationId": "enqueue_rescan_api_watchlist__ticker__rescan_post",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JobStatus"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/watchlist/rescan-all": {
-      "post": {
-        "tags": [
-          "jobs"
-        ],
-        "summary": "Enqueue Rescan All",
-        "description": "Enqueue a rescan job for every active watchlist ticker.",
-        "operationId": "enqueue_rescan_all_api_watchlist_rescan_all_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/RescanAllRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
+    "paths": {
+        "/api/health": {
+            "get": {
+                "tags": [
+                    "health"
                 ],
-                "title": "Payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/JobStatus"
-                  },
-                  "type": "array",
-                  "title": "Response Enqueue Rescan All Api Watchlist Rescan All Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/jobs/{job_id}": {
-      "get": {
-        "tags": [
-          "jobs"
-        ],
-        "summary": "Get Job",
-        "operationId": "get_job_api_jobs__job_id__get",
-        "parameters": [
-          {
-            "name": "job_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Job Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JobStatus"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/volatility/series": {
-      "get": {
-        "tags": [
-          "volatility"
-        ],
-        "summary": "Get Volatility Series",
-        "operationId": "get_volatility_series_api_stock__ticker__volatility_series_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VolatilitySeriesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/provider-usage/summary": {
-      "get": {
-        "tags": [
-          "provider-usage"
-        ],
-        "summary": "Provider Usage Summary",
-        "operationId": "provider_usage_summary_api_provider_usage_summary_get",
-        "parameters": [
-          {
-            "name": "provider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "uw",
-                "massive",
-                "all"
-              ],
-              "type": "string",
-              "default": "all",
-              "title": "Provider"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageSummaryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/provider-usage/endpoints": {
-      "get": {
-        "tags": [
-          "provider-usage"
-        ],
-        "summary": "Provider Usage Endpoints",
-        "operationId": "provider_usage_endpoints_api_provider_usage_endpoints_get",
-        "parameters": [
-          {
-            "name": "provider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "uw",
-                "massive",
-                "all"
-              ],
-              "type": "string",
-              "default": "all",
-              "title": "Provider"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/provider-usage/tickers": {
-      "get": {
-        "tags": [
-          "provider-usage"
-        ],
-        "summary": "Provider Usage Tickers",
-        "operationId": "provider_usage_tickers_api_provider_usage_tickers_get",
-        "parameters": [
-          {
-            "name": "provider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "uw",
-                "massive",
-                "all"
-              ],
-              "type": "string",
-              "default": "all",
-              "title": "Provider"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/provider-usage/requests": {
-      "get": {
-        "tags": [
-          "provider-usage"
-        ],
-        "summary": "Provider Usage Requests",
-        "operationId": "provider_usage_requests_api_provider_usage_requests_get",
-        "parameters": [
-          {
-            "name": "provider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "uw",
-                "massive",
-                "all"
-              ],
-              "type": "string",
-              "default": "all",
-              "title": "Provider"
-            }
-          },
-          {
-            "name": "ticker",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "status_family",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "enum": [
-                    "2xx",
-                    "3xx",
-                    "4xx",
-                    "5xx",
-                    "transport_error"
-                  ],
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Status Family"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 100,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderUsageRequestsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/trade-insights": {
-      "get": {
-        "tags": [
-          "trade-insights"
-        ],
-        "summary": "Get Trade Insights",
-        "operationId": "get_trade_insights_api_stock__ticker__trade_insights_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TradeInsightsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/trade-insights/ai-analysis": {
-      "post": {
-        "tags": [
-          "trade-insights"
-        ],
-        "summary": "Post Trade Insights Ai Analysis",
-        "operationId": "post_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis_post",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/TradeInsightAiAnalysisRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "title": "Request"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/trade-insights/ai-analysis/latest": {
-      "get": {
-        "tags": [
-          "trade-insights"
-        ],
-        "summary": "Get Latest Trade Insights Ai Analysis",
-        "operationId": "get_latest_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis_latest_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
+                "summary": "Health",
+                "operationId": "health_api_health_get",
+                "parameters": [
                     {
-                      "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
+                        "name": "source",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "uw",
+                                "massive"
+                            ],
+                            "type": "string",
+                            "default": "uw",
+                            "title": "Source"
+                        }
                     },
                     {
-                      "type": "null"
+                        "name": "record_window_hours",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "number",
+                                    "maximum": 168,
+                                    "minimum": 0.1
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Record Window Hours"
+                        }
+                    },
+                    {
+                        "name": "record_min_coverage",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "number",
+                            "maximum": 1.0,
+                            "minimum": 0.0,
+                            "default": 0.9,
+                            "title": "Record Min Coverage"
+                        }
+                    },
+                    {
+                        "name": "record_tables",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Record Tables"
+                        }
                     }
-                  ],
-                  "title": "Response Get Latest Trade Insights Ai Analysis Api Stock  Ticker  Trade Insights Ai Analysis Latest Get"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HealthResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+        },
+        "/api/watchlist": {
+            "get": {
+                "tags": [
+                    "watchlist"
+                ],
+                "summary": "Get Watchlist",
+                "operationId": "get_watchlist_api_watchlist_get",
+                "parameters": [
+                    {
+                        "name": "sector",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Sector"
+                        }
+                    },
+                    {
+                        "name": "setup",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'",
+                            "title": "Setup"
+                        },
+                        "description": "e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'"
+                    },
+                    {
+                        "name": "fresh_within_minutes",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 1
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Fresh Within Minutes"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WatchlistResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stock/{ticker}/trade-insights/ai-analysis/{analysis_id}": {
-      "get": {
-        "tags": [
-          "trade-insights"
-        ],
-        "summary": "Get Trade Insights Ai Analysis",
-        "operationId": "get_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis__analysis_id__get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Ticker"
-            }
-          },
-          {
-            "name": "analysis_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Analysis Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/gex": {
-      "get": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Get Gex",
-        "operationId": "get_gex_api_regime_gex_get",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "SPX",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GexResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/gex/scan": {
-      "post": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Trigger Gex Scan",
-        "description": "Run a GEX scan synchronously against UW and persist.",
-        "operationId": "trigger_gex_scan_api_regime_gex_scan_post",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "SPX",
-              "title": "Ticker"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Trigger Gex Scan Api Regime Gex Scan Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/vol-backdrop": {
-      "get": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Get Vol Backdrop",
-        "operationId": "get_vol_backdrop_api_regime_vol_backdrop_get",
-        "parameters": [
-          {
-            "name": "days",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 365,
-              "minimum": 5,
-              "default": 90,
-              "title": "Days"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VolBackdropResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime": {
-      "get": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Get Regime",
-        "operationId": "get_regime_api_regime_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CriResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/scan": {
-      "post": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Trigger Cri Scan",
-        "description": "Run a CRI scan synchronously off the warm store; persist a snapshot.",
-        "operationId": "trigger_cri_scan_api_regime_scan_post",
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CriScanResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/vcg": {
-      "get": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Get Vcg",
-        "operationId": "get_vcg_api_regime_vcg_get",
-        "parameters": [
-          {
-            "name": "proxy",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "HYG",
-              "title": "Proxy"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VcgResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/vcg/scan": {
-      "post": {
-        "tags": [
-          "regime"
-        ],
-        "summary": "Trigger Vcg Scan",
-        "description": "Run a VCG scan synchronously off the warm store; persist a snapshot.",
-        "operationId": "trigger_vcg_scan_api_regime_vcg_scan_post",
-        "parameters": [
-          {
-            "name": "proxy",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "HYG",
-              "title": "Proxy"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VcgScanResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/guidance": {
-      "get": {
-        "tags": [
-          "regime",
-          "regime"
-        ],
-        "summary": "Get Guidance",
-        "operationId": "get_guidance_api_regime_guidance_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GuidanceResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/regime/validation": {
-      "get": {
-        "tags": [
-          "regime",
-          "regime"
-        ],
-        "summary": "Get Validation",
-        "operationId": "get_validation_api_regime_validation_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/gold/gauge": {
-      "get": {
-        "tags": [
-          "gold",
-          "gold"
-        ],
-        "summary": "Get Gauge",
-        "operationId": "get_gauge_api_gold_gauge_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GoldGaugeResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/gold/inputs/{series_id}": {
-      "get": {
-        "tags": [
-          "gold",
-          "gold"
-        ],
-        "summary": "Get Input Series",
-        "operationId": "get_input_series_api_gold_inputs__series_id__get",
-        "parameters": [
-          {
-            "name": "series_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Series Id"
-            }
-          },
-          {
-            "name": "from",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "From"
-            }
-          },
-          {
-            "name": "to",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "To"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GoldInputSeriesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/gold/state": {
-      "get": {
-        "tags": [
-          "gold",
-          "gold"
-        ],
-        "summary": "Get State",
-        "operationId": "get_state_api_gold_state_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GoldStateResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/gold/lenses/{lens_id}": {
-      "get": {
-        "tags": [
-          "gold",
-          "gold"
-        ],
-        "summary": "Get Lens",
-        "operationId": "get_lens_api_gold_lenses__lens_id__get",
-        "parameters": [
-          {
-            "name": "lens_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "structural",
-                "cyclical",
-                "valuation"
-              ],
-              "type": "string",
-              "title": "Lens Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GoldLensResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/gold/replay": {
-      "get": {
-        "tags": [
-          "gold",
-          "gold"
-        ],
-        "summary": "Get Replay",
-        "operationId": "get_replay_api_gold_replay_get",
-        "parameters": [
-          {
-            "name": "as_of",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date",
-              "description": "Reconstruct posture for this obs_date",
-              "title": "As Of"
             },
-            "description": "Reconstruct posture for this obs_date"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GoldStateResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/scanner": {
-      "get": {
-        "tags": [
-          "scanner",
-          "scanner"
-        ],
-        "summary": "Get Scanner",
-        "operationId": "get_scanner_api_scanner_get",
-        "parameters": [
-          {
-            "name": "tier_1_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Tier 1 Only"
-            }
-          },
-          {
-            "name": "type_f_only",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Type F Only"
-            }
-          },
-          {
-            "name": "sector",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
+            "post": {
+                "tags": [
+                    "watchlist"
+                ],
+                "summary": "Post Watchlist",
+                "operationId": "post_watchlist_api_watchlist_post",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WatchlistMutation"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Post Watchlist Api Watchlist Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Sector"
             }
-          },
-          {
-            "name": "freshness_hours",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
+        },
+        "/api/watchlist/queue": {
+            "get": {
+                "tags": [
+                    "watchlist"
+                ],
+                "summary": "Get Watchlist Queue",
+                "description": "Lightweight queue snapshot for the dashboard's QueueProgress widget.\n\nReturns only the rescan-queue summary \u2014 no card joins, no meta. Designed\nfor the 2.5s polling loop in QueueProgress so the dashboard doesn't\nrefetch the full watchlist payload every tick.",
+                "operationId": "get_watchlist_queue_api_watchlist_queue_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/QueueSummary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/watchlist/{ticker}": {
+            "delete": {
+                "tags": [
+                    "watchlist"
+                ],
+                "summary": "Delete Watchlist",
+                "operationId": "delete_watchlist_api_watchlist__ticker__delete",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "watchlist"
+                ],
+                "summary": "Patch Watchlist",
+                "operationId": "patch_watchlist_api_watchlist__ticker__patch",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WatchlistPatch"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Patch Watchlist Api Watchlist  Ticker  Patch"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Freshness Hours"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ScannerResponse"
+        },
+        "/api/stock/{ticker}": {
+            "get": {
+                "tags": [
+                    "stock"
+                ],
+                "summary": "Get Stock",
+                "operationId": "get_stock_api_stock__ticker__get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SingleStockReport"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+        },
+        "/api/stock/{ticker}/history": {
+            "get": {
+                "tags": [
+                    "stock"
+                ],
+                "summary": "Get Stock History",
+                "description": "Daily rollup for the Market Structure tab's history table.\n\nOne row per trading day, sorted newest-first. Today's row may have\nspot=None if the post-close OHLC pull hasn't fired yet.",
+                "operationId": "get_stock_history_api_stock__ticker__history_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StockHistoryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
+        },
+        "/api/stock/{ticker}/runs": {
+            "get": {
+                "tags": [
+                    "stock"
+                ],
+                "summary": "List Runs",
+                "operationId": "list_runs_api_stock__ticker__runs_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                    },
+                                    "title": "Response List Runs Api Stock  Ticker  Runs Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/runs/{run_id}": {
+            "get": {
+                "tags": [
+                    "stock"
+                ],
+                "summary": "Get Specific Run",
+                "operationId": "get_specific_run_api_stock__ticker__runs__run_id__get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "title": "Run Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SingleStockReport"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/ohlc/{ticker}": {
+            "get": {
+                "tags": [
+                    "ohlc"
+                ],
+                "summary": "Get Ohlc",
+                "operationId": "get_ohlc_api_ohlc__ticker__get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 365,
+                            "minimum": 1,
+                            "default": 30,
+                            "title": "Days"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/OhlcRow"
+                                    },
+                                    "title": "Response Get Ohlc Api Ohlc  Ticker  Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cockpit/{ticker}/state": {
+            "get": {
+                "tags": [
+                    "cockpit"
+                ],
+                "summary": "Get Cockpit State",
+                "operationId": "get_cockpit_state_api_cockpit__ticker__state_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "asof",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Asof"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CockpitStateResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cockpit/{ticker}/dealer": {
+            "get": {
+                "tags": [
+                    "cockpit"
+                ],
+                "summary": "Get Cockpit Dealer",
+                "operationId": "get_cockpit_dealer_api_cockpit__ticker__dealer_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "asof",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Asof"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CockpitDealerResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cockpit/{ticker}/surface": {
+            "get": {
+                "tags": [
+                    "cockpit"
+                ],
+                "summary": "Get Cockpit Surface",
+                "operationId": "get_cockpit_surface_api_cockpit__ticker__surface_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "asof",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Asof"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CockpitSurfaceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cockpit/{ticker}/flow-im": {
+            "get": {
+                "tags": [
+                    "cockpit"
+                ],
+                "summary": "Get Cockpit Flow Im",
+                "operationId": "get_cockpit_flow_im_api_cockpit__ticker__flow_im_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "asof",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Asof"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CockpitFlowImResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cockpit/{ticker}/vrp": {
+            "get": {
+                "tags": [
+                    "cockpit"
+                ],
+                "summary": "Get Cockpit Vrp",
+                "operationId": "get_cockpit_vrp_api_cockpit__ticker__vrp_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "asof",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Asof"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CockpitVrpResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/watchlist/{ticker}/rescan": {
+            "post": {
+                "tags": [
+                    "jobs"
+                ],
+                "summary": "Enqueue Rescan",
+                "operationId": "enqueue_rescan_api_watchlist__ticker__rescan_post",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JobStatus"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/watchlist/rescan-all": {
+            "post": {
+                "tags": [
+                    "jobs"
+                ],
+                "summary": "Enqueue Rescan All",
+                "description": "Enqueue a rescan job for every active watchlist ticker.",
+                "operationId": "enqueue_rescan_all_api_watchlist_rescan_all_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/RescanAllRequest"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "title": "Payload"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/JobStatus"
+                                    },
+                                    "type": "array",
+                                    "title": "Response Enqueue Rescan All Api Watchlist Rescan All Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/jobs/{job_id}": {
+            "get": {
+                "tags": [
+                    "jobs"
+                ],
+                "summary": "Get Job",
+                "operationId": "get_job_api_jobs__job_id__get",
+                "parameters": [
+                    {
+                        "name": "job_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Job Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JobStatus"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/volatility/series": {
+            "get": {
+                "tags": [
+                    "volatility"
+                ],
+                "summary": "Get Volatility Series",
+                "operationId": "get_volatility_series_api_stock__ticker__volatility_series_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VolatilitySeriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/provider-usage/summary": {
+            "get": {
+                "tags": [
+                    "provider-usage"
+                ],
+                "summary": "Provider Usage Summary",
+                "operationId": "provider_usage_summary_api_provider_usage_summary_get",
+                "parameters": [
+                    {
+                        "name": "provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "uw",
+                                "massive",
+                                "all"
+                            ],
+                            "type": "string",
+                            "default": "all",
+                            "title": "Provider"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProviderUsageSummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/provider-usage/endpoints": {
+            "get": {
+                "tags": [
+                    "provider-usage"
+                ],
+                "summary": "Provider Usage Endpoints",
+                "operationId": "provider_usage_endpoints_api_provider_usage_endpoints_get",
+                "parameters": [
+                    {
+                        "name": "provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "uw",
+                                "massive",
+                                "all"
+                            ],
+                            "type": "string",
+                            "default": "all",
+                            "title": "Provider"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/provider-usage/tickers": {
+            "get": {
+                "tags": [
+                    "provider-usage"
+                ],
+                "summary": "Provider Usage Tickers",
+                "operationId": "provider_usage_tickers_api_provider_usage_tickers_get",
+                "parameters": [
+                    {
+                        "name": "provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "uw",
+                                "massive",
+                                "all"
+                            ],
+                            "type": "string",
+                            "default": "all",
+                            "title": "Provider"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProviderUsageBreakdownResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/provider-usage/requests": {
+            "get": {
+                "tags": [
+                    "provider-usage"
+                ],
+                "summary": "Provider Usage Requests",
+                "operationId": "provider_usage_requests_api_provider_usage_requests_get",
+                "parameters": [
+                    {
+                        "name": "provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "uw",
+                                "massive",
+                                "all"
+                            ],
+                            "type": "string",
+                            "default": "all",
+                            "title": "Provider"
+                        }
+                    },
+                    {
+                        "name": "ticker",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "status_family",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "enum": [
+                                        "2xx",
+                                        "3xx",
+                                        "4xx",
+                                        "5xx",
+                                        "transport_error"
+                                    ],
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Status Family"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 100,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProviderUsageRequestsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/trade-insights": {
+            "get": {
+                "tags": [
+                    "trade-insights"
+                ],
+                "summary": "Get Trade Insights",
+                "operationId": "get_trade_insights_api_stock__ticker__trade_insights_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TradeInsightsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/trade-insights/ai-analysis": {
+            "post": {
+                "tags": [
+                    "trade-insights"
+                ],
+                "summary": "Post Trade Insights Ai Analysis",
+                "operationId": "post_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis_post",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/TradeInsightAiAnalysisRequest"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "title": "Request"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/trade-insights/ai-analysis/latest": {
+            "get": {
+                "tags": [
+                    "trade-insights"
+                ],
+                "summary": "Get Latest Trade Insights Ai Analysis",
+                "operationId": "get_latest_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis_latest_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "title": "Response Get Latest Trade Insights Ai Analysis Api Stock  Ticker  Trade Insights Ai Analysis Latest Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/stock/{ticker}/trade-insights/ai-analysis/{analysis_id}": {
+            "get": {
+                "tags": [
+                    "trade-insights"
+                ],
+                "summary": "Get Trade Insights Ai Analysis",
+                "operationId": "get_trade_insights_ai_analysis_api_stock__ticker__trade_insights_ai_analysis__analysis_id__get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Ticker"
+                        }
+                    },
+                    {
+                        "name": "analysis_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Analysis Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TradeInsightAiAnalysisResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/gex": {
+            "get": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Get Gex",
+                "operationId": "get_gex_api_regime_gex_get",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "SPX",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GexResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/gex/scan": {
+            "post": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Trigger Gex Scan",
+                "description": "Run a GEX scan synchronously against UW and persist.",
+                "operationId": "trigger_gex_scan_api_regime_gex_scan_post",
+                "parameters": [
+                    {
+                        "name": "ticker",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "SPX",
+                            "title": "Ticker"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Trigger Gex Scan Api Regime Gex Scan Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/vol-backdrop": {
+            "get": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Get Vol Backdrop",
+                "operationId": "get_vol_backdrop_api_regime_vol_backdrop_get",
+                "parameters": [
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 365,
+                            "minimum": 5,
+                            "default": 90,
+                            "title": "Days"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VolBackdropResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime": {
+            "get": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Get Regime",
+                "operationId": "get_regime_api_regime_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CriResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/scan": {
+            "post": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Trigger Cri Scan",
+                "description": "Run a CRI scan synchronously off the warm store; persist a snapshot.",
+                "operationId": "trigger_cri_scan_api_regime_scan_post",
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CriScanResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/vcg": {
+            "get": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Get Vcg",
+                "operationId": "get_vcg_api_regime_vcg_get",
+                "parameters": [
+                    {
+                        "name": "proxy",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "HYG",
+                            "title": "Proxy"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VcgResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/vcg/scan": {
+            "post": {
+                "tags": [
+                    "regime"
+                ],
+                "summary": "Trigger Vcg Scan",
+                "description": "Run a VCG scan synchronously off the warm store; persist a snapshot.",
+                "operationId": "trigger_vcg_scan_api_regime_vcg_scan_post",
+                "parameters": [
+                    {
+                        "name": "proxy",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "HYG",
+                            "title": "Proxy"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/VcgScanResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/guidance": {
+            "get": {
+                "tags": [
+                    "regime",
+                    "regime"
+                ],
+                "summary": "Get Guidance",
+                "operationId": "get_guidance_api_regime_guidance_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GuidanceResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/regime/validation": {
+            "get": {
+                "tags": [
+                    "regime",
+                    "regime"
+                ],
+                "summary": "Get Validation",
+                "operationId": "get_validation_api_regime_validation_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/gold/gauge": {
+            "get": {
+                "tags": [
+                    "gold",
+                    "gold"
+                ],
+                "summary": "Get Gauge",
+                "operationId": "get_gauge_api_gold_gauge_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GoldGaugeResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/gold/inputs/{series_id}": {
+            "get": {
+                "tags": [
+                    "gold",
+                    "gold"
+                ],
+                "summary": "Get Input Series",
+                "operationId": "get_input_series_api_gold_inputs__series_id__get",
+                "parameters": [
+                    {
+                        "name": "series_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Series Id"
+                        }
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "From"
+                        }
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "To"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GoldInputSeriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/gold/state": {
+            "get": {
+                "tags": [
+                    "gold",
+                    "gold"
+                ],
+                "summary": "Get State",
+                "operationId": "get_state_api_gold_state_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GoldStateResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/gold/lenses/{lens_id}": {
+            "get": {
+                "tags": [
+                    "gold",
+                    "gold"
+                ],
+                "summary": "Get Lens",
+                "operationId": "get_lens_api_gold_lenses__lens_id__get",
+                "parameters": [
+                    {
+                        "name": "lens_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "enum": [
+                                "structural",
+                                "cyclical",
+                                "valuation"
+                            ],
+                            "type": "string",
+                            "title": "Lens Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GoldLensResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/gold/replay": {
+            "get": {
+                "tags": [
+                    "gold",
+                    "gold"
+                ],
+                "summary": "Get Replay",
+                "operationId": "get_replay_api_gold_replay_get",
+                "parameters": [
+                    {
+                        "name": "as_of",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "date",
+                            "description": "Reconstruct posture for this obs_date",
+                            "title": "As Of"
+                        },
+                        "description": "Reconstruct posture for this obs_date"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GoldStateResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/scanner": {
+            "get": {
+                "tags": [
+                    "scanner",
+                    "scanner"
+                ],
+                "summary": "Get Scanner",
+                "operationId": "get_scanner_api_scanner_get",
+                "parameters": [
+                    {
+                        "name": "tier_1_only",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Tier 1 Only"
+                        }
+                    },
+                    {
+                        "name": "type_f_only",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Type F Only"
+                        }
+                    },
+                    {
+                        "name": "sector",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Sector"
+                        }
+                    },
+                    {
+                        "name": "freshness_hours",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Freshness Hours"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ScannerResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/scanner/discover": {
+            "get": {
+                "tags": [
+                    "scanner",
+                    "scanner"
+                ],
+                "summary": "Get Scanner Discover",
+                "description": "Pull market-wide flow alerts, run DCF per ticker, exclude watchlist, top-N.",
+                "operationId": "get_scanner_discover_api_scanner_discover_get",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 50,
+                            "minimum": 1,
+                            "default": 20,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "alerts_limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 500,
+                            "minimum": 50,
+                            "default": 200,
+                            "title": "Alerts Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DiscoveryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     },
-    "/api/scanner/discover": {
-      "get": {
-        "tags": [
-          "scanner",
-          "scanner"
-        ],
-        "summary": "Get Scanner Discover",
-        "description": "Pull market-wide flow alerts, run DCF per ticker, exclude watchlist, top-N.",
-        "operationId": "get_scanner_discover_api_scanner_discover_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 50,
-              "minimum": 1,
-              "default": 20,
-              "title": "Limit"
+    "components": {
+        "schemas": {
+            "CandidateStructure": {
+                "properties": {
+                    "idea_id": {
+                        "type": "string",
+                        "title": "Idea Id"
+                    },
+                    "structure": {
+                        "type": "string",
+                        "title": "Structure"
+                    },
+                    "thesis": {
+                        "type": "string",
+                        "title": "Thesis"
+                    },
+                    "expression_type": {
+                        "type": "string",
+                        "title": "Expression Type"
+                    },
+                    "legs": {
+                        "items": {
+                            "$ref": "#/components/schemas/InsightLeg"
+                        },
+                        "type": "array",
+                        "title": "Legs",
+                        "default": []
+                    },
+                    "net_credit_debit": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Credit Debit"
+                    },
+                    "max_profit": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Profit"
+                    },
+                    "max_loss": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Loss"
+                    },
+                    "breakevens": {
+                        "items": {
+                            "type": "string",
+                            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                        },
+                        "type": "array",
+                        "title": "Breakevens",
+                        "default": []
+                    },
+                    "profit_zone": {
+                        "type": "string",
+                        "title": "Profit Zone",
+                        "default": ""
+                    },
+                    "edge_source": {
+                        "type": "string",
+                        "title": "Edge Source",
+                        "default": ""
+                    },
+                    "risk_flags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Risk Flags",
+                        "default": []
+                    },
+                    "rank": {
+                        "type": "integer",
+                        "title": "Rank"
+                    },
+                    "status": {
+                        "type": "string",
+                        "title": "Status",
+                        "default": "candidate"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "idea_id",
+                    "structure",
+                    "thesis",
+                    "expression_type",
+                    "rank"
+                ],
+                "title": "CandidateStructure"
+            },
+            "ChainFlowReadRow": {
+                "properties": {
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume"
+                    },
+                    "call_open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Open Interest"
+                    },
+                    "put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume"
+                    },
+                    "put_open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Open Interest"
+                    },
+                    "call_put_volume_ratio": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Put Volume Ratio"
+                    },
+                    "volume_oi_note": {
+                        "type": "string",
+                        "title": "Volume Oi Note",
+                        "default": ""
+                    },
+                    "read": {
+                        "type": "string",
+                        "title": "Read",
+                        "default": ""
+                    },
+                    "requires_t1_oi_confirmation": {
+                        "type": "boolean",
+                        "title": "Requires T1 Oi Confirmation",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "strike"
+                ],
+                "title": "ChainFlowReadRow"
+            },
+            "CockpitDealerMetrics": {
+                "properties": {
+                    "pin_candidate_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Candidate Strike"
+                    },
+                    "pin_candidate_expiry": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Candidate Expiry"
+                    },
+                    "pin_source_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Source Date"
+                    },
+                    "pin_distance_sigma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Distance Sigma"
+                    },
+                    "pin_regime_flag": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Regime Flag"
+                    },
+                    "dealer_net_vanna_proxy": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dealer Net Vanna Proxy"
+                    },
+                    "dealer_net_charm_proxy": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dealer Net Charm Proxy"
+                    },
+                    "flow_color_lookback_3d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "put_heavy",
+                                    "call_heavy",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Color Lookback 3D"
+                    },
+                    "flow_put_premium_3d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Put Premium 3D"
+                    },
+                    "flow_call_premium_3d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Call Premium 3D"
+                    },
+                    "iv_30d_delta_5d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv 30D Delta 5D"
+                    },
+                    "net_gamma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gamma"
+                    },
+                    "net_gamma_sign": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "positive",
+                                    "negative",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gamma Sign"
+                    },
+                    "gamma_regime": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "long_gamma",
+                                    "short_gamma",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gamma Regime"
+                    },
+                    "vanna_conditional_reading": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "grind_up",
+                                    "reverse_selloff",
+                                    "reflexive_sell_pressure",
+                                    "weak_noise"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Conditional Reading"
+                    },
+                    "directional_imbalance_3d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Directional Imbalance 3D"
+                    },
+                    "vanna_oi_change_bias": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "call_oi_build",
+                                    "put_oi_build",
+                                    "mixed"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Oi Change Bias"
+                    },
+                    "charm_regime": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "operative_magnet",
+                                    "broken_magnet",
+                                    "opex_vortex",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Regime"
+                    },
+                    "charm_stress_override": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Stress Override"
+                    }
+                },
+                "type": "object",
+                "title": "CockpitDealerMetrics"
+            },
+            "CockpitDealerPoint": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "call_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Vanna"
+                    },
+                    "put_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Vanna"
+                    },
+                    "call_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Charm"
+                    },
+                    "put_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Charm"
+                    },
+                    "exposure_call_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Exposure Call Vanna"
+                    },
+                    "exposure_put_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Exposure Put Vanna"
+                    },
+                    "exposure_call_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Exposure Call Charm"
+                    },
+                    "exposure_put_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Exposure Put Charm"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry",
+                    "strike"
+                ],
+                "title": "CockpitDealerPoint"
+            },
+            "CockpitDealerResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "metrics": {
+                        "$ref": "#/components/schemas/CockpitDealerMetrics"
+                    },
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitDealerPoint"
+                        },
+                        "type": "array",
+                        "title": "Points"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "market_date"
+                ],
+                "title": "CockpitDealerResponse"
+            },
+            "CockpitFlowAlert": {
+                "properties": {
+                    "alert_id": {
+                        "type": "string",
+                        "title": "Alert Id"
+                    },
+                    "option_chain": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Option Chain"
+                    },
+                    "expiry": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expiry"
+                    },
+                    "strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strike"
+                    },
+                    "option_type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Option Type"
+                    },
+                    "total_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Premium"
+                    },
+                    "volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volume"
+                    },
+                    "open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Open Interest"
+                    },
+                    "total_ask_side_prem": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Ask Side Prem"
+                    },
+                    "total_bid_side_prem": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Bid Side Prem"
+                    },
+                    "has_sweep": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Sweep"
+                    },
+                    "has_floor": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Floor"
+                    },
+                    "has_multileg": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Multileg"
+                    },
+                    "all_opening_trades": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All Opening Trades"
+                    },
+                    "alert_rule": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Alert Rule"
+                    },
+                    "flow_footprint_label": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "directional_whale",
+                                    "hedge_flow",
+                                    "dealer_hedge",
+                                    "gamma_scalper",
+                                    "unclassified"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Footprint Label"
+                    },
+                    "aggressor_label_confidence": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Aggressor Label Confidence"
+                    },
+                    "created_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "alert_id"
+                ],
+                "title": "CockpitFlowAlert"
+            },
+            "CockpitFlowImResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "alerts": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitFlowAlert"
+                        },
+                        "type": "array",
+                        "title": "Alerts"
+                    },
+                    "implied_moves": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitImPoint"
+                        },
+                        "type": "array",
+                        "title": "Implied Moves"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "market_date"
+                ],
+                "title": "CockpitFlowImResponse"
+            },
+            "CockpitImPoint": {
+                "properties": {
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "days": {
+                        "type": "integer",
+                        "title": "Days"
+                    },
+                    "volatility": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volatility"
+                    },
+                    "implied_move_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Perc"
+                    },
+                    "implied_move_expected_abs": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Expected Abs"
+                    },
+                    "percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Percentile"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "market_date",
+                    "days"
+                ],
+                "title": "CockpitImPoint"
+            },
+            "CockpitSkewPoint": {
+                "properties": {
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "expiry": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expiry"
+                    },
+                    "risk_reversal": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Risk Reversal"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "market_date"
+                ],
+                "title": "CockpitSkewPoint"
+            },
+            "CockpitStateResponse": {
+                "properties": {
+                    "state": {
+                        "$ref": "#/components/schemas/MatrixState"
+                    },
+                    "freshness": {
+                        "$ref": "#/components/schemas/MatrixSourceFreshness"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "state",
+                    "freshness"
+                ],
+                "title": "CockpitStateResponse"
+            },
+            "CockpitSurfaceResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "skew": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitSkewPoint"
+                        },
+                        "type": "array",
+                        "title": "Skew"
+                    },
+                    "term": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitTermPoint"
+                        },
+                        "type": "array",
+                        "title": "Term"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "market_date"
+                ],
+                "title": "CockpitSurfaceResponse"
+            },
+            "CockpitTermPoint": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "dte": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dte"
+                    },
+                    "volatility": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volatility"
+                    },
+                    "implied_move_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Perc"
+                    },
+                    "implied_move_expected_abs": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Expected Abs"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "CockpitTermPoint"
+            },
+            "CockpitVrpPoint": {
+                "properties": {
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    },
+                    "rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv"
+                    },
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "iv_rank_1y": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank 1Y"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "market_date"
+                ],
+                "title": "CockpitVrpPoint"
+            },
+            "CockpitVrpResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/CockpitVrpPoint"
+                        },
+                        "type": "array",
+                        "title": "Points"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "market_date"
+                ],
+                "title": "CockpitVrpResponse"
+            },
+            "CrashTriggerBlock": {
+                "properties": {
+                    "fired": {
+                        "type": "boolean",
+                        "title": "Fired",
+                        "default": false
+                    },
+                    "triggered": {
+                        "type": "boolean",
+                        "title": "Triggered",
+                        "default": false
+                    },
+                    "conditions": {
+                        "$ref": "#/components/schemas/CrashTriggerConditions"
+                    },
+                    "values": {
+                        "$ref": "#/components/schemas/CrashTriggerValues"
+                    }
+                },
+                "type": "object",
+                "title": "CrashTriggerBlock"
+            },
+            "CrashTriggerConditions": {
+                "properties": {
+                    "spx_below_100d_ma": {
+                        "type": "boolean",
+                        "title": "Spx Below 100D Ma",
+                        "default": false
+                    },
+                    "realized_vol_gt_25": {
+                        "type": "boolean",
+                        "title": "Realized Vol Gt 25",
+                        "default": false
+                    },
+                    "cor1m_gt_60": {
+                        "type": "boolean",
+                        "title": "Cor1M Gt 60",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "title": "CrashTriggerConditions"
+            },
+            "CrashTriggerValues": {
+                "properties": {
+                    "realized_vol": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Realized Vol"
+                    },
+                    "cor1m": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M"
+                    }
+                },
+                "type": "object",
+                "title": "CrashTriggerValues"
+            },
+            "CriBlock": {
+                "properties": {
+                    "score": {
+                        "type": "number",
+                        "title": "Score",
+                        "default": 0.0
+                    },
+                    "level": {
+                        "type": "string",
+                        "enum": [
+                            "LOW",
+                            "ELEVATED",
+                            "HIGH",
+                            "CRITICAL"
+                        ],
+                        "title": "Level",
+                        "default": "LOW"
+                    },
+                    "composite_version": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "enum": [
+                                    1,
+                                    2,
+                                    3
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Composite Version"
+                    },
+                    "components": {
+                        "$ref": "#/components/schemas/CriComponents"
+                    }
+                },
+                "type": "object",
+                "title": "CriBlock"
+            },
+            "CriComponents": {
+                "properties": {
+                    "vix": {
+                        "type": "number",
+                        "title": "Vix",
+                        "default": 0.0
+                    },
+                    "vvix": {
+                        "type": "number",
+                        "title": "Vvix",
+                        "default": 0.0
+                    },
+                    "correlation": {
+                        "type": "number",
+                        "title": "Correlation",
+                        "default": 0.0
+                    },
+                    "momentum": {
+                        "type": "number",
+                        "title": "Momentum",
+                        "default": 0.0
+                    }
+                },
+                "type": "object",
+                "title": "CriComponents",
+                "description": "Four 0-25 component scores summed into the composite 0-100."
+            },
+            "CriHistoryEntry": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "title": "Date"
+                    },
+                    "vix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix"
+                    },
+                    "vvix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vvix"
+                    },
+                    "spy": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spy"
+                    },
+                    "cor1m": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M"
+                    },
+                    "realized_vol": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Realized Vol"
+                    },
+                    "spx_vs_ma_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spx Vs Ma Pct"
+                    },
+                    "vix_5d_roc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix 5D Roc"
+                    },
+                    "vvix_5d_roc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vvix 5D Roc"
+                    },
+                    "cor1m_5d_change": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M 5D Change"
+                    },
+                    "pullback_20d_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pullback 20D Pct"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "CriHistoryEntry"
+            },
+            "CriResponse": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "empty"
+                        ],
+                        "title": "Status",
+                        "default": "empty"
+                    },
+                    "scan_time": {
+                        "type": "string",
+                        "title": "Scan Time",
+                        "default": ""
+                    },
+                    "date": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date"
+                    },
+                    "vix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix"
+                    },
+                    "vvix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vvix"
+                    },
+                    "spy": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spy"
+                    },
+                    "vix_5d_roc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix 5D Roc"
+                    },
+                    "vvix_5d_roc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vvix 5D Roc"
+                    },
+                    "vvix_vix_ratio": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vvix Vix Ratio"
+                    },
+                    "spx_100d_ma": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spx 100D Ma"
+                    },
+                    "spx_distance_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spx Distance Pct"
+                    },
+                    "cor1m": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M"
+                    },
+                    "cor1m_previous_close": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M Previous Close"
+                    },
+                    "cor1m_5d_change": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cor1M 5D Change"
+                    },
+                    "realized_vol": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Realized Vol"
+                    },
+                    "vix3m": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix3M"
+                    },
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "vix_zscore_30d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix Zscore 30D"
+                    },
+                    "vix_vix3m_ratio": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix Vix3M Ratio"
+                    },
+                    "pullback_20d_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pullback 20D Pct"
+                    },
+                    "vix_delta_3d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vix Delta 3D"
+                    },
+                    "spx_source": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "SPX",
+                                    "SPY"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spx Source"
+                    },
+                    "cri": {
+                        "$ref": "#/components/schemas/CriBlock"
+                    },
+                    "cta": {
+                        "$ref": "#/components/schemas/CtaBlock"
+                    },
+                    "crash_trigger": {
+                        "$ref": "#/components/schemas/CrashTriggerBlock"
+                    },
+                    "history": {
+                        "items": {
+                            "$ref": "#/components/schemas/CriHistoryEntry"
+                        },
+                        "type": "array",
+                        "title": "History"
+                    },
+                    "spy_closes": {
+                        "items": {
+                            "type": "number"
+                        },
+                        "type": "array",
+                        "title": "Spy Closes"
+                    }
+                },
+                "type": "object",
+                "title": "CriResponse",
+                "description": "Crash Risk Indicator snapshot (latest scan)."
+            },
+            "CriScanResponse": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "skipped"
+                        ],
+                        "title": "Status",
+                        "default": "ok"
+                    },
+                    "scanner": {
+                        "type": "string",
+                        "const": "cri",
+                        "title": "Scanner",
+                        "default": "cri"
+                    },
+                    "row_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Row Id"
+                    },
+                    "reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reason"
+                    }
+                },
+                "type": "object",
+                "title": "CriScanResponse",
+                "description": "Response body for POST /api/regime/scan."
+            },
+            "CtaBlock": {
+                "properties": {
+                    "realized_vol": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Realized Vol"
+                    },
+                    "exposure_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Exposure Pct"
+                    },
+                    "forced_reduction_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Forced Reduction Pct"
+                    },
+                    "forced_reduction": {
+                        "type": "boolean",
+                        "title": "Forced Reduction",
+                        "default": false
+                    },
+                    "est_selling_bn": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Est Selling Bn"
+                    },
+                    "selling_usd_b": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Selling Usd B"
+                    }
+                },
+                "type": "object",
+                "title": "CtaBlock"
+            },
+            "DiscoveryCandidate": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "hit": {
+                        "$ref": "#/components/schemas/ScannerSignalHit"
+                    },
+                    "bias": {
+                        "type": "string",
+                        "enum": [
+                            "bullish",
+                            "bearish",
+                            "neutral",
+                            "mixed"
+                        ],
+                        "title": "Bias"
+                    },
+                    "bias_strength": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "strong",
+                                    "moderate",
+                                    "weak"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bias Strength"
+                    },
+                    "alert_count": {
+                        "type": "integer",
+                        "title": "Alert Count"
+                    },
+                    "sector": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sector"
+                    },
+                    "latest_alert_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latest Alert At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "hit",
+                    "bias",
+                    "alert_count"
+                ],
+                "title": "DiscoveryCandidate",
+                "description": "Non-watchlist ticker surfaced by the market-wide flow-alerts feed.\n\nDCF-only \u2014 the deeper signals (DP, EIC, GEX) need per-ticker context that\nrequires a deep scan. Promote to the watchlist to get those."
+            },
+            "DiscoveryResponse": {
+                "properties": {
+                    "candidates": {
+                        "items": {
+                            "$ref": "#/components/schemas/DiscoveryCandidate"
+                        },
+                        "type": "array",
+                        "title": "Candidates"
+                    },
+                    "fetched_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Fetched At"
+                    },
+                    "source": {
+                        "type": "string",
+                        "const": "market_wide_flow_alerts",
+                        "title": "Source",
+                        "default": "market_wide_flow_alerts"
+                    },
+                    "alerts_pulled": {
+                        "type": "integer",
+                        "title": "Alerts Pulled"
+                    },
+                    "earnings_unknown_dropped": {
+                        "type": "integer",
+                        "title": "Earnings Unknown Dropped",
+                        "default": 0
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "candidates",
+                    "fetched_at",
+                    "alerts_pulled"
+                ],
+                "title": "DiscoveryResponse"
+            },
+            "DivergencePoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "iv_z": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Z"
+                    },
+                    "rv_z": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv Z"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "DivergencePoint"
+            },
+            "ExposuresSummaryRow": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "dte": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dte"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "net_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Vanna"
+                    },
+                    "top_vanna_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Top Vanna Strike"
+                    },
+                    "top_vanna_value": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Top Vanna Value"
+                    },
+                    "delta_shock_1pt_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Delta Shock 1Pt Iv"
+                    },
+                    "vanna_regime": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Regime"
+                    },
+                    "vanna_flip": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Flip"
+                    },
+                    "vanna_headline": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Headline"
+                    },
+                    "vanna_subtitle": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Subtitle"
+                    },
+                    "net_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Charm"
+                    },
+                    "charm_pin_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Pin Strike"
+                    },
+                    "charm_above_sum": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Above Sum"
+                    },
+                    "charm_below_sum": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Below Sum"
+                    },
+                    "charm_imbalance_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Imbalance Pct"
+                    },
+                    "charm_signal_quality": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Signal Quality"
+                    },
+                    "charm_flip": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Flip"
+                    },
+                    "charm_headline": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Headline"
+                    },
+                    "charm_subtitle": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Subtitle"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "ExposuresSummaryRow",
+                "description": "Per-(expiry) derived summary used to drive the Vanna/Charm sub-tab\nheadline narrative + 4 tiles. Computed by cards/exposures.py and\npersisted to uw_scan.exposures_summary."
+            },
+            "FlowAlert": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id"
+                    },
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "option_chain": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Option Chain"
+                    },
+                    "type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Type"
+                    },
+                    "expiry": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expiry"
+                    },
+                    "strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strike"
+                    },
+                    "price": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Price"
+                    },
+                    "underlying_price": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Underlying Price"
+                    },
+                    "total_size": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Size"
+                    },
+                    "total_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Premium"
+                    },
+                    "total_ask_side_prem": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Ask Side Prem"
+                    },
+                    "total_bid_side_prem": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Bid Side Prem"
+                    },
+                    "volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volume"
+                    },
+                    "open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Open Interest"
+                    },
+                    "volume_oi_ratio": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volume Oi Ratio"
+                    },
+                    "has_sweep": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Sweep"
+                    },
+                    "has_floor": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Floor"
+                    },
+                    "has_multileg": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Has Multileg"
+                    },
+                    "all_opening_trades": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "All Opening Trades"
+                    },
+                    "iv_start": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Start"
+                    },
+                    "iv_end": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv End"
+                    },
+                    "alert_rule": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Alert Rule"
+                    },
+                    "flow_footprint_label": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "directional_whale",
+                                    "hedge_flow",
+                                    "dealer_hedge",
+                                    "gamma_scalper",
+                                    "unclassified"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Footprint Label"
+                    },
+                    "aggressor_label_confidence": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Aggressor Label Confidence"
+                    },
+                    "rule_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rule Id"
+                    },
+                    "sector": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sector"
+                    },
+                    "issue_type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Issue Type"
+                    },
+                    "next_earnings_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Earnings Date"
+                    },
+                    "created_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "ticker"
+                ],
+                "title": "FlowAlert"
+            },
+            "FlowSnapshot": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "flow_count": {
+                        "type": "integer",
+                        "title": "Flow Count"
+                    },
+                    "flow_count_is_limited": {
+                        "type": "boolean",
+                        "title": "Flow Count Is Limited",
+                        "default": false
+                    },
+                    "flow_count_30d_avg": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Count 30D Avg"
+                    },
+                    "flow_count_vs_30d_avg": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Count Vs 30D Avg"
+                    },
+                    "flow_count_30d_days": {
+                        "type": "integer",
+                        "title": "Flow Count 30D Days",
+                        "default": 0
+                    },
+                    "top_alert_rule": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Top Alert Rule"
+                    },
+                    "net_premium": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Net Premium"
+                    },
+                    "bull_premium": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Bull Premium"
+                    },
+                    "bear_premium": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Bear Premium"
+                    },
+                    "ask_side_premium": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Ask Side Premium"
+                    },
+                    "bid_side_premium": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Bid Side Premium"
+                    },
+                    "top_alerts": {
+                        "items": {
+                            "$ref": "#/components/schemas/FlowAlert"
+                        },
+                        "type": "array",
+                        "title": "Top Alerts",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "flow_count",
+                    "net_premium",
+                    "bull_premium",
+                    "bear_premium",
+                    "ask_side_premium",
+                    "bid_side_premium"
+                ],
+                "title": "FlowSnapshot"
+            },
+            "GammaBlock": {
+                "properties": {
+                    "flip_distance": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flip Distance"
+                    },
+                    "flip_price": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flip Price"
+                    },
+                    "per_1pct_move": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Per 1Pct Move"
+                    },
+                    "max_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Strike"
+                    },
+                    "expiring_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expiring Pct"
+                    },
+                    "expiring_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expiring Date"
+                    }
+                },
+                "type": "object",
+                "title": "GammaBlock"
+            },
+            "GexBias": {
+                "properties": {
+                    "direction": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Direction"
+                    },
+                    "reasons": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Reasons"
+                    },
+                    "days_above_flip": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Days Above Flip"
+                    },
+                    "flip_migration": {
+                        "items": {
+                            "$ref": "#/components/schemas/GexFlipMigrationEntry"
+                        },
+                        "type": "array",
+                        "title": "Flip Migration"
+                    }
+                },
+                "type": "object",
+                "title": "GexBias"
+            },
+            "GexBucket": {
+                "properties": {
+                    "strike": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strike"
+                    },
+                    "call_gex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Gex"
+                    },
+                    "put_gex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Gex"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "pct_from_spot": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pct From Spot"
+                    },
+                    "tag": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tag"
+                    }
+                },
+                "type": "object",
+                "title": "GexBucket"
+            },
+            "GexExpectedRange": {
+                "properties": {
+                    "low": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Low"
+                    },
+                    "high": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "High"
+                    },
+                    "iv_1d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv 1D"
+                    }
+                },
+                "type": "object",
+                "title": "GexExpectedRange"
+            },
+            "GexFlipMigrationEntry": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "title": "Date"
+                    },
+                    "flip": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flip"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "GexFlipMigrationEntry"
+            },
+            "GexHistoryEntry": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "title": "Date"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "net_dex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Dex"
+                    },
+                    "gex_flip": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gex Flip"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "atm_iv": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Atm Iv"
+                    },
+                    "vol_pc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vol Pc"
+                    },
+                    "bias": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bias"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "GexHistoryEntry"
+            },
+            "GexIvData": {
+                "properties": {
+                    "iv30d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv30D"
+                    },
+                    "iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank"
+                    },
+                    "hv30": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Hv30"
+                    },
+                    "mq_iv30d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mq Iv30D"
+                    },
+                    "mq_iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mq Iv Rank"
+                    },
+                    "source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source"
+                    }
+                },
+                "type": "object",
+                "title": "GexIvData"
+            },
+            "GexLevels": {
+                "properties": {
+                    "gex_flip": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "max_magnet": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "second_magnet": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "max_accelerator": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "put_wall": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "call_wall": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "GexLevels"
+            },
+            "GexMqLevels": {
+                "properties": {
+                    "source_date": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source Date"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "hvl": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Hvl"
+                    },
+                    "call_resistance_all": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Resistance All"
+                    },
+                    "call_resistance_0dte": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Resistance 0Dte"
+                    },
+                    "put_support_all": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Support All"
+                    },
+                    "put_support_0dte": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Support 0Dte"
+                    },
+                    "expected_high": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected High"
+                    },
+                    "expected_low": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected Low"
+                    },
+                    "distance_to_hvl_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Distance To Hvl Pct"
+                    },
+                    "iv30d": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv30D"
+                    },
+                    "hv30": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Hv30"
+                    },
+                    "iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank"
+                    },
+                    "top_gex_strikes": {
+                        "items": {
+                            "type": "number"
+                        },
+                        "type": "array",
+                        "title": "Top Gex Strikes"
+                    }
+                },
+                "type": "object",
+                "title": "GexMqLevels"
+            },
+            "GexResponse": {
+                "properties": {
+                    "scan_time": {
+                        "type": "string",
+                        "title": "Scan Time",
+                        "default": ""
+                    },
+                    "market_open": {
+                        "type": "boolean",
+                        "title": "Market Open",
+                        "default": false
+                    },
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker",
+                        "default": "SPX"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "close": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Close"
+                    },
+                    "prev_close": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Close"
+                    },
+                    "market_time": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Market Time"
+                    },
+                    "tape_time": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tape Time"
+                    },
+                    "spot_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Source"
+                    },
+                    "day_change": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Day Change"
+                    },
+                    "day_change_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Day Change Pct"
+                    },
+                    "data_date": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Data Date"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "net_dex": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Dex"
+                    },
+                    "atm_iv": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Atm Iv"
+                    },
+                    "vol_pc": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vol Pc"
+                    },
+                    "levels": {
+                        "$ref": "#/components/schemas/GexLevels"
+                    },
+                    "profile": {
+                        "items": {
+                            "$ref": "#/components/schemas/GexBucket"
+                        },
+                        "type": "array",
+                        "title": "Profile"
+                    },
+                    "expected_range": {
+                        "$ref": "#/components/schemas/GexExpectedRange"
+                    },
+                    "bias": {
+                        "$ref": "#/components/schemas/GexBias"
+                    },
+                    "history": {
+                        "items": {
+                            "$ref": "#/components/schemas/GexHistoryEntry"
+                        },
+                        "type": "array",
+                        "title": "History"
+                    },
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexIvData"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "mq": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexMqLevels"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "source_delta": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDelta"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "GexResponse"
+            },
+            "GexSourceDelta": {
+                "properties": {
+                    "flip_vs_hvl": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "put_wall_vs_support_all": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "put_wall_vs_support_0dte": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "call_wall_vs_resistance_all": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "call_wall_vs_resistance_0dte": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GexSourceDeltaEntry"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "GexSourceDelta"
+            },
+            "GexSourceDeltaEntry": {
+                "properties": {
+                    "uw": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uw"
+                    },
+                    "mq": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mq"
+                    },
+                    "delta": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Delta"
+                    }
+                },
+                "type": "object",
+                "title": "GexSourceDeltaEntry"
+            },
+            "GoldCbCountryHistory": {
+                "properties": {
+                    "country_iso3": {
+                        "type": "string",
+                        "title": "Country Iso3"
+                    },
+                    "country_name": {
+                        "type": "string",
+                        "title": "Country Name"
+                    },
+                    "bucket": {
+                        "type": "string",
+                        "title": "Bucket"
+                    },
+                    "latest_reserves_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latest Reserves T"
+                    },
+                    "history": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldHistoryPoint"
+                        },
+                        "type": "array",
+                        "title": "History",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "country_iso3",
+                    "country_name",
+                    "bucket"
+                ],
+                "title": "GoldCbCountryHistory"
+            },
+            "GoldCorrelationBand": {
+                "properties": {
+                    "mean": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Mean"
+                    },
+                    "std": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Std"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "mean",
+                    "std"
+                ],
+                "title": "GoldCorrelationBand"
+            },
+            "GoldCorrelationHistory": {
+                "properties": {
+                    "gold_dfii10": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldCorrelationPoint"
+                        },
+                        "type": "array",
+                        "title": "Gold Dfii10",
+                        "default": []
+                    },
+                    "gold_dxy": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldCorrelationPoint"
+                        },
+                        "type": "array",
+                        "title": "Gold Dxy",
+                        "default": []
+                    },
+                    "gold_gpr": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldCorrelationPoint"
+                        },
+                        "type": "array",
+                        "title": "Gold Gpr",
+                        "default": []
+                    },
+                    "pre_2022_band": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GoldCorrelationBand"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "GoldCorrelationHistory",
+                "description": "Tier 5 correlation-history panel inputs."
+            },
+            "GoldCorrelationPoint": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "value": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Value"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "value"
+                ],
+                "title": "GoldCorrelationPoint"
+            },
+            "GoldCyclicalPostureModel": {
+                "properties": {
+                    "zone_label": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Zone Label"
+                    },
+                    "posture_chip": {
+                        "type": "string",
+                        "enum": [
+                            "FAVORABLE",
+                            "NEUTRAL",
+                            "STRETCHED",
+                            "SUSPENDED",
+                            "DEGRADED"
+                        ],
+                        "title": "Posture Chip"
+                    },
+                    "cpi_yoy": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cpi Yoy"
+                    },
+                    "t5yifr": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "T5Yifr"
+                    },
+                    "t5yifr_pct_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "T5Yifr Pct 52W"
+                    },
+                    "dfii10": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dfii10"
+                    },
+                    "dfii10_60d_change_bps": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dfii10 60D Change Bps"
+                    },
+                    "dxy": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dxy"
+                    },
+                    "dxy_60d_sigma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dxy 60D Sigma"
+                    },
+                    "gpr_value": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gpr Value"
+                    },
+                    "gpr_pct_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gpr Pct 52W"
+                    },
+                    "factors": {
+                        "additionalProperties": {
+                            "type": "number"
+                        },
+                        "type": "object",
+                        "title": "Factors",
+                        "default": {}
+                    },
+                    "two_force_text": {
+                        "$ref": "#/components/schemas/GoldTwoForceText"
+                    },
+                    "narrative_text": {
+                        "type": "string",
+                        "title": "Narrative Text"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "posture_chip",
+                    "two_force_text",
+                    "narrative_text"
+                ],
+                "title": "GoldCyclicalPostureModel"
+            },
+            "GoldDataFreshnessSource": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "title": "Id"
+                    },
+                    "last_as_of": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last As Of"
+                    },
+                    "stale_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Stale Seconds"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "missing"
+                        ],
+                        "title": "Status",
+                        "default": "ok"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id"
+                ],
+                "title": "GoldDataFreshnessSource",
+                "description": "Per-source freshness for the Tier 1 Data Freshness card."
+            },
+            "GoldDecompositionRow": {
+                "properties": {
+                    "lens": {
+                        "type": "string",
+                        "enum": [
+                            "L1",
+                            "L2",
+                            "L3"
+                        ],
+                        "title": "Lens"
+                    },
+                    "factor": {
+                        "type": "string",
+                        "title": "Factor"
+                    },
+                    "contribution": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Contribution"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lens",
+                    "factor",
+                    "contribution"
+                ],
+                "title": "GoldDecompositionRow",
+                "description": "One row of the Tier 5 lens-decomposition bars."
+            },
+            "GoldGaugeResponse": {
+                "properties": {
+                    "current": {
+                        "$ref": "#/components/schemas/GoldGaugeState"
+                    },
+                    "history_252d": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldGaugeTimeSeriesPoint"
+                        },
+                        "type": "array",
+                        "title": "History 252D"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "current",
+                    "history_252d"
+                ],
+                "title": "GoldGaugeResponse"
+            },
+            "GoldGaugeState": {
+                "properties": {
+                    "corr_60d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 60D"
+                    },
+                    "corr_126d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 126D"
+                    },
+                    "corr_252d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 252D"
+                    },
+                    "corr_504d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 504D"
+                    },
+                    "corr_252d_returns": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 252D Returns"
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": [
+                            "operative",
+                            "partial",
+                            "suspended"
+                        ],
+                        "title": "State"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "state"
+                ],
+                "title": "GoldGaugeState"
+            },
+            "GoldGaugeTimeSeriesPoint": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "corr_252d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Corr 252D"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "corr_252d"
+                ],
+                "title": "GoldGaugeTimeSeriesPoint"
+            },
+            "GoldHistoryPoint": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "value": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Value"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "value"
+                ],
+                "title": "GoldHistoryPoint"
+            },
+            "GoldInputProvenance": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "as_of": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "As Of"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "as_of"
+                ],
+                "title": "GoldInputProvenance"
+            },
+            "GoldInputSeriesPoint": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "value": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Value"
+                    },
+                    "as_of": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "As Of"
+                    },
+                    "release_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Release Date"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "value",
+                    "as_of"
+                ],
+                "title": "GoldInputSeriesPoint"
+            },
+            "GoldInputSeriesResponse": {
+                "properties": {
+                    "series_id": {
+                        "type": "string",
+                        "title": "Series Id"
+                    },
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldInputSeriesPoint"
+                        },
+                        "type": "array",
+                        "title": "Points"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "series_id",
+                    "points"
+                ],
+                "title": "GoldInputSeriesResponse"
+            },
+            "GoldLensResponse": {
+                "properties": {
+                    "lens_id": {
+                        "type": "string",
+                        "enum": [
+                            "structural",
+                            "cyclical",
+                            "valuation"
+                        ],
+                        "title": "Lens Id"
+                    },
+                    "posture": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/GoldStructuralPostureModel"
+                            },
+                            {
+                                "$ref": "#/components/schemas/GoldCyclicalPostureModel"
+                            },
+                            {
+                                "$ref": "#/components/schemas/GoldValuationPostureModel"
+                            }
+                        ],
+                        "title": "Posture"
+                    },
+                    "detail": {
+                        "additionalProperties": {
+                            "items": {
+                                "$ref": "#/components/schemas/GoldInputSeriesPoint"
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lens_id",
+                    "posture",
+                    "detail"
+                ],
+                "title": "GoldLensResponse",
+                "description": "Detail payload for one lens (richer than the summary in GoldStateResponse)."
+            },
+            "GoldSpotTile": {
+                "properties": {
+                    "last": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Last"
+                    },
+                    "delta_abs": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Delta Abs"
+                    },
+                    "delta_pct": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Delta Pct"
+                    },
+                    "high": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "High"
+                    },
+                    "low": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Low"
+                    },
+                    "open": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Open"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "last",
+                    "delta_abs",
+                    "delta_pct",
+                    "high",
+                    "low",
+                    "open"
+                ],
+                "title": "GoldSpotTile",
+                "description": "XAU/USD snapshot used by the Tier 1 KPI strip."
+            },
+            "GoldStateResponse": {
+                "properties": {
+                    "obs_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Obs Date"
+                    },
+                    "computed_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Computed At"
+                    },
+                    "gauge": {
+                        "$ref": "#/components/schemas/GoldGaugeState"
+                    },
+                    "spot": {
+                        "$ref": "#/components/schemas/GoldSpotTile"
+                    },
+                    "structural": {
+                        "$ref": "#/components/schemas/GoldStructuralPostureModel"
+                    },
+                    "cyclical": {
+                        "$ref": "#/components/schemas/GoldCyclicalPostureModel"
+                    },
+                    "valuation": {
+                        "$ref": "#/components/schemas/GoldValuationPostureModel"
+                    },
+                    "inputs_used": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/GoldInputProvenance"
+                        },
+                        "type": "object",
+                        "title": "Inputs Used"
+                    },
+                    "data_freshness": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldDataFreshnessSource"
+                        },
+                        "type": "array",
+                        "title": "Data Freshness",
+                        "default": []
+                    },
+                    "decomposition_rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldDecompositionRow"
+                        },
+                        "type": "array",
+                        "title": "Decomposition Rows",
+                        "default": []
+                    },
+                    "correlation_history": {
+                        "$ref": "#/components/schemas/GoldCorrelationHistory",
+                        "default": {
+                            "gold_dfii10": [],
+                            "gold_dxy": [],
+                            "gold_gpr": []
+                        }
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "obs_date",
+                    "computed_at",
+                    "gauge",
+                    "spot",
+                    "structural",
+                    "cyclical",
+                    "valuation",
+                    "inputs_used"
+                ],
+                "title": "GoldStateResponse"
+            },
+            "GoldStructuralPostureModel": {
+                "properties": {
+                    "state_label": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Label"
+                    },
+                    "posture_chip": {
+                        "type": "string",
+                        "enum": [
+                            "FAVORABLE",
+                            "NEUTRAL",
+                            "STRETCHED",
+                            "SUSPENDED",
+                            "DEGRADED"
+                        ],
+                        "title": "Posture Chip"
+                    },
+                    "cb_strategic_12m_sum_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cb Strategic 12M Sum T"
+                    },
+                    "cb_tactical_12m_sum_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cb Tactical 12M Sum T"
+                    },
+                    "cb_diversifier_12m_sum_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cb Diversifier 12M Sum T"
+                    },
+                    "cb_52w_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cb 52W Pct"
+                    },
+                    "gld_holdings_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gld Holdings T"
+                    },
+                    "gld_30d_net_flow_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gld 30D Net Flow T"
+                    },
+                    "comex_registered_oz": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Comex Registered Oz"
+                    },
+                    "comex_20d_roc_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Comex 20D Roc Pct"
+                    },
+                    "lbma_30d_momentum_t": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Lbma 30D Momentum T"
+                    },
+                    "cot_mm_net_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cot Mm Net Pct"
+                    },
+                    "cot_mm_4w_change_sigma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cot Mm 4W Change Sigma"
+                    },
+                    "uw_25d_skew_sigma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uw 25D Skew Sigma"
+                    },
+                    "fx_basket_dxy_z": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Fx Basket Dxy Z"
+                    },
+                    "xau_cny_premium_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Xau Cny Premium Pct"
+                    },
+                    "gld_history": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldHistoryPoint"
+                        },
+                        "type": "array",
+                        "title": "Gld History",
+                        "default": []
+                    },
+                    "gold_history": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldHistoryPoint"
+                        },
+                        "type": "array",
+                        "title": "Gold History",
+                        "default": []
+                    },
+                    "cb_country_history": {
+                        "items": {
+                            "$ref": "#/components/schemas/GoldCbCountryHistory"
+                        },
+                        "type": "array",
+                        "title": "Cb Country History",
+                        "default": []
+                    },
+                    "narrative_text": {
+                        "type": "string",
+                        "title": "Narrative Text"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "posture_chip",
+                    "narrative_text"
+                ],
+                "title": "GoldStructuralPostureModel"
+            },
+            "GoldTwoForceText": {
+                "properties": {
+                    "discount_rate": {
+                        "type": "string",
+                        "title": "Discount Rate"
+                    },
+                    "hedge_demand": {
+                        "type": "string",
+                        "title": "Hedge Demand"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "discount_rate",
+                    "hedge_demand"
+                ],
+                "title": "GoldTwoForceText"
+            },
+            "GoldValuationPostureModel": {
+                "properties": {
+                    "flag": {
+                        "type": "string",
+                        "enum": [
+                            "Low",
+                            "Moderate",
+                            "High",
+                            "Severe"
+                        ],
+                        "title": "Flag"
+                    },
+                    "posture_chip": {
+                        "type": "string",
+                        "enum": [
+                            "FAVORABLE",
+                            "NEUTRAL",
+                            "STRETCHED",
+                            "SUSPENDED",
+                            "DEGRADED"
+                        ],
+                        "title": "Posture Chip"
+                    },
+                    "real_price_percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Real Price Percentile"
+                    },
+                    "gold_m2_ratio_percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gold M2 Ratio Percentile"
+                    },
+                    "gold_oil_ratio_percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gold Oil Ratio Percentile"
+                    },
+                    "gold_spx_ratio_percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gold Spx Ratio Percentile"
+                    },
+                    "narrative_text": {
+                        "type": "string",
+                        "title": "Narrative Text"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "flag",
+                    "posture_chip",
+                    "narrative_text"
+                ],
+                "title": "GoldValuationPostureModel"
+            },
+            "GuidanceResponse": {
+                "properties": {
+                    "state": {
+                        "type": "string",
+                        "title": "State"
+                    },
+                    "posture": {
+                        "type": "string",
+                        "enum": [
+                            "opportunistic",
+                            "neutral",
+                            "cautious",
+                            "defensive"
+                        ],
+                        "title": "Posture"
+                    },
+                    "body_md": {
+                        "type": "string",
+                        "title": "Body Md"
+                    },
+                    "matched_condition": {
+                        "type": "string",
+                        "title": "Matched Condition"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "state",
+                    "posture",
+                    "body_md",
+                    "matched_condition"
+                ],
+                "title": "GuidanceResponse"
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "HealthResponse": {
+                "properties": {
+                    "ok": {
+                        "type": "boolean",
+                        "title": "Ok"
+                    },
+                    "db": {
+                        "type": "string",
+                        "title": "Db"
+                    },
+                    "scheduler_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scheduler Lag Seconds"
+                    },
+                    "last_full_scan_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Full Scan At"
+                    },
+                    "reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reason"
+                    },
+                    "worker_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Worker Lag Seconds"
+                    },
+                    "scheduler_heartbeat_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scheduler Heartbeat Lag Seconds"
+                    },
+                    "scheduler_heartbeat_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scheduler Heartbeat Name"
+                    },
+                    "rescan_heartbeat_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rescan Heartbeat Lag Seconds"
+                    },
+                    "spot_refresh_heartbeat_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Refresh Heartbeat Lag Seconds"
+                    },
+                    "spot_quote_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Quote Lag Seconds"
+                    },
+                    "latest_spot_quote_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latest Spot Quote At"
+                    },
+                    "latest_spot_quote_fetched_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latest Spot Quote Fetched At"
+                    },
+                    "watchlist_size": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Watchlist Size"
+                    },
+                    "source": {
+                        "type": "string",
+                        "title": "Source",
+                        "default": "UnusualWhales"
+                    },
+                    "latency_p95_ms": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latency P95 Ms"
+                    },
+                    "http_2xx": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Http 2Xx"
+                    },
+                    "http_4xx": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Http 4Xx"
+                    },
+                    "http_5xx": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Http 5Xx"
+                    },
+                    "uw_today": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uw Today"
+                    },
+                    "cache_hit_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Hit Pct"
+                    },
+                    "throughput_window_minutes": {
+                        "type": "number",
+                        "title": "Throughput Window Minutes",
+                        "default": 0.0
+                    },
+                    "requests_per_minute": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Requests Per Minute"
+                    },
+                    "http_429": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Http 429"
+                    },
+                    "avg_scan_duration_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg Scan Duration Seconds"
+                    },
+                    "queue_drain_rate_per_minute": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Queue Drain Rate Per Minute"
+                    },
+                    "record_health_ok": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Record Health Ok"
+                    },
+                    "record_health": {
+                        "items": {
+                            "$ref": "#/components/schemas/RecordHealthCheck"
+                        },
+                        "type": "array",
+                        "title": "Record Health"
+                    },
+                    "workers": {
+                        "items": {
+                            "$ref": "#/components/schemas/WorkerHealth"
+                        },
+                        "type": "array",
+                        "title": "Workers"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ok",
+                    "db"
+                ],
+                "title": "HealthResponse"
+            },
+            "InsightBadge": {
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "title": "Code"
+                    },
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "severity": {
+                        "type": "string",
+                        "title": "Severity",
+                        "default": "info"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "code",
+                    "label"
+                ],
+                "title": "InsightBadge"
+            },
+            "InsightLeg": {
+                "properties": {
+                    "side": {
+                        "type": "string",
+                        "title": "Side"
+                    },
+                    "option_symbol": {
+                        "type": "string",
+                        "title": "Option Symbol"
+                    },
+                    "option_right": {
+                        "type": "string",
+                        "title": "Option Right"
+                    },
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "mid": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mid"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "side",
+                    "option_symbol",
+                    "option_right",
+                    "expiry",
+                    "strike"
+                ],
+                "title": "InsightLeg"
+            },
+            "InsightSignalRow": {
+                "properties": {
+                    "lens": {
+                        "type": "string",
+                        "title": "Lens"
+                    },
+                    "read": {
+                        "type": "string",
+                        "title": "Read"
+                    },
+                    "evidence": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Evidence",
+                        "default": []
+                    },
+                    "conflicts": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Conflicts",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lens",
+                    "read"
+                ],
+                "title": "InsightSignalRow"
+            },
+            "InsightsSynthesis": {
+                "properties": {
+                    "dominant_story": {
+                        "type": "string",
+                        "title": "Dominant Story",
+                        "default": ""
+                    },
+                    "preferred_idea_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Preferred Idea Id"
+                    },
+                    "best_risk_reward_idea_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Best Risk Reward Idea Id"
+                    },
+                    "avoid": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Avoid",
+                        "default": []
+                    },
+                    "required_before_sizing": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Required Before Sizing",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "title": "InsightsSynthesis"
+            },
+            "IvHistogramBin": {
+                "properties": {
+                    "lo": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Lo"
+                    },
+                    "hi": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Hi"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "title": "Count"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "lo",
+                    "hi",
+                    "count"
+                ],
+                "title": "IvHistogramBin"
+            },
+            "IvHvPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    },
+                    "rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "IvHvPoint"
+            },
+            "IvOfIvPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    },
+                    "iv_of_iv_20": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Of Iv 20"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "IvOfIvPoint"
+            },
+            "IvPercentileDistribution": {
+                "properties": {
+                    "bins": {
+                        "items": {
+                            "$ref": "#/components/schemas/IvHistogramBin"
+                        },
+                        "type": "array",
+                        "title": "Bins",
+                        "default": []
+                    },
+                    "current_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Current Iv"
+                    },
+                    "current_pctile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Current Pctile"
+                    }
+                },
+                "type": "object",
+                "title": "IvPercentileDistribution"
+            },
+            "JobStatus": {
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "title": "Job Id"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "queued",
+                            "running",
+                            "done",
+                            "failed"
+                        ],
+                        "title": "Status"
+                    },
+                    "run_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Run Id"
+                    },
+                    "error": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Error"
+                    },
+                    "requested_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Requested At"
+                    },
+                    "started_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Started At"
+                    },
+                    "finished_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "job_id",
+                    "status",
+                    "requested_at"
+                ],
+                "title": "JobStatus"
+            },
+            "MarketAggregates": {
+                "properties": {
+                    "call_oi_total": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Oi Total"
+                    },
+                    "put_oi_total": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Oi Total"
+                    },
+                    "call_volume_total": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume Total"
+                    },
+                    "put_volume_total": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume Total"
+                    },
+                    "call_volume_ask_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume Ask Side"
+                    },
+                    "call_volume_bid_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume Bid Side"
+                    },
+                    "put_volume_ask_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume Ask Side"
+                    },
+                    "put_volume_bid_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume Bid Side"
+                    },
+                    "pcr_oi": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Oi"
+                    },
+                    "pcr_vol": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Vol"
+                    },
+                    "iv30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv30D"
+                    },
+                    "market_cap": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Market Cap"
+                    },
+                    "aum": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Aum"
+                    }
+                },
+                "type": "object",
+                "title": "MarketAggregates",
+                "description": "Per-ticker aggregate fields sourced from the bulk-screener endpoint.\n\nPopulated by pipeline.run_single_stock alongside the existing per-section\nsub-models. Feeds the watchlist card POSITIONING and SKEW blocks."
+            },
+            "MarketStructure": {
+                "properties": {
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "nearest_expiry": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Nearest Expiry"
+                    },
+                    "total_call_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Call Gex"
+                    },
+                    "total_put_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Put Gex"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "total_call_dex_oi": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Call Dex Oi"
+                    },
+                    "total_put_dex_oi": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Total Put Dex Oi"
+                    },
+                    "max_pain": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Pain"
+                    },
+                    "top_call_oi_strikes": {
+                        "items": {
+                            "type": "string",
+                            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                        },
+                        "type": "array",
+                        "title": "Top Call Oi Strikes",
+                        "default": []
+                    },
+                    "top_put_oi_strikes": {
+                        "items": {
+                            "type": "string",
+                            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                        },
+                        "type": "array",
+                        "title": "Top Put Oi Strikes",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "title": "MarketStructure"
+            },
+            "MarketStructureLevels": {
+                "properties": {
+                    "gex_flip": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "call_wall": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "put_wall": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "max_magnet": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "second_magnet": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "max_accel": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "title": "MarketStructureLevels",
+                "description": "Derived strike-level reference points used by the Market Structure tab.\n\nConventions follow FlashAlpha / SpotGamma:\n  - gex_flip: lowest strike where running cumulative net_gex flips sign\n  - call_wall: strike with largest call-side gamma (typically above spot)\n  - put_wall: strike with largest put-side gamma magnitude (typically below spot)\n  - max_magnet: strike with largest positive net_gex above spot (pulls price up)\n  - second_magnet: strike with second-largest positive net_gex above spot\n  - max_accel: strike with most-negative net_gex below the flip (movement accelerator)"
+            },
+            "MatrixSourceFreshness": {
+                "properties": {
+                    "vanna_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Charm"
+                    },
+                    "skew": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew"
+                    },
+                    "term": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Term"
+                    },
+                    "im_vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Im Vrp"
+                    },
+                    "vrp_rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp Rv"
+                    },
+                    "oi": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Oi"
+                    }
+                },
+                "type": "object",
+                "title": "MatrixSourceFreshness"
+            },
+            "MatrixState": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "threshold_version": {
+                        "type": "integer",
+                        "title": "Threshold Version",
+                        "default": 1
+                    },
+                    "vanna_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Vanna State"
+                    },
+                    "charm_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Charm State"
+                    },
+                    "skew_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Skew State"
+                    },
+                    "term_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Term State"
+                    },
+                    "im_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Im State"
+                    },
+                    "flow_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Flow State"
+                    },
+                    "vrp_state": {
+                        "type": "string",
+                        "enum": [
+                            "vol_up",
+                            "vol_down",
+                            "neutral",
+                            "stale"
+                        ],
+                        "title": "Vrp State"
+                    },
+                    "consistency_tier": {
+                        "type": "string",
+                        "enum": [
+                            "strict",
+                            "strong",
+                            "weak",
+                            "no_trade",
+                            "insufficient_data"
+                        ],
+                        "title": "Consistency Tier"
+                    },
+                    "cluster_coverage_ok": {
+                        "type": "boolean",
+                        "title": "Cluster Coverage Ok"
+                    },
+                    "term_classification": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "contango",
+                                    "event_back",
+                                    "liquidity_back",
+                                    "mixed"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Term Classification"
+                    },
+                    "skew_25d_zscore_180d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew 25D Zscore 180D"
+                    },
+                    "iv_atm_30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Atm 30D"
+                    },
+                    "rv_30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv 30D"
+                    },
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "vrp_zscore_60d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp Zscore 60D"
+                    },
+                    "implied_move_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Pct"
+                    },
+                    "front_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Front Iv"
+                    },
+                    "back_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Back Iv"
+                    },
+                    "front_back_spread": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Front Back Spread"
+                    },
+                    "pin_distance_sigma": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pin Distance Sigma"
+                    },
+                    "vrp_sign_flip_status": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "string",
+                                "const": "insufficient_history"
+                            }
+                        ],
+                        "title": "Vrp Sign Flip Status",
+                        "default": "insufficient_history"
+                    },
+                    "vrp_sign_flip_aligned_days": {
+                        "type": "integer",
+                        "title": "Vrp Sign Flip Aligned Days",
+                        "default": 0
+                    },
+                    "vanna_conditional_reading": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "grind_up",
+                                    "reverse_selloff",
+                                    "reflexive_sell_pressure",
+                                    "weak_noise"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Conditional Reading"
+                    },
+                    "directional_imbalance_3d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Directional Imbalance 3D"
+                    },
+                    "vanna_oi_change_bias": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "call_oi_build",
+                                    "put_oi_build",
+                                    "mixed"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vanna Oi Change Bias"
+                    },
+                    "charm_regime": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "operative_magnet",
+                                    "broken_magnet",
+                                    "opex_vortex",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Charm Regime"
+                    },
+                    "charm_stress_override": {
+                        "type": "boolean",
+                        "title": "Charm Stress Override",
+                        "default": false
+                    },
+                    "skew_25d_5d_change": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew 25D 5D Change"
+                    },
+                    "skew_regime": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "smirk",
+                                    "accelerated",
+                                    "crash_smile",
+                                    "neutral"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew Regime"
+                    },
+                    "skew_term_structure": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew Term Structure"
+                    },
+                    "single_point_bump_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Single Point Bump Pct"
+                    },
+                    "full_curve_slope_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Full Curve Slope Pct"
+                    },
+                    "term_johnson_slope_pc1": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Term Johnson Slope Pc1"
+                    },
+                    "atm_straddle_mid": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Atm Straddle Mid"
+                    },
+                    "implied_move_expected_abs": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Expected Abs"
+                    },
+                    "implied_move_event_percentile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Event Percentile"
+                    },
+                    "vrp_zscore_252d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp Zscore 252D"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "market_date",
+                    "vanna_state",
+                    "charm_state",
+                    "skew_state",
+                    "term_state",
+                    "im_state",
+                    "flow_state",
+                    "vrp_state",
+                    "consistency_tier",
+                    "cluster_coverage_ok"
+                ],
+                "title": "MatrixState"
+            },
+            "MaxPainRow": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "max_pain": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Pain"
+                    },
+                    "close": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Close"
+                    },
+                    "open": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Open"
+                    },
+                    "next_upper_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Upper Strike"
+                    },
+                    "next_lower_strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Lower Strike"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "MaxPainRow"
+            },
+            "OhlcRow": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "open": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Open"
+                    },
+                    "high": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "High"
+                    },
+                    "low": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Low"
+                    },
+                    "close": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Close"
+                    },
+                    "volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volume"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date",
+                    "close"
+                ],
+                "title": "OhlcRow"
+            },
+            "OiChangeRow": {
+                "properties": {
+                    "underlying_symbol": {
+                        "type": "string",
+                        "title": "Underlying Symbol"
+                    },
+                    "option_symbol": {
+                        "type": "string",
+                        "title": "Option Symbol"
+                    },
+                    "curr_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Curr Date"
+                    },
+                    "last_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Date"
+                    },
+                    "curr_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Curr Oi"
+                    },
+                    "last_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Oi"
+                    },
+                    "oi_diff_plain": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Oi Diff Plain"
+                    },
+                    "oi_change": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Oi Change"
+                    },
+                    "volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Volume"
+                    },
+                    "trades": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Trades"
+                    },
+                    "avg_price": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg Price"
+                    },
+                    "last_fill": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Fill"
+                    },
+                    "days_of_oi_increases": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Days Of Oi Increases"
+                    },
+                    "days_of_vol_greater_than_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Days Of Vol Greater Than Oi"
+                    },
+                    "percentage_of_total": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Percentage Of Total"
+                    },
+                    "rnk": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rnk"
+                    },
+                    "prev_ask_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Ask Volume"
+                    },
+                    "prev_bid_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Bid Volume"
+                    },
+                    "prev_mid_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Mid Volume"
+                    },
+                    "prev_neutral_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Neutral Volume"
+                    },
+                    "prev_multi_leg_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Multi Leg Volume"
+                    },
+                    "prev_stock_multi_leg_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Stock Multi Leg Volume"
+                    },
+                    "prev_total_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prev Total Premium"
+                    },
+                    "last_ask": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Ask"
+                    },
+                    "last_bid": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Bid"
+                    },
+                    "ask_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Ask Volume"
+                    },
+                    "bid_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bid Volume"
+                    },
+                    "mid_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mid Volume"
+                    },
+                    "no_side_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "No Side Volume"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "underlying_symbol",
+                    "option_symbol"
+                ],
+                "title": "OiChangeRow"
+            },
+            "OosLabel": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "definition": {
+                        "type": "string",
+                        "title": "Definition"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name",
+                    "definition"
+                ],
+                "title": "OosLabel"
+            },
+            "OosScore": {
+                "properties": {
+                    "model": {
+                        "type": "string",
+                        "title": "Model"
+                    },
+                    "auc_dd5": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Auc Dd5"
+                    },
+                    "auc_vix30": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Auc Vix30"
+                    },
+                    "auc_dd10": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Auc Dd10"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "model"
+                ],
+                "title": "OosScore"
+            },
+            "OosSummary": {
+                "properties": {
+                    "as_of": {
+                        "type": "string",
+                        "title": "As Of"
+                    },
+                    "notebook": {
+                        "type": "string",
+                        "title": "Notebook"
+                    },
+                    "method": {
+                        "type": "string",
+                        "title": "Method"
+                    },
+                    "labels": {
+                        "items": {
+                            "$ref": "#/components/schemas/OosLabel"
+                        },
+                        "type": "array",
+                        "title": "Labels"
+                    },
+                    "scores": {
+                        "items": {
+                            "$ref": "#/components/schemas/OosScore"
+                        },
+                        "type": "array",
+                        "title": "Scores"
+                    },
+                    "interpretation": {
+                        "type": "string",
+                        "title": "Interpretation"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "as_of",
+                    "notebook",
+                    "method",
+                    "labels",
+                    "scores",
+                    "interpretation"
+                ],
+                "title": "OosSummary"
+            },
+            "OptionChainPerStrikeRow": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume"
+                    },
+                    "put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume"
+                    },
+                    "call_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Oi"
+                    },
+                    "put_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Oi"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry",
+                    "strike"
+                ],
+                "title": "OptionChainPerStrikeRow",
+                "description": "Aggregated (expiry, strike) snapshot \u2014 both volume and OI in one row.\n\nBacks both strike-profile charts (Volume and OI variants)."
+            },
+            "OptionIntradayProfile": {
+                "properties": {
+                    "option_symbol": {
+                        "type": "string",
+                        "title": "Option Symbol"
+                    },
+                    "trade_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Trade Date"
+                    },
+                    "total_volume": {
+                        "type": "integer",
+                        "title": "Total Volume",
+                        "default": 0
+                    },
+                    "first_trade_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "First Trade Time"
+                    },
+                    "last_trade_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Trade Time"
+                    },
+                    "peak_window_start": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Peak Window Start"
+                    },
+                    "peak_window_end": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Peak Window End"
+                    },
+                    "peak_window_share_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Peak Window Share Pct"
+                    },
+                    "sparkline": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "type": "array",
+                        "title": "Sparkline",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "option_symbol",
+                    "trade_date"
+                ],
+                "title": "OptionIntradayProfile",
+                "description": "Derived per-contract intraday tape view for the OI movers table.\n\nBuilt by ``cards.intraday_profile.derive_intraday_profile`` from persisted\n:class:`OptionContractIntradayBucket` rows. Volume here is side-aggregated\n(ask + bid + mid + multi). The 12-point sparkline is a fixed-length\ndownsample so the UI renders a stable width regardless of how many\nminute bars the contract actually had."
+            },
+            "OptionsDailyRow": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume"
+                    },
+                    "put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume"
+                    },
+                    "call_volume_ask_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume Ask Side"
+                    },
+                    "call_volume_bid_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Volume Bid Side"
+                    },
+                    "put_volume_ask_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume Ask Side"
+                    },
+                    "put_volume_bid_side": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Volume Bid Side"
+                    },
+                    "call_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Premium"
+                    },
+                    "put_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Premium"
+                    },
+                    "net_call_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Call Premium"
+                    },
+                    "net_put_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Put Premium"
+                    },
+                    "bullish_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bullish Premium"
+                    },
+                    "bearish_premium": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bearish Premium"
+                    },
+                    "call_open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Open Interest"
+                    },
+                    "put_open_interest": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Open Interest"
+                    },
+                    "avg_3_day_call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 3 Day Call Volume"
+                    },
+                    "avg_3_day_put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 3 Day Put Volume"
+                    },
+                    "avg_7_day_call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 7 Day Call Volume"
+                    },
+                    "avg_7_day_put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 7 Day Put Volume"
+                    },
+                    "avg_30_day_call_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 30 Day Call Volume"
+                    },
+                    "avg_30_day_put_volume": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Avg 30 Day Put Volume"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "OptionsDailyRow",
+                "description": "One row per trading day from UW /options-volume.\n\n``bullish_premium`` here is whole-tape (UW), distinct from the\nalert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot."
+            },
+            "PositioningBlock": {
+                "properties": {
+                    "call_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Oi"
+                    },
+                    "put_oi": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Oi"
+                    },
+                    "pcr_oi": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Oi"
+                    },
+                    "pcr_vol": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Vol"
+                    },
+                    "pcr_delta_30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Delta 30D"
+                    }
+                },
+                "type": "object",
+                "title": "PositioningBlock"
+            },
+            "ProviderUsageBreakdownResponse": {
+                "properties": {
+                    "provider_day_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day Start"
+                    },
+                    "provider_day_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day End"
+                    },
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProviderUsageBreakdownRow"
+                        },
+                        "type": "array",
+                        "title": "Rows"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "provider_day_start",
+                    "provider_day_end",
+                    "rows"
+                ],
+                "title": "ProviderUsageBreakdownResponse"
+            },
+            "ProviderUsageBreakdownRow": {
+                "properties": {
+                    "key": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Key"
+                    },
+                    "total_requests": {
+                        "type": "integer",
+                        "title": "Total Requests"
+                    },
+                    "http_2xx": {
+                        "type": "integer",
+                        "title": "Http 2Xx"
+                    },
+                    "http_3xx": {
+                        "type": "integer",
+                        "title": "Http 3Xx"
+                    },
+                    "http_4xx": {
+                        "type": "integer",
+                        "title": "Http 4Xx"
+                    },
+                    "http_5xx": {
+                        "type": "integer",
+                        "title": "Http 5Xx"
+                    },
+                    "transport_errors": {
+                        "type": "integer",
+                        "title": "Transport Errors"
+                    },
+                    "latency_p95_ms": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latency P95 Ms"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                    "total_requests",
+                    "http_2xx",
+                    "http_3xx",
+                    "http_4xx",
+                    "http_5xx",
+                    "transport_errors",
+                    "latency_p95_ms"
+                ],
+                "title": "ProviderUsageBreakdownRow"
+            },
+            "ProviderUsageRequestRow": {
+                "properties": {
+                    "request_id": {
+                        "type": "integer",
+                        "title": "Request Id"
+                    },
+                    "provider": {
+                        "type": "string",
+                        "title": "Provider"
+                    },
+                    "endpoint_key": {
+                        "type": "string",
+                        "title": "Endpoint Key"
+                    },
+                    "method": {
+                        "type": "string",
+                        "title": "Method"
+                    },
+                    "path": {
+                        "type": "string",
+                        "title": "Path"
+                    },
+                    "ticker": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Ticker"
+                    },
+                    "params": {
+                        "additionalProperties": true,
+                        "type": "object",
+                        "title": "Params"
+                    },
+                    "status_code": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Status Code"
+                    },
+                    "status_family": {
+                        "type": "string",
+                        "title": "Status Family"
+                    },
+                    "request_started_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Request Started At"
+                    },
+                    "request_finished_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Request Finished At"
+                    },
+                    "latency_ms": {
+                        "type": "integer",
+                        "title": "Latency Ms"
+                    },
+                    "attempt": {
+                        "type": "integer",
+                        "title": "Attempt"
+                    },
+                    "run_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Run Id"
+                    },
+                    "job_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Job Name"
+                    },
+                    "provider_request_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Provider Request Id"
+                    },
+                    "official_daily_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Official Daily Count"
+                    },
+                    "official_daily_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Official Daily Limit"
+                    },
+                    "official_minute_remaining": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Official Minute Remaining"
+                    },
+                    "official_minute_reset": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Official Minute Reset"
+                    },
+                    "error_message": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Error Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "request_id",
+                    "provider",
+                    "endpoint_key",
+                    "method",
+                    "path",
+                    "ticker",
+                    "params",
+                    "status_code",
+                    "status_family",
+                    "request_started_at",
+                    "request_finished_at",
+                    "latency_ms",
+                    "attempt",
+                    "run_id",
+                    "job_name",
+                    "provider_request_id",
+                    "official_daily_count",
+                    "official_daily_limit",
+                    "official_minute_remaining",
+                    "official_minute_reset",
+                    "error_message"
+                ],
+                "title": "ProviderUsageRequestRow"
+            },
+            "ProviderUsageRequestsResponse": {
+                "properties": {
+                    "provider_day_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day Start"
+                    },
+                    "provider_day_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day End"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "title": "Limit"
+                    },
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProviderUsageRequestRow"
+                        },
+                        "type": "array",
+                        "title": "Rows"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "provider_day_start",
+                    "provider_day_end",
+                    "limit",
+                    "rows"
+                ],
+                "title": "ProviderUsageRequestsResponse"
+            },
+            "ProviderUsageSummaryResponse": {
+                "properties": {
+                    "provider_day_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day Start"
+                    },
+                    "provider_day_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Provider Day End"
+                    },
+                    "total_requests": {
+                        "type": "integer",
+                        "title": "Total Requests"
+                    },
+                    "http_2xx": {
+                        "type": "integer",
+                        "title": "Http 2Xx"
+                    },
+                    "http_3xx": {
+                        "type": "integer",
+                        "title": "Http 3Xx"
+                    },
+                    "http_4xx": {
+                        "type": "integer",
+                        "title": "Http 4Xx"
+                    },
+                    "http_5xx": {
+                        "type": "integer",
+                        "title": "Http 5Xx"
+                    },
+                    "transport_errors": {
+                        "type": "integer",
+                        "title": "Transport Errors"
+                    },
+                    "latency_p95_ms": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latency P95 Ms"
+                    },
+                    "uw_latest_daily_count": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uw Latest Daily Count"
+                    },
+                    "uw_latest_daily_limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Uw Latest Daily Limit"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "provider_day_start",
+                    "provider_day_end",
+                    "total_requests",
+                    "http_2xx",
+                    "http_3xx",
+                    "http_4xx",
+                    "http_5xx",
+                    "transport_errors",
+                    "latency_p95_ms",
+                    "uw_latest_daily_count",
+                    "uw_latest_daily_limit"
+                ],
+                "title": "ProviderUsageSummaryResponse"
+            },
+            "QueueStatus": {
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "title": "Job Id"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "queued",
+                            "running",
+                            "done",
+                            "failed"
+                        ],
+                        "title": "Status"
+                    },
+                    "queue_position": {
+                        "type": "integer",
+                        "title": "Queue Position"
+                    },
+                    "requested_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Requested At"
+                    },
+                    "started_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Started At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "job_id",
+                    "status",
+                    "queue_position",
+                    "requested_at"
+                ],
+                "title": "QueueStatus"
+            },
+            "QueueSummary": {
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "title": "Total",
+                        "default": 0
+                    },
+                    "queued": {
+                        "type": "integer",
+                        "title": "Queued",
+                        "default": 0
+                    },
+                    "running": {
+                        "type": "integer",
+                        "title": "Running",
+                        "default": 0
+                    },
+                    "oldest_requested_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Oldest Requested At"
+                    }
+                },
+                "type": "object",
+                "title": "QueueSummary"
+            },
+            "RecordHealthCheck": {
+                "properties": {
+                    "table": {
+                        "type": "string",
+                        "title": "Table"
+                    },
+                    "window_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Window Start"
+                    },
+                    "expected_tickers": {
+                        "type": "integer",
+                        "title": "Expected Tickers"
+                    },
+                    "expected_min_tickers": {
+                        "type": "integer",
+                        "title": "Expected Min Tickers"
+                    },
+                    "actual_tickers": {
+                        "type": "integer",
+                        "title": "Actual Tickers"
+                    },
+                    "expected_min_rows": {
+                        "type": "integer",
+                        "title": "Expected Min Rows"
+                    },
+                    "actual_rows": {
+                        "type": "integer",
+                        "title": "Actual Rows"
+                    },
+                    "latest_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Latest At"
+                    },
+                    "ok": {
+                        "type": "boolean",
+                        "title": "Ok"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "table",
+                    "window_start",
+                    "expected_tickers",
+                    "expected_min_tickers",
+                    "actual_tickers",
+                    "expected_min_rows",
+                    "actual_rows",
+                    "ok"
+                ],
+                "title": "RecordHealthCheck"
+            },
+            "RegimeQuadrantBlock": {
+                "properties": {
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/RegimeQuadrantPoint"
+                        },
+                        "type": "array",
+                        "title": "Points",
+                        "default": []
+                    },
+                    "latest": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/RegimeQuadrantLatest"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "cutoff_corr": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cutoff Corr"
+                    }
+                },
+                "type": "object",
+                "title": "RegimeQuadrantBlock"
+            },
+            "RegimeQuadrantLatest": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "rvol_pctile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rvol Pctile"
+                    },
+                    "spy_corr_21": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spy Corr 21"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State",
+                        "default": ""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "RegimeQuadrantLatest"
+            },
+            "RegimeQuadrantPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "rvol_pctile": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rvol Pctile"
+                    },
+                    "spy_corr_21": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spy Corr 21"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "RegimeQuadrantPoint"
+            },
+            "RescanAllRequest": {
+                "properties": {
+                    "confirmed": {
+                        "type": "boolean",
+                        "title": "Confirmed",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "title": "RescanAllRequest"
+            },
+            "ReturnsBlock": {
+                "properties": {
+                    "d1": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "D1"
+                    },
+                    "w1": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "W1"
+                    },
+                    "d30": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "D30"
+                    }
+                },
+                "type": "object",
+                "title": "ReturnsBlock",
+                "description": "Wire shape: d1 / w1 / d30. No aliases \u2014 FastAPI would otherwise serialize\nthem as JSON keys and break the frontend contract."
+            },
+            "RvCorrPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv"
+                    },
+                    "spy_corr_21": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spy Corr 21"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "RvCorrPoint"
+            },
+            "ScannerCandidate": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "is_type_f": {
+                        "type": "boolean",
+                        "title": "Is Type F"
+                    },
+                    "raw_score": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Raw Score"
+                    },
+                    "confluence_score": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Confluence Score"
+                    },
+                    "final_score": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Final Score"
+                    },
+                    "hits": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScannerSignalHit"
+                        },
+                        "type": "array",
+                        "title": "Hits"
+                    },
+                    "context_flags": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScannerContextFlag"
+                        },
+                        "type": "array",
+                        "title": "Context Flags"
+                    },
+                    "gates": {
+                        "$ref": "#/components/schemas/ScannerGatesStatus"
+                    },
+                    "bias": {
+                        "type": "string",
+                        "enum": [
+                            "bullish",
+                            "bearish",
+                            "neutral",
+                            "mixed"
+                        ],
+                        "title": "Bias"
+                    },
+                    "bias_strength": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "strong",
+                                    "moderate",
+                                    "weak"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Bias Strength"
+                    },
+                    "setup": {
+                        "type": "string",
+                        "enum": [
+                            "ready",
+                            "caution",
+                            "blocked"
+                        ],
+                        "title": "Setup"
+                    },
+                    "setup_reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Setup Reason"
+                    },
+                    "scanned_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Scanned At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "spot",
+                    "is_type_f",
+                    "raw_score",
+                    "confluence_score",
+                    "final_score",
+                    "hits",
+                    "context_flags",
+                    "gates",
+                    "bias",
+                    "setup",
+                    "scanned_at"
+                ],
+                "title": "ScannerCandidate"
+            },
+            "ScannerContextFlag": {
+                "properties": {
+                    "layer": {
+                        "type": "string",
+                        "const": "pcr_sentiment",
+                        "title": "Layer"
+                    },
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "value": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Value"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "layer",
+                    "label",
+                    "value"
+                ],
+                "title": "ScannerContextFlag"
+            },
+            "ScannerGatedTicker": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "enum": [
+                            "regime_block",
+                            "stale_scan"
+                        ],
+                        "title": "Reason"
+                    },
+                    "blocking_chip": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "SUSPENDED",
+                                    "DEGRADED"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Blocking Chip"
+                    },
+                    "scanned_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scanned At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "reason",
+                    "scanned_at"
+                ],
+                "title": "ScannerGatedTicker"
+            },
+            "ScannerGatesStatus": {
+                "properties": {
+                    "earnings": {
+                        "type": "string",
+                        "enum": [
+                            "pass",
+                            "block"
+                        ],
+                        "title": "Earnings"
+                    },
+                    "liquidity": {
+                        "type": "string",
+                        "enum": [
+                            "pass",
+                            "block"
+                        ],
+                        "title": "Liquidity"
+                    },
+                    "regime": {
+                        "type": "string",
+                        "enum": [
+                            "pass",
+                            "block"
+                        ],
+                        "title": "Regime"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "earnings",
+                    "liquidity",
+                    "regime"
+                ],
+                "title": "ScannerGatesStatus"
+            },
+            "ScannerResponse": {
+                "properties": {
+                    "scanned_universe_size": {
+                        "type": "integer",
+                        "title": "Scanned Universe Size"
+                    },
+                    "candidates_with_hits": {
+                        "type": "integer",
+                        "title": "Candidates With Hits"
+                    },
+                    "candidates": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScannerCandidate"
+                        },
+                        "type": "array",
+                        "title": "Candidates"
+                    },
+                    "gated": {
+                        "items": {
+                            "$ref": "#/components/schemas/ScannerGatedTicker"
+                        },
+                        "type": "array",
+                        "title": "Gated"
+                    },
+                    "generated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Generated At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "scanned_universe_size",
+                    "candidates_with_hits",
+                    "candidates",
+                    "gated",
+                    "generated_at"
+                ],
+                "title": "ScannerResponse"
+            },
+            "ScannerSignalHit": {
+                "properties": {
+                    "signal_type": {
+                        "type": "string",
+                        "enum": [
+                            "deep_conviction_flow",
+                            "dark_pool_accumulation",
+                            "earnings_iv_crush",
+                            "gex_pinning"
+                        ],
+                        "title": "Signal Type"
+                    },
+                    "tier": {
+                        "type": "integer",
+                        "enum": [
+                            1,
+                            2
+                        ],
+                        "title": "Tier"
+                    },
+                    "score": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Score"
+                    },
+                    "evidence": {
+                        "additionalProperties": true,
+                        "type": "object",
+                        "title": "Evidence"
+                    },
+                    "freshness": {
+                        "type": "string",
+                        "enum": [
+                            "live",
+                            "stale",
+                            "unavailable"
+                        ],
+                        "title": "Freshness"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "signal_type",
+                    "tier",
+                    "score",
+                    "evidence",
+                    "freshness"
+                ],
+                "title": "ScannerSignalHit"
+            },
+            "SetupBlock": {
+                "properties": {
+                    "type": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Type"
+                    },
+                    "direction": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Direction"
+                    },
+                    "score": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Score"
+                    }
+                },
+                "type": "object",
+                "title": "SetupBlock"
+            },
+            "SetupClassification": {
+                "properties": {
+                    "setup_type": {
+                        "type": "string",
+                        "title": "Setup Type"
+                    },
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "direction": {
+                        "type": "string",
+                        "title": "Direction"
+                    },
+                    "score": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Score"
+                    },
+                    "confirmations": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Confirmations",
+                        "default": []
+                    },
+                    "warnings": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Warnings",
+                        "default": []
+                    },
+                    "notes": {
+                        "type": "string",
+                        "title": "Notes",
+                        "default": ""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "setup_type",
+                    "label",
+                    "direction",
+                    "score"
+                ],
+                "title": "SetupClassification"
+            },
+            "ShortDataRow": {
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "title": "Symbol"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timestamp"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name"
+                    },
+                    "short_shares_available": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Short Shares Available"
+                    },
+                    "fee_rate": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Fee Rate"
+                    },
+                    "rebate_rate": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rebate Rate"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "symbol",
+                    "timestamp"
+                ],
+                "title": "ShortDataRow"
+            },
+            "SingleStockReport": {
+                "properties": {
+                    "run_id": {
+                        "type": "integer",
+                        "title": "Run Id"
+                    },
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "generated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Generated At"
+                    },
+                    "spot_quoted_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Quoted At"
+                    },
+                    "spot_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Source"
+                    },
+                    "short_int_note": {
+                        "type": "string",
+                        "title": "Short Int Note",
+                        "default": "n/a (UW endpoint does not expose %)"
+                    },
+                    "market_structure": {
+                        "$ref": "#/components/schemas/MarketStructure"
+                    },
+                    "volatility": {
+                        "$ref": "#/components/schemas/VolatilityProfile"
+                    },
+                    "flow": {
+                        "$ref": "#/components/schemas/FlowSnapshot"
+                    },
+                    "vrp": {
+                        "$ref": "#/components/schemas/VRPAssessment"
+                    },
+                    "setup": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/SetupClassification"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "trade_plan": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TradePlan"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "dark_pool_notional": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dark Pool Notional"
+                    },
+                    "dark_pool_print_count": {
+                        "type": "integer",
+                        "title": "Dark Pool Print Count",
+                        "default": 0
+                    },
+                    "short_data": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ShortDataRow"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "max_pain_rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/MaxPainRow"
+                        },
+                        "type": "array",
+                        "title": "Max Pain Rows",
+                        "default": []
+                    },
+                    "oi_change_top": {
+                        "items": {
+                            "$ref": "#/components/schemas/OiChangeRow"
+                        },
+                        "type": "array",
+                        "title": "Oi Change Top",
+                        "default": []
+                    },
+                    "oi_change_intraday_profiles": {
+                        "items": {
+                            "$ref": "#/components/schemas/OptionIntradayProfile"
+                        },
+                        "type": "array",
+                        "title": "Oi Change Intraday Profiles",
+                        "default": []
+                    },
+                    "aggregates": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MarketAggregates"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "strike_gex_curve": {
+                        "items": {
+                            "$ref": "#/components/schemas/StrikeGexBucket"
+                        },
+                        "type": "array",
+                        "title": "Strike Gex Curve",
+                        "default": []
+                    },
+                    "market_structure_levels": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/MarketStructureLevels"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "options_timeline": {
+                        "items": {
+                            "$ref": "#/components/schemas/OptionsDailyRow"
+                        },
+                        "type": "array",
+                        "title": "Options Timeline",
+                        "default": []
+                    },
+                    "option_chain_per_strike": {
+                        "items": {
+                            "$ref": "#/components/schemas/OptionChainPerStrikeRow"
+                        },
+                        "type": "array",
+                        "title": "Option Chain Per Strike",
+                        "default": []
+                    },
+                    "strike_exposures": {
+                        "items": {
+                            "$ref": "#/components/schemas/StrikeExposureRow"
+                        },
+                        "type": "array",
+                        "title": "Strike Exposures",
+                        "default": []
+                    },
+                    "exposures_summary": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExposuresSummaryRow"
+                        },
+                        "type": "array",
+                        "title": "Exposures Summary",
+                        "default": []
+                    },
+                    "next_earnings_date": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Earnings Date"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "run_id",
+                    "ticker",
+                    "generated_at",
+                    "market_structure",
+                    "volatility",
+                    "flow",
+                    "vrp"
+                ],
+                "title": "SingleStockReport"
+            },
+            "SkewBlock": {
+                "properties": {
+                    "rr25d_30dte": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rr25D 30Dte"
+                    }
+                },
+                "type": "object",
+                "title": "SkewBlock"
+            },
+            "SmileExpiryCurve": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "points": {
+                        "items": {
+                            "$ref": "#/components/schemas/SmilePoint"
+                        },
+                        "type": "array",
+                        "title": "Points",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "SmileExpiryCurve"
+            },
+            "SmilePoint": {
+                "properties": {
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "strike"
+                ],
+                "title": "SmilePoint"
+            },
+            "SourceReconciliation": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "title": "Status",
+                        "default": "UNKNOWN"
+                    },
+                    "headline": {
+                        "type": "string",
+                        "title": "Headline",
+                        "default": "Source reconciliation unavailable"
+                    },
+                    "primary_iv_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Primary Iv Source"
+                    },
+                    "relative_shape_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Relative Shape Source"
+                    },
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/SourceReconciliationRow"
+                        },
+                        "type": "array",
+                        "title": "Rows",
+                        "default": []
+                    },
+                    "decision": {
+                        "type": "string",
+                        "title": "Decision",
+                        "default": "Use deterministic data only where source agreement is understood."
+                    }
+                },
+                "type": "object",
+                "title": "SourceReconciliation"
+            },
+            "SourceReconciliationRow": {
+                "properties": {
+                    "source_pair": {
+                        "type": "string",
+                        "title": "Source Pair"
+                    },
+                    "price_agreement": {
+                        "type": "string",
+                        "title": "Price Agreement",
+                        "default": ""
+                    },
+                    "iv_agreement": {
+                        "type": "string",
+                        "title": "Iv Agreement",
+                        "default": ""
+                    },
+                    "decision": {
+                        "type": "string",
+                        "title": "Decision",
+                        "default": ""
+                    },
+                    "strike": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strike"
+                    },
+                    "source_a_call_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source A Call Iv"
+                    },
+                    "source_b_call_iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source B Call Iv"
+                    },
+                    "iv_diff": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Diff"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "source_pair"
+                ],
+                "title": "SourceReconciliationRow"
+            },
+            "StockHistoryResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/StockHistoryRow"
+                        },
+                        "type": "array",
+                        "title": "Rows",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker"
+                ],
+                "title": "StockHistoryResponse"
+            },
+            "StockHistoryRow": {
+                "properties": {
+                    "market_date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Market Date"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "gex_flip": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gex Flip"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "net_dex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Dex"
+                    },
+                    "iv30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv30D"
+                    },
+                    "pcr_vol": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pcr Vol"
+                    },
+                    "bias": {
+                        "type": "string",
+                        "title": "Bias",
+                        "default": "NEUTRAL"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "market_date"
+                ],
+                "title": "StockHistoryRow",
+                "description": "One per-trading-day rollup of a ticker's market structure.\n\nBuilt from the latest successful scan_run on that date. spot comes from\ndaily_ohlc.close so it's a stable end-of-day reference (NULL for the\ncurrent trading day until the OHLC pull fires post-close)."
+            },
+            "StrikeExposureRow": {
+                "properties": {
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "dte": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dte"
+                    },
+                    "call_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Vanna"
+                    },
+                    "put_vanna": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Vanna"
+                    },
+                    "call_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Charm"
+                    },
+                    "put_charm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Charm"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "strike",
+                    "expiry"
+                ],
+                "title": "StrikeExposureRow",
+                "description": "One per-(expiry, strike) raw row from exposures_by_expiry_strike,\ncarrying the call/put split for vanna and charm so the FE can render\nNet + Call/Put curves without an extra fetch."
+            },
+            "StrikeGexBucket": {
+                "properties": {
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "call_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Call Gex"
+                    },
+                    "put_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Put Gex"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "strike",
+                    "expiry"
+                ],
+                "title": "StrikeGexBucket",
+                "description": "One row of the per-strike, per-expiry GEX curve persisted on each scan run."
+            },
+            "TermMoveRow": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "dte": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dte"
+                    },
+                    "atm_straddle": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Atm Straddle"
+                    },
+                    "implied_move_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move Perc"
+                    },
+                    "daily_implied_move_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Daily Implied Move Perc"
+                    },
+                    "read": {
+                        "type": "string",
+                        "title": "Read",
+                        "default": ""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "TermMoveRow"
+            },
+            "TermStructureExpiryRow": {
+                "properties": {
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "dte": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Dte"
+                    },
+                    "by_strike": {
+                        "additionalProperties": {
+                            "type": "string",
+                            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                        },
+                        "type": "object",
+                        "title": "By Strike",
+                        "default": {}
+                    },
+                    "strikes": {
+                        "additionalProperties": {
+                            "type": "string",
+                            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                        },
+                        "type": "object",
+                        "title": "Strikes",
+                        "default": {}
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "expiry"
+                ],
+                "title": "TermStructureExpiryRow"
+            },
+            "TradeInsightAiAnalysisRequest": {
+                "properties": {
+                    "force_rerun": {
+                        "type": "boolean",
+                        "title": "Force Rerun",
+                        "default": false
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "TradeInsightAiAnalysisRequest"
+            },
+            "TradeInsightAiAnalysisResponse": {
+                "properties": {
+                    "analysis_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Analysis Id"
+                    },
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "run_id": {
+                        "type": "integer",
+                        "title": "Run Id"
+                    },
+                    "trade_insights_input_hash": {
+                        "type": "string",
+                        "title": "Trade Insights Input Hash"
+                    },
+                    "analysis_input_hash": {
+                        "type": "string",
+                        "title": "Analysis Input Hash"
+                    },
+                    "model": {
+                        "type": "string",
+                        "title": "Model"
+                    },
+                    "prompt_version": {
+                        "type": "string",
+                        "title": "Prompt Version"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "queued",
+                            "running",
+                            "succeeded",
+                            "failed"
+                        ],
+                        "title": "Status"
+                    },
+                    "produced_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Produced At"
+                    },
+                    "outcome": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TradeInsightAiOutcome"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "markdown": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Markdown"
+                    },
+                    "error_message": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Error Message"
+                    },
+                    "requested_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Requested At"
+                    },
+                    "started_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Started At"
+                    },
+                    "finished_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At"
+                    },
+                    "reused": {
+                        "type": "boolean",
+                        "title": "Reused",
+                        "default": false
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "analysis_id",
+                    "ticker",
+                    "run_id",
+                    "trade_insights_input_hash",
+                    "analysis_input_hash",
+                    "model",
+                    "prompt_version",
+                    "status",
+                    "requested_at"
+                ],
+                "title": "TradeInsightAiAnalysisResponse"
+            },
+            "TradeInsightAiBestExpression": {
+                "properties": {
+                    "idea_id": {
+                        "type": "string",
+                        "title": "Idea Id"
+                    },
+                    "structure": {
+                        "type": "string",
+                        "title": "Structure"
+                    },
+                    "role": {
+                        "type": "string",
+                        "title": "Role"
+                    },
+                    "why": {
+                        "type": "string",
+                        "title": "Why"
+                    },
+                    "caveats": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Caveats"
+                    },
+                    "status_observed": {
+                        "type": "string",
+                        "title": "Status Observed"
+                    },
+                    "risk_flags_observed": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Risk Flags Observed"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "idea_id",
+                    "structure",
+                    "role",
+                    "why",
+                    "status_observed"
+                ],
+                "title": "TradeInsightAiBestExpression"
+            },
+            "TradeInsightAiConflict": {
+                "properties": {
+                    "lens": {
+                        "type": "string",
+                        "title": "Lens"
+                    },
+                    "severity": {
+                        "type": "string",
+                        "title": "Severity"
+                    },
+                    "description": {
+                        "type": "string",
+                        "title": "Description"
+                    },
+                    "affected_idea_ids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Affected Idea Ids"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "lens",
+                    "severity",
+                    "description"
+                ],
+                "title": "TradeInsightAiConflict"
+            },
+            "TradeInsightAiDominantRead": {
+                "properties": {
+                    "headline": {
+                        "type": "string",
+                        "title": "Headline"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary"
+                    },
+                    "confidence_commentary": {
+                        "type": "string",
+                        "title": "Confidence Commentary"
+                    },
+                    "data_quality_commentary": {
+                        "type": "string",
+                        "title": "Data Quality Commentary"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "headline",
+                    "summary",
+                    "confidence_commentary",
+                    "data_quality_commentary"
+                ],
+                "title": "TradeInsightAiDominantRead"
+            },
+            "TradeInsightAiGuardrails": {
+                "properties": {
+                    "statuses_preserved": {
+                        "type": "boolean",
+                        "title": "Statuses Preserved"
+                    },
+                    "risk_flags_preserved": {
+                        "type": "boolean",
+                        "title": "Risk Flags Preserved"
+                    },
+                    "no_executable_recommendations": {
+                        "type": "boolean",
+                        "title": "No Executable Recommendations"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "statuses_preserved",
+                    "risk_flags_preserved",
+                    "no_executable_recommendations"
+                ],
+                "title": "TradeInsightAiGuardrails"
+            },
+            "TradeInsightAiHeadline": {
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "stance": {
+                        "type": "string",
+                        "enum": [
+                            "bullish",
+                            "bearish",
+                            "neutral",
+                            "mixed",
+                            "wait"
+                        ],
+                        "title": "Stance"
+                    },
+                    "stance_label": {
+                        "type": "string",
+                        "title": "Stance Label"
+                    },
+                    "score": {
+                        "type": "integer",
+                        "title": "Score"
+                    },
+                    "score_scale": {
+                        "type": "integer",
+                        "title": "Score Scale",
+                        "default": 100
+                    },
+                    "conviction": {
+                        "type": "string",
+                        "title": "Conviction"
+                    },
+                    "conviction_label": {
+                        "type": "string",
+                        "title": "Conviction Label"
+                    },
+                    "top_reason": {
+                        "type": "string",
+                        "title": "Top Reason"
+                    },
+                    "primary_risk": {
+                        "type": "string",
+                        "title": "Primary Risk"
+                    },
+                    "watch_trigger": {
+                        "type": "string",
+                        "title": "Watch Trigger"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "title",
+                    "stance",
+                    "stance_label",
+                    "score",
+                    "conviction",
+                    "conviction_label",
+                    "top_reason",
+                    "primary_risk",
+                    "watch_trigger"
+                ],
+                "title": "TradeInsightAiHeadline"
+            },
+            "TradeInsightAiHighlight": {
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    },
+                    "source_path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source Path"
+                    },
+                    "note": {
+                        "type": "string",
+                        "title": "Note",
+                        "default": ""
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "label",
+                    "value"
+                ],
+                "title": "TradeInsightAiHighlight"
+            },
+            "TradeInsightAiLevel": {
+                "properties": {
+                    "price": {
+                        "type": "string",
+                        "title": "Price"
+                    },
+                    "kind": {
+                        "type": "string",
+                        "title": "Kind"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    },
+                    "importance": {
+                        "type": "string",
+                        "title": "Importance",
+                        "default": "normal"
+                    },
+                    "source_path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source Path"
+                    },
+                    "note": {
+                        "type": "string",
+                        "title": "Note",
+                        "default": ""
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "price",
+                    "kind",
+                    "value"
+                ],
+                "title": "TradeInsightAiLevel"
+            },
+            "TradeInsightAiMetricCard": {
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    },
+                    "tone": {
+                        "type": "string",
+                        "title": "Tone",
+                        "default": "neutral"
+                    },
+                    "source_path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source Path"
+                    },
+                    "note": {
+                        "type": "string",
+                        "title": "Note",
+                        "default": ""
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "label",
+                    "value"
+                ],
+                "title": "TradeInsightAiMetricCard"
+            },
+            "TradeInsightAiOutcome": {
+                "properties": {
+                    "schema_version": {
+                        "type": "string",
+                        "title": "Schema Version"
+                    },
+                    "analysis_produced_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Analysis Produced At"
+                    },
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "underlying_price": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Underlying Price"
+                    },
+                    "snapshot": {
+                        "$ref": "#/components/schemas/TradeInsightAiSnapshotMeta"
+                    },
+                    "headline": {
+                        "$ref": "#/components/schemas/TradeInsightAiHeadline"
+                    },
+                    "metric_cards": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiMetricCard"
+                        },
+                        "type": "array",
+                        "title": "Metric Cards"
+                    },
+                    "scenario_cards": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiScenarioCard"
+                        },
+                        "type": "array",
+                        "title": "Scenario Cards"
+                    },
+                    "score_breakdown": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiScoreBreakdown"
+                        },
+                        "type": "array",
+                        "title": "Score Breakdown"
+                    },
+                    "section_cards": {
+                        "$ref": "#/components/schemas/TradeInsightAiSectionCards"
+                    },
+                    "vrp_assessment": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TradeInsightAiVrpAssessment"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "preferred_expression": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TradeInsightAiPreferredExpression"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "dominant_read": {
+                        "$ref": "#/components/schemas/TradeInsightAiDominantRead"
+                    },
+                    "best_expressions": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiBestExpression"
+                        },
+                        "type": "array",
+                        "title": "Best Expressions"
+                    },
+                    "conflicts": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiConflict"
+                        },
+                        "type": "array",
+                        "title": "Conflicts"
+                    },
+                    "required_checks": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiRequiredCheck"
+                        },
+                        "type": "array",
+                        "title": "Required Checks"
+                    },
+                    "rejected_ideas": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiRejectedIdea"
+                        },
+                        "type": "array",
+                        "title": "Rejected Ideas"
+                    },
+                    "missing_data": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Missing Data"
+                    },
+                    "rendering": {
+                        "$ref": "#/components/schemas/TradeInsightAiRendering"
+                    },
+                    "guardrails": {
+                        "$ref": "#/components/schemas/TradeInsightAiGuardrails"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "schema_version",
+                    "analysis_produced_at",
+                    "ticker",
+                    "snapshot",
+                    "headline",
+                    "metric_cards",
+                    "scenario_cards",
+                    "score_breakdown",
+                    "section_cards",
+                    "dominant_read",
+                    "rendering",
+                    "guardrails"
+                ],
+                "title": "TradeInsightAiOutcome"
+            },
+            "TradeInsightAiPreferredExpression": {
+                "properties": {
+                    "idea_id": {
+                        "type": "string",
+                        "title": "Idea Id"
+                    },
+                    "structure": {
+                        "type": "string",
+                        "title": "Structure"
+                    },
+                    "title": {
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "subtitle": {
+                        "type": "string",
+                        "title": "Subtitle",
+                        "default": ""
+                    },
+                    "estimated_entry": {
+                        "type": "string",
+                        "title": "Estimated Entry",
+                        "default": ""
+                    },
+                    "max_profit_observed": {
+                        "type": "string",
+                        "title": "Max Profit Observed",
+                        "default": ""
+                    },
+                    "max_loss_observed": {
+                        "type": "string",
+                        "title": "Max Loss Observed",
+                        "default": ""
+                    },
+                    "reward_risk": {
+                        "type": "string",
+                        "title": "Reward Risk",
+                        "default": ""
+                    },
+                    "why": {
+                        "type": "string",
+                        "title": "Why"
+                    },
+                    "management_notes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Management Notes"
+                    },
+                    "status_observed": {
+                        "type": "string",
+                        "title": "Status Observed"
+                    },
+                    "risk_flags_observed": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Risk Flags Observed"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "idea_id",
+                    "structure",
+                    "title",
+                    "why",
+                    "status_observed"
+                ],
+                "title": "TradeInsightAiPreferredExpression"
+            },
+            "TradeInsightAiRejectedIdea": {
+                "properties": {
+                    "idea_id": {
+                        "type": "string",
+                        "title": "Idea Id"
+                    },
+                    "structure": {
+                        "type": "string",
+                        "title": "Structure"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "title": "Reason"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "idea_id",
+                    "structure",
+                    "reason"
+                ],
+                "title": "TradeInsightAiRejectedIdea"
+            },
+            "TradeInsightAiRendering": {
+                "properties": {
+                    "disclaimer": {
+                        "type": "string",
+                        "title": "Disclaimer"
+                    },
+                    "card_order": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Card Order"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "disclaimer"
+                ],
+                "title": "TradeInsightAiRendering"
+            },
+            "TradeInsightAiRequiredCheck": {
+                "properties": {
+                    "check": {
+                        "type": "string",
+                        "title": "Check"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "title": "Reason"
+                    },
+                    "blocks_sizing": {
+                        "type": "boolean",
+                        "title": "Blocks Sizing",
+                        "default": true
+                    },
+                    "source": {
+                        "type": "string",
+                        "title": "Source",
+                        "default": ""
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "check",
+                    "reason"
+                ],
+                "title": "TradeInsightAiRequiredCheck"
+            },
+            "TradeInsightAiScenarioCard": {
+                "properties": {
+                    "case": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "upside",
+                                    "base",
+                                    "downside"
+                                ]
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Case"
+                    },
+                    "tone": {
+                        "type": "string",
+                        "title": "Tone",
+                        "default": "neutral"
+                    },
+                    "title": {
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "description": {
+                        "type": "string",
+                        "title": "Description"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "case",
+                    "title",
+                    "description"
+                ],
+                "title": "TradeInsightAiScenarioCard"
+            },
+            "TradeInsightAiScoreBreakdown": {
+                "properties": {
+                    "section": {
+                        "type": "string",
+                        "title": "Section"
+                    },
+                    "score": {
+                        "type": "integer",
+                        "title": "Score"
+                    },
+                    "max_score": {
+                        "type": "integer",
+                        "title": "Max Score"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "section",
+                    "score",
+                    "max_score",
+                    "summary"
+                ],
+                "title": "TradeInsightAiScoreBreakdown"
+            },
+            "TradeInsightAiSectionCard": {
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "score": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Score"
+                    },
+                    "max_score": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Score"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary"
+                    },
+                    "highlights": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiHighlight"
+                        },
+                        "type": "array",
+                        "title": "Highlights"
+                    },
+                    "levels": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiLevel"
+                        },
+                        "type": "array",
+                        "title": "Levels"
+                    },
+                    "data_quality": {
+                        "type": "string",
+                        "title": "Data Quality",
+                        "default": "unknown"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "title",
+                    "summary"
+                ],
+                "title": "TradeInsightAiSectionCard"
+            },
+            "TradeInsightAiSectionCards": {
+                "properties": {
+                    "market_structure": {
+                        "$ref": "#/components/schemas/TradeInsightAiSectionCard"
+                    },
+                    "volatility": {
+                        "$ref": "#/components/schemas/TradeInsightAiSectionCard"
+                    },
+                    "flow_positioning": {
+                        "$ref": "#/components/schemas/TradeInsightAiSectionCard"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "market_structure",
+                    "volatility",
+                    "flow_positioning"
+                ],
+                "title": "TradeInsightAiSectionCards"
+            },
+            "TradeInsightAiSnapshotMeta": {
+                "properties": {
+                    "run_id": {
+                        "type": "integer",
+                        "title": "Run Id"
+                    },
+                    "trade_insights_input_hash": {
+                        "type": "string",
+                        "title": "Trade Insights Input Hash"
+                    },
+                    "analysis_input_hash": {
+                        "type": "string",
+                        "title": "Analysis Input Hash"
+                    },
+                    "data_as_of": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Data As Of"
+                    },
+                    "freshness_label": {
+                        "type": "string",
+                        "title": "Freshness Label",
+                        "default": "unknown"
+                    },
+                    "source_notes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Source Notes"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "run_id",
+                    "trade_insights_input_hash",
+                    "analysis_input_hash"
+                ],
+                "title": "TradeInsightAiSnapshotMeta"
+            },
+            "TradeInsightAiVrpAssessment": {
+                "properties": {
+                    "signal": {
+                        "type": "string",
+                        "title": "Signal"
+                    },
+                    "title": {
+                        "type": "string",
+                        "title": "Title"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary"
+                    },
+                    "metrics": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradeInsightAiMetricCard"
+                        },
+                        "type": "array",
+                        "title": "Metrics"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "title": "Reason"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "signal",
+                    "title",
+                    "summary",
+                    "reason"
+                ],
+                "title": "TradeInsightAiVrpAssessment"
+            },
+            "TradeInsightsHeader": {
+                "properties": {
+                    "dominant_bias": {
+                        "type": "string",
+                        "title": "Dominant Bias",
+                        "default": "NEUTRAL"
+                    },
+                    "primary_setup": {
+                        "type": "string",
+                        "title": "Primary Setup",
+                        "default": "NO_CLEAR_SETUP"
+                    },
+                    "confidence_label": {
+                        "type": "string",
+                        "title": "Confidence Label",
+                        "default": "LOW"
+                    },
+                    "data_quality_label": {
+                        "type": "string",
+                        "title": "Data Quality Label",
+                        "default": "INSUFFICIENT"
+                    },
+                    "idea_count": {
+                        "type": "integer",
+                        "title": "Idea Count",
+                        "default": 0
+                    },
+                    "preferred_idea_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Preferred Idea Id"
+                    },
+                    "badges": {
+                        "items": {
+                            "$ref": "#/components/schemas/InsightBadge"
+                        },
+                        "type": "array",
+                        "title": "Badges",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "title": "TradeInsightsHeader"
+            },
+            "TradeInsightsResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "as_of": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "As Of"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "title": "Mode",
+                        "default": "research"
+                    },
+                    "header": {
+                        "$ref": "#/components/schemas/TradeInsightsHeader"
+                    },
+                    "source_reconciliation": {
+                        "$ref": "#/components/schemas/SourceReconciliation",
+                        "default": {
+                            "status": "UNKNOWN",
+                            "headline": "Source reconciliation unavailable",
+                            "rows": [],
+                            "decision": "Use deterministic data only where source agreement is understood."
+                        }
+                    },
+                    "signal_stack": {
+                        "items": {
+                            "$ref": "#/components/schemas/InsightSignalRow"
+                        },
+                        "type": "array",
+                        "title": "Signal Stack",
+                        "default": []
+                    },
+                    "flow_table": {
+                        "items": {
+                            "$ref": "#/components/schemas/ChainFlowReadRow"
+                        },
+                        "type": "array",
+                        "title": "Flow Table",
+                        "default": []
+                    },
+                    "term_structure_table": {
+                        "items": {
+                            "$ref": "#/components/schemas/TermMoveRow"
+                        },
+                        "type": "array",
+                        "title": "Term Structure Table",
+                        "default": []
+                    },
+                    "candidate_structures": {
+                        "items": {
+                            "$ref": "#/components/schemas/CandidateStructure"
+                        },
+                        "type": "array",
+                        "title": "Candidate Structures",
+                        "default": []
+                    },
+                    "synthesis": {
+                        "$ref": "#/components/schemas/InsightsSynthesis",
+                        "default": {
+                            "dominant_story": "",
+                            "avoid": [],
+                            "required_before_sizing": []
+                        }
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "header"
+                ],
+                "title": "TradeInsightsResponse"
+            },
+            "TradePlan": {
+                "properties": {
+                    "structure": {
+                        "type": "string",
+                        "title": "Structure"
+                    },
+                    "direction": {
+                        "type": "string",
+                        "title": "Direction"
+                    },
+                    "legs": {
+                        "items": {
+                            "$ref": "#/components/schemas/TradePlanLeg"
+                        },
+                        "type": "array",
+                        "title": "Legs",
+                        "default": []
+                    },
+                    "rationale": {
+                        "type": "string",
+                        "title": "Rationale"
+                    },
+                    "max_loss": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Loss"
+                    },
+                    "max_profit": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Profit"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "structure",
+                    "direction",
+                    "rationale"
+                ],
+                "title": "TradePlan"
+            },
+            "TradePlanLeg": {
+                "properties": {
+                    "option_symbol": {
+                        "type": "string",
+                        "title": "Option Symbol"
+                    },
+                    "side": {
+                        "type": "string",
+                        "title": "Side"
+                    },
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "expiry": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Expiry"
+                    },
+                    "mid": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mid"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "option_symbol",
+                    "side",
+                    "strike",
+                    "expiry"
+                ],
+                "title": "TradePlanLeg"
+            },
+            "VRPAssessment": {
+                "properties": {
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "signal": {
+                        "type": "string",
+                        "title": "Signal"
+                    },
+                    "note": {
+                        "type": "string",
+                        "title": "Note"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "signal",
+                    "note"
+                ],
+                "title": "VRPAssessment"
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    },
+                    "input": {
+                        "title": "Input"
+                    },
+                    "ctx": {
+                        "type": "object",
+                        "title": "Context"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            },
+            "ValidationResponse": {
+                "properties": {
+                    "backtest_md": {
+                        "type": "string",
+                        "title": "Backtest Md"
+                    },
+                    "backtest_csv_rows": {
+                        "type": "integer",
+                        "title": "Backtest Csv Rows"
+                    },
+                    "oos": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OosSummary"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "backtest_md",
+                    "backtest_csv_rows"
+                ],
+                "title": "ValidationResponse",
+                "description": "Combined warm-store backtest + OOS notebook summary."
+            },
+            "VcgAttribution": {
+                "properties": {
+                    "vvix_pct": {
+                        "type": "number",
+                        "title": "Vvix Pct",
+                        "default": 0.0
+                    },
+                    "vix_pct": {
+                        "type": "number",
+                        "title": "Vix Pct",
+                        "default": 0.0
+                    },
+                    "vvix_component": {
+                        "type": "number",
+                        "title": "Vvix Component",
+                        "default": 0.0
+                    },
+                    "vix_component": {
+                        "type": "number",
+                        "title": "Vix Component",
+                        "default": 0.0
+                    },
+                    "model_implied": {
+                        "type": "number",
+                        "title": "Model Implied",
+                        "default": 0.0
+                    }
+                },
+                "type": "object",
+                "title": "VcgAttribution"
+            },
+            "VcgHistoryEntry": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "title": "Date"
+                    },
+                    "residual": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Residual"
+                    },
+                    "vcg": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vcg"
+                    },
+                    "vcg_adj": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vcg Adj"
+                    },
+                    "beta1": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Beta1"
+                    },
+                    "beta2": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Beta2"
+                    },
+                    "vix": {
+                        "type": "number",
+                        "title": "Vix",
+                        "default": 0.0
+                    },
+                    "vvix": {
+                        "type": "number",
+                        "title": "Vvix",
+                        "default": 0.0
+                    },
+                    "credit": {
+                        "type": "number",
+                        "title": "Credit",
+                        "default": 0.0
+                    },
+                    "ro": {
+                        "type": "integer",
+                        "title": "Ro",
+                        "default": 0
+                    },
+                    "edr": {
+                        "type": "integer",
+                        "title": "Edr",
+                        "default": 0
+                    },
+                    "tier": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tier"
+                    },
+                    "bounce": {
+                        "type": "integer",
+                        "title": "Bounce",
+                        "default": 0
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "VcgHistoryEntry"
+            },
+            "VcgResponse": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "empty"
+                        ],
+                        "title": "Status",
+                        "default": "empty"
+                    },
+                    "scan_time": {
+                        "type": "string",
+                        "title": "Scan Time",
+                        "default": ""
+                    },
+                    "date": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Date"
+                    },
+                    "credit_proxy": {
+                        "type": "string",
+                        "title": "Credit Proxy",
+                        "default": "HYG"
+                    },
+                    "signal": {
+                        "$ref": "#/components/schemas/VcgSignal"
+                    },
+                    "history": {
+                        "items": {
+                            "$ref": "#/components/schemas/VcgHistoryEntry"
+                        },
+                        "type": "array",
+                        "title": "History"
+                    }
+                },
+                "type": "object",
+                "title": "VcgResponse",
+                "description": "Volatility-Credit Gap snapshot (latest scan)."
+            },
+            "VcgScanResponse": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "skipped"
+                        ],
+                        "title": "Status",
+                        "default": "ok"
+                    },
+                    "scanner": {
+                        "type": "string",
+                        "const": "vcg",
+                        "title": "Scanner",
+                        "default": "vcg"
+                    },
+                    "proxy": {
+                        "type": "string",
+                        "title": "Proxy",
+                        "default": "HYG"
+                    },
+                    "row_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Row Id"
+                    },
+                    "reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reason"
+                    }
+                },
+                "type": "object",
+                "title": "VcgScanResponse",
+                "description": "Response body for POST /api/regime/vcg/scan."
+            },
+            "VcgSignal": {
+                "properties": {
+                    "vcg": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vcg"
+                    },
+                    "vcg_adj": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vcg Adj"
+                    },
+                    "residual": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Residual"
+                    },
+                    "beta1_vvix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Beta1 Vvix"
+                    },
+                    "beta2_vix": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Beta2 Vix"
+                    },
+                    "alpha": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Alpha"
+                    },
+                    "vix": {
+                        "type": "number",
+                        "title": "Vix",
+                        "default": 0.0
+                    },
+                    "vvix": {
+                        "type": "number",
+                        "title": "Vvix",
+                        "default": 0.0
+                    },
+                    "credit_price": {
+                        "type": "number",
+                        "title": "Credit Price",
+                        "default": 0.0
+                    },
+                    "credit_5d_return_pct": {
+                        "type": "number",
+                        "title": "Credit 5D Return Pct",
+                        "default": 0.0
+                    },
+                    "ro": {
+                        "type": "integer",
+                        "title": "Ro",
+                        "default": 0
+                    },
+                    "edr": {
+                        "type": "integer",
+                        "title": "Edr",
+                        "default": 0
+                    },
+                    "tier": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tier"
+                    },
+                    "bounce": {
+                        "type": "integer",
+                        "title": "Bounce",
+                        "default": 0
+                    },
+                    "vvix_severity": {
+                        "type": "string",
+                        "enum": [
+                            "extreme",
+                            "elevated",
+                            "moderate"
+                        ],
+                        "title": "Vvix Severity",
+                        "default": "moderate"
+                    },
+                    "sign_ok": {
+                        "type": "boolean",
+                        "title": "Sign Ok",
+                        "default": true
+                    },
+                    "sign_suppressed": {
+                        "type": "boolean",
+                        "title": "Sign Suppressed",
+                        "default": false
+                    },
+                    "pi_panic": {
+                        "type": "number",
+                        "title": "Pi Panic",
+                        "default": 0.0
+                    },
+                    "regime": {
+                        "type": "string",
+                        "enum": [
+                            "PANIC",
+                            "TRANSITION",
+                            "DIVERGENCE"
+                        ],
+                        "title": "Regime",
+                        "default": "DIVERGENCE"
+                    },
+                    "interpretation": {
+                        "type": "string",
+                        "enum": [
+                            "RISK_OFF",
+                            "EDR",
+                            "WATCH",
+                            "BOUNCE",
+                            "NORMAL",
+                            "SUPPRESSED",
+                            "PANIC",
+                            "INSUFFICIENT_DATA"
+                        ],
+                        "title": "Interpretation",
+                        "default": "NORMAL"
+                    },
+                    "attribution": {
+                        "$ref": "#/components/schemas/VcgAttribution"
+                    }
+                },
+                "type": "object",
+                "title": "VcgSignal"
+            },
+            "VolBackdropPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "close": {
+                        "type": "number",
+                        "title": "Close"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date",
+                    "close"
+                ],
+                "title": "VolBackdropPoint"
+            },
+            "VolBackdropResponse": {
+                "properties": {
+                    "series": {
+                        "additionalProperties": {
+                            "items": {
+                                "$ref": "#/components/schemas/VolBackdropPoint"
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Series"
+                    },
+                    "term_structure_ratio": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Term Structure Ratio"
+                    },
+                    "term_structure_state": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Term Structure State"
+                    },
+                    "as_of": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "As Of"
+                    }
+                },
+                "type": "object",
+                "title": "VolBackdropResponse",
+                "description": "Vol-complex time series + VIX term-structure (regime page header strip)."
+            },
+            "VolHeaderBlock": {
+                "properties": {
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    },
+                    "rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv"
+                    },
+                    "iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank"
+                    },
+                    "iv_rank_1y": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank 1Y"
+                    },
+                    "iv_low_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Low 52W"
+                    },
+                    "iv_high_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv High 52W"
+                    },
+                    "rv_low_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv Low 52W"
+                    },
+                    "rv_high_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv High 52W"
+                    },
+                    "iv_percentile_30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Percentile 30D"
+                    },
+                    "implied_move_30d_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move 30D Perc"
+                    },
+                    "skew_25d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew 25D"
+                    },
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "vrp_signal": {
+                        "type": "string",
+                        "title": "Vrp Signal",
+                        "default": ""
+                    },
+                    "vrp_note": {
+                        "type": "string",
+                        "title": "Vrp Note",
+                        "default": ""
+                    }
+                },
+                "type": "object",
+                "title": "VolHeaderBlock"
+            },
+            "VolatilityProfile": {
+                "properties": {
+                    "iv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv"
+                    },
+                    "iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank"
+                    },
+                    "iv_low_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Low 52W"
+                    },
+                    "iv_high_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv High 52W"
+                    },
+                    "rv": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv"
+                    },
+                    "rv_low_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv Low 52W"
+                    },
+                    "rv_high_52w": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Rv High 52W"
+                    },
+                    "iv_rank_1y": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank 1Y"
+                    },
+                    "iv_percentile_30d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Percentile 30D"
+                    },
+                    "implied_move_30d_perc": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Implied Move 30D Perc"
+                    },
+                    "skew_25d": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Skew 25D"
+                    },
+                    "term_dte_to_iv": {
+                        "items": {
+                            "prefixItems": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                                }
+                            ],
+                            "type": "array",
+                            "maxItems": 2,
+                            "minItems": 2
+                        },
+                        "type": "array",
+                        "title": "Term Dte To Iv",
+                        "default": []
+                    }
+                },
+                "type": "object",
+                "title": "VolatilityProfile"
+            },
+            "VolatilitySeriesResponse": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "as_of": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "As Of"
+                    },
+                    "backfill_status": {
+                        "type": "string",
+                        "title": "Backfill Status"
+                    },
+                    "header": {
+                        "$ref": "#/components/schemas/VolHeaderBlock"
+                    },
+                    "term_structure": {
+                        "items": {
+                            "$ref": "#/components/schemas/TermStructureExpiryRow"
+                        },
+                        "type": "array",
+                        "title": "Term Structure",
+                        "default": []
+                    },
+                    "smile": {
+                        "items": {
+                            "$ref": "#/components/schemas/SmileExpiryCurve"
+                        },
+                        "type": "array",
+                        "title": "Smile",
+                        "default": []
+                    },
+                    "hv_iv_history": {
+                        "items": {
+                            "$ref": "#/components/schemas/IvHvPoint"
+                        },
+                        "type": "array",
+                        "title": "Hv Iv History",
+                        "default": []
+                    },
+                    "iv_percentile_distribution": {
+                        "$ref": "#/components/schemas/IvPercentileDistribution",
+                        "default": {
+                            "bins": []
+                        }
+                    },
+                    "iv_of_iv": {
+                        "items": {
+                            "$ref": "#/components/schemas/IvOfIvPoint"
+                        },
+                        "type": "array",
+                        "title": "Iv Of Iv",
+                        "default": []
+                    },
+                    "rv_spy_corr": {
+                        "items": {
+                            "$ref": "#/components/schemas/RvCorrPoint"
+                        },
+                        "type": "array",
+                        "title": "Rv Spy Corr",
+                        "default": []
+                    },
+                    "regime_quadrant": {
+                        "$ref": "#/components/schemas/RegimeQuadrantBlock",
+                        "default": {
+                            "points": []
+                        }
+                    },
+                    "divergence": {
+                        "items": {
+                            "$ref": "#/components/schemas/DivergencePoint"
+                        },
+                        "type": "array",
+                        "title": "Divergence",
+                        "default": []
+                    },
+                    "divergence_headline": {
+                        "type": "string",
+                        "title": "Divergence Headline",
+                        "default": ""
+                    },
+                    "vrp_spread": {
+                        "items": {
+                            "$ref": "#/components/schemas/VrpDailyPoint"
+                        },
+                        "type": "array",
+                        "title": "Vrp Spread",
+                        "default": []
+                    },
+                    "vrp_spread_headline": {
+                        "type": "string",
+                        "title": "Vrp Spread Headline",
+                        "default": ""
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "as_of",
+                    "backfill_status",
+                    "header"
+                ],
+                "title": "VolatilitySeriesResponse"
+            },
+            "VrpDailyPoint": {
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "format": "date",
+                        "title": "Date"
+                    },
+                    "vrp": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp"
+                    },
+                    "vrp_z_20": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Vrp Z 20"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "date"
+                ],
+                "title": "VrpDailyPoint"
+            },
+            "WatchlistCard": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "sector": {
+                        "type": "string",
+                        "title": "Sector"
+                    },
+                    "pinned": {
+                        "type": "boolean",
+                        "title": "Pinned"
+                    },
+                    "sort_rank": {
+                        "type": "integer",
+                        "title": "Sort Rank"
+                    },
+                    "spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot"
+                    },
+                    "spot_quoted_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Quoted At"
+                    },
+                    "spot_source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Spot Source"
+                    },
+                    "scanned_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scanned At"
+                    },
+                    "iv_atm": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Atm"
+                    },
+                    "iv_rank": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Iv Rank"
+                    },
+                    "market_cap": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Market Cap"
+                    },
+                    "aum": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Aum"
+                    },
+                    "setup": {
+                        "$ref": "#/components/schemas/SetupBlock"
+                    },
+                    "aggression_pct": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Aggression Pct"
+                    },
+                    "returns": {
+                        "$ref": "#/components/schemas/ReturnsBlock"
+                    },
+                    "gamma": {
+                        "$ref": "#/components/schemas/GammaBlock"
+                    },
+                    "skew": {
+                        "$ref": "#/components/schemas/SkewBlock"
+                    },
+                    "positioning": {
+                        "$ref": "#/components/schemas/PositioningBlock"
+                    },
+                    "queue": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/QueueStatus"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "sector",
+                    "pinned",
+                    "sort_rank",
+                    "setup",
+                    "returns",
+                    "gamma",
+                    "skew",
+                    "positioning"
+                ],
+                "title": "WatchlistCard"
+            },
+            "WatchlistMutation": {
+                "properties": {
+                    "ticker": {
+                        "type": "string",
+                        "title": "Ticker"
+                    },
+                    "sector": {
+                        "type": "string",
+                        "title": "Sector"
+                    },
+                    "notes": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Notes"
+                    },
+                    "pinned": {
+                        "type": "boolean",
+                        "title": "Pinned",
+                        "default": false
+                    },
+                    "sort_rank": {
+                        "type": "integer",
+                        "title": "Sort Rank",
+                        "default": 0
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ticker",
+                    "sector"
+                ],
+                "title": "WatchlistMutation"
+            },
+            "WatchlistPatch": {
+                "properties": {
+                    "sector": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sector"
+                    },
+                    "notes": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Notes"
+                    },
+                    "pinned": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pinned"
+                    },
+                    "sort_rank": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sort Rank"
+                    }
+                },
+                "type": "object",
+                "title": "WatchlistPatch"
+            },
+            "WatchlistResponse": {
+                "properties": {
+                    "scanned_at_min": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scanned At Min"
+                    },
+                    "scanned_at_max": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scanned At Max"
+                    },
+                    "scheduler_lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Scheduler Lag Seconds"
+                    },
+                    "queue": {
+                        "$ref": "#/components/schemas/QueueSummary"
+                    },
+                    "tickers": {
+                        "items": {
+                            "$ref": "#/components/schemas/WatchlistCard"
+                        },
+                        "type": "array",
+                        "title": "Tickers"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "tickers"
+                ],
+                "title": "WatchlistResponse"
+            },
+            "WorkerHealth": {
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "title": "Label"
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "uw",
+                            "massive",
+                            "ai"
+                        ],
+                        "title": "Role"
+                    },
+                    "index": {
+                        "type": "integer",
+                        "title": "Index"
+                    },
+                    "heartbeat_name": {
+                        "type": "string",
+                        "title": "Heartbeat Name"
+                    },
+                    "lag_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Lag Seconds"
+                    },
+                    "last_beat_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Beat At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "label",
+                    "role",
+                    "index",
+                    "heartbeat_name"
+                ],
+                "title": "WorkerHealth"
+            },
+            "uw_scan__api__schemas__GexLevel": {
+                "properties": {
+                    "strike": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strike"
+                    },
+                    "gamma": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gamma"
+                    },
+                    "distance": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Distance"
+                    },
+                    "distance_pct": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Distance Pct"
+                    }
+                },
+                "type": "object",
+                "title": "GexLevel"
+            },
+            "uw_scan__models__GexLevel": {
+                "properties": {
+                    "strike": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Strike"
+                    },
+                    "net_gex": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Net Gex"
+                    },
+                    "pct_from_spot": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Pct From Spot"
+                    },
+                    "gamma_per_dollar": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Gamma Per Dollar"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "strike"
+                ],
+                "title": "GexLevel",
+                "description": "One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).\n\n`gamma_per_dollar` is the per-strike net_gex used as the \"$N per $1\" sensitivity\nfigure on the tile \u2014 the dollar value of dealer hedging triggered by a $1 move."
             }
-          },
-          {
-            "name": "alerts_limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 50,
-              "default": 200,
-              "title": "Alerts Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DiscoveryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
         }
-      }
     }
-  },
-  "components": {
-    "schemas": {
-      "CandidateStructure": {
-        "properties": {
-          "idea_id": {
-            "type": "string",
-            "title": "Idea Id"
-          },
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "thesis": {
-            "type": "string",
-            "title": "Thesis"
-          },
-          "expression_type": {
-            "type": "string",
-            "title": "Expression Type"
-          },
-          "legs": {
-            "items": {
-              "$ref": "#/components/schemas/InsightLeg"
-            },
-            "type": "array",
-            "title": "Legs",
-            "default": []
-          },
-          "net_credit_debit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Credit Debit"
-          },
-          "max_profit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Profit"
-          },
-          "max_loss": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Loss"
-          },
-          "breakevens": {
-            "items": {
-              "type": "string",
-              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-            },
-            "type": "array",
-            "title": "Breakevens",
-            "default": []
-          },
-          "profit_zone": {
-            "type": "string",
-            "title": "Profit Zone",
-            "default": ""
-          },
-          "edge_source": {
-            "type": "string",
-            "title": "Edge Source",
-            "default": ""
-          },
-          "risk_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags",
-            "default": []
-          },
-          "rank": {
-            "type": "integer",
-            "title": "Rank"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "candidate"
-          }
-        },
-        "type": "object",
-        "required": [
-          "idea_id",
-          "structure",
-          "thesis",
-          "expression_type",
-          "rank"
-        ],
-        "title": "CandidateStructure"
-      },
-      "ChainFlowReadRow": {
-        "properties": {
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "call_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume"
-          },
-          "call_open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Open Interest"
-          },
-          "put_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume"
-          },
-          "put_open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Open Interest"
-          },
-          "call_put_volume_ratio": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Put Volume Ratio"
-          },
-          "volume_oi_note": {
-            "type": "string",
-            "title": "Volume Oi Note",
-            "default": ""
-          },
-          "read": {
-            "type": "string",
-            "title": "Read",
-            "default": ""
-          },
-          "requires_t1_oi_confirmation": {
-            "type": "boolean",
-            "title": "Requires T1 Oi Confirmation",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "strike"
-        ],
-        "title": "ChainFlowReadRow"
-      },
-      "CockpitDealerMetrics": {
-        "properties": {
-          "pin_candidate_strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Candidate Strike"
-          },
-          "pin_candidate_expiry": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Candidate Expiry"
-          },
-          "pin_source_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Source Date"
-          },
-          "pin_distance_sigma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Distance Sigma"
-          },
-          "pin_regime_flag": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Regime Flag"
-          },
-          "dealer_net_vanna_proxy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dealer Net Vanna Proxy"
-          },
-          "dealer_net_charm_proxy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dealer Net Charm Proxy"
-          },
-          "flow_color_lookback_3d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "put_heavy",
-                  "call_heavy",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Color Lookback 3D"
-          },
-          "flow_put_premium_3d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Put Premium 3D"
-          },
-          "flow_call_premium_3d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Call Premium 3D"
-          },
-          "iv_30d_delta_5d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv 30D Delta 5D"
-          },
-          "net_gamma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gamma"
-          },
-          "net_gamma_sign": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "positive",
-                  "negative",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gamma Sign"
-          },
-          "gamma_regime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "long_gamma",
-                  "short_gamma",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gamma Regime"
-          },
-          "vanna_conditional_reading": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "grind_up",
-                  "reverse_selloff",
-                  "reflexive_sell_pressure",
-                  "weak_noise"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vanna Conditional Reading"
-          },
-          "directional_imbalance_3d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Directional Imbalance 3D"
-          },
-          "vanna_oi_change_bias": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "call_oi_build",
-                  "put_oi_build",
-                  "mixed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vanna Oi Change Bias"
-          },
-          "charm_regime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "operative_magnet",
-                  "broken_magnet",
-                  "opex_vortex",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Charm Regime"
-          },
-          "charm_stress_override": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Charm Stress Override"
-          }
-        },
-        "type": "object",
-        "title": "CockpitDealerMetrics"
-      },
-      "CockpitDealerPoint": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "call_vanna": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Vanna"
-          },
-          "put_vanna": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Vanna"
-          },
-          "call_charm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Charm"
-          },
-          "put_charm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Charm"
-          },
-          "exposure_call_vanna": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exposure Call Vanna"
-          },
-          "exposure_put_vanna": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exposure Put Vanna"
-          },
-          "exposure_call_charm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exposure Call Charm"
-          },
-          "exposure_put_charm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exposure Put Charm"
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry",
-          "strike"
-        ],
-        "title": "CockpitDealerPoint"
-      },
-      "CockpitDealerResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "metrics": {
-            "$ref": "#/components/schemas/CockpitDealerMetrics"
-          },
-          "points": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitDealerPoint"
-            },
-            "type": "array",
-            "title": "Points"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "market_date"
-        ],
-        "title": "CockpitDealerResponse"
-      },
-      "CockpitFlowAlert": {
-        "properties": {
-          "alert_id": {
-            "type": "string",
-            "title": "Alert Id"
-          },
-          "option_chain": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option Chain"
-          },
-          "expiry": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry"
-          },
-          "strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strike"
-          },
-          "option_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option Type"
-          },
-          "total_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Premium"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume"
-          },
-          "open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Open Interest"
-          },
-          "total_ask_side_prem": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Ask Side Prem"
-          },
-          "total_bid_side_prem": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Bid Side Prem"
-          },
-          "has_sweep": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Sweep"
-          },
-          "has_floor": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Floor"
-          },
-          "has_multileg": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Multileg"
-          },
-          "all_opening_trades": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "All Opening Trades"
-          },
-          "alert_rule": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Alert Rule"
-          },
-          "flow_footprint_label": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "directional_whale",
-                  "hedge_flow",
-                  "dealer_hedge",
-                  "gamma_scalper",
-                  "unclassified"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Footprint Label"
-          },
-          "aggressor_label_confidence": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aggressor Label Confidence"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "alert_id"
-        ],
-        "title": "CockpitFlowAlert"
-      },
-      "CockpitFlowImResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "alerts": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitFlowAlert"
-            },
-            "type": "array",
-            "title": "Alerts"
-          },
-          "implied_moves": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitImPoint"
-            },
-            "type": "array",
-            "title": "Implied Moves"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "market_date"
-        ],
-        "title": "CockpitFlowImResponse"
-      },
-      "CockpitImPoint": {
-        "properties": {
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "days": {
-            "type": "integer",
-            "title": "Days"
-          },
-          "volatility": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volatility"
-          },
-          "implied_move_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Perc"
-          },
-          "implied_move_expected_abs": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Expected Abs"
-          },
-          "percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Percentile"
-          }
-        },
-        "type": "object",
-        "required": [
-          "market_date",
-          "days"
-        ],
-        "title": "CockpitImPoint"
-      },
-      "CockpitSkewPoint": {
-        "properties": {
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "expiry": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry"
-          },
-          "risk_reversal": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Risk Reversal"
-          }
-        },
-        "type": "object",
-        "required": [
-          "market_date"
-        ],
-        "title": "CockpitSkewPoint"
-      },
-      "CockpitStateResponse": {
-        "properties": {
-          "state": {
-            "$ref": "#/components/schemas/MatrixState"
-          },
-          "freshness": {
-            "$ref": "#/components/schemas/MatrixSourceFreshness"
-          }
-        },
-        "type": "object",
-        "required": [
-          "state",
-          "freshness"
-        ],
-        "title": "CockpitStateResponse"
-      },
-      "CockpitSurfaceResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "skew": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitSkewPoint"
-            },
-            "type": "array",
-            "title": "Skew"
-          },
-          "term": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitTermPoint"
-            },
-            "type": "array",
-            "title": "Term"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "market_date"
-        ],
-        "title": "CockpitSurfaceResponse"
-      },
-      "CockpitTermPoint": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "dte": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dte"
-          },
-          "volatility": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volatility"
-          },
-          "implied_move_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Perc"
-          },
-          "implied_move_expected_abs": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Expected Abs"
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry"
-        ],
-        "title": "CockpitTermPoint"
-      },
-      "CockpitVrpPoint": {
-        "properties": {
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          },
-          "rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv"
-          },
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "iv_rank_1y": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank 1Y"
-          }
-        },
-        "type": "object",
-        "required": [
-          "market_date"
-        ],
-        "title": "CockpitVrpPoint"
-      },
-      "CockpitVrpResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "points": {
-            "items": {
-              "$ref": "#/components/schemas/CockpitVrpPoint"
-            },
-            "type": "array",
-            "title": "Points"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "market_date"
-        ],
-        "title": "CockpitVrpResponse"
-      },
-      "CrashTriggerBlock": {
-        "properties": {
-          "fired": {
-            "type": "boolean",
-            "title": "Fired",
-            "default": false
-          },
-          "triggered": {
-            "type": "boolean",
-            "title": "Triggered",
-            "default": false
-          },
-          "conditions": {
-            "$ref": "#/components/schemas/CrashTriggerConditions"
-          },
-          "values": {
-            "$ref": "#/components/schemas/CrashTriggerValues"
-          }
-        },
-        "type": "object",
-        "title": "CrashTriggerBlock"
-      },
-      "CrashTriggerConditions": {
-        "properties": {
-          "spx_below_100d_ma": {
-            "type": "boolean",
-            "title": "Spx Below 100D Ma",
-            "default": false
-          },
-          "realized_vol_gt_25": {
-            "type": "boolean",
-            "title": "Realized Vol Gt 25",
-            "default": false
-          },
-          "cor1m_gt_60": {
-            "type": "boolean",
-            "title": "Cor1M Gt 60",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "CrashTriggerConditions"
-      },
-      "CrashTriggerValues": {
-        "properties": {
-          "realized_vol": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Realized Vol"
-          },
-          "cor1m": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M"
-          }
-        },
-        "type": "object",
-        "title": "CrashTriggerValues"
-      },
-      "CriBlock": {
-        "properties": {
-          "score": {
-            "type": "number",
-            "title": "Score",
-            "default": 0.0
-          },
-          "level": {
-            "type": "string",
-            "enum": [
-              "LOW",
-              "ELEVATED",
-              "HIGH",
-              "CRITICAL"
-            ],
-            "title": "Level",
-            "default": "LOW"
-          },
-          "composite_version": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "enum": [
-                  1,
-                  2,
-                  3
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Composite Version"
-          },
-          "components": {
-            "$ref": "#/components/schemas/CriComponents"
-          }
-        },
-        "type": "object",
-        "title": "CriBlock"
-      },
-      "CriComponents": {
-        "properties": {
-          "vix": {
-            "type": "number",
-            "title": "Vix",
-            "default": 0.0
-          },
-          "vvix": {
-            "type": "number",
-            "title": "Vvix",
-            "default": 0.0
-          },
-          "correlation": {
-            "type": "number",
-            "title": "Correlation",
-            "default": 0.0
-          },
-          "momentum": {
-            "type": "number",
-            "title": "Momentum",
-            "default": 0.0
-          }
-        },
-        "type": "object",
-        "title": "CriComponents",
-        "description": "Four 0-25 component scores summed into the composite 0-100."
-      },
-      "CriHistoryEntry": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "vix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix"
-          },
-          "vvix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vvix"
-          },
-          "spy": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spy"
-          },
-          "cor1m": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M"
-          },
-          "realized_vol": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Realized Vol"
-          },
-          "spx_vs_ma_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spx Vs Ma Pct"
-          },
-          "vix_5d_roc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix 5D Roc"
-          },
-          "vvix_5d_roc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vvix 5D Roc"
-          },
-          "cor1m_5d_change": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M 5D Change"
-          },
-          "pullback_20d_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pullback 20D Pct"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "CriHistoryEntry"
-      },
-      "CriResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "empty"
-            ],
-            "title": "Status",
-            "default": "empty"
-          },
-          "scan_time": {
-            "type": "string",
-            "title": "Scan Time",
-            "default": ""
-          },
-          "date": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Date"
-          },
-          "vix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix"
-          },
-          "vvix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vvix"
-          },
-          "spy": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spy"
-          },
-          "vix_5d_roc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix 5D Roc"
-          },
-          "vvix_5d_roc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vvix 5D Roc"
-          },
-          "vvix_vix_ratio": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vvix Vix Ratio"
-          },
-          "spx_100d_ma": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spx 100D Ma"
-          },
-          "spx_distance_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spx Distance Pct"
-          },
-          "cor1m": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M"
-          },
-          "cor1m_previous_close": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M Previous Close"
-          },
-          "cor1m_5d_change": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cor1M 5D Change"
-          },
-          "realized_vol": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Realized Vol"
-          },
-          "vix3m": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix3M"
-          },
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "vix_zscore_30d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix Zscore 30D"
-          },
-          "vix_vix3m_ratio": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix Vix3M Ratio"
-          },
-          "pullback_20d_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pullback 20D Pct"
-          },
-          "vix_delta_3d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vix Delta 3D"
-          },
-          "spx_source": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "SPX",
-                  "SPY"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spx Source"
-          },
-          "cri": {
-            "$ref": "#/components/schemas/CriBlock"
-          },
-          "cta": {
-            "$ref": "#/components/schemas/CtaBlock"
-          },
-          "crash_trigger": {
-            "$ref": "#/components/schemas/CrashTriggerBlock"
-          },
-          "history": {
-            "items": {
-              "$ref": "#/components/schemas/CriHistoryEntry"
-            },
-            "type": "array",
-            "title": "History"
-          },
-          "spy_closes": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
-            "title": "Spy Closes"
-          }
-        },
-        "type": "object",
-        "title": "CriResponse",
-        "description": "Crash Risk Indicator snapshot (latest scan)."
-      },
-      "CriScanResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "skipped"
-            ],
-            "title": "Status",
-            "default": "ok"
-          },
-          "scanner": {
-            "type": "string",
-            "const": "cri",
-            "title": "Scanner",
-            "default": "cri"
-          },
-          "row_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Row Id"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          }
-        },
-        "type": "object",
-        "title": "CriScanResponse",
-        "description": "Response body for POST /api/regime/scan."
-      },
-      "CtaBlock": {
-        "properties": {
-          "realized_vol": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Realized Vol"
-          },
-          "exposure_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Exposure Pct"
-          },
-          "forced_reduction_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Forced Reduction Pct"
-          },
-          "forced_reduction": {
-            "type": "boolean",
-            "title": "Forced Reduction",
-            "default": false
-          },
-          "est_selling_bn": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Est Selling Bn"
-          },
-          "selling_usd_b": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Selling Usd B"
-          }
-        },
-        "type": "object",
-        "title": "CtaBlock"
-      },
-      "DiscoveryCandidate": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "hit": {
-            "$ref": "#/components/schemas/ScannerSignalHit"
-          },
-          "bias": {
-            "type": "string",
-            "enum": [
-              "bullish",
-              "bearish",
-              "neutral",
-              "mixed"
-            ],
-            "title": "Bias"
-          },
-          "bias_strength": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "strong",
-                  "moderate",
-                  "weak"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bias Strength"
-          },
-          "alert_count": {
-            "type": "integer",
-            "title": "Alert Count"
-          },
-          "sector": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sector"
-          },
-          "latest_alert_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Alert At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "hit",
-          "bias",
-          "alert_count"
-        ],
-        "title": "DiscoveryCandidate",
-        "description": "Non-watchlist ticker surfaced by the market-wide flow-alerts feed.\n\nDCF-only \u2014 the deeper signals (DP, EIC, GEX) need per-ticker context that\nrequires a deep scan. Promote to the watchlist to get those."
-      },
-      "DiscoveryResponse": {
-        "properties": {
-          "candidates": {
-            "items": {
-              "$ref": "#/components/schemas/DiscoveryCandidate"
-            },
-            "type": "array",
-            "title": "Candidates"
-          },
-          "fetched_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Fetched At"
-          },
-          "source": {
-            "type": "string",
-            "const": "market_wide_flow_alerts",
-            "title": "Source",
-            "default": "market_wide_flow_alerts"
-          },
-          "alerts_pulled": {
-            "type": "integer",
-            "title": "Alerts Pulled"
-          },
-          "earnings_unknown_dropped": {
-            "type": "integer",
-            "title": "Earnings Unknown Dropped",
-            "default": 0
-          }
-        },
-        "type": "object",
-        "required": [
-          "candidates",
-          "fetched_at",
-          "alerts_pulled"
-        ],
-        "title": "DiscoveryResponse"
-      },
-      "DivergencePoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "iv_z": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Z"
-          },
-          "rv_z": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv Z"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "DivergencePoint"
-      },
-      "FlowAlert": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "option_chain": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Option Chain"
-          },
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "expiry": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiry"
-          },
-          "strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strike"
-          },
-          "price": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Price"
-          },
-          "underlying_price": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Underlying Price"
-          },
-          "total_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Size"
-          },
-          "total_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Premium"
-          },
-          "total_ask_side_prem": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Ask Side Prem"
-          },
-          "total_bid_side_prem": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Bid Side Prem"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume"
-          },
-          "open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Open Interest"
-          },
-          "volume_oi_ratio": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume Oi Ratio"
-          },
-          "has_sweep": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Sweep"
-          },
-          "has_floor": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Floor"
-          },
-          "has_multileg": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Has Multileg"
-          },
-          "all_opening_trades": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "All Opening Trades"
-          },
-          "iv_start": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Start"
-          },
-          "iv_end": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv End"
-          },
-          "alert_rule": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Alert Rule"
-          },
-          "flow_footprint_label": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "directional_whale",
-                  "hedge_flow",
-                  "dealer_hedge",
-                  "gamma_scalper",
-                  "unclassified"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Footprint Label"
-          },
-          "aggressor_label_confidence": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aggressor Label Confidence"
-          },
-          "rule_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rule Id"
-          },
-          "sector": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sector"
-          },
-          "issue_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Issue Type"
-          },
-          "next_earnings_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Earnings Date"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "ticker"
-        ],
-        "title": "FlowAlert"
-      },
-      "FlowSnapshot": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "flow_count": {
-            "type": "integer",
-            "title": "Flow Count"
-          },
-          "flow_count_is_limited": {
-            "type": "boolean",
-            "title": "Flow Count Is Limited",
-            "default": false
-          },
-          "flow_count_30d_avg": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Count 30D Avg"
-          },
-          "flow_count_vs_30d_avg": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flow Count Vs 30D Avg"
-          },
-          "flow_count_30d_days": {
-            "type": "integer",
-            "title": "Flow Count 30D Days",
-            "default": 0
-          },
-          "top_alert_rule": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Top Alert Rule"
-          },
-          "net_premium": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Net Premium"
-          },
-          "bull_premium": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Bull Premium"
-          },
-          "bear_premium": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Bear Premium"
-          },
-          "ask_side_premium": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Ask Side Premium"
-          },
-          "bid_side_premium": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Bid Side Premium"
-          },
-          "top_alerts": {
-            "items": {
-              "$ref": "#/components/schemas/FlowAlert"
-            },
-            "type": "array",
-            "title": "Top Alerts",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "flow_count",
-          "net_premium",
-          "bull_premium",
-          "bear_premium",
-          "ask_side_premium",
-          "bid_side_premium"
-        ],
-        "title": "FlowSnapshot"
-      },
-      "GammaBlock": {
-        "properties": {
-          "flip_distance": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flip Distance"
-          },
-          "flip_price": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flip Price"
-          },
-          "per_1pct_move": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Per 1Pct Move"
-          },
-          "max_strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Strike"
-          },
-          "expiring_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiring Pct"
-          },
-          "expiring_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expiring Date"
-          }
-        },
-        "type": "object",
-        "title": "GammaBlock"
-      },
-      "GexBias": {
-        "properties": {
-          "direction": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Direction"
-          },
-          "reasons": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Reasons"
-          },
-          "days_above_flip": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Days Above Flip"
-          },
-          "flip_migration": {
-            "items": {
-              "$ref": "#/components/schemas/GexFlipMigrationEntry"
-            },
-            "type": "array",
-            "title": "Flip Migration"
-          }
-        },
-        "type": "object",
-        "title": "GexBias"
-      },
-      "GexBucket": {
-        "properties": {
-          "strike": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strike"
-          },
-          "call_gex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Gex"
-          },
-          "put_gex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Gex"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "pct_from_spot": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pct From Spot"
-          },
-          "tag": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tag"
-          }
-        },
-        "type": "object",
-        "title": "GexBucket"
-      },
-      "GexExpectedRange": {
-        "properties": {
-          "low": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Low"
-          },
-          "high": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High"
-          },
-          "iv_1d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv 1D"
-          }
-        },
-        "type": "object",
-        "title": "GexExpectedRange"
-      },
-      "GexFlipMigrationEntry": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "flip": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Flip"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "GexFlipMigrationEntry"
-      },
-      "GexHistoryEntry": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "net_dex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Dex"
-          },
-          "gex_flip": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gex Flip"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "atm_iv": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atm Iv"
-          },
-          "vol_pc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vol Pc"
-          },
-          "bias": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bias"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "GexHistoryEntry"
-      },
-      "GexIvData": {
-        "properties": {
-          "iv30d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv30D"
-          },
-          "iv_rank": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank"
-          },
-          "hv30": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hv30"
-          },
-          "mq_iv30d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mq Iv30D"
-          },
-          "mq_iv_rank": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mq Iv Rank"
-          },
-          "source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source"
-          }
-        },
-        "type": "object",
-        "title": "GexIvData"
-      },
-      "GexLevels": {
-        "properties": {
-          "gex_flip": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_magnet": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "second_magnet": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_accelerator": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "put_wall": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_wall": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__api__schemas__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "GexLevels"
-      },
-      "GexMqLevels": {
-        "properties": {
-          "source_date": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Date"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "hvl": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hvl"
-          },
-          "call_resistance_all": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Resistance All"
-          },
-          "call_resistance_0dte": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Resistance 0Dte"
-          },
-          "put_support_all": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Support All"
-          },
-          "put_support_0dte": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Support 0Dte"
-          },
-          "expected_high": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expected High"
-          },
-          "expected_low": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Expected Low"
-          },
-          "distance_to_hvl_pct": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Distance To Hvl Pct"
-          },
-          "iv30d": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv30D"
-          },
-          "hv30": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hv30"
-          },
-          "iv_rank": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank"
-          },
-          "top_gex_strikes": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array",
-            "title": "Top Gex Strikes"
-          }
-        },
-        "type": "object",
-        "title": "GexMqLevels"
-      },
-      "GexResponse": {
-        "properties": {
-          "scan_time": {
-            "type": "string",
-            "title": "Scan Time",
-            "default": ""
-          },
-          "market_open": {
-            "type": "boolean",
-            "title": "Market Open",
-            "default": false
-          },
-          "ticker": {
-            "type": "string",
-            "title": "Ticker",
-            "default": "SPX"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "close": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Close"
-          },
-          "prev_close": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Close"
-          },
-          "market_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Market Time"
-          },
-          "tape_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tape Time"
-          },
-          "spot_source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Source"
-          },
-          "day_change": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Day Change"
-          },
-          "day_change_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Day Change Pct"
-          },
-          "data_date": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Date"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "net_dex": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Dex"
-          },
-          "atm_iv": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atm Iv"
-          },
-          "vol_pc": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vol Pc"
-          },
-          "levels": {
-            "$ref": "#/components/schemas/GexLevels"
-          },
-          "profile": {
-            "items": {
-              "$ref": "#/components/schemas/GexBucket"
-            },
-            "type": "array",
-            "title": "Profile"
-          },
-          "expected_range": {
-            "$ref": "#/components/schemas/GexExpectedRange"
-          },
-          "bias": {
-            "$ref": "#/components/schemas/GexBias"
-          },
-          "history": {
-            "items": {
-              "$ref": "#/components/schemas/GexHistoryEntry"
-            },
-            "type": "array",
-            "title": "History"
-          },
-          "iv": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexIvData"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "mq": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexMqLevels"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "source_delta": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDelta"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "GexResponse"
-      },
-      "GexSourceDelta": {
-        "properties": {
-          "flip_vs_hvl": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDeltaEntry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "put_wall_vs_support_all": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDeltaEntry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "put_wall_vs_support_0dte": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDeltaEntry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_wall_vs_resistance_all": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDeltaEntry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_wall_vs_resistance_0dte": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GexSourceDeltaEntry"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "GexSourceDelta"
-      },
-      "GexSourceDeltaEntry": {
-        "properties": {
-          "uw": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uw"
-          },
-          "mq": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mq"
-          },
-          "delta": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Delta"
-          }
-        },
-        "type": "object",
-        "title": "GexSourceDeltaEntry"
-      },
-      "GoldCbCountryHistory": {
-        "properties": {
-          "country_iso3": {
-            "type": "string",
-            "title": "Country Iso3"
-          },
-          "country_name": {
-            "type": "string",
-            "title": "Country Name"
-          },
-          "bucket": {
-            "type": "string",
-            "title": "Bucket"
-          },
-          "latest_reserves_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Reserves T"
-          },
-          "history": {
-            "items": {
-              "$ref": "#/components/schemas/GoldHistoryPoint"
-            },
-            "type": "array",
-            "title": "History",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "country_iso3",
-          "country_name",
-          "bucket"
-        ],
-        "title": "GoldCbCountryHistory"
-      },
-      "GoldCorrelationBand": {
-        "properties": {
-          "mean": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Mean"
-          },
-          "std": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Std"
-          }
-        },
-        "type": "object",
-        "required": [
-          "mean",
-          "std"
-        ],
-        "title": "GoldCorrelationBand"
-      },
-      "GoldCorrelationHistory": {
-        "properties": {
-          "gold_dfii10": {
-            "items": {
-              "$ref": "#/components/schemas/GoldCorrelationPoint"
-            },
-            "type": "array",
-            "title": "Gold Dfii10",
-            "default": []
-          },
-          "gold_dxy": {
-            "items": {
-              "$ref": "#/components/schemas/GoldCorrelationPoint"
-            },
-            "type": "array",
-            "title": "Gold Dxy",
-            "default": []
-          },
-          "gold_gpr": {
-            "items": {
-              "$ref": "#/components/schemas/GoldCorrelationPoint"
-            },
-            "type": "array",
-            "title": "Gold Gpr",
-            "default": []
-          },
-          "pre_2022_band": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GoldCorrelationBand"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "GoldCorrelationHistory",
-        "description": "Tier 5 correlation-history panel inputs."
-      },
-      "GoldCorrelationPoint": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "value": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Value"
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "value"
-        ],
-        "title": "GoldCorrelationPoint"
-      },
-      "GoldCyclicalPostureModel": {
-        "properties": {
-          "zone_label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Zone Label"
-          },
-          "posture_chip": {
-            "type": "string",
-            "enum": [
-              "FAVORABLE",
-              "NEUTRAL",
-              "STRETCHED",
-              "SUSPENDED",
-              "DEGRADED"
-            ],
-            "title": "Posture Chip"
-          },
-          "cpi_yoy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cpi Yoy"
-          },
-          "t5yifr": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "T5Yifr"
-          },
-          "t5yifr_pct_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "T5Yifr Pct 52W"
-          },
-          "dfii10": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dfii10"
-          },
-          "dfii10_60d_change_bps": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dfii10 60D Change Bps"
-          },
-          "dxy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dxy"
-          },
-          "dxy_60d_sigma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dxy 60D Sigma"
-          },
-          "gpr_value": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gpr Value"
-          },
-          "gpr_pct_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gpr Pct 52W"
-          },
-          "factors": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "type": "object",
-            "title": "Factors",
-            "default": {}
-          },
-          "two_force_text": {
-            "$ref": "#/components/schemas/GoldTwoForceText"
-          },
-          "narrative_text": {
-            "type": "string",
-            "title": "Narrative Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "posture_chip",
-          "two_force_text",
-          "narrative_text"
-        ],
-        "title": "GoldCyclicalPostureModel"
-      },
-      "GoldDataFreshnessSource": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "last_as_of": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last As Of"
-          },
-          "stale_seconds": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Stale Seconds"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "missing"
-            ],
-            "title": "Status",
-            "default": "ok"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "title": "GoldDataFreshnessSource",
-        "description": "Per-source freshness for the Tier 1 Data Freshness card."
-      },
-      "GoldDecompositionRow": {
-        "properties": {
-          "lens": {
-            "type": "string",
-            "enum": [
-              "L1",
-              "L2",
-              "L3"
-            ],
-            "title": "Lens"
-          },
-          "factor": {
-            "type": "string",
-            "title": "Factor"
-          },
-          "contribution": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Contribution"
-          }
-        },
-        "type": "object",
-        "required": [
-          "lens",
-          "factor",
-          "contribution"
-        ],
-        "title": "GoldDecompositionRow",
-        "description": "One row of the Tier 5 lens-decomposition bars."
-      },
-      "GoldGaugeResponse": {
-        "properties": {
-          "current": {
-            "$ref": "#/components/schemas/GoldGaugeState"
-          },
-          "history_252d": {
-            "items": {
-              "$ref": "#/components/schemas/GoldGaugeTimeSeriesPoint"
-            },
-            "type": "array",
-            "title": "History 252D"
-          }
-        },
-        "type": "object",
-        "required": [
-          "current",
-          "history_252d"
-        ],
-        "title": "GoldGaugeResponse"
-      },
-      "GoldGaugeState": {
-        "properties": {
-          "corr_60d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 60D"
-          },
-          "corr_126d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 126D"
-          },
-          "corr_252d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 252D"
-          },
-          "corr_504d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 504D"
-          },
-          "corr_252d_returns": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 252D Returns"
-          },
-          "state": {
-            "type": "string",
-            "enum": [
-              "operative",
-              "partial",
-              "suspended"
-            ],
-            "title": "State"
-          }
-        },
-        "type": "object",
-        "required": [
-          "state"
-        ],
-        "title": "GoldGaugeState"
-      },
-      "GoldGaugeTimeSeriesPoint": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "corr_252d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Corr 252D"
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "corr_252d"
-        ],
-        "title": "GoldGaugeTimeSeriesPoint"
-      },
-      "GoldHistoryPoint": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "value": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Value"
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "value"
-        ],
-        "title": "GoldHistoryPoint"
-      },
-      "GoldInputProvenance": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "as_of": {
-            "type": "string",
-            "format": "date-time",
-            "title": "As Of"
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "as_of"
-        ],
-        "title": "GoldInputProvenance"
-      },
-      "GoldInputSeriesPoint": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "value": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Value"
-          },
-          "as_of": {
-            "type": "string",
-            "format": "date-time",
-            "title": "As Of"
-          },
-          "release_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Release Date"
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "value",
-          "as_of"
-        ],
-        "title": "GoldInputSeriesPoint"
-      },
-      "GoldInputSeriesResponse": {
-        "properties": {
-          "series_id": {
-            "type": "string",
-            "title": "Series Id"
-          },
-          "points": {
-            "items": {
-              "$ref": "#/components/schemas/GoldInputSeriesPoint"
-            },
-            "type": "array",
-            "title": "Points"
-          }
-        },
-        "type": "object",
-        "required": [
-          "series_id",
-          "points"
-        ],
-        "title": "GoldInputSeriesResponse"
-      },
-      "GoldLensResponse": {
-        "properties": {
-          "lens_id": {
-            "type": "string",
-            "enum": [
-              "structural",
-              "cyclical",
-              "valuation"
-            ],
-            "title": "Lens Id"
-          },
-          "posture": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GoldStructuralPostureModel"
-              },
-              {
-                "$ref": "#/components/schemas/GoldCyclicalPostureModel"
-              },
-              {
-                "$ref": "#/components/schemas/GoldValuationPostureModel"
-              }
-            ],
-            "title": "Posture"
-          },
-          "detail": {
-            "additionalProperties": {
-              "items": {
-                "$ref": "#/components/schemas/GoldInputSeriesPoint"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "required": [
-          "lens_id",
-          "posture",
-          "detail"
-        ],
-        "title": "GoldLensResponse",
-        "description": "Detail payload for one lens (richer than the summary in GoldStateResponse)."
-      },
-      "GoldSpotTile": {
-        "properties": {
-          "last": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Last"
-          },
-          "delta_abs": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Delta Abs"
-          },
-          "delta_pct": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Delta Pct"
-          },
-          "high": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "High"
-          },
-          "low": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Low"
-          },
-          "open": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Open"
-          }
-        },
-        "type": "object",
-        "required": [
-          "last",
-          "delta_abs",
-          "delta_pct",
-          "high",
-          "low",
-          "open"
-        ],
-        "title": "GoldSpotTile",
-        "description": "XAU/USD snapshot used by the Tier 1 KPI strip."
-      },
-      "GoldStateResponse": {
-        "properties": {
-          "obs_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Obs Date"
-          },
-          "computed_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Computed At"
-          },
-          "gauge": {
-            "$ref": "#/components/schemas/GoldGaugeState"
-          },
-          "spot": {
-            "$ref": "#/components/schemas/GoldSpotTile"
-          },
-          "structural": {
-            "$ref": "#/components/schemas/GoldStructuralPostureModel"
-          },
-          "cyclical": {
-            "$ref": "#/components/schemas/GoldCyclicalPostureModel"
-          },
-          "valuation": {
-            "$ref": "#/components/schemas/GoldValuationPostureModel"
-          },
-          "inputs_used": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/GoldInputProvenance"
-            },
-            "type": "object",
-            "title": "Inputs Used"
-          },
-          "data_freshness": {
-            "items": {
-              "$ref": "#/components/schemas/GoldDataFreshnessSource"
-            },
-            "type": "array",
-            "title": "Data Freshness",
-            "default": []
-          },
-          "decomposition_rows": {
-            "items": {
-              "$ref": "#/components/schemas/GoldDecompositionRow"
-            },
-            "type": "array",
-            "title": "Decomposition Rows",
-            "default": []
-          },
-          "correlation_history": {
-            "$ref": "#/components/schemas/GoldCorrelationHistory",
-            "default": {
-              "gold_dfii10": [],
-              "gold_dxy": [],
-              "gold_gpr": []
-            }
-          }
-        },
-        "type": "object",
-        "required": [
-          "obs_date",
-          "computed_at",
-          "gauge",
-          "spot",
-          "structural",
-          "cyclical",
-          "valuation",
-          "inputs_used"
-        ],
-        "title": "GoldStateResponse"
-      },
-      "GoldStructuralPostureModel": {
-        "properties": {
-          "state_label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "State Label"
-          },
-          "posture_chip": {
-            "type": "string",
-            "enum": [
-              "FAVORABLE",
-              "NEUTRAL",
-              "STRETCHED",
-              "SUSPENDED",
-              "DEGRADED"
-            ],
-            "title": "Posture Chip"
-          },
-          "cb_strategic_12m_sum_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cb Strategic 12M Sum T"
-          },
-          "cb_tactical_12m_sum_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cb Tactical 12M Sum T"
-          },
-          "cb_diversifier_12m_sum_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cb Diversifier 12M Sum T"
-          },
-          "cb_52w_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cb 52W Pct"
-          },
-          "gld_holdings_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gld Holdings T"
-          },
-          "gld_30d_net_flow_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gld 30D Net Flow T"
-          },
-          "comex_registered_oz": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Comex Registered Oz"
-          },
-          "comex_20d_roc_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Comex 20D Roc Pct"
-          },
-          "lbma_30d_momentum_t": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lbma 30D Momentum T"
-          },
-          "cot_mm_net_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cot Mm Net Pct"
-          },
-          "cot_mm_4w_change_sigma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cot Mm 4W Change Sigma"
-          },
-          "uw_25d_skew_sigma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uw 25D Skew Sigma"
-          },
-          "fx_basket_dxy_z": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fx Basket Dxy Z"
-          },
-          "xau_cny_premium_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Xau Cny Premium Pct"
-          },
-          "gld_history": {
-            "items": {
-              "$ref": "#/components/schemas/GoldHistoryPoint"
-            },
-            "type": "array",
-            "title": "Gld History",
-            "default": []
-          },
-          "gold_history": {
-            "items": {
-              "$ref": "#/components/schemas/GoldHistoryPoint"
-            },
-            "type": "array",
-            "title": "Gold History",
-            "default": []
-          },
-          "cb_country_history": {
-            "items": {
-              "$ref": "#/components/schemas/GoldCbCountryHistory"
-            },
-            "type": "array",
-            "title": "Cb Country History",
-            "default": []
-          },
-          "narrative_text": {
-            "type": "string",
-            "title": "Narrative Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "posture_chip",
-          "narrative_text"
-        ],
-        "title": "GoldStructuralPostureModel"
-      },
-      "GoldTwoForceText": {
-        "properties": {
-          "discount_rate": {
-            "type": "string",
-            "title": "Discount Rate"
-          },
-          "hedge_demand": {
-            "type": "string",
-            "title": "Hedge Demand"
-          }
-        },
-        "type": "object",
-        "required": [
-          "discount_rate",
-          "hedge_demand"
-        ],
-        "title": "GoldTwoForceText"
-      },
-      "GoldValuationPostureModel": {
-        "properties": {
-          "flag": {
-            "type": "string",
-            "enum": [
-              "Low",
-              "Moderate",
-              "High",
-              "Severe"
-            ],
-            "title": "Flag"
-          },
-          "posture_chip": {
-            "type": "string",
-            "enum": [
-              "FAVORABLE",
-              "NEUTRAL",
-              "STRETCHED",
-              "SUSPENDED",
-              "DEGRADED"
-            ],
-            "title": "Posture Chip"
-          },
-          "real_price_percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Real Price Percentile"
-          },
-          "gold_m2_ratio_percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gold M2 Ratio Percentile"
-          },
-          "gold_oil_ratio_percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gold Oil Ratio Percentile"
-          },
-          "gold_spx_ratio_percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gold Spx Ratio Percentile"
-          },
-          "narrative_text": {
-            "type": "string",
-            "title": "Narrative Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "flag",
-          "posture_chip",
-          "narrative_text"
-        ],
-        "title": "GoldValuationPostureModel"
-      },
-      "GuidanceResponse": {
-        "properties": {
-          "state": {
-            "type": "string",
-            "title": "State"
-          },
-          "posture": {
-            "type": "string",
-            "enum": [
-              "opportunistic",
-              "neutral",
-              "cautious",
-              "defensive"
-            ],
-            "title": "Posture"
-          },
-          "body_md": {
-            "type": "string",
-            "title": "Body Md"
-          },
-          "matched_condition": {
-            "type": "string",
-            "title": "Matched Condition"
-          }
-        },
-        "type": "object",
-        "required": [
-          "state",
-          "posture",
-          "body_md",
-          "matched_condition"
-        ],
-        "title": "GuidanceResponse"
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
-      },
-      "HealthResponse": {
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          },
-          "db": {
-            "type": "string",
-            "title": "Db"
-          },
-          "scheduler_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scheduler Lag Seconds"
-          },
-          "last_full_scan_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Full Scan At"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "worker_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Worker Lag Seconds"
-          },
-          "scheduler_heartbeat_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scheduler Heartbeat Lag Seconds"
-          },
-          "scheduler_heartbeat_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scheduler Heartbeat Name"
-          },
-          "rescan_heartbeat_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rescan Heartbeat Lag Seconds"
-          },
-          "spot_refresh_heartbeat_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Refresh Heartbeat Lag Seconds"
-          },
-          "spot_quote_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Quote Lag Seconds"
-          },
-          "latest_spot_quote_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Spot Quote At"
-          },
-          "latest_spot_quote_fetched_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest Spot Quote Fetched At"
-          },
-          "watchlist_size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Watchlist Size"
-          },
-          "source": {
-            "type": "string",
-            "title": "Source",
-            "default": "UnusualWhales"
-          },
-          "latency_p95_ms": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latency P95 Ms"
-          },
-          "http_2xx": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Http 2Xx"
-          },
-          "http_4xx": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Http 4Xx"
-          },
-          "http_5xx": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Http 5Xx"
-          },
-          "uw_today": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uw Today"
-          },
-          "cache_hit_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cache Hit Pct"
-          },
-          "throughput_window_minutes": {
-            "type": "number",
-            "title": "Throughput Window Minutes",
-            "default": 0.0
-          },
-          "requests_per_minute": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Requests Per Minute"
-          },
-          "http_429": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Http 429"
-          },
-          "avg_scan_duration_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg Scan Duration Seconds"
-          },
-          "queue_drain_rate_per_minute": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Queue Drain Rate Per Minute"
-          },
-          "record_health_ok": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Record Health Ok"
-          },
-          "record_health": {
-            "items": {
-              "$ref": "#/components/schemas/RecordHealthCheck"
-            },
-            "type": "array",
-            "title": "Record Health"
-          },
-          "workers": {
-            "items": {
-              "$ref": "#/components/schemas/WorkerHealth"
-            },
-            "type": "array",
-            "title": "Workers"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ok",
-          "db"
-        ],
-        "title": "HealthResponse"
-      },
-      "InsightBadge": {
-        "properties": {
-          "code": {
-            "type": "string",
-            "title": "Code"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "severity": {
-            "type": "string",
-            "title": "Severity",
-            "default": "info"
-          }
-        },
-        "type": "object",
-        "required": [
-          "code",
-          "label"
-        ],
-        "title": "InsightBadge"
-      },
-      "InsightLeg": {
-        "properties": {
-          "side": {
-            "type": "string",
-            "title": "Side"
-          },
-          "option_symbol": {
-            "type": "string",
-            "title": "Option Symbol"
-          },
-          "option_right": {
-            "type": "string",
-            "title": "Option Right"
-          },
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "mid": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mid"
-          }
-        },
-        "type": "object",
-        "required": [
-          "side",
-          "option_symbol",
-          "option_right",
-          "expiry",
-          "strike"
-        ],
-        "title": "InsightLeg"
-      },
-      "InsightSignalRow": {
-        "properties": {
-          "lens": {
-            "type": "string",
-            "title": "Lens"
-          },
-          "read": {
-            "type": "string",
-            "title": "Read"
-          },
-          "evidence": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Evidence",
-            "default": []
-          },
-          "conflicts": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Conflicts",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "lens",
-          "read"
-        ],
-        "title": "InsightSignalRow"
-      },
-      "InsightsSynthesis": {
-        "properties": {
-          "dominant_story": {
-            "type": "string",
-            "title": "Dominant Story",
-            "default": ""
-          },
-          "preferred_idea_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Preferred Idea Id"
-          },
-          "best_risk_reward_idea_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Best Risk Reward Idea Id"
-          },
-          "avoid": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Avoid",
-            "default": []
-          },
-          "required_before_sizing": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Required Before Sizing",
-            "default": []
-          }
-        },
-        "type": "object",
-        "title": "InsightsSynthesis"
-      },
-      "IvHistogramBin": {
-        "properties": {
-          "lo": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Lo"
-          },
-          "hi": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Hi"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
-        },
-        "type": "object",
-        "required": [
-          "lo",
-          "hi",
-          "count"
-        ],
-        "title": "IvHistogramBin"
-      },
-      "IvHvPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          },
-          "rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "IvHvPoint"
-      },
-      "IvOfIvPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          },
-          "iv_of_iv_20": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Of Iv 20"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "IvOfIvPoint"
-      },
-      "IvPercentileDistribution": {
-        "properties": {
-          "bins": {
-            "items": {
-              "$ref": "#/components/schemas/IvHistogramBin"
-            },
-            "type": "array",
-            "title": "Bins",
-            "default": []
-          },
-          "current_iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Current Iv"
-          },
-          "current_pctile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Current Pctile"
-          }
-        },
-        "type": "object",
-        "title": "IvPercentileDistribution"
-      },
-      "JobStatus": {
-        "properties": {
-          "job_id": {
-            "type": "string",
-            "title": "Job Id"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "running",
-              "done",
-              "failed"
-            ],
-            "title": "Status"
-          },
-          "run_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Run Id"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          },
-          "requested_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Requested At"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "job_id",
-          "status",
-          "requested_at"
-        ],
-        "title": "JobStatus"
-      },
-      "MarketAggregates": {
-        "properties": {
-          "call_oi_total": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Oi Total"
-          },
-          "put_oi_total": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Oi Total"
-          },
-          "call_volume_total": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume Total"
-          },
-          "put_volume_total": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume Total"
-          },
-          "call_volume_ask_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume Ask Side"
-          },
-          "call_volume_bid_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume Bid Side"
-          },
-          "put_volume_ask_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume Ask Side"
-          },
-          "put_volume_bid_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume Bid Side"
-          },
-          "pcr_oi": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Oi"
-          },
-          "pcr_vol": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Vol"
-          },
-          "iv30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv30D"
-          },
-          "market_cap": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
-          }
-        },
-        "type": "object",
-        "title": "MarketAggregates",
-        "description": "Per-ticker aggregate fields sourced from the bulk-screener endpoint.\n\nPopulated by pipeline.run_single_stock alongside the existing per-section\nsub-models. Feeds the watchlist card POSITIONING and SKEW blocks."
-      },
-      "MarketStructure": {
-        "properties": {
-          "spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "nearest_expiry": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nearest Expiry"
-          },
-          "total_call_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Call Gex"
-          },
-          "total_put_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Put Gex"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "total_call_dex_oi": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Call Dex Oi"
-          },
-          "total_put_dex_oi": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total Put Dex Oi"
-          },
-          "max_pain": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Pain"
-          },
-          "top_call_oi_strikes": {
-            "items": {
-              "type": "string",
-              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-            },
-            "type": "array",
-            "title": "Top Call Oi Strikes",
-            "default": []
-          },
-          "top_put_oi_strikes": {
-            "items": {
-              "type": "string",
-              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-            },
-            "type": "array",
-            "title": "Top Put Oi Strikes",
-            "default": []
-          }
-        },
-        "type": "object",
-        "title": "MarketStructure"
-      },
-      "MarketStructureLevels": {
-        "properties": {
-          "gex_flip": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_wall": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "put_wall": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_magnet": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "second_magnet": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_accel": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/uw_scan__models__GexLevel"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "title": "MarketStructureLevels",
-        "description": "Derived strike-level reference points used by the Market Structure tab.\n\nConventions follow FlashAlpha / SpotGamma:\n  - gex_flip: lowest strike where running cumulative net_gex flips sign\n  - call_wall: strike with largest call-side gamma (typically above spot)\n  - put_wall: strike with largest put-side gamma magnitude (typically below spot)\n  - max_magnet: strike with largest positive net_gex above spot (pulls price up)\n  - second_magnet: strike with second-largest positive net_gex above spot\n  - max_accel: strike with most-negative net_gex below the flip (movement accelerator)"
-      },
-      "MatrixSourceFreshness": {
-        "properties": {
-          "vanna_charm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vanna Charm"
-          },
-          "skew": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew"
-          },
-          "term": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Term"
-          },
-          "im_vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Im Vrp"
-          },
-          "vrp_rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp Rv"
-          },
-          "oi": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Oi"
-          }
-        },
-        "type": "object",
-        "title": "MatrixSourceFreshness"
-      },
-      "MatrixState": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "threshold_version": {
-            "type": "integer",
-            "title": "Threshold Version",
-            "default": 1
-          },
-          "vanna_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Vanna State"
-          },
-          "charm_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Charm State"
-          },
-          "skew_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Skew State"
-          },
-          "term_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Term State"
-          },
-          "im_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Im State"
-          },
-          "flow_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Flow State"
-          },
-          "vrp_state": {
-            "type": "string",
-            "enum": [
-              "vol_up",
-              "vol_down",
-              "neutral",
-              "stale"
-            ],
-            "title": "Vrp State"
-          },
-          "consistency_tier": {
-            "type": "string",
-            "enum": [
-              "strict",
-              "strong",
-              "weak",
-              "no_trade",
-              "insufficient_data"
-            ],
-            "title": "Consistency Tier"
-          },
-          "cluster_coverage_ok": {
-            "type": "boolean",
-            "title": "Cluster Coverage Ok"
-          },
-          "term_classification": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "contango",
-                  "event_back",
-                  "liquidity_back",
-                  "mixed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Term Classification"
-          },
-          "skew_25d_zscore_180d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew 25D Zscore 180D"
-          },
-          "iv_atm_30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Atm 30D"
-          },
-          "rv_30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv 30D"
-          },
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "vrp_zscore_60d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp Zscore 60D"
-          },
-          "implied_move_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Pct"
-          },
-          "front_iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Front Iv"
-          },
-          "back_iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Back Iv"
-          },
-          "front_back_spread": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Front Back Spread"
-          },
-          "pin_distance_sigma": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pin Distance Sigma"
-          },
-          "vrp_sign_flip_status": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "string",
-                "const": "insufficient_history"
-              }
-            ],
-            "title": "Vrp Sign Flip Status",
-            "default": "insufficient_history"
-          },
-          "vrp_sign_flip_aligned_days": {
-            "type": "integer",
-            "title": "Vrp Sign Flip Aligned Days",
-            "default": 0
-          },
-          "vanna_conditional_reading": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "grind_up",
-                  "reverse_selloff",
-                  "reflexive_sell_pressure",
-                  "weak_noise"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vanna Conditional Reading"
-          },
-          "directional_imbalance_3d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Directional Imbalance 3D"
-          },
-          "vanna_oi_change_bias": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "call_oi_build",
-                  "put_oi_build",
-                  "mixed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vanna Oi Change Bias"
-          },
-          "charm_regime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "operative_magnet",
-                  "broken_magnet",
-                  "opex_vortex",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Charm Regime"
-          },
-          "charm_stress_override": {
-            "type": "boolean",
-            "title": "Charm Stress Override",
-            "default": false
-          },
-          "skew_25d_5d_change": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew 25D 5D Change"
-          },
-          "skew_regime": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "smirk",
-                  "accelerated",
-                  "crash_smile",
-                  "neutral"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew Regime"
-          },
-          "skew_term_structure": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew Term Structure"
-          },
-          "single_point_bump_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Single Point Bump Pct"
-          },
-          "full_curve_slope_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Full Curve Slope Pct"
-          },
-          "term_johnson_slope_pc1": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Term Johnson Slope Pc1"
-          },
-          "atm_straddle_mid": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atm Straddle Mid"
-          },
-          "implied_move_expected_abs": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Expected Abs"
-          },
-          "implied_move_event_percentile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Event Percentile"
-          },
-          "vrp_zscore_252d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp Zscore 252D"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "market_date",
-          "vanna_state",
-          "charm_state",
-          "skew_state",
-          "term_state",
-          "im_state",
-          "flow_state",
-          "vrp_state",
-          "consistency_tier",
-          "cluster_coverage_ok"
-        ],
-        "title": "MatrixState"
-      },
-      "MaxPainRow": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "max_pain": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Pain"
-          },
-          "close": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Close"
-          },
-          "open": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Open"
-          },
-          "next_upper_strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Upper Strike"
-          },
-          "next_lower_strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Lower Strike"
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry"
-        ],
-        "title": "MaxPainRow"
-      },
-      "OhlcRow": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "open": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Open"
-          },
-          "high": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "High"
-          },
-          "low": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Low"
-          },
-          "close": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Close"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "close"
-        ],
-        "title": "OhlcRow"
-      },
-      "OiChangeRow": {
-        "properties": {
-          "underlying_symbol": {
-            "type": "string",
-            "title": "Underlying Symbol"
-          },
-          "option_symbol": {
-            "type": "string",
-            "title": "Option Symbol"
-          },
-          "curr_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Curr Date"
-          },
-          "last_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Date"
-          },
-          "curr_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Curr Oi"
-          },
-          "last_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Oi"
-          },
-          "oi_diff_plain": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Oi Diff Plain"
-          },
-          "oi_change": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Oi Change"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume"
-          },
-          "trades": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trades"
-          },
-          "avg_price": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg Price"
-          },
-          "last_fill": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Fill"
-          },
-          "days_of_oi_increases": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Days Of Oi Increases"
-          },
-          "days_of_vol_greater_than_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Days Of Vol Greater Than Oi"
-          },
-          "percentage_of_total": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Percentage Of Total"
-          },
-          "rnk": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rnk"
-          },
-          "prev_ask_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Ask Volume"
-          },
-          "prev_bid_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Bid Volume"
-          },
-          "prev_mid_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Mid Volume"
-          },
-          "prev_neutral_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Neutral Volume"
-          },
-          "prev_multi_leg_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Multi Leg Volume"
-          },
-          "prev_stock_multi_leg_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Stock Multi Leg Volume"
-          },
-          "prev_total_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Prev Total Premium"
-          },
-          "last_ask": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Ask"
-          },
-          "last_bid": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Bid"
-          },
-          "ask_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ask Volume"
-          },
-          "bid_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bid Volume"
-          },
-          "mid_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mid Volume"
-          },
-          "no_side_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "No Side Volume"
-          }
-        },
-        "type": "object",
-        "required": [
-          "underlying_symbol",
-          "option_symbol"
-        ],
-        "title": "OiChangeRow"
-      },
-      "OosLabel": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "definition": {
-            "type": "string",
-            "title": "Definition"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "definition"
-        ],
-        "title": "OosLabel"
-      },
-      "OosScore": {
-        "properties": {
-          "model": {
-            "type": "string",
-            "title": "Model"
-          },
-          "auc_dd5": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Auc Dd5"
-          },
-          "auc_vix30": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Auc Vix30"
-          },
-          "auc_dd10": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Auc Dd10"
-          }
-        },
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "title": "OosScore"
-      },
-      "OosSummary": {
-        "properties": {
-          "as_of": {
-            "type": "string",
-            "title": "As Of"
-          },
-          "notebook": {
-            "type": "string",
-            "title": "Notebook"
-          },
-          "method": {
-            "type": "string",
-            "title": "Method"
-          },
-          "labels": {
-            "items": {
-              "$ref": "#/components/schemas/OosLabel"
-            },
-            "type": "array",
-            "title": "Labels"
-          },
-          "scores": {
-            "items": {
-              "$ref": "#/components/schemas/OosScore"
-            },
-            "type": "array",
-            "title": "Scores"
-          },
-          "interpretation": {
-            "type": "string",
-            "title": "Interpretation"
-          }
-        },
-        "type": "object",
-        "required": [
-          "as_of",
-          "notebook",
-          "method",
-          "labels",
-          "scores",
-          "interpretation"
-        ],
-        "title": "OosSummary"
-      },
-      "OptionChainPerStrikeRow": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "call_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume"
-          },
-          "put_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume"
-          },
-          "call_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Oi"
-          },
-          "put_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Oi"
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry",
-          "strike"
-        ],
-        "title": "OptionChainPerStrikeRow",
-        "description": "Aggregated (expiry, strike) snapshot \u2014 both volume and OI in one row.\n\nBacks both strike-profile charts (Volume and OI variants)."
-      },
-      "OptionIntradayProfile": {
-        "properties": {
-          "option_symbol": {
-            "type": "string",
-            "title": "Option Symbol"
-          },
-          "trade_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Trade Date"
-          },
-          "total_volume": {
-            "type": "integer",
-            "title": "Total Volume",
-            "default": 0
-          },
-          "first_trade_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "First Trade Time"
-          },
-          "last_trade_time": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Trade Time"
-          },
-          "peak_window_start": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Peak Window Start"
-          },
-          "peak_window_end": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Peak Window End"
-          },
-          "peak_window_share_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Peak Window Share Pct"
-          },
-          "sparkline": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Sparkline",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "option_symbol",
-          "trade_date"
-        ],
-        "title": "OptionIntradayProfile",
-        "description": "Derived per-contract intraday tape view for the OI movers table.\n\nBuilt by ``cards.intraday_profile.derive_intraday_profile`` from persisted\n:class:`OptionContractIntradayBucket` rows. Volume here is side-aggregated\n(ask + bid + mid + multi). The 12-point sparkline is a fixed-length\ndownsample so the UI renders a stable width regardless of how many\nminute bars the contract actually had."
-      },
-      "OptionsDailyRow": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "call_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume"
-          },
-          "put_volume": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume"
-          },
-          "call_volume_ask_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume Ask Side"
-          },
-          "call_volume_bid_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Volume Bid Side"
-          },
-          "put_volume_ask_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume Ask Side"
-          },
-          "put_volume_bid_side": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Volume Bid Side"
-          },
-          "call_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Premium"
-          },
-          "put_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Premium"
-          },
-          "net_call_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Call Premium"
-          },
-          "net_put_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Put Premium"
-          },
-          "bullish_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bullish Premium"
-          },
-          "bearish_premium": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bearish Premium"
-          },
-          "call_open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Open Interest"
-          },
-          "put_open_interest": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Open Interest"
-          },
-          "avg_3_day_call_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 3 Day Call Volume"
-          },
-          "avg_3_day_put_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 3 Day Put Volume"
-          },
-          "avg_7_day_call_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 7 Day Call Volume"
-          },
-          "avg_7_day_put_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 7 Day Put Volume"
-          },
-          "avg_30_day_call_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 30 Day Call Volume"
-          },
-          "avg_30_day_put_volume": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Avg 30 Day Put Volume"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "OptionsDailyRow",
-        "description": "One row per trading day from UW /options-volume.\n\n``bullish_premium`` here is whole-tape (UW), distinct from the\nalert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot."
-      },
-      "PositioningBlock": {
-        "properties": {
-          "call_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Oi"
-          },
-          "put_oi": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Oi"
-          },
-          "pcr_oi": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Oi"
-          },
-          "pcr_vol": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Vol"
-          },
-          "pcr_delta_30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Delta 30D"
-          }
-        },
-        "type": "object",
-        "title": "PositioningBlock"
-      },
-      "ProviderUsageBreakdownResponse": {
-        "properties": {
-          "provider_day_start": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day Start"
-          },
-          "provider_day_end": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day End"
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/ProviderUsageBreakdownRow"
-            },
-            "type": "array",
-            "title": "Rows"
-          }
-        },
-        "type": "object",
-        "required": [
-          "provider_day_start",
-          "provider_day_end",
-          "rows"
-        ],
-        "title": "ProviderUsageBreakdownResponse"
-      },
-      "ProviderUsageBreakdownRow": {
-        "properties": {
-          "key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Key"
-          },
-          "total_requests": {
-            "type": "integer",
-            "title": "Total Requests"
-          },
-          "http_2xx": {
-            "type": "integer",
-            "title": "Http 2Xx"
-          },
-          "http_3xx": {
-            "type": "integer",
-            "title": "Http 3Xx"
-          },
-          "http_4xx": {
-            "type": "integer",
-            "title": "Http 4Xx"
-          },
-          "http_5xx": {
-            "type": "integer",
-            "title": "Http 5Xx"
-          },
-          "transport_errors": {
-            "type": "integer",
-            "title": "Transport Errors"
-          },
-          "latency_p95_ms": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latency P95 Ms"
-          }
-        },
-        "type": "object",
-        "required": [
-          "key",
-          "total_requests",
-          "http_2xx",
-          "http_3xx",
-          "http_4xx",
-          "http_5xx",
-          "transport_errors",
-          "latency_p95_ms"
-        ],
-        "title": "ProviderUsageBreakdownRow"
-      },
-      "ProviderUsageRequestRow": {
-        "properties": {
-          "request_id": {
-            "type": "integer",
-            "title": "Request Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
-          "endpoint_key": {
-            "type": "string",
-            "title": "Endpoint Key"
-          },
-          "method": {
-            "type": "string",
-            "title": "Method"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "ticker": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ticker"
-          },
-          "params": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Params"
-          },
-          "status_code": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Status Code"
-          },
-          "status_family": {
-            "type": "string",
-            "title": "Status Family"
-          },
-          "request_started_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Request Started At"
-          },
-          "request_finished_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Request Finished At"
-          },
-          "latency_ms": {
-            "type": "integer",
-            "title": "Latency Ms"
-          },
-          "attempt": {
-            "type": "integer",
-            "title": "Attempt"
-          },
-          "run_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Run Id"
-          },
-          "job_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Job Name"
-          },
-          "provider_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider Request Id"
-          },
-          "official_daily_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Official Daily Count"
-          },
-          "official_daily_limit": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Official Daily Limit"
-          },
-          "official_minute_remaining": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Official Minute Remaining"
-          },
-          "official_minute_reset": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Official Minute Reset"
-          },
-          "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error Message"
-          }
-        },
-        "type": "object",
-        "required": [
-          "request_id",
-          "provider",
-          "endpoint_key",
-          "method",
-          "path",
-          "ticker",
-          "params",
-          "status_code",
-          "status_family",
-          "request_started_at",
-          "request_finished_at",
-          "latency_ms",
-          "attempt",
-          "run_id",
-          "job_name",
-          "provider_request_id",
-          "official_daily_count",
-          "official_daily_limit",
-          "official_minute_remaining",
-          "official_minute_reset",
-          "error_message"
-        ],
-        "title": "ProviderUsageRequestRow"
-      },
-      "ProviderUsageRequestsResponse": {
-        "properties": {
-          "provider_day_start": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day Start"
-          },
-          "provider_day_end": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day End"
-          },
-          "limit": {
-            "type": "integer",
-            "title": "Limit"
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/ProviderUsageRequestRow"
-            },
-            "type": "array",
-            "title": "Rows"
-          }
-        },
-        "type": "object",
-        "required": [
-          "provider_day_start",
-          "provider_day_end",
-          "limit",
-          "rows"
-        ],
-        "title": "ProviderUsageRequestsResponse"
-      },
-      "ProviderUsageSummaryResponse": {
-        "properties": {
-          "provider_day_start": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day Start"
-          },
-          "provider_day_end": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Provider Day End"
-          },
-          "total_requests": {
-            "type": "integer",
-            "title": "Total Requests"
-          },
-          "http_2xx": {
-            "type": "integer",
-            "title": "Http 2Xx"
-          },
-          "http_3xx": {
-            "type": "integer",
-            "title": "Http 3Xx"
-          },
-          "http_4xx": {
-            "type": "integer",
-            "title": "Http 4Xx"
-          },
-          "http_5xx": {
-            "type": "integer",
-            "title": "Http 5Xx"
-          },
-          "transport_errors": {
-            "type": "integer",
-            "title": "Transport Errors"
-          },
-          "latency_p95_ms": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latency P95 Ms"
-          },
-          "uw_latest_daily_count": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uw Latest Daily Count"
-          },
-          "uw_latest_daily_limit": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Uw Latest Daily Limit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "provider_day_start",
-          "provider_day_end",
-          "total_requests",
-          "http_2xx",
-          "http_3xx",
-          "http_4xx",
-          "http_5xx",
-          "transport_errors",
-          "latency_p95_ms",
-          "uw_latest_daily_count",
-          "uw_latest_daily_limit"
-        ],
-        "title": "ProviderUsageSummaryResponse"
-      },
-      "QueueStatus": {
-        "properties": {
-          "job_id": {
-            "type": "string",
-            "title": "Job Id"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "running",
-              "done",
-              "failed"
-            ],
-            "title": "Status"
-          },
-          "queue_position": {
-            "type": "integer",
-            "title": "Queue Position"
-          },
-          "requested_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Requested At"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "job_id",
-          "status",
-          "queue_position",
-          "requested_at"
-        ],
-        "title": "QueueStatus"
-      },
-      "QueueSummary": {
-        "properties": {
-          "total": {
-            "type": "integer",
-            "title": "Total",
-            "default": 0
-          },
-          "queued": {
-            "type": "integer",
-            "title": "Queued",
-            "default": 0
-          },
-          "running": {
-            "type": "integer",
-            "title": "Running",
-            "default": 0
-          },
-          "oldest_requested_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Oldest Requested At"
-          }
-        },
-        "type": "object",
-        "title": "QueueSummary"
-      },
-      "RecordHealthCheck": {
-        "properties": {
-          "table": {
-            "type": "string",
-            "title": "Table"
-          },
-          "window_start": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Window Start"
-          },
-          "expected_tickers": {
-            "type": "integer",
-            "title": "Expected Tickers"
-          },
-          "expected_min_tickers": {
-            "type": "integer",
-            "title": "Expected Min Tickers"
-          },
-          "actual_tickers": {
-            "type": "integer",
-            "title": "Actual Tickers"
-          },
-          "expected_min_rows": {
-            "type": "integer",
-            "title": "Expected Min Rows"
-          },
-          "actual_rows": {
-            "type": "integer",
-            "title": "Actual Rows"
-          },
-          "latest_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Latest At"
-          },
-          "ok": {
-            "type": "boolean",
-            "title": "Ok"
-          }
-        },
-        "type": "object",
-        "required": [
-          "table",
-          "window_start",
-          "expected_tickers",
-          "expected_min_tickers",
-          "actual_tickers",
-          "expected_min_rows",
-          "actual_rows",
-          "ok"
-        ],
-        "title": "RecordHealthCheck"
-      },
-      "RegimeQuadrantBlock": {
-        "properties": {
-          "points": {
-            "items": {
-              "$ref": "#/components/schemas/RegimeQuadrantPoint"
-            },
-            "type": "array",
-            "title": "Points",
-            "default": []
-          },
-          "latest": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RegimeQuadrantLatest"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "cutoff_corr": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cutoff Corr"
-          }
-        },
-        "type": "object",
-        "title": "RegimeQuadrantBlock"
-      },
-      "RegimeQuadrantLatest": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "rvol_pctile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rvol Pctile"
-          },
-          "spy_corr_21": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spy Corr 21"
-          },
-          "state": {
-            "type": "string",
-            "title": "State",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "RegimeQuadrantLatest"
-      },
-      "RegimeQuadrantPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "rvol_pctile": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rvol Pctile"
-          },
-          "spy_corr_21": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spy Corr 21"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "RegimeQuadrantPoint"
-      },
-      "RescanAllRequest": {
-        "properties": {
-          "confirmed": {
-            "type": "boolean",
-            "title": "Confirmed",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "RescanAllRequest"
-      },
-      "ReturnsBlock": {
-        "properties": {
-          "d1": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "D1"
-          },
-          "w1": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "W1"
-          },
-          "d30": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "D30"
-          }
-        },
-        "type": "object",
-        "title": "ReturnsBlock",
-        "description": "Wire shape: d1 / w1 / d30. No aliases \u2014 FastAPI would otherwise serialize\nthem as JSON keys and break the frontend contract."
-      },
-      "RvCorrPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv"
-          },
-          "spy_corr_21": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spy Corr 21"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "RvCorrPoint"
-      },
-      "ScannerCandidate": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "is_type_f": {
-            "type": "boolean",
-            "title": "Is Type F"
-          },
-          "raw_score": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Raw Score"
-          },
-          "confluence_score": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Confluence Score"
-          },
-          "final_score": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Final Score"
-          },
-          "hits": {
-            "items": {
-              "$ref": "#/components/schemas/ScannerSignalHit"
-            },
-            "type": "array",
-            "title": "Hits"
-          },
-          "context_flags": {
-            "items": {
-              "$ref": "#/components/schemas/ScannerContextFlag"
-            },
-            "type": "array",
-            "title": "Context Flags"
-          },
-          "gates": {
-            "$ref": "#/components/schemas/ScannerGatesStatus"
-          },
-          "bias": {
-            "type": "string",
-            "enum": [
-              "bullish",
-              "bearish",
-              "neutral",
-              "mixed"
-            ],
-            "title": "Bias"
-          },
-          "bias_strength": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "strong",
-                  "moderate",
-                  "weak"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Bias Strength"
-          },
-          "setup": {
-            "type": "string",
-            "enum": [
-              "ready",
-              "caution",
-              "blocked"
-            ],
-            "title": "Setup"
-          },
-          "setup_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Setup Reason"
-          },
-          "scanned_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Scanned At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "spot",
-          "is_type_f",
-          "raw_score",
-          "confluence_score",
-          "final_score",
-          "hits",
-          "context_flags",
-          "gates",
-          "bias",
-          "setup",
-          "scanned_at"
-        ],
-        "title": "ScannerCandidate"
-      },
-      "ScannerContextFlag": {
-        "properties": {
-          "layer": {
-            "type": "string",
-            "const": "pcr_sentiment",
-            "title": "Layer"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "value": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Value"
-          }
-        },
-        "type": "object",
-        "required": [
-          "layer",
-          "label",
-          "value"
-        ],
-        "title": "ScannerContextFlag"
-      },
-      "ScannerGatedTicker": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "reason": {
-            "type": "string",
-            "enum": [
-              "regime_block",
-              "stale_scan"
-            ],
-            "title": "Reason"
-          },
-          "blocking_chip": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "SUSPENDED",
-                  "DEGRADED"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Blocking Chip"
-          },
-          "scanned_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scanned At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "reason",
-          "scanned_at"
-        ],
-        "title": "ScannerGatedTicker"
-      },
-      "ScannerGatesStatus": {
-        "properties": {
-          "earnings": {
-            "type": "string",
-            "enum": [
-              "pass",
-              "block"
-            ],
-            "title": "Earnings"
-          },
-          "liquidity": {
-            "type": "string",
-            "enum": [
-              "pass",
-              "block"
-            ],
-            "title": "Liquidity"
-          },
-          "regime": {
-            "type": "string",
-            "enum": [
-              "pass",
-              "block"
-            ],
-            "title": "Regime"
-          }
-        },
-        "type": "object",
-        "required": [
-          "earnings",
-          "liquidity",
-          "regime"
-        ],
-        "title": "ScannerGatesStatus"
-      },
-      "ScannerResponse": {
-        "properties": {
-          "scanned_universe_size": {
-            "type": "integer",
-            "title": "Scanned Universe Size"
-          },
-          "candidates_with_hits": {
-            "type": "integer",
-            "title": "Candidates With Hits"
-          },
-          "candidates": {
-            "items": {
-              "$ref": "#/components/schemas/ScannerCandidate"
-            },
-            "type": "array",
-            "title": "Candidates"
-          },
-          "gated": {
-            "items": {
-              "$ref": "#/components/schemas/ScannerGatedTicker"
-            },
-            "type": "array",
-            "title": "Gated"
-          },
-          "generated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Generated At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "scanned_universe_size",
-          "candidates_with_hits",
-          "candidates",
-          "gated",
-          "generated_at"
-        ],
-        "title": "ScannerResponse"
-      },
-      "ScannerSignalHit": {
-        "properties": {
-          "signal_type": {
-            "type": "string",
-            "enum": [
-              "deep_conviction_flow",
-              "dark_pool_accumulation",
-              "earnings_iv_crush",
-              "gex_pinning"
-            ],
-            "title": "Signal Type"
-          },
-          "tier": {
-            "type": "integer",
-            "enum": [
-              1,
-              2
-            ],
-            "title": "Tier"
-          },
-          "score": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Score"
-          },
-          "evidence": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Evidence"
-          },
-          "freshness": {
-            "type": "string",
-            "enum": [
-              "live",
-              "stale",
-              "unavailable"
-            ],
-            "title": "Freshness"
-          }
-        },
-        "type": "object",
-        "required": [
-          "signal_type",
-          "tier",
-          "score",
-          "evidence",
-          "freshness"
-        ],
-        "title": "ScannerSignalHit"
-      },
-      "SetupBlock": {
-        "properties": {
-          "type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Type"
-          },
-          "direction": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Direction"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score"
-          }
-        },
-        "type": "object",
-        "title": "SetupBlock"
-      },
-      "SetupClassification": {
-        "properties": {
-          "setup_type": {
-            "type": "string",
-            "title": "Setup Type"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "direction": {
-            "type": "string",
-            "title": "Direction"
-          },
-          "score": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Score"
-          },
-          "confirmations": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Confirmations",
-            "default": []
-          },
-          "warnings": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Warnings",
-            "default": []
-          },
-          "notes": {
-            "type": "string",
-            "title": "Notes",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "setup_type",
-          "label",
-          "direction",
-          "score"
-        ],
-        "title": "SetupClassification"
-      },
-      "ShortDataRow": {
-        "properties": {
-          "symbol": {
-            "type": "string",
-            "title": "Symbol"
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Timestamp"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "short_shares_available": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Short Shares Available"
-          },
-          "fee_rate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Fee Rate"
-          },
-          "rebate_rate": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rebate Rate"
-          }
-        },
-        "type": "object",
-        "required": [
-          "symbol",
-          "timestamp"
-        ],
-        "title": "ShortDataRow"
-      },
-      "SingleStockReport": {
-        "properties": {
-          "run_id": {
-            "type": "integer",
-            "title": "Run Id"
-          },
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "generated_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Generated At"
-          },
-          "spot_quoted_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Quoted At"
-          },
-          "spot_source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Source"
-          },
-          "short_int_note": {
-            "type": "string",
-            "title": "Short Int Note",
-            "default": "n/a (UW endpoint does not expose %)"
-          },
-          "market_structure": {
-            "$ref": "#/components/schemas/MarketStructure"
-          },
-          "volatility": {
-            "$ref": "#/components/schemas/VolatilityProfile"
-          },
-          "flow": {
-            "$ref": "#/components/schemas/FlowSnapshot"
-          },
-          "vrp": {
-            "$ref": "#/components/schemas/VRPAssessment"
-          },
-          "setup": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SetupClassification"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "trade_plan": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TradePlan"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "dark_pool_notional": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dark Pool Notional"
-          },
-          "dark_pool_print_count": {
-            "type": "integer",
-            "title": "Dark Pool Print Count",
-            "default": 0
-          },
-          "short_data": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShortDataRow"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_pain_rows": {
-            "items": {
-              "$ref": "#/components/schemas/MaxPainRow"
-            },
-            "type": "array",
-            "title": "Max Pain Rows",
-            "default": []
-          },
-          "oi_change_top": {
-            "items": {
-              "$ref": "#/components/schemas/OiChangeRow"
-            },
-            "type": "array",
-            "title": "Oi Change Top",
-            "default": []
-          },
-          "oi_change_intraday_profiles": {
-            "items": {
-              "$ref": "#/components/schemas/OptionIntradayProfile"
-            },
-            "type": "array",
-            "title": "Oi Change Intraday Profiles",
-            "default": []
-          },
-          "aggregates": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/MarketAggregates"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strike_gex_curve": {
-            "items": {
-              "$ref": "#/components/schemas/StrikeGexBucket"
-            },
-            "type": "array",
-            "title": "Strike Gex Curve",
-            "default": []
-          },
-          "market_structure_levels": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/MarketStructureLevels"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "options_timeline": {
-            "items": {
-              "$ref": "#/components/schemas/OptionsDailyRow"
-            },
-            "type": "array",
-            "title": "Options Timeline",
-            "default": []
-          },
-          "option_chain_per_strike": {
-            "items": {
-              "$ref": "#/components/schemas/OptionChainPerStrikeRow"
-            },
-            "type": "array",
-            "title": "Option Chain Per Strike",
-            "default": []
-          },
-          "next_earnings_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Next Earnings Date"
-          }
-        },
-        "type": "object",
-        "required": [
-          "run_id",
-          "ticker",
-          "generated_at",
-          "market_structure",
-          "volatility",
-          "flow",
-          "vrp"
-        ],
-        "title": "SingleStockReport"
-      },
-      "SkewBlock": {
-        "properties": {
-          "rr25d_30dte": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rr25D 30Dte"
-          }
-        },
-        "type": "object",
-        "title": "SkewBlock"
-      },
-      "SmileExpiryCurve": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "points": {
-            "items": {
-              "$ref": "#/components/schemas/SmilePoint"
-            },
-            "type": "array",
-            "title": "Points",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry"
-        ],
-        "title": "SmileExpiryCurve"
-      },
-      "SmilePoint": {
-        "properties": {
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          }
-        },
-        "type": "object",
-        "required": [
-          "strike"
-        ],
-        "title": "SmilePoint"
-      },
-      "SourceReconciliation": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "UNKNOWN"
-          },
-          "headline": {
-            "type": "string",
-            "title": "Headline",
-            "default": "Source reconciliation unavailable"
-          },
-          "primary_iv_source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Primary Iv Source"
-          },
-          "relative_shape_source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Relative Shape Source"
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/SourceReconciliationRow"
-            },
-            "type": "array",
-            "title": "Rows",
-            "default": []
-          },
-          "decision": {
-            "type": "string",
-            "title": "Decision",
-            "default": "Use deterministic data only where source agreement is understood."
-          }
-        },
-        "type": "object",
-        "title": "SourceReconciliation"
-      },
-      "SourceReconciliationRow": {
-        "properties": {
-          "source_pair": {
-            "type": "string",
-            "title": "Source Pair"
-          },
-          "price_agreement": {
-            "type": "string",
-            "title": "Price Agreement",
-            "default": ""
-          },
-          "iv_agreement": {
-            "type": "string",
-            "title": "Iv Agreement",
-            "default": ""
-          },
-          "decision": {
-            "type": "string",
-            "title": "Decision",
-            "default": ""
-          },
-          "strike": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strike"
-          },
-          "source_a_call_iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source A Call Iv"
-          },
-          "source_b_call_iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source B Call Iv"
-          },
-          "iv_diff": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Diff"
-          }
-        },
-        "type": "object",
-        "required": [
-          "source_pair"
-        ],
-        "title": "SourceReconciliationRow"
-      },
-      "StockHistoryResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "rows": {
-            "items": {
-              "$ref": "#/components/schemas/StockHistoryRow"
-            },
-            "type": "array",
-            "title": "Rows",
-            "default": []
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker"
-        ],
-        "title": "StockHistoryResponse"
-      },
-      "StockHistoryRow": {
-        "properties": {
-          "market_date": {
-            "type": "string",
-            "format": "date",
-            "title": "Market Date"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "gex_flip": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gex Flip"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "net_dex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Dex"
-          },
-          "iv30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv30D"
-          },
-          "pcr_vol": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pcr Vol"
-          },
-          "bias": {
-            "type": "string",
-            "title": "Bias",
-            "default": "NEUTRAL"
-          }
-        },
-        "type": "object",
-        "required": [
-          "market_date"
-        ],
-        "title": "StockHistoryRow",
-        "description": "One per-trading-day rollup of a ticker's market structure.\n\nBuilt from the latest successful scan_run on that date. spot comes from\ndaily_ohlc.close so it's a stable end-of-day reference (NULL for the\ncurrent trading day until the OHLC pull fires post-close)."
-      },
-      "StrikeGexBucket": {
-        "properties": {
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "call_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Call Gex"
-          },
-          "put_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Put Gex"
-          }
-        },
-        "type": "object",
-        "required": [
-          "strike",
-          "expiry"
-        ],
-        "title": "StrikeGexBucket",
-        "description": "One row of the per-strike, per-expiry GEX curve persisted on each scan run."
-      },
-      "TermMoveRow": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "dte": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dte"
-          },
-          "atm_straddle": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Atm Straddle"
-          },
-          "implied_move_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move Perc"
-          },
-          "daily_implied_move_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Daily Implied Move Perc"
-          },
-          "read": {
-            "type": "string",
-            "title": "Read",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry"
-        ],
-        "title": "TermMoveRow"
-      },
-      "TermStructureExpiryRow": {
-        "properties": {
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "dte": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dte"
-          },
-          "by_strike": {
-            "additionalProperties": {
-              "type": "string",
-              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-            },
-            "type": "object",
-            "title": "By Strike",
-            "default": {}
-          },
-          "strikes": {
-            "additionalProperties": {
-              "type": "string",
-              "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-            },
-            "type": "object",
-            "title": "Strikes",
-            "default": {}
-          }
-        },
-        "type": "object",
-        "required": [
-          "expiry"
-        ],
-        "title": "TermStructureExpiryRow"
-      },
-      "TradeInsightAiAnalysisRequest": {
-        "properties": {
-          "force_rerun": {
-            "type": "boolean",
-            "title": "Force Rerun",
-            "default": false
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "title": "TradeInsightAiAnalysisRequest"
-      },
-      "TradeInsightAiAnalysisResponse": {
-        "properties": {
-          "analysis_id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Analysis Id"
-          },
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "run_id": {
-            "type": "integer",
-            "title": "Run Id"
-          },
-          "trade_insights_input_hash": {
-            "type": "string",
-            "title": "Trade Insights Input Hash"
-          },
-          "analysis_input_hash": {
-            "type": "string",
-            "title": "Analysis Input Hash"
-          },
-          "model": {
-            "type": "string",
-            "title": "Model"
-          },
-          "prompt_version": {
-            "type": "string",
-            "title": "Prompt Version"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "running",
-              "succeeded",
-              "failed"
-            ],
-            "title": "Status"
-          },
-          "produced_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Produced At"
-          },
-          "outcome": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TradeInsightAiOutcome"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "markdown": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Markdown"
-          },
-          "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error Message"
-          },
-          "requested_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Requested At"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At"
-          },
-          "reused": {
-            "type": "boolean",
-            "title": "Reused",
-            "default": false
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "analysis_id",
-          "ticker",
-          "run_id",
-          "trade_insights_input_hash",
-          "analysis_input_hash",
-          "model",
-          "prompt_version",
-          "status",
-          "requested_at"
-        ],
-        "title": "TradeInsightAiAnalysisResponse"
-      },
-      "TradeInsightAiBestExpression": {
-        "properties": {
-          "idea_id": {
-            "type": "string",
-            "title": "Idea Id"
-          },
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
-          "why": {
-            "type": "string",
-            "title": "Why"
-          },
-          "caveats": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Caveats"
-          },
-          "status_observed": {
-            "type": "string",
-            "title": "Status Observed"
-          },
-          "risk_flags_observed": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags Observed"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "idea_id",
-          "structure",
-          "role",
-          "why",
-          "status_observed"
-        ],
-        "title": "TradeInsightAiBestExpression"
-      },
-      "TradeInsightAiConflict": {
-        "properties": {
-          "lens": {
-            "type": "string",
-            "title": "Lens"
-          },
-          "severity": {
-            "type": "string",
-            "title": "Severity"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "affected_idea_ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Affected Idea Ids"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "lens",
-          "severity",
-          "description"
-        ],
-        "title": "TradeInsightAiConflict"
-      },
-      "TradeInsightAiDominantRead": {
-        "properties": {
-          "headline": {
-            "type": "string",
-            "title": "Headline"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          },
-          "confidence_commentary": {
-            "type": "string",
-            "title": "Confidence Commentary"
-          },
-          "data_quality_commentary": {
-            "type": "string",
-            "title": "Data Quality Commentary"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "headline",
-          "summary",
-          "confidence_commentary",
-          "data_quality_commentary"
-        ],
-        "title": "TradeInsightAiDominantRead"
-      },
-      "TradeInsightAiGuardrails": {
-        "properties": {
-          "statuses_preserved": {
-            "type": "boolean",
-            "title": "Statuses Preserved"
-          },
-          "risk_flags_preserved": {
-            "type": "boolean",
-            "title": "Risk Flags Preserved"
-          },
-          "no_executable_recommendations": {
-            "type": "boolean",
-            "title": "No Executable Recommendations"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "statuses_preserved",
-          "risk_flags_preserved",
-          "no_executable_recommendations"
-        ],
-        "title": "TradeInsightAiGuardrails"
-      },
-      "TradeInsightAiHeadline": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "stance": {
-            "type": "string",
-            "enum": [
-              "bullish",
-              "bearish",
-              "neutral",
-              "mixed",
-              "wait"
-            ],
-            "title": "Stance"
-          },
-          "stance_label": {
-            "type": "string",
-            "title": "Stance Label"
-          },
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
-          "score_scale": {
-            "type": "integer",
-            "title": "Score Scale",
-            "default": 100
-          },
-          "conviction": {
-            "type": "string",
-            "title": "Conviction"
-          },
-          "conviction_label": {
-            "type": "string",
-            "title": "Conviction Label"
-          },
-          "top_reason": {
-            "type": "string",
-            "title": "Top Reason"
-          },
-          "primary_risk": {
-            "type": "string",
-            "title": "Primary Risk"
-          },
-          "watch_trigger": {
-            "type": "string",
-            "title": "Watch Trigger"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "title",
-          "stance",
-          "stance_label",
-          "score",
-          "conviction",
-          "conviction_label",
-          "top_reason",
-          "primary_risk",
-          "watch_trigger"
-        ],
-        "title": "TradeInsightAiHeadline"
-      },
-      "TradeInsightAiHighlight": {
-        "properties": {
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "value": {
-            "type": "string",
-            "title": "Value"
-          },
-          "source_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Path"
-          },
-          "note": {
-            "type": "string",
-            "title": "Note",
-            "default": ""
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "label",
-          "value"
-        ],
-        "title": "TradeInsightAiHighlight"
-      },
-      "TradeInsightAiLevel": {
-        "properties": {
-          "price": {
-            "type": "string",
-            "title": "Price"
-          },
-          "kind": {
-            "type": "string",
-            "title": "Kind"
-          },
-          "value": {
-            "type": "string",
-            "title": "Value"
-          },
-          "importance": {
-            "type": "string",
-            "title": "Importance",
-            "default": "normal"
-          },
-          "source_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Path"
-          },
-          "note": {
-            "type": "string",
-            "title": "Note",
-            "default": ""
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "price",
-          "kind",
-          "value"
-        ],
-        "title": "TradeInsightAiLevel"
-      },
-      "TradeInsightAiMetricCard": {
-        "properties": {
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "value": {
-            "type": "string",
-            "title": "Value"
-          },
-          "tone": {
-            "type": "string",
-            "title": "Tone",
-            "default": "neutral"
-          },
-          "source_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Path"
-          },
-          "note": {
-            "type": "string",
-            "title": "Note",
-            "default": ""
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "label",
-          "value"
-        ],
-        "title": "TradeInsightAiMetricCard"
-      },
-      "TradeInsightAiOutcome": {
-        "properties": {
-          "schema_version": {
-            "type": "string",
-            "title": "Schema Version"
-          },
-          "analysis_produced_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Analysis Produced At"
-          },
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "underlying_price": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Underlying Price"
-          },
-          "snapshot": {
-            "$ref": "#/components/schemas/TradeInsightAiSnapshotMeta"
-          },
-          "headline": {
-            "$ref": "#/components/schemas/TradeInsightAiHeadline"
-          },
-          "metric_cards": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiMetricCard"
-            },
-            "type": "array",
-            "title": "Metric Cards"
-          },
-          "scenario_cards": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiScenarioCard"
-            },
-            "type": "array",
-            "title": "Scenario Cards"
-          },
-          "score_breakdown": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiScoreBreakdown"
-            },
-            "type": "array",
-            "title": "Score Breakdown"
-          },
-          "section_cards": {
-            "$ref": "#/components/schemas/TradeInsightAiSectionCards"
-          },
-          "vrp_assessment": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TradeInsightAiVrpAssessment"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "preferred_expression": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TradeInsightAiPreferredExpression"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "dominant_read": {
-            "$ref": "#/components/schemas/TradeInsightAiDominantRead"
-          },
-          "best_expressions": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiBestExpression"
-            },
-            "type": "array",
-            "title": "Best Expressions"
-          },
-          "conflicts": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiConflict"
-            },
-            "type": "array",
-            "title": "Conflicts"
-          },
-          "required_checks": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiRequiredCheck"
-            },
-            "type": "array",
-            "title": "Required Checks"
-          },
-          "rejected_ideas": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiRejectedIdea"
-            },
-            "type": "array",
-            "title": "Rejected Ideas"
-          },
-          "missing_data": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Data"
-          },
-          "rendering": {
-            "$ref": "#/components/schemas/TradeInsightAiRendering"
-          },
-          "guardrails": {
-            "$ref": "#/components/schemas/TradeInsightAiGuardrails"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "schema_version",
-          "analysis_produced_at",
-          "ticker",
-          "snapshot",
-          "headline",
-          "metric_cards",
-          "scenario_cards",
-          "score_breakdown",
-          "section_cards",
-          "dominant_read",
-          "rendering",
-          "guardrails"
-        ],
-        "title": "TradeInsightAiOutcome"
-      },
-      "TradeInsightAiPreferredExpression": {
-        "properties": {
-          "idea_id": {
-            "type": "string",
-            "title": "Idea Id"
-          },
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "subtitle": {
-            "type": "string",
-            "title": "Subtitle",
-            "default": ""
-          },
-          "estimated_entry": {
-            "type": "string",
-            "title": "Estimated Entry",
-            "default": ""
-          },
-          "max_profit_observed": {
-            "type": "string",
-            "title": "Max Profit Observed",
-            "default": ""
-          },
-          "max_loss_observed": {
-            "type": "string",
-            "title": "Max Loss Observed",
-            "default": ""
-          },
-          "reward_risk": {
-            "type": "string",
-            "title": "Reward Risk",
-            "default": ""
-          },
-          "why": {
-            "type": "string",
-            "title": "Why"
-          },
-          "management_notes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Management Notes"
-          },
-          "status_observed": {
-            "type": "string",
-            "title": "Status Observed"
-          },
-          "risk_flags_observed": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risk Flags Observed"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "idea_id",
-          "structure",
-          "title",
-          "why",
-          "status_observed"
-        ],
-        "title": "TradeInsightAiPreferredExpression"
-      },
-      "TradeInsightAiRejectedIdea": {
-        "properties": {
-          "idea_id": {
-            "type": "string",
-            "title": "Idea Id"
-          },
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "idea_id",
-          "structure",
-          "reason"
-        ],
-        "title": "TradeInsightAiRejectedIdea"
-      },
-      "TradeInsightAiRendering": {
-        "properties": {
-          "disclaimer": {
-            "type": "string",
-            "title": "Disclaimer"
-          },
-          "card_order": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Card Order"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "disclaimer"
-        ],
-        "title": "TradeInsightAiRendering"
-      },
-      "TradeInsightAiRequiredCheck": {
-        "properties": {
-          "check": {
-            "type": "string",
-            "title": "Check"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          },
-          "blocks_sizing": {
-            "type": "boolean",
-            "title": "Blocks Sizing",
-            "default": true
-          },
-          "source": {
-            "type": "string",
-            "title": "Source",
-            "default": ""
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "check",
-          "reason"
-        ],
-        "title": "TradeInsightAiRequiredCheck"
-      },
-      "TradeInsightAiScenarioCard": {
-        "properties": {
-          "case": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "upside",
-                  "base",
-                  "downside"
-                ]
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Case"
-          },
-          "tone": {
-            "type": "string",
-            "title": "Tone",
-            "default": "neutral"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "case",
-          "title",
-          "description"
-        ],
-        "title": "TradeInsightAiScenarioCard"
-      },
-      "TradeInsightAiScoreBreakdown": {
-        "properties": {
-          "section": {
-            "type": "string",
-            "title": "Section"
-          },
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
-          "max_score": {
-            "type": "integer",
-            "title": "Max Score"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "section",
-          "score",
-          "max_score",
-          "summary"
-        ],
-        "title": "TradeInsightAiScoreBreakdown"
-      },
-      "TradeInsightAiSectionCard": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score"
-          },
-          "max_score": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Score"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          },
-          "highlights": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiHighlight"
-            },
-            "type": "array",
-            "title": "Highlights"
-          },
-          "levels": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiLevel"
-            },
-            "type": "array",
-            "title": "Levels"
-          },
-          "data_quality": {
-            "type": "string",
-            "title": "Data Quality",
-            "default": "unknown"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "title",
-          "summary"
-        ],
-        "title": "TradeInsightAiSectionCard"
-      },
-      "TradeInsightAiSectionCards": {
-        "properties": {
-          "market_structure": {
-            "$ref": "#/components/schemas/TradeInsightAiSectionCard"
-          },
-          "volatility": {
-            "$ref": "#/components/schemas/TradeInsightAiSectionCard"
-          },
-          "flow_positioning": {
-            "$ref": "#/components/schemas/TradeInsightAiSectionCard"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "market_structure",
-          "volatility",
-          "flow_positioning"
-        ],
-        "title": "TradeInsightAiSectionCards"
-      },
-      "TradeInsightAiSnapshotMeta": {
-        "properties": {
-          "run_id": {
-            "type": "integer",
-            "title": "Run Id"
-          },
-          "trade_insights_input_hash": {
-            "type": "string",
-            "title": "Trade Insights Input Hash"
-          },
-          "analysis_input_hash": {
-            "type": "string",
-            "title": "Analysis Input Hash"
-          },
-          "data_as_of": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data As Of"
-          },
-          "freshness_label": {
-            "type": "string",
-            "title": "Freshness Label",
-            "default": "unknown"
-          },
-          "source_notes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Source Notes"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "run_id",
-          "trade_insights_input_hash",
-          "analysis_input_hash"
-        ],
-        "title": "TradeInsightAiSnapshotMeta"
-      },
-      "TradeInsightAiVrpAssessment": {
-        "properties": {
-          "signal": {
-            "type": "string",
-            "title": "Signal"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          },
-          "metrics": {
-            "items": {
-              "$ref": "#/components/schemas/TradeInsightAiMetricCard"
-            },
-            "type": "array",
-            "title": "Metrics"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "signal",
-          "title",
-          "summary",
-          "reason"
-        ],
-        "title": "TradeInsightAiVrpAssessment"
-      },
-      "TradeInsightsHeader": {
-        "properties": {
-          "dominant_bias": {
-            "type": "string",
-            "title": "Dominant Bias",
-            "default": "NEUTRAL"
-          },
-          "primary_setup": {
-            "type": "string",
-            "title": "Primary Setup",
-            "default": "NO_CLEAR_SETUP"
-          },
-          "confidence_label": {
-            "type": "string",
-            "title": "Confidence Label",
-            "default": "LOW"
-          },
-          "data_quality_label": {
-            "type": "string",
-            "title": "Data Quality Label",
-            "default": "INSUFFICIENT"
-          },
-          "idea_count": {
-            "type": "integer",
-            "title": "Idea Count",
-            "default": 0
-          },
-          "preferred_idea_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Preferred Idea Id"
-          },
-          "badges": {
-            "items": {
-              "$ref": "#/components/schemas/InsightBadge"
-            },
-            "type": "array",
-            "title": "Badges",
-            "default": []
-          }
-        },
-        "type": "object",
-        "title": "TradeInsightsHeader"
-      },
-      "TradeInsightsResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "as_of": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "As Of"
-          },
-          "mode": {
-            "type": "string",
-            "title": "Mode",
-            "default": "research"
-          },
-          "header": {
-            "$ref": "#/components/schemas/TradeInsightsHeader"
-          },
-          "source_reconciliation": {
-            "$ref": "#/components/schemas/SourceReconciliation",
-            "default": {
-              "status": "UNKNOWN",
-              "headline": "Source reconciliation unavailable",
-              "rows": [],
-              "decision": "Use deterministic data only where source agreement is understood."
-            }
-          },
-          "signal_stack": {
-            "items": {
-              "$ref": "#/components/schemas/InsightSignalRow"
-            },
-            "type": "array",
-            "title": "Signal Stack",
-            "default": []
-          },
-          "flow_table": {
-            "items": {
-              "$ref": "#/components/schemas/ChainFlowReadRow"
-            },
-            "type": "array",
-            "title": "Flow Table",
-            "default": []
-          },
-          "term_structure_table": {
-            "items": {
-              "$ref": "#/components/schemas/TermMoveRow"
-            },
-            "type": "array",
-            "title": "Term Structure Table",
-            "default": []
-          },
-          "candidate_structures": {
-            "items": {
-              "$ref": "#/components/schemas/CandidateStructure"
-            },
-            "type": "array",
-            "title": "Candidate Structures",
-            "default": []
-          },
-          "synthesis": {
-            "$ref": "#/components/schemas/InsightsSynthesis",
-            "default": {
-              "dominant_story": "",
-              "avoid": [],
-              "required_before_sizing": []
-            }
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "header"
-        ],
-        "title": "TradeInsightsResponse"
-      },
-      "TradePlan": {
-        "properties": {
-          "structure": {
-            "type": "string",
-            "title": "Structure"
-          },
-          "direction": {
-            "type": "string",
-            "title": "Direction"
-          },
-          "legs": {
-            "items": {
-              "$ref": "#/components/schemas/TradePlanLeg"
-            },
-            "type": "array",
-            "title": "Legs",
-            "default": []
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          },
-          "max_loss": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Loss"
-          },
-          "max_profit": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Profit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "structure",
-          "direction",
-          "rationale"
-        ],
-        "title": "TradePlan"
-      },
-      "TradePlanLeg": {
-        "properties": {
-          "option_symbol": {
-            "type": "string",
-            "title": "Option Symbol"
-          },
-          "side": {
-            "type": "string",
-            "title": "Side"
-          },
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "expiry": {
-            "type": "string",
-            "format": "date",
-            "title": "Expiry"
-          },
-          "mid": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Mid"
-          }
-        },
-        "type": "object",
-        "required": [
-          "option_symbol",
-          "side",
-          "strike",
-          "expiry"
-        ],
-        "title": "TradePlanLeg"
-      },
-      "VRPAssessment": {
-        "properties": {
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "signal": {
-            "type": "string",
-            "title": "Signal"
-          },
-          "note": {
-            "type": "string",
-            "title": "Note"
-          }
-        },
-        "type": "object",
-        "required": [
-          "signal",
-          "note"
-        ],
-        "title": "VRPAssessment"
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
-          }
-        },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      },
-      "ValidationResponse": {
-        "properties": {
-          "backtest_md": {
-            "type": "string",
-            "title": "Backtest Md"
-          },
-          "backtest_csv_rows": {
-            "type": "integer",
-            "title": "Backtest Csv Rows"
-          },
-          "oos": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OosSummary"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "backtest_md",
-          "backtest_csv_rows"
-        ],
-        "title": "ValidationResponse",
-        "description": "Combined warm-store backtest + OOS notebook summary."
-      },
-      "VcgAttribution": {
-        "properties": {
-          "vvix_pct": {
-            "type": "number",
-            "title": "Vvix Pct",
-            "default": 0.0
-          },
-          "vix_pct": {
-            "type": "number",
-            "title": "Vix Pct",
-            "default": 0.0
-          },
-          "vvix_component": {
-            "type": "number",
-            "title": "Vvix Component",
-            "default": 0.0
-          },
-          "vix_component": {
-            "type": "number",
-            "title": "Vix Component",
-            "default": 0.0
-          },
-          "model_implied": {
-            "type": "number",
-            "title": "Model Implied",
-            "default": 0.0
-          }
-        },
-        "type": "object",
-        "title": "VcgAttribution"
-      },
-      "VcgHistoryEntry": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "title": "Date"
-          },
-          "residual": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Residual"
-          },
-          "vcg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vcg"
-          },
-          "vcg_adj": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vcg Adj"
-          },
-          "beta1": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beta1"
-          },
-          "beta2": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beta2"
-          },
-          "vix": {
-            "type": "number",
-            "title": "Vix",
-            "default": 0.0
-          },
-          "vvix": {
-            "type": "number",
-            "title": "Vvix",
-            "default": 0.0
-          },
-          "credit": {
-            "type": "number",
-            "title": "Credit",
-            "default": 0.0
-          },
-          "ro": {
-            "type": "integer",
-            "title": "Ro",
-            "default": 0
-          },
-          "edr": {
-            "type": "integer",
-            "title": "Edr",
-            "default": 0
-          },
-          "tier": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tier"
-          },
-          "bounce": {
-            "type": "integer",
-            "title": "Bounce",
-            "default": 0
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "VcgHistoryEntry"
-      },
-      "VcgResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "empty"
-            ],
-            "title": "Status",
-            "default": "empty"
-          },
-          "scan_time": {
-            "type": "string",
-            "title": "Scan Time",
-            "default": ""
-          },
-          "date": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Date"
-          },
-          "credit_proxy": {
-            "type": "string",
-            "title": "Credit Proxy",
-            "default": "HYG"
-          },
-          "signal": {
-            "$ref": "#/components/schemas/VcgSignal"
-          },
-          "history": {
-            "items": {
-              "$ref": "#/components/schemas/VcgHistoryEntry"
-            },
-            "type": "array",
-            "title": "History"
-          }
-        },
-        "type": "object",
-        "title": "VcgResponse",
-        "description": "Volatility-Credit Gap snapshot (latest scan)."
-      },
-      "VcgScanResponse": {
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "skipped"
-            ],
-            "title": "Status",
-            "default": "ok"
-          },
-          "scanner": {
-            "type": "string",
-            "const": "vcg",
-            "title": "Scanner",
-            "default": "vcg"
-          },
-          "proxy": {
-            "type": "string",
-            "title": "Proxy",
-            "default": "HYG"
-          },
-          "row_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Row Id"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          }
-        },
-        "type": "object",
-        "title": "VcgScanResponse",
-        "description": "Response body for POST /api/regime/vcg/scan."
-      },
-      "VcgSignal": {
-        "properties": {
-          "vcg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vcg"
-          },
-          "vcg_adj": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vcg Adj"
-          },
-          "residual": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Residual"
-          },
-          "beta1_vvix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beta1 Vvix"
-          },
-          "beta2_vix": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Beta2 Vix"
-          },
-          "alpha": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Alpha"
-          },
-          "vix": {
-            "type": "number",
-            "title": "Vix",
-            "default": 0.0
-          },
-          "vvix": {
-            "type": "number",
-            "title": "Vvix",
-            "default": 0.0
-          },
-          "credit_price": {
-            "type": "number",
-            "title": "Credit Price",
-            "default": 0.0
-          },
-          "credit_5d_return_pct": {
-            "type": "number",
-            "title": "Credit 5D Return Pct",
-            "default": 0.0
-          },
-          "ro": {
-            "type": "integer",
-            "title": "Ro",
-            "default": 0
-          },
-          "edr": {
-            "type": "integer",
-            "title": "Edr",
-            "default": 0
-          },
-          "tier": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tier"
-          },
-          "bounce": {
-            "type": "integer",
-            "title": "Bounce",
-            "default": 0
-          },
-          "vvix_severity": {
-            "type": "string",
-            "enum": [
-              "extreme",
-              "elevated",
-              "moderate"
-            ],
-            "title": "Vvix Severity",
-            "default": "moderate"
-          },
-          "sign_ok": {
-            "type": "boolean",
-            "title": "Sign Ok",
-            "default": true
-          },
-          "sign_suppressed": {
-            "type": "boolean",
-            "title": "Sign Suppressed",
-            "default": false
-          },
-          "pi_panic": {
-            "type": "number",
-            "title": "Pi Panic",
-            "default": 0.0
-          },
-          "regime": {
-            "type": "string",
-            "enum": [
-              "PANIC",
-              "TRANSITION",
-              "DIVERGENCE"
-            ],
-            "title": "Regime",
-            "default": "DIVERGENCE"
-          },
-          "interpretation": {
-            "type": "string",
-            "enum": [
-              "RISK_OFF",
-              "EDR",
-              "WATCH",
-              "BOUNCE",
-              "NORMAL",
-              "SUPPRESSED",
-              "PANIC",
-              "INSUFFICIENT_DATA"
-            ],
-            "title": "Interpretation",
-            "default": "NORMAL"
-          },
-          "attribution": {
-            "$ref": "#/components/schemas/VcgAttribution"
-          }
-        },
-        "type": "object",
-        "title": "VcgSignal"
-      },
-      "VolBackdropPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "close": {
-            "type": "number",
-            "title": "Close"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date",
-          "close"
-        ],
-        "title": "VolBackdropPoint"
-      },
-      "VolBackdropResponse": {
-        "properties": {
-          "series": {
-            "additionalProperties": {
-              "items": {
-                "$ref": "#/components/schemas/VolBackdropPoint"
-              },
-              "type": "array"
-            },
-            "type": "object",
-            "title": "Series"
-          },
-          "term_structure_ratio": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Term Structure Ratio"
-          },
-          "term_structure_state": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Term Structure State"
-          },
-          "as_of": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "As Of"
-          }
-        },
-        "type": "object",
-        "title": "VolBackdropResponse",
-        "description": "Vol-complex time series + VIX term-structure (regime page header strip)."
-      },
-      "VolHeaderBlock": {
-        "properties": {
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          },
-          "rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv"
-          },
-          "iv_rank": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank"
-          },
-          "iv_rank_1y": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank 1Y"
-          },
-          "iv_low_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Low 52W"
-          },
-          "iv_high_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv High 52W"
-          },
-          "rv_low_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv Low 52W"
-          },
-          "rv_high_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv High 52W"
-          },
-          "iv_percentile_30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Percentile 30D"
-          },
-          "implied_move_30d_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move 30D Perc"
-          },
-          "skew_25d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew 25D"
-          },
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "vrp_signal": {
-            "type": "string",
-            "title": "Vrp Signal",
-            "default": ""
-          },
-          "vrp_note": {
-            "type": "string",
-            "title": "Vrp Note",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "title": "VolHeaderBlock"
-      },
-      "VolatilityProfile": {
-        "properties": {
-          "iv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv"
-          },
-          "iv_rank": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank"
-          },
-          "iv_low_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Low 52W"
-          },
-          "iv_high_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv High 52W"
-          },
-          "rv": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv"
-          },
-          "rv_low_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv Low 52W"
-          },
-          "rv_high_52w": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rv High 52W"
-          },
-          "iv_rank_1y": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank 1Y"
-          },
-          "iv_percentile_30d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Percentile 30D"
-          },
-          "implied_move_30d_perc": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Implied Move 30D Perc"
-          },
-          "skew_25d": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Skew 25D"
-          },
-          "term_dte_to_iv": {
-            "items": {
-              "prefixItems": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "string",
-                  "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-                }
-              ],
-              "type": "array",
-              "maxItems": 2,
-              "minItems": 2
-            },
-            "type": "array",
-            "title": "Term Dte To Iv",
-            "default": []
-          }
-        },
-        "type": "object",
-        "title": "VolatilityProfile"
-      },
-      "VolatilitySeriesResponse": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "as_of": {
-            "type": "string",
-            "format": "date",
-            "title": "As Of"
-          },
-          "backfill_status": {
-            "type": "string",
-            "title": "Backfill Status"
-          },
-          "header": {
-            "$ref": "#/components/schemas/VolHeaderBlock"
-          },
-          "term_structure": {
-            "items": {
-              "$ref": "#/components/schemas/TermStructureExpiryRow"
-            },
-            "type": "array",
-            "title": "Term Structure",
-            "default": []
-          },
-          "smile": {
-            "items": {
-              "$ref": "#/components/schemas/SmileExpiryCurve"
-            },
-            "type": "array",
-            "title": "Smile",
-            "default": []
-          },
-          "hv_iv_history": {
-            "items": {
-              "$ref": "#/components/schemas/IvHvPoint"
-            },
-            "type": "array",
-            "title": "Hv Iv History",
-            "default": []
-          },
-          "iv_percentile_distribution": {
-            "$ref": "#/components/schemas/IvPercentileDistribution",
-            "default": {
-              "bins": []
-            }
-          },
-          "iv_of_iv": {
-            "items": {
-              "$ref": "#/components/schemas/IvOfIvPoint"
-            },
-            "type": "array",
-            "title": "Iv Of Iv",
-            "default": []
-          },
-          "rv_spy_corr": {
-            "items": {
-              "$ref": "#/components/schemas/RvCorrPoint"
-            },
-            "type": "array",
-            "title": "Rv Spy Corr",
-            "default": []
-          },
-          "regime_quadrant": {
-            "$ref": "#/components/schemas/RegimeQuadrantBlock",
-            "default": {
-              "points": []
-            }
-          },
-          "divergence": {
-            "items": {
-              "$ref": "#/components/schemas/DivergencePoint"
-            },
-            "type": "array",
-            "title": "Divergence",
-            "default": []
-          },
-          "divergence_headline": {
-            "type": "string",
-            "title": "Divergence Headline",
-            "default": ""
-          },
-          "vrp_spread": {
-            "items": {
-              "$ref": "#/components/schemas/VrpDailyPoint"
-            },
-            "type": "array",
-            "title": "Vrp Spread",
-            "default": []
-          },
-          "vrp_spread_headline": {
-            "type": "string",
-            "title": "Vrp Spread Headline",
-            "default": ""
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "as_of",
-          "backfill_status",
-          "header"
-        ],
-        "title": "VolatilitySeriesResponse"
-      },
-      "VrpDailyPoint": {
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date",
-            "title": "Date"
-          },
-          "vrp": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp"
-          },
-          "vrp_z_20": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Vrp Z 20"
-          }
-        },
-        "type": "object",
-        "required": [
-          "date"
-        ],
-        "title": "VrpDailyPoint"
-      },
-      "WatchlistCard": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "sector": {
-            "type": "string",
-            "title": "Sector"
-          },
-          "pinned": {
-            "type": "boolean",
-            "title": "Pinned"
-          },
-          "sort_rank": {
-            "type": "integer",
-            "title": "Sort Rank"
-          },
-          "spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot"
-          },
-          "spot_quoted_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Quoted At"
-          },
-          "spot_source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Spot Source"
-          },
-          "scanned_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scanned At"
-          },
-          "iv_atm": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Atm"
-          },
-          "iv_rank": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Iv Rank"
-          },
-          "market_cap": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Market Cap"
-          },
-          "aum": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aum"
-          },
-          "setup": {
-            "$ref": "#/components/schemas/SetupBlock"
-          },
-          "aggression_pct": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Aggression Pct"
-          },
-          "returns": {
-            "$ref": "#/components/schemas/ReturnsBlock"
-          },
-          "gamma": {
-            "$ref": "#/components/schemas/GammaBlock"
-          },
-          "skew": {
-            "$ref": "#/components/schemas/SkewBlock"
-          },
-          "positioning": {
-            "$ref": "#/components/schemas/PositioningBlock"
-          },
-          "queue": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QueueStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "sector",
-          "pinned",
-          "sort_rank",
-          "setup",
-          "returns",
-          "gamma",
-          "skew",
-          "positioning"
-        ],
-        "title": "WatchlistCard"
-      },
-      "WatchlistMutation": {
-        "properties": {
-          "ticker": {
-            "type": "string",
-            "title": "Ticker"
-          },
-          "sector": {
-            "type": "string",
-            "title": "Sector"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "pinned": {
-            "type": "boolean",
-            "title": "Pinned",
-            "default": false
-          },
-          "sort_rank": {
-            "type": "integer",
-            "title": "Sort Rank",
-            "default": 0
-          }
-        },
-        "type": "object",
-        "required": [
-          "ticker",
-          "sector"
-        ],
-        "title": "WatchlistMutation"
-      },
-      "WatchlistPatch": {
-        "properties": {
-          "sector": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sector"
-          },
-          "notes": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Notes"
-          },
-          "pinned": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pinned"
-          },
-          "sort_rank": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sort Rank"
-          }
-        },
-        "type": "object",
-        "title": "WatchlistPatch"
-      },
-      "WatchlistResponse": {
-        "properties": {
-          "scanned_at_min": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scanned At Min"
-          },
-          "scanned_at_max": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scanned At Max"
-          },
-          "scheduler_lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Scheduler Lag Seconds"
-          },
-          "queue": {
-            "$ref": "#/components/schemas/QueueSummary"
-          },
-          "tickers": {
-            "items": {
-              "$ref": "#/components/schemas/WatchlistCard"
-            },
-            "type": "array",
-            "title": "Tickers"
-          }
-        },
-        "type": "object",
-        "required": [
-          "tickers"
-        ],
-        "title": "WatchlistResponse"
-      },
-      "WorkerHealth": {
-        "properties": {
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "uw",
-              "massive",
-              "ai"
-            ],
-            "title": "Role"
-          },
-          "index": {
-            "type": "integer",
-            "title": "Index"
-          },
-          "heartbeat_name": {
-            "type": "string",
-            "title": "Heartbeat Name"
-          },
-          "lag_seconds": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Lag Seconds"
-          },
-          "last_beat_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Beat At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "label",
-          "role",
-          "index",
-          "heartbeat_name"
-        ],
-        "title": "WorkerHealth"
-      },
-      "uw_scan__api__schemas__GexLevel": {
-        "properties": {
-          "strike": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Strike"
-          },
-          "gamma": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gamma"
-          },
-          "distance": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Distance"
-          },
-          "distance_pct": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Distance Pct"
-          }
-        },
-        "type": "object",
-        "title": "GexLevel"
-      },
-      "uw_scan__models__GexLevel": {
-        "properties": {
-          "strike": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Strike"
-          },
-          "net_gex": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Net Gex"
-          },
-          "pct_from_spot": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pct From Spot"
-          },
-          "gamma_per_dollar": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Gamma Per Dollar"
-          }
-        },
-        "type": "object",
-        "required": [
-          "strike"
-        ],
-        "title": "GexLevel",
-        "description": "One labeled level on the GEX curve (e.g. CALL WALL, PUT WALL, MAX MAGNET).\n\n`gamma_per_dollar` is the per-strike net_gex used as the \"$N per $1\" sensitivity\nfigure on the tile \u2014 the dollar value of dealer hedging triggered by a $1 move."
-      }
-    }
-  }
 }

--- a/tests/integration/reports/test_single_stock_exposures.py
+++ b/tests/integration/reports/test_single_stock_exposures.py
@@ -1,0 +1,84 @@
+"""Report assembler attaches strike_exposures and exposures_summary."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import GreekExposureRow
+from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.storage.repository import Repository
+
+
+def _seed_exposures(
+    repo: Repository, ticker: str, run_id: int, market_date: date
+) -> None:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, %s, now()) ON CONFLICT DO NOTHING",
+            (run_id, ticker),
+        )
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.exposures_by_expiry_strike
+                (run_id, ticker, market_date, expiry, strike, dte,
+                 call_vanna, put_vanna, call_charm, put_charm,
+                 call_gex, put_gex, call_delta, put_delta)
+            VALUES
+                (%s, %s, %s, '2026-05-30', 100, 9, 100, -30, -2000, 500, 0, 0, 0, 0),
+                (%s, %s, %s, '2026-05-30', 110, 9, 200, -50, -3000, 800, 0, 0, 0, 0)
+            """,
+            (run_id, ticker, market_date, run_id, ticker, market_date),
+        )
+    repo.conn.commit()
+
+
+def test_report_includes_strike_exposures_and_summary(
+    seeded_db_empty_cards: Repository,
+):
+    repo = seeded_db_empty_cards
+    market_date = date.fromisoformat("2026-05-21")
+    _seed_exposures(repo, "TSLA", run_id=20, market_date=market_date)
+
+    raw = [
+        GreekExposureRow(
+            date=market_date,
+            expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("100"),
+            dte=9,
+            call_vanna=Decimal("100"),
+            put_vanna=Decimal("-30"),
+            call_charm=Decimal("-2000"),
+            put_charm=Decimal("500"),
+        ),
+        GreekExposureRow(
+            date=market_date,
+            expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("110"),
+            dte=9,
+            call_vanna=Decimal("200"),
+            put_vanna=Decimal("-50"),
+            call_charm=Decimal("-3000"),
+            put_charm=Decimal("800"),
+        ),
+    ]
+    repo.upsert_exposures_summary(
+        run_id=20,
+        ticker="TSLA",
+        market_date=market_date,
+        rows=build_summary_rows(raw, spot=Decimal("105")),
+    )
+    repo.conn.commit()
+
+    report = assemble_single_stock_report(ticker="TSLA", run_id=20, repo=repo)
+    assert len(report.strike_exposures) == 2
+    assert {row.strike for row in report.strike_exposures} == {
+        Decimal("100"),
+        Decimal("110"),
+    }
+    assert len(report.exposures_summary) == 1
+    summary = report.exposures_summary[0]
+    assert summary.expiry == date.fromisoformat("2026-05-30")
+    assert summary.vanna_headline

--- a/tests/integration/storage/test_exposures_summary_migration.py
+++ b/tests/integration/storage/test_exposures_summary_migration.py
@@ -1,0 +1,70 @@
+"""Smoke test for migration 051 — table + PK + index exist; re-running migrate.sh is a no-op."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from uw_scan.storage.repository import Repository
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_exposures_summary_table_created(seeded_db_empty_cards: Repository):
+    """conftest's _reset_and_migrate already ran migrate.sh; assert the table + columns exist."""
+    repo = seeded_db_empty_cards
+    with repo.conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('uw_scan.exposures_summary')")
+        assert cur.fetchone()[0] is not None
+
+        cur.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+            WHERE table_schema = 'uw_scan' AND table_name = 'exposures_summary'
+            """
+        )
+        cols = {row[0] for row in cur.fetchall()}
+        for c in (
+            "run_id",
+            "ticker",
+            "expiry",
+            "market_date",
+            "dte",
+            "spot",
+            "net_vanna",
+            "top_vanna_strike",
+            "top_vanna_value",
+            "delta_shock_1pt_iv",
+            "vanna_regime",
+            "vanna_flip",
+            "vanna_headline",
+            "vanna_subtitle",
+            "net_charm",
+            "charm_pin_strike",
+            "charm_above_sum",
+            "charm_below_sum",
+            "charm_imbalance_pct",
+            "charm_signal_quality",
+            "charm_flip",
+            "charm_headline",
+            "charm_subtitle",
+            "computed_at",
+        ):
+            assert c in cols, f"missing column: {c}"
+
+
+def test_migration_is_idempotent(seeded_db_empty_cards: Repository):
+    """Re-running scripts/migrate.sh on the already-migrated DB must be a no-op."""
+    repo = seeded_db_empty_cards
+    test_db = os.environ["UW_SCAN_TEST_DB_NAME"]
+    env = {**os.environ, "UW_SCAN_DB_NAME": test_db}
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    with repo.conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM uw_scan.exposures_summary")
+        assert cur.fetchone()[0] == 0

--- a/tests/integration/storage/test_exposures_summary_repository.py
+++ b/tests/integration/storage/test_exposures_summary_repository.py
@@ -1,0 +1,109 @@
+"""Round-trip + idempotency tests for exposures_summary persistence."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.models import ExposuresSummaryRow
+from uw_scan.storage.repository import Repository
+
+
+def _row(expiry: str, net_v: str = "1000") -> ExposuresSummaryRow:
+    return ExposuresSummaryRow(
+        expiry=date.fromisoformat(expiry),
+        dte=10,
+        spot=Decimal("100"),
+        net_vanna=Decimal(net_v),
+        top_vanna_strike=Decimal("105"),
+        top_vanna_value=Decimal("500"),
+        delta_shock_1pt_iv=Decimal("10"),
+        vanna_regime="procyclical",
+        vanna_flip=Decimal("110"),
+        vanna_headline="Long Vanna",
+        vanna_subtitle="...",
+        net_charm=Decimal("-2000"),
+        charm_pin_strike=Decimal("105"),
+        charm_above_sum=Decimal("-1500"),
+        charm_below_sum=Decimal("500"),
+        charm_imbalance_pct=Decimal("0.5"),
+        charm_signal_quality="aligned",
+        charm_flip=Decimal("108"),
+        charm_headline="Mechanical SELL pressure into the close",
+        charm_subtitle="...",
+    )
+
+
+def _seed_scan_run(repo: Repository, run_id: int) -> None:
+    """exposures_summary FK-references scan_runs(run_id) ON DELETE CASCADE
+    (migration 051), so we need a parent scan_runs row before the child upsert."""
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, 'TSLA', now()) ON CONFLICT DO NOTHING",
+            (run_id,),
+        )
+    repo.conn.commit()
+
+
+def test_upsert_and_fetch_round_trip(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=1)
+
+    n = repo.upsert_exposures_summary(
+        run_id=1,
+        ticker="TSLA",
+        market_date=date.fromisoformat("2026-05-21"),
+        rows=[_row("2026-05-30"), _row("2026-06-20")],
+    )
+    assert n == 2
+    repo.conn.commit()
+
+    fetched = repo.fetch_exposures_summary(run_id=1, ticker="TSLA")
+    assert len(fetched) == 2
+    expiries = {r["expiry"] for r in fetched}
+    assert expiries == {
+        date.fromisoformat("2026-05-30"),
+        date.fromisoformat("2026-06-20"),
+    }
+
+
+def test_upsert_is_idempotent(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=2)
+
+    repo.upsert_exposures_summary(
+        2, "TSLA", date.fromisoformat("2026-05-21"), [_row("2026-05-30", net_v="1000")]
+    )
+    repo.upsert_exposures_summary(
+        2, "TSLA", date.fromisoformat("2026-05-21"), [_row("2026-05-30", net_v="9999")]
+    )
+    repo.conn.commit()
+
+    fetched = repo.fetch_exposures_summary(2, "TSLA")
+    assert len(fetched) == 1
+    assert Decimal(str(fetched[0]["net_vanna"])) == Decimal("9999")
+
+
+def test_fetch_strike_exposures_returns_per_expiry_strike_rows(
+    seeded_db_empty_cards: Repository,
+):
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=3)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.exposures_by_expiry_strike
+                (run_id, ticker, market_date, expiry, strike, dte,
+                 call_vanna, put_vanna, call_charm, put_charm)
+            VALUES
+                (3, 'TSLA', '2026-05-21', '2026-05-30', 100, 9, 50, -10, -1000, 200),
+                (3, 'TSLA', '2026-05-21', '2026-05-30', 110, 9, 80, -20, -2000, 400)
+            """
+        )
+    repo.conn.commit()
+
+    out = repo.fetch_strike_exposures(run_id=3, ticker="TSLA")
+    assert len(out) == 2
+    strikes = {Decimal(str(r["strike"])) for r in out}
+    assert strikes == {Decimal("100"), Decimal("110")}

--- a/tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py
+++ b/tests/integration/worker/test_cockpit_snapshot_persists_exposures_summary.py
@@ -1,0 +1,71 @@
+"""Cockpit daily snapshot must persist exposures_summary after greek_exposure rows."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import GreekExposureRow
+from uw_scan.storage.repository import Repository
+
+
+def _seed_scan_run(repo: Repository, run_id: int) -> None:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {repo._schema}.scan_runs (run_id, ticker, started_at) "
+            "VALUES (%s, 'TSLA', now()) ON CONFLICT DO NOTHING",
+            (run_id,),
+        )
+    repo.conn.commit()
+
+
+def test_summary_persisted_alongside_greek_exposure(seeded_db_empty_cards: Repository):
+    """Smoke: insert greek-exposure rows, call build_summary_rows + upsert,
+    one summary row appears per expiry."""
+    repo = seeded_db_empty_cards
+    _seed_scan_run(repo, run_id=10)
+
+    rows = [
+        GreekExposureRow(
+            date=date.fromisoformat("2026-05-21"),
+            expiry=date.fromisoformat("2026-05-30"),
+            strike=Decimal("100"),
+            dte=9,
+            call_vanna=Decimal("100"),
+            put_vanna=Decimal("-30"),
+            call_charm=Decimal("-2000"),
+            put_charm=Decimal("500"),
+        ),
+        GreekExposureRow(
+            date=date.fromisoformat("2026-05-21"),
+            expiry=date.fromisoformat("2026-06-20"),
+            strike=Decimal("100"),
+            dte=30,
+            call_vanna=Decimal("10"),
+            put_vanna=Decimal("-5"),
+            call_charm=Decimal("-200"),
+            put_charm=Decimal("50"),
+        ),
+    ]
+    repo.insert_greek_exposure_rows(run_id=10, ticker="TSLA", rows=rows)
+    repo.conn.commit()
+
+    summary = build_summary_rows(rows, spot=Decimal("100"))
+    repo.upsert_exposures_summary(
+        run_id=10,
+        ticker="TSLA",
+        market_date=date.fromisoformat("2026-05-21"),
+        rows=summary,
+    )
+    repo.conn.commit()
+
+    fetched = repo.fetch_exposures_summary(10, "TSLA")
+    assert len(fetched) == 2
+    expiries = {r["expiry"] for r in fetched}
+    assert expiries == {
+        date.fromisoformat("2026-05-30"),
+        date.fromisoformat("2026-06-20"),
+    }
+    assert all(r["vanna_headline"] for r in fetched)
+    assert all(r["charm_headline"] for r in fetched)

--- a/tests/unit/cards/test_exposures_charm.py
+++ b/tests/unit/cards/test_exposures_charm.py
@@ -1,0 +1,121 @@
+"""Charm derivers — pure functions over GreekExposureRow lists."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import (
+    charm_flip,
+    charm_imbalance,
+    charm_narrative,
+    charm_pin_strike,
+    charm_signal_quality,
+    net_charm,
+)
+from uw_scan.models import GreekExposureRow
+
+
+def _r(
+    strike: str, expiry: str, call_c: str | None, put_c: str | None
+) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        call_charm=Decimal(call_c) if call_c is not None else None,
+        put_charm=Decimal(put_c) if put_c is not None else None,
+    )
+
+
+def test_net_charm_sums_call_plus_put():
+    rows = [
+        _r("100", "2026-05-30", "-1000000", "200000"),
+        _r("110", "2026-05-30", "-500000", "100000"),
+    ]
+    assert net_charm(rows) == Decimal("-1200000")
+
+
+def test_net_charm_empty_returns_none():
+    assert net_charm([]) is None
+
+
+def test_charm_pin_strike_picks_max_abs():
+    rows = [
+        _r("100", "2026-05-30", "100", "200"),
+        _r("110", "2026-05-30", "-5000", "-2000"),
+        _r("120", "2026-05-30", "500", "-100"),
+    ]
+    assert charm_pin_strike(rows) == Decimal("110")
+
+
+def test_charm_pin_strike_empty_returns_none():
+    assert charm_pin_strike([]) is None
+
+
+def test_charm_imbalance_splits_above_and_below_spot():
+    rows = [
+        _r("90", "2026-05-30", "1000", "500"),
+        _r("100", "2026-05-30", "200", "100"),
+        _r("110", "2026-05-30", "-3000", "-2000"),
+        _r("120", "2026-05-30", "-1000", "-500"),
+    ]
+    above, below, imb_pct = charm_imbalance(rows, spot=Decimal("100"))
+    assert above == Decimal("-6500")
+    assert below == Decimal("1500")
+    # imbalance % = |above - below| / (|above| + |below|) = 8000 / 8000 = 1.0
+    assert imb_pct == Decimal("8000") / Decimal("8000")
+
+
+def test_charm_signal_quality_aligned_when_same_sign():
+    assert (
+        charm_signal_quality(live=Decimal("-100000"), positioning=Decimal("-50000"))
+        == "aligned"
+    )
+
+
+def test_charm_signal_quality_mixed_when_opposing_signs():
+    assert (
+        charm_signal_quality(live=Decimal("-100000"), positioning=Decimal("50000"))
+        == "mixed"
+    )
+
+
+def test_charm_signal_quality_weak_when_either_near_zero():
+    assert (
+        charm_signal_quality(live=Decimal("0"), positioning=Decimal("-50000")) == "weak"
+    )
+
+
+def test_charm_flip_picks_cumulative_sign_change():
+    rows = [
+        _r("90", "2026-05-30", "1000", "500"),
+        _r("100", "2026-05-30", "200", "100"),
+        _r("110", "2026-05-30", "-3000", "-1500"),
+        _r("120", "2026-05-30", "-100", "-50"),
+    ]
+    assert charm_flip(rows, spot=Decimal("100")) == Decimal("110")
+
+
+def test_charm_narrative_sell_pressure_when_negative():
+    headline, subtitle = charm_narrative(
+        net_charm_value=Decimal("-15000000"),
+        signal_quality="aligned",
+    )
+    assert "SELL" in headline
+
+
+def test_charm_narrative_buy_pressure_when_positive():
+    headline, _ = charm_narrative(
+        net_charm_value=Decimal("8000000"),
+        signal_quality="aligned",
+    )
+    assert "BUY" in headline
+
+
+def test_charm_narrative_neutral_when_weak():
+    headline, _ = charm_narrative(
+        net_charm_value=Decimal("0"),
+        signal_quality="weak",
+    )
+    assert "Limited" in headline or "Neutral" in headline

--- a/tests/unit/cards/test_exposures_summary.py
+++ b/tests/unit/cards/test_exposures_summary.py
@@ -1,0 +1,74 @@
+"""End-to-end deriver: GreekExposureRow list -> ExposuresSummaryRow per expiry."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import build_summary_rows
+from uw_scan.models import ExposuresSummaryRow, GreekExposureRow
+
+
+def _r(strike: str, expiry: str, **kw) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        dte=kw.get("dte"),
+        call_vanna=Decimal(kw["cv"]) if "cv" in kw else None,
+        put_vanna=Decimal(kw["pv"]) if "pv" in kw else None,
+        call_charm=Decimal(kw["cc"]) if "cc" in kw else None,
+        put_charm=Decimal(kw["pc"]) if "pc" in kw else None,
+    )
+
+
+def test_build_summary_rows_groups_by_expiry():
+    rows = [
+        _r("100", "2026-05-30", dte=9, cv="100", pv="-50", cc="-2000", pc="500"),
+        _r("110", "2026-05-30", dte=9, cv="200", pv="-80", cc="-3000", pc="600"),
+        _r("100", "2026-06-20", dte=30, cv="10", pv="-5", cc="-200", pc="50"),
+    ]
+    out = build_summary_rows(rows, spot=Decimal("105"))
+    assert len(out) == 2
+
+    by_expiry = {r.expiry: r for r in out}
+    near = by_expiry[date.fromisoformat("2026-05-30")]
+    far = by_expiry[date.fromisoformat("2026-06-20")]
+
+    assert isinstance(near, ExposuresSummaryRow)
+    assert near.dte == 9
+    assert near.spot == Decimal("105")
+
+    assert near.net_vanna == Decimal("170")
+    assert near.net_charm == Decimal("-3900")
+    assert near.vanna_headline
+    assert near.charm_headline
+
+    assert far.net_vanna == Decimal("5")
+
+
+def test_build_summary_rows_empty_returns_empty_list():
+    assert build_summary_rows([], spot=Decimal("100")) == []
+
+
+def test_build_summary_rows_spot_none_still_produces_rows():
+    """Charm imbalance returns (0,0,None) when spot is None — must not crash."""
+    rows = [_r("100", "2026-05-30", dte=9, cv="50", pv="50", cc="-1000", pc="500")]
+    out = build_summary_rows(rows, spot=None)
+    assert len(out) == 1
+    assert out[0].spot is None
+    assert out[0].charm_imbalance_pct is None
+
+
+def test_build_summary_rows_mixed_dte_same_expiry_collapses_to_one_row():
+    """Multiple dte values for the same expiry must NOT produce duplicate PK rows
+    (table PK is (run_id, ticker, expiry)). The builder picks min non-null dte."""
+    rows = [
+        _r("100", "2026-05-30", dte=9, cv="100", pv="-50", cc="-1000", pc="500"),
+        _r("110", "2026-05-30", dte=10, cv="80", pv="-30", cc="-2000", pc="800"),
+        _r("105", "2026-05-30", dte=None, cv="50", pv="-20", cc="-500", pc="100"),
+    ]
+    out = build_summary_rows(rows, spot=Decimal("105"))
+    assert len(out) == 1
+    assert out[0].dte == 9
+    assert out[0].net_vanna == Decimal("130")

--- a/tests/unit/cards/test_exposures_vanna.py
+++ b/tests/unit/cards/test_exposures_vanna.py
@@ -1,0 +1,130 @@
+"""Vanna derivers — pure functions over GreekExposureRow lists."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards.exposures import (
+    delta_shock_1pt_iv,
+    net_vanna,
+    top_vanna_strike,
+    vanna_flip,
+    vanna_narrative,
+    vanna_regime,
+)
+from uw_scan.models import GreekExposureRow
+
+
+def _r(
+    strike: str, expiry: str, call_v: str | None, put_v: str | None
+) -> GreekExposureRow:
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        call_vanna=Decimal(call_v) if call_v is not None else None,
+        put_vanna=Decimal(put_v) if put_v is not None else None,
+    )
+
+
+def test_net_vanna_sums_call_plus_put_across_rows():
+    rows = [
+        _r("100", "2026-05-30", "100", "-30"),
+        _r("110", "2026-05-30", "200", "-40"),
+    ]
+    assert net_vanna(rows) == Decimal("230")
+
+
+def test_net_vanna_handles_nulls_silently():
+    rows = [
+        _r("100", "2026-05-30", "100", None),
+        _r("110", "2026-05-30", None, "-40"),
+    ]
+    assert net_vanna(rows) == Decimal("60")
+
+
+def test_net_vanna_empty_returns_none():
+    assert net_vanna([]) is None
+
+
+def test_top_vanna_strike_picks_max_absolute_per_strike():
+    rows = [
+        _r("100", "2026-05-30", "50", "-10"),
+        _r("110", "2026-05-30", "-200", "30"),
+        _r("120", "2026-05-30", "80", "20"),
+    ]
+    strike, value = top_vanna_strike(rows)
+    assert strike == Decimal("110")
+    assert value == Decimal("-170")
+
+
+def test_top_vanna_strike_empty_returns_none():
+    assert top_vanna_strike([]) is None
+
+
+def test_delta_shock_1pt_iv_is_net_vanna_times_001():
+    """UW vanna is dDelta per unit of vol (decimal); 1pt IV = 0.01."""
+    rows = [_r("100", "2026-05-30", "10000", "-2000")]
+    assert delta_shock_1pt_iv(rows) == Decimal("80.00")
+
+
+def test_vanna_regime_procyclical_when_net_positive():
+    assert vanna_regime(Decimal("1500000")) == "procyclical"
+
+
+def test_vanna_regime_countercyclical_when_net_negative():
+    assert vanna_regime(Decimal("-1500000")) == "countercyclical"
+
+
+def test_vanna_regime_neutral_below_threshold():
+    assert vanna_regime(Decimal("500")) == "neutral"
+    assert vanna_regime(None) == "neutral"
+
+
+def test_vanna_flip_picks_first_cumulative_sign_change():
+    rows = [
+        _r("90", "2026-05-30", "-100", "0"),
+        _r("100", "2026-05-30", "-50", "0"),
+        _r("110", "2026-05-30", "200", "0"),
+        _r("120", "2026-05-30", "50", "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("100")) == Decimal("110")
+
+
+def test_vanna_flip_no_sign_change_returns_none():
+    rows = [
+        _r("90", "2026-05-30", "10", "0"),
+        _r("100", "2026-05-30", "20", "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("95")) is None
+
+
+def test_vanna_flip_picks_lowest_ge_spot_when_multiple():
+    """Spec rule: lowest sign-flip >= spot; fall back to lowest overall otherwise."""
+    rows = [
+        _r("80", "2026-05-30", "-100", "0"),
+        _r("90", "2026-05-30", "200", "0"),
+        _r("100", "2026-05-30", "-300", "0"),
+        _r("110", "2026-05-30", "400", "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("100")) == Decimal("100")
+
+
+def test_vanna_flip_falls_back_to_lowest_when_no_flip_above_spot():
+    rows = [
+        _r("80", "2026-05-30", "-100", "0"),
+        _r("90", "2026-05-30", "200", "0"),
+    ]
+    assert vanna_flip(rows, spot=Decimal("150")) == Decimal("90")
+
+
+def test_vanna_narrative_procyclical():
+    headline, subtitle = vanna_narrative(Decimal("1300000"), "procyclical")
+    assert "Long Vanna" in headline
+    assert "IV" in subtitle
+
+
+def test_vanna_narrative_countercyclical():
+    headline, subtitle = vanna_narrative(Decimal("-800000"), "countercyclical")
+    assert "Short Vanna" in headline

--- a/tests/unit/test_models_exports.py
+++ b/tests/unit/test_models_exports.py
@@ -1,6 +1,5 @@
 import importlib
 
-
 PUBLIC_MODEL_EXPORTS = [
     "_UwBase",
     "MatrixDirection",
@@ -143,3 +142,16 @@ def test_uw_scan_models_keeps_public_imports():
 
     if hasattr(models, "__all__"):
         assert set(PUBLIC_MODEL_EXPORTS) <= set(models.__all__)
+
+
+def test_new_exposure_models_exported():
+    from uw_scan import models
+
+    assert "StrikeExposureRow" in models.__all__
+    assert "ExposuresSummaryRow" in models.__all__
+    # _preserve_public_module rewrites __module__ to "uw_scan.models" for
+    # contract identity (see src/uw_scan/models/_base.py). Asserting the
+    # public module is what protects the OpenAPI component name from
+    # accidentally drifting back to the implementation module.
+    assert models.StrikeExposureRow.__module__ == "uw_scan.models"
+    assert models.ExposuresSummaryRow.__module__ == "uw_scan.models"

--- a/tests/unit/test_report_assembly.py
+++ b/tests/unit/test_report_assembly.py
@@ -112,7 +112,7 @@ class _StubRepo:
             },
         ]
 
-    def fetch_exposures_summary(self, run_id: int, ticker: str) -> dict:
+    def fetch_exposures_aggregate(self, run_id: int, ticker: str) -> dict:
         return {
             "total_call_gex": Decimal("1000000"),
             "total_put_gex": Decimal("-500000"),

--- a/tests/unit/test_report_assembly.py
+++ b/tests/unit/test_report_assembly.py
@@ -120,6 +120,12 @@ class _StubRepo:
             "total_put_dex": Decimal("-30000"),
         }
 
+    def fetch_strike_exposures(self, run_id: int, ticker: str) -> list[dict]:
+        return []
+
+    def fetch_exposures_summary(self, run_id: int, ticker: str) -> list[dict]:
+        return []
+
     def fetch_top_oi_strikes(self, ticker: str, limit: int = 5):
         return [Decimal("440"), Decimal("450")], [Decimal("430"), Decimal("420")]
 

--- a/tests/unit/worker/test_cockpit_daily_snapshot_summary_wiring.py
+++ b/tests/unit/worker/test_cockpit_daily_snapshot_summary_wiring.py
@@ -1,0 +1,63 @@
+"""Unit wiring test: the per-expiry loop helper must call
+upsert_exposures_summary whenever fetch_greek_exposure returns rows. Guards
+against silent regression of the Slice 3 wiring."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+
+def _ge_row(expiry: str, strike: str):
+    from uw_scan.models import GreekExposureRow
+
+    return GreekExposureRow(
+        date=date.fromisoformat("2026-05-21"),
+        expiry=date.fromisoformat(expiry),
+        strike=Decimal(strike),
+        dte=9,
+        call_vanna=Decimal("100"),
+        put_vanna=Decimal("-30"),
+        call_charm=Decimal("-2000"),
+        put_charm=Decimal("500"),
+    )
+
+
+def test_per_expiry_loop_persists_exposures_summary(monkeypatch):
+    """The per-expiry loop helper must call upsert_exposures_summary once per
+    expiry whenever fetch_greek_exposure returned rows."""
+    from uw_scan.worker.jobs import cockpit_daily_snapshot as job
+
+    fake_repo = MagicMock()
+    fake_repo._schema = "uw_scan"
+    fake_repo.insert_greeks_rows.return_value = 0
+    fake_repo.insert_greek_exposure_rows.return_value = 2
+    fake_repo.upsert_skew_rows.return_value = 0
+
+    monkeypatch.setattr(
+        job,
+        "fetch_greek_exposure",
+        lambda *_a, **_k: [
+            _ge_row("2026-05-30", "100"),
+            _ge_row("2026-05-30", "110"),
+        ],
+    )
+    monkeypatch.setattr(job, "fetch_greeks", lambda *_a, **_k: [])
+    monkeypatch.setattr(job, "fetch_skew", lambda *_a, **_k: [])
+
+    job._persist_greeks_per_expiry(
+        client=MagicMock(),
+        repo=fake_repo,
+        run_id=999,
+        ticker="TSLA",
+        market_date=date.fromisoformat("2026-05-21"),
+        expiries=[date.fromisoformat("2026-05-30")],
+        spot_for_derive=Decimal("100"),
+    )
+
+    assert fake_repo.upsert_exposures_summary.called, (
+        "Wiring failure: per-expiry loop did not call upsert_exposures_summary "
+        "after insert_greek_exposure_rows. Re-check Slice 3 wiring."
+    )
+    assert fake_repo.upsert_exposures_summary.call_count >= 1

--- a/web/components/stock/panels/greeks/CallPutExposureChart.tsx
+++ b/web/components/stock/panels/greeks/CallPutExposureChart.tsx
@@ -1,0 +1,232 @@
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+  type Point,
+} from "@/lib/svgChart";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+
+export type CallPutPoint = {
+  strike: number;
+  callValue: number | null;
+  putValue: number | null;
+};
+
+type Props = {
+  curve: CallPutPoint[];
+  spot: number | null;
+  yLabel: "Vanna" | "Charm";
+  title: string;
+  width?: number;
+  height?: number;
+};
+
+const PAD = { top: 36, right: 24, bottom: 40, left: 64 };
+const CALL_COLOR = "var(--positive)";
+const PUT_COLOR = "var(--negative)";
+const SPOT_COLOR = "var(--warning)";
+
+export function CallPutExposureChart({
+  curve,
+  spot,
+  yLabel,
+  title,
+  width = 560,
+  height = 360,
+}: Props) {
+  const finiteCall = curve.filter(
+    (c) =>
+      Number.isFinite(c.strike) &&
+      c.callValue != null &&
+      Number.isFinite(c.callValue as number),
+  );
+  const finitePut = curve.filter(
+    (c) =>
+      Number.isFinite(c.strike) &&
+      c.putValue != null &&
+      Number.isFinite(c.putValue as number),
+  );
+  const finiteStrikes = curve.filter(
+    (c) =>
+      Number.isFinite(c.strike) && (c.callValue != null || c.putValue != null),
+  );
+
+  const panel: React.CSSProperties = {
+    background: "var(--bg-panel)",
+    border: "1px solid var(--border-dim)",
+    borderRadius: 4,
+    padding: 16,
+    fontFamily: "var(--font-mono)",
+  };
+
+  if (finiteStrikes.length === 0) {
+    return (
+      <div style={panel}>
+        <div
+          style={{
+            fontSize: 13,
+            color: "var(--text-secondary)",
+            marginBottom: 8,
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          Not enough data to render the curve.
+        </div>
+      </div>
+    );
+  }
+
+  const allY = [
+    ...finiteCall.map((c) => c.callValue as number),
+    ...finitePut.map((c) => c.putValue as number),
+  ];
+  const xDomain =
+    finiteStrikes.length >= 2
+      ? finiteDomain(finiteStrikes.map((c) => c.strike))!
+      : (() => {
+          const s = finiteStrikes[0].strike;
+          const half = spot != null ? Math.abs(s - spot) || s * 0.05 : s * 0.05;
+          return { lo: s - half, hi: s + half, count: 1 };
+        })();
+  const yDomain =
+    allY.length >= 2
+      ? finiteDomain(allY)!
+      : (() => {
+          const v = allY[0] != null ? Math.abs(allY[0]) : 1;
+          return { lo: -v, hi: v, count: 1 };
+        })();
+
+  const innerW = width - PAD.left - PAD.right;
+  const innerH = height - PAD.top - PAD.bottom;
+  const xScale = linearScale([xDomain.lo, xDomain.hi], [0, innerW]);
+  const yAbs = Math.max(Math.abs(yDomain.lo), Math.abs(yDomain.hi), 1);
+  const yScale = linearScale([-yAbs, yAbs], [innerH, 0]);
+
+  const callPoints: Point[] = finiteCall.map((c) => [
+    xScale(c.strike),
+    yScale(c.callValue as number),
+  ]);
+  const putPoints: Point[] = finitePut.map((c) => [
+    xScale(c.strike),
+    yScale(c.putValue as number),
+  ]);
+
+  const xTicks = niceTicks(xDomain.lo, xDomain.hi, 6);
+  const yTicks = niceTicks(-yAbs, yAbs, 5);
+
+  return (
+    <div style={panel}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
+        <div style={{ fontSize: 13, color: "var(--text-secondary)" }}>
+          {title}
+        </div>
+        <div style={{ display: "flex", gap: 12, fontSize: 11 }}>
+          <span style={{ color: CALL_COLOR }}>— Call {yLabel}</span>
+          <span style={{ color: PUT_COLOR }}>— Put {yLabel}</span>
+        </div>
+      </div>
+      <svg width={width} height={height} role="img" aria-label={title}>
+        <title>{title}</title>
+        <g transform={`translate(${PAD.left},${PAD.top})`}>
+          {yTicks.map((t) => (
+            <g key={`y-${t}`}>
+              <line
+                x1={0}
+                x2={innerW}
+                y1={yScale(t)}
+                y2={yScale(t)}
+                stroke="var(--border-dim)"
+                strokeWidth={t === 0 ? 1 : 0.5}
+              />
+              <text
+                x={-8}
+                y={yScale(t)}
+                dy="0.32em"
+                textAnchor="end"
+                fontSize={10}
+                fill="var(--text-muted)"
+              >
+                {fmtMoneyAbbrev(t)}
+              </text>
+            </g>
+          ))}
+          {xTicks.map((t) => (
+            <text
+              key={`x-${t}`}
+              x={xScale(t)}
+              y={innerH + 18}
+              textAnchor="middle"
+              fontSize={10}
+              fill="var(--text-muted)"
+            >
+              {t.toFixed(0)}
+            </text>
+          ))}
+
+          {spot != null && xDomain.lo <= spot && spot <= xDomain.hi && (
+            <>
+              <line
+                data-testid="spot-line"
+                x1={xScale(spot)}
+                x2={xScale(spot)}
+                y1={0}
+                y2={innerH}
+                stroke={SPOT_COLOR}
+                strokeWidth={1}
+              />
+              <text x={xScale(spot) + 6} y={12} fontSize={10} fill={SPOT_COLOR}>
+                Price: {spot.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {callPoints.length >= 2 && (
+            <path
+              data-testid="call-line"
+              d={pathFromPoints(callPoints)}
+              stroke={CALL_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {callPoints.length === 1 && (
+            <circle
+              data-testid="call-point"
+              cx={callPoints[0][0]}
+              cy={callPoints[0][1]}
+              r={4}
+              fill={CALL_COLOR}
+            />
+          )}
+          {putPoints.length >= 2 && (
+            <path
+              data-testid="put-line"
+              d={pathFromPoints(putPoints)}
+              stroke={PUT_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {putPoints.length === 1 && (
+            <circle
+              data-testid="put-point"
+              cx={putPoints[0][0]}
+              cy={putPoints[0][1]}
+              r={4}
+              fill={PUT_COLOR}
+            />
+          )}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/web/components/stock/panels/greeks/CharmPanel.tsx
+++ b/web/components/stock/panels/greeks/CharmPanel.tsx
@@ -178,14 +178,35 @@ export function CharmPanel({ ticker, strikeExposures, summary }: Props) {
         />
       </div>
 
-      <ExpiryDropdown
-        options={sortedSummary.map((r) => ({
-          value: r.expiry,
-          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
-        }))}
-        value={summaryRow.expiry}
-        onChange={setSelected}
-      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <ExpiryDropdown
+          options={sortedSummary.map((r) => ({
+            value: r.expiry,
+            label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+          }))}
+          value={summaryRow.expiry}
+          onChange={setSelected}
+        />
+        {rowsForExpiry.length === 0 && (
+          <span
+            style={{
+              fontSize: 11,
+              fontFamily: "var(--font-mono)",
+              color: "var(--text-muted)",
+              fontStyle: "italic",
+            }}
+          >
+            Aggregate only — per-strike chart available on nearest expiry.
+          </span>
+        )}
+      </div>
 
       <div
         style={{

--- a/web/components/stock/panels/greeks/CharmPanel.tsx
+++ b/web/components/stock/panels/greeks/CharmPanel.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { components } from "@/lib/types";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+import { CallPutExposureChart } from "./CallPutExposureChart";
+import { ExpiryDropdown } from "./ExpiryDropdown";
+import { ExposureTile } from "./ExposureTile";
+import { NetExposureChart } from "./NetExposureChart";
+
+type StrikeExposureRow = components["schemas"]["StrikeExposureRow"];
+type ExposuresSummaryRow = components["schemas"]["ExposuresSummaryRow"];
+
+type Props = {
+  ticker: string;
+  strikeExposures: StrikeExposureRow[];
+  summary: ExposuresSummaryRow[];
+};
+
+const toNum = (v: string | number | null | undefined): number | null => {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const toSpot = (v: string | number | null | undefined): number | null => {
+  const n = toNum(v);
+  return n != null && n > 0 ? n : null;
+};
+
+export function CharmPanel({ ticker, strikeExposures, summary }: Props) {
+  const sortedSummary = useMemo(
+    () => [...summary].sort((a, b) => (a.expiry < b.expiry ? -1 : 1)),
+    [summary],
+  );
+  const defaultExpiry = useMemo(() => {
+    const live = sortedSummary
+      .filter((r) => r.dte == null || (r.dte as number) >= 0)
+      .sort(
+        (a, b) => ((a.dte ?? 99999) as number) - ((b.dte ?? 99999) as number),
+      );
+    return (live[0] ?? sortedSummary[0])?.expiry ?? null;
+  }, [sortedSummary]);
+  const [selected, setSelected] = useState<string | null>(defaultExpiry);
+
+  if (sortedSummary.length === 0) {
+    return (
+      <div style={{ color: "var(--text-muted)", fontSize: 12, padding: 16 }}>
+        Charm data not yet available for this run.
+      </div>
+    );
+  }
+
+  const summaryRow =
+    sortedSummary.find((r) => r.expiry === selected) ?? sortedSummary[0];
+  const rowsForExpiry = strikeExposures.filter(
+    (r) => r.expiry === summaryRow.expiry,
+  );
+
+  const netCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      netValue: (toNum(r.call_charm) ?? 0) + (toNum(r.put_charm) ?? 0),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const callPutCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      callValue: toNum(r.call_charm),
+      putValue: toNum(r.put_charm),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const dte = summaryRow.dte ?? null;
+  const spot = toSpot(summaryRow.spot);
+  const flip = toNum(summaryRow.charm_flip);
+  const netCharm = toNum(summaryRow.net_charm);
+  const pin = toNum(summaryRow.charm_pin_strike);
+  const imb = toNum(summaryRow.charm_imbalance_pct);
+  const aboveSum = toNum(summaryRow.charm_above_sum);
+  const belowSum = toNum(summaryRow.charm_below_sum);
+
+  const liveTone =
+    netCharm == null || Math.abs(netCharm) < 1000
+      ? "muted"
+      : netCharm < 0
+        ? "negative"
+        : "positive";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: "var(--accent-vol)",
+            textTransform: "uppercase",
+          }}
+        >
+          Timer · Charm
+        </div>
+        <div
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: "var(--text-primary)",
+          }}
+        >
+          {summaryRow.charm_headline ?? "Charm pressure"}
+        </div>
+        {summaryRow.charm_subtitle && (
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--text-secondary)",
+              fontStyle: "italic",
+            }}
+          >
+            {summaryRow.charm_subtitle}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+        }}
+      >
+        <ExposureTile
+          label="Live charm"
+          value={fmtMoneyAbbrev(netCharm)}
+          sub={
+            netCharm == null
+              ? undefined
+              : netCharm < 0
+                ? "Sell pressure"
+                : netCharm > 0
+                  ? "Buy pressure"
+                  : "Flat"
+          }
+          tone={liveTone}
+        />
+        <ExposureTile
+          label="Positioning"
+          value={fmtMoneyAbbrev(
+            aboveSum != null && belowSum != null ? aboveSum - belowSum : null,
+          )}
+          sub={imb != null ? `${(imb * 100).toFixed(0)}% imbalance` : "—"}
+        />
+        <ExposureTile
+          label="Signal quality"
+          value={summaryRow.charm_signal_quality ?? "weak"}
+          sub={
+            summaryRow.charm_signal_quality === "aligned"
+              ? "live and positioning align"
+              : summaryRow.charm_signal_quality === "mixed"
+                ? "live and positioning disagree"
+                : "thin signal"
+          }
+          tone={
+            summaryRow.charm_signal_quality === "aligned" ? liveTone : "muted"
+          }
+        />
+        <ExposureTile
+          label="Where it matters"
+          value={pin != null ? `$${pin.toFixed(2)}` : "—"}
+          sub={
+            pin != null && spot != null
+              ? `${(((pin - spot) / spot) * 100).toFixed(1)}% from spot`
+              : undefined
+          }
+        />
+      </div>
+
+      <ExpiryDropdown
+        options={sortedSummary.map((r) => ({
+          value: r.expiry,
+          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+        }))}
+        value={summaryRow.expiry}
+        onChange={setSelected}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <NetExposureChart
+          curve={netCurve}
+          spot={spot}
+          flipStrike={flip}
+          yLabel="Charm"
+          title={`Net Charm Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+        <CallPutExposureChart
+          curve={callPutCurve}
+          spot={spot}
+          yLabel="Charm"
+          title={`Charm Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/panels/greeks/ExpiryDropdown.tsx
+++ b/web/components/stock/panels/greeks/ExpiryDropdown.tsx
@@ -1,52 +1,119 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+
+type Option = { value: string; label: string };
+
 type Props = {
-  options: { value: string; label: string }[];
+  options: Option[];
   value: string;
   onChange: (next: string) => void;
 };
 
+const CONTROL_LABEL: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  letterSpacing: 1.5,
+  color: "var(--text-muted)",
+  textTransform: "uppercase",
+};
+
+const TRIGGER: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  background: "var(--bg-panel)",
+  color: "var(--text-primary)",
+  border: "1px solid var(--border-dim)",
+  padding: "2px 8px",
+  listStyle: "none",
+  cursor: "pointer",
+  minWidth: 140,
+  display: "inline-flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: 8,
+};
+
+// Native <details> dropdown styled to match FlowTab's StrikeRangeSelect —
+// avoids macOS native <select> chrome (white pill, blue selection) that
+// fights the Argon dark theme.
 export function ExpiryDropdown({ options, value, onChange }: Props) {
+  const ref = useRef<HTMLDetailsElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const onDown = (e: MouseEvent) => {
+      if (el.open && !el.contains(e.target as Node)) {
+        el.open = false;
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, []);
+
+  const current = options.find((o) => o.value === value)?.label ?? "—";
+
   return (
     <label
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: 8,
-        fontFamily: "var(--font-mono)",
-        fontSize: 12,
-        color: "var(--text-secondary)",
       }}
     >
-      <span
-        style={{
-          fontSize: 10,
-          letterSpacing: 1.5,
-          color: "var(--text-muted)",
-          textTransform: "uppercase",
-        }}
-      >
-        Expiry:
-      </span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        style={{
-          background: "var(--bg-panel)",
-          color: "var(--text-primary)",
-          border: "1px solid var(--border-dim)",
-          borderRadius: 4,
-          padding: "4px 8px",
-          fontFamily: "var(--font-mono)",
-          fontSize: 12,
-        }}
-      >
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+      <span style={CONTROL_LABEL}>Expiry:</span>
+      <details ref={ref} style={{ position: "relative" }}>
+        <summary style={TRIGGER}>
+          <span>{current}</span>
+          <span style={{ color: "var(--text-muted)" }}>▾</span>
+        </summary>
+        <div
+          role="listbox"
+          style={{
+            position: "absolute",
+            zIndex: 20,
+            marginTop: 4,
+            minWidth: 160,
+            maxHeight: 320,
+            overflowY: "auto",
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border-dim)",
+            padding: 4,
+          }}
+        >
+          {options.map((o) => {
+            const active = o.value === value;
+            return (
+              <button
+                key={o.value}
+                type="button"
+                role="option"
+                aria-selected={active}
+                onClick={(e) => {
+                  onChange(o.value);
+                  (
+                    e.currentTarget.closest("details") as HTMLDetailsElement
+                  ).open = false;
+                }}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  textAlign: "left",
+                  padding: "4px 8px",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  background: active ? "var(--accent-bg)" : "transparent",
+                  color: active ? "var(--bg-panel)" : "var(--text-primary)",
+                  border: "none",
+                  cursor: "pointer",
+                }}
+              >
+                {o.label}
+              </button>
+            );
+          })}
+        </div>
+      </details>
     </label>
   );
 }

--- a/web/components/stock/panels/greeks/ExpiryDropdown.tsx
+++ b/web/components/stock/panels/greeks/ExpiryDropdown.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+type Props = {
+  options: { value: string; label: string }[];
+  value: string;
+  onChange: (next: string) => void;
+};
+
+export function ExpiryDropdown({ options, value, onChange }: Props) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 8,
+        fontFamily: "var(--font-mono)",
+        fontSize: 12,
+        color: "var(--text-secondary)",
+      }}
+    >
+      <span
+        style={{
+          fontSize: 10,
+          letterSpacing: 1.5,
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+        }}
+      >
+        Expiry:
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          background: "var(--bg-panel)",
+          color: "var(--text-primary)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          padding: "4px 8px",
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+        }}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/web/components/stock/panels/greeks/ExposureTile.tsx
+++ b/web/components/stock/panels/greeks/ExposureTile.tsx
@@ -1,0 +1,65 @@
+type Tone = "positive" | "negative" | "warning" | "muted" | "default";
+
+const TONE_COLOR: Record<Tone, string> = {
+  positive: "var(--positive)",
+  negative: "var(--negative)",
+  warning: "var(--warning)",
+  muted: "var(--text-muted)",
+  default: "var(--text-primary)",
+};
+
+type Props = {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: Tone;
+};
+
+export function ExposureTile({ label, value, sub, tone = "default" }: Props) {
+  return (
+    <div
+      data-testid="exposure-tile"
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: "10px 14px",
+        fontFamily: "var(--font-mono)",
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: 1.5,
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: 22,
+          fontWeight: 700,
+          color: TONE_COLOR[tone],
+          whiteSpace: "nowrap",
+        }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-secondary)",
+            marginTop: 2,
+          }}
+        >
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/stock/panels/greeks/GreekSubTabs.tsx
+++ b/web/components/stock/panels/greeks/GreekSubTabs.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import type { components } from "@/lib/types";
+import { GexProfileChart } from "@/components/stock/panels/GexProfileChart";
+import { CharmPanel } from "./CharmPanel";
+import { VannaPanel } from "./VannaPanel";
+
+type Report = components["schemas"]["SingleStockReport"];
+type Tab = "GEX" | "VANNA" | "CHARM";
+const TABS: Tab[] = ["GEX", "VANNA", "CHARM"];
+
+const ACTIVE_TAB: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  color: "var(--text-primary)",
+  borderBottom: "2px solid var(--accent-vol)",
+};
+const TAB_BASE: React.CSSProperties = {
+  background: "transparent",
+  border: "none",
+  borderBottom: "2px solid transparent",
+  padding: "8px 16px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 12,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  cursor: "pointer",
+};
+
+export function GreekSubTabs({ report }: { report: Report }) {
+  const [tab, setTab] = useState<Tab>("GEX");
+
+  return (
+    <div
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+        padding: 16,
+      }}
+    >
+      <div
+        role="tablist"
+        style={{
+          display: "flex",
+          gap: 4,
+          borderBottom: "1px solid var(--border-dim)",
+          marginBottom: 16,
+        }}
+      >
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            style={tab === t ? { ...TAB_BASE, ...ACTIVE_TAB } : TAB_BASE}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {tab === "GEX" && <GexProfileChart report={report} />}
+      {tab === "VANNA" && (
+        <VannaPanel
+          ticker={report.ticker}
+          strikeExposures={report.strike_exposures ?? []}
+          summary={report.exposures_summary ?? []}
+        />
+      )}
+      {tab === "CHARM" && (
+        <CharmPanel
+          ticker={report.ticker}
+          strikeExposures={report.strike_exposures ?? []}
+          summary={report.exposures_summary ?? []}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/components/stock/panels/greeks/NetExposureChart.tsx
+++ b/web/components/stock/panels/greeks/NetExposureChart.tsx
@@ -1,0 +1,228 @@
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+  type Point,
+} from "@/lib/svgChart";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+
+export type NetExposurePoint = {
+  strike: number;
+  netValue: number | null;
+};
+
+type Props = {
+  curve: NetExposurePoint[];
+  spot: number | null;
+  flipStrike: number | null;
+  yLabel: "Vanna" | "Charm";
+  title: string;
+  width?: number;
+  height?: number;
+};
+
+const PAD = { top: 36, right: 24, bottom: 40, left: 64 };
+const NET_COLOR = "var(--accent-vol)";
+const SPOT_COLOR = "var(--warning)";
+
+export function NetExposureChart({
+  curve,
+  spot,
+  flipStrike,
+  yLabel,
+  title,
+  width = 560,
+  height = 360,
+}: Props) {
+  const finitePts = curve.filter(
+    (c) =>
+      Number.isFinite(c.strike) &&
+      c.netValue != null &&
+      Number.isFinite(c.netValue as number),
+  );
+
+  const panel: React.CSSProperties = {
+    background: "var(--bg-panel)",
+    border: "1px solid var(--border-dim)",
+    borderRadius: 4,
+    padding: 16,
+    fontFamily: "var(--font-mono)",
+  };
+
+  if (finitePts.length === 0) {
+    return (
+      <div style={panel}>
+        <div
+          style={{
+            fontSize: 13,
+            color: "var(--text-secondary)",
+            marginBottom: 8,
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          Not enough data to render the curve.
+        </div>
+      </div>
+    );
+  }
+
+  const xDomain =
+    finitePts.length >= 2
+      ? finiteDomain(finitePts.map((c) => c.strike))!
+      : (() => {
+          const s = finitePts[0].strike;
+          const half = spot != null ? Math.abs(s - spot) || s * 0.05 : s * 0.05;
+          return { lo: s - half, hi: s + half, count: 1 };
+        })();
+  const yDomain =
+    finitePts.length >= 2
+      ? finiteDomain(finitePts.map((c) => c.netValue))!
+      : (() => {
+          const v = Math.abs(finitePts[0].netValue as number);
+          return { lo: -v, hi: v, count: 1 };
+        })();
+
+  const innerW = width - PAD.left - PAD.right;
+  const innerH = height - PAD.top - PAD.bottom;
+
+  const xScale = linearScale([xDomain.lo, xDomain.hi], [0, innerW]);
+  const yAbs = Math.max(Math.abs(yDomain.lo), Math.abs(yDomain.hi), 1);
+  const yScale = linearScale([-yAbs, yAbs], [innerH, 0]);
+
+  const points: Point[] = finitePts.map((c) => [
+    xScale(c.strike),
+    yScale(c.netValue as number),
+  ]);
+
+  const xTicks = niceTicks(xDomain.lo, xDomain.hi, 6);
+  const yTicks = niceTicks(-yAbs, yAbs, 5);
+
+  return (
+    <div style={panel}>
+      <div
+        style={{
+          fontSize: 13,
+          color: "var(--text-secondary)",
+          marginBottom: 8,
+        }}
+      >
+        {title}
+      </div>
+      <svg width={width} height={height} role="img" aria-label={title}>
+        <title>{title}</title>
+        <g transform={`translate(${PAD.left},${PAD.top})`}>
+          {yTicks.map((t) => (
+            <g key={`y-${t}`}>
+              <line
+                x1={0}
+                x2={innerW}
+                y1={yScale(t)}
+                y2={yScale(t)}
+                stroke="var(--border-dim)"
+                strokeWidth={t === 0 ? 1 : 0.5}
+              />
+              <text
+                x={-8}
+                y={yScale(t)}
+                dy="0.32em"
+                textAnchor="end"
+                fontSize={10}
+                fill="var(--text-muted)"
+              >
+                {fmtMoneyAbbrev(t)}
+              </text>
+            </g>
+          ))}
+
+          {xTicks.map((t) => (
+            <text
+              key={`x-${t}`}
+              x={xScale(t)}
+              y={innerH + 18}
+              textAnchor="middle"
+              fontSize={10}
+              fill="var(--text-muted)"
+            >
+              {t.toFixed(0)}
+            </text>
+          ))}
+
+          {spot != null && xDomain.lo <= spot && spot <= xDomain.hi && (
+            <>
+              <line
+                data-testid="spot-line"
+                x1={xScale(spot)}
+                x2={xScale(spot)}
+                y1={0}
+                y2={innerH}
+                stroke={SPOT_COLOR}
+                strokeWidth={1}
+              />
+              <text x={xScale(spot) + 6} y={12} fontSize={10} fill={SPOT_COLOR}>
+                Price: {spot.toFixed(2)}
+              </text>
+            </>
+          )}
+
+          {flipStrike != null &&
+            xDomain.lo <= flipStrike &&
+            flipStrike <= xDomain.hi && (
+              <>
+                <line
+                  data-testid="flip-line"
+                  x1={xScale(flipStrike)}
+                  x2={xScale(flipStrike)}
+                  y1={0}
+                  y2={innerH}
+                  stroke={NET_COLOR}
+                  strokeWidth={1}
+                  strokeDasharray="4 3"
+                />
+                <text
+                  x={xScale(flipStrike) + 6}
+                  y={26}
+                  fontSize={10}
+                  fill={NET_COLOR}
+                >
+                  {yLabel} flip: {flipStrike.toFixed(2)}
+                </text>
+              </>
+            )}
+
+          {points.length >= 2 && (
+            <path
+              data-testid="net-line"
+              d={pathFromPoints(points)}
+              stroke={NET_COLOR}
+              strokeWidth={2}
+              fill="none"
+            />
+          )}
+          {points.length === 1 && (
+            <circle
+              data-testid="net-point"
+              cx={points[0][0]}
+              cy={points[0][1]}
+              r={4}
+              fill={NET_COLOR}
+            />
+          )}
+        </g>
+
+        <text
+          x={16}
+          y={PAD.top + innerH / 2}
+          textAnchor="middle"
+          transform={`rotate(-90, 16, ${PAD.top + innerH / 2})`}
+          fontSize={10}
+          fill="var(--text-muted)"
+        >
+          {yLabel}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/web/components/stock/panels/greeks/VannaPanel.tsx
+++ b/web/components/stock/panels/greeks/VannaPanel.tsx
@@ -177,14 +177,35 @@ export function VannaPanel({ ticker, strikeExposures, summary }: Props) {
         />
       </div>
 
-      <ExpiryDropdown
-        options={sortedSummary.map((r) => ({
-          value: r.expiry,
-          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
-        }))}
-        value={summaryRow.expiry}
-        onChange={setSelected}
-      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <ExpiryDropdown
+          options={sortedSummary.map((r) => ({
+            value: r.expiry,
+            label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+          }))}
+          value={summaryRow.expiry}
+          onChange={setSelected}
+        />
+        {rowsForExpiry.length === 0 && (
+          <span
+            style={{
+              fontSize: 11,
+              fontFamily: "var(--font-mono)",
+              color: "var(--text-muted)",
+              fontStyle: "italic",
+            }}
+          >
+            Aggregate only — per-strike chart available on nearest expiry.
+          </span>
+        )}
+      </div>
 
       <div
         style={{

--- a/web/components/stock/panels/greeks/VannaPanel.tsx
+++ b/web/components/stock/panels/greeks/VannaPanel.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { components } from "@/lib/types";
+import { fmtMoneyAbbrev } from "@/lib/formatters";
+import { CallPutExposureChart } from "./CallPutExposureChart";
+import { ExpiryDropdown } from "./ExpiryDropdown";
+import { ExposureTile } from "./ExposureTile";
+import { NetExposureChart } from "./NetExposureChart";
+
+type StrikeExposureRow = components["schemas"]["StrikeExposureRow"];
+type ExposuresSummaryRow = components["schemas"]["ExposuresSummaryRow"];
+
+type Props = {
+  ticker: string;
+  strikeExposures: StrikeExposureRow[];
+  summary: ExposuresSummaryRow[];
+};
+
+const toNum = (v: string | number | null | undefined): number | null => {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+// Guards spot values from poisoning charm imbalance / "% from spot" math.
+// Mirrors the backend `_safe_spot` rejection of 0/negative/non-finite values.
+const toSpot = (v: string | number | null | undefined): number | null => {
+  const n = toNum(v);
+  return n != null && n > 0 ? n : null;
+};
+
+export function VannaPanel({ ticker, strikeExposures, summary }: Props) {
+  const sortedSummary = useMemo(
+    () => [...summary].sort((a, b) => (a.expiry < b.expiry ? -1 : 1)),
+    [summary],
+  );
+  const defaultExpiry = useMemo(() => {
+    const live = sortedSummary
+      .filter((r) => r.dte == null || (r.dte as number) >= 0)
+      .sort(
+        (a, b) => ((a.dte ?? 99999) as number) - ((b.dte ?? 99999) as number),
+      );
+    return (live[0] ?? sortedSummary[0])?.expiry ?? null;
+  }, [sortedSummary]);
+  const [selected, setSelected] = useState<string | null>(defaultExpiry);
+
+  if (sortedSummary.length === 0) {
+    return (
+      <div style={{ color: "var(--text-muted)", fontSize: 12, padding: 16 }}>
+        Vanna data not yet available for this run.
+      </div>
+    );
+  }
+
+  const summaryRow =
+    sortedSummary.find((r) => r.expiry === selected) ?? sortedSummary[0];
+  const rowsForExpiry = strikeExposures.filter(
+    (r) => r.expiry === summaryRow.expiry,
+  );
+
+  const netCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      netValue: (toNum(r.call_vanna) ?? 0) + (toNum(r.put_vanna) ?? 0),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const callPutCurve = rowsForExpiry
+    .map((r) => ({
+      strike: toNum(r.strike) ?? NaN,
+      callValue: toNum(r.call_vanna),
+      putValue: toNum(r.put_vanna),
+    }))
+    .filter((p) => Number.isFinite(p.strike))
+    .sort((a, b) => a.strike - b.strike);
+
+  const dte = summaryRow.dte ?? null;
+  const spot = toSpot(summaryRow.spot);
+  const flip = toNum(summaryRow.vanna_flip);
+  const netVanna = toNum(summaryRow.net_vanna);
+  const tone =
+    netVanna == null || Math.abs(netVanna) < 1000
+      ? "muted"
+      : netVanna > 0
+        ? "positive"
+        : "negative";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div>
+        <div
+          style={{
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: "var(--accent-vol)",
+            textTransform: "uppercase",
+          }}
+        >
+          Volatility · Vanna
+        </div>
+        <div
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: "var(--text-primary)",
+          }}
+        >
+          {summaryRow.vanna_headline ?? "Vanna positioning"}
+        </div>
+        {summaryRow.vanna_subtitle && (
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--text-secondary)",
+              fontStyle: "italic",
+            }}
+          >
+            {summaryRow.vanna_subtitle}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+        }}
+      >
+        <ExposureTile
+          label="Net Vanna"
+          value={fmtMoneyAbbrev(netVanna)}
+          sub={
+            netVanna == null
+              ? undefined
+              : netVanna > 0
+                ? "Long"
+                : netVanna < 0
+                  ? "Short"
+                  : "Flat"
+          }
+          tone={tone}
+        />
+        <ExposureTile
+          label="Top vol-sensitive strike"
+          value={
+            summaryRow.top_vanna_strike != null
+              ? `$${Number(summaryRow.top_vanna_strike).toFixed(2)}`
+              : "—"
+          }
+          sub={fmtMoneyAbbrev(toNum(summaryRow.top_vanna_value))}
+        />
+        <ExposureTile
+          label="Δ from +1pt IV"
+          value={fmtMoneyAbbrev(toNum(summaryRow.delta_shock_1pt_iv))}
+          sub="Dealers sell when IV up"
+        />
+        <ExposureTile
+          label="Vol-shock regime"
+          value={summaryRow.vanna_regime ?? "neutral"}
+          sub={
+            summaryRow.vanna_regime === "procyclical"
+              ? "amplifies down moves"
+              : summaryRow.vanna_regime === "countercyclical"
+                ? "dampens down moves"
+                : "limited impact"
+          }
+          tone={
+            summaryRow.vanna_regime === "procyclical"
+              ? "negative"
+              : summaryRow.vanna_regime === "countercyclical"
+                ? "positive"
+                : "muted"
+          }
+        />
+      </div>
+
+      <ExpiryDropdown
+        options={sortedSummary.map((r) => ({
+          value: r.expiry,
+          label: `${r.expiry}${r.dte != null ? ` (${r.dte}d)` : ""}`,
+        }))}
+        value={summaryRow.expiry}
+        onChange={setSelected}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <NetExposureChart
+          curve={netCurve}
+          spot={spot}
+          flipStrike={flip}
+          yLabel="Vanna"
+          title={`Net Vanna Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+        <CallPutExposureChart
+          curve={callPutCurve}
+          spot={spot}
+          yLabel="Vanna"
+          title={`Vanna Exposure (${dte ?? "?"} DTE) — ${ticker}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/tabs/MarketStructureTab.tsx
+++ b/web/components/stock/tabs/MarketStructureTab.tsx
@@ -4,7 +4,7 @@ import { GexLevelTiles } from "../panels/GexLevelTiles";
 import { ExpectedRangeBar } from "../panels/ExpectedRangeBar";
 import { DirectionalBiasPanel } from "../panels/DirectionalBiasPanel";
 import { MarketStructureHistoryTable } from "../panels/MarketStructureHistoryTable";
-import { GexProfileChart } from "../panels/GexProfileChart";
+import { GreekSubTabs } from "../panels/greeks/GreekSubTabs";
 import { MaxPainTable } from "../panels/MaxPainTable";
 
 type Report = components["schemas"]["SingleStockReport"];
@@ -31,7 +31,7 @@ export async function MarketStructureTab({ report }: { report: Report }) {
         <ExpectedRangeBar report={report} />
         <DirectionalBiasPanel report={report} history={historyRows} />
       </div>
-      <GexProfileChart report={report} />
+      <GreekSubTabs report={report} />
       <MarketStructureHistoryTable rows={historyRows} />
       <MaxPainTable rows={report.max_pain_rows} />
     </div>

--- a/web/lib/formatters.ts
+++ b/web/lib/formatters.ts
@@ -19,6 +19,18 @@ export function fmtMoney(
   return opts.signed ? `+$${fmt}` : `$${fmt}`;
 }
 
+export function fmtMoneyAbbrev(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (v === 0) return "$0";
+  const sign = v >= 0 ? "+" : "-";
+  const abs = Math.abs(v);
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}
+
 export function fmtDecimal(v: number | null | undefined, digits = 2): string {
   if (v == null || !Number.isFinite(v)) return "—";
   return v.toLocaleString("en-US", {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1329,6 +1329,57 @@ export interface components {
             /** Rv Z */
             rv_z?: string | null;
         };
+        /**
+         * ExposuresSummaryRow
+         * @description Per-(expiry) derived summary used to drive the Vanna/Charm sub-tab
+         *     headline narrative + 4 tiles. Computed by cards/exposures.py and
+         *     persisted to uw_scan.exposures_summary.
+         */
+        ExposuresSummaryRow: {
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /** Dte */
+            dte?: number | null;
+            /** Spot */
+            spot?: string | null;
+            /** Net Vanna */
+            net_vanna?: string | null;
+            /** Top Vanna Strike */
+            top_vanna_strike?: string | null;
+            /** Top Vanna Value */
+            top_vanna_value?: string | null;
+            /** Delta Shock 1Pt Iv */
+            delta_shock_1pt_iv?: string | null;
+            /** Vanna Regime */
+            vanna_regime?: string | null;
+            /** Vanna Flip */
+            vanna_flip?: string | null;
+            /** Vanna Headline */
+            vanna_headline?: string | null;
+            /** Vanna Subtitle */
+            vanna_subtitle?: string | null;
+            /** Net Charm */
+            net_charm?: string | null;
+            /** Charm Pin Strike */
+            charm_pin_strike?: string | null;
+            /** Charm Above Sum */
+            charm_above_sum?: string | null;
+            /** Charm Below Sum */
+            charm_below_sum?: string | null;
+            /** Charm Imbalance Pct */
+            charm_imbalance_pct?: string | null;
+            /** Charm Signal Quality */
+            charm_signal_quality?: string | null;
+            /** Charm Flip */
+            charm_flip?: string | null;
+            /** Charm Headline */
+            charm_headline?: string | null;
+            /** Charm Subtitle */
+            charm_subtitle?: string | null;
+        };
         /** FlowAlert */
         FlowAlert: {
             /** Id */
@@ -3213,6 +3264,16 @@ export interface components {
              * @default []
              */
             option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
+            /**
+             * Strike Exposures
+             * @default []
+             */
+            strike_exposures: components["schemas"]["StrikeExposureRow"][];
+            /**
+             * Exposures Summary
+             * @default []
+             */
+            exposures_summary: components["schemas"]["ExposuresSummaryRow"][];
             /** Next Earnings Date */
             next_earnings_date?: string | null;
         };
@@ -3337,6 +3398,31 @@ export interface components {
              * @default NEUTRAL
              */
             bias: string;
+        };
+        /**
+         * StrikeExposureRow
+         * @description One per-(expiry, strike) raw row from exposures_by_expiry_strike,
+         *     carrying the call/put split for vanna and charm so the FE can render
+         *     Net + Call/Put curves without an extra fetch.
+         */
+        StrikeExposureRow: {
+            /** Strike */
+            strike: string;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /** Dte */
+            dte?: number | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Put Charm */
+            put_charm?: string | null;
         };
         /**
          * StrikeGexBucket

--- a/web/tests/e2e/marketStructureGreekSubTabs.spec.ts
+++ b/web/tests/e2e/marketStructureGreekSubTabs.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+// /stock/[ticker]/page.tsx redirects to /stock/[ticker]/market-structure,
+// so navigating straight to the canonical URL avoids relying on the TabBar
+// link selector (which could break if the label/href changes).
+
+test.describe("Market Structure greek sub-tabs", () => {
+  test("default tab is GEX and shows GEX Profile", async ({ page }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await expect(page.getByRole("tab", { name: "GEX" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("switching to VANNA reveals the Vanna headline or empty state", async ({
+    page,
+  }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await page.getByRole("tab", { name: "VANNA" }).click();
+    await expect(
+      page.locator(
+        "text=/Long Vanna|Short Vanna|Neutral Vanna|Vanna data not yet available/",
+      ),
+    ).toBeVisible();
+  });
+
+  test("switching to CHARM reveals charm headline / empty state", async ({
+    page,
+  }) => {
+    await page.goto("/stock/TSLA/market-structure");
+    await page.getByRole("tab", { name: "CHARM" }).click();
+    await expect(
+      page.locator(
+        "text=/Mechanical (SELL|BUY)|Limited charm|Charm data not yet available/",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/web/tests/unit/formatters.test.ts
+++ b/web/tests/unit/formatters.test.ts
@@ -3,6 +3,7 @@ import {
   fmtDateTimeWithZone,
   fmtDecimal,
   fmtMoney,
+  fmtMoneyAbbrev,
   fmtPct,
   fmtRelativeAgo,
   fmtRelativeDay,
@@ -32,6 +33,22 @@ describe("fmtMoney", () => {
     expect(fmtMoney(1_748_151, { signed: true })).toBe("+$1,748,151");
     expect(fmtMoney(-50_000_000, { signed: true })).toBe("-$50,000,000");
     expect(fmtMoney(0, { signed: true })).toBe("+$0");
+  });
+});
+
+describe("fmtMoneyAbbrev", () => {
+  it("formats values >= 1T with T suffix", () => {
+    expect(fmtMoneyAbbrev(1_500_000_000_000)).toBe("+$1.5T");
+    expect(fmtMoneyAbbrev(-1_500_000_000_000)).toBe("-$1.5T");
+  });
+  it("formats millions, thousands", () => {
+    expect(fmtMoneyAbbrev(1_300_000)).toBe("+$1.3M");
+    expect(fmtMoneyAbbrev(-227_050)).toBe("-$227.1K");
+    expect(fmtMoneyAbbrev(0)).toBe("$0");
+  });
+  it("returns dash for null/undefined", () => {
+    expect(fmtMoneyAbbrev(null)).toBe("—");
+    expect(fmtMoneyAbbrev(undefined)).toBe("—");
   });
 });
 

--- a/web/tests/unit/greekCharts/CallPutExposureChart.test.tsx
+++ b/web/tests/unit/greekCharts/CallPutExposureChart.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CallPutExposureChart } from "@/components/stock/panels/greeks/CallPutExposureChart";
+
+const curve = [
+  { strike: 90, callValue: 100, putValue: -50 },
+  { strike: 100, callValue: 200, putValue: -100 },
+  { strike: 110, callValue: 80, putValue: -150 },
+];
+
+describe("CallPutExposureChart", () => {
+  it("draws two paths", () => {
+    const { container } = render(
+      <CallPutExposureChart
+        curve={curve}
+        spot={100}
+        yLabel="Vanna"
+        title="Vanna Exposure — TSLA"
+      />,
+    );
+    expect(
+      container.querySelector("path[data-testid='call-line']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='put-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders the spot reference line", () => {
+    const { container } = render(
+      <CallPutExposureChart
+        curve={curve}
+        spot={100}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(
+      container.querySelector("line[data-testid='spot-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders empty state when curve is empty", () => {
+    const { container, queryByText } = render(
+      <CallPutExposureChart curve={[]} spot={null} yLabel="Vanna" title="x" />,
+    );
+    expect(container.querySelector("path[data-testid='call-line']")).toBeNull();
+    expect(queryByText(/not enough/i)).not.toBeNull();
+  });
+});

--- a/web/tests/unit/greekCharts/CharmPanel.test.tsx
+++ b/web/tests/unit/greekCharts/CharmPanel.test.tsx
@@ -1,0 +1,81 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CharmPanel } from "@/components/stock/panels/greeks/CharmPanel";
+
+const strikeExposures = [
+  {
+    strike: "100",
+    expiry: "2026-05-30",
+    dte: 9,
+    call_vanna: "0",
+    put_vanna: "0",
+    call_charm: "-2000",
+    put_charm: "500",
+  },
+  {
+    strike: "110",
+    expiry: "2026-05-30",
+    dte: 9,
+    call_vanna: "0",
+    put_vanna: "0",
+    call_charm: "-3000",
+    put_charm: "800",
+  },
+] as never[];
+
+const summary = [
+  {
+    expiry: "2026-05-30",
+    dte: 9,
+    spot: "105",
+    net_vanna: "0",
+    top_vanna_strike: null,
+    top_vanna_value: null,
+    delta_shock_1pt_iv: null,
+    vanna_regime: "neutral",
+    vanna_flip: null,
+    vanna_headline: "",
+    vanna_subtitle: "",
+    net_charm: "-3700",
+    charm_pin_strike: "110",
+    charm_above_sum: "-2200",
+    charm_below_sum: "0",
+    charm_imbalance_pct: "1.0",
+    charm_signal_quality: "aligned",
+    charm_flip: "108",
+    charm_headline: "Mechanical SELL pressure into the close",
+    charm_subtitle: "Strongest near $110.00",
+  },
+] as never[];
+
+describe("CharmPanel", () => {
+  it("renders the SELL pressure headline + 4 tiles + charts", () => {
+    const { container, getByText } = render(
+      <CharmPanel
+        ticker="TSLA"
+        strikeExposures={strikeExposures}
+        summary={summary}
+      />,
+    );
+    expect(getByText(/Mechanical SELL/)).toBeTruthy();
+    expect(
+      container.querySelectorAll("[data-testid='exposure-tile']"),
+    ).toHaveLength(4);
+    expect(
+      container.querySelector("path[data-testid='net-line']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='call-line']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='put-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders an empty state when no summary present", () => {
+    const { queryByText } = render(
+      <CharmPanel ticker="TSLA" strikeExposures={[]} summary={[]} />,
+    );
+    expect(queryByText(/not yet available/i)).not.toBeNull();
+  });
+});

--- a/web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
+++ b/web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ExpiryDropdown } from "@/components/stock/panels/greeks/ExpiryDropdown";
+
+describe("ExpiryDropdown", () => {
+  it("renders one <option> per expiry with dte annotation", () => {
+    const { container } = render(
+      <ExpiryDropdown
+        options={[
+          { value: "2026-05-30", label: "2026-05-30 (9d)" },
+          { value: "2026-06-20", label: "2026-06-20 (30d)" },
+        ]}
+        value="2026-05-30"
+        onChange={() => {}}
+      />,
+    );
+    const opts = container.querySelectorAll("option");
+    expect(opts).toHaveLength(2);
+    expect(opts[0].textContent).toContain("2026-05-30");
+    expect(opts[0].textContent).toContain("9d");
+  });
+
+  it("fires onChange with the new value", () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <ExpiryDropdown
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        value="a"
+        onChange={handle}
+      />,
+    );
+    const select = container.querySelector("select")!;
+    fireEvent.change(select, { target: { value: "b" } });
+    expect(handle).toHaveBeenCalledWith("b");
+  });
+});

--- a/web/tests/unit/greekCharts/ExposureTile.test.tsx
+++ b/web/tests/unit/greekCharts/ExposureTile.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExposureTile } from "@/components/stock/panels/greeks/ExposureTile";
+
+describe("ExposureTile", () => {
+  it("renders label, value, and optional sub-line", () => {
+    const { getByText } = render(
+      <ExposureTile label="Net Vanna" value="+$1.3M" sub="Long" />,
+    );
+    expect(getByText("Net Vanna")).toBeTruthy();
+    expect(getByText("+$1.3M")).toBeTruthy();
+    expect(getByText("Long")).toBeTruthy();
+  });
+
+  it("accepts a tone override for the value color", () => {
+    const { getByText } = render(
+      <ExposureTile label="x" value="-$15.5T" tone="negative" />,
+    );
+    const v = getByText("-$15.5T");
+    expect(v.getAttribute("style") || "").toContain("var(--negative)");
+  });
+});

--- a/web/tests/unit/greekCharts/GreekSubTabs.test.tsx
+++ b/web/tests/unit/greekCharts/GreekSubTabs.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GreekSubTabs } from "@/components/stock/panels/greeks/GreekSubTabs";
+
+const fakeReport = {
+  ticker: "TSLA",
+  strike_gex_curve: [],
+  market_structure: { spot: "100" },
+  market_structure_levels: null,
+  strike_exposures: [],
+  exposures_summary: [],
+} as never;
+
+describe("GreekSubTabs", () => {
+  it("renders GEX panel by default", () => {
+    const { getByText, queryByText } = render(
+      <GreekSubTabs report={fakeReport} />,
+    );
+    expect(getByText("GEX").getAttribute("aria-selected")).toBe("true");
+    expect(queryByText(/Vanna data not yet available/)).toBeNull();
+    expect(queryByText(/Charm data not yet available/)).toBeNull();
+  });
+
+  it("switches to Vanna sub-tab on click", () => {
+    const { getByText } = render(<GreekSubTabs report={fakeReport} />);
+    fireEvent.click(getByText("VANNA"));
+    expect(getByText("VANNA").getAttribute("aria-selected")).toBe("true");
+    expect(getByText(/Vanna data not yet available/)).toBeTruthy();
+  });
+
+  it("switches to Charm sub-tab on click", () => {
+    const { getByText } = render(<GreekSubTabs report={fakeReport} />);
+    fireEvent.click(getByText("CHARM"));
+    expect(getByText(/Charm data not yet available/)).toBeTruthy();
+  });
+});

--- a/web/tests/unit/greekCharts/NetExposureChart.test.tsx
+++ b/web/tests/unit/greekCharts/NetExposureChart.test.tsx
@@ -1,0 +1,92 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NetExposureChart } from "@/components/stock/panels/greeks/NetExposureChart";
+
+const curve = [
+  { strike: 90, netValue: -100 },
+  { strike: 100, netValue: -50 },
+  { strike: 110, netValue: 200 },
+  { strike: 120, netValue: 250 },
+];
+
+describe("NetExposureChart", () => {
+  it("draws a path covering all finite points", () => {
+    const { container } = render(
+      <NetExposureChart
+        curve={curve}
+        spot={105}
+        flipStrike={110}
+        yLabel="Vanna"
+        title="Net Vanna Exposure (9 DTE) — TSLA"
+      />,
+    );
+    const path = container.querySelector("path[data-testid='net-line']");
+    expect(path).not.toBeNull();
+    const d = path!.getAttribute("d") ?? "";
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.match(/L/g)?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders the spot reference line", () => {
+    const { container } = render(
+      <NetExposureChart
+        curve={curve}
+        spot={105}
+        flipStrike={null}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(
+      container.querySelector("line[data-testid='spot-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders the flip reference line when flipStrike provided", () => {
+    const { container } = render(
+      <NetExposureChart
+        curve={curve}
+        spot={105}
+        flipStrike={110}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(
+      container.querySelector("line[data-testid='flip-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders empty state when curve has zero finite points", () => {
+    const { container, queryByText } = render(
+      <NetExposureChart
+        curve={[]}
+        spot={105}
+        flipStrike={null}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(container.querySelector("path[data-testid='net-line']")).toBeNull();
+    expect(queryByText(/not enough/i)).not.toBeNull();
+  });
+
+  it("renders a single-point marker (no line) when curve has exactly one finite point", () => {
+    const { container, queryByText } = render(
+      <NetExposureChart
+        curve={[{ strike: 100, netValue: 5000 }]}
+        spot={100}
+        flipStrike={null}
+        yLabel="Vanna"
+        title="x"
+      />,
+    );
+    expect(queryByText(/not enough/i)).toBeNull();
+    expect(
+      container.querySelector("circle[data-testid='net-point']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("line[data-testid='spot-line']"),
+    ).not.toBeNull();
+  });
+});

--- a/web/tests/unit/greekCharts/VannaPanel.test.tsx
+++ b/web/tests/unit/greekCharts/VannaPanel.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { VannaPanel } from "@/components/stock/panels/greeks/VannaPanel";
+
+const strikeExposures = [
+  {
+    strike: "100",
+    expiry: "2026-05-30",
+    dte: 9,
+    call_vanna: "100",
+    put_vanna: "-30",
+    call_charm: "0",
+    put_charm: "0",
+  },
+  {
+    strike: "110",
+    expiry: "2026-05-30",
+    dte: 9,
+    call_vanna: "200",
+    put_vanna: "-80",
+    call_charm: "0",
+    put_charm: "0",
+  },
+] as never[];
+
+const summary = [
+  {
+    expiry: "2026-05-30",
+    dte: 9,
+    spot: "105",
+    net_vanna: "190",
+    top_vanna_strike: "110",
+    top_vanna_value: "120",
+    delta_shock_1pt_iv: "1.9",
+    vanna_regime: "procyclical",
+    vanna_flip: "108",
+    vanna_headline:
+      "Long Vanna — IV spikes pressure stock lower via dealer selling",
+    vanna_subtitle: "subtitle...",
+    net_charm: "0",
+    charm_pin_strike: null,
+    charm_above_sum: "0",
+    charm_below_sum: "0",
+    charm_imbalance_pct: null,
+    charm_signal_quality: "weak",
+    charm_flip: null,
+    charm_headline: "",
+    charm_subtitle: "",
+  },
+] as never[];
+
+describe("VannaPanel", () => {
+  it("renders headline, four tiles, expiry dropdown, and both charts", () => {
+    const { container, getByText } = render(
+      <VannaPanel
+        ticker="TSLA"
+        strikeExposures={strikeExposures}
+        summary={summary}
+      />,
+    );
+    expect(getByText(/Long Vanna/)).toBeTruthy();
+    expect(
+      container.querySelectorAll("[data-testid='exposure-tile']"),
+    ).toHaveLength(4);
+    expect(container.querySelector("select")).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='net-line']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='call-line']"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("path[data-testid='put-line']"),
+    ).not.toBeNull();
+  });
+
+  it("renders an empty state when there's no summary at all", () => {
+    const { queryByText } = render(
+      <VannaPanel ticker="TSLA" strikeExposures={[]} summary={[]} />,
+    );
+    expect(queryByText(/not yet available/i)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds VANNA and CHARM sub-tabs inside the per-ticker Market Structure tab, with the existing GEX profile chart now living inside a peer GEX sub-tab.
- Each panel: auto-generated headline narrative + 4 tiles + expiry dropdown + Net curve and Call/Put split curve. Layout mirrors the UnusualWhales reference UI.
- Backend: new `exposures_summary` table (migration 051), pure-function derivers in `cards/exposures.py`, additive fields on `SingleStockReport` (`strike_exposures`, `exposures_summary`). Wired into both `cockpit_daily_snapshot.py` (cockpit universe) and `pipeline.py` (per-ticker watchlist scans).
- Frontend: hand-rolled SVG line charts under `web/components/stock/panels/greeks/` (no chart library, per `web/CLAUDE.md`).

## Architecture
Slice-by-slice commits land 7 milestones:

1. `feat(market-structure): add StrikeExposureRow/ExposuresSummaryRow + exposures_summary table` — Pydantic contracts + migration 051 (BIGINT FK ON DELETE CASCADE to scan_runs)
2. `feat(cards): add vanna+charm derivers and per-expiry summary builder` — `net_vanna`, `top_vanna_strike`, `delta_shock_1pt_iv`, `vanna_regime`, `vanna_flip`, `vanna_narrative`, charm equivalents, `build_summary_rows`
3. `feat(storage,worker): persist exposures_summary on every greek-exposure write` — `upsert_exposures_summary` + rename `fetch_exposures_summary` → `fetch_exposures_aggregate` (frees the name for the new per-expiry list-returning fetcher) + worker/pipeline wiring with `_safe_spot` guard
4. `feat(report,api): expose strike_exposures + exposures_summary on SingleStockReport` — OpenAPI snapshot regenerated; `web/lib/types.ts` regenerated
5. `feat(web): add Vanna/Charm chart primitives + fmtMoneyAbbrev formatter` — `NetExposureChart`, `CallPutExposureChart`, single-point fallback for thin-OI expiries
6. `feat(web): add VannaPanel + CharmPanel client islands` — 4-up tile grid + expiry dropdown + side-by-side charts
7. `feat(web): integrate GreekSubTabs into MarketStructureTab` — `role="tablist"` switcher; GEX is the default tab

## Verification

**Backend (Python, `uv run pytest`):**
- All 583 tests in the touched suites pass (`tests/unit`, `tests/integration/{storage,reports,worker,api}`)
- Migration 051 applies cleanly and is idempotent on re-run
- Round-trip + idempotency tests for `upsert_exposures_summary` pass
- Wiring test asserts `_persist_greeks_per_expiry` calls `upsert_exposures_summary` (guards against silent regression)
- OpenAPI snapshot test passes; diff is purely additive (2 new component schemas + 2 new fields on `SingleStockReport`, 0 removed)

**Frontend (web, `npm`):**
- `npm run typecheck`: passes
- `npm run test`: 279 vitest tests pass across 47 files
- Sign convention verified word-for-word against the UW reference UI screenshot in the design spec

## Test plan
- [ ] `bash scripts/migrate.sh` applies migration 051 against an existing DB without error
- [ ] After a full scan or cockpit snapshot for TSLA, `SELECT COUNT(*) FROM uw_scan.exposures_summary WHERE ticker='TSLA'` returns rows (one per scanned expiry)
- [ ] Visit `/stock/TSLA/market-structure` — three tabs (GEX | VANNA | CHARM) are visible; GEX renders by default with the existing chart
- [ ] Click VANNA: header reads "Long Vanna…" / "Short Vanna…" / "Neutral Vanna…" matching the sign of `net_vanna`; 4 tiles render; expiry dropdown changes the curves
- [ ] Click CHARM: header reads "Mechanical SELL/BUY pressure into the close" or "Limited charm pressure…"; tile values are consistent
- [ ] `cd web && npm run test:e2e -- marketStructureGreekSubTabs` is green against a live stack

---

## Follow-up: multi-expiry dropdown + per-ticker UW call audit (2026-05-21)

Three commits stacked on top of the original 8 after UI testing surfaced a UX gap and a worker-startup bug.

### `7c9820a — fix(storage): exclude gex_scan_* runs from latest_run_id lookup`

The SPX/SPY GEX scanner cron job writes scan_runs rows tagged with notes like `gex_scan_SPY` every 5 min, populating only the GEX slice. For SPY these accumulated to 1000+ rows and shadowed any legitimate full-scan rescan because `latest_run_id()` ordered by `run_id DESC` picked them first — the report assembler then read an empty slice and the UI showed "no data" until the next rescan landed *after* the next cron tick. Same shape fix as the existing `flow_data_refresh` exclusion.

### `9e4e128 — feat(market-structure): wire multi-expiry vanna/charm dropdown`

The Vanna/Charm sub-tabs only showed the nearest expiry because `/greek-exposure/strike-expiry` requires a specific `expiry` parameter — fanning out to N calls to render the term structure would have been prohibitive. Adds the companion `/greek-exposure/expiry` endpoint, which returns aggregated greeks for **all** expiries in one call (no per-strike granularity).

Pipeline now does a two-pass upsert on `exposures_summary`:
- **Pass 1 (8c)** — aggregate-only rows for every expiry; populates tile values (`net_vanna`, `net_charm`, `vanna_regime`) for the dropdown
- **Pass 2 (8d)** — strike-detail pass overwrites the nearest expiry with strike-derived fields (`top_strike`, `vanna_flip`, charm pin/imbalance/flip, `signal_quality`) for the chart panels

Frontend swaps the native `<select>` for a `<details>`-based dropdown to match the Argon theme (mirrors FlowTab's `StrikeRangeSelect`). Panels show an *"Aggregate only — per-strike chart available on nearest expiry"* notice when the selected expiry has no strike rows.

New surfaces: `GreekExposureByExpiryRow` (Pydantic), `normalize_greek_exposure_by_expiry`, `fetch_greek_exposure_by_expiry`, `cards.exposures.build_summary_rows_from_aggregate` + `_charm_narrative_from_net`.

Cost: +1 UW call per ticker rescan; covers the full term structure across ~25 expiries.

### `dd18aca — perf(pipeline): drop redundant /option-contracts re-fetch and /iv-rank call`

Audit of per-ticker rescan UW calls surfaced two redundancies:

| # | Removal | Why redundant |
|---|---|---|
| 1 | Step 15 `/option-contracts?option_symbol[]=…` re-fetch | Hits same UW endpoint as step 14 and returns identical rows already in `contracts` — see `normalize_option_contracts_by_symbol` ("Same shape as option_contracts") |
| 2 | Step 2 `/iv-rank` call | `/volatility/stats.iv_rank == /iv-rank.iv_rank_1y` empirically to 4 decimals across the watchlist. `cockpit_daily_snapshot.py` still calls `fetch_iv_rank` for SPX/SPY/QQQ/IWM where the trailing series feeds the cockpit history chart |

**Net audit result:**

| Scope | Before | After | Saved |
|---|---|---|---|
| Per-ticker rescan | 19 calls | 17 calls | 2 (10.5%) |
| Watchlist rescan-all (102 tickers) | ~1,938 | ~1,734 | 204 |
| Daily cron (~10 rescan-all equivalents) | ~19.4k | ~17.3k | ~2k |
| Yearly | ~7.07M | ~6.33M | ~745k |

(Net effect across all three follow-up commits: +1 call from the new `/greek-exposure/expiry` endpoint, -2 calls from the dedupes = -1 net per ticker.)

### Verification of follow-ups

- All 424 unit tests pass post-iv-rank consolidation
- AMZN rescan (run 11675) audit table confirms 17 unique endpoint slugs, each called exactly once
- `iv_rank` row no longer present in audit table; API still returns identical `iv_rank: 22.9081` and `iv_rank_1y: 22.9081`
- Playwright-verified: multi-expiry dropdown works on TSLA/AMZN/SPY/QQQ; aggregate-only notice renders correctly for distant expiries with no strike data
- SPY rescan now renders the full panel (was shadowed by `gex_scan_*` ghost runs before the `latest_run_id` fix)
