### PR TITLE
Document product design and polish rates UI

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,150 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-24T00:00:00+08:00",
+  "title": "Design System: Unusual Whales Opportunity Scanner",
+  "extensions": {
+    "colorMeta": {
+      "base-void": {
+        "role": "neutral",
+        "displayName": "Base Void",
+        "canonical": "#0a0f14",
+        "tonalRamp": ["#05080b", "#0a0f14", "#0f1519", "#151c22", "#1e293b", "#475569", "#94a3b8", "#e2e8f0"]
+      },
+      "signal-teal": {
+        "role": "primary",
+        "displayName": "Signal Teal",
+        "canonical": "#05ad98",
+        "tonalRamp": ["#022b27", "#03564d", "#048a7a", "#05ad98", "#0fcfb5", "#5eead4", "#99f6e4", "#ccfbf1"]
+      },
+      "risk-red": {
+        "role": "secondary",
+        "displayName": "Risk Red",
+        "canonical": "#e85d6c",
+        "tonalRamp": ["#3f0b13", "#7a1827", "#b4233a", "#d4183d", "#e85d6c", "#f4a0aa", "#ffd4da", "#fff0f2"]
+      },
+      "warning-amber": {
+        "role": "secondary",
+        "displayName": "Warning Amber",
+        "canonical": "#f5a623",
+        "tonalRamp": ["#3a2302", "#6f4305", "#a76508", "#d4910a", "#f5a623", "#f8c15d", "#ffe1a3", "#fff3d7"]
+      },
+      "volatility-violet": {
+        "role": "tertiary",
+        "displayName": "Volatility Violet",
+        "canonical": "#8b5cf6",
+        "tonalRamp": ["#24104f", "#3b1c7a", "#5b2bbd", "#7c3aed", "#8b5cf6", "#a78bfa", "#ddd6fe", "#f3f0ff"]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Route Display",
+        "purpose": "Compact route headers and large data labels."
+      },
+      "body": {
+        "displayName": "Analytical Body",
+        "purpose": "Short explanatory reads and synthesis text."
+      },
+      "label": {
+        "displayName": "Data Label",
+        "purpose": "Chips, timestamps, metadata, and compact table headings."
+      }
+    },
+    "shadows": [
+      {
+        "name": "dialog-shadow",
+        "value": "0 24px 64px rgba(0, 0, 0, 0.44)",
+        "purpose": "Blocking dialogs and confirmations."
+      },
+      {
+        "name": "popover-shadow",
+        "value": "0 12px 30px rgba(0, 0, 0, 0.35)",
+        "purpose": "Tooltips and compact floating explanations."
+      }
+    ],
+    "motion": [
+      {
+        "name": "ease-out",
+        "value": "cubic-bezier(0.25, 1, 0.5, 1)",
+        "purpose": "Short state transitions for product controls."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "mobile-shell",
+        "value": "720px"
+      },
+      {
+        "name": "rates-collapse",
+        "value": "880px"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Default compact action used in dashboard and scanner toolbars.",
+      "html": "<button class=\"ds-btn-secondary\">Scan all</button>",
+      "css": ".ds-btn-secondary { padding: 4px 10px; font-family: IBM Plex Mono, monospace; font-size: 11px; background: transparent; color: #94a3b8; border: 1px solid #1e293b; border-radius: 3px; } .ds-btn-secondary:hover { color: #e2e8f0; border-color: #05ad98; } .ds-btn-secondary:focus-visible { outline: 2px solid #e2e8f0; outline-offset: 2px; }"
+    },
+    {
+      "name": "Active Chip",
+      "kind": "chip",
+      "refersTo": "chip-active",
+      "description": "Selected filter state.",
+      "html": "<button class=\"ds-chip-active\">C-BULL</button>",
+      "css": ".ds-chip-active { padding: 4px 10px; font-family: IBM Plex Mono, monospace; font-size: 11px; background: #05ad98; color: #0a0f14; border: 1px solid #05ad98; border-radius: 3px; } .ds-chip-active:focus-visible { outline: 2px solid #e2e8f0; outline-offset: 2px; }"
+    },
+    {
+      "name": "Data Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Dense bordered product surface for metrics and analytical blocks.",
+      "html": "<article class=\"ds-card\"><span>IVR</span><strong>42</strong><small>updated 09:32</small></article>",
+      "css": ".ds-card { padding: 12px; background: #0f1519; color: #e2e8f0; border: 1px solid #1e293b; border-radius: 4px; font-family: IBM Plex Mono, monospace; } .ds-card span, .ds-card small { display: block; color: #475569; font-size: 11px; text-transform: uppercase; } .ds-card strong { display: block; margin: 7px 0; font-size: 24px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Desk Tape",
+    "overview": "This product should feel like a live trading desk condensed into software: quiet, dark, compact, source-aware, and precise. It is not trying to impress with decoration. It earns trust by making dense data scannable and by keeping the same component vocabulary across watchlist cards, scanner candidates, stock detail panels, macro views, and admin controls.",
+    "keyCharacteristics": [
+      "Dark operational surfaces with restrained teal as the primary action and current-state accent.",
+      "Mono-heavy labels and data blocks, with Inter available for longer explanatory copy.",
+      "Compact cards and tables using 4px corners, 1px borders, and narrow gaps.",
+      "Semantic colors tied to market meaning, not decoration."
+    ],
+    "rules": [
+      {
+        "name": "The Meaning-First Color Rule",
+        "body": "Do not introduce color unless it communicates state, category, selection, freshness, or chart series identity.",
+        "section": "colors"
+      },
+      {
+        "name": "The Data Label Rule",
+        "body": "Labels, timestamps, IDs, and metric captions use IBM Plex Mono. Longer human-readable reads may use Inter.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat-At-Rest Rule",
+        "body": "Cards, tables, route sections, and charts do not use shadows at rest.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do keep route surfaces on `--bg-base`, `--bg-panel`, and `--bg-panel-raised`.",
+      "Do use 4px card corners and 1px borders for most product panels.",
+      "Do reserve teal, red, amber, violet, and magenta for semantic state or chart identity.",
+      "Do use mono labels for compact data and timestamps.",
+      "Do keep layouts dense, predictable, and source-aware."
+    ],
+    "donts": [
+      "Don't add marketing-page hero composition to product routes.",
+      "Don't use decorative gradients, glassmorphism, or large ambient blur.",
+      "Don't introduce navy-and-gold fintech styling.",
+      "Don't use side-stripe borders as card accents.",
+      "Don't use gradient text.",
+      "Don't change the palette per route unless the data role requires it."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,221 @@
+---
+name: Unusual Whales Opportunity Scanner
+description: Dense options and macro research cockpit for watchlist triage.
+colors:
+  base-void: "#0a0f14"
+  panel-ink: "#0f1519"
+  raised-ink: "#151c22"
+  border-slate: "#1e293b"
+  text-primary: "#e2e8f0"
+  text-secondary: "#94a3b8"
+  text-muted: "#475569"
+  signal-teal: "#05ad98"
+  signal-teal-strong: "#0fcfb5"
+  signal-teal-deep: "#048a7a"
+  risk-red: "#e85d6c"
+  warning-amber: "#f5a623"
+  volatility-violet: "#8b5cf6"
+  dislocation-magenta: "#d946a8"
+typography:
+  display:
+    fontFamily: "IBM Plex Mono, monospace"
+    fontSize: "24px"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "1px"
+  headline:
+    fontFamily: "Inter, -apple-system, sans-serif"
+    fontSize: "22px"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "0"
+  title:
+    fontFamily: "IBM Plex Mono, monospace"
+    fontSize: "13px"
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: "0.08em"
+  body:
+    fontFamily: "Inter, -apple-system, sans-serif"
+    fontSize: "13px"
+    fontWeight: 500
+    lineHeight: 1.5
+    letterSpacing: "0"
+  label:
+    fontFamily: "IBM Plex Mono, monospace"
+    fontSize: "11px"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "1px"
+rounded:
+  xs: "2px"
+  sm: "3px"
+  md: "4px"
+  lg: "8px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+components:
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.text-secondary}"
+    rounded: "{rounded.sm}"
+    padding: "4px 10px"
+  button-primary:
+    backgroundColor: "{colors.signal-teal}"
+    textColor: "{colors.base-void}"
+    rounded: "{rounded.sm}"
+    padding: "4px 10px"
+  card:
+    backgroundColor: "{colors.panel-ink}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.md}"
+    padding: "12px"
+  chip-active:
+    backgroundColor: "{colors.signal-teal}"
+    textColor: "{colors.base-void}"
+    rounded: "{rounded.sm}"
+    padding: "4px 10px"
+---
+
+# Design System: Unusual Whales Opportunity Scanner
+
+## 1. Overview
+
+**Creative North Star: "The Desk Tape"**
+
+This product should feel like a live trading desk condensed into software: quiet, dark, compact, source-aware, and precise. It is not trying to impress with decoration. It earns trust by making dense data scannable and by keeping the same component vocabulary across watchlist cards, scanner candidates, stock detail panels, macro views, and admin controls.
+
+The visual system is flat by default. Depth comes from tonal layers, 1px borders, and compact spacing. Semantic color is reserved for state and meaning: positive flow, negative/risk, warning, volatility, dislocation, and muted neutral evidence.
+
+**Key Characteristics:**
+
+- Dark operational surfaces with restrained teal as the primary action and current-state accent.
+- Mono-heavy labels and data blocks, with Inter available for longer explanatory copy.
+- Compact cards and tables using 4px corners, 1px borders, and narrow gaps.
+- Semantic colors tied to market meaning, not decoration.
+
+## 2. Colors
+
+The palette is a dark, tinted neutral system with one primary teal accent and a small set of market-state colors.
+
+### Primary
+
+- **Signal Teal** (#05ad98): Primary actions, active chips, current/live indicators, constructive or positive state.
+- **Signal Teal Strong** (#0fcfb5): High-emphasis teal for charts or stronger live-state emphasis.
+- **Signal Teal Deep** (#048a7a): Light-theme positive state and lower-luminance teal variants.
+
+### Secondary
+
+- **Risk Red** (#e85d6c): Bearish, negative, stale, fault, and risk states.
+- **Warning Amber** (#f5a623): Caution, queue/running, mixed reads, and attention states.
+- **Volatility Violet** (#8b5cf6): Volatility-specific accents and comparison series.
+- **Dislocation Magenta** (#d946a8): Dislocation or extreme condition accents.
+
+### Neutral
+
+- **Base Void** (#0a0f14): Main dark background.
+- **Panel Ink** (#0f1519): Primary panel and card surface.
+- **Raised Ink** (#151c22): Hover, raised panel, and secondary surface.
+- **Border Slate** (#1e293b): Hairline borders, dividers, chart axes, and structural separation.
+- **Primary Text** (#e2e8f0): Main values and headings.
+- **Secondary Text** (#94a3b8): Supporting data and descriptions.
+- **Muted Text** (#475569): Timestamps, small labels, inactive nav, and disabled details.
+
+### Named Rules
+
+**The Meaning-First Color Rule.** Do not introduce color unless it communicates state, category, selection, freshness, or chart series identity.
+
+## 3. Typography
+
+**Display Font:** IBM Plex Mono, with monospace fallback  
+**Body Font:** Inter, with system sans fallback  
+**Label/Mono Font:** IBM Plex Mono
+
+**Character:** The product reads like a terminal-native research cockpit, but with enough Inter in explanatory copy to keep dense pages legible.
+
+### Hierarchy
+
+- **Display** (700, 24px, 1.1): Route headers such as DASHBOARD, SCANNER, and dense page titles.
+- **Headline** (700, 22px, 1.2): Section headings and larger analytical panel titles.
+- **Title** (700, 13px, 1.25): Card headers, table section labels, and compact panel titles.
+- **Body** (500, 13px, 1.5): Explanatory readouts, tooltips, and synthesis text. Keep prose around 65-75ch when possible.
+- **Label** (700, 11px, uppercase, 1px tracking): Chips, table headers, metadata, status pills, and metric labels.
+
+### Named Rules
+
+**The Data Label Rule.** Labels, timestamps, IDs, and metric captions use IBM Plex Mono. Longer human-readable reads may use Inter.
+
+## 4. Elevation
+
+The system is flat by default and uses tonal layering instead of shadows. Panels separate through `--bg-base`, `--bg-panel`, `--bg-panel-raised`, and 1px `--border-dim` strokes. Shadows are reserved for dialogs and popovers where overlay separation is necessary.
+
+### Shadow Vocabulary
+
+- **Dialog Shadow** (`0 24px 64px rgba(0, 0, 0, 0.44)`): Blocking dialogs and confirmation surfaces.
+- **Popover Shadow** (`0 12px 30px rgba(0, 0, 0, 0.35)`): Tooltips and small floating explanatory panels.
+
+### Named Rules
+
+**The Flat-At-Rest Rule.** Cards, tables, route sections, and charts do not use shadows at rest.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** Tight rectangular controls with 3px radius.
+- **Primary:** Signal Teal background with Base Void text, compact 4px by 10px padding.
+- **Hover / Focus:** Use existing focus-visible outline and border shifts. Keep motion short and state-driven.
+- **Secondary / Ghost:** Transparent background, Border Slate stroke, Secondary Text label.
+
+### Chips
+
+- **Style:** 3px radius, mono 11px label, compact horizontal padding.
+- **State:** Active chips use Signal Teal fill with Base Void text. Inactive chips are transparent with Border Slate and Secondary Text.
+
+### Cards / Containers
+
+- **Corner Style:** 4px for most product surfaces, 8px only for large route sections or charts that need extra breathing room.
+- **Background:** Panel Ink for cards, Raised Ink for hover or secondary panels, Base Void for nested chart/table wells.
+- **Shadow Strategy:** No shadows at rest.
+- **Border:** Always 1px Border Slate or the themed `--border-dim`.
+- **Internal Padding:** 12px for dense cards, 16-24px for larger analytical sections.
+
+### Inputs / Fields
+
+- **Style:** Base Void background, Border Slate stroke, 4px radius, Primary Text value.
+- **Focus:** Use a 2px focus-visible outline or Border Focus shift.
+- **Error / Disabled:** Use Risk Red for errors, Muted Text for disabled, and avoid saturated fills on inactive controls.
+
+### Navigation
+
+- **Style:** Sidebar and route tabs are mono, compact, and restrained. Active state uses a clear border or filled chip, not decorative color blocks.
+- **Mobile Treatment:** Collapse horizontal navigation into scrollable rows. Preserve stable hit targets and avoid layout shifts.
+
+### Data Tables
+
+- **Style:** Mono numeric data, 1px dividers, right-aligned numeric columns, left-aligned labels.
+- **Density:** Dense is correct. Add whitespace only where it improves scan order.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** keep route surfaces on `--bg-base`, `--bg-panel`, and `--bg-panel-raised`.
+- **Do** use 4px card corners and 1px borders for most product panels.
+- **Do** reserve teal, red, amber, violet, and magenta for semantic state or chart identity.
+- **Do** use mono labels for compact data and timestamps.
+- **Do** keep layouts dense, predictable, and source-aware.
+
+### Don't:
+
+- **Don't** add marketing-page hero composition to product routes.
+- **Don't** use decorative gradients, glassmorphism, or large ambient blur.
+- **Don't** introduce navy-and-gold fintech styling.
+- **Don't** use side-stripe borders as card accents.
+- **Don't** use gradient text.
+- **Don't** change the palette per route unless the data role requires it.
+

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,38 @@
+---
+register: product
+name: Unusual Whales Opportunity Scanner
+---
+
+# Product Context
+
+Unusual Whales Opportunity Scanner is a task-focused trading research cockpit for watchlist-driven options analytics. It turns provider data, persisted scans, dealer positioning, volatility surfaces, macro regime signals, gold posture, index cockpit data, and rates context into dense pages that help an experienced operator decide what deserves attention.
+
+## Users
+
+The primary user is an options-oriented trader or researcher who already understands flow, gamma, implied volatility, macro rates, and market structure. They are not being onboarded into basic concepts; they need compact evidence, source freshness, and enough raw context to trust or reject a setup quickly.
+
+## Product Purpose
+
+The product exists to compress noisy market data into a disciplined triage workflow:
+
+- Find candidates across the watchlist and discovered flow.
+- Open the single-name page for the why behind a candidate.
+- Cross-check market-wide regime, gold, index dealer state, and rates before acting.
+- Preserve analytical outputs in Postgres so the UI is a review surface, not a transient calculation scratchpad.
+
+## Voice
+
+The interface should feel like a live desk tool: terse, numeric, source-aware, and skeptical. Labels can be compact and technical. Copy should explain state or consequence, not market basics.
+
+## Visual Direction
+
+Design serves the task. The app uses a restrained dark operating-room palette, mono-heavy labels, flat bordered surfaces, compact grids, and semantic color only where it carries trading meaning. The screen should feel operational and consistent across Dashboard, Scanner, Stock, Gold, Cockpit, Regime, Admin, and Rates.
+
+## Anti-References
+
+- Do not make the app feel like a marketing landing page.
+- Do not add decorative gradients, oversized hero treatments, or glass panels.
+- Do not introduce glossy fintech navy-and-gold styling.
+- Do not invent new palettes for individual routes unless a data role requires it.
+- Do not make cards feel soft or consumer-app rounded.
+

--- a/web/app/rates/error.tsx
+++ b/web/app/rates/error.tsx
@@ -6,13 +6,22 @@ export default function Error({ error }: { error: Error }) {
       style={{
         minHeight: "100vh",
         padding: 32,
-        background: "#f4f3fd",
-        color: "#3b3852",
+        background: "var(--bg-base)",
+        color: "var(--text-primary)",
         fontFamily: "var(--font-sans)",
       }}
     >
-      <h1 style={{ margin: 0, fontSize: 24 }}>Rates desk unavailable</h1>
-      <p style={{ maxWidth: 760 }}>
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-mono)",
+          fontSize: 24,
+          letterSpacing: 1,
+        }}
+      >
+        RATES DESK UNAVAILABLE
+      </h1>
+      <p style={{ maxWidth: 760, color: "var(--text-secondary)" }}>
         The rates API returned an error instead of a persisted snapshot.
       </p>
       <pre
@@ -20,10 +29,11 @@ export default function Error({ error }: { error: Error }) {
           maxWidth: 960,
           overflowX: "auto",
           padding: 16,
-          background: "#ffffff",
-          border: "1px solid #dedbec",
-          borderRadius: 8,
-          color: "#8f2e3c",
+          background: "var(--bg-panel)",
+          border: "1px solid var(--border-dim)",
+          borderRadius: 4,
+          color: "var(--negative)",
+          fontFamily: "var(--font-mono)",
         }}
       >
         {error.message}

--- a/web/app/rates/loading.tsx
+++ b/web/app/rates/loading.tsx
@@ -4,8 +4,8 @@ export default function Loading() {
       style={{
         minHeight: "100vh",
         padding: 32,
-        background: "#f4f3fd",
-        color: "#3b3852",
+        background: "var(--bg-base)",
+        color: "var(--text-muted)",
         fontFamily: "var(--font-mono)",
         fontSize: 12,
         textTransform: "uppercase",

--- a/web/components/rates/RatesDesk.module.css
+++ b/web/components/rates/RatesDesk.module.css
@@ -16,8 +16,7 @@
   padding: 16px 0 12px;
   margin: 0 auto 18px;
   max-width: 1440px;
-  background: rgba(10, 15, 20, 0.88);
-  backdrop-filter: blur(14px);
+  background: var(--bg-base);
   border-bottom: 1px solid var(--border-dim);
 }
 
@@ -45,13 +44,14 @@
 }
 
 .header h1 {
+  font-family: var(--font-mono), "IBM Plex Mono", monospace;
   font-size: 26px;
   line-height: 1.1;
   white-space: nowrap;
 }
 
 .header h1 span {
-  color: var(--negative);
+  color: var(--positive);
 }
 
 .titleLockup p,
@@ -119,10 +119,14 @@
   font-size: 13px;
   font-weight: 700;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: 3px;
   background: transparent;
   padding: 10px 12px;
   white-space: nowrap;
+  transition:
+    border-color 160ms var(--ease-out),
+    color 160ms var(--ease-out),
+    background 160ms var(--ease-out);
 }
 
 .nav a:hover,
@@ -133,9 +137,9 @@
 }
 
 .navActive {
-  background: var(--text-primary);
-  border-color: var(--text-primary);
-  color: var(--bg-base);
+  background: var(--accent-bg);
+  border-color: var(--accent-bg);
+  color: var(--accent-text);
 }
 
 .section {
@@ -144,7 +148,7 @@
   padding: 20px;
   background: var(--bg-panel);
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   scroll-margin-top: 104px;
 }
 
@@ -166,8 +170,9 @@
   align-items: center;
   min-height: 26px;
   padding: 0 10px;
-  border-radius: 999px;
-  background: rgba(5, 173, 152, 0.12);
+  border: 1px solid rgba(5, 173, 152, 0.32);
+  border-radius: 3px;
+  background: rgba(5, 173, 152, 0.08);
   color: var(--positive);
   font-size: 11px;
   text-transform: uppercase;
@@ -183,9 +188,9 @@
 
 .kpiTile {
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 14px;
-  background: var(--bg-panel-raised);
+  background: var(--bg-panel);
 }
 
 .kpiTile span,
@@ -217,15 +222,12 @@
 
 .stanceCard {
   --stance-accent: var(--text-muted);
-  --stance-tint: rgba(74, 92, 113, 0.16);
   position: relative;
   min-height: 150px;
   overflow: hidden;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background:
-    linear-gradient(135deg, var(--stance-tint), transparent 58%),
-    var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   padding: 18px;
 }
 
@@ -238,7 +240,7 @@
   font-size: 42px;
   font-weight: 800;
   line-height: 1;
-  opacity: 0.16;
+  opacity: 0.08;
   pointer-events: none;
   user-select: none;
 }
@@ -269,17 +271,14 @@
 
 .stancePositive {
   --stance-accent: var(--positive);
-  --stance-tint: rgba(5, 173, 152, 0.14);
 }
 
 .stanceNegative {
   --stance-accent: var(--negative);
-  --stance-tint: rgba(255, 91, 113, 0.14);
 }
 
 .stanceNeutral {
   --stance-accent: var(--text-secondary);
-  --stance-tint: rgba(74, 92, 113, 0.14);
 }
 
 .curveGrid {
@@ -293,9 +292,9 @@
 .tableWrap {
   min-width: 0;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   overflow: hidden;
-  background: var(--bg-panel-raised);
+  background: var(--bg-panel);
 }
 
 .chartPanel {
@@ -336,7 +335,7 @@
 .chartLegend i {
   width: 22px;
   height: 3px;
-  border-radius: 999px;
+  border-radius: 2px;
 }
 
 .chartPanel svg {
@@ -420,8 +419,8 @@
 .synthesis,
 .sourceRow {
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   padding: 12px;
 }
 
@@ -463,8 +462,8 @@
 .decompSources {
   min-width: 0;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   padding: 18px;
 }
 
@@ -529,22 +528,18 @@
   min-width: 0;
   min-height: 124px;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--bg-base);
   padding: 9px;
   align-items: start;
 }
 
 .decompTilePrimary {
-  background:
-    linear-gradient(135deg, rgba(255, 91, 113, 0.12), transparent 62%),
-    var(--bg-base);
+  border-color: rgba(232, 93, 108, 0.38);
 }
 
 .decompTileAccent {
-  background:
-    linear-gradient(135deg, rgba(5, 173, 152, 0.12), transparent 62%),
-    var(--bg-base);
+  border-color: rgba(5, 173, 152, 0.38);
 }
 
 .decompTile span,
@@ -603,7 +598,7 @@
 .ratesReadGrid article {
   min-width: 0;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--bg-base);
   padding: 14px;
 }
@@ -736,7 +731,7 @@
   display: block;
   height: 10px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: 2px;
   background: var(--bg-base);
 }
 
@@ -770,7 +765,7 @@
 .decompSourceGrid article {
   min-height: 128px;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--bg-base);
   padding: 16px;
 }
@@ -808,12 +803,8 @@
   flex-direction: column;
   gap: 12px;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: linear-gradient(
-    180deg,
-    rgba(5, 173, 152, 0.16),
-    var(--bg-panel-raised)
-  );
+  border-radius: 4px;
+  background: var(--bg-panel);
   color: var(--text-primary);
   padding: 18px;
 }
@@ -831,8 +822,8 @@
 
 .scoreGroup {
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   overflow: hidden;
 }
 
@@ -869,7 +860,7 @@
   width: 68px;
   padding: 7px 8px;
   border: 1px solid var(--border-dim);
-  border-radius: 6px;
+  border-radius: 4px;
   background: var(--bg-base);
   color: var(--text-primary);
 }
@@ -921,8 +912,8 @@
   min-height: 360px;
   flex-direction: column;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   padding: 18px;
 }
 
@@ -1007,7 +998,7 @@
   gap: 6px;
   min-width: 0;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--bg-base);
   padding: 11px 6px;
   text-align: center;
@@ -1032,7 +1023,7 @@
   display: block;
   height: 5px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: 2px;
   background: var(--bg-hover);
 }
 
@@ -1048,7 +1039,7 @@
   min-height: 130px;
   place-items: center;
   border: 1px dashed var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   color: var(--text-muted);
   font-size: 12px;
   font-weight: 800;
@@ -1076,15 +1067,15 @@
   gap: 14px;
   min-width: 0;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
-  background: var(--bg-panel-raised);
+  border-radius: 4px;
+  background: var(--bg-panel);
   padding: 18px;
 }
 
 .supplyTableWrap {
   overflow-x: auto;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
 }
 
 .supplyTable {
@@ -1166,7 +1157,7 @@
 .positioningTableWrap {
   overflow-x: auto;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
 }
 
 .positioningTable {
@@ -1260,7 +1251,7 @@
   margin: 16vh auto 0;
   padding: 28px;
   border: 1px solid var(--border-dim);
-  border-radius: 8px;
+  border-radius: 4px;
   background: var(--bg-panel);
 }
 

--- a/web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
+++ b/web/tests/unit/greekCharts/ExpiryDropdown.test.tsx
@@ -1,10 +1,10 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ExpiryDropdown } from "@/components/stock/panels/greeks/ExpiryDropdown";
 
 describe("ExpiryDropdown", () => {
-  it("renders one <option> per expiry with dte annotation", () => {
-    const { container } = render(
+  it("renders one option per expiry with dte annotation", () => {
+    render(
       <ExpiryDropdown
         options={[
           { value: "2026-05-30", label: "2026-05-30 (9d)" },
@@ -14,15 +14,17 @@ describe("ExpiryDropdown", () => {
         onChange={() => {}}
       />,
     );
-    const opts = container.querySelectorAll("option");
+    const opts = screen.getAllByRole("option");
     expect(opts).toHaveLength(2);
     expect(opts[0].textContent).toContain("2026-05-30");
     expect(opts[0].textContent).toContain("9d");
+    expect(opts[0].getAttribute("aria-selected")).toBe("true");
+    expect(opts[1].getAttribute("aria-selected")).toBe("false");
   });
 
   it("fires onChange with the new value", () => {
     const handle = vi.fn();
-    const { container } = render(
+    render(
       <ExpiryDropdown
         options={[
           { value: "a", label: "A" },
@@ -32,8 +34,7 @@ describe("ExpiryDropdown", () => {
         onChange={handle}
       />,
     );
-    const select = container.querySelector("select")!;
-    fireEvent.change(select, { target: { value: "b" } });
+    fireEvent.click(screen.getByRole("option", { name: "B" }));
     expect(handle).toHaveBeenCalledWith("b");
   });
 });

--- a/web/tests/unit/greekCharts/VannaPanel.test.tsx
+++ b/web/tests/unit/greekCharts/VannaPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { VannaPanel } from "@/components/stock/panels/greeks/VannaPanel";
 
@@ -62,7 +62,8 @@ describe("VannaPanel", () => {
     expect(
       container.querySelectorAll("[data-testid='exposure-tile']"),
     ).toHaveLength(4);
-    expect(container.querySelector("select")).not.toBeNull();
+    expect(screen.getByText("Expiry:")).toBeTruthy();
+    expect(screen.getByRole("listbox")).toBeTruthy();
     expect(
       container.querySelector("path[data-testid='net-line']"),
     ).not.toBeNull();


### PR DESCRIPTION
## Summary
- add root PRODUCT.md and DESIGN.md plus the Impeccable design sidecar for the existing Argon-style product UI
- align the rates page visual treatment with the rest of the app without changing its layout
- move rates loading/error states off the old hardcoded light palette and onto shared theme tokens

## Verification
- `git diff --check`
- `cd web && npm run typecheck`
- `cd web && npx eslint app/rates/error.tsx app/rates/loading.tsx components/rates/RatesDesk.tsx components/rates/RatesCurveChart.tsx components/rates/RatesScorecard.tsx` (0 errors; existing `RatesScorecard` hook dependency warning remains)
- `cd web && npm run test` remains red on the pre-existing Greek chart tests expecting a native `<select>` in `ExpiryDropdown`/`VannaPanel`
- live browser check: `http://127.0.0.1:3002/rates` loaded against local API with Supply and Positioning rendering live data after local migration/backfill
