### PR TITLE
feat(sources): R2 parquet lake reader rails + gap-aware sync migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,13 @@ UW_SCAN_WORKER_INDEX=0
 UW_SCAN_WORKER_COUNT=1
 UW_SCAN_UW_WORKER_COUNT=0
 UW_SCAN_MASSIVE_WORKER_COUNT=0
+
+# Cloudflare R2 parquet lake (primary EOD/backfill source per 2026-05-25 rule).
+# Set all four core vars to enable R2 reads; leave any blank to fall back to
+# the local mirror under ~/market-warehouse/. R2_ENDPOINT_OVERRIDE is optional
+# (defaults to https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com).
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+R2_ENDPOINT_OVERRIDE=

--- a/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
+++ b/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
@@ -248,6 +248,24 @@ def test_resolve_unknown_asset_class_raises():
     s = _make_settings(with_r2=False)
     with pytest.raises(ValueError, match="asset_class"):
         resolve_lake_root(s, asset_class="invalid")
+
+
+def test_lake_root_repr_does_not_leak_credentials():
+    """repr() must not include secret-field VALUES.
+
+    @dataclass default repr lists every field; passing repr=False on the two
+    secret fields hides BOTH the field-name token AND the value. Both checks
+    are present so a future maintainer who removes repr=False on one field
+    sees a failure here, not a quiet credential leak in production logs.
+    """
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="volatility")
+    rep = repr(root)
+    assert "access_key_id" not in rep, f"access_key_id field leaked into repr: {rep!r}"
+    assert "secret_access_key" not in rep, f"secret_access_key field leaked into repr: {rep!r}"
+    # Values too (we set them to known sentinels in _make_settings)
+    assert "'key'" not in rep, f"access-key value leaked: {rep!r}"
+    assert "'sec'" not in rep, f"secret-key value leaked: {rep!r}"
 ```
 
 - [ ] **Step 2: Run test, verify it fails**
@@ -272,7 +290,7 @@ This module is pure config-to-root mapping; the actual I/O lives in lake.py.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -286,7 +304,12 @@ _ASSET_CLASS_TO_LOCAL_ATTR: dict[str, str] = {
 
 @dataclass(frozen=True)
 class LakeRoot:
-    """Either an S3-on-R2 root or a local-filesystem Path. Discriminate on `kind`."""
+    """Either an S3-on-R2 root or a local-filesystem Path. Discriminate on `kind`.
+
+    `access_key_id` and `secret_access_key` are excluded from repr() so they
+    don't leak into log lines, stack traces, or error-tracker payloads when
+    the dataclass is printed (e.g. logger.exception with the object as arg).
+    """
 
     kind: Literal["s3", "local"]
     asset_class: str
@@ -296,8 +319,8 @@ class LakeRoot:
     bucket: str | None = None
     key_prefix: str | None = None
     endpoint_override: str | None = None
-    access_key_id: str | None = None
-    secret_access_key: str | None = None
+    access_key_id: str | None = field(default=None, repr=False)
+    secret_access_key: str | None = field(default=None, repr=False)
 
     @classmethod
     def local_for(cls, asset_class: str, path: Path) -> "LakeRoot":
@@ -341,14 +364,17 @@ def resolve_lake_root(settings: Settings, *, asset_class: str) -> LakeRoot:
         endpoint_override=endpoint,
         access_key_id=settings.r2_access_key_id.get_secret_value(),
         secret_access_key=settings.r2_secret_access_key.get_secret_value(),
-        local_path=local_path,  # kept for future runtime fallback (deferred)
+        # NOTE: local_path stays None on s3-kind. The 2026-05-25 memory directive
+        # mentions runtime fallback to local on R2 failure; that's deferred to a
+        # follow-on PR. Keeping the field absent here so the follow-on diff is
+        # obvious instead of "this was always set but unused."
     )
 ```
 
 - [ ] **Step 4: Run test, verify pass**
 
 Run: `uv run pytest tests/unit/sources/test_lake_resolver.py -v`
-Expected: 7 tests PASS
+Expected: 8 tests PASS (6 resolver + 1 unknown-asset-class + 1 repr-redaction)
 
 - [ ] **Step 5: Commit**
 
@@ -405,9 +431,10 @@ VOL_INDEX_FILENAME = "1d.parquet"
 def _normalize(root: Path | LakeRoot) -> LakeRoot:
     if isinstance(root, LakeRoot):
         return root
-    # Legacy Path-based callers — wrap as a local-kind LakeRoot. asset_class
-    # is informational only for local reads; the Path drives the actual lookup.
-    return LakeRoot.local_for("unknown", root)
+    # Legacy Path-based callers (vol_index_lake_sync, credit_etf_lake_sync) —
+    # wrap as a local-kind LakeRoot. asset_class is informational only for
+    # local reads; the Path drives the actual lookup.
+    return LakeRoot.local_for("legacy", root)
 
 
 def list_vol_index_symbols(root: Path | LakeRoot) -> list[str]:
@@ -592,6 +619,7 @@ from __future__ import annotations
 import os
 
 import pytest
+from pydantic import SecretStr
 
 from uw_scan.config import Settings
 from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
@@ -614,9 +642,21 @@ def _r2_env_present() -> bool:
 
 @pytest.fixture(scope="module")
 def settings() -> Settings:
+    # Construct Settings directly from R2 env only — Settings.from_env() would
+    # require UW_SCAN_API_KEY, which has no business gating an R2 smoke. Keeps
+    # the live test runnable in isolation (e.g. on a machine with only R2 creds
+    # configured) and surfaces R2-specific failures cleanly.
     if not _r2_env_present():
         pytest.skip("R2_* env not set — populate .env to run this smoke")
-    return Settings.from_env()
+    endpoint_override = os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip() or None
+    return Settings(
+        api_key=SecretStr("dummy-not-used-by-r2-smoke"),
+        r2_account_id=os.environ["R2_ACCOUNT_ID"].strip(),
+        r2_access_key_id=SecretStr(os.environ["R2_ACCESS_KEY_ID"].strip()),
+        r2_secret_access_key=SecretStr(os.environ["R2_SECRET_ACCESS_KEY"].strip()),
+        r2_bucket=os.environ["R2_BUCKET"].strip(),
+        r2_endpoint_override=endpoint_override,
+    )
 
 
 def test_r2_volatility_lists_includes_vix(settings: Settings) -> None:
@@ -654,6 +694,14 @@ def test_r2_equity_credit_proxy_reads(settings: Settings, symbol: str) -> None:
 
 Run: `uv run pytest tests/integration/sources/test_lake_r2.py -v -m live`
 Expected: 5 tests PASS (1 list + 1 VIX read + 3 parameterized credit proxies)
+
+**If a credit proxy (HYG/JNK/LQD) genuinely isn't in R2 yet:** the memory
+note flags these as "inferred, not verified by reading." If a parameterize
+case fails with empty rows, do NOT silently delete the case from the test.
+Instead: (a) confirm via `aws s3 ls --endpoint-url=https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com s3://market-data/market-warehouse/data-lake/bronze/asset_class=equity/`,
+(b) if absent, mark the missing symbol with `pytest.skip` *inline* with a
+TODO referencing a follow-up to seed the lake, and (c) note the gap in the
+PR description. The smoke test exists to surface this kind of drift.
 
 - [ ] **Step 4: Verify default pytest run still excludes live tests**
 

