### PR TITLE
feat(ai): swing-HOLD prompt + dealer-regime/vanna-charm evidence

### DIFF
--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -26,7 +26,6 @@ from uw_scan.models import (
     TradeInsightsResponse,
 )
 
-
 ASSEMBLER_VERSION = "trade-insights-v1"
 
 
@@ -142,7 +141,9 @@ def _build_flow_table(contracts: list[dict]) -> list[ChainFlowReadRow]:
     return rows
 
 
-def _build_source_reconciliation(repo, run_id: int, ticker: str) -> SourceReconciliation:
+def _build_source_reconciliation(
+    repo, run_id: int, ticker: str
+) -> SourceReconciliation:
     fetch = getattr(repo, "fetch_source_reconciliation_rows", None)
     rows = fetch(run_id, ticker) if fetch is not None else []
     if not rows:
@@ -201,7 +202,9 @@ def _build_term_rows(
                 atm_straddle=atm_by_expiry.get(r["expiry"]),
                 implied_move_perc=move,
                 daily_implied_move_perc=daily,
-                read="Front elevated" if dte is not None and dte <= 7 else "Back expiry",
+                read="Front elevated"
+                if dte is not None and dte <= 7
+                else "Back expiry",
             )
         )
     return rows
@@ -219,16 +222,80 @@ def _leg(side: str, c: dict) -> InsightLeg:
     )
 
 
-def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[CandidateStructure]:
+# Swing-horizon DTE window for deterministic candidate generation.
+# Anything outside this range is excluded from directional candidates so the
+# AI prompt is never handed a same-day or far-dated expiry to choose from.
+# Calendar spreads relax the upper bound on the far leg (see below).
+SWING_DTE_MIN = 7
+SWING_DTE_MAX = 30
+SWING_DTE_PREFERRED_MIN = 10
+SWING_DTE_PREFERRED_MAX = 21
+SWING_CALENDAR_FAR_DTE_MAX = 60
+
+
+def _expiry_rank(dte: int) -> int:
+    """Lower is preferred. The 10-21 DTE band matches the prompt's MUST rule,
+    so it ranks ahead of the 7-9 fallback and the 22-30 tail. Within the
+    preferred band, the 12-16 DTE sweet spot ranks first (balances theta
+    decay against gamma path risk for a 1-2 week swing)."""
+    if 12 <= dte <= 16:
+        return 0
+    if SWING_DTE_PREFERRED_MIN <= dte <= SWING_DTE_PREFERRED_MAX:
+        return 1
+    if 22 <= dte <= SWING_DTE_MAX:
+        return 2
+    return 3  # 7-9 DTE fallback, only used when nothing else exists
+
+
+def _build_candidates(
+    contracts: list[dict],
+    spot: Decimal | None,
+    *,
+    as_of: datetime | None = None,
+    dte_min: int = SWING_DTE_MIN,
+    dte_max: int = SWING_DTE_MAX,
+    calendar_far_dte_max: int = SWING_CALENDAR_FAR_DTE_MAX,
+) -> list[CandidateStructure]:
     if spot is None:
         return []
+    # Filter to the swing window (7-30 DTE by default). Directional structures
+    # (verticals, condor, straddle) only consider contracts inside the window;
+    # calendars treat the window as the *near*-leg constraint and allow the
+    # far leg to extend out to calendar_far_dte_max.
+    if as_of is not None:
+        as_of_date = as_of.date() if isinstance(as_of, datetime) else as_of
+
+        def _dte_of(contract: dict) -> int:
+            return (contract["parsed"].expiry - as_of_date).days
+
+        in_swing = [c for c in contracts if dte_min <= _dte_of(c) <= dte_max]
+        in_swing_or_far = [
+            c for c in contracts if dte_min <= _dte_of(c) <= calendar_far_dte_max
+        ]
+
+        # Sort by (expiry preference, strike distance) so candidates land in
+        # the 10-21 DTE band when liquidity allows, falling back to 7-9 or
+        # 22-30 only when nothing closer to the prompt's preferred window
+        # exists. Without this, the closest-to-spot strike wins regardless of
+        # expiry — and the chain's most-liquid ATM strike is usually on the
+        # weekly closest to today, dragging candidates to 7 DTE.
+        def _sort_key(c: dict) -> tuple[int, Decimal]:
+            return (_expiry_rank(_dte_of(c)), abs(c["parsed"].strike - spot))
+
+    else:
+        in_swing = list(contracts)
+        in_swing_or_far = list(contracts)
+
+        def _sort_key(c: dict) -> tuple[int, Decimal]:
+            return (0, abs(c["parsed"].strike - spot))
+
     calls = sorted(
-        [c for c in contracts if c["parsed"].right == "C" and c.get("mid") is not None],
-        key=lambda c: abs(c["parsed"].strike - spot),
+        [c for c in in_swing if c["parsed"].right == "C" and c.get("mid") is not None],
+        key=_sort_key,
     )
     puts = sorted(
-        [c for c in contracts if c["parsed"].right == "P" and c.get("mid") is not None],
-        key=lambda c: abs(c["parsed"].strike - spot),
+        [c for c in in_swing if c["parsed"].right == "P" and c.get("mid") is not None],
+        key=_sort_key,
     )
     candidates: list[CandidateStructure] = []
 
@@ -297,7 +364,12 @@ def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[Candi
         put_spread = next(
             (c for c in candidates if c.structure == "put_credit_spread"), None
         )
-        if call_spread and put_spread and call_spread.net_credit_debit and put_spread.net_credit_debit:
+        if (
+            call_spread
+            and put_spread
+            and call_spread.net_credit_debit
+            and put_spread.net_credit_debit
+        ):
             # Iron condor math: max loss equals the wider wing's width minus the
             # TOTAL credit collected from both verticals. Only one wing can be
             # breached at expiry, so the loss on that wing is (width - credit),
@@ -330,13 +402,30 @@ def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[Candi
                 )
             )
 
-    front_expiry = min((c["parsed"].expiry for c in contracts), default=None)
-    if front_expiry is not None:
-        front_calls = [c for c in calls if c["parsed"].expiry == front_expiry]
-        front_puts = [p for p in puts if p["parsed"].expiry == front_expiry]
+    # Straddle expiry follows the same preference rank as the verticals so a
+    # 14-DTE straddle outranks a 7-DTE one. Theta decay punishes long-vol
+    # structures hardest at sub-10-DTE, so a swing straddle must not land at
+    # the absolute front of the swing window when a preferred-band expiry
+    # exists. The `calls`/`puts` lists are already preference-sorted; pick the
+    # expiry of the first call that also has a matching put.
+    if as_of is not None and (calls or puts):
+        as_of_date = as_of.date() if isinstance(as_of, datetime) else as_of
+        put_expiries = {p["parsed"].expiry for p in puts}
+        swing_front_expiry = next(
+            (c["parsed"].expiry for c in calls if c["parsed"].expiry in put_expiries),
+            None,
+        )
+    else:
+        swing_front_expiry = min((c["parsed"].expiry for c in in_swing), default=None)
+    if swing_front_expiry is not None:
+        front_calls = [c for c in calls if c["parsed"].expiry == swing_front_expiry]
+        front_puts = [p for p in puts if p["parsed"].expiry == swing_front_expiry]
         if front_calls and front_puts:
             call = front_calls[0]
-            put = min(front_puts, key=lambda p: abs(p["parsed"].strike - call["parsed"].strike))
+            put = min(
+                front_puts,
+                key=lambda p: abs(p["parsed"].strike - call["parsed"].strike),
+            )
             debit = call["mid"] + put["mid"]
             strike = call["parsed"].strike
             candidates.append(
@@ -359,10 +448,23 @@ def _build_candidates(contracts: list[dict], spot: Decimal | None) -> list[Candi
                 )
             )
 
+    # Calendar near-leg lives in the swing window; the far leg is allowed
+    # out to calendar_far_dte_max so the term-structure dislocation is real.
+    # Far-leg sort is plain strike-distance — the far-leg expiry is implicitly
+    # selected by the calendar_pairs loop preferring the earliest matching
+    # near→far pair off `calls`, which is already swing-preference sorted.
+    far_calls = sorted(
+        [
+            c
+            for c in in_swing_or_far
+            if c["parsed"].right == "C" and c.get("mid") is not None
+        ],
+        key=lambda c: abs(c["parsed"].strike - spot),
+    )
     calendar_pairs = [
         (near, far)
         for near in calls
-        for far in calls
+        for far in far_calls
         if near["parsed"].strike == far["parsed"].strike
         and near["parsed"].expiry < far["parsed"].expiry
     ]
