### PR TITLE
fix(gex): parser key mismatch + stale-expiry filter in scan pipeline

### DIFF
--- a/src/uw_scan/cards/greek_exposure_history.py
+++ b/src/uw_scan/cards/greek_exposure_history.py
@@ -46,13 +46,12 @@ def parse_greek_exposure_history(body: dict | None) -> list[dict]:
             # UW history payload uses ``call_gamma`` / ``put_gamma`` keys
             # (dollar gamma exposure summed across strikes). Older
             # snapshots may use ``call_gex`` / ``put_gex``; coalesce both
-            # so cached payloads round-trip.
-            call_gex = float(
-                r.get("call_gamma", r.get("call_gex", 0)) or 0,
-            )
-            put_gex = float(
-                r.get("put_gamma", r.get("put_gex", 0)) or 0,
-            )
+            # so cached payloads round-trip. ``dict.get(key, default)``
+            # returns the explicit ``None`` if the key exists with value
+            # ``None`` — that short-circuits past the fallback key — so
+            # we coalesce manually instead.
+            call_gex = float(_coalesce(r, "call_gamma", "call_gex") or 0)
+            put_gex = float(_coalesce(r, "put_gamma", "put_gex") or 0)
             call_delta = float(r.get("call_delta", 0) or 0)
             put_delta = float(r.get("put_delta", 0) or 0)
         except (TypeError, ValueError) as exc:
@@ -71,6 +70,20 @@ def parse_greek_exposure_history(body: dict | None) -> list[dict]:
         )
     out.sort(key=lambda r: r["date"])
     return out
+
+
+def _coalesce(row: dict, primary: str, fallback: str) -> Any:
+    """Return the first non-None value across the two keys.
+
+    Unlike ``row.get(primary, row.get(fallback, 0))`` which returns the
+    explicit ``None`` when ``primary`` is present-but-null (and therefore
+    never consults ``fallback``), this picks the fallback whenever
+    ``primary`` is missing OR null.
+    """
+    v = row.get(primary)
+    if v is None:
+        v = row.get(fallback)
+    return v
 
 
 def _coerce_date(v: Any) -> date | None:

--- a/src/uw_scan/cards/greek_exposure_history.py
+++ b/src/uw_scan/cards/greek_exposure_history.py
@@ -7,10 +7,12 @@ Used by:
 
 No DB, no network. Pure dict → list[dict] transformation.
 
