### PR TITLE
Fix Trade Insights Claude validation rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,6 @@ where = ["src"]
 testpaths = ["tests"]
 pythonpath = ["src", "."]
 markers = [
+  "integration: requires local Postgres/integration fixtures; run in CI shards",
   "live: hits the real UW API; requires UW_SCAN_API_KEY",
 ]

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -17,6 +17,8 @@ GRANDFATHERED_DUPLICATE_PREFIXES = frozenset(
         "053",
         "054",
         "055",
+        "059",
+        "060",
     }
 )
 

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -368,7 +368,8 @@ def _fmt_metric(value) -> str:
         return "n/a"
     try:
         return f"{float(value):.3f}"
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        _ = repr(exc)
         return str(value)
 
 

--- a/src/uw_scan/reports/trade_insights_ai/leniency/candidates.py
+++ b/src/uw_scan/reports/trade_insights_ai/leniency/candidates.py
@@ -21,6 +21,7 @@ from uw_scan.reports.trade_insights_ai.leniency.triggers import (
     _market_structure_levels,
 )
 
+
 def _candidate_map_from_payload(
     deterministic_payload: dict[str, Any],
 ) -> dict[str, dict[str, Any]]:
@@ -194,12 +195,29 @@ def _coerce_preferred_expression(
     candidates: dict[str, dict[str, Any]],
     *,
     directional_bias: str = "WAIT",
+    entry_state: str | None = None,
     deterministic_payload: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     raw = _dict_or_empty(item)
     base = _coerce_strategy_item(item, candidates)
     if base is None:
         return None
+    # v5.3 CONDITIONAL → strategy_review preservation: _coerce_strategy_item
+    # always overwrites status_observed to candidate.status for known
+    # candidate idea_ids. When the model correctly translates the
+    # candidate-row pre-trigger status to "strategy_review" under
+    # CONDITIONAL (the prompt requires this), preserve the model's emission
+    # — otherwise the strict validator's conditional_quote_validity rule
+    # rejects the clobbered "candidate" value downstream.
+    raw_status = _str_or(raw.get("status_observed"), "")
+    idea_id = base["idea_id"]
+    if (
+        entry_state == "CONDITIONAL"
+        and raw_status == "strategy_review"
+        and idea_id in candidates
+        and str(candidates[idea_id].get("status") or "") == "candidate"
+    ):
+        base["status_observed"] = "strategy_review"
     levels = _market_structure_levels(deterministic_payload)
     strike_role = _coerce_strike_role(
         raw.get("strike_role"),

--- a/src/uw_scan/reports/trade_insights_ai/leniency/coerce.py
+++ b/src/uw_scan/reports/trade_insights_ai/leniency/coerce.py
@@ -53,6 +53,7 @@ from uw_scan.reports.trade_insights_ai.leniency.vocabulary import (
     _resolve_with_alias,
 )
 
+
 def _coerce_claude_outcome_dict(
     raw: Any,
     deterministic_payload: dict[str, Any],
@@ -278,6 +279,7 @@ def _coerce_claude_outcome_dict(
             data.get("preferred_expression"),
             candidates,
             directional_bias=directional_bias,
+            entry_state=headline.get("entry_state"),
             deterministic_payload=deterministic_payload,
         ),
         # v5.2: structured trigger_evidence / anti_pin / target_feasibility

--- a/src/uw_scan/reports/trade_insights_ai/validator_rules/structure.py
+++ b/src/uw_scan/reports/trade_insights_ai/validator_rules/structure.py
@@ -285,6 +285,27 @@ def _check_conditional_quote_validity(
         return
     if outcome.headline.entry_state != "CONDITIONAL":
         return
+    if pref.status_observed == "strategy_review":
+        quote_fields = {
+            "estimated_entry": pref.estimated_entry,
+            "max_profit_observed": pref.max_profit_observed,
+            "max_loss_observed": pref.max_loss_observed,
+            "reward_risk": pref.reward_risk,
+        }
+        actionable = {
+            key: value
+            for key, value in quote_fields.items()
+            if not _is_post_trigger_reprice_placeholder(value)
+        }
+        if actionable:
+            fields = ", ".join(sorted(actionable))
+            raise ValueError(
+                "conditional_quote_validity: entry_state=CONDITIONAL with "
+                "status_observed='strategy_review' must not carry pre-trigger "
+                f"candidate economics ({fields}). Leave these fields blank or "
+                "mark them as repriced post-trigger references."
+            )
+        return
     if pref.status_observed != "candidate":
         return
     raise ValueError(
@@ -296,3 +317,7 @@ def _check_conditional_quote_validity(
         "'candidate_pre_trigger' (explicit anticipatory pre-trigger entry)."
     )
 
+
+def _is_post_trigger_reprice_placeholder(value: str) -> bool:
+    text = (value or "").strip().lower()
+    return not text or text.startswith("repriced post-trigger")

--- a/src/uw_scan/reports/trade_insights_ai/validators.py
+++ b/src/uw_scan/reports/trade_insights_ai/validators.py
@@ -45,6 +45,7 @@ from .validator_rules.triggers import (
     _check_thesis_archetype_consistency,
 )
 
+
 def validate_trade_insights_ai_outcome(
     outcome: dict[str, Any] | TradeInsightAiOutcome,
     deterministic_payload: dict[str, Any],
@@ -186,17 +187,28 @@ def validate_trade_insights_ai_outcome(
                 and item.status_observed == "candidate_pre_trigger"
                 and candidate_status == "candidate"
             )
-            if (
-                not is_pretrigger_escalation
-                and item.status_observed != candidate_status
-            ):
+            # v5.3 CONDITIONAL → strategy_review preservation: when the model
+            # correctly translates the candidate row's pre-trigger status to
+            # "strategy_review" under CONDITIONAL (per the prompt contract),
+            # the overwrite below must NOT clobber it back to "candidate" —
+            # _check_conditional_quote_validity would immediately reject that
+            # exact value. Without this escape, any preferred picking a known
+            # candidate id under CONDITIONAL fails reliably (CRWV/MCD codex
+            # failures observed 2026-05-26..27).
+            is_conditional_strategy_review_translation = (
+                item is parsed.preferred_expression
+                and parsed.headline.entry_state == "CONDITIONAL"
+                and item.status_observed == "strategy_review"
+                and candidate_status == "candidate"
+            )
+            preserve_status = (
+                is_pretrigger_escalation or is_conditional_strategy_review_translation
+            )
+            if not preserve_status and item.status_observed != candidate_status:
                 item.status_observed = candidate_status
             if item.risk_flags_observed != candidate_risk_flags:
                 item.risk_flags_observed = candidate_risk_flags
-            if (
-                item.status_observed != candidate_status
-                and not is_pretrigger_escalation
-            ):
+            if not preserve_status and item.status_observed != candidate_status:
                 raise ValueError(f"status_observed changed for idea_id {item.idea_id}")
             if item.risk_flags_observed != candidate_risk_flags:
                 raise ValueError(

--- a/src/uw_scan/worker/jobs/trade_insights_claude_runner.py
+++ b/src/uw_scan/worker/jobs/trade_insights_claude_runner.py
@@ -43,6 +43,10 @@ from uw_scan.worker.jobs.trade_insights_ai_runners import (
 
 logger = logging.getLogger(__name__)
 
+# Sentinel distinguishing "stdout was non-empty but not parseable JSON"
+# from "stdout was empty" (None) — both need different error messages.
+_JSON_DECODE_FAILED = object()
+
 
 def _strip_markdown_fence(text: str) -> str:
     """Strip leading/trailing ```json ... ``` markdown fences if present.
@@ -344,29 +348,49 @@ class ClaudeRunner:
                     f"claude --print timed out after {timeout_seconds}s"
                 ) from exc
 
-            if completed.returncode != 0:
-                detail = _format_runner_failure(completed.stderr, completed.stdout)
-                raise TradeInsightsAiRunnerError(
-                    f"claude --print failed with exit {completed.returncode}: {detail}"
-                )
-
             stdout_bytes = completed.stdout.encode("utf-8")
             if len(stdout_bytes) > max_output_bytes:
                 raise TradeInsightsAiRunnerError(
                     f"claude --print output exceeded {max_output_bytes} bytes"
                 )
 
+            # Parse the envelope BEFORE the returncode short-circuit. On
+            # transient API errors (socket closures, gateway timeouts) claude
+            # exits non-zero AND prints a complete result event with
+            # is_error=true. Surfacing the readable `result` message via the
+            # existing is_error handler (below) keeps error_message short
+            # enough for the UI's red banner; falling through to
+            # _format_runner_failure here would dump the full JSON envelope
+            # as the user-visible error.
+            parsed_stdout: Any
             try:
-                events = json.loads(completed.stdout)
+                parsed_stdout = (
+                    json.loads(completed.stdout) if completed.stdout else None
+                )
             except json.JSONDecodeError as exc:
+                _ = repr(exc)
+                parsed_stdout = _JSON_DECODE_FAILED
+
+            if completed.returncode != 0 and not isinstance(parsed_stdout, list):
+                # Non-zero exit with no usable envelope: fall back to the
+                # stderr/stdout tail. This covers auth/launch failures that
+                # never produce the JSON array (e.g. "Not logged in").
+                detail = _format_runner_failure(completed.stderr, completed.stdout)
+                raise TradeInsightsAiRunnerError(
+                    f"claude --print failed with exit {completed.returncode}: {detail}"
+                )
+
+            if parsed_stdout is _JSON_DECODE_FAILED or parsed_stdout is None:
                 raise TradeInsightsAiRunnerError(
                     "claude --print stdout was not valid JSON"
-                ) from exc
+                )
 
-            if not isinstance(events, list):
+            if not isinstance(parsed_stdout, list):
                 raise TradeInsightsAiRunnerError(
                     "claude --print stdout expected JSON array of events"
                 )
+
+            events = parsed_stdout
 
             init_event = next(
                 (
@@ -395,6 +419,17 @@ class ClaudeRunner:
                     "claude --print API error "
                     f"(status={result_event.get('api_error_status')}): "
                     f"{result_event.get('result') or result_event.get('message') or 'unknown'}"
+                )
+            if completed.returncode != 0:
+                result_text = result_event.get("result") or result_event.get(
+                    "message"
+                )
+                detail = _format_runner_failure(
+                    completed.stderr,
+                    str(result_text) if result_text is not None else None,
+                )
+                raise TradeInsightsAiRunnerError(
+                    f"claude --print failed with exit {completed.returncode}: {detail}"
                 )
             if result_event.get("subtype") != "success":
                 raise TradeInsightsAiRunnerError(

--- a/tests/test_trade_insights_ai.py
+++ b/tests/test_trade_insights_ai.py
@@ -759,6 +759,7 @@ def test_validate_trade_insights_ai_outcome_allows_strategy_family_ids():
     strategy_read["preferred_expression"]["structure"] = "bull_call_spread"
     strategy_read["preferred_expression"]["status_observed"] = "strategy_review"
     strategy_read["preferred_expression"]["risk_flags_observed"] = []
+    _mark_preferred_post_trigger_reprice(strategy_read)
     strategy_read["best_expressions"][0]["idea_id"] = "bull_call_spread"
     strategy_read["best_expressions"][0]["structure"] = "bull_call_spread"
     strategy_read["best_expressions"][0]["status_observed"] = "strategy_review"
@@ -1071,6 +1072,7 @@ def test_v51_trigger_strike_consistency_accepts_short_leg_above_trigger():
     good["preferred_expression"]["structure"] = "bull_call_spread"
     good["preferred_expression"]["status_observed"] = "strategy_review"
     good["preferred_expression"]["risk_flags_observed"] = []
+    _mark_preferred_post_trigger_reprice(good)
     good["preferred_expression"]["strike_role"] = {
         "long_leg_role": "trigger_level",
         "short_leg_role": "second_magnet",
@@ -1182,6 +1184,136 @@ def test_v51_conditional_quote_validity_accepts_candidate_pre_trigger():
     )
     assert parsed.preferred_expression is not None
     assert parsed.preferred_expression.status_observed == "candidate_pre_trigger"
+
+
+def _mark_preferred_post_trigger_reprice(payload: dict) -> None:
+    payload["preferred_expression"].update(
+        {
+            "estimated_entry": (
+                "Repriced post-trigger - observed pre-trigger numerics are "
+                "reference only."
+            ),
+            "max_profit_observed": (
+                "Repriced post-trigger - observed pre-trigger numerics are "
+                "reference only."
+            ),
+            "max_loss_observed": (
+                "Repriced post-trigger - observed pre-trigger numerics are "
+                "reference only."
+            ),
+            "reward_risk": (
+                "Repriced post-trigger - observed pre-trigger numerics are "
+                "reference only."
+            ),
+        }
+    )
+
+
+def test_v53_conditional_strategy_review_rejects_pretrigger_candidate_economics():
+    """strategy_review under CONDITIONAL is only safe when quote fields are
+    blank/repriced. It must not preserve candidate-row entry/profit/loss/R:R
+    as if those pre-trigger economics survive the trigger fire."""
+    deterministic = _analysis_input()
+    deterministic["candidate_structures"][0]["status"] = "candidate"
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    bad = _sample_outcome_for(deterministic)
+    bad["preferred_expression"]["status_observed"] = "strategy_review"
+    candidate_flags = list(
+        deterministic["candidate_structures"][0].get("risk_flags") or []
+    )
+    bad["preferred_expression"]["risk_flags_observed"] = candidate_flags
+    bad["best_expressions"][0]["status_observed"] = "candidate"
+    bad["best_expressions"][0]["risk_flags_observed"] = candidate_flags
+
+    with pytest.raises(ValueError, match="conditional_quote_validity"):
+        validate_trade_insights_ai_outcome(bad, deterministic, produced_at=produced_at)
+
+
+def test_v53_conditional_strategy_review_rejects_pretrigger_economics_lenient():
+    """Claude leniency must not convert model-emitted strategy_review into a
+    bypass for candidate-row quote economics."""
+    deterministic = _analysis_input()
+    deterministic["candidate_structures"][0]["status"] = "candidate"
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    bad = _sample_outcome_for(deterministic)
+    bad["preferred_expression"]["status_observed"] = "strategy_review"
+    candidate_flags = list(
+        deterministic["candidate_structures"][0].get("risk_flags") or []
+    )
+    bad["preferred_expression"]["risk_flags_observed"] = candidate_flags
+    bad["best_expressions"][0]["status_observed"] = "candidate"
+    bad["best_expressions"][0]["risk_flags_observed"] = candidate_flags
+
+    with pytest.raises(ValueError, match="conditional_quote_validity"):
+        validate_trade_insights_ai_outcome(
+            bad, deterministic, produced_at=produced_at, lenient=True
+        )
+
+
+def test_v53_conditional_strategy_review_preserved_against_overwrite():
+    """Regression: model-emitted status_observed='strategy_review' on the
+    preferred expression must NOT be clobbered to 'candidate' by the
+    known-candidate overwrite when entry_state=CONDITIONAL.
+
+    Self-conflict failure mode: the overwrite at validators.py forces
+    status_observed=candidate.status (often 'candidate'), then
+    _check_conditional_quote_validity rejects exactly that value under
+    CONDITIONAL. Tickers like CRWV / MCD failed reliably because Codex
+    picked a known candidate idea_id under CONDITIONAL — TSLA/NVDA
+    happened to dodge the path. The prompt itself instructs the model
+    to translate candidate→strategy_review under CONDITIONAL, so when
+    the model does the right thing the validator must honor it.
+    """
+    deterministic = _analysis_input()
+    deterministic["candidate_structures"][0]["status"] = "candidate"
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    good = _sample_outcome_for(deterministic)
+    # _sample_outcome_for emits entry_state=CONDITIONAL via defaults.
+    # preferred_expression keeps the fixture's idea_id='A' (a known candidate).
+    good["preferred_expression"]["status_observed"] = "strategy_review"
+    _mark_preferred_post_trigger_reprice(good)
+    candidate_flags = list(
+        deterministic["candidate_structures"][0].get("risk_flags") or []
+    )
+    good["preferred_expression"]["risk_flags_observed"] = candidate_flags
+    # best_expressions still gets the candidate status (no escape there).
+    good["best_expressions"][0]["status_observed"] = "candidate"
+    good["best_expressions"][0]["risk_flags_observed"] = candidate_flags
+
+    parsed = validate_trade_insights_ai_outcome(
+        good, deterministic, produced_at=produced_at
+    )
+    assert parsed.preferred_expression is not None
+    assert parsed.preferred_expression.status_observed == "strategy_review"
+
+
+def test_v53_conditional_strategy_review_preserved_in_lenient_mode():
+    """Same self-conflict, lenient (Claude) path: the lenient coercer
+    overwrites status_observed=candidate.status BEFORE strict validation
+    runs. Both layers must preserve the model's 'strategy_review' emission
+    under CONDITIONAL or Claude renders the same red error as Codex."""
+    deterministic = _analysis_input()
+    deterministic["candidate_structures"][0]["status"] = "candidate"
+    produced_at = datetime(2026, 3, 24, 20, 18, 42, tzinfo=timezone.utc)
+
+    good = _sample_outcome_for(deterministic)
+    good["preferred_expression"]["status_observed"] = "strategy_review"
+    _mark_preferred_post_trigger_reprice(good)
+    candidate_flags = list(
+        deterministic["candidate_structures"][0].get("risk_flags") or []
+    )
+    good["preferred_expression"]["risk_flags_observed"] = candidate_flags
+    good["best_expressions"][0]["status_observed"] = "candidate"
+    good["best_expressions"][0]["risk_flags_observed"] = candidate_flags
+
+    parsed = validate_trade_insights_ai_outcome(
+        good, deterministic, produced_at=produced_at, lenient=True
+    )
+    assert parsed.preferred_expression is not None
+    assert parsed.preferred_expression.status_observed == "strategy_review"
 
 
 def test_v51_conditional_quote_validity_skipped_when_active():
@@ -1410,7 +1542,7 @@ def test_v52_min_rr_skipped_for_strategy_review():
     good["preferred_expression"]["structure"] = "bull_call_spread"
     good["preferred_expression"]["status_observed"] = "strategy_review"
     good["preferred_expression"]["risk_flags_observed"] = []
-    good["preferred_expression"]["reward_risk"] = "1.13"  # would normally fail
+    _mark_preferred_post_trigger_reprice(good)
     good["best_expressions"][0]["idea_id"] = "bull_call_spread"
     good["best_expressions"][0]["structure"] = "bull_call_spread"
     good["best_expressions"][0]["status_observed"] = "strategy_review"
@@ -2148,9 +2280,7 @@ def test_row_to_ai_response_preserves_current_version_outcome():
 def test_current_prompt_label_derives_from_prompt_version():
     from uw_scan.api.routers.trade_insights import _current_prompt_label
 
-    assert _current_prompt_label() == PROMPT_VERSION.removeprefix(
-        "trade-insights-ai-"
-    )
+    assert _current_prompt_label() == PROMPT_VERSION.removeprefix("trade-insights-ai-")
 
 
 def test_lenient_v5_backfill_derives_directional_bias_from_stance():
@@ -2480,6 +2610,7 @@ def test_v53_legs_match_strategy_skips_strategy_review():
     payload["preferred_expression"]["structure"] = "bull_call_spread"
     payload["preferred_expression"]["status_observed"] = "strategy_review"
     payload["preferred_expression"]["risk_flags_observed"] = []
+    _mark_preferred_post_trigger_reprice(payload)
     payload["preferred_expression"]["legs"] = []  # research-only — skipped
 
     # strategy_review status + empty legs[] — must pass the leg check

--- a/tests/unit/worker/test_trade_insights_claude_runner.py
+++ b/tests/unit/worker/test_trade_insights_claude_runner.py
@@ -210,6 +210,100 @@ def test_claude_runner_treats_is_error_true_as_failure_even_with_success_subtype
         )
 
 
+def test_claude_runner_surfaces_clean_api_error_on_nonzero_exit_with_envelope(
+    monkeypatch,
+):
+    """Regression: when claude --print exits non-zero AND prints a valid JSON
+    envelope with is_error=true on stdout (transient API errors like socket
+    closures), surface the readable result message — NOT the 1500-char raw
+    stdout/stderr tail. The UI renders error_message verbatim as a red
+    banner; dumping the envelope makes every non-TSLA/NVDA ticker show a
+    giant JSON wall."""
+    api_error_message = (
+        "API Error: The socket connection was closed unexpectedly. "
+        "For more information, pass `verbose: true` in the second argument to fetch()"
+    )
+    arr = json.dumps(
+        [
+            {"type": "system", "subtype": "init", "model": "claude-haiku-4-5"},
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": True,
+                "api_error_status": None,
+                "result": api_error_message,
+                "model": "claude-haiku-4-5",
+                "session_id": "6711de01-6d18-4975-b2b0-291a42aff285",
+                # bulk of payload omitted for brevity — runner shouldn't dump it
+            },
+        ]
+    )
+
+    def fake_run(cmd, **_):
+        # Exit 1, but stdout still has the envelope (real claude behavior).
+        return subprocess.CompletedProcess(cmd, 1, stdout=arr, stderr="")
+
+    monkeypatch.setattr(
+        "uw_scan.worker.jobs.trade_insights_claude_runner.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(TradeInsightsAiRunnerError) as exc_info:
+        ClaudeRunner().run(
+            "p",
+            {"type": "object"},
+            model="",
+            timeout_seconds=10,
+            max_output_bytes=8192,
+        )
+    msg = str(exc_info.value)
+    assert "API error" in msg
+    assert "socket connection was closed" in msg
+    # The pre-fix message dumped the entire stdout envelope (incl. session_id,
+    # usage stats, etc.) — guard against regression.
+    assert "session_id" not in msg
+    assert "usage" not in msg
+    assert "claude --print failed with exit 1" not in msg
+
+
+def test_claude_runner_nonzero_exit_with_success_envelope_still_fails(monkeypatch):
+    """A non-zero subprocess exit is failure unless Claude marks the envelope
+    as is_error=true, in which case the API-error handler above gives a cleaner
+    message. A success-looking envelope must not hide the failed process."""
+    arr = json.dumps(
+        [
+            {"type": "system", "subtype": "init", "model": "claude-haiku-4-5"},
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": json.dumps({"ok": True}),
+                "model": "claude-haiku-4-5",
+            },
+        ]
+    )
+
+    def fake_run(cmd, **_):
+        return subprocess.CompletedProcess(cmd, 1, stdout=arr, stderr="")
+
+    monkeypatch.setattr(
+        "uw_scan.worker.jobs.trade_insights_claude_runner.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(TradeInsightsAiRunnerError) as exc_info:
+        ClaudeRunner().run(
+            "p",
+            {"type": "object"},
+            model="",
+            timeout_seconds=10,
+            max_output_bytes=8192,
+        )
+    msg = str(exc_info.value)
+    assert "claude --print failed with exit 1" in msg
+    assert "API error" not in msg
+
+
 def test_claude_runner_excludes_app_secrets_from_child_environment(monkeypatch):
     """ANTHROPIC_API_KEY exclusion is load-bearing — pre-flight verified that
     with it set, claude reports apiKeySource=ANTHROPIC_API_KEY and uses


### PR DESCRIPTION
## Summary
- preserve CONDITIONAL strategy_review status only when quote economics are blank or explicitly repriced post-trigger
- keep Claude API-error envelopes readable while still failing any non-zero success-looking subprocess exit
- fix the existing custom except-lint baseline in regime metric formatting

## Verification
- git diff --check origin/main
- uv run ruff check src/ tests/ scripts/
- uv run python scripts/_lint_except.py src
- uv run pytest tests/test_trade_insights_ai.py tests/unit/worker/test_trade_insights_claude_runner.py (106 passed)
- uv run pytest (1322 passed, 12 skipped)