@@ -418,17 +520,25 @@ def assemble_trade_insights(
     contracts = _normalized_contracts(repo.fetch_option_contracts_rich(run_id, ticker))
     source_reconciliation = _build_source_reconciliation(repo, run_id, ticker)
     flow_rows = _build_flow_table(contracts)
-    term_rows = _build_term_rows(repo.fetch_iv_term_rows(run_id, ticker), contracts, spot)
-    candidates = _build_candidates(contracts, spot)
+    term_rows = _build_term_rows(
+        repo.fetch_iv_term_rows(run_id, ticker), contracts, spot
+    )
+    candidates = _build_candidates(contracts, spot, as_of=as_of)
     # Event data is still not wired through this assembler, so it stays visible
     # as a required pre-sizing check. It should not suppress the research read
     # or erase the best defined-risk candidate.
     event_data_known = False
-    liquidity_ready = bool(contracts) and all(c.max_loss is not None for c in candidates)
+    liquidity_ready = bool(contracts) and all(
+        c.max_loss is not None for c in candidates
+    )
 
-    badges: list[InsightBadge] = [InsightBadge(code="DEFINED_RISK_ONLY", label="Defined-risk only")]
+    badges: list[InsightBadge] = [
+        InsightBadge(code="DEFINED_RISK_ONLY", label="Defined-risk only")
+    ]
     if not contracts:
-        badges.append(InsightBadge(code="NO_CHAIN", label="No option chain", severity="warning"))
+        badges.append(
+            InsightBadge(code="NO_CHAIN", label="No option chain", severity="warning")
+        )
     if source_reconciliation.status in {"UNKNOWN", "MIXED"}:
         badges.append(
             InsightBadge(
@@ -458,11 +568,15 @@ def assemble_trade_insights(
         InsightSignalRow(
             lens="VOL_LEVEL",
             read="IV_RV_PROXY_AVAILABLE",
-            evidence=["Use Volatility tab IV-RV spread proxy; true model-free VRP not computed."],
+            evidence=[
+                "Use Volatility tab IV-RV spread proxy; true model-free VRP not computed."
+            ],
         ),
         InsightSignalRow(
             lens="FLOW",
-            read="CALL_DEMAND" if any((r.call_put_volume_ratio or 0) > 1 for r in flow_rows) else "MIXED",
+            read="CALL_DEMAND"
+            if any((r.call_put_volume_ratio or 0) > 1 for r in flow_rows)
+            else "MIXED",
             evidence=[f"{len(flow_rows)} strike rows available"],
         ),
         InsightSignalRow(
@@ -475,7 +589,9 @@ def assemble_trade_insights(
     can_prefer = bool(candidates) and liquidity_ready
     preferred = candidates[0].idea_id if can_prefer else None
     for candidate in candidates:
-        candidate.status = "preferred" if candidate.idea_id == preferred else "candidate"
+        candidate.status = (
+            "preferred" if candidate.idea_id == preferred else "candidate"
+        )
     return TradeInsightsResponse(
         ticker=ticker,
         as_of=as_of,

--- a/src/uw_scan/reports/trade_insights.py
+++ b/src/uw_scan/reports/trade_insights.py
@@ -222,29 +222,33 @@ def _leg(side: str, c: dict) -> InsightLeg:
     )
 
 
-# Swing-horizon DTE window for deterministic candidate generation.
-# Anything outside this range is excluded from directional candidates so the
-# AI prompt is never handed a same-day or far-dated expiry to choose from.
-# Calendar spreads relax the upper bound on the far leg (see below).
-SWING_DTE_MIN = 7
-SWING_DTE_MAX = 30
-SWING_DTE_PREFERRED_MIN = 10
-SWING_DTE_PREFERRED_MAX = 21
-SWING_CALENDAR_FAR_DTE_MAX = 60
+# Swing-HOLD DTE window. The trade is HELD 5-10 trading sessions (1-2 weeks);
+# entry expiry must leave enough time premium so that the EXIT at 7-14 days
+# later is not stranded at peak gamma / theta crush. 21-60 DTE entry leaves
+# 7-46 DTE remaining at exit. Anything shorter than 21 DTE puts the exit
+# inside the 0-7 DTE crush zone; anything longer than 60 DTE makes the option
+# too desensitized to the 1-2 week ticker-specific catalysts. Calendar spreads
+# relax the upper bound on the far leg (see below).
+SWING_DTE_MIN = 21
+SWING_DTE_MAX = 60
+SWING_DTE_PREFERRED_MIN = 28
+SWING_DTE_PREFERRED_MAX = 45
+SWING_CALENDAR_FAR_DTE_MAX = 90
 
 
 def _expiry_rank(dte: int) -> int:
-    """Lower is preferred. The 10-21 DTE band matches the prompt's MUST rule,
-    so it ranks ahead of the 7-9 fallback and the 22-30 tail. Within the
-    preferred band, the 12-16 DTE sweet spot ranks first (balances theta
-    decay against gamma path risk for a 1-2 week swing)."""
-    if 12 <= dte <= 16:
+    """Lower is preferred. The 28-45 DTE band is the textbook swing-hold
+    entry window (max theta-harvest for credit structures; mild theta drag for
+    long premium). Within the preferred band, the 30-38 DTE sweet spot ranks
+    first. The 46-60 DTE long tail ranks above the 21-27 DTE short tail
+    because the latter is closer to the theta-crush exit zone."""
+    if 30 <= dte <= 38:
         return 0
     if SWING_DTE_PREFERRED_MIN <= dte <= SWING_DTE_PREFERRED_MAX:
         return 1
-    if 22 <= dte <= SWING_DTE_MAX:
+    if 46 <= dte <= SWING_DTE_MAX:
         return 2
-    return 3  # 7-9 DTE fallback, only used when nothing else exists
+    return 3  # 21-27 DTE fallback, only used when nothing else exists
 
 
 def _build_candidates(
@@ -258,10 +262,12 @@ def _build_candidates(
 ) -> list[CandidateStructure]:
     if spot is None:
         return []
-    # Filter to the swing window (7-30 DTE by default). Directional structures
-    # (verticals, condor, straddle) only consider contracts inside the window;
-    # calendars treat the window as the *near*-leg constraint and allow the
-    # far leg to extend out to calendar_far_dte_max.
+    # Filter to the swing-HOLD entry window (21-60 DTE by default; preferred
+    # 28-45). Directional structures (verticals, condor, straddle) only
+    # consider contracts inside the window; calendars treat the window as the
+    # *near*-leg constraint and allow the far leg to extend out to
+    # calendar_far_dte_max (default 90 DTE) so the back leg still has premium
+    # remaining after the 1-2 week hold consumes the front.
     if as_of is not None:
         as_of_date = as_of.date() if isinstance(as_of, datetime) else as_of
 
@@ -274,11 +280,12 @@ def _build_candidates(
         ]
 
         # Sort by (expiry preference, strike distance) so candidates land in
-        # the 10-21 DTE band when liquidity allows, falling back to 7-9 or
-        # 22-30 only when nothing closer to the prompt's preferred window
-        # exists. Without this, the closest-to-spot strike wins regardless of
-        # expiry — and the chain's most-liquid ATM strike is usually on the
-        # weekly closest to today, dragging candidates to 7 DTE.
+        # the 28-45 DTE band when liquidity allows, falling back to 46-60 or
+        # 21-27 only when nothing closer to the preferred window exists.
+        # Without this, the closest-to-spot strike wins regardless of expiry —
+        # and the chain's most-liquid ATM strike is usually on the weekly
+        # closest to today, dragging candidates toward the lower DTE bound
+        # where the 1-2 week hold would land in the theta-crush zone.
         def _sort_key(c: dict) -> tuple[int, Decimal]:
             return (_expiry_rank(_dte_of(c)), abs(c["parsed"].strike - spot))
 

--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from uw_scan.models import TradeInsightAiOutcome
 
-PROMPT_VERSION = "trade-insights-ai-v3"
+PROMPT_VERSION = "trade-insights-ai-v4"
 STRATEGY_FAMILY_IDS = frozenset(
     {
         "long_stock",
@@ -55,13 +55,20 @@ SWING_STRATEGY_FAMILY_IDS = frozenset(
 )
 FINAL_RATING_VALUES = ("A", "B", "C", "D", "F")
 
-MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist analyzing one stock for a 1-2 week SWING entry.
+MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist analyzing one stock for a 1-2 week SWING HOLD entry.
 
 Time horizon (FIXED, not negotiable):
-- Entry decisions are evaluated over 5-10 trading sessions.
-- Preferred-trade expiry MUST be 10-21 DTE (calendars: short leg 10-21 DTE, long leg 21-60 DTE).
-- Reject any candidate with DTE < 7 or DTE > 30 as `horizon_mismatch`, even if it appears in the supplied candidate_structures list.
-- Triggers and invalidations are stated in daily-close terms or 2-session confirmations, never intraday wicks or single-session tape patterns.
+- The trade is HELD 5-10 trading sessions (1-2 calendar weeks). The trade is
+  NOT held to expiry.
+- Entry-expiry DTE MUST be 28-45 (preferred) or 21-60 (allowed). This leaves
+  7-46 DTE remaining at exit. Do NOT pick an expiry that lands inside the
+  5-10 session hold window — exiting at 0-7 DTE puts the trade at peak gamma
+  and theta crush.
+- Calendars: short (near) leg 21-45 DTE; long (far) leg 45-90 DTE.
+- Reject any candidate with entry DTE < 21 or > 60 as `horizon_mismatch`,
+  even if it appears in the supplied candidate_structures list.
+- Triggers and invalidations are stated in daily-close terms or 2-session
+  confirmations, never intraday wicks or single-session tape patterns.
 
 Evidence weighting at this horizon:
 
@@ -69,30 +76,32 @@ PRIMARY (the call hangs on these):
 - Dealer regime label + gamma/vanna/charm sub-scores
   (tabs.market_structure.dealer_regime.{label, gamma_score, vanna_score, charm_score, headline, subtitle})
 - Per-expiry vanna regime + vanna_flip, charm_pin_strike + charm_imbalance_pct + charm_signal_quality
-  for rows where 7 <= dte <= 21 only
+  for rows where 21 <= dte <= 60 only (the entry-expiry window)
   (tabs.market_structure.exposures_summary[])
 - GEX flip vs spot, call wall, put wall, max magnet, max accel
   (tabs.market_structure.market_structure_levels)
-- IV vs RV at the 14-21d horizon, term structure shape across 7-21 DTE
+- IV vs RV at the 28-45d horizon, term structure shape across 21-60 DTE
   (tabs.volatility.{header, term_structure})
 - 90d GEX history extreme vs current — is today at a historically mean-reverting level?
-- Earnings in window — HARD VETO if next_earnings_date falls before chosen expiry,
-  unless the trade is explicitly an earnings IV-crush play (see Earnings filter below).
+- Earnings in window — HARD VETO if next_earnings_date falls inside the 5-10
+  session hold (NOT the full DTE-to-expiry), unless the trade is explicitly
+  an earnings IV-crush play (see Earnings filter below).
 
 SECONDARY (confirms or contradicts, never the primary thesis):
 - Multi-day OI build (tabs.positioning.oi_change_top), persistent top alerts
 - Dark pool notional trend, short interest / borrow fee
 - Skew (sets cost of bullish vs bearish bets)
 
-CONTEXT only (do NOT base the call on these at swing horizon):
+CONTEXT only (do NOT base the call on these at swing-hold horizon):
 - 0DTE GEX and 0DTE share (tabs.volatility.dealer_regime_header.{odte_net_gex, odte_share_pct})
-  — same-day dealer hedging, not next-week direction
-- Any candidate_structures row whose preferred expiry is < 7 DTE — reject as `horizon_mismatch`
+  — same-day dealer hedging, not 1-2 week direction
+- Any candidate_structures row whose preferred entry expiry is < 21 DTE —
+  reject as `horizon_mismatch` (exit would land in theta-crush zone)
 - Intraday tape direction, single-session bid/ask premium tilts
 
 Hard rules:
 - Do not invent data. If a field is missing, say "Missing / not provided."
-- Pick a winner. If pillars conflict, name the winning pillar for the 1-2 week swing horizon and downgrade conviction by one letter — do not default to no-trade unless >=2 of the 4 pillars are missing data.
+- Pick a winner. If pillars conflict, name the winning pillar for the 1-2 week swing-hold horizon and downgrade conviction by one letter — do not default to no-trade unless >=2 of the 4 pillars are missing data.
 - Recommendations are research-only. No order placement, no position sizing in dollars, no imperative trade instructions.
 - Do not use the words "mixed", "unclear", or "monitor closely" in the Call section without a specific price level and a time window in the same sentence.
 
@@ -104,7 +113,7 @@ Spot: {{spot}}
 
 Now produce the report using EXACTLY the structure below. Do not add sections. Do not repeat tables.
 
-# {{ticker}} — {one-line decision: bias + structure + 10-21 DTE expiry}
+# {{ticker}} — {one-line decision: bias + structure + entry-expiry DTE in [21, 60], to hold 1-2 weeks}
 
 ## Call
 
@@ -113,12 +122,12 @@ Now produce the report using EXACTLY the structure below. Do not add sections. D
 | Bias | bullish / bearish / range / no_trade |
 | Vol overlay | long_vol / short_vol / neutral |
 | Conviction | A / B / C / D / F (one letter — see rating ladder below) |
-| Preferred expiry | YYYY-MM-DD with DTE in [10, 21] |
+| Preferred entry expiry | YYYY-MM-DD with DTE in [21, 60] — preferred [28, 45]. This is ENTRY DTE; the trade exits at +5 to +10 sessions, not at expiry. |
 | Preferred structure | one of SWING_STRATEGY_FAMILY_IDS |
 | Trigger | "two daily closes above/below X with confirming Y" — daily-close terms |
 | Invalidation | "daily close above/below X" — daily-close terms |
 | Target level | named level from market_structure_levels (call_wall / put_wall / max_magnet / max_accel / gex_flip) |
-| Time stop | "close at mid after 7 trading sessions if neither trigger nor invalidation fires" |
+| Time stop | "close at mid after 7-10 trading sessions if neither trigger nor invalidation fires" |
 
 ## Why (<=120 words)
 
@@ -128,10 +137,10 @@ Three sentences max, one per supporting pillar. Cite primary evidence by source 
 
 | Field | Value |
 |---|---|
-| Preferred expiry | YYYY-MM-DD (must appear in tabs.volatility.term_structure with 10 <= dte <= 21) |
-| DTE | integer in [10, 21] |
-| Why this expiry | one sentence citing IV level vs adjacent expiries, vanna regime in the window, or charm window position |
-| Alternative | second expiry in 10-21 DTE band, or "none — only one swing-window expiry has acceptable liquidity" |
+| Preferred entry expiry | YYYY-MM-DD (must appear in tabs.volatility.term_structure with 21 <= dte <= 60; prefer 28 <= dte <= 45) |
+| Entry DTE | integer in [21, 60] (preferred [28, 45]) |
+| Why this expiry | one sentence citing IV level vs adjacent expiries, vanna regime in the entry-expiry window, or charm window position. State explicitly that this DTE leaves comfortable premium after the 5-10 session hold. |
+| Alternative | second expiry in 28-45 DTE band, or "none — only one swing-hold expiry has acceptable liquidity" |
 
 ## Scenarios (3 rows, probabilities sum to 100%)
 
@@ -146,7 +155,7 @@ Three sentences max, one per supporting pillar. Cite primary evidence by source 
 | Severity | One-sentence conflict, citing the pillars in tension |
 |---|---|
 
-State which pillar wins for the 1-2 week swing horizon and why, in one sentence.
+State which pillar wins for the 1-2 week swing-hold horizon and why, in one sentence.
 
 ## Required Checks (cap = 2)
 
@@ -157,16 +166,16 @@ Each row must be either pre-entry (resolvable before the trigger fires) or in-tr
 
 ## Rejected Ideas (min 3, max 5)
 
-| Strategy | Why rejected at 1-2 week swing horizon |
+| Strategy | Why rejected at 1-2 week swing-hold horizon |
 |---|---|
 
-Use canonical strategy ids from STRATEGY_FAMILY_IDS. At least one rejection must explicitly cite horizon mismatch (e.g. "long_stock is not a swing structure in this product") or the safety override ("short_strangle: undefined-risk short-vol, blocked by project policy").
+Use canonical strategy ids from STRATEGY_FAMILY_IDS. At least one rejection must explicitly cite horizon mismatch (e.g. "long_stock is not a swing options structure in this product", or "<14 DTE candidate exits at peak gamma/theta") or the safety override ("short_strangle: undefined-risk short-vol, blocked by project policy").
 
 ## Earnings filter
 
-If tabs.positioning.next_earnings_date falls between today and the chosen expiry, choose ONE:
+If tabs.positioning.next_earnings_date falls inside the 5-10 session HOLD window (NOT the full entry-DTE-to-expiry), choose ONE:
 - (a) Reject the candidate as `event_risk_in_window`, recommend `no_trade` or a watchlist entry triggering post-earnings. (Default.)
-- (b) Accept ONLY if the trade is explicitly an earnings IV-crush play AND term structure shows clear front-expiry crush opportunity. Tag risk_flags_observed with ["earnings_in_window", "event_iv_crush_thesis"] and justify in headline.subtitle.
+- (b) Accept ONLY if the trade is explicitly an earnings IV-crush play AND term structure shows clear front-expiry crush opportunity. Tag risk_flags_observed with ["earnings_in_window", "event_iv_crush_thesis"] and justify in headline.subtitle. Note that an earnings IV-crush play typically wants front-expiry (sub-21 DTE) entry — which conflicts with the swing-hold DTE rule above. If you take this path, state explicitly that you are overriding the standard swing-hold horizon for the event-only crush window.
 
 Rating ladder (single letter in headline.conviction; one-clause label in headline.conviction_label):
 - A: Actionable, high conviction (3 of 4 pillars aligned, no missing primary evidence)
@@ -179,7 +188,7 @@ Confidence (headline.score, 0-100 integer; headline.score_scale = 100):
 - 85-100: 4 of 4 pillars (market structure, volatility, flow, positioning) aligned, no missing primary fields. Conviction A territory.
 - 70-84:  3 of 4 pillars aligned with one medium conflict, or 4 aligned with one primary field missing. Conviction A/B.
 - 55-69:  2 of 4 pillars aligned with the dominant pillar winning clearly. Conviction B/C.
-- 40-54:  Pillars conflict but a winner can still be named for the 1-2 week horizon. Conviction C.
+- 40-54:  Pillars conflict but a winner can still be named for the 1-2 week swing-hold horizon. Conviction C.
 - 20-39:  No clean winner, or 2+ primary fields missing. Conviction D.
 - 0-19:   Data insufficient — primary evidence absent. Conviction F.
 Set headline.score honestly against this rubric. Do NOT default to 0; if you can name a dominant pillar and a structure, you can score at least 40.
@@ -477,7 +486,7 @@ def build_trade_insights_ai_analysis_input(
                 ),
                 # PR #61: dealer-regime summary (label, gamma/vanna/charm
                 # sub-scores, 0DTE GEX, headline narrative). Primary evidence
-                # at the 1-2 week swing horizon.
+                # at the 1-2 week swing-hold horizon.
                 "dealer_regime": dealer_regime,
                 # PR #60: per-expiry vanna + charm derivations. Front 6
                 # expiries — caller filters to the swing window when reading.
@@ -687,14 +696,18 @@ def build_trade_insights_ai_prompt(prompt_payload: dict[str, Any]) -> str:
         "missing_data instead of inventing a path.\n"
         "Preserve every candidate status, every risk_flags array, and every deterministic "
         "max_loss/max_profit value exactly as supplied.\n"
-        "Horizon enforcement: every candidate_structures row whose preferred expiry has "
-        "DTE < 7 or DTE > 30 must be rejected as horizon_mismatch in rejected_ideas. The "
-        "deterministic candidate list is already filtered to the 7-30 DTE swing window by "
-        "the upstream assembler; if no swing-window candidates exist, set "
-        "preferred_expression to a no_trade strategy-family entry rather than recommending "
-        "an out-of-horizon candidate.\n"
+        "Horizon enforcement (swing HOLD, not swing expiry): every "
+        "candidate_structures row whose preferred entry expiry has DTE < 21 or "
+        "DTE > 60 must be rejected as horizon_mismatch in rejected_ideas. The "
+        "trade is HELD 5-10 trading sessions; entry expiry must leave enough "
+        "premium that the exit is not at peak gamma/theta crush. The "
+        "deterministic candidate list is already filtered to the 21-60 DTE "
+        "swing-hold window (preferred 28-45) by the upstream assembler; if no "
+        "swing-hold candidates exist, set preferred_expression to a no_trade "
+        "strategy-family entry rather than recommending an out-of-horizon "
+        "candidate.\n"
         "Do not defer solely because a deterministic candidate status is needs_check; give "
-        "a research-only recommendation when the swing-horizon evidence supports one and "
+        "a research-only recommendation when the swing-hold evidence supports one and "
         "put remaining checks into the trigger, risk, watchlist, or readiness language.\n"
         "Project safety override: do not recommend naked short options or undefined-risk "
         "short-vol structures. If the prompt's strategy list includes one, reject it unless "
@@ -719,7 +732,7 @@ def build_trade_insights_ai_prompt(prompt_payload: dict[str, Any]) -> str:
         "status_observed to 'strategy_review' and risk_flags_observed to [].\n"
         f"headline.conviction MUST be a single letter from {list(FINAL_RATING_VALUES)} "
         "(rating ladder in the prompt above). headline.conviction_label holds the "
-        "one-clause explanation. headline.score is the swing-horizon confidence "
+        "one-clause explanation. headline.score is the swing-hold confidence "
         "percentage (integer 0-100, scored against the Confidence rubric in the prompt). "
         "headline.score_scale must be 100. Do not leave score=0 unless data is genuinely "
         "insufficient (Conviction F); a real dominant-pillar read scores at least 40.\n"

--- a/src/uw_scan/reports/trade_insights_ai.py
+++ b/src/uw_scan/reports/trade_insights_ai.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from uw_scan.models import TradeInsightAiOutcome
 
-PROMPT_VERSION = "trade-insights-ai-v2"
+PROMPT_VERSION = "trade-insights-ai-v3"
 STRATEGY_FAMILY_IDS = frozenset(
     {
         "long_stock",
@@ -33,75 +33,68 @@ STRATEGY_FAMILY_IDS = frozenset(
     }
 )
 PREFERRED_STRATEGY_FAMILY_IDS = STRATEGY_FAMILY_IDS - {"short_strangle"}
+# Subset valid as `preferred_expression` / `best_expressions` at the 1-2 week
+# swing horizon. Excludes:
+#   long_stock         — not a swing options structure in this product
+#   covered_call       — 30-45d income trade, requires existing stock
+#   cash_secured_put   — same, 30-45d income posture
+#   short_strangle     — undefined-risk, blocked by safety override
+# Rejected-ideas slots may still reference the full STRATEGY_FAMILY_IDS so the
+# model can explain why an excluded family is the wrong tool at this horizon.
+SWING_STRATEGY_FAMILY_IDS = frozenset(
+    {
+        "long_call",
+        "call_debit_spread",
+        "long_put",
+        "put_debit_spread",
+        "put_credit_spread",
+        "iron_condor",
+        "calendar_spread",
+        "no_trade",
+    }
+)
 FINAL_RATING_VALUES = ("A", "B", "C", "D", "F")
 
-MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist, market-structure analyst, and risk manager.
+MARKET_INTELLIGENCE_PROMPT = """You are an institutional options strategist analyzing one stock for a 1-2 week SWING entry.
 
-Your job is to analyze one stock using three evidence pillars:
+Time horizon (FIXED, not negotiable):
+- Entry decisions are evaluated over 5-10 trading sessions.
+- Preferred-trade expiry MUST be 10-21 DTE (calendars: short leg 10-21 DTE, long leg 21-60 DTE).
+- Reject any candidate with DTE < 7 or DTE > 30 as `horizon_mismatch`, even if it appears in the supplied candidate_structures list.
+- Triggers and invalidations are stated in daily-close terms or 2-session confirmations, never intraday wicks or single-session tape patterns.
 
-1. Market Structure
-   - Spot price
-   - GEX flip
-   - Net GEX
-   - Net DEX
-   - Gamma magnets / max pain / put wall / call wall
-   - GEX profile by strike
-   - Expected range
-   - Dealer gamma regime
-   - Support / resistance from options positioning
+Evidence weighting at this horizon:
 
-2. Volatility
-   - IV ATM
-   - Realized volatility
-   - IV/RV ratio
-   - VRP
-   - IV rank / IV percentile
-   - Term structure
-   - Skew
-   - IV distribution
-   - IV vs RV time series
-   - Regime quadrant: Goldilocks / Fragile Calm / Stock Picker / Systemic Panic
+PRIMARY (the call hangs on these):
+- Dealer regime label + gamma/vanna/charm sub-scores
+  (tabs.market_structure.dealer_regime.{label, gamma_score, vanna_score, charm_score, headline, subtitle})
+- Per-expiry vanna regime + vanna_flip, charm_pin_strike + charm_imbalance_pct + charm_signal_quality
+  for rows where 7 <= dte <= 21 only
+  (tabs.market_structure.exposures_summary[])
+- GEX flip vs spot, call wall, put wall, max magnet, max accel
+  (tabs.market_structure.market_structure_levels)
+- IV vs RV at the 14-21d horizon, term structure shape across 7-21 DTE
+  (tabs.volatility.{header, term_structure})
+- 90d GEX history extreme vs current — is today at a historically mean-reverting level?
+- Earnings in window — HARD VETO if next_earnings_date falls before chosen expiry,
+  unless the trade is explicitly an earnings IV-crush play (see Earnings filter below).
 
-3. Flow and Positioning
-   - Options premium
-   - Bull vs bear premium
-   - Call / put volume
-   - Call / put OI
-   - Top alerts
-   - OI change movers
-   - Dark pool prints
-   - Short availability / borrow fee / rebate
-   - Sweep / repeated hit / churn flags
-   - Large notional strikes and expiries
+SECONDARY (confirms or contradicts, never the primary thesis):
+- Multi-day OI build (tabs.positioning.oi_change_top), persistent top alerts
+- Dark pool notional trend, short interest / borrow fee
+- Skew (sets cost of bullish vs bearish bets)
 
-The objective is to produce a high-quality trading interpretation, not a dashboard summary.
+CONTEXT only (do NOT base the call on these at swing horizon):
+- 0DTE GEX and 0DTE share (tabs.volatility.dealer_regime_header.{odte_net_gex, odte_share_pct})
+  — same-day dealer hedging, not next-week direction
+- Any candidate_structures row whose preferred expiry is < 7 DTE — reject as `horizon_mismatch`
+- Intraday tape direction, single-session bid/ask premium tilts
 
-Important rules:
-
-- Do not invent data.
-- Only use the input provided.
-- If a required field is missing, say “Missing / not provided.”
-- Do not overfit to one metric.
-- Do not blindly say bullish just because call premium is high.
-- Do not blindly say bearish just because puts are active.
-- Resolve conflicts explicitly.
-- Distinguish between:
-  - directional signal
-  - volatility signal
-  - positioning signal
-  - execution readiness
-- Explain whether the setup favors:
-  - long stock
-  - long calls
-  - call debit spread
-  - put credit spread
-  - covered call
-  - short strangle / iron condor
-  - long put / put debit spread
-  - no trade
-- If the data is contradictory or incomplete, recommend “watch / wait” and specify exactly what would make it actionable.
-- Trade recommendations must include entry trigger, invalidation level, target zone, time horizon, preferred option structure, and risk notes.
-- All recommendations are research-only and not financial advice.
+Hard rules:
+- Do not invent data. If a field is missing, say "Missing / not provided."
+- Pick a winner. If pillars conflict, name the winning pillar for the 1-2 week swing horizon and downgrade conviction by one letter — do not default to no-trade unless >=2 of the 4 pillars are missing data.
+- Recommendations are research-only. No order placement, no position sizing in dollars, no imperative trade instructions.
+- Do not use the words "mixed", "unclear", or "monitor closely" in the Call section without a specific price level and a time window in the same sentence.
 
 Input:
 
@@ -109,321 +102,89 @@ Ticker: {{ticker}}
 As-of date: {{as_of_date}}
 Spot: {{spot}}
 
-Market Structure Data:
-{{market_structure_data}}
+Now produce the report using EXACTLY the structure below. Do not add sections. Do not repeat tables.
 
-Volatility Data:
-{{volatility_data}}
+# {{ticker}} — {one-line decision: bias + structure + 10-21 DTE expiry}
 
-Flow and Positioning Data:
-{{flow_positioning_data}}
+## Call
 
-Optional User Context:
-- Current position: {{current_position_or_none}}
-- Trading horizon: {{trading_horizon}}
-- Risk tolerance: {{risk_tolerance}}
-- Preferred strategy type: {{preferred_strategy_type}}
-- Earnings / event calendar known? {{event_calendar_status}}
-
-Now produce the analysis using the following structure.
-
-# {{ticker}} Options Market Intelligence Report
-
-## 1. Executive Decision
-
-Give one clear headline:
-
-- Bullish directional
-- Bearish directional
-- Range-bound / pinned
-- Volatility-selling setup
-- Volatility-buying setup
-- Conflicted / no-trade
-
-Then provide:
-
-| Field | Answer |
+| Field | Value |
 |---|---|
-| Primary Setup | One sentence |
-| Trade Bias | Bullish / Bearish / Range / Volatility |
-| Confidence | High / Medium / Low |
-| Actionability | Ready / Watchlist / No Trade |
-| Best Structure | Specific option or stock structure |
-| Main Risk | One sentence |
-| Key Trigger | One sentence |
+| Bias | bullish / bearish / range / no_trade |
+| Vol overlay | long_vol / short_vol / neutral |
+| Conviction | A / B / C / D / F (one letter — see rating ladder below) |
+| Preferred expiry | YYYY-MM-DD with DTE in [10, 21] |
+| Preferred structure | one of SWING_STRATEGY_FAMILY_IDS |
+| Trigger | "two daily closes above/below X with confirming Y" — daily-close terms |
+| Invalidation | "daily close above/below X" — daily-close terms |
+| Target level | named level from market_structure_levels (call_wall / put_wall / max_magnet / max_accel / gex_flip) |
+| Time stop | "close at mid after 7 trading sessions if neither trigger nor invalidation fires" |
 
-Do not write generic language. Make a decision.
+## Why (<=120 words)
 
-## 2. Market Structure Interpretation
+Three sentences max, one per supporting pillar. Cite primary evidence by source path the first time a claim appears. Name the single biggest conflicting piece of evidence in one clause — not a paragraph.
 
-Analyze the market structure in plain English.
+## Expiry Selection (mandatory)
 
-Must cover:
+| Field | Value |
+|---|---|
+| Preferred expiry | YYYY-MM-DD (must appear in tabs.volatility.term_structure with 10 <= dte <= 21) |
+| DTE | integer in [10, 21] |
+| Why this expiry | one sentence citing IV level vs adjacent expiries, vanna regime in the window, or charm window position |
+| Alternative | second expiry in 10-21 DTE band, or "none — only one swing-window expiry has acceptable liquidity" |
 
-- Where spot is relative to GEX flip.
-- Whether spot is above or below the dealer regime boundary.
-- Whether net GEX is stabilizing or destabilizing.
-- Whether net DEX supports directional acceleration or mean reversion.
-- Where the nearest magnets are.
-- Whether price is likely pinned, pulled upward, pulled downward, or exposed to acceleration.
-- Which strikes are likely support and resistance.
-- Whether the expected range is narrow, wide, useful, or unreliable.
+## Scenarios (3 rows, probabilities sum to 100%)
 
-Output:
-
-### Market Structure Read
-
-State the core read in 3-5 sentences.
-
-### Key Levels
-
-| Level | Price | Meaning | Trading Use |
-|---|---:|---|---|
-| Spot | | Current reference | |
-| GEX Flip | | Regime boundary | |
-| Max Magnet | | Attraction / pin risk | |
-| Put Wall | | Downside support / risk level | |
-| Call Wall / Resistance | | Upside resistance | |
-| Max Accel | | Acceleration risk | |
-
-### Market Structure Verdict
-
-Choose one:
-
-- Bullish with positive gamma support
-- Bullish but pinned
-- Bearish below flip
-- Range-bound / magnet-dominated
-- Fragile because positive gamma conflicts with aggressive flow
-- Unclear due to missing data
-
-Explain why.
-
-## 3. Volatility Interpretation
-
-Analyze whether volatility is cheap, fair, or rich.
-
-Must cover:
-
-- IV vs RV
-- VRP
-- IV rank / percentile
-- term structure
-- skew
-- whether volatility selling or buying is favored
-- whether high IV is justified by event risk
-- whether the setup favors defined-risk or undefined-risk structures
-
-Output:
-
-### Volatility Read
-
-3-5 sentences.
-
-### Volatility Evidence
-
-| Metric | Value | Interpretation |
-|---|---:|---|
-| IV ATM | | |
-| RV | | |
-| IV/RV | | |
-| VRP | | |
-| IV Rank | | |
-| IV Percentile | | |
-| Skew | | |
-| Term Structure | | |
-
-### Volatility Verdict
-
-Choose one:
-
-- IV rich, short-vol favored
-- IV cheap, long-vol favored
-- IV rich but dangerous to sell due to flow/event risk
-- IV fair, no edge
-- Data insufficient
-
-Then explain which option structures fit the volatility regime.
-
-## 4. Flow and Positioning Interpretation
-
-Analyze whether flow confirms or contradicts market structure.
-
-Must cover:
-
-- Bull premium vs bear premium
-- Call demand vs put demand
-- Ask-side vs bid-side premium
-- Volume/OI quality
-- Whether alerts are opening, closing, churn, or ambiguous
-- Whether large call flow is bullish speculation, call overwriting, closing, or mixed
-- Whether large put flow is protection, bearish bet, or premium sale
-- Dark pool / short interest context if available
-
-Output:
-
-### Flow Read
-
-3-5 sentences.
-
-### Flow Quality Check
-
-| Signal | Read | Quality |
-|---|---|---|
-| Bull premium vs bear premium | | Strong / Medium / Weak |
-| Ask vs bid premium | | |
-| Call volume / OI | | |
-| Put volume / OI | | |
-| Top alerts | | |
-| OI change | | |
-| Dark pool / short data | | |
-
-### Flow Verdict
-
-Choose one:
-
-- Clean bullish accumulation
-- Bullish but crowded
-- Bearish protection building
-- Bearish speculation
-- Short-vol / overwrite activity
-- Churn / noisy / low signal
-- Mixed and not actionable
-
-Explain why.
-
-## 5. Cross-Pillar Conflict Resolution
-
-This is the most important section.
-
-Create a table:
-
-| Pillar | Bias | Strength | Evidence | Conflict |
-|---|---|---:|---|---|
-| Market Structure | Bull / Bear / Range | 1-5 | | |
-| Volatility | Long vol / Short vol / Neutral | 1-5 | | |
-| Flow | Bull / Bear / Mixed | 1-5 | | |
-
-Then answer:
-
-1. What is the dominant signal?
-2. What is the biggest contradiction?
-3. Which data should be trusted more for the next 1-5 trading days?
-4. Which data should be trusted more for the next 2-6 weeks?
-5. What would invalidate the current interpretation?
-
-Do not skip this. Do not say “mixed” without explaining what wins.
-
-## 6. Scenario Map
-
-Produce three scenarios.
-
-| Scenario | Probability | Trigger | Expected Move | Best Trade |
+| Scenario | Probability | Trigger (daily close) | Level | Best expression |
 |---|---:|---|---|---|
-| Bullish Breakout | % | | | |
-| Range / Pin | % | | | |
-| Bearish Breakdown | % | | | |
+| upside | % | | named level | SWING_STRATEGY_FAMILY_IDS member |
+| base | % | | named level | SWING_STRATEGY_FAMILY_IDS member |
+| downside | % | | named level | SWING_STRATEGY_FAMILY_IDS member |
 
-Probabilities must sum to 100%.
+## Conflicts (cap = 2; severities high or medium only)
 
-Use the options levels to define triggers.
-
-Example style:
-
-- Bullish breakout if spot holds above GEX flip and breaks above max magnet / call wall with confirming call OI expansion.
-- Range if spot remains between flip and magnet with positive GEX.
-- Bearish breakdown if spot loses flip and put wall fails.
-
-## 7. Trade Recommendation
-
-Give a concrete recommendation, but only if actionability is sufficient.
-
-If actionable, provide:
-
-### Preferred Trade
-
-| Field | Recommendation |
+| Severity | One-sentence conflict, citing the pillars in tension |
 |---|---|
-| Structure | |
-| Direction | |
-| Entry Trigger | |
-| Entry Zone | |
-| Expiry | |
-| Strike Selection Logic | |
-| Target | |
-| Stop / Invalidation | |
-| Position Size | Conservative / Normal / Small only |
-| Why This Structure | |
-| Main Risk | |
 
-If not actionable, provide:
+State which pillar wins for the 1-2 week swing horizon and why, in one sentence.
 
-### No-Trade / Watchlist Plan
+## Required Checks (cap = 2)
 
-| Watch Item | Trigger Needed | Why It Matters |
-|---|---|---|
-| Price | | |
-| OI confirmation | | |
-| IV confirmation | | |
-| Flow confirmation | | |
-| Event check | | |
+| Check | What confirms |
+|---|---|
 
-## 8. Strategy Selection Logic
+Each row must be either pre-entry (resolvable before the trigger fires) or in-trade (a monitor with an action). Do not list more than 2.
 
-Choose the best structure from the following, and explain why others are rejected.
+## Rejected Ideas (min 3, max 5)
 
-Possible structures:
+| Strategy | Why rejected at 1-2 week swing horizon |
+|---|---|
 
-- Long stock
-- Long call
-- Call debit spread
-- Put credit spread
-- Covered call
-- Cash-secured put
-- Iron condor
-- Short strangle
-- Long put
-- Put debit spread
-- Calendar spread
-- No trade
+Use canonical strategy ids from STRATEGY_FAMILY_IDS. At least one rejection must explicitly cite horizon mismatch (e.g. "long_stock is not a swing structure in this product") or the safety override ("short_strangle: undefined-risk short-vol, blocked by project policy").
 
-Output:
+## Earnings filter
 
-| Strategy | Fit | Reason |
-|---|---|---|
-| Long stock | Good / Bad / Conditional | |
-| Long call | | |
-| Call debit spread | | |
-| Put credit spread | | |
-| Covered call | | |
-| Iron condor | | |
-| Long put / put spread | | |
-| No trade | | |
+If tabs.positioning.next_earnings_date falls between today and the chosen expiry, choose ONE:
+- (a) Reject the candidate as `event_risk_in_window`, recommend `no_trade` or a watchlist entry triggering post-earnings. (Default.)
+- (b) Accept ONLY if the trade is explicitly an earnings IV-crush play AND term structure shows clear front-expiry crush opportunity. Tag risk_flags_observed with ["earnings_in_window", "event_iv_crush_thesis"] and justify in headline.subtitle.
 
-## 9. Final Trading Plan
+Rating ladder (single letter in headline.conviction; one-clause label in headline.conviction_label):
+- A: Actionable, high conviction (3 of 4 pillars aligned, no missing primary evidence)
+- B: Actionable, small size (pillars aligned with one medium conflict, or one primary field missing)
+- C: Watchlist (trigger not yet fired, primary thesis present but unconfirmed)
+- D: No trade (pillars conflict at this horizon and no clean winner)
+- F: Data insufficient (>=2 primary fields missing)
 
-End with a direct, practical summary:
+Confidence (headline.score, 0-100 integer; headline.score_scale = 100):
+- 85-100: 4 of 4 pillars (market structure, volatility, flow, positioning) aligned, no missing primary fields. Conviction A territory.
+- 70-84:  3 of 4 pillars aligned with one medium conflict, or 4 aligned with one primary field missing. Conviction A/B.
+- 55-69:  2 of 4 pillars aligned with the dominant pillar winning clearly. Conviction B/C.
+- 40-54:  Pillars conflict but a winner can still be named for the 1-2 week horizon. Conviction C.
+- 20-39:  No clean winner, or 2+ primary fields missing. Conviction D.
+- 0-19:   Data insufficient — primary evidence absent. Conviction F.
+Set headline.score honestly against this rubric. Do NOT default to 0; if you can name a dominant pillar and a structure, you can score at least 40.
 
-- Base case:
-- Best trade:
-- Avoid:
-- Add risk only if:
-- Reduce / hedge if:
-- Key level to watch:
-- Key options signal to watch:
-- Final rating:
-
-The final rating must be one of:
-
-- A: Actionable high-conviction
-- B: Actionable but size small
-- C: Watchlist only
-- D: No trade
-- F: Data insufficient
-
-Do not end with vague commentary.
-Do not simply repeat the dashboard.
-Do not use generic phrases like “monitor closely” unless you specify what to monitor and what action follows."""
+Do not end with vague commentary. Do not repeat any table. Do not use the word "monitor" without a level and a session count."""
 
 _VOLATILE_HASH_KEYS = {
     "analysis_input_hash",
@@ -554,6 +315,41 @@ def _prune_chain_rows(
     return list(by_key.values())[:limit]
 
 
+def _prune_strike_exposures(
+    rows: list[dict[str, Any]],
+    *,
+    spot: Any,
+    expiry_limit: int = 4,
+    strikes_per_side: int = 10,
+) -> list[dict[str, Any]]:
+    """Cap vanna/charm per-strike rows: keep the front `expiry_limit` expiries
+    inside the swing window and, within each expiry, ±`strikes_per_side` around
+    spot. Order is preserved by (expiry, strike)."""
+    if not rows:
+        return []
+    by_expiry: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_expiry.setdefault(str(row.get("expiry")), []).append(row)
+    expiries = sorted(by_expiry.keys())[:expiry_limit]
+    if not expiries:
+        return []
+    spot_dec = _to_decimal_or_zero(spot) if spot is not None else None
+    pruned: list[dict[str, Any]] = []
+    for expiry in expiries:
+        rows_for_expiry = by_expiry[expiry]
+        if spot_dec is None:
+            kept = rows_for_expiry
+        else:
+            kept = sorted(
+                rows_for_expiry,
+                key=lambda row: abs(_to_decimal_or_zero(row.get("strike")) - spot_dec),
+            )[: strikes_per_side * 2]
+        pruned.extend(
+            sorted(kept, key=lambda row: _to_decimal_or_zero(row.get("strike")))
+        )
+    return pruned
+
+
 def _strip_volatile_for_hash(value: Any) -> Any:
     if isinstance(value, dict):
         return {
@@ -594,6 +390,38 @@ def build_trade_insights_ai_analysis_input(
         "spot"
     ) or volatility_series_payload.get("spot")
     missing_data: list[str] = []
+
+    dealer_regime = stock_report_payload.get("dealer_regime") or {}
+    exposures_summary = _sorted_front(
+        list(stock_report_payload.get("exposures_summary") or []),
+        6,
+    )
+    strike_exposures = _prune_strike_exposures(
+        list(stock_report_payload.get("strike_exposures") or []),
+        spot=spot,
+    )
+    if not dealer_regime:
+        missing_data.append("tabs.market_structure.dealer_regime is empty")
+    if not exposures_summary:
+        missing_data.append("tabs.market_structure.exposures_summary is empty")
+    # Compact mirror so the Volatility tab consumer can quote regime sub-bars
+    # without cross-tab path-walking that has historically caused validator
+    # rejections (source_path prefix does not exist...).
+    dealer_regime_header = (
+        {
+            "label": dealer_regime.get("label"),
+            "score": dealer_regime.get("score"),
+            "gamma_score": dealer_regime.get("gamma_score"),
+            "vanna_score": dealer_regime.get("vanna_score"),
+            "charm_score": dealer_regime.get("charm_score"),
+            "odte_net_gex": dealer_regime.get("odte_net_gex"),
+            "odte_share_pct": dealer_regime.get("odte_share_pct"),
+            "headline": dealer_regime.get("headline"),
+            "subtitle": dealer_regime.get("subtitle"),
+        }
+        if dealer_regime
+        else {}
+    )
 
     stock_history_rows = _sorted_recent(
         list((stock_history_payload.get("rows") or [])),
@@ -647,6 +475,16 @@ def build_trade_insights_ai_analysis_input(
                     list(stock_report_payload.get("max_pain_rows") or []),
                     12,
                 ),
+                # PR #61: dealer-regime summary (label, gamma/vanna/charm
+                # sub-scores, 0DTE GEX, headline narrative). Primary evidence
+                # at the 1-2 week swing horizon.
+                "dealer_regime": dealer_regime,
+                # PR #60: per-expiry vanna + charm derivations. Front 6
+                # expiries — caller filters to the swing window when reading.
+                "exposures_summary": exposures_summary,
+                # PR #60: per-strike call/put vanna+charm. Pruned to front 4
+                # expiries × ±10 strikes around spot.
+                "strike_exposures": strike_exposures,
                 "stock_history": {
                     **{
                         key: value
@@ -695,6 +533,9 @@ def build_trade_insights_ai_analysis_input(
                 )
                 or "",
                 "spot": volatility_series_payload.get("spot"),
+                # Mirror of dealer_regime so the Vol-regime panel consumer can
+                # cite Γ/V/C sub-bars and 0DTE share without crossing tabs.
+                "dealer_regime_header": dealer_regime_header,
             },
             "flow": {
                 "flow": stock_report_payload.get("flow") or {},
@@ -828,50 +669,67 @@ def build_trade_insights_ai_prompt(prompt_payload: dict[str, Any]) -> str:
         "Integration notes for this local JSON runner:\n"
         "Analyze only the supplied combined deterministic prompt payload below.\n"
         "Do not fetch outside data. Do not use tools. Do not invent unavailable fields.\n"
-        "Map the prompt placeholders from the JSON payload: ticker from ticker, as_of date "
-        "from tabs.trade_insights.as_of or analysis_produced_at, spot from underlying_price "
-        "or tabs.market_structure.market_structure.spot, market structure data from "
-        "tabs.market_structure, volatility data from tabs.volatility, and flow/positioning "
-        "data from tabs.flow and tabs.positioning.\n"
-        "For optional user context, use Missing / not provided unless the payload explicitly "
-        "contains that field.\n"
-        "Build the read from Market Structure, Volatility, Flow, and positioning before "
-        "discussing candidate expressions.\n"
+        "Payload key map: ticker <- ticker; as_of <- tabs.trade_insights.as_of or "
+        "analysis_produced_at; spot <- underlying_price or "
+        "tabs.market_structure.market_structure.spot; market structure <- "
+        "tabs.market_structure (primary keys: tabs.market_structure.dealer_regime, "
+        "tabs.market_structure.exposures_summary, tabs.market_structure.strike_exposures, "
+        "tabs.market_structure.market_structure_levels, tabs.market_structure.strike_gex_curve); "
+        "volatility <- tabs.volatility (including tabs.volatility.dealer_regime_header); "
+        "flow <- tabs.flow; positioning <- tabs.positioning.\n"
         "Use analysis_produced_at exactly as supplied; do not invent a different production time.\n"
-        f"schema_version must exactly equal {PROMPT_VERSION}.\n"
+        f"schema_version MUST be exactly the string {PROMPT_VERSION!r} (do not abbreviate or "
+        "reformat). This is also stamped as a JSON-schema const.\n"
+        "Source-path rule (HARD): every source_path in the outcome must resolve to a key path "
+        "that exists in the payload. Do not cite synthetic paths such as "
+        "tabs.x.y[-1].field or .header.iv unless that exact key exists. If a value is not "
+        "in the payload, leave the field out and add a 'Missing / not provided' note to "
+        "missing_data instead of inventing a path.\n"
         "Preserve every candidate status, every risk_flags array, and every deterministic "
         "max_loss/max_profit value exactly as supplied.\n"
+        "Horizon enforcement: every candidate_structures row whose preferred expiry has "
+        "DTE < 7 or DTE > 30 must be rejected as horizon_mismatch in rejected_ideas. The "
+        "deterministic candidate list is already filtered to the 7-30 DTE swing window by "
+        "the upstream assembler; if no swing-window candidates exist, set "
+        "preferred_expression to a no_trade strategy-family entry rather than recommending "
+        "an out-of-horizon candidate.\n"
         "Do not defer solely because a deterministic candidate status is needs_check; give "
-        "a research-only recommendation when the supplied evidence supports one, and put "
-        "remaining checks into the trigger, risk, watchlist, or readiness language.\n"
+        "a research-only recommendation when the swing-horizon evidence supports one and "
+        "put remaining checks into the trigger, risk, watchlist, or readiness language.\n"
         "Project safety override: do not recommend naked short options or undefined-risk "
-        "short-vol structures; if the prompt's strategy list includes one, reject it unless "
-        "it is converted to a defined-risk alternative such as an iron condor.\n"
-        "Avoid order placement, position sizing, personalized financial advice, and imperative "
-        "trade instructions.\n"
-        "Map the full report into the existing TradeInsightAiOutcome JSON fields: use headline "
-        "and dominant_read for Executive Decision, section_cards for the three pillar reads, "
-        "conflicts for cross-pillar conflict resolution, scenario_cards for the scenario map, "
-        "preferred_expression and best_expressions for the preferred trade/readiness, "
-        "required_checks for precise triggers or confirmations, rejected_ideas for strategy "
-        "selection rejects, and rendering.disclaimer/final text for research-only framing.\n"
-        "For preferred_expression, best_expressions, and rejected_ideas idea_id fields, use "
-        "a supplied candidate_structures idea_id when referencing a deterministic candidate. "
-        "When referencing a strategy family from Strategy Selection Logic in "
-        "preferred_expression or best_expressions, use only one canonical strategy id "
-        f"from {sorted(PREFERRED_STRATEGY_FAMILY_IDS)}. For strategy-family "
-        "preferred_expression or best_expressions entries, set status_observed to "
-        "strategy_review and risk_flags_observed to []. rejected_ideas may reference "
-        f"any canonical strategy id from {sorted(STRATEGY_FAMILY_IDS)}.\n"
-        f"Put only one final rating letter from {list(FINAL_RATING_VALUES)} in "
-        "headline.conviction; put the explanatory rating text in "
-        "headline.conviction_label.\n"
+        "short-vol structures. If the prompt's strategy list includes one, reject it unless "
+        "converted to a defined-risk alternative such as an iron condor.\n"
+        "Avoid order placement, position sizing in dollars, personalized financial advice, "
+        "and imperative trade instructions.\n"
+        "Outcome field mapping: headline + dominant_read <- Call section; section_cards <- "
+        "Why paragraph (one card per supporting pillar, max 3); conflicts <- Conflicts table "
+        "(cap 2); scenario_cards <- Scenarios table (exactly 3, probabilities sum to 100); "
+        "preferred_expression + best_expressions <- Call.preferred_structure / Expiry "
+        "Selection; required_checks <- Required Checks table (cap 2); rejected_ideas <- "
+        "Rejected Ideas table (min 3, max 5); rendering.disclaimer/final <- research-only "
+        "framing only.\n"
+        "idea_id rules (HARD): preferred_expression.idea_id, every best_expressions[].idea_id, "
+        "and every rejected_ideas[].idea_id MUST be either (a) the idea_id of a row in the "
+        "supplied candidate_structures array, or (b) a canonical strategy family id. Never "
+        "free text. For preferred_expression and best_expressions at this horizon, the "
+        f"strategy-family option is restricted to {sorted(SWING_STRATEGY_FAMILY_IDS)}. "
+        "rejected_ideas may reference any canonical strategy id from "
+        f"{sorted(STRATEGY_FAMILY_IDS)} so an out-of-horizon family can be explicitly rejected.\n"
+        "For strategy-family preferred_expression / best_expressions entries, set "
+        "status_observed to 'strategy_review' and risk_flags_observed to [].\n"
+        f"headline.conviction MUST be a single letter from {list(FINAL_RATING_VALUES)} "
+        "(rating ladder in the prompt above). headline.conviction_label holds the "
+        "one-clause explanation. headline.score is the swing-horizon confidence "
+        "percentage (integer 0-100, scored against the Confidence rubric in the prompt). "
+        "headline.score_scale must be 100. Do not leave score=0 unless data is genuinely "
+        "insufficient (Conviction F); a real dominant-pillar read scores at least 40.\n"
         "Set guardrails.no_executable_recommendations=true when recommendations remain "
-        "research-only, non-imperative, and not order-placement instructions; this field does "
-        "not prohibit research recommendations.\n"
-        "Keep the result compact enough for the AI Analysis card while preserving the "
-        "decision, conflict resolution, scenario map, preferred structure, and final rating "
-        "requested above.\n"
+        "research-only, non-imperative, and not order-placement instructions; this flag does "
+        "not prohibit research-only recommendations.\n"
+        "Keep the markdown output (rendering.markdown if emitted) under ~3 KB / ~400 words. "
+        "Do not repeat any table. Do not list more than 2 required_checks or more than 2 "
+        "conflicts. Do not emit a Strategy Selection 12-row grid — only rejected_ideas "
+        "(min 3, max 5).\n"
         "Emit only JSON conforming to the TradeInsightAiOutcome schema.\n\n"
         "Payload:\n"
         f"{payload_json}\n"
@@ -996,9 +854,15 @@ def _validate_source_path_item(
             "source_path is required unless the item is a missing-data note"
         )
     lowered = source_path.lower()
-    for unavailable in ("charm", "vanna", "short_interest"):
-        if unavailable in lowered and not _missing_data_mentions(outcome, unavailable):
-            raise ValueError(f"unavailable source field referenced: {source_path}")
+    # `vanna` and `charm` used to be unavailable in this product; PR #60 made
+    # them first-class fields via exposures_summary + strike_exposures. Allow
+    # references provided the path family resolves below. `short_interest` is
+    # still indirect — only the `short_data` block is forwarded — so it stays
+    # gated on a missing-data acknowledgement.
+    if "short_interest" in lowered and not _missing_data_mentions(
+        outcome, "short_interest"
+    ):
+        raise ValueError(f"unavailable source field referenced: {source_path}")
     canonical_source_path = _canonical_source_path(source_path, deterministic_payload)
     if canonical_source_path != source_path:
         item.source_path = canonical_source_path
@@ -1129,12 +993,20 @@ def validate_trade_insights_ai_outcome(
 def render_trade_insights_ai_markdown(outcome: TradeInsightAiOutcome) -> str:
     """Render compact Markdown from validated structured output."""
 
+    # `headline.score` is repurposed as a 0-100 confidence percentage. We
+    # render it as "Confidence: N/100", and suppress the line when the model
+    # left it blank (0/0) — drives the cosmetic v3 follow-up.
+    confidence_line: list[str] = []
+    if outcome.headline.score or outcome.headline.score_scale:
+        confidence_line.append(
+            f"Confidence: {outcome.headline.score}/{outcome.headline.score_scale}"
+        )
     lines: list[str] = [
         f"# {outcome.ticker} - {outcome.headline.stance_label}",
         outcome.headline.title,
         "",
         f"Produced: {_iso_z(outcome.analysis_produced_at)}",
-        f"Score: {outcome.headline.score}/{outcome.headline.score_scale}",
+        *confidence_line,
         f"Conviction: {outcome.headline.conviction} - {outcome.headline.conviction_label}",
         f"Top reason: {outcome.headline.top_reason}",
         f"Primary risk: {outcome.headline.primary_risk}",
@@ -1199,7 +1071,11 @@ def render_trade_insights_ai_markdown(outcome: TradeInsightAiOutcome) -> str:
         lines.extend(["", "## Required Checks"])
         for item in outcome.required_checks:
             blocker = "blocks sizing" if item.blocks_sizing else "informational"
-            lines.append(f"- {item.check}: {item.reason} ({blocker})")
+            # Strip trailing period from `check` so the title — reason join
+            # doesn't render as "...fires.: Liquidity must support..." (the
+            # model frequently terminates the check phrase with punctuation).
+            check_text = item.check.rstrip(". ").rstrip()
+            lines.append(f"- {check_text} — {item.reason} ({blocker})")
 
     if outcome.rejected_ideas:
         lines.extend(["", "## Rejected Ideas"])

--- a/src/uw_scan/worker/jobs/trade_insights_ai.py
+++ b/src/uw_scan/worker/jobs/trade_insights_ai.py
@@ -28,6 +28,38 @@ class TradeInsightsAiRunnerError(RuntimeError):
     """Controlled failure from the local Codex CLI runner."""
 
 
+def _format_codex_failure(
+    stderr: str | None,
+    stdout: str | None,
+    *,
+    tail_chars: int = 1500,
+) -> str:
+    """Format codex CLI stderr/stdout for the analysis row's error_message.
+
+    `codex exec --output-schema` echoes the entire prompt and schema to
+    stderr as a side effect. When codex fails, the human-readable cause
+    (usage limit, auth, schema validation) lives at the END of the stream,
+    not the start — keeping the first N chars is exactly the worst slice.
+    This helper keeps the TAIL and lifts any `ERROR:` lines to the front so
+    quota/auth failures stay visible even if the tail is dominated by the
+    echoed prompt.
+    """
+    stderr_clean = (stderr or "").strip()
+    stdout_clean = (stdout or "").strip()
+    combined = "\n".join(p for p in (stderr_clean, stdout_clean) if p)
+    if not combined:
+        return "(no output)"
+    error_lines: dict[str, None] = {}
+    for ln in combined.splitlines():
+        stripped = ln.strip()
+        if stripped.startswith(("ERROR:", "error:", "Error:")):
+            error_lines.setdefault(stripped, None)
+    tail = combined[-tail_chars:] if len(combined) > tail_chars else combined
+    if error_lines:
+        return "[errors] " + " | ".join(error_lines.keys()) + " | [tail] " + tail
+    return tail
+
+
 def _codex_child_env() -> dict[str, str]:
     allowed_exact = {
         "CODEX_HOME",
@@ -102,9 +134,9 @@ def run_codex_trade_insights_analysis(
             ) from exc
 
         if completed.returncode != 0:
-            detail = (completed.stderr or completed.stdout or "").strip()
+            detail = _format_codex_failure(completed.stderr, completed.stdout)
             raise TradeInsightsAiRunnerError(
-                f"codex exec failed with exit {completed.returncode}: {detail[:1000]}"
+                f"codex exec failed with exit {completed.returncode}: {detail}"
             )
         if not result_path.exists():
             raise TradeInsightsAiRunnerError("codex exec did not write a final message")

--- a/tests/integration/test_trade_insights_pipeline_persistence.py
+++ b/tests/integration/test_trade_insights_pipeline_persistence.py
@@ -9,13 +9,15 @@ from uw_scan.models import (
     OptionContractRow,
     SingleStockReport,
     TermStructureRow,
-    VRPAssessment,
     VolatilityProfile,
+    VRPAssessment,
 )
 from uw_scan.pipeline import _persist_trade_insights_for_run
 
 
-def _contract(symbol: str, bid: str, ask: str, volume: int, oi: int) -> OptionContractRow:
+def _contract(
+    symbol: str, bid: str, ask: str, volume: int, oi: int
+) -> OptionContractRow:
     return OptionContractRow(
         option_symbol=symbol,
         last_price=Decimal(bid),
@@ -34,16 +36,19 @@ def _contract(symbol: str, bid: str, ask: str, volume: int, oi: int) -> OptionCo
 def test_trade_insights_pipeline_persistence_is_idempotent(seeded_db_empty_cards):
     repo = seeded_db_empty_cards
     run_id = repo.insert_scan_run("TSLA")
+    # Expiries inside the swing-HOLD entry window (21-60 DTE from 2026-05-13):
+    #   2026-06-19 -> DTE 37 (preferred 28-45 band)
+    #   2026-06-26 -> DTE 44 (preferred 28-45 band)
     repo.insert_option_contract_rows(
         run_id,
         "TSLA",
         [
-            _contract("TSLA260515P00420000", "6.10", "6.30", 450, 500),
-            _contract("TSLA260515P00425000", "8.00", "8.20", 600, 700),
-            _contract("TSLA260515P00430000", "10.20", "10.50", 900, 850),
-            _contract("TSLA260515C00430000", "9.40", "9.60", 1500, 1000),
-            _contract("TSLA260515C00435000", "6.90", "7.10", 1200, 800),
-            _contract("TSLA260522C00430000", "13.80", "14.20", 700, 900),
+            _contract("TSLA260619P00420000", "6.10", "6.30", 450, 500),
+            _contract("TSLA260619P00425000", "8.00", "8.20", 600, 700),
+            _contract("TSLA260619P00430000", "10.20", "10.50", 900, 850),
+            _contract("TSLA260619C00430000", "9.40", "9.60", 1500, 1000),
+            _contract("TSLA260619C00435000", "6.90", "7.10", 1200, 800),
+            _contract("TSLA260626C00430000", "13.80", "14.20", 700, 900),
         ],
     )
     repo.insert_iv_term_rows(
@@ -52,15 +57,15 @@ def test_trade_insights_pipeline_persistence_is_idempotent(seeded_db_empty_cards
             TermStructureRow(
                 ticker="TSLA",
                 date=date(2026, 5, 13),
-                expiry=date(2026, 5, 15),
-                dte=4,
+                expiry=date(2026, 6, 19),
+                dte=37,
                 implied_move_perc=Decimal("0.048"),
             ),
             TermStructureRow(
                 ticker="TSLA",
                 date=date(2026, 5, 13),
-                expiry=date(2026, 5, 22),
-                dte=11,
+                expiry=date(2026, 6, 26),
+                dte=44,
                 implied_move_perc=Decimal("0.067"),
             ),
         ],

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -115,32 +115,33 @@ def _contract(
 
 
 class FakeTradeInsightsRepo:
-    """Fixture spans two expiries inside the 7-30 DTE swing window so the
+    """Fixture spans the swing-HOLD entry window (21-60 DTE) so the
     deterministic candidate generator can build all 5 structures (verticals,
     iron condor, straddle, calendar). Dates relative to as_of=2026-05-13:
-    5/22 = 9 DTE (swing near), 6/05 = 23 DTE (swing back / calendar far)."""
+    6/12 = 30 DTE (swing sweet spot, rank 0), 7/24 = 72 DTE (outside swing
+    entry window but inside calendar far-leg max of 90 DTE)."""
 
     def fetch_option_contracts_rich(self, run_id: int, ticker: str):
         return [
-            # Swing near (9 DTE): full strike grid for verticals + condor + straddle
+            # Swing entry (30 DTE): full strike grid for verticals + condor + straddle
             _contract(
-                "TSLA260522P00420000", bid="6.10", ask="6.30", volume=450, oi=500
+                "TSLA260612P00420000", bid="6.10", ask="6.30", volume=450, oi=500
             ),
             _contract(
-                "TSLA260522P00425000", bid="8.00", ask="8.20", volume=600, oi=700
+                "TSLA260612P00425000", bid="8.00", ask="8.20", volume=600, oi=700
             ),
             _contract(
-                "TSLA260522P00430000", bid="10.20", ask="10.50", volume=900, oi=850
+                "TSLA260612P00430000", bid="10.20", ask="10.50", volume=900, oi=850
             ),
             _contract(
-                "TSLA260522C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000
+                "TSLA260612C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000
             ),
             _contract(
-                "TSLA260522C00435000", bid="6.90", ask="7.10", volume=1200, oi=800
+                "TSLA260612C00435000", bid="6.90", ask="7.10", volume=1200, oi=800
             ),
-            # Swing back (23 DTE): far leg for calendar at the ATM strike
+            # Calendar far leg (72 DTE): single ATM call for the calendar spread.
             _contract(
-                "TSLA260605C00430000",
+                "TSLA260724C00430000",
                 bid="13.80",
                 ask="14.20",
                 iv="0.48",
@@ -152,13 +153,13 @@ class FakeTradeInsightsRepo:
     def fetch_iv_term_rows(self, run_id: int, ticker: str):
         return [
             {
-                "expiry": date(2026, 5, 22),
-                "dte": 9,
+                "expiry": date(2026, 6, 12),
+                "dte": 30,
                 "implied_move_perc": Decimal("0.048"),
             },
             {
-                "expiry": date(2026, 6, 5),
-                "dte": 23,
+                "expiry": date(2026, 7, 24),
+                "dte": 72,
                 "implied_move_perc": Decimal("0.067"),
             },
         ]

--- a/tests/test_trade_insights.py
+++ b/tests/test_trade_insights.py
@@ -115,28 +115,52 @@ def _contract(
 
 
 class FakeTradeInsightsRepo:
+    """Fixture spans two expiries inside the 7-30 DTE swing window so the
+    deterministic candidate generator can build all 5 structures (verticals,
+    iron condor, straddle, calendar). Dates relative to as_of=2026-05-13:
+    5/22 = 9 DTE (swing near), 6/05 = 23 DTE (swing back / calendar far)."""
+
     def fetch_option_contracts_rich(self, run_id: int, ticker: str):
         return [
-            _contract("TSLA260515P00420000", bid="6.10", ask="6.30", volume=450, oi=500),
-            _contract("TSLA260515P00425000", bid="8.00", ask="8.20", volume=600, oi=700),
-            _contract("TSLA260515P00430000", bid="10.20", ask="10.50", volume=900, oi=850),
-            _contract("TSLA260515C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000),
-            _contract("TSLA260515C00435000", bid="6.90", ask="7.10", volume=1200, oi=800),
-            _contract("TSLA260522C00430000", bid="13.80", ask="14.20", iv="0.48", volume=700, oi=900),
+            # Swing near (9 DTE): full strike grid for verticals + condor + straddle
+            _contract(
+                "TSLA260522P00420000", bid="6.10", ask="6.30", volume=450, oi=500
+            ),
+            _contract(
+                "TSLA260522P00425000", bid="8.00", ask="8.20", volume=600, oi=700
+            ),
+            _contract(
+                "TSLA260522P00430000", bid="10.20", ask="10.50", volume=900, oi=850
+            ),
+            _contract(
+                "TSLA260522C00430000", bid="9.40", ask="9.60", volume=1500, oi=1000
+            ),
+            _contract(
+                "TSLA260522C00435000", bid="6.90", ask="7.10", volume=1200, oi=800
+            ),
+            # Swing back (23 DTE): far leg for calendar at the ATM strike
+            _contract(
+                "TSLA260605C00430000",
+                bid="13.80",
+                ask="14.20",
+                iv="0.48",
+                volume=700,
+                oi=900,
+            ),
         ]
 
     def fetch_iv_term_rows(self, run_id: int, ticker: str):
         return [
             {
-                "expiry": date(2026, 5, 15),
-                "dte": 4,
+                "expiry": date(2026, 5, 22),
+                "dte": 9,
                 "implied_move_perc": Decimal("0.048"),
             },
             {
-                "expiry": date(2026, 5, 22),
-                "dte": 11,
+                "expiry": date(2026, 6, 5),
+                "dte": 23,
                 "implied_move_perc": Decimal("0.067"),
-            }
+            },
         ]
 
     def fetch_source_reconciliation_rows(self, run_id: int, ticker: str):
@@ -174,12 +198,14 @@ def test_assemble_trade_insights_builds_research_response():
     assert response.synthesis.best_risk_reward_idea_id == "A"
     assert response.candidate_structures[0].status == "preferred"
     assert all(
-        c.status in {"preferred", "candidate"}
-        for c in response.candidate_structures
+        c.status in {"preferred", "candidate"} for c in response.candidate_structures
     )
     assert not any(c.status == "needs_check" for c in response.candidate_structures)
     assert "Executable recommendation language" not in response.synthesis.avoid
-    assert "Confirm event calendar through all expiries" in response.synthesis.required_before_sizing
+    assert (
+        "Confirm event calendar through all expiries"
+        in response.synthesis.required_before_sizing
+    )
 
 
 def test_iron_condor_max_loss_matches_width_minus_total_credit():
@@ -198,8 +224,12 @@ def test_iron_condor_max_loss_matches_width_minus_total_credit():
         spot=Decimal("428"),
     )
     ic = next(c for c in response.candidate_structures if c.structure == "iron_condor")
-    call_spread = next(c for c in response.candidate_structures if c.structure == "call_credit_spread")
-    put_spread = next(c for c in response.candidate_structures if c.structure == "put_credit_spread")
+    call_spread = next(
+        c for c in response.candidate_structures if c.structure == "call_credit_spread"
+    )
+    put_spread = next(
+        c for c in response.candidate_structures if c.structure == "put_credit_spread"
+    )
 
     expected_credit = (call_spread.net_credit_debit or Decimal("0")) + (
         put_spread.net_credit_debit or Decimal("0")

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -566,12 +566,13 @@ def test_trade_insights_ai_prompt_payload_and_prompt_are_recommendation_oriented
         "analysis_input_hash"
     ] == hash_trade_insights_ai_analysis_input(analysis_input)
     assert (
-        "You are an institutional options strategist analyzing one stock for a 1-2 week SWING entry."
+        "You are an institutional options strategist analyzing one stock for a 1-2 week SWING HOLD entry."
         in prompt
     )
-    # Swing horizon is hard-coded, not optional context.
+    # Swing-hold horizon is hard-coded, not optional context.
     assert "Time horizon (FIXED, not negotiable)" in prompt
-    assert "Preferred-trade expiry MUST be 10-21 DTE" in prompt
+    assert "The trade is HELD 5-10 trading sessions" in prompt
+    assert "Entry-expiry DTE MUST be 28-45 (preferred) or 21-60 (allowed)" in prompt
     assert "horizon_mismatch" in prompt
     # New PR #60 / #61 evidence is wired into the payload key map.
     assert "tabs.market_structure.dealer_regime" in prompt

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -566,35 +566,36 @@ def test_trade_insights_ai_prompt_payload_and_prompt_are_recommendation_oriented
         "analysis_input_hash"
     ] == hash_trade_insights_ai_analysis_input(analysis_input)
     assert (
-        "You are an institutional options strategist, market-structure analyst, and risk manager."
+        "You are an institutional options strategist analyzing one stock for a 1-2 week SWING entry."
         in prompt
     )
-    assert "Analyze only the supplied combined deterministic prompt payload" in prompt
-    assert "Do not fetch outside data" in prompt
-    assert "1. Market Structure" in prompt
-    assert "2. Volatility" in prompt
-    assert "3. Flow and Positioning" in prompt
-    assert (
-        "The objective is to produce a high-quality trading interpretation, not a dashboard summary."
-        in prompt
-    )
-    assert "Trade recommendations must include entry trigger" in prompt
+    # Swing horizon is hard-coded, not optional context.
+    assert "Time horizon (FIXED, not negotiable)" in prompt
+    assert "Preferred-trade expiry MUST be 10-21 DTE" in prompt
+    assert "horizon_mismatch" in prompt
+    # New PR #60 / #61 evidence is wired into the payload key map.
+    assert "tabs.market_structure.dealer_regime" in prompt
+    assert "tabs.market_structure.exposures_summary" in prompt
+    assert "tabs.market_structure.strike_exposures" in prompt
+    # 4-section report structure replaces the prior 9-section template.
+    assert "## Call" in prompt
+    assert "## Why" in prompt
+    assert "## Expiry Selection (mandatory)" in prompt
+    assert "## Scenarios (3 rows, probabilities sum to 100%)" in prompt
+    # No section_cards 1-9 grid, no needs_check deferral.
+    assert "## 5. Cross-Pillar Conflict Resolution" not in prompt
     assert (
         "Do not defer solely because a deterministic candidate status is needs_check"
         in prompt
     )
-    assert "All recommendations are research-only and not financial advice." in prompt
-    assert f"schema_version must exactly equal {PROMPT_VERSION}" in prompt
-    assert (
-        "Map the full report into the existing TradeInsightAiOutcome JSON fields"
-        in prompt
-    )
-    assert "does not prohibit research recommendations" in prompt
-    assert "# {{ticker}} Options Market Intelligence Report" in prompt
-    assert "## 5. Cross-Pillar Conflict Resolution" in prompt
-    assert "The final rating must be one of:" in prompt
-    assert "Preserve every candidate status" in prompt
-    assert "Treat all needs_check candidates as not executable" not in prompt
+    # Source-path discipline + schema_version are now appendix-level rules.
+    assert "Source-path rule (HARD)" in prompt
+    assert f"schema_version MUST be exactly the string {PROMPT_VERSION!r}" in prompt
+    # idea_id rule and SWING-restricted preferred_expression.
+    assert "idea_id rules (HARD)" in prompt
+    for swing_family in ("long_call", "call_debit_spread", "iron_condor", "no_trade"):
+        assert swing_family in prompt
+    # Output framing: still research-only, still bounded JSON.
     assert "Emit only JSON" in prompt
     assert '"tabs"' in prompt
 
@@ -757,13 +758,16 @@ def test_validate_trade_insights_ai_outcome_rejects_source_path_problems():
     deterministic = _analysis_input()
     produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
 
-    unavailable = _sample_outcome_for(deterministic)
-    unavailable["metric_cards"][0]["source_path"] = (
+    # `charm` / `vanna` paths are no longer unavailable since PR #60 forwarded
+    # exposures_summary + strike_exposures into the payload. A non-existent
+    # charm path now falls through to the generic prefix-existence check.
+    nonexistent_charm = _sample_outcome_for(deterministic)
+    nonexistent_charm["metric_cards"][0]["source_path"] = (
         "tabs.market_structure.charm_summary"
     )
-    with pytest.raises(ValueError, match="unavailable"):
+    with pytest.raises(ValueError, match="source_path"):
         validate_trade_insights_ai_outcome(
-            unavailable, deterministic, produced_at=produced_at
+            nonexistent_charm, deterministic, produced_at=produced_at
         )
 
     missing_source_path = _sample_outcome_for(deterministic)

--- a/tests/unit/worker/test_trade_insights_ai_runner.py
+++ b/tests/unit/worker/test_trade_insights_ai_runner.py
@@ -135,6 +135,74 @@ def test_codex_runner_nonzero_exit_raises_controlled_failure(monkeypatch):
         )
 
 
+def test_codex_runner_lifts_error_lines_to_front_of_failure_message(monkeypatch):
+    """Regression: when codex echoes a long prompt to stderr before dying, the
+    real `ERROR:` line lives at the END of the stream. The worker must surface
+    that line in the exception message so quota/auth failures show up in
+    `trade_insight_ai_analyses.error_message` instead of a noisy banner.
+    """
+    banner_and_echoed_prompt = (
+        "OpenAI Codex v0.132.0\n"
+        "--------\n"
+        "workdir: /tmp/x\nmodel: gpt-5.5\n"
+        + ("user\nYou are an institutional options strategist...\n" * 50)
+        + "\nERROR: You've hit your usage limit. Visit chatgpt.com/codex"
+    )
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr=banner_and_echoed_prompt
+        )
+
+    monkeypatch.setattr(
+        "uw_scan.worker.jobs.trade_insights_ai.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(TradeInsightsAiRunnerError) as exc_info:
+        run_codex_trade_insights_analysis(
+            "prompt",
+            {"type": "object"},
+            model="",
+            timeout_seconds=1,
+            max_output_bytes=1024,
+        )
+    message = str(exc_info.value)
+    assert "codex exec failed with exit 1" in message
+    # The lifted ERROR: prefix must appear before the [tail] section so the
+    # actionable cause is the first thing an operator reads.
+    assert "[errors]" in message
+    assert "You've hit your usage limit" in message
+    assert message.index("[errors]") < message.index("[tail]")
+
+
+def test_codex_runner_falls_back_to_tail_when_no_error_lines(monkeypatch):
+    """When stderr has no `ERROR:` lines (e.g. a generic non-zero exit),
+    fall back to the TAIL of the combined streams — never the head, which
+    is the boring banner/prompt echo."""
+    long_noise = "x" * 5000 + "\nfinal-cause-line"
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 7, stdout="", stderr=long_noise)
+
+    monkeypatch.setattr(
+        "uw_scan.worker.jobs.trade_insights_ai.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(TradeInsightsAiRunnerError) as exc_info:
+        run_codex_trade_insights_analysis(
+            "prompt",
+            {"type": "object"},
+            model="",
+            timeout_seconds=1,
+            max_output_bytes=1024,
+        )
+    message = str(exc_info.value)
+    assert "final-cause-line" in message  # tail kept, not head
+    assert message.count("x") < 4000  # the 5000-char banner head was dropped
+
+
 def test_codex_runner_oversized_output_raises_controlled_failure(monkeypatch):
     def fake_run(cmd, **kwargs):
         result_path = Path(cmd[cmd.index("--output-last-message") + 1])


### PR DESCRIPTION
## Summary

Trade Insights AI v4 prompt + payload contract + worker error-capture fix. Three commits on this branch:

1. **de8e4a1 — v3 (initial):** payload forwards `dealer_regime`, `exposures_summary`, `strike_exposures` from PR #60 / #61 into `tabs.market_structure`. Prompt rewritten as a 4-section directional template (Call / Why / Expiry Selection / Scenarios) restricted to defined-risk swing structures. Added Confidence 0-100 + 6-band rubric.

2. **108cd9b — v4 (load-bearing fix):** corrected a semantic mistake — v3 conflated **swing HOLD** with **swing EXPIRY**. For a 1-2 week hold, picking a 10-21 DTE expiry forces the exit at 0-7 DTE (peak gamma/theta crush). v4 entry-DTE window is 21-60 (preferred 28-45) so 7-46 DTE remains at exit.

3. **fb6ab98 — diagnostic fix:** when codex CLI fails, surface the real cause in `trade_insight_ai_analyses.error_message`. Diagnosed via NVDA failure where the old worker stored 1000 chars of codex banner + echoed prompt and clipped off the `ERROR: usage limit` line at the end.

## v3 → v4 comparison (real codex runs on TSLA)

| | v3 | v4 |
|---|---|---|
| Preferred expiry | 2026-06-05 | 2026-06-26 |
| Entry DTE | 14 | 35 |
| DTE remaining at exit (after 7-10d hold) | 0-7 (peak crush) | 21-28 (comfortable) |
| Structure | put_credit_spread | iron_condor |
| Conviction | C | C |
| Confidence | 58/100 | 54/100 |

## Diagnostic fix (commit 3)

The original worker captured `(stderr or stdout)[:1000]` — but codex `--output-schema` echoes the full prompt + banner to stderr, with the actual error appearing at the END. The HEAD slice is always the boring banner. New `_format_codex_failure` helper:

- combines stderr + stdout (codex writes diagnostics to both depending on failure mode);
- lifts any `ERROR:` / `error:` line to the front of the message;
- keeps the TAIL (last 1500 chars) instead of the head.

Verified against the NVDA quota failure — `error_message` now starts with `[errors] ERROR: You've hit your usage limit. ... try again at 6:18 PM. | [tail] ...` instead of `OpenAI Codex v0.132.0\n--------\nworkdir: ...\n user\n You are an institutional options strategist...`.

## Operational note

The version guard at `worker/jobs/trade_insights_ai.py:159` rejects rows tagged with a `prompt_version` other than the worker's loaded constant. APScheduler workers do not hot-reload module-level constants — **dev/prod operators must restart AI workers after this lands** or queued v4 rows will fail with `obsolete prompt_version v4 superseded by v3`.

## Verified end-to-end

- TSLA: POST `/api/stock/TSLA/trade-insights/ai-analysis` (force_rerun) → worker claimed → codex succeeded in 56s → row `e0be288e` has `prompt_version=v4`, `status=succeeded`, markdown picks 2026-06-26 at 35 DTE ✓
- NVDA: same path → codex failed in ~4s (account quota exhausted) → new diagnostic surfaces `ERROR: You've hit your usage limit` at the front of error_message ✓
- `/latest` returns the v4 row; web UI at `/stock/TSLA` reads it directly

## Known follow-ups (separate PRs)

1. `cards/exposures.py` emits `vanna_regime=procyclical` for every expiry; charm fields only populated for the 1-DTE front row. With v4's 21-60 DTE entry window, the model frequently sees "no rows with 21 <= dte <= 60" and downgrades conviction.
2. `cards/dealer_regime.py` clamps `vanna_score` / `charm_score` to ±1.0 and emits `odte_share_pct: 1.0` on TSLA.
3. `STRATEGY_FAMILY_IDS` has `put_credit_spread` but no `call_credit_spread` — asymmetric canonical list.
4. The worker still marks quota-exhausted rows as `failed`. Future enhancement could detect the quota class and reset to `queued` with `next_retry_at` so the rolling window self-heals.

## Test plan

- [x] `uv run pytest tests/test_trade_insights.py tests/test_trade_insights_ai.py tests/unit/worker/test_trade_insights_ai_runner.py` — 38 passed
- [x] End-to-end smoke test on TSLA via the worker path → DB → web UI
- [x] Verify `prompt_version=trade-insights-ai-v4` in the persisted row
- [x] Verify chosen DTE inside [21, 60]
- [x] Verify the diagnostic fix surfaces the real `ERROR:` line on a NVDA quota failure