-Note: UW returns ``call_gex / put_gex / call_delta / put_delta`` per day
-(aggregated across all strikes). It does NOT return historical gex_flip
-or historical price — those have to come from other sources (our own
-``gex_snapshots`` for flip, ``daily_ohlc`` / ``vol_index_daily`` for spot).
+Note: UW returns ``call_gamma / put_gamma / call_delta / put_delta`` per
+day (aggregated across all strikes; ``call_gamma`` is the call-side dollar
+gamma exposure summed across strikes, same units as our ``call_gex``
+column). It does NOT return historical gex_flip or historical price —
+those have to come from other sources (our own ``gex_snapshots`` for
+flip, ``daily_ohlc`` / ``vol_index_daily`` for spot).
 """
 
 from __future__ import annotations
@@ -41,8 +43,16 @@ def parse_greek_exposure_history(body: dict | None) -> list[dict]:
             d = _coerce_date(r.get("date"))
             if d is None:
                 continue
-            call_gex = float(r.get("call_gex", 0) or 0)
-            put_gex = float(r.get("put_gex", 0) or 0)
+            # UW history payload uses ``call_gamma`` / ``put_gamma`` keys
+            # (dollar gamma exposure summed across strikes). Older
+            # snapshots may use ``call_gex`` / ``put_gex``; coalesce both
+            # so cached payloads round-trip.
+            call_gex = float(
+                r.get("call_gamma", r.get("call_gex", 0)) or 0,
+            )
+            put_gex = float(
+                r.get("put_gamma", r.get("put_gex", 0)) or 0,
+            )
             call_delta = float(r.get("call_delta", 0) or 0)
             put_delta = float(r.get("put_delta", 0) or 0)
         except (TypeError, ValueError) as exc:

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -206,7 +206,19 @@ def run_single_stock(
                 valid_term.sort(key=lambda r: r.expiry)
                 nearest_expiry = valid_term[0].expiry
         if nearest_expiry is None:
+            # Loud fallback: either UW returned no term_rows at all, or
+            # every row was already-expired. The next-Friday synthetic may
+            # not exist on UW (no chain for that date) — surface via WARN
+            # so the operator can investigate instead of silently fetching
+            # an empty per-strike partition.
             nearest_expiry = _next_friday(today_et)
+            logger.warning(
+                "term_structure_fallback ticker=%s reason=%s today_et=%s synthetic_expiry=%s",
+                ticker,
+                "empty" if not term_rows else "all_expired",
+                today_et.isoformat(),
+                nearest_expiry.isoformat(),
+            )
         expiry_str = nearest_expiry.isoformat()
 
         # 7. Skew

--- a/src/uw_scan/pipeline.py
+++ b/src/uw_scan/pipeline.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import logging
 from datetime import date as _date
+from datetime import datetime as _datetime
 from datetime import timedelta
 from decimal import Decimal
 from functools import lru_cache
+from zoneinfo import ZoneInfo
 
 import psycopg
 
@@ -111,6 +113,12 @@ def _next_friday(today: _date) -> _date:
     return today + timedelta(days=days_ahead)
 
 
+def _today_et() -> _date:
+    """Today in US/Eastern. Pipeline runs in the worker's local tz (HK),
+    so we have to convert explicitly to match the options-market day."""
+    return _datetime.now(ZoneInfo("America/New_York")).date()
+
+
 def _persist_trade_insights_for_run(
     *,
     repo: Repository,
@@ -186,12 +194,19 @@ def run_single_stock(
         repo.insert_interpolated_iv_rows(run_id, ticker, interp_rows)
 
         # Pick the nearest expiry from term structure for expiry-required calls.
+        # UW occasionally returns already-expired dates in term_rows (e.g. SPY
+        # term still listing yesterday's 0DTE as dte=0 in the post-close
+        # window) — filter to expiry >= today_ET so we never write stale
+        # per-strike rows.
+        today_et = _today_et()
         nearest_expiry: _date | None = None
         if term_rows:
-            sorted_term = sorted(term_rows, key=lambda r: r.expiry)
-            nearest_expiry = sorted_term[0].expiry
+            valid_term = [r for r in term_rows if r.expiry >= today_et]
+            if valid_term:
+                valid_term.sort(key=lambda r: r.expiry)
+                nearest_expiry = valid_term[0].expiry
         if nearest_expiry is None:
-            nearest_expiry = _next_friday(_date.today())
+            nearest_expiry = _next_friday(today_et)
         expiry_str = nearest_expiry.isoformat()
 
         # 7. Skew

--- a/tests/unit/test_greek_exposure_history_parser.py
+++ b/tests/unit/test_greek_exposure_history_parser.py
@@ -3,6 +3,7 @@
 from datetime import date
 
 import pytest
+
 from uw_scan.cards.greek_exposure_history import parse_greek_exposure_history
 
 
@@ -61,6 +62,34 @@ def test_handles_empty_or_missing_data() -> None:
     assert parse_greek_exposure_history({}) == []
     assert parse_greek_exposure_history({"data": None}) == []
     assert parse_greek_exposure_history({"data": []}) == []
+
+
+def test_parses_real_uw_shape_call_gamma_put_gamma() -> None:
+    """UW's actual /greek-exposure payload uses call_gamma/put_gamma keys
+    (not call_gex/put_gex). Regression for the silent-zero bug where the
+    parser defaulted to 0 because the keys never matched."""
+    body = {
+        "data": [
+            {
+                "date": "2026-05-20",
+                "put_charm": "279949437.8628",
+                "put_delta": "-122956330.6777",
+                "put_gamma": "-3985304.2473",
+                "put_vanna": "-478402822.7442",
+                "call_charm": "-216807965.9165",
+                "call_delta": "204991256.2086",
+                "call_gamma": "3412731.7633",
+                "call_vanna": "36743805.0725",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 1
+    assert rows[0]["call_gex"] == pytest.approx(3412731.7633)
+    assert rows[0]["put_gex"] == pytest.approx(-3985304.2473)
+    assert rows[0]["net_gex"] == pytest.approx(-572572.4840)
+    assert rows[0]["call_delta"] == pytest.approx(204991256.2086)
+    assert rows[0]["put_delta"] == pytest.approx(-122956330.6777)
 
 
 def test_accepts_iso_date_strings_or_date_objects() -> None:

--- a/tests/unit/test_greek_exposure_history_parser.py
+++ b/tests/unit/test_greek_exposure_history_parser.py
@@ -92,6 +92,51 @@ def test_parses_real_uw_shape_call_gamma_put_gamma() -> None:
     assert rows[0]["put_delta"] == pytest.approx(-122956330.6777)
 
 
+def test_coalesces_when_call_gamma_is_explicit_null() -> None:
+    """If UW (or a cached older payload) carries ``call_gamma: None`` while
+    ``call_gex`` is populated, we should fall back to ``call_gex``. The naive
+    ``r.get('call_gamma', r.get('call_gex', 0))`` returns ``None`` here and
+    short-circuits past the fallback — _coalesce fixes that."""
+    body = {
+        "data": [
+            {
+                "date": "2026-05-20",
+                "call_gamma": None,
+                "put_gamma": None,
+                "call_gex": "42",
+                "put_gex": "-17",
+                "call_delta": "1",
+                "put_delta": "-1",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert len(rows) == 1
+    assert rows[0]["call_gex"] == pytest.approx(42.0)
+    assert rows[0]["put_gex"] == pytest.approx(-17.0)
+
+
+def test_call_gamma_wins_when_both_keys_present() -> None:
+    """If both ``call_gamma`` and ``call_gex`` are present and non-null,
+    ``call_gamma`` (the current UW shape) takes precedence."""
+    body = {
+        "data": [
+            {
+                "date": "2026-05-20",
+                "call_gamma": "100",
+                "put_gamma": "-50",
+                "call_gex": "999",
+                "put_gex": "-999",
+                "call_delta": "0",
+                "put_delta": "0",
+            },
+        ]
+    }
+    rows = parse_greek_exposure_history(body)
+    assert rows[0]["call_gex"] == pytest.approx(100.0)
+    assert rows[0]["put_gex"] == pytest.approx(-50.0)
+
+
 def test_accepts_iso_date_strings_or_date_objects() -> None:
     body = {
         "data": [


### PR DESCRIPTION
## Summary

Two bugs that together made the dealer-regime panel's `Γ vs prev close` and `0-1d rolls off` fields permanently empty:

### Bug 1 — parser silently wrote zeros (`call_gex` vs `call_gamma`)

`parse_greek_exposure_history` read `r.get(\"call_gex\", 0) or 0`, but UW's `/greek-exposure` payload uses `call_gamma` / `put_gamma`. With `or 0` defaulting, **every row silently wrote zeros** to `greek_exposure_daily.{call_gex,put_gex}`. Across 250 daily SPX/SPY rows in DB, all values were zero — and only those two tickers had any rows at all (the `gex_scan` job is the sole writer and only runs for SPX/SPY).

Confirmed via raw_payloads dump (`audit_id=131572`, SPY 2026-05-20):
```json
{\"call_gamma\":\"3412731.7633\",\"put_gamma\":\"-3985304.2473\",
 \"call_delta\":\"204991256.2086\",\"put_delta\":\"-122956330.6777\"}
```

Fix coalesces both keys so cached payloads (with the old `call_gex` shape, if any) still parse.

### Bug 2 — pipeline picked already-expired contracts

`pipeline.py:188-195` did `sorted(term_rows, key=lambda r: r.expiry)[0]` with no past-date filter. UW's term_structure occasionally still lists yesterday's expiry as `dte=0` in the pre-open window — the pipeline grabbed that stale expiry, fetched its already-expired per-strike data, and wrote `exposures_by_expiry_strike` rows that `compute_gamma_decay` then threw away. Observed on TSLA today: all 9 of today's scans wrote 125 rows each at `expiry=2026-05-20` (yesterday).

New `_today_et()` helper anchors the cutoff to US/Eastern so the worker's HK local time doesn't shift the boundary by half a day.

## Backfill (run separately, not in this PR)

After this fix landed locally:
- **SPX + SPY** (500 rows) re-parsed from cached `raw_payloads` — zero new UW calls
- **99 watchlist tickers** (~25K rows) fetched fresh via UW `/greek-exposure`
- TSLA re-scan with the fixed pipeline now writes `expiry=2026-05-22` (today's nearest valid) instead of `2026-05-20`

Browser verification on `/stock/TSLA`: `Γ VS PREV CLOSE: -$300.02K -81%` (was \"— —\").

## Test plan

- [x] `uv run pytest tests/unit/test_greek_exposure_history_parser.py -v` — 5/5 pass including new regression test for the real UW payload shape (\`call_gamma\`/\`put_gamma\` keys)
- [x] Backfill verified: 100+ watchlist tickers now have non-zero `prev_close_net_gex` in `/api/regime/dealer`
- [ ] After merge: restart the worker (\`bash scripts/dev.sh\`) so APScheduler picks up the new parser. The next \`gex_scan_SPY\` / \`gex_scan_SPX\` tick will then preserve real values instead of overwriting with zeros.

## Files

- \`src/uw_scan/cards/greek_exposure_history.py\` — coalesce \`call_gamma\`/\`call_gex\` parser keys (+ docstring update)
- \`src/uw_scan/pipeline.py\` — \`_today_et()\` helper + filter \`term_rows\` to \`expiry >= today_ET\` before picking nearest
- \`tests/unit/test_greek_exposure_history_parser.py\` — regression test for real UW shape