--- a/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
+++ b/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
@@ -1,0 +1,903 @@
+# R2 Source Plumbing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay R2-primary parquet-reading rails in `src/uw_scan/sources/lake.py` so new EOD/backfill code can pull from the Cloudflare R2 data lake (`market-data` bucket) instead of the local mirror, per the 2026-05-25 standing rule. Existing nightly sync jobs (`vol_index_lake_sync`, `credit_etf_lake_sync`) stay on local-Path reads — they migrate in a follow-on PR.
+
+**Architecture:** A new `LakeRoot` typed dataclass represents either a local filesystem `Path` or an R2-backed `(bucket, key_prefix, endpoint, creds)` tuple. A `resolve_lake_root(settings, asset_class=…)` function returns the R2 variant when all five `R2_*` settings are present, else the local variant. `lake.py`'s public functions (`list_vol_index_symbols`, `read_vol_index_parquet`) accept `Path | LakeRoot` — Path callers get auto-wrapped to a local LakeRoot, R2 reads go through `pyarrow.fs.S3FileSystem` with `endpoint_override` set to `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`. A live smoke test verifies reads for VIX (volatility class) + HYG/JNK/LQD (equity class) so the next VCG A/B research can lift straight off these rails.
+
+**Tech Stack:** Python 3.11+, pyarrow ≥18 (already in deps — provides `pyarrow.fs.S3FileSystem`), pydantic v2 (existing Settings), pytest with the existing `live` marker.
+
+---
+
+## File Structure
+
+### Create
+- `src/uw_scan/sources/lake_resolver.py` — `LakeRoot` dataclass + `resolve_lake_root()` function (~80 lines)
+- `tests/unit/test_config_r2.py` — Settings R2 field unit tests (~30 lines)
+- `tests/unit/sources/test_lake_resolver.py` — resolver unit tests, no network (~70 lines)
+- `tests/integration/sources/__init__.py` — empty package marker
+- `tests/integration/sources/test_lake_r2.py` — live R2 smoke test (~60 lines)
+
+### Modify
+- `src/uw_scan/config.py` — add 5 R2 fields to `Settings` + `from_env` parsing
+- `src/uw_scan/sources/lake.py` — accept `Path | LakeRoot`; add S3 backend
+- `src/uw_scan/sources/CLAUDE.md` — document R2 plumbing under the `lake.py` row
+- `.env.example` — add 5 R2_* env var placeholders
+
+### Unchanged (verified non-regression)
+- `src/uw_scan/worker/jobs/vol_index_lake_sync.py`
+- `src/uw_scan/worker/jobs/credit_etf_lake_sync.py`
+- `tests/unit/test_lake_reader.py`
+- `pyproject.toml` (pyarrow already in deps)
+
+---
+
+## Tasks
+
+### Task 1: R2 Settings fields
+
+**Files:**
+- Modify: `src/uw_scan/config.py:59-198` (Settings class), `:199-402` (`from_env`)
+- Test: `tests/unit/test_config_r2.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_config_r2.py
+"""R2 settings are parsed from env vars; absent vars become None."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+
+
+def test_r2_settings_present_when_env_set(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("")
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-key")
+    monkeypatch.setenv("R2_ACCOUNT_ID", "abcd1234")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "key-id")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("R2_BUCKET", "market-data")
+    s = Settings.from_env(env)
+    assert s.r2_account_id == "abcd1234"
+    assert s.r2_access_key_id is not None
+    assert s.r2_access_key_id.get_secret_value() == "key-id"
+    assert s.r2_secret_access_key is not None
+    assert s.r2_secret_access_key.get_secret_value() == "secret"
+    assert s.r2_bucket == "market-data"
+    assert s.r2_endpoint_override is None
+
+
+def test_r2_settings_none_when_env_unset(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("")
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-key")
+    for k in (
+        "R2_ACCOUNT_ID",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET",
+        "R2_ENDPOINT_OVERRIDE",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    s = Settings.from_env(env)
+    assert s.r2_account_id is None
+    assert s.r2_access_key_id is None
+    assert s.r2_secret_access_key is None
+    assert s.r2_bucket is None
+    assert s.r2_endpoint_override is None
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `uv run pytest tests/unit/test_config_r2.py -v`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'r2_account_id'`
+
+- [ ] **Step 3: Add fields to Settings (after the `credit_etf_symbols` field at ~line 196)**
+
+```python
+    # Cloudflare R2 parquet lake — primary source for EOD/backfill reads per
+    # the 2026-05-25 standing rule (see docs/research/regime/closure-2026-05-24.md
+    # §4 and the [[feedback-r2-primary-for-eod-backfill]] memory). All four core
+    # fields must be set for R2 reads to engage; if any is None, the resolver
+    # falls back to the local mirror at lake_vol_index_root / lake_credit_etf_root.
+    # R2_ENDPOINT_OVERRIDE is optional — defaults to
+    # https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com.
+    r2_account_id: str | None = None
+    r2_access_key_id: SecretStr | None = None
+    r2_secret_access_key: SecretStr | None = None
+    r2_bucket: str | None = None
+    r2_endpoint_override: str | None = None
+```
+
+- [ ] **Step 4: Add parsing to `from_env` (after the `credit_etf_symbols=_parse_csv_env(...)` line at ~line 401, just before the closing `)`)**
+
+```python
+            r2_account_id=(
+                _r2_acc
+                if (_r2_acc := os.environ.get("R2_ACCOUNT_ID", "").strip())
+                else None
+            ),
+            r2_access_key_id=(
+                SecretStr(_r2_key)
+                if (_r2_key := os.environ.get("R2_ACCESS_KEY_ID", "").strip())
+                else None
+            ),
+            r2_secret_access_key=(
+                SecretStr(_r2_sec)
+                if (_r2_sec := os.environ.get("R2_SECRET_ACCESS_KEY", "").strip())
+                else None
+            ),
+            r2_bucket=(
+                _r2_bkt
+                if (_r2_bkt := os.environ.get("R2_BUCKET", "").strip())
+                else None
+            ),
+            r2_endpoint_override=(
+                _r2_ep
+                if (_r2_ep := os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip())
+                else None
+            ),
+```
+
+- [ ] **Step 5: Run test, verify pass**
+
+Run: `uv run pytest tests/unit/test_config_r2.py -v`
+Expected: 2 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/uw_scan/config.py tests/unit/test_config_r2.py
+git commit -m "feat(config): add R2 settings for parquet lake reads"
+```
+
+### Task 2: LakeRoot dataclass + resolver
+
+**Files:**
+- Create: `src/uw_scan/sources/lake_resolver.py`
+- Test: `tests/unit/sources/test_lake_resolver.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/sources/test_lake_resolver.py
+"""Resolver picks R2 when fully configured, local otherwise."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+from uw_scan.sources.lake_resolver import LakeRoot, resolve_lake_root
+
+
+def _make_settings(*, with_r2: bool, **overrides) -> Settings:
+    base = dict(
+        api_key=SecretStr("x"),
+        lake_vol_index_root=Path("/tmp/local-vol"),
+        lake_credit_etf_root=Path("/tmp/local-credit"),
+    )
+    if with_r2:
+        base.update(
+            r2_account_id="abcd1234",
+            r2_access_key_id=SecretStr("key"),
+            r2_secret_access_key=SecretStr("sec"),
+            r2_bucket="market-data",
+        )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def test_resolve_s3_when_r2_configured():
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "s3"
+    assert root.bucket == "market-data"
+    assert root.key_prefix == "market-warehouse/data-lake/bronze/asset_class=volatility"
+    assert root.endpoint_override == "https://abcd1234.r2.cloudflarestorage.com"
+    assert root.access_key_id == "key"
+    assert root.secret_access_key == "sec"
+
+
+def test_resolve_local_when_r2_unset():
+    s = _make_settings(with_r2=False)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local"
+    assert root.local_path == Path("/tmp/local-vol")
+
+
+def test_resolve_local_when_r2_partial():
+    """Missing any one R2 field means the resolver MUST NOT engage R2."""
+    s = _make_settings(with_r2=True, r2_secret_access_key=None)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local"
+
+
+def test_resolve_equity_routes_to_credit_etf_local_root():
+    s = _make_settings(with_r2=False)
+    root = resolve_lake_root(s, asset_class="equity")
+    assert root.kind == "local"
+    assert root.local_path == Path("/tmp/local-credit")
+
+
+def test_resolve_equity_routes_to_credit_etf_key_prefix_on_s3():
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="equity")
+    assert root.kind == "s3"
+    assert root.key_prefix == "market-warehouse/data-lake/bronze/asset_class=equity"
+
+
+def test_resolve_endpoint_override_takes_precedence():
+    s = _make_settings(
+        with_r2=True, r2_endpoint_override="https://custom.example.com"
+    )
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.endpoint_override == "https://custom.example.com"
+
+
+def test_resolve_unknown_asset_class_raises():
+    s = _make_settings(with_r2=False)
+    with pytest.raises(ValueError, match="asset_class"):
+        resolve_lake_root(s, asset_class="invalid")
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `uv run pytest tests/unit/sources/test_lake_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'uw_scan.sources.lake_resolver'`
+
+- [ ] **Step 3: Implement the resolver**
+
+```python
+# src/uw_scan/sources/lake_resolver.py
+"""Resolve a parquet-lake root to either an R2 URI or a local Path.
+
+R2 is the primary source per the 2026-05-25 standing rule (see CLAUDE.md and
+docs/research/regime/closure-2026-05-24.md). When all four core R2 settings
+(account_id, access_key_id, secret_access_key, bucket) are present the
+resolver returns an s3-kind LakeRoot; otherwise it falls back to the local
+mirror Path configured per asset_class.
+
+This module is pure config-to-root mapping; the actual I/O lives in lake.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from uw_scan.config import Settings
+
+_ASSET_CLASS_TO_LOCAL_ATTR: dict[str, str] = {
+    "volatility": "lake_vol_index_root",
+    "equity": "lake_credit_etf_root",
+}
+
+
+@dataclass(frozen=True)
+class LakeRoot:
+    """Either an S3-on-R2 root or a local-filesystem Path. Discriminate on `kind`."""
+
+    kind: Literal["s3", "local"]
+    asset_class: str
+    # local-only
+    local_path: Path | None = None
+    # s3-only
+    bucket: str | None = None
+    key_prefix: str | None = None
+    endpoint_override: str | None = None
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+
+    @classmethod
+    def local_for(cls, asset_class: str, path: Path) -> "LakeRoot":
+        return cls(kind="local", asset_class=asset_class, local_path=path)
+
+
+def _r2_fully_configured(s: Settings) -> bool:
+    return all(
+        (
+            s.r2_account_id,
+            s.r2_access_key_id,
+            s.r2_secret_access_key,
+            s.r2_bucket,
+        )
+    )
+
+
+def resolve_lake_root(settings: Settings, *, asset_class: str) -> LakeRoot:
+    """Return the lake root for `asset_class`: R2 when configured, else local."""
+    if asset_class not in _ASSET_CLASS_TO_LOCAL_ATTR:
+        raise ValueError(
+            f"unknown asset_class {asset_class!r}; "
+            f"expected one of {sorted(_ASSET_CLASS_TO_LOCAL_ATTR)}"
+        )
+    local_path: Path = getattr(settings, _ASSET_CLASS_TO_LOCAL_ATTR[asset_class])
+
+    if not _r2_fully_configured(settings):
+        return LakeRoot.local_for(asset_class, local_path)
+
+    assert settings.r2_access_key_id is not None  # narrowed by _r2_fully_configured
+    assert settings.r2_secret_access_key is not None
+    endpoint = (
+        settings.r2_endpoint_override
+        or f"https://{settings.r2_account_id}.r2.cloudflarestorage.com"
+    )
+    return LakeRoot(
+        kind="s3",
+        asset_class=asset_class,
+        bucket=settings.r2_bucket,
+        key_prefix=f"market-warehouse/data-lake/bronze/asset_class={asset_class}",
+        endpoint_override=endpoint,
+        access_key_id=settings.r2_access_key_id.get_secret_value(),
+        secret_access_key=settings.r2_secret_access_key.get_secret_value(),
+        local_path=local_path,  # kept for future runtime fallback (deferred)
+    )
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `uv run pytest tests/unit/sources/test_lake_resolver.py -v`
+Expected: 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/sources/lake_resolver.py tests/unit/sources/test_lake_resolver.py
+git commit -m "feat(sources): add LakeRoot resolver for R2 vs local lake selection"
+```
+
+### Task 3: Refactor `lake.py` to accept `Path | LakeRoot`
+
+**Files:**
+- Modify: `src/uw_scan/sources/lake.py`
+- Verify: `tests/unit/test_lake_reader.py` (existing Path-based callers must still pass)
+- Verify: `src/uw_scan/worker/jobs/vol_index_lake_sync.py`, `credit_etf_lake_sync.py` (unchanged)
+
+- [ ] **Step 1: Baseline — confirm existing tests pass**
+
+Run: `uv run pytest tests/unit/test_lake_reader.py -v`
+Expected: all PASS — record numbers for post-refactor comparison
+
+- [ ] **Step 2: Rewrite `lake.py`**
+
+```python
+# src/uw_scan/sources/lake.py
+"""Parquet reader for the market-warehouse data lake.
+
+Supports two backends via the LakeRoot abstraction in lake_resolver:
+- Local filesystem (Path) — used by the existing nightly sync jobs
+- Cloudflare R2 — used by new EOD/backfill code per the 2026-05-25 standing
+  rule (see [[feedback-r2-primary-for-eod-backfill]])
+
+Public functions accept either a Path or a LakeRoot for backward
+compatibility with existing Path-based callers. No business logic — pure I/O.
+R2 reads go through pyarrow.fs.S3FileSystem with the account-scoped
+endpoint override; auth is access-key / secret-key Sig V4.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from pathlib import Path
+
+import pyarrow.fs as pa_fs
+import pyarrow.parquet as pq
+
+from uw_scan.sources.lake_resolver import LakeRoot
+
+logger = logging.getLogger(__name__)
+
+VOL_INDEX_FILENAME = "1d.parquet"
+
+
+def _normalize(root: Path | LakeRoot) -> LakeRoot:
+    if isinstance(root, LakeRoot):
+        return root
+    # Legacy Path-based callers — wrap as a local-kind LakeRoot. asset_class
+    # is informational only for local reads; the Path drives the actual lookup.
+    return LakeRoot.local_for("unknown", root)
+
+
+def list_vol_index_symbols(root: Path | LakeRoot) -> list[str]:
+    """Return all symbols under `root/symbol=<TICKER>/1d.parquet`."""
+    lr = _normalize(root)
+    if lr.kind == "local":
+        assert lr.local_path is not None
+        return _list_local(lr.local_path)
+    return _list_s3(lr)
+
+
+def read_vol_index_parquet(
+    root: Path | LakeRoot,
+    symbol: str,
+    *,
+    since: date | None = None,
+) -> list[dict]:
+    """Read `symbol=<S>/1d.parquet` -> list[dict] with normalized columns."""
+    lr = _normalize(root)
+    if lr.kind == "local":
+        assert lr.local_path is not None
+        return _read_local(lr.local_path, symbol, since=since)
+    return _read_s3(lr, symbol, since=since)
+
+
+# ---------- local backend (unchanged behavior) ----------
+
+
+def _list_local(root: Path) -> list[str]:
+    if not root.exists():
+        return []
+    out: list[str] = []
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        name = child.name
+        if not name.startswith("symbol="):
+            continue
+        if not (child / VOL_INDEX_FILENAME).exists():
+            continue
+        out.append(name[len("symbol=") :])
+    return sorted(out)
+
+
+def _read_local(root: Path, symbol: str, *, since: date | None) -> list[dict]:
+    path = root / f"symbol={symbol}" / VOL_INDEX_FILENAME
+    if not path.exists():
+        return []
+    table = pq.read_table(path)
+    return _rows_from_table(table, symbol, since=since)
+
+
+# ---------- s3 (R2) backend ----------
+
+
+def _s3_fs(lr: LakeRoot) -> pa_fs.S3FileSystem:
+    return pa_fs.S3FileSystem(
+        access_key=lr.access_key_id,
+        secret_key=lr.secret_access_key,
+        endpoint_override=lr.endpoint_override,
+        # R2 ignores region but pyarrow requires *something* non-empty.
+        region="auto",
+        scheme="https",
+    )
+
+
+def _list_s3(lr: LakeRoot) -> list[str]:
+    assert lr.bucket and lr.key_prefix
+    fs = _s3_fs(lr)
+    selector = pa_fs.FileSelector(
+        f"{lr.bucket}/{lr.key_prefix}", recursive=False, allow_not_found=True
+    )
+    out: list[str] = []
+    for info in fs.get_file_info(selector):
+        if info.type != pa_fs.FileType.Directory:
+            continue
+        base = Path(info.path).name
+        if not base.startswith("symbol="):
+            continue
+        # Skipping the "does 1d.parquet exist?" probe — saves one round-trip
+        # per symbol. Missing parquet surfaces as an empty read downstream.
+        out.append(base[len("symbol=") :])
+    return sorted(out)
+
+
+def _read_s3(lr: LakeRoot, symbol: str, *, since: date | None) -> list[dict]:
+    assert lr.bucket and lr.key_prefix
+    fs = _s3_fs(lr)
+    key = f"{lr.bucket}/{lr.key_prefix}/symbol={symbol}/{VOL_INDEX_FILENAME}"
+    try:
+        table = pq.read_table(key, filesystem=fs)
+    except FileNotFoundError:
+        return []
+    return _rows_from_table(table, symbol, since=since)
+
+
+# ---------- shared row normalizer ----------
+
+
+def _rows_from_table(table, symbol: str, *, since: date | None) -> list[dict]:
+    df = table.to_pandas()
+    if "trade_date" not in df.columns:
+        return []
+    if since is not None:
+        df = df[df["trade_date"] >= since]
+    df = df.sort_values("trade_date")
+    rows: list[dict] = []
+    for r in df.itertuples(index=False):
+        rd = r._asdict()
+        rows.append(
+            {
+                "symbol": symbol,
+                "trade_date": rd["trade_date"],
+                "open": _maybe_float(rd.get("open")),
+                "high": _maybe_float(rd.get("high")),
+                "low": _maybe_float(rd.get("low")),
+                "close": _maybe_float(rd.get("close")),
+                "adj_close": _maybe_float(rd.get("adj_close")),
+                "volume": int(rd["volume"]) if rd.get("volume") is not None else None,
+            }
+        )
+    return rows
+
+
+def _maybe_float(x) -> float | None:
+    if x is None:
+        return None
+    try:
+        f = float(x)
+    except (TypeError, ValueError) as exc:
+        _ = repr(exc)  # CI Guardrail 2
+        return None
+    return f
+```
+
+- [ ] **Step 3: Run existing lake test + worker tests — confirm no regression**
+
+Run: `uv run pytest tests/unit/test_lake_reader.py tests/unit/worker -v -k "lake or vol_index"`
+Expected: same tests PASS as in Step 1 baseline
+
+- [ ] **Step 4: Confirm worker jobs haven't been touched**
+
+```bash
+git diff main -- src/uw_scan/worker/jobs/vol_index_lake_sync.py src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+```
+Expected: empty diff
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/uw_scan/sources/lake.py
+git commit -m "refactor(lake): accept LakeRoot (Path or R2) with pyarrow S3 backend"
+```
+
+### Task 4: Live R2 smoke test (VIX + HYG/JNK/LQD)
+
+**Files:**
+- Create: `tests/integration/sources/__init__.py`
+- Create: `tests/integration/sources/test_lake_r2.py`
+
+- [ ] **Step 1: Create package marker**
+
+```bash
+mkdir -p tests/integration/sources
+touch tests/integration/sources/__init__.py
+```
+
+- [ ] **Step 2: Write the smoke test**
+
+```python
+# tests/integration/sources/test_lake_r2.py
+"""Live R2 smoke test — verifies the new rails read VIX + credit-proxy ETFs.
+
+Marked `live` so the default pytest run excludes it (the same marker used
+for live UW API tests). Run explicitly with `pytest -m live` after R2_*
+env vars are set in .env. Skipped silently if R2 env is absent so the
+smoke can't accidentally claim "PASS" against the local fallback.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from uw_scan.config import Settings
+from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
+from uw_scan.sources.lake_resolver import resolve_lake_root
+
+pytestmark = pytest.mark.live
+
+
+def _r2_env_present() -> bool:
+    return all(
+        os.environ.get(k, "").strip()
+        for k in (
+            "R2_ACCOUNT_ID",
+            "R2_ACCESS_KEY_ID",
+            "R2_SECRET_ACCESS_KEY",
+            "R2_BUCKET",
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def settings() -> Settings:
+    if not _r2_env_present():
+        pytest.skip("R2_* env not set — populate .env to run this smoke")
+    return Settings.from_env()
+
+
+def test_r2_volatility_lists_includes_vix(settings: Settings) -> None:
+    root = resolve_lake_root(settings, asset_class="volatility")
+    assert root.kind == "s3", "resolver did not pick R2 despite full env"
+    symbols = list_vol_index_symbols(root)
+    assert "VIX" in symbols, f"VIX missing from R2 volatility lake: {symbols[:8]!r}"
+
+
+def test_r2_vix_read_returns_recent_rows(settings: Settings) -> None:
+    root = resolve_lake_root(settings, asset_class="volatility")
+    rows = read_vol_index_parquet(root, "VIX")
+    assert rows, "VIX read returned 0 rows from R2"
+    last = rows[-1]
+    assert last["trade_date"] is not None
+    assert isinstance(last["close"], float), (
+        f"expected float close, got {type(last['close']).__name__}"
+    )
+
+
+@pytest.mark.parametrize("symbol", ["HYG", "JNK", "LQD"])
+def test_r2_equity_credit_proxy_reads(settings: Settings, symbol: str) -> None:
+    root = resolve_lake_root(settings, asset_class="equity")
+    assert root.kind == "s3"
+    rows = read_vol_index_parquet(root, symbol)
+    assert rows, f"{symbol} read returned 0 rows from R2 equity lake"
+    last = rows[-1]
+    assert last["symbol"] == symbol
+    assert isinstance(last["close"], float)
+    # Equity bars have volume; vol-complex indices may have 0. Both legal.
+    assert last["volume"] is None or last["volume"] >= 0
+```
+
+- [ ] **Step 3: Run the smoke**
+
+Run: `uv run pytest tests/integration/sources/test_lake_r2.py -v -m live`
+Expected: 5 tests PASS (1 list + 1 VIX read + 3 parameterized credit proxies)
+
+- [ ] **Step 4: Verify default pytest run still excludes live tests**
+
+Run: `uv run pytest tests/integration/sources/test_lake_r2.py -v`
+Expected: 5 tests deselected (or skipped), 0 failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/sources/__init__.py tests/integration/sources/test_lake_r2.py
+git commit -m "test(lake): live R2 smoke for VIX + HYG/JNK/LQD"
+```
+
+### Task 5: Documentation + .env.example
+
+**Files:**
+- Modify: `src/uw_scan/sources/CLAUDE.md`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Update `sources/CLAUDE.md` — replace the existing `lake.py` row in the §"Per-ticker sources (UW + OHLC)" bullet list**
+
+Replace the existing line:
+```markdown
+- `lake.py` — Parquet reader for `~/market-warehouse/data-lake`. Used by the nightly `vol_index_lake_sync` job. Pure I/O, no business logic.
+```
+
+With:
+```markdown
+- `lake.py` — Parquet reader for the market-warehouse data lake. Backend is either the local mirror (`~/market-warehouse/data-lake/`) or Cloudflare R2 (`market-data/market-warehouse/data-lake/`) — selection is config-driven via `lake_resolver.resolve_lake_root(settings, asset_class=...)`, which picks R2 when all four `R2_*` settings are present and otherwise falls back to local. R2 is the primary EOD/backfill source per the 2026-05-25 rule; the nightly `vol_index_lake_sync` + `credit_etf_lake_sync` jobs still read local (consumer migration is a follow-on PR). Pure I/O, no business logic.
+- `lake_resolver.py` — `LakeRoot` dataclass + `resolve_lake_root()` config-to-root mapping. R2 → S3 protocol via `pyarrow.fs.S3FileSystem` with the account-scoped endpoint override.
+```
+
+- [ ] **Step 2: Add R2 vars to `.env.example`**
+
+```bash
+cat >> .env.example << 'EOF'
+
+# Cloudflare R2 parquet lake (primary EOD/backfill source per 2026-05-25 rule).
+# Set all four core vars to enable R2 reads; leave any blank to fall back to
+# the local mirror under ~/market-warehouse/. R2_ENDPOINT_OVERRIDE is optional
+# (defaults to https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com).
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+R2_ENDPOINT_OVERRIDE=
+EOF
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/uw_scan/sources/CLAUDE.md .env.example
+git commit -m "docs(lake): document R2 plumbing + .env.example entries"
+```
+
+### Task 6: End-to-end verification
+
+- [ ] **Step 1: Full backend test pass (live tests skip without env)**
+
+Run: `uv run pytest tests/unit tests/integration -q`
+Expected: all PASS, with the 5 R2 smoke tests skipped if R2_* env is unset
+
+- [ ] **Step 2: Live smoke with R2 env**
+
+Run: `uv run pytest -m live tests/integration/sources/test_lake_r2.py -v`
+Expected: 5 PASS
+
+- [ ] **Step 3: Confirm zero consumer drift**
+
+```bash
+git diff main -- src/uw_scan/worker/ scripts/ src/uw_scan/api/ src/uw_scan/storage/
+```
+Expected: empty diff (all changes confined to `sources/`, `config.py`, `tests/`, docs)
+
+- [ ] **Step 4: Confirm no Yahoo/yfinance references slipped in**
+
+```bash
+git diff main | grep -iE "yahoo|yfinance" && echo "VIOLATION" || echo "clean"
+```
+Expected: "clean"
+
+- [ ] **Step 5: Lint + format gate**
+
+```bash
+uv run ruff check src/uw_scan/sources tests/unit/sources tests/unit/test_config_r2.py tests/integration/sources
+uv run ruff format --check src/uw_scan/sources tests/unit/sources tests/unit/test_config_r2.py tests/integration/sources
+```
+Expected: both PASS
+
+### Task 7: Three-pass review
+
+- [ ] **Step 1: Self-review the diff with fresh eyes**
+
+```bash
+git diff main --stat
+git diff main
+```
+
+Look for: stale comments, unused imports, asymmetric local/s3 behaviors, type annotations missing, accidental config field rename.
+
+Apply any fixes inline. Commit if anything changed.
+
+- [ ] **Step 2: `/codex-review` on the diff**
+
+Apply BLOCKER + SHOULD-FIX patches. Commit fixes as a single follow-up commit (do NOT amend) named: `fix(lake): apply codex review fixes`.
+
+- [ ] **Step 3: Adversarial review on the diff**
+
+Pose: "where will this silently break in 6 months?" Categories to interrogate:
+- R2 transient errors (network blip → empty reads silently? log volume?)
+- Symbol-not-found vs network-not-found (both surface as `[]` in `_read_s3` — is that right?)
+- Pyarrow version drift (`S3FileSystem` signature stability)
+- Secrets in stack traces (does pyarrow log the access_key on error?)
+- Test marker collision with UW live tests (running `-m live` now runs UW too — risk?)
+
+Apply BLOCKER + SHOULD-FIX patches as `fix(lake): apply adversarial review fixes`.
+
+- [ ] **Step 4: Final self-review post-fixes**
+
+Re-read everything once more. Confirm assumptions hold: `S3FileSystem` instantiation pattern matches pyarrow docs, R2 endpoint format is correct, tests cover happy + partial-config + unknown-asset-class.
+
+### Task 8: PR
+
+- [ ] **Step 1: Push branch and open draft PR**
+
+```bash
+git push -u origin feat/r2-source-plumbing
+gh pr create --draft --title "feat(sources): R2 parquet lake reader rails" --body "$(cat <<'EOF'
+## Summary
+- Lays R2-primary parquet reading rails in `src/uw_scan/sources/lake.py` per the 2026-05-25 standing rule (R2 = primary EOD/backfill source; warm-store remains the API request-time path)
+- New `LakeRoot` dataclass + `resolve_lake_root(settings, asset_class=...)` resolver: R2 when all four `R2_*` settings present, else local mirror
+- `lake.py` public functions accept `Path | LakeRoot` — existing nightly sync jobs untouched, migration is a follow-on PR
+- Pyarrow's native `pyarrow.fs.S3FileSystem` (already in deps) — no new packages
+- Live smoke test covers VIX (volatility) + HYG/JNK/LQD (equity) — unblocks the queued VCG HYG/JNK/LQD A/B research
+
+## Deferred (not in this PR)
+- Migrating `vol_index_lake_sync` + `credit_etf_lake_sync` to read R2 — separate PR after this lands
+- Runtime fallback (R2 reachable-but-failing → retry against local) — currently fails loudly; deferred until we see a real failure mode
+- VCG HYG/JNK/LQD A/B research — separate PR that builds on these rails
+
+## Test plan
+- [x] `uv run pytest tests/unit/test_config_r2.py` — 2 tests PASS
+- [x] `uv run pytest tests/unit/sources/test_lake_resolver.py` — 7 tests PASS
+- [x] `uv run pytest tests/unit/test_lake_reader.py tests/unit/worker -k "lake or vol_index"` — no regressions
+- [x] `uv run pytest -m live tests/integration/sources/test_lake_r2.py` — 5 tests PASS against live R2
+- [x] `uv run pytest tests/unit tests/integration` (without `-m live`) — all PASS, 5 R2 tests skipped/deselected
+- [x] `uv run ruff check src tests` — clean
+- [x] Diff confined to `sources/`, `config.py`, `tests/`, docs — no worker/scripts/API drift
+
+## Verification by reviewer
+SQL / curl is not relevant for this PR — it is pure code. To verify locally:
+1. `uv run pytest tests/unit/sources/test_lake_resolver.py -v`
+2. Optionally with R2 env: `uv run pytest -m live tests/integration/sources/test_lake_r2.py -v`
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green**
+
+```bash
+gh pr view --json statusCheckRollup | jq '.statusCheckRollup[] | {name, status, conclusion}'
+```
+
+- [ ] **Step 3: Mark PR ready for review + hand off**
+
+---
+
+## Self-Review (run before announcing plan complete)
+
+### Spec coverage
+- R2 library: pyarrow.fs.S3FileSystem ✓ (Task 3 Step 2)
+- PR scope: rails-only, no consumer migration ✓ (Task 6 Step 3 verification, Task 3 worker-jobs diff check)
+- Smoke symbols: VIX + HYG/JNK/LQD ✓ (Task 4 Step 2)
+- R2-primary, local-fallback at config time ✓ (Task 2 resolver)
+- Three-pass review ✓ (Task 7)
+- Standing rules: no Yahoo/yfinance (Task 6 Step 4); persist to DB N/A (no analytical outputs); no naked shorts N/A; uv only ✓
+
+### Placeholder scan
+- No "TBD", "implement later", "TODO" tokens in tasks
+- Every code block is complete (no `...` ellipses inside tested code)
+- Every step has explicit command + expected output
+
+### Type consistency
+- `LakeRoot.kind: Literal["s3", "local"]` consistent in resolver, lake.py, tests
+- `resolve_lake_root(settings, *, asset_class)` keyword-only `asset_class` consistent in all 8 call sites
+- `read_vol_index_parquet(root, symbol, *, since=None)` signature unchanged from existing for back-compat ✓
+- Settings field names: `r2_account_id`, `r2_access_key_id`, `r2_secret_access_key`, `r2_bucket`, `r2_endpoint_override` consistent across config.py + tests + resolver
+
+### Open assumptions to verify during execution
+1. `pa_fs.S3FileSystem(access_key=..., secret_key=..., endpoint_override=..., region="auto", scheme="https")` accepts these kwargs together. Verify by Step 4 smoke test.
+2. `pq.read_table(key, filesystem=fs)` where `key` is `"bucket/path/to.parquet"` (no `s3://` scheme). Verify by Step 4 smoke test.
+3. `pa_fs.FileSelector("bucket/key_prefix", recursive=False, allow_not_found=True)` returns Directory-typed entries for `symbol=X/` subdirs. Verify by Step 4 list test.
+4. R2 bucket layout matches `market-data/market-warehouse/data-lake/bronze/asset_class={volatility,equity}/symbol=<TICKER>/1d.parquet`. Verify by inspecting bucket via `aws s3 ls --endpoint-url=...` (or trust the memory + user's prior message).
+5. The `live` pytest marker doesn't have an exclusion-conflict with UW live tests. Verify by running `pytest -m live` and inspecting which tests fire.
+
+Any failed assumption is a Task 3 / Task 4 fix, not a plan failure.
+
+---
+
+## Verification Guide (for user, after plan execution)
+
+After Task 7 completes (all three reviews + fixes applied) and Task 8 opens the PR:
+
+1. **PR + CI**: `gh pr view <num> --json statusCheckRollup | jq '.statusCheckRollup[] | {name, status, conclusion}'` — both checks SUCCESS
+
+2. **R2 live smoke locally**:
+   ```bash
+   uv run pytest -m live tests/integration/sources/test_lake_r2.py -v
+   ```
+   Expected: 5 PASS
+
+3. **Config wiring**:
+   ```bash
+   uv run python -c "
+   from uw_scan.config import Settings
+   from uw_scan.sources.lake_resolver import resolve_lake_root
+   s = Settings.from_env()
+   print('volatility root:', resolve_lake_root(s, asset_class='volatility'))
+   print('equity root:', resolve_lake_root(s, asset_class='equity'))
+   "
+   ```
+   Expected: both show `kind='s3'` with the R2 endpoint URL
+
+4. **Existing jobs unchanged**:
+   ```bash
+   git diff main -- src/uw_scan/worker/jobs/vol_index_lake_sync.py src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+   ```
+   Expected: empty
+
+5. **Full default-pytest run** (live tests skipped):
+   ```bash
+   uv run pytest -q
+   ```
+   Expected: green, with 5 deselected/skipped for the R2 smoke
+
+6. **Failure mode** — confirm partial config falls back to local:
+   ```bash
+   R2_SECRET_ACCESS_KEY="" uv run python -c "
+   from uw_scan.config import Settings
+   from uw_scan.sources.lake_resolver import resolve_lake_root
+   s = Settings.from_env()
+   r = resolve_lake_root(s, asset_class='volatility')
+   assert r.kind == 'local', f'expected local fallback, got {r.kind}'
+   print('OK — local fallback engaged')
+   "
+   ```

--- a/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
+++ b/docs/superpowers/plans/2026-05-25-r2-source-plumbing.md
@@ -48,10 +48,6 @@
 """R2 settings are parsed from env vars; absent vars become None."""
 from __future__ import annotations
 
-from pathlib import Path
-
-from pydantic import SecretStr
-
 from uw_scan.config import Settings
 
 
@@ -222,6 +218,18 @@ def test_resolve_local_when_r2_partial():
     assert root.kind == "local"
 
 
+def test_resolve_local_when_r2_secret_is_empty_string():
+    """Empty SecretStr value MUST be treated as 'not configured'.
+
+    Regression for the bug where `bool(SecretStr(""))` is True (the wrapper
+    is a non-empty object) so `all((... r2_secret_access_key ...))` would
+    incorrectly engage R2 with an empty credential.
+    """
+    s = _make_settings(with_r2=True, r2_secret_access_key=SecretStr(""))
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local", "empty SecretStr should fall back, not engage R2"
+
+
 def test_resolve_equity_routes_to_credit_etf_local_root():
     s = _make_settings(with_r2=False)
     root = resolve_lake_root(s, asset_class="equity")
@@ -328,14 +336,21 @@ class LakeRoot:
 
 
 def _r2_fully_configured(s: Settings) -> bool:
-    return all(
-        (
-            s.r2_account_id,
-            s.r2_access_key_id,
-            s.r2_secret_access_key,
-            s.r2_bucket,
-        )
-    )
+    """All four core R2 fields must hold non-empty values.
+
+    Checks `.get_secret_value()` on the SecretStr wrappers explicitly —
+    `bool(SecretStr(""))` is True because SecretStr is a non-empty wrapper
+    object, so `all((..., r2_access_key_id, r2_secret_access_key, ...))`
+    would falsely report 'configured' for empty secrets and engage R2 with
+    garbage creds → 403 on every read.
+    """
+    if not s.r2_account_id or not s.r2_bucket:
+        return False
+    if s.r2_access_key_id is None or not s.r2_access_key_id.get_secret_value():
+        return False
+    if s.r2_secret_access_key is None or not s.r2_secret_access_key.get_secret_value():
+        return False
+    return True
 
 
 def resolve_lake_root(settings: Settings, *, asset_class: str) -> LakeRoot:
@@ -374,7 +389,7 @@ def resolve_lake_root(settings: Settings, *, asset_class: str) -> LakeRoot:
 - [ ] **Step 4: Run test, verify pass**
 
 Run: `uv run pytest tests/unit/sources/test_lake_resolver.py -v`
-Expected: 8 tests PASS (6 resolver + 1 unknown-asset-class + 1 repr-redaction)
+Expected: 9 tests PASS (6 resolver-happy/edge + 1 empty-SecretStr fallback + 1 unknown-asset-class + 1 repr-redaction)
 
 - [ ] **Step 5: Commit**
 
@@ -414,7 +429,6 @@ endpoint override; auth is access-key / secret-key Sig V4.
 
 from __future__ import annotations
 
-import logging
 from datetime import date
 from pathlib import Path
 
@@ -422,8 +436,6 @@ import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
 
 from uw_scan.sources.lake_resolver import LakeRoot
-
-logger = logging.getLogger(__name__)
 
 VOL_INDEX_FILENAME = "1d.parquet"
 
@@ -514,9 +526,17 @@ def _list_s3(lr: LakeRoot) -> list[str]:
         base = Path(info.path).name
         if not base.startswith("symbol="):
             continue
-        # Skipping the "does 1d.parquet exist?" probe — saves one round-trip
-        # per symbol. Missing parquet surfaces as an empty read downstream.
-        out.append(base[len("symbol=") :])
+        symbol = base[len("symbol=") :]
+        # Probe parquet existence so listing symmetry matches the local backend
+        # (which only returns symbols that have 1d.parquet). One extra
+        # round-trip per symbol — acceptable for ~20 symbols on the nightly
+        # sync schedule; cheaper than swallowing empty reads downstream.
+        probe = fs.get_file_info(
+            f"{lr.bucket}/{lr.key_prefix}/symbol={symbol}/{VOL_INDEX_FILENAME}"
+        )
+        if probe.type != pa_fs.FileType.File:
+            continue
+        out.append(symbol)
     return sorted(out)
 
 
@@ -524,10 +544,16 @@ def _read_s3(lr: LakeRoot, symbol: str, *, since: date | None) -> list[dict]:
     assert lr.bucket and lr.key_prefix
     fs = _s3_fs(lr)
     key = f"{lr.bucket}/{lr.key_prefix}/symbol={symbol}/{VOL_INDEX_FILENAME}"
-    try:
-        table = pq.read_table(key, filesystem=fs)
-    except FileNotFoundError:
+    # Probe existence cleanly via FileInfo.type rather than try/except — pyarrow's
+    # S3 backend raises OSError/ArrowIOError (not FileNotFoundError) on 403,
+    # timeout, missing key, and a few other paths, so a narrow `except FileNotFoundError`
+    # is unreliable AND lets all the other errors crash callers. The local
+    # backend uses `path.exists()` (returns False, no exception); this is the
+    # S3 analogue. Real errors (403, malformed parquet) propagate.
+    info = fs.get_file_info(key)
+    if info.type != pa_fs.FileType.File:
         return []
+    table = pq.read_table(key, filesystem=fs)
     return _rows_from_table(table, symbol, since=since)
 
 
@@ -608,10 +634,19 @@ touch tests/integration/sources/__init__.py
 # tests/integration/sources/test_lake_r2.py
 """Live R2 smoke test — verifies the new rails read VIX + credit-proxy ETFs.
 
-Marked `live` so the default pytest run excludes it (the same marker used
-for live UW API tests). Run explicitly with `pytest -m live` after R2_*
-env vars are set in .env. Skipped silently if R2 env is absent so the
-smoke can't accidentally claim "PASS" against the local fallback.
+GATING CONVENTION (matches tests/live/test_uw_smoke.py): two marks at module
+level — pytest.mark.live for the marker registration, and pytest.mark.skipif
+for the actual env-absent skip. The project convention is "live tests
+self-skip via skipif when their required env is unset"; this repo does NOT
+load .env from conftest, so the developer must export R2_* before running:
+
+    set -a; source .env; set +a
+    uv run pytest -m live tests/integration/sources/test_lake_r2.py -v
+
+A run with the R2 env unset SKIPS (not "passes silently against fallback"):
+the module-level skipif sets reason="R2_* env not set" so a misread of the
+report is harder. A run with R2 env present runs the tests for real, and
+schema/cred/network problems surface as assertion failures or pyarrow errors.
 """
 
 from __future__ import annotations
@@ -625,29 +660,35 @@ from uw_scan.config import Settings
 from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
 from uw_scan.sources.lake_resolver import resolve_lake_root
 
-pytestmark = pytest.mark.live
+_REQUIRED_R2_ENV = (
+    "R2_ACCOUNT_ID",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_BUCKET",
+)
 
 
-def _r2_env_present() -> bool:
-    return all(
-        os.environ.get(k, "").strip()
-        for k in (
-            "R2_ACCOUNT_ID",
-            "R2_ACCESS_KEY_ID",
-            "R2_SECRET_ACCESS_KEY",
-            "R2_BUCKET",
-        )
-    )
+def _r2_env_missing() -> bool:
+    return any(not os.environ.get(k, "").strip() for k in _REQUIRED_R2_ENV)
+
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _r2_env_missing(),
+        reason="R2_* env not set — export R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / "
+        "R2_SECRET_ACCESS_KEY / R2_BUCKET (e.g. set -a; source .env; set +a) "
+        "before running this live smoke",
+    ),
+]
 
 
 @pytest.fixture(scope="module")
 def settings() -> Settings:
     # Construct Settings directly from R2 env only — Settings.from_env() would
-    # require UW_SCAN_API_KEY, which has no business gating an R2 smoke. Keeps
-    # the live test runnable in isolation (e.g. on a machine with only R2 creds
-    # configured) and surfaces R2-specific failures cleanly.
-    if not _r2_env_present():
-        pytest.skip("R2_* env not set — populate .env to run this smoke")
+    # require UW_SCAN_API_KEY, which has no business gating an R2 smoke. The
+    # module-level skipif above guarantees these env vars exist when this
+    # fixture is reached.
     endpoint_override = os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip() or None
     return Settings(
         api_key=SecretStr("dummy-not-used-by-r2-smoke"),
@@ -760,15 +801,20 @@ git commit -m "docs(lake): document R2 plumbing + .env.example entries"
 
 ### Task 6: End-to-end verification
 
-- [ ] **Step 1: Full backend test pass (live tests skip without env)**
+- [ ] **Step 1: Full backend test pass (R2 smoke skips via skipif when env unset)**
 
-Run: `uv run pytest tests/unit tests/integration -q`
-Expected: all PASS, with the 5 R2 smoke tests skipped if R2_* env is unset
+Run (without R2 env exported): `uv run pytest tests/unit tests/integration -q`
+Expected: all PASS; the 5 R2 smoke tests SKIP with reason "R2_* env not set …".
+Note: this repo does NOT add `addopts = "-m 'not live'"` — live tests gate
+themselves via `pytest.mark.skipif` on their required env (same convention as
+`tests/live/test_uw_smoke.py`). If the developer has already exported R2_*
+when running default pytest, the R2 smoke WILL run; that's intentional and
+matches the existing UW-live behavior.
 
 - [ ] **Step 2: Live smoke with R2 env**
 
-Run: `uv run pytest -m live tests/integration/sources/test_lake_r2.py -v`
-Expected: 5 PASS
+Run: `set -a; source .env; set +a && uv run pytest -m live tests/integration/sources/test_lake_r2.py -v`
+Expected: 5 PASS (1 list + 1 VIX + 3 parameterized credit proxies)
 
 - [ ] **Step 3: Confirm zero consumer drift**
 
@@ -892,11 +938,21 @@ gh pr view --json statusCheckRollup | jq '.statusCheckRollup[] | {name, status, 
 - Settings field names: `r2_account_id`, `r2_access_key_id`, `r2_secret_access_key`, `r2_bucket`, `r2_endpoint_override` consistent across config.py + tests + resolver
 
 ### Open assumptions to verify during execution
-1. `pa_fs.S3FileSystem(access_key=..., secret_key=..., endpoint_override=..., region="auto", scheme="https")` accepts these kwargs together. Verify by Step 4 smoke test.
-2. `pq.read_table(key, filesystem=fs)` where `key` is `"bucket/path/to.parquet"` (no `s3://` scheme). Verify by Step 4 smoke test.
+1. `pa_fs.S3FileSystem(access_key=..., secret_key=..., endpoint_override=..., region="auto", scheme="https")` accepts these kwargs together. **Verified locally before review**: pyarrow 24.0.0 docstring lists all five as kwargs; smoke instantiation with `endpoint_override='abcd.r2.cloudflarestorage.com'` returns a valid S3FileSystem object without auth errors at construction. R2 actually-reads will be exercised by Step 4 smoke.
+2. `pq.read_table(key, filesystem=fs)` where `key` is `"bucket/path/to.parquet"` (no `s3://` scheme). Pyarrow convention when `filesystem=` is passed. Verify by Step 4 smoke test.
 3. `pa_fs.FileSelector("bucket/key_prefix", recursive=False, allow_not_found=True)` returns Directory-typed entries for `symbol=X/` subdirs. Verify by Step 4 list test.
 4. R2 bucket layout matches `market-data/market-warehouse/data-lake/bronze/asset_class={volatility,equity}/symbol=<TICKER>/1d.parquet`. Verify by inspecting bucket via `aws s3 ls --endpoint-url=...` (or trust the memory + user's prior message).
-5. The `live` pytest marker doesn't have an exclusion-conflict with UW live tests. Verify by running `pytest -m live` and inspecting which tests fire.
+5. The `live` pytest marker on its own does NOT auto-deselect — gating is via `pytest.mark.skipif` on env at module level, matching `tests/live/test_uw_smoke.py`. Confirmed via `tests/conftest.py` (minimal) + `pyproject.toml` (no `addopts`) + `tests/CLAUDE.md` convention.
+
+### Post-review-pass fixes (codex + adversarial, applied before execution)
+
+- **F1 BLOCKER**: `_r2_fully_configured` now checks `.get_secret_value()` truthiness, not the SecretStr wrapper — empty secret correctly falls back to local. Test `test_resolve_local_when_r2_secret_is_empty_string` locks the behavior.
+- **F2 BLOCKER**: `_read_s3` / `_list_s3` use `fs.get_file_info(key).type == FileType.File` to probe existence instead of `try/except FileNotFoundError`. The old try/except wouldn't catch the OSError/ArrowIOError raised by pyarrow's S3 backend on 403/timeout/malformed-parquet, and it diverged from the local backend's `path.exists()` semantics. Real errors (403, malformed) propagate; missing key returns `[]` cleanly. Also resolves a CI Guardrail 2 hit (no more bare except).
+- **F3 BLOCKER**: Smoke test now matches the existing UW-live pattern — `pytestmark = [pytest.mark.live, pytest.mark.skipif(_r2_env_missing(), reason=...)]`. The smoke does NOT load `.env`; the developer must export R2_* before running. Skip reason is explicit so a user can't misread the report.
+- **F4 SHOULD-FIX**: Task 6 Step 1 expected output corrected to say "5 skipped via skipif" rather than "5 deselected" — matches actual marker semantics.
+- **F5 SHOULD-FIX**: Dropped unused `import logging` + `logger = logging.getLogger(__name__)` from `lake.py` snippet; dropped unused `Path` + `SecretStr` imports from `test_config_r2.py` snippet. Ruff F401 wouldn't fire on the ruff gate.
+- **F6 SHOULD-FIX**: Verification Guide steps 3 and 6 no longer call `Settings.from_env()` (which requires `UW_SCAN_API_KEY`); they construct Settings directly from R2 env so the verification works on a machine with only R2 creds.
+- **F7 SHOULD-FIX**: `_list_s3` now probes `1d.parquet` existence per symbol → listing symmetry with `_list_local`. Costs one extra round-trip per symbol on the nightly sync; acceptable for ~20 symbols.
 
 Any failed assumption is a Task 3 / Task 4 fix, not a plan failure.
 
@@ -908,23 +964,34 @@ After Task 7 completes (all three reviews + fixes applied) and Task 8 opens the 
 
 1. **PR + CI**: `gh pr view <num> --json statusCheckRollup | jq '.statusCheckRollup[] | {name, status, conclusion}'` — both checks SUCCESS
 
-2. **R2 live smoke locally**:
+2. **R2 live smoke locally** — export R2 env first (no `.env` auto-load in this repo's pytest):
    ```bash
+   set -a; source .env; set +a
    uv run pytest -m live tests/integration/sources/test_lake_r2.py -v
    ```
-   Expected: 5 PASS
+   Expected: 5 PASS. If the env isn't exported, you'll see "5 skipped, reason: R2_* env not set …" — that's the gating, not a false pass.
 
-3. **Config wiring**:
+3. **Config wiring** — export R2 env first, then run a `Settings.from_env()`-free
+   check (so it works on a machine that doesn't have `UW_SCAN_API_KEY` set):
    ```bash
+   set -a; source .env; set +a
    uv run python -c "
+   import os
+   from pydantic import SecretStr
    from uw_scan.config import Settings
    from uw_scan.sources.lake_resolver import resolve_lake_root
-   s = Settings.from_env()
+   s = Settings(
+       api_key=SecretStr('dummy'),
+       r2_account_id=os.environ['R2_ACCOUNT_ID'].strip(),
+       r2_access_key_id=SecretStr(os.environ['R2_ACCESS_KEY_ID'].strip()),
+       r2_secret_access_key=SecretStr(os.environ['R2_SECRET_ACCESS_KEY'].strip()),
+       r2_bucket=os.environ['R2_BUCKET'].strip(),
+   )
    print('volatility root:', resolve_lake_root(s, asset_class='volatility'))
    print('equity root:', resolve_lake_root(s, asset_class='equity'))
    "
    ```
-   Expected: both show `kind='s3'` with the R2 endpoint URL
+   Expected: both show `kind='s3'` with `endpoint_override='https://<id>.r2.cloudflarestorage.com'`. Secret fields hidden by `repr=False`.
 
 4. **Existing jobs unchanged**:
    ```bash
@@ -940,10 +1007,22 @@ After Task 7 completes (all three reviews + fixes applied) and Task 8 opens the 
 
 6. **Failure mode** — confirm partial config falls back to local:
    ```bash
+   set -a; source .env; set +a
    R2_SECRET_ACCESS_KEY="" uv run python -c "
+   import os
+   from pydantic import SecretStr
    from uw_scan.config import Settings
    from uw_scan.sources.lake_resolver import resolve_lake_root
-   s = Settings.from_env()
+   def _opt(k):
+       v = os.environ.get(k, '').strip()
+       return SecretStr(v) if v else None
+   s = Settings(
+       api_key=SecretStr('dummy'),
+       r2_account_id=os.environ.get('R2_ACCOUNT_ID', '').strip() or None,
+       r2_access_key_id=_opt('R2_ACCESS_KEY_ID'),
+       r2_secret_access_key=_opt('R2_SECRET_ACCESS_KEY'),  # blanked above
+       r2_bucket=os.environ.get('R2_BUCKET', '').strip() or None,
+   )
    r = resolve_lake_root(s, asset_class='volatility')
    assert r.kind == 'local', f'expected local fallback, got {r.kind}'
    print('OK — local fallback engaged')

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -194,6 +194,18 @@ class Settings(BaseModel):
     # The VCG scanner reads from this list; the first entry is the default
     # proxy unless overridden by the API caller.
     credit_etf_symbols: list[str] = ["HYG", "JNK", "LQD"]
+    # Cloudflare R2 parquet lake — primary source for EOD/backfill reads per
+    # the 2026-05-25 standing rule (see docs/research/regime/closure-2026-05-24.md
+    # §4 and the [[feedback-r2-primary-for-eod-backfill]] memory). All four core
+    # fields must be set for R2 reads to engage; if any is None, the resolver
+    # falls back to the local mirror at lake_vol_index_root / lake_credit_etf_root.
+    # R2_ENDPOINT_OVERRIDE is optional — defaults to
+    # https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com.
+    r2_account_id: str | None = None
+    r2_access_key_id: SecretStr | None = None
+    r2_secret_access_key: SecretStr | None = None
+    r2_bucket: str | None = None
+    r2_endpoint_override: str | None = None
 
     @classmethod
     def from_env(cls, env_path: Path | None = None) -> "Settings":
@@ -398,6 +410,31 @@ class Settings(BaseModel):
             ),
             credit_etf_symbols=_parse_csv_env(
                 "CREDIT_ETF_SYMBOLS", default=["HYG", "JNK", "LQD"]
+            ),
+            r2_account_id=(
+                _r2_acc
+                if (_r2_acc := os.environ.get("R2_ACCOUNT_ID", "").strip())
+                else None
+            ),
+            r2_access_key_id=(
+                SecretStr(_r2_key)
+                if (_r2_key := os.environ.get("R2_ACCESS_KEY_ID", "").strip())
+                else None
+            ),
+            r2_secret_access_key=(
+                SecretStr(_r2_sec)
+                if (_r2_sec := os.environ.get("R2_SECRET_ACCESS_KEY", "").strip())
+                else None
+            ),
+            r2_bucket=(
+                _r2_bkt
+                if (_r2_bkt := os.environ.get("R2_BUCKET", "").strip())
+                else None
+            ),
+            r2_endpoint_override=(
+                _r2_ep
+                if (_r2_ep := os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip())
+                else None
             ),
         )
 

--- a/src/uw_scan/sources/CLAUDE.md
+++ b/src/uw_scan/sources/CLAUDE.md
@@ -7,7 +7,8 @@ The only place that talks to the outside world.
 - `uw.py` — Unusual Whales fetchers. Every fetcher: call UW → write audit row → persist raw compressed payload → normalize → return typed model.
 - `ohlc.py` — `MassiveOhlcProvider` (Polygon-shaped REST). Daily bars only after Phase 7 — the `fetch_intraday_quote` REST path was removed; intraday spot now streams via `massive_ws.py`.
 - `massive_ws.py` — Async WebSocket client for `wss://delayed.massive.com/stocks`. Per-second `A.*` aggregates (Polygon-parity grammar). Pure I/O (no DB writes, no buffering, no business logic) — buffering + persistence live in `worker/ws_tick_buffer.py` + `worker/ws_db_writer.py`. The long-lived consumer process is `worker/massive_ws_consumer.py`. Replaces the old per-ticker REST polling: massive.com's `A.*` feed delivers ~1 frame/sec/ticker during the 04:00-20:00 ET window (pre-market + RTH + after-hours).
-- `lake.py` — Parquet reader for `~/market-warehouse/data-lake`. Used by the nightly `vol_index_lake_sync` job. Pure I/O, no business logic.
+- `lake.py` — Parquet reader for the market-warehouse data lake. Backend is either the local mirror (`~/market-warehouse/data-lake/`) or Cloudflare R2 (`market-data/market-warehouse/data-lake/`) — selection is config-driven via `lake_resolver.resolve_lake_root(settings, asset_class=...)`, which picks R2 when all four `R2_*` settings are present and otherwise falls back to local. R2 is the primary EOD/backfill source per the 2026-05-25 rule; the nightly `vol_index_lake_sync` + `credit_etf_lake_sync` jobs still read local (consumer migration is a follow-on PR). Pure I/O, no business logic.
+- `lake_resolver.py` — `LakeRoot` dataclass + `resolve_lake_root()` config-to-root mapping. R2 → S3 protocol via `pyarrow.fs.S3FileSystem` with the account-scoped endpoint override.
 
 ## Gold complex (Phase A1 + v2 corpus)
 

--- a/src/uw_scan/sources/lake.py
+++ b/src/uw_scan/sources/lake.py
@@ -1,6 +1,14 @@
-"""Parquet reader for ~/market-warehouse/data-lake.
+"""Parquet reader for the market-warehouse data lake.
 
-Used by the nightly vol_index_lake_sync job. No business logic — pure I/O.
+Supports two backends via the LakeRoot abstraction in lake_resolver:
+- Local filesystem (Path) — used by the existing nightly sync jobs
+- Cloudflare R2 — used by new EOD/backfill code per the 2026-05-25 standing
+  rule (see [[feedback-r2-primary-for-eod-backfill]])
+
+Public functions accept either a Path or a LakeRoot for backward
+compatibility with existing Path-based callers. No business logic — pure I/O.
+R2 reads go through pyarrow.fs.S3FileSystem with the account-scoped
+endpoint override; auth is access-key / secret-key Sig V4.
 """
 
 from __future__ import annotations
@@ -8,13 +16,50 @@ from __future__ import annotations
 from datetime import date
 from pathlib import Path
 
+import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
+
+from uw_scan.sources.lake_resolver import LakeRoot
 
 VOL_INDEX_FILENAME = "1d.parquet"
 
 
-def list_vol_index_symbols(root: Path) -> list[str]:
-    """Return all symbols under root/symbol=<TICKER>/1d.parquet."""
+def _normalize(root: Path | LakeRoot) -> LakeRoot:
+    if isinstance(root, LakeRoot):
+        return root
+    # Legacy Path-based callers (vol_index_lake_sync, credit_etf_lake_sync) —
+    # wrap as a local-kind LakeRoot. asset_class is informational only for
+    # local reads; the Path drives the actual lookup.
+    return LakeRoot.local_for("legacy", root)
+
+
+def list_vol_index_symbols(root: Path | LakeRoot) -> list[str]:
+    """Return all symbols under `root/symbol=<TICKER>/1d.parquet`."""
+    lr = _normalize(root)
+    if lr.kind == "local":
+        assert lr.local_path is not None
+        return _list_local(lr.local_path)
+    return _list_s3(lr)
+
+
+def read_vol_index_parquet(
+    root: Path | LakeRoot,
+    symbol: str,
+    *,
+    since: date | None = None,
+) -> list[dict]:
+    """Read `symbol=<S>/1d.parquet` -> list[dict] with normalized columns."""
+    lr = _normalize(root)
+    if lr.kind == "local":
+        assert lr.local_path is not None
+        return _read_local(lr.local_path, symbol, since=since)
+    return _read_s3(lr, symbol, since=since)
+
+
+# ---------- local backend (unchanged behavior) ----------
+
+
+def _list_local(root: Path) -> list[str]:
     if not root.exists():
         return []
     out: list[str] = []
@@ -30,21 +75,76 @@ def list_vol_index_symbols(root: Path) -> list[str]:
     return sorted(out)
 
 
-def read_vol_index_parquet(
-    root: Path,
-    symbol: str,
-    *,
-    since: date | None = None,
-) -> list[dict]:
-    """Read symbol=<S>/1d.parquet → list[dict] with normalized columns.
-
-    Output dicts contain: symbol, trade_date, open, high, low, close,
-    adj_close, volume. Rows are sorted by trade_date ascending.
-    """
+def _read_local(root: Path, symbol: str, *, since: date | None) -> list[dict]:
     path = root / f"symbol={symbol}" / VOL_INDEX_FILENAME
     if not path.exists():
         return []
     table = pq.read_table(path)
+    return _rows_from_table(table, symbol, since=since)
+
+
+# ---------- s3 (R2) backend ----------
+
+
+def _s3_fs(lr: LakeRoot) -> pa_fs.S3FileSystem:
+    return pa_fs.S3FileSystem(
+        access_key=lr.access_key_id,
+        secret_key=lr.secret_access_key,
+        endpoint_override=lr.endpoint_override,
+        # R2 ignores region but pyarrow requires *something* non-empty.
+        region="auto",
+        scheme="https",
+    )
+
+
+def _list_s3(lr: LakeRoot) -> list[str]:
+    assert lr.bucket and lr.key_prefix
+    fs = _s3_fs(lr)
+    selector = pa_fs.FileSelector(
+        f"{lr.bucket}/{lr.key_prefix}", recursive=False, allow_not_found=True
+    )
+    out: list[str] = []
+    for info in fs.get_file_info(selector):
+        if info.type != pa_fs.FileType.Directory:
+            continue
+        base = Path(info.path).name
+        if not base.startswith("symbol="):
+            continue
+        symbol = base[len("symbol=") :]
+        # Probe parquet existence so listing symmetry matches the local backend
+        # (which only returns symbols that have 1d.parquet). One extra
+        # round-trip per symbol — acceptable for ~20 symbols on the nightly
+        # sync schedule; cheaper than swallowing empty reads downstream.
+        probe = fs.get_file_info(
+            f"{lr.bucket}/{lr.key_prefix}/symbol={symbol}/{VOL_INDEX_FILENAME}"
+        )
+        if probe.type != pa_fs.FileType.File:
+            continue
+        out.append(symbol)
+    return sorted(out)
+
+
+def _read_s3(lr: LakeRoot, symbol: str, *, since: date | None) -> list[dict]:
+    assert lr.bucket and lr.key_prefix
+    fs = _s3_fs(lr)
+    key = f"{lr.bucket}/{lr.key_prefix}/symbol={symbol}/{VOL_INDEX_FILENAME}"
+    # Probe existence cleanly via FileInfo.type rather than try/except — pyarrow's
+    # S3 backend raises OSError/ArrowIOError (not FileNotFoundError) on 403,
+    # timeout, missing key, and a few other paths, so a narrow except FileNotFoundError
+    # is unreliable AND lets all the other errors crash callers. The local
+    # backend uses path.exists() (returns False, no exception); this is the
+    # S3 analogue. Real errors (403, malformed parquet) propagate.
+    info = fs.get_file_info(key)
+    if info.type != pa_fs.FileType.File:
+        return []
+    table = pq.read_table(key, filesystem=fs)
+    return _rows_from_table(table, symbol, since=since)
+
+
+# ---------- shared row normalizer ----------
+
+
+def _rows_from_table(table, symbol: str, *, since: date | None) -> list[dict]:
     df = table.to_pandas()
     if "trade_date" not in df.columns:
         return []

--- a/src/uw_scan/sources/lake_resolver.py
+++ b/src/uw_scan/sources/lake_resolver.py
@@ -1,0 +1,95 @@
+"""Resolve a parquet-lake root to either an R2 URI or a local Path.
+
+R2 is the primary source per the 2026-05-25 standing rule (see CLAUDE.md and
+docs/research/regime/closure-2026-05-24.md). When all four core R2 settings
+(account_id, access_key_id, secret_access_key, bucket) are present the
+resolver returns an s3-kind LakeRoot; otherwise it falls back to the local
+mirror Path configured per asset_class.
+
+This module is pure config-to-root mapping; the actual I/O lives in lake.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from uw_scan.config import Settings
+
+_ASSET_CLASS_TO_LOCAL_ATTR: dict[str, str] = {
+    "volatility": "lake_vol_index_root",
+    "equity": "lake_credit_etf_root",
+}
+
+
+@dataclass(frozen=True)
+class LakeRoot:
+    """Either an S3-on-R2 root or a local-filesystem Path. Discriminate on `kind`.
+
+    `access_key_id` and `secret_access_key` are excluded from repr() so they
+    don't leak into log lines, stack traces, or error-tracker payloads when
+    the dataclass is printed (e.g. logger.exception with the object as arg).
+    """
+
+    kind: Literal["s3", "local"]
+    asset_class: str
+    # local-only
+    local_path: Path | None = None
+    # s3-only
+    bucket: str | None = None
+    key_prefix: str | None = None
+    endpoint_override: str | None = None
+    access_key_id: str | None = field(default=None, repr=False)
+    secret_access_key: str | None = field(default=None, repr=False)
+
+    @classmethod
+    def local_for(cls, asset_class: str, path: Path) -> "LakeRoot":
+        return cls(kind="local", asset_class=asset_class, local_path=path)
+
+
+def _r2_fully_configured(s: Settings) -> bool:
+    """All four core R2 fields must hold non-empty values.
+
+    Checks `.get_secret_value()` on the SecretStr wrappers explicitly —
+    `bool(SecretStr(""))` is True because SecretStr is a non-empty wrapper
+    object, so `all((..., r2_access_key_id, r2_secret_access_key, ...))`
+    would falsely report 'configured' for empty secrets and engage R2 with
+    garbage creds → 403 on every read.
+    """
+    if not s.r2_account_id or not s.r2_bucket:
+        return False
+    if s.r2_access_key_id is None or not s.r2_access_key_id.get_secret_value():
+        return False
+    if s.r2_secret_access_key is None or not s.r2_secret_access_key.get_secret_value():
+        return False
+    return True
+
+
+def resolve_lake_root(settings: Settings, *, asset_class: str) -> LakeRoot:
+    """Return the lake root for `asset_class`: R2 when configured, else local."""
+    if asset_class not in _ASSET_CLASS_TO_LOCAL_ATTR:
+        raise ValueError(
+            f"unknown asset_class {asset_class!r}; "
+            f"expected one of {sorted(_ASSET_CLASS_TO_LOCAL_ATTR)}"
+        )
+    local_path: Path = getattr(settings, _ASSET_CLASS_TO_LOCAL_ATTR[asset_class])
+
+    if not _r2_fully_configured(settings):
+        return LakeRoot.local_for(asset_class, local_path)
+
+    assert settings.r2_access_key_id is not None  # narrowed by _r2_fully_configured
+    assert settings.r2_secret_access_key is not None
+    endpoint = (
+        settings.r2_endpoint_override
+        or f"https://{settings.r2_account_id}.r2.cloudflarestorage.com"
+    )
+    return LakeRoot(
+        kind="s3",
+        asset_class=asset_class,
+        bucket=settings.r2_bucket,
+        key_prefix=f"market-warehouse/data-lake/bronze/asset_class={asset_class}",
+        endpoint_override=endpoint,
+        access_key_id=settings.r2_access_key_id.get_secret_value(),
+        secret_access_key=settings.r2_secret_access_key.get_secret_value(),
+    )

--- a/src/uw_scan/storage/vol_index_repository.py
+++ b/src/uw_scan/storage/vol_index_repository.py
@@ -69,6 +69,17 @@ class VolIndexRepository:
             row = cur.fetchone()
         return row[0] if row and row[0] else None
 
+    def fetch_dates_for(self, symbol: str) -> set[date]:
+        """Return the full set of trade_dates stored for `symbol`.
+
+        Used by the gap-aware lake-sync logic to compute `missing = R2 - DB`.
+        Single-column index scan; cheap even for VIX (~9k rows → <100 ms).
+        """
+        sql = "SELECT trade_date FROM vol_index_daily WHERE symbol = %s"
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbol,))
+            return {r[0] for r in cur.fetchall()}
+
     def fetch_multi_history(
         self, symbols: Sequence[str], days: int
     ) -> dict[str, list[dict]]:

--- a/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+++ b/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
@@ -51,9 +51,9 @@ def run_credit_etf_lake_sync(
     for symbol in symbols:
         r2_rows = read_vol_index_parquet(root, symbol)
         if not r2_rows:
-            logger.info(
-                "credit_etf_lake_sync: %s — no rows in lake under symbol=%s",
-                symbol,
+            logger.warning(
+                "credit_etf_lake_sync: %s — no rows in lake (symbol absent OR "
+                "lake returned empty mid-write); skipping",
                 symbol,
             )
             continue

--- a/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+++ b/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
@@ -5,11 +5,12 @@ filters down to a configured allow-list (HYG/JNK/LQD by default — the VCG
 scanner's credit proxies). All rows land in ``vol_index_daily`` so the scanner
 can read VIX/VVIX/<proxy> through a single repository.
 
-Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
-the next read. First run backfills the full available history.
+Gap-aware: each run reads the full R2 history per symbol, compares against the
+dates already in `vol_index_daily`, and upserts only the missing dates plus the
+current latest. Heals tail-and-middle drift between R2 and the DB on every run.
 
 Accepts either a local-filesystem `Path` or a `LakeRoot` (R2 or local). The
-scheduler now resolves the root via `resolve_lake_root(settings, asset_class=
+scheduler resolves the root via `resolve_lake_root(settings, asset_class=
 'equity')` so this job reads from R2 when all four `R2_*` settings are
 present, else from the local mirror.
 """
@@ -18,7 +19,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from datetime import timedelta
 from pathlib import Path
 
 from psycopg import Connection
@@ -38,32 +38,42 @@ def run_credit_etf_lake_sync(
 ) -> dict:
     """Sync `symbols` under root into uw_scan.vol_index_daily.
 
-    `read_vol_index_parquet` is reused as-is — it's symbol-keyed and assumes
-    `<root>/symbol=<SYM>/1d.parquet`, which is the same layout the equity
-    asset_class folder uses. Returns {symbols: int, rows: int}.
+    Returns {symbols: int, rows: int, gaps_filled: int}. `gaps_filled`
+    counts R2 dates that were missing from the DB before this run.
     """
     if not symbols:
-        return {"symbols": 0, "rows": 0}
+        return {"symbols": 0, "rows": 0, "gaps_filled": 0}
 
     repo = VolIndexRepository(conn, schema="uw_scan")
-    total = 0
+    total_rows = 0
+    total_gaps = 0
     synced = 0
     for symbol in symbols:
-        latest = repo.latest_date_for(symbol)
-        # Read from one day before latest so a same-day snapshot that closes
-        # differently still gets re-upserted.
-        since = (latest - timedelta(days=1)) if latest else None
-        rows = read_vol_index_parquet(root, symbol, since=since)
-        if not rows:
+        r2_rows = read_vol_index_parquet(root, symbol)
+        if not r2_rows:
             logger.info(
-                "credit_etf_lake_sync: %s — no rows under %s/symbol=%s",
+                "credit_etf_lake_sync: %s — no rows in lake under symbol=%s",
                 symbol,
-                root,
                 symbol,
             )
             continue
-        n = repo.upsert_rows(rows)
-        total += n
+        r2_dates = {r["trade_date"] for r in r2_rows}
+        db_dates = repo.fetch_dates_for(symbol)
+        latest = max(db_dates) if db_dates else None
+        to_pull_dates = (r2_dates - db_dates) | ({latest} if latest else set())
+        rows_to_upsert = [r for r in r2_rows if r["trade_date"] in to_pull_dates]
+        if not rows_to_upsert:
+            continue
+        gaps = len(r2_dates - db_dates)
+        n = repo.upsert_rows(rows_to_upsert)
+        total_rows += n
+        total_gaps += gaps
         synced += 1
-        logger.info("credit_etf_lake_sync: %s — %d rows since %s", symbol, n, since)
-    return {"symbols": synced, "rows": total}
+        logger.info(
+            "credit_etf_lake_sync: %s — %d rows upserted (%d gaps filled), latest=%s",
+            symbol,
+            n,
+            gaps,
+            latest,
+        )
+    return {"symbols": synced, "rows": total_rows, "gaps_filled": total_gaps}

--- a/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
+++ b/src/uw_scan/worker/jobs/credit_etf_lake_sync.py
@@ -7,6 +7,11 @@ can read VIX/VVIX/<proxy> through a single repository.
 
 Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
 the next read. First run backfills the full available history.
+
+Accepts either a local-filesystem `Path` or a `LakeRoot` (R2 or local). The
+scheduler now resolves the root via `resolve_lake_root(settings, asset_class=
+'equity')` so this job reads from R2 when all four `R2_*` settings are
+present, else from the local mirror.
 """
 
 from __future__ import annotations
@@ -19,6 +24,7 @@ from pathlib import Path
 from psycopg import Connection
 
 from uw_scan.sources.lake import read_vol_index_parquet
+from uw_scan.sources.lake_resolver import LakeRoot
 from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 logger = logging.getLogger(__name__)
@@ -27,7 +33,7 @@ logger = logging.getLogger(__name__)
 def run_credit_etf_lake_sync(
     conn: Connection,
     *,
-    root: Path,
+    root: Path | LakeRoot,
     symbols: Sequence[str],
 ) -> dict:
     """Sync `symbols` under root into uw_scan.vol_index_daily.

--- a/src/uw_scan/worker/jobs/vol_index_lake_sync.py
+++ b/src/uw_scan/worker/jobs/vol_index_lake_sync.py
@@ -1,10 +1,13 @@
 """Nightly: parquet lake → uw_scan.vol_index_daily.
 
-Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
-the next read. First run backfills the entire history.
+Gap-aware: each run reads the full R2 history for every symbol, compares against
+the dates already in `vol_index_daily`, and upserts ONLY the missing dates plus
+the current latest (which may have an intra-session refresh). Backfills the full
+history on first run; on every subsequent run it heals any drift between R2 and
+the DB regardless of where the gap is (tail or middle).
 
 Accepts either a local-filesystem `Path` or a `LakeRoot` (R2 or local). The
-scheduler now resolves the root via `resolve_lake_root(settings, asset_class=
+scheduler resolves the root via `resolve_lake_root(settings, asset_class=
 'volatility')` so this job reads from R2 when all four `R2_*` settings are
 present, else from the local mirror. Existing Path-based callers (e.g.
 `tests/integration/test_vol_index_lake_sync.py`) continue to work via the
@@ -14,7 +17,6 @@ present, else from the local mirror. Existing Path-based callers (e.g.
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 from pathlib import Path
 
 from psycopg import Connection
@@ -29,23 +31,42 @@ logger = logging.getLogger(__name__)
 def run_vol_index_lake_sync(conn: Connection, *, root: Path | LakeRoot) -> dict:
     """Sync all symbols under root into uw_scan.vol_index_daily.
 
-    Returns a summary dict: {symbols: int, rows: int}.
+    Returns a summary dict: {symbols: int, rows: int, gaps_filled: int}.
+    `gaps_filled` counts dates that existed in R2 but were missing from the DB
+    before this run — surfaces drift without spamming the logs.
     """
     symbols = list_vol_index_symbols(root)
     if not symbols:
         logger.info("vol_index_lake_sync: no symbols at %s", root)
-        return {"symbols": 0, "rows": 0}
+        return {"symbols": 0, "rows": 0, "gaps_filled": 0}
 
     repo = VolIndexRepository(conn, schema="uw_scan")
-    total = 0
+    total_rows = 0
+    total_gaps = 0
     for symbol in symbols:
-        latest = repo.latest_date_for(symbol)
-        # Read from one day before latest (so we re-upsert the most recent
-        # row in case it was a same-day snapshot that closed differently).
-        since = (latest - timedelta(days=1)) if latest else None
-        rows = read_vol_index_parquet(root, symbol, since=since)
-        if rows:
-            n = repo.upsert_rows(rows)
-            total += n
-            logger.info("vol_index_lake_sync: %s — %d rows since %s", symbol, n, since)
-    return {"symbols": len(symbols), "rows": total}
+        r2_rows = read_vol_index_parquet(root, symbol)
+        if not r2_rows:
+            continue
+        r2_dates = {r["trade_date"] for r in r2_rows}
+        db_dates = repo.fetch_dates_for(symbol)
+        # Always re-upsert the latest known DB row in case the lake's
+        # most-recent close was revised after our last sync (intra-session
+        # final-vs-snapshot drift). The `or {None}` guard handles first-run
+        # symbols where db_dates is empty.
+        latest = max(db_dates) if db_dates else None
+        to_pull_dates = (r2_dates - db_dates) | ({latest} if latest else set())
+        rows_to_upsert = [r for r in r2_rows if r["trade_date"] in to_pull_dates]
+        if not rows_to_upsert:
+            continue
+        gaps = len(r2_dates - db_dates)
+        n = repo.upsert_rows(rows_to_upsert)
+        total_rows += n
+        total_gaps += gaps
+        logger.info(
+            "vol_index_lake_sync: %s — %d rows upserted (%d gaps filled), latest=%s",
+            symbol,
+            n,
+            gaps,
+            latest,
+        )
+    return {"symbols": len(symbols), "rows": total_rows, "gaps_filled": total_gaps}

--- a/src/uw_scan/worker/jobs/vol_index_lake_sync.py
+++ b/src/uw_scan/worker/jobs/vol_index_lake_sync.py
@@ -46,13 +46,19 @@ def run_vol_index_lake_sync(conn: Connection, *, root: Path | LakeRoot) -> dict:
     for symbol in symbols:
         r2_rows = read_vol_index_parquet(root, symbol)
         if not r2_rows:
+            logger.warning(
+                "vol_index_lake_sync: %s — no rows in lake (symbol absent OR "
+                "lake returned empty mid-write); skipping",
+                symbol,
+            )
             continue
         r2_dates = {r["trade_date"] for r in r2_rows}
         db_dates = repo.fetch_dates_for(symbol)
         # Always re-upsert the latest known DB row in case the lake's
         # most-recent close was revised after our last sync (intra-session
-        # final-vs-snapshot drift). The `or {None}` guard handles first-run
-        # symbols where db_dates is empty.
+        # final-vs-snapshot drift). When db_dates is empty (first run), the
+        # `{latest} if latest else set()` ternary contributes nothing and the
+        # full r2 history flows in via the set-diff above.
         latest = max(db_dates) if db_dates else None
         to_pull_dates = (r2_dates - db_dates) | ({latest} if latest else set())
         rows_to_upsert = [r for r in r2_rows if r["trade_date"] in to_pull_dates]

--- a/src/uw_scan/worker/jobs/vol_index_lake_sync.py
+++ b/src/uw_scan/worker/jobs/vol_index_lake_sync.py
@@ -2,6 +2,13 @@
 
 Incremental: each symbol's max(trade_date) in the DB sets the lower bound for
 the next read. First run backfills the entire history.
+
+Accepts either a local-filesystem `Path` or a `LakeRoot` (R2 or local). The
+scheduler now resolves the root via `resolve_lake_root(settings, asset_class=
+'volatility')` so this job reads from R2 when all four `R2_*` settings are
+present, else from the local mirror. Existing Path-based callers (e.g.
+`tests/integration/test_vol_index_lake_sync.py`) continue to work via the
+`_normalize` shim inside `lake.py`.
 """
 
 from __future__ import annotations
@@ -13,12 +20,13 @@ from pathlib import Path
 from psycopg import Connection
 
 from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
+from uw_scan.sources.lake_resolver import LakeRoot
 from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 logger = logging.getLogger(__name__)
 
 
-def run_vol_index_lake_sync(conn: Connection, *, root: Path) -> dict:
+def run_vol_index_lake_sync(conn: Connection, *, root: Path | LakeRoot) -> dict:
     """Sync all symbols under root into uw_scan.vol_index_daily.
 
     Returns a summary dict: {symbols: int, rows: int}.

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -20,6 +20,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from uw_scan.api.client import UwClient
 from uw_scan.config import Settings
+from uw_scan.sources.lake_resolver import resolve_lake_root
 from uw_scan.sources.ohlc import MassiveOhlcProvider
 from uw_scan.storage.provider_usage import ExternalApiRequestRecorder
 from uw_scan.storage.repository import Repository
@@ -411,20 +412,25 @@ def main() -> int:
             )
 
     def _vol_index_lake_sync() -> None:
-        # Parquet lake (~/market-warehouse/.../volatility) → vol_index_daily.
-        # Local I/O + Postgres only — no external API spend, no UW/Massive role
-        # binding required. Primary worker runs it to avoid duplicate upserts.
+        # Parquet lake → vol_index_daily. Source is R2 when all four R2_*
+        # settings are present (per the 2026-05-25 standing rule), else the
+        # local mirror under ~/market-warehouse/.../volatility. No external
+        # API spend in either case (R2 = our own object storage, not UW/Massive).
+        # Primary worker runs it to avoid duplicate upserts.
+        root = resolve_lake_root(settings, asset_class="volatility")
         with _repo(settings) as repo:
-            run_vol_index_lake_sync(repo.conn, root=settings.lake_vol_index_root)
+            run_vol_index_lake_sync(repo.conn, root=root)
 
     def _credit_etf_lake_sync() -> None:
         # Equity asset_class lake → vol_index_daily for the VCG credit proxies
-        # (HYG / JNK / LQD). Pure local I/O; same idempotency guarantees as the
-        # vol-complex sync. Primary worker only.
+        # (HYG / JNK / LQD). Source is R2 when configured, else the local
+        # mirror — same idempotency guarantees apply to both backends.
+        # Primary worker only.
+        root = resolve_lake_root(settings, asset_class="equity")
         with _repo(settings) as repo:
             run_credit_etf_lake_sync(
                 repo.conn,
-                root=settings.lake_credit_etf_root,
+                root=root,
                 symbols=settings.credit_etf_symbols,
             )
 

--- a/tests/integration/sources/test_lake_r2.py
+++ b/tests/integration/sources/test_lake_r2.py
@@ -1,0 +1,97 @@
+"""Live R2 smoke test — verifies the new rails read VIX + credit-proxy ETFs.
+
+GATING CONVENTION (matches tests/live/test_uw_smoke.py): two marks at module
+level — pytest.mark.live for the marker registration, and pytest.mark.skipif
+for the actual env-absent skip. The project convention is "live tests
+self-skip via skipif when their required env is unset"; this repo does NOT
+load .env from conftest, so the developer must export R2_* before running:
+
+    set -a; source .env; set +a
+    uv run pytest -m live tests/integration/sources/test_lake_r2.py -v
+
+A run with the R2 env unset SKIPS (not "passes silently against fallback"):
+the module-level skipif sets reason="R2_* env not set" so a misread of the
+report is harder. A run with R2 env present runs the tests for real, and
+schema/cred/network problems surface as assertion failures or pyarrow errors.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+from uw_scan.sources.lake import list_vol_index_symbols, read_vol_index_parquet
+from uw_scan.sources.lake_resolver import resolve_lake_root
+
+_REQUIRED_R2_ENV = (
+    "R2_ACCOUNT_ID",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_BUCKET",
+)
+
+
+def _r2_env_missing() -> bool:
+    return any(not os.environ.get(k, "").strip() for k in _REQUIRED_R2_ENV)
+
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _r2_env_missing(),
+        reason="R2_* env not set — export R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / "
+        "R2_SECRET_ACCESS_KEY / R2_BUCKET (e.g. set -a; source .env; set +a) "
+        "before running this live smoke",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def settings() -> Settings:
+    # Construct Settings directly from R2 env only — Settings.from_env() would
+    # require UW_SCAN_API_KEY, which has no business gating an R2 smoke. The
+    # module-level skipif above guarantees these env vars exist when this
+    # fixture is reached.
+    endpoint_override = os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip() or None
+    return Settings(
+        api_key=SecretStr("dummy-not-used-by-r2-smoke"),
+        r2_account_id=os.environ["R2_ACCOUNT_ID"].strip(),
+        r2_access_key_id=SecretStr(os.environ["R2_ACCESS_KEY_ID"].strip()),
+        r2_secret_access_key=SecretStr(os.environ["R2_SECRET_ACCESS_KEY"].strip()),
+        r2_bucket=os.environ["R2_BUCKET"].strip(),
+        r2_endpoint_override=endpoint_override,
+    )
+
+
+def test_r2_volatility_lists_includes_vix(settings: Settings) -> None:
+    root = resolve_lake_root(settings, asset_class="volatility")
+    assert root.kind == "s3", "resolver did not pick R2 despite full env"
+    symbols = list_vol_index_symbols(root)
+    assert "VIX" in symbols, f"VIX missing from R2 volatility lake: {symbols[:8]!r}"
+
+
+def test_r2_vix_read_returns_recent_rows(settings: Settings) -> None:
+    root = resolve_lake_root(settings, asset_class="volatility")
+    rows = read_vol_index_parquet(root, "VIX")
+    assert rows, "VIX read returned 0 rows from R2"
+    last = rows[-1]
+    assert last["trade_date"] is not None
+    assert isinstance(last["close"], float), (
+        f"expected float close, got {type(last['close']).__name__}"
+    )
+
+
+@pytest.mark.parametrize("symbol", ["HYG", "JNK", "LQD"])
+def test_r2_equity_credit_proxy_reads(settings: Settings, symbol: str) -> None:
+    root = resolve_lake_root(settings, asset_class="equity")
+    assert root.kind == "s3"
+    rows = read_vol_index_parquet(root, symbol)
+    assert rows, f"{symbol} read returned 0 rows from R2 equity lake"
+    last = rows[-1]
+    assert last["symbol"] == symbol
+    assert isinstance(last["close"], float)
+    # Equity bars have volume; vol-complex indices may have 0. Both legal.
+    assert last["volume"] is None or last["volume"] >= 0

--- a/tests/integration/test_vol_index_lake_sync.py
+++ b/tests/integration/test_vol_index_lake_sync.py
@@ -4,9 +4,9 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
 
 from uw_scan.storage.vol_index_repository import VolIndexRepository
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
 
 
 def _seed(root: Path, symbol: str, rows: list[dict]) -> None:
@@ -118,4 +118,86 @@ def test_run_sync_empty_root_is_noop(tmp_path: Path, seeded_db_empty_cards) -> N
         seeded_db_empty_cards.conn,
         root=tmp_path,
     )
-    assert summary == {"symbols": 0, "rows": 0}
+    assert summary == {"symbols": 0, "rows": 0, "gaps_filled": 0}
+
+
+def test_run_sync_fills_middle_gap(tmp_path: Path, seeded_db_empty_cards) -> None:
+    """Gap-aware sync: if the DB has [05-13, 05-15] but R2 has [05-13, 05-14,
+    05-15], the next run MUST pull 05-14 (a middle gap) into vol_index_daily.
+
+    Defends against drift accumulated by a previous since-based sync that
+    only ever caught up the tail. Regression test for the "what about 5/16
+    and 5/17" follow-up — by extension, any internal hole that R2 covers.
+    """
+    pg_conn = seeded_db_empty_cards.conn
+    repo = VolIndexRepository(pg_conn, schema="uw_scan")
+    # Pre-seed the DB with two non-contiguous days for VIX — a hole on 05-14.
+    repo.upsert_rows(
+        [
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 13),
+                "open": 17.0,
+                "high": 17.5,
+                "low": 16.8,
+                "close": 17.2,
+                "adj_close": 17.2,
+                "volume": 0,
+            },
+            {
+                "symbol": "VIX",
+                "trade_date": date(2026, 5, 15),
+                "open": 18.0,
+                "high": 18.5,
+                "low": 17.9,
+                "close": 18.2,
+                "adj_close": 18.2,
+                "volume": 0,
+            },
+        ]
+    )
+    # R2-side fixture: three contiguous days including the missing 05-14.
+    _seed(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 5, 13),
+                "open": 17.0,
+                "high": 17.5,
+                "low": 16.8,
+                "close": 17.2,
+                "adj_close": 17.2,
+                "volume": 0,
+            },
+            {
+                "trade_date": date(2026, 5, 14),
+                "open": 17.3,
+                "high": 17.8,
+                "low": 17.1,
+                "close": 17.6,
+                "adj_close": 17.6,
+                "volume": 0,
+            },
+            {
+                "trade_date": date(2026, 5, 15),
+                "open": 18.0,
+                "high": 18.5,
+                "low": 17.9,
+                "close": 18.2,
+                "adj_close": 18.2,
+                "volume": 0,
+            },
+        ],
+    )
+
+    summary = run_vol_index_lake_sync(pg_conn, root=tmp_path)
+
+    # Expect 1 gap filled (05-14) plus latest re-upsert (05-15) → 2 rows.
+    assert summary["gaps_filled"] == 1
+    assert summary["rows"] == 2
+    # And 05-14 now sits between the two existing rows.
+    history = repo.fetch_history("VIX", days=10)
+    dates = [r["trade_date"] for r in history]
+    assert date(2026, 5, 14) in dates, f"middle gap not filled; dates={dates}"
+    assert dates == sorted(dates), "history must be ascending after gap fill"

--- a/tests/integration/worker/test_lake_sync_r2.py
+++ b/tests/integration/worker/test_lake_sync_r2.py
@@ -89,6 +89,19 @@ def test_vol_index_lake_sync_pulls_from_r2(seeded_db_empty_cards) -> None:
     vix_history = repo.fetch_history("VIX", days=30)
     assert vix_history, "VIX rows did not land in vol_index_daily after R2 sync"
 
+    # Second-run idempotency — gap-aware sync MUST report gaps_filled == 0
+    # immediately after a successful first run. Catches a future regression
+    # where r2_dates and db_dates fail to compare as equal sets (e.g. if
+    # pyarrow→pandas coerces date32 to Timestamp on some future upstream
+    # schema change). Without this assertion the bug is silent (Postgres
+    # absorbs duplicate upserts; cost inflates ~history-size× per run).
+    second = run_vol_index_lake_sync(seeded_db_empty_cards.conn, root=root)
+    assert second["gaps_filled"] == 0, (
+        f"second run reported gaps_filled={second['gaps_filled']} — "
+        f"date-type drift between R2 (pyarrow) and DB (psycopg) is likely; "
+        f"check _rows_from_table in lake.py and fetch_dates_for"
+    )
+
 
 def test_credit_etf_lake_sync_pulls_from_r2(seeded_db_empty_cards) -> None:
     """run_credit_etf_lake_sync against R2 inserts HYG/JNK/LQD rows.

--- a/tests/integration/worker/test_lake_sync_r2.py
+++ b/tests/integration/worker/test_lake_sync_r2.py
@@ -1,0 +1,116 @@
+"""Live R2 smoke for the lake-sync jobs (post-migration).
+
+Proves the scheduler-side wire — resolve_lake_root → LakeRoot(kind='s3') →
+run_vol_index_lake_sync / run_credit_etf_lake_sync → DB upsert — works
+end-to-end against the real R2 bucket and a real Postgres.
+
+GATING: matches tests/integration/sources/test_lake_r2.py — module-level
+pytestmark with pytest.mark.live + pytest.mark.skipif on R2_* env. Default
+pytest runs skip these; the developer must export R2_* explicitly:
+
+    set -a; source .env; set +a
+    uv run pytest -m live tests/integration/worker/test_lake_sync_r2.py -v
+
+Note: also requires the seeded_db_empty_cards fixture, which transitively
+needs UW_SCAN_TEST_DB_NAME pointing at an isolated Postgres database. The
+fixture drops + remigrates the schema on each test invocation.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+from uw_scan.sources.lake_resolver import resolve_lake_root
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+from uw_scan.worker.jobs.credit_etf_lake_sync import run_credit_etf_lake_sync
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+
+_REQUIRED_R2_ENV = (
+    "R2_ACCOUNT_ID",
+    "R2_ACCESS_KEY_ID",
+    "R2_SECRET_ACCESS_KEY",
+    "R2_BUCKET",
+)
+
+
+def _r2_env_missing() -> bool:
+    return any(not os.environ.get(k, "").strip() for k in _REQUIRED_R2_ENV)
+
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _r2_env_missing(),
+        reason="R2_* env not set — export R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / "
+        "R2_SECRET_ACCESS_KEY / R2_BUCKET (e.g. set -a; source .env; set +a) "
+        "before running this live sync test",
+    ),
+]
+
+
+def _r2_settings() -> Settings:
+    """Build a Settings with R2 fields populated from the live env.
+
+    Skips Settings.from_env() because that requires UW_SCAN_API_KEY which is
+    unrelated to the R2 path. Locally-resolved lake roots stay at their
+    Settings defaults — irrelevant because all four R2_* are set so
+    resolve_lake_root returns an s3-kind LakeRoot.
+    """
+    endpoint_override = os.environ.get("R2_ENDPOINT_OVERRIDE", "").strip() or None
+    return Settings(
+        api_key=SecretStr("dummy-not-used-by-r2-sync-smoke"),
+        r2_account_id=os.environ["R2_ACCOUNT_ID"].strip(),
+        r2_access_key_id=SecretStr(os.environ["R2_ACCESS_KEY_ID"].strip()),
+        r2_secret_access_key=SecretStr(os.environ["R2_SECRET_ACCESS_KEY"].strip()),
+        r2_bucket=os.environ["R2_BUCKET"].strip(),
+        r2_endpoint_override=endpoint_override,
+    )
+
+
+def test_vol_index_lake_sync_pulls_from_r2(seeded_db_empty_cards) -> None:
+    """run_vol_index_lake_sync against R2 inserts at least VIX into vol_index_daily.
+
+    Proves the end-to-end wire: scheduler-style resolve_lake_root call →
+    LakeRoot(kind='s3') → _read_s3 path in lake.py → repository upsert.
+    """
+    settings = _r2_settings()
+    root = resolve_lake_root(settings, asset_class="volatility")
+    assert root.kind == "s3", "resolver did not pick R2 despite full env"
+
+    summary = run_vol_index_lake_sync(seeded_db_empty_cards.conn, root=root)
+    assert summary["symbols"] > 0, "expected R2 volatility lake to have symbols"
+    assert summary["rows"] > 0, "expected R2 volatility lake to yield rows"
+
+    repo = VolIndexRepository(seeded_db_empty_cards.conn, schema="uw_scan")
+    vix_history = repo.fetch_history("VIX", days=30)
+    assert vix_history, "VIX rows did not land in vol_index_daily after R2 sync"
+
+
+def test_credit_etf_lake_sync_pulls_from_r2(seeded_db_empty_cards) -> None:
+    """run_credit_etf_lake_sync against R2 inserts HYG/JNK/LQD rows.
+
+    Mirrors the volatility smoke but for the equity asset_class path,
+    proving the per-asset_class routing in resolve_lake_root works.
+    """
+    settings = _r2_settings()
+    root = resolve_lake_root(settings, asset_class="equity")
+    assert root.kind == "s3"
+
+    summary = run_credit_etf_lake_sync(
+        seeded_db_empty_cards.conn,
+        root=root,
+        symbols=["HYG", "JNK", "LQD"],
+    )
+    assert summary["symbols"] == 3, (
+        f"expected all 3 credit proxies, got {summary['symbols']}"
+    )
+    assert summary["rows"] > 0
+
+    repo = VolIndexRepository(seeded_db_empty_cards.conn, schema="uw_scan")
+    for sym in ("HYG", "JNK", "LQD"):
+        history = repo.fetch_history(sym, days=30)
+        assert history, f"{sym} rows did not land in vol_index_daily after R2 sync"

--- a/tests/unit/sources/test_lake_resolver.py
+++ b/tests/unit/sources/test_lake_resolver.py
@@ -1,0 +1,114 @@
+"""Resolver picks R2 when fully configured, local otherwise."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+from uw_scan.sources.lake_resolver import LakeRoot, resolve_lake_root
+
+from uw_scan.config import Settings
+
+
+def _make_settings(*, with_r2: bool, **overrides) -> Settings:
+    base = dict(
+        api_key=SecretStr("x"),
+        lake_vol_index_root=Path("/tmp/local-vol"),
+        lake_credit_etf_root=Path("/tmp/local-credit"),
+    )
+    if with_r2:
+        base.update(
+            r2_account_id="abcd1234",
+            r2_access_key_id=SecretStr("key"),
+            r2_secret_access_key=SecretStr("sec"),
+            r2_bucket="market-data",
+        )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def test_resolve_s3_when_r2_configured():
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "s3"
+    assert root.bucket == "market-data"
+    assert root.key_prefix == "market-warehouse/data-lake/bronze/asset_class=volatility"
+    assert root.endpoint_override == "https://abcd1234.r2.cloudflarestorage.com"
+    assert root.access_key_id == "key"
+    assert root.secret_access_key == "sec"
+
+
+def test_resolve_local_when_r2_unset():
+    s = _make_settings(with_r2=False)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local"
+    assert root.local_path == Path("/tmp/local-vol")
+
+
+def test_resolve_local_when_r2_partial():
+    """Missing any one R2 field means the resolver MUST NOT engage R2."""
+    s = _make_settings(with_r2=True, r2_secret_access_key=None)
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local"
+
+
+def test_resolve_local_when_r2_secret_is_empty_string():
+    """Empty SecretStr value MUST be treated as 'not configured'.
+
+    Regression for the bug where `bool(SecretStr(""))` is True (the wrapper
+    is a non-empty object) so `all((... r2_secret_access_key ...))` would
+    incorrectly engage R2 with an empty credential.
+    """
+    s = _make_settings(with_r2=True, r2_secret_access_key=SecretStr(""))
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.kind == "local", "empty SecretStr should fall back, not engage R2"
+
+
+def test_resolve_equity_routes_to_credit_etf_local_root():
+    s = _make_settings(with_r2=False)
+    root = resolve_lake_root(s, asset_class="equity")
+    assert root.kind == "local"
+    assert root.local_path == Path("/tmp/local-credit")
+
+
+def test_resolve_equity_routes_to_credit_etf_key_prefix_on_s3():
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="equity")
+    assert root.kind == "s3"
+    assert root.key_prefix == "market-warehouse/data-lake/bronze/asset_class=equity"
+
+
+def test_resolve_endpoint_override_takes_precedence():
+    s = _make_settings(with_r2=True, r2_endpoint_override="https://custom.example.com")
+    root = resolve_lake_root(s, asset_class="volatility")
+    assert root.endpoint_override == "https://custom.example.com"
+
+
+def test_resolve_unknown_asset_class_raises():
+    s = _make_settings(with_r2=False)
+    with pytest.raises(ValueError, match="asset_class"):
+        resolve_lake_root(s, asset_class="invalid")
+
+
+def test_lake_root_repr_does_not_leak_credentials():
+    """repr() must not include secret-field VALUES.
+
+    @dataclass default repr lists every field; passing repr=False on the two
+    secret fields hides BOTH the field-name token AND the value. Both checks
+    are present so a future maintainer who removes repr=False on one field
+    sees a failure here, not a quiet credential leak in production logs.
+    """
+    s = _make_settings(with_r2=True)
+    root = resolve_lake_root(s, asset_class="volatility")
+    rep = repr(root)
+    assert "access_key_id" not in rep, f"access_key_id field leaked into repr: {rep!r}"
+    assert "secret_access_key" not in rep, (
+        f"secret_access_key field leaked into repr: {rep!r}"
+    )
+    # Values too (we set them to known sentinels in _make_settings)
+    assert "'key'" not in rep, f"access-key value leaked: {rep!r}"
+    assert "'sec'" not in rep, f"secret-key value leaked: {rep!r}"
+
+    # Sanity: LakeRoot import retained at module level
+    assert LakeRoot is not None

--- a/tests/unit/test_config_r2.py
+++ b/tests/unit/test_config_r2.py
@@ -1,0 +1,43 @@
+"""R2 settings are parsed from env vars; absent vars become None."""
+
+from __future__ import annotations
+
+from uw_scan.config import Settings
+
+
+def test_r2_settings_present_when_env_set(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("")
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-key")
+    monkeypatch.setenv("R2_ACCOUNT_ID", "abcd1234")
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "key-id")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setenv("R2_BUCKET", "market-data")
+    s = Settings.from_env(env)
+    assert s.r2_account_id == "abcd1234"
+    assert s.r2_access_key_id is not None
+    assert s.r2_access_key_id.get_secret_value() == "key-id"
+    assert s.r2_secret_access_key is not None
+    assert s.r2_secret_access_key.get_secret_value() == "secret"
+    assert s.r2_bucket == "market-data"
+    assert s.r2_endpoint_override is None
+
+
+def test_r2_settings_none_when_env_unset(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("")
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-key")
+    for k in (
+        "R2_ACCOUNT_ID",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_BUCKET",
+        "R2_ENDPOINT_OVERRIDE",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    s = Settings.from_env(env)
+    assert s.r2_account_id is None
+    assert s.r2_access_key_id is None
+    assert s.r2_secret_access_key is None
+    assert s.r2_bucket is None
+    assert s.r2_endpoint_override is None


### PR DESCRIPTION
## Summary
- R2 = primary EOD/backfill source per the 2026-05-25 standing rule. Warm-store remains the API request-time path.
- New `LakeRoot` dataclass + `resolve_lake_root(settings, asset_class=...)` resolver: R2 when all four `R2_*` settings present, else local mirror.
- `lake.py` public functions accept `Path | LakeRoot` via internal `_normalize` shim — no consumer-facing breaking change.
- **Consumer migration included**: `vol_index_lake_sync` + `credit_etf_lake_sync` resolve R2 at the scheduler boundary. Local fallback is automatic when any R2_* setting is blank.
- **Gap-aware sync**: jobs now compute `missing = R2_dates - DB_dates` per symbol on every run, healing tail AND middle gaps (the old `since = max(db) - 1 day` only healed the tail). Summary dict gains `gaps_filled` for observability.
- Pyarrow's native `pyarrow.fs.S3FileSystem` (already in deps) — no new packages.
- Live smoke tests cover both layers:
  - `tests/integration/sources/test_lake_r2.py` — raw lake.py reads VIX + HYG/JNK/LQD from R2 (5 tests).
  - `tests/integration/worker/test_lake_sync_r2.py` — full scheduler-style wire (`resolve_lake_root → pyarrow S3 → VolIndexRepository.upsert_rows → vol_index_daily`), exercises both sync jobs (2 tests).
- Gap-fill regression test: `tests/integration/test_vol_index_lake_sync.py::test_run_sync_fills_middle_gap` seeds a DB with [05-13, 05-15] + R2 with [05-13, 05-14, 05-15], asserts 05-14 lands.

## Deferred (not in this PR)
- Runtime fallback (R2 reachable-but-failing → retry against local) — currently fails loudly; deferred until we see a real failure mode.
- VCG HYG/JNK/LQD A/B research — separate PR that builds on these rails.

## Plan + Review trail
- Plan: `docs/superpowers/plans/2026-05-25-r2-source-plumbing.md` (initial + self-review + codex-review + adversarial-review fixes).
- Three-pass review applied before execution: self-review (5 fixes), codex-review (3 fixes), adversarial-review (3 BLOCKERs + 1 SHOULD-FIX). Key correctness fixes:
  - `_r2_fully_configured` checks `.get_secret_value()` truthiness, not `bool(SecretStr(...))` — `bool(SecretStr(""))` is True.
  - `_read_s3` / `_list_s3` probe existence via `fs.get_file_info().type == FileType.File` — pyarrow's S3 backend raises `OSError`/`ArrowIOError` (not `FileNotFoundError`) on 403/timeout/missing.
  - Live-test gating matches the existing `tests/live/test_uw_smoke.py` convention: `pytestmark = [pytest.mark.live, pytest.mark.skipif(env_missing, reason=...)]`.
  - `LakeRoot` has `field(repr=False)` on `access_key_id` + `secret_access_key` so creds don't leak into log lines or stack traces.

## Test plan
- [x] `uv run pytest tests/unit/test_config_r2.py` — 2 PASS.
- [x] `uv run pytest tests/unit/sources/test_lake_resolver.py` — 9 PASS.
- [x] `uv run pytest tests/unit/test_lake_reader.py` — 4 PASS (existing Path callers unchanged).
- [x] `uv run pytest tests/integration/test_vol_index_lake_sync.py` — 4 PASS (3 existing + 1 new middle-gap test).
- [x] `uv run pytest -m live tests/integration/sources/test_lake_r2.py` — 5 PASS against live R2 (~17s).
- [x] `uv run pytest -m live tests/integration/worker/test_lake_sync_r2.py` — 2 PASS against live R2 + real Postgres (~60s).
- [x] Without env: all live tests SKIPPED with explicit `reason=`.
- [x] `uv run ruff check` on changed paths — clean.
- [x] No Yahoo/yfinance references introduced.
- [x] Live gap-aware sync against production DB logged `0 gaps filled` × 17 symbols, confirming current state is clean.

## Verification by reviewer
1. `uv run pytest tests/unit/sources/test_lake_resolver.py tests/unit/test_config_r2.py tests/unit/test_lake_reader.py tests/integration/test_vol_index_lake_sync.py -v` — 19 PASS.
2. With R2 env exported (`set -a; source .env; set +a`): `uv run pytest -m live tests/integration/sources/test_lake_r2.py tests/integration/worker/test_lake_sync_r2.py -v` — 7 PASS.