### PR TITLE
feat(canary): research-only full-history form-sweep — score-form hypothesis rejected

### DIFF
--- a/docs/research/regime/canary-5yr-executive-summary.md
+++ b/docs/research/regime/canary-5yr-executive-summary.md
@@ -397,9 +397,11 @@ CCA n=4 is still small. BTD n=12 is enough for meaningful event statistics in a 
 Three structural concerns surfaced by the 15-year data that warrant a v2 design pass:
 
 ### v2-A: Drop speed from the composite score; surface state separately
-- **Evidence**: vol-only AUC ≥ composite AUC at every horizon × every subset
+- **Evidence (v1, walk-forward)**: vol-only AUC ≥ composite AUC at every horizon × every subset
+- **Evidence (2026-05-27 form-sweep, §13)**: vol-only-gap at 60d survives all four score forms (+0.020 to +0.027 across linear / convex / concave / sigmoid). The penalty from including speed in the composite is **not a score-curvature artifact** — it is structural to how speed weights the rank.
 - **Proposal**: API exposes three fields — `vol_resolution_score` (current composite minus speed), `speed_state` (NEUTRAL/CCA/BTD/BOTH), `warning_cap` (boolean veto). Composite score deprecated.
 - **Cost**: COMPOSITE_VERSION → 2, methodology doc update, full backfill rerun with `--overwrite`
+- **Priority (post-form-sweep)**: **PROMOTED to top of v2 queue.** The form-sweep negative result strengthens the case that vol predicts and speed contextualizes.
 
 ### v2-B: STRONG_BUY threshold appears too high
 - **Evidence**: Zero hits in 15 years including 2008-vintage shocks (2011 debt downgrade, 2015 China, 2018 Volmageddon, 2020 COVID — none cleared 75). Max score in dataset is 66.4 (2020-11-12).
@@ -407,9 +409,15 @@ Three structural concerns surfaced by the 15-year data that warrant a v2 design 
 - **Cost**: Calibration constant tweak. Doesn't require COMPOSITE_VERSION bump (band thresholds are post-score classifications).
 
 ### v2-C: WATCH band is overfiring; score is anti-predictive within BUY
-- **Evidence**: 39% of all days are WATCH (vs design intent of ~25%). BUY-band internal AUC is 0.35-0.45 — regression-to-mean dominates.
-- **Proposal**: Score-form sweep against full 2011 dataset (current `linear` was picked against 2015-2019 only); test `convex` and `sigmoid` which compress middle scores into NONE and push extremes higher.
-- **Cost**: One `--form-sweep` run + threshold re-tune. May or may not require COMPOSITE_VERSION bump depending on whether band thresholds change.
+- **Original evidence (v1)**: 39% of all days are WATCH (vs design intent of ~25%). BUY-band internal AUC is 0.35-0.45 — regression-to-mean dominates.
+- **Original proposal**: Score-form sweep against full 2011 dataset; test `convex` / `concave` / `sigmoid` which compress middle scores into NONE and push extremes higher.
+- **2026-05-27 form-sweep verdict (§13)**: **Score-form hypothesis REJECTED.** No form improves 60d AUC over linear by ≥ 0.02. WATCH% remains >30% for all forms (concave worsens it to 46.4%). STRONG_BUY% = 0.0% for all forms. BUY-band rank inversion persists in 3 of 4 forms (concave barely clears 0.50 only by inflating WATCH).
+- **Reframed proposal (band / ordinal-regime redesign)**: The v1 pathology is not a ramp-curvature problem. Possible directions:
+  1. Treat continuous score as diagnostic; band as the decision-facing output.
+  2. Collapse to ordinal state: `NONE` / `WATCH` / `BUY`; remove `STRONG_BUY` (never fires anyway).
+  3. Tighten WATCH threshold or split into "early watch" vs "actionable watch".
+  4. Cap or flatten score *inside* BUY — do not imply "higher BUY score = better forward return".
+- **Cost (reframed)**: Methodology design pass + threshold redesign + UI semantics update. Likely requires COMPOSITE_VERSION bump only if internal score generation changes; pure band reinterpretation does not.
 
 ### v2-D (open question, not yet a candidate): capitulation scorer
 - **Evidence**: User intuition is "score should max during max fear" (capitulation). Current design maxes during recovery (mean-reversion). 2025-03 CCA peak score was only 33.4 despite SPX drawing down ~10%. 2020-Q1 COVID also muted under v1.
@@ -451,7 +459,60 @@ The alternative — retune calibration before merge — would invalidate the emp
 | 5 | **Merge PR #83** | — | **READY** |
 | 6 | File v2-A / v2-B / v2-C / v2-D as GitHub issues | 30 min | follow-up |
 | 7 | UI window picker on Validation panel (let user pick WF window) | 2 hr | LOW priority |
-| 8 | Run `--form-sweep` against full 2011 dataset to inform v2-C | 1 hr | medium priority |
+| 8 | ~~Run `--form-sweep` against full 2011 dataset to inform v2-C~~ | ~~1 hr~~ | ✓ DONE 2026-05-27 — see §13. Score-form hypothesis rejected. |
+
+---
+
+## 13. Full-history form-sweep result (2026-05-27, addendum to §10 v2-C)
+
+Research-only sweep across all four score forms (`linear` / `convex` / `concave` / `sigmoid`) over the full `canary_snapshots` window (2011-02-08 → 2026-05-21, 3,843 days each).
+
+**Persistence:** 4 rows in `regime_backtest_runs` with `run_scope='research'`, shared `batch_id=a71b88a4-7904-4653-aa70-611f24e9fbf1`, all `is_winning_form=false`, invisible to production-scope queries. Calibration JSON untouched (MD5 unchanged).
+
+| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |
+|---------|-------:|--------:|--------:|------:|-------:|-----:|------------:|-----------------:|-------------------:|
+| linear  |  0.620 |   0.627 |   0.619 |  55.2 |   39.3 |  5.5 |         0.0 |            0.348 |             +0.023 |
+| convex  |  0.616 |   0.623 |   0.608 |  60.8 |   34.8 |  4.4 |         0.0 |            0.369 |             +0.027 |
+| concave |  0.624 |   0.628 |   0.628 |  46.3 |   46.4 |  7.2 |         0.0 |            0.505 |             +0.020 |
+| sigmoid |  0.623 |   0.632 |   0.627 |  56.0 |   38.4 |  5.6 |         0.0 |            0.340 |             +0.025 |
+
+### Verdict
+
+**The v1 pathology is not a score-form problem.** No alternative form dominates linear; specifically:
+
+- Best 60d AUC is concave at 0.628 vs linear 0.619 — only +0.009 (well under the +0.02 promotion bar).
+- WATCH overfire is universal: all forms > 30%; concave makes it worse at 46.4%.
+- STRONG_BUY never fires in any form (0.0% across the board).
+- BUY-band rank inversion (< 0.50) persists in linear, convex, sigmoid; concave clears 0.505 only by paying with massive WATCH expansion.
+- Vol-only gap at 60d survives every form (+0.020 to +0.027) — **strengthens v2-A**, not v2-C.
+
+### Decisions taken from this result
+
+| Item | Decision |
+|---|---|
+| Score form | **Keep `linear`.** No change. |
+| Calibration JSON | **Do not touch.** |
+| `COMPOSITE_VERSION` | **Do not bump.** No formula change. |
+| v2-A (drop speed from composite) | **Promoted** to top of v2 queue (vol predicts, speed contextualizes — survives all four forms). |
+| v2-B (lower STRONG_BUY threshold) | **Hold** — wait for v2-C ordinal redesign to settle band semantics first. |
+| v2-C (was: score-form change) | **Reframed.** Score-form hypothesis rejected. Promote to band / ordinal-regime redesign (4 directions listed above). |
+| Future form-selection passes | **Do not run.** The negative result is the answer. |
+
+### Why this is a successful negative result
+
+The cheap hypothesis ("just swap to convex/concave/sigmoid") was the one most likely to be tried first and the one most likely to ship subtle harm if accepted without falsification. The form-sweep run cost ~5 minutes of compute and prevented an entire wrong v2 design cycle. The fact that no form "wins" is itself the answer: the next design pass must address **score semantics and band interpretation**, not **ramp curvature**.
+
+### Reproduce
+
+```bash
+# Re-render the latest complete batch (no recompute, just re-render):
+PGUSER=chenxi UW_SCAN_API_KEY=local-smoke \
+  uv run python -m uw_scan.reports.regime_canary_backtest_report
+
+# Run a fresh sweep (creates a new batch_id, persists 4 new research rows):
+PGUSER=chenxi UW_SCAN_API_KEY=local-smoke \
+  uv run python scripts/backtest_canary.py --form-sweep-full
+```
 
 ---
 

--- a/docs/superpowers/plans/2026-05-27-canary-form-sweep-full-plan.md
+++ b/docs/superpowers/plans/2026-05-27-canary-form-sweep-full-plan.md
@@ -46,6 +46,19 @@
 - `web/**` (no UI changes)
 - Any migration file
 
+**Schema dependencies (informational — not modified in this PR):**
+
+The form sweep writes to `regime_backtest_runs` + `regime_backtest_daily` only. It does NOT write to `canary_snapshots`. The relevant schema invariants this PR relies on:
+
+| Object | Migration | Invariant this PR depends on |
+|---|---|---|
+| `regime_backtest_runs.params` | `057:28` | JSONB — `params->>'phase'` and `params->>'batch_id'` filters work natively |
+| `regime_backtest_runs.run_scope` | `059:14-17, 58-65, 77-79` | TEXT NOT NULL DEFAULT `'production'`, CHECK IN (`'production'`, `'research'`). Production-invisibility keystone. |
+| `regime_backtest_runs_indicator_check` | `060:13` | CHECK IN (`'cri'`, `'vcg'`, `'canary'`). Allows our writes. |
+| `regime_backtest_daily.run_id` FK | `057:45` | `ON DELETE CASCADE`. Cleanup-on-failure can delete via `regime_backtest_runs` only; daily rows follow. |
+| `regime_backtest_daily` PK | `057:50` | `(run_id, trade_date)`. No `id` column — never `WHERE id = ...` against this table. |
+| `canary_snapshots.canary_score_form_chk` | `059_canary_snapshots:56-60` | CHECK IN (`'linear'`, `'convex'`, `'concave'`, `'sigmoid'`). Not touched by this PR, but if a future change adds a 5th composite form to the renderer's canonical-order list, this CHECK must be widened in parallel. |
+
 ---
 
 ## Task 1: Synthetic vol-complex fixture for integration tests

--- a/docs/superpowers/plans/2026-05-27-canary-form-sweep-full-plan.md
+++ b/docs/superpowers/plans/2026-05-27-canary-form-sweep-full-plan.md
@@ -1,0 +1,2038 @@
+# Canary Full-History Form-Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--form-sweep-full` subcommand that runs all 4 score forms (`linear`, `convex`, `concave`, `sigmoid`) against the full backfilled `canary_snapshots` dataset (2011-02-08 → present), persists 4 rows tagged with `run_scope='research'` and a shared `batch_id` to `regime_backtest_runs` (with `is_winning_form=False` hardcoded + cleanup-on-failure), and prints a 4-form comparison table via a new pure-function renderer.
+
+**Architecture:** New CLI subcommand in `scripts/backtest_canary.py`, a focused command implementation in `src/uw_scan/reports/regime_canary_form_sweep_full.py`, and a pure-function renderer in `src/uw_scan/reports/regime_canary_backtest_report.py`. `scripts/backtest_canary.py` is already >1,000 lines, so this plan intentionally does **not** add the command body there; it adds only argparse wiring plus a thin wrapper that passes existing helper functions (`_compute_canary_series`, `_aucs_for_rows`, `_band_counts`, `_block_bootstrap_auc_ci`, `_clean_nans`, `_entry_lagged_label`, `_auc`, `LABEL_SPECS`, `COMPOSITE_VERSION`) into the focused module. Adds one new repository method (`delete_runs_by_batch_id`) for cleanup-on-failure. No changes to `cmd_form_sweep`, `cmd_walk_forward`, `cmd_robustness`, the OOS gate, the calibration JSON, or any API/UI surface.
+
+**Tech Stack:** Python 3.13 + uv (runtime), psycopg 3 (DB), pytest + pytest-postgresql (tests), Postgres 15 (uw_scan schema, migrations 057 + 059).
+
+**Prerequisites before starting:**
+1. Read the spec: `docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md` (especially §4.2 for persistence shape, §4.4 for guardrails, §5 for ACs).
+2. Set up an isolated workspace via the `superpowers:using-git-worktrees` skill — branch name suggestion: `feat/canary-form-sweep-full`.
+3. Run a baseline `uv run pytest tests/unit/ tests/integration/regime/ -x` to confirm the worktree starts green. If anything fails, stop and investigate before touching code.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Responsibility |
+|---|---|
+| `tests/integration/regime/_canary_form_sweep_fixture.py` | Synthetic vol-complex fixture (600 days × {VIX, VVIX, VIX3M, COR1M, SPX}) seeded into `vol_index_daily` + 200 days seeded into `canary_snapshots`. Sized so `_entry_lagged_label(..., 60, ...)` yields ≥140 finite 60d AUC labels. Shared by all integration tests in this PR. |
+| `tests/unit/test_within_band_aucs.py` | 5 unit tests for `_within_band_aucs` (no DB). |
+| `tests/unit/test_canary_form_sweep_renderer.py` | 15 unit tests for `render_canary_form_sweep_compare` (no DB) — covers all 7 observation rules plus the `none` fallback. |
+| `tests/unit/test_canary_form_sweep_cli.py` | 1 unit test for the custom `--form-sweep-full` mutual-exclusion guard (no DB). |
+| `tests/integration/regime/test_canary_form_sweep_full.py` | 14 integration tests covering: repository batch delete (3 — basic / no-op / scope-correctness), wrapper persistence smoke (5 — batch_id sharing, daily-row n_days equality, summary schema, capsys stdout assertion, compute-before-persist invariant), cleanup-on-failure with transaction rollback (1), latest-complete-batch / incomplete-batch skipping (2), and OOS-gate / validation-API / calibration-file invisibility (3). |
+| `src/uw_scan/reports/regime_canary_form_sweep_full.py` | Focused command implementation + `_within_band_aucs`; receives existing `scripts/backtest_canary.py` helpers through explicit dependency injection so the package module does not import the script. |
+| `src/uw_scan/reports/regime_canary_backtest_report.py` | Pure-function renderer + module-private DB loader + `__main__` block. Mirrors the layout of `regime_backtest_report.py` (CRI) and `regime_vcg_backtest_report.py` (VCG). |
+
+**Files to modify:**
+
+| Path | What changes |
+|---|---|
+| `scripts/backtest_canary.py` | Add `--form-sweep-full` argparse flag, mutual-exclusion count-check at top of `main()`, dispatch branch in `main()`, and a thin `cmd_form_sweep_full` wrapper (~15 LOC) that delegates to `regime_canary_form_sweep_full.py`. No edits to existing functions. |
+| `src/uw_scan/storage/regime_backtest_repository.py` | Add `delete_runs_by_batch_id(batch_id: str) -> int` method (~15 LOC). |
+
+**Files NOT touched** (would-be drift if changed; abort task if you find yourself editing these):
+- `canary-calibration-v1.json`
+- `src/uw_scan/scanners/canary.py`
+- `src/uw_scan/cards/canary_scoring.py`
+- `src/uw_scan/cards/canary_calibration.py`
+- `src/uw_scan/api/routers/regime.py`
+- `tests/integration/regime/test_canary_oos_gate.py`
+- `web/**` (no UI changes)
+- Any migration file
+
+---
+
+## Task 1: Synthetic vol-complex fixture for integration tests
+
+**Files:**
+- Create: `tests/integration/regime/_canary_form_sweep_fixture.py`
+
+This fixture seeds 600 days × 5 symbols of synthetic-but-coherent vol-complex data into `vol_index_daily` and 200 days into `canary_snapshots`. Required by every integration test in this PR.
+
+**Sizing rationale:** the form-sweep-full computes `_entry_lagged_label(rows, 60, ...)` for the 60d AUC. With only 50 snapshots, all 60d labels collapse to `None` (no row at `i+60`), which then breaks the renderer's `:.3f` formatting. We need ≥120 evaluable canary-series rows; that requires a snapshot window ≥120 days, which in turn requires vol_index ≥ 350 (MIN_ALIGNED_BARS warm-up) + 120 = 470 days minimum. Sizing to 600 + 200 leaves comfortable headroom for 60d/20d/5d horizons (200 - 60 = 140 finite 60d labels).
+
+Coherence rule: prices and ratios are bounded (VIX ∈ [10, 50], VVIX ∈ [70, 130], VIX3M ≈ VIX × 1.05, SPX random-walk from 1000 base, COR1M ∈ [30, 70]). No actual signal patterns — just enough to make the scoring pipeline run end-to-end without raising.
+
+- [ ] **Step 1: Write the fixture file**
+
+```python
+# tests/integration/regime/_canary_form_sweep_fixture.py
+"""Synthetic vol-complex fixture for canary form-sweep-full integration tests.
+
+Seeds 600 trading days × 5 symbols into vol_index_daily (enough to clear the
+350-bar MIN_ALIGNED_BARS warm-up with ~250 bars beyond) plus 200 days into
+canary_snapshots so the MIN/MAX(data_date) window supports 60d forward labels
+(60d AUC requires at least 60 buffer rows past the eval region).
+
+Coherent but not realistic — designed to make the scoring pipeline run
+without raising, NOT to produce meaningful AUC values. Tests in this PR
+assert SHAPE (4 rows, batch_id present, etc.), not numeric correctness.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import numpy as np
+
+
+def _trading_days(start: date, n: int) -> list[date]:
+    """n consecutive Mon-Fri days starting from `start` (skip Sat/Sun)."""
+    out: list[date] = []
+    d = start
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def seed_vol_index(conn, *, schema: str, n_days: int = 600) -> list[date]:
+    """Insert n_days × {VIX, VVIX, VIX3M, COR1M, SPX} into vol_index_daily.
+
+    Default is 600 (≥ 350 warm-up + ≥ 200 evaluable). Returns the list of
+    trading dates (oldest first).
+    """
+    rng = np.random.default_rng(seed=42)
+    dates = _trading_days(date(2010, 1, 4), n_days)
+
+    spx = 1000.0 * np.cumprod(1 + rng.normal(0.0003, 0.01, n_days))
+    vix = np.clip(15 + 5 * rng.standard_normal(n_days), 10, 50)
+    vvix = np.clip(95 + 10 * rng.standard_normal(n_days), 70, 130)
+    vix3m = vix * 1.05 + rng.normal(0, 0.5, n_days)
+    cor1m = np.clip(50 + 8 * rng.standard_normal(n_days), 30, 70)
+
+    rows = []
+    for i, d in enumerate(dates):
+        for sym, arr in (("SPX", spx), ("VIX", vix), ("VVIX", vvix),
+                         ("VIX3M", vix3m), ("COR1M", cor1m)):
+            rows.append((sym, d, Decimal(str(round(float(arr[i]), 4)))))
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO {schema}.vol_index_daily "
+            "(symbol, trade_date, close) VALUES (%s, %s, %s) "
+            "ON CONFLICT (symbol, trade_date) DO NOTHING",
+            rows,
+        )
+    conn.commit()
+    return dates
+
+
+def seed_canary_snapshots(conn, *, schema: str, dates: list[date],
+                          n_snapshots: int = 200) -> tuple[date, date]:
+    """Insert n_snapshots synthetic canary_snapshots rows.
+
+    Default is 200 so that the form-sweep-full's 60d AUC labels are finite
+    (200 - 60 = 140 evaluable rows per band). Uses the LAST n_snapshots from
+    `dates` (i.e. the most recent slice). Returns (min_date, max_date).
+    """
+    seed_dates = dates[-n_snapshots:]
+    rows = []
+    for d in seed_dates:
+        rows.append((
+            d,
+            1,                  # composite_version
+            "linear",           # score_form
+            Decimal("20.0"),    # score
+            Decimal("20.0"),    # raw_score
+            "NONE",             # band
+            Decimal("5.0"),     # tactical_score
+            Decimal("10.0"),    # structural_score
+            0,                  # speed_score (constraint allows 0, 8, or 20)
+            "NONE",             # warning_state
+            "abc123",           # payload_hash (any string)
+            '{"inputs": {"spx_close": 1500.0}}',  # payload JSONB
+        ))
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO {schema}.canary_snapshots "
+            "(data_date, composite_version, score_form, score, raw_score, "
+            " band, tactical_score, structural_score, speed_score, "
+            " warning_state, payload_hash, payload) "
+            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb) "
+            "ON CONFLICT (data_date, composite_version) DO NOTHING",
+            rows,
+        )
+    conn.commit()
+    return (seed_dates[0], seed_dates[-1])
+```
+
+- [ ] **Step 2: Verify import path resolves**
+
+Run: `uv run python -c "from tests.integration.regime._canary_form_sweep_fixture import seed_vol_index, seed_canary_snapshots; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Milestone checkpoint**
+
+```bash
+git add tests/integration/regime/_canary_form_sweep_fixture.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 2: `_within_band_aucs` helper + unit tests
+
+**Files:**
+- Create/modify: `src/uw_scan/reports/regime_canary_form_sweep_full.py` (add helper near the focused command implementation)
+- Create: `tests/unit/test_within_band_aucs.py`
+
+This helper computes the within-band AUC pattern from `cmd_robustness`'s `_auc_for_indices` (line ~979) but as a reusable function. Critical invariant: labels are computed once over the full series, then filtered by band — NOT computed per-subset (the latter drops the last 60 days from every subset, which was the v1 robustness bug).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_within_band_aucs.py
+"""Unit tests for _within_band_aucs."""
+
+import math
+
+import pytest
+
+from scripts import backtest_canary as canary_backtest
+from uw_scan.reports.regime_canary_form_sweep_full import (
+    CanaryFormSweepDeps,
+    _within_band_aucs as _impl_within_band_aucs,
+)
+
+
+def _deps() -> CanaryFormSweepDeps:
+    return CanaryFormSweepDeps(
+        compute_canary_series=canary_backtest._compute_canary_series,
+        aucs_for_rows=canary_backtest._aucs_for_rows,
+        band_counts=canary_backtest._band_counts,
+        block_bootstrap_auc_ci=canary_backtest._block_bootstrap_auc_ci,
+        clean_nans=canary_backtest._clean_nans,
+        entry_lagged_label=canary_backtest._entry_lagged_label,
+        auc=canary_backtest._auc,
+        label_specs=canary_backtest.LABEL_SPECS,
+        composite_version=canary_backtest.COMPOSITE_VERSION,
+    )
+
+
+def _within_band_aucs(rows: list[dict]) -> dict[str, dict[str, float]]:
+    return _impl_within_band_aucs(rows, _deps())
+
+
+def _row(score: float, band: str, spx: float, date_str: str = "2020-01-01") -> dict:
+    """Minimal row shape for the helper. Only fields actually read."""
+    from datetime import date
+    return {"score": score, "band": band, "spx": spx, "date": date.fromisoformat(date_str)}
+
+
+def _date_str(offset: int) -> str:
+    from datetime import date, timedelta
+    return (date(2020, 1, 1) + timedelta(days=offset)).isoformat()
+
+
+def test_empty_rows_returns_empty():
+    out = _within_band_aucs([])
+    assert out == {"NONE": {}, "WATCH": {}, "BUY": {}, "STRONG_BUY": {}}
+
+
+def test_band_with_no_rows_returns_nan():
+    # All rows in NONE band — WATCH/BUY/STRONG_BUY should return NaN per horizon.
+    rows = [_row(10, "NONE", 100.0 + i, _date_str(i)) for i in range(80)]
+    out = _within_band_aucs(rows)
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert math.isnan(out["WATCH"][h])
+        assert math.isnan(out["BUY"][h])
+
+
+def test_all_same_label_returns_nan():
+    # Construct so forward labels are all 0 (no >2% moves) — AUC is undefined.
+    rows = [_row(50, "BUY", 100.0, _date_str(i)) for i in range(80)]
+    out = _within_band_aucs(rows)
+    # BUY band's AUCs all NaN because positive class is empty.
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert math.isnan(out["BUY"][h])
+
+
+def test_normal_case_matches_filtered_auc():
+    """Normal: 3 bands populated, labels computed once over full series."""
+    from scripts.backtest_canary import _auc, _entry_lagged_label, LABEL_SPECS
+    rng = __import__("numpy").random.default_rng(seed=1)
+    n = 100
+    bands = ["NONE"] * 40 + ["WATCH"] * 40 + ["BUY"] * 20
+    rng.shuffle(bands)
+    spx_path = 100.0 + __import__("numpy").cumsum(rng.normal(0.001, 0.01, n))
+    rows = [_row(float(i + rng.standard_normal()), bands[i], float(spx_path[i]),
+                 _date_str(i)) for i in range(n)]
+    out = _within_band_aucs(rows)
+    # Recompute reference per-band by hand and confirm equality.
+    for band in ("NONE", "WATCH", "BUY"):
+        idxs = [i for i, r in enumerate(rows) if r["band"] == band]
+        for name, h, thr in LABEL_SPECS:
+            labels_full = _entry_lagged_label(rows, h, thr)
+            band_scores = [rows[i]["score"] for i in idxs]
+            band_labels = [labels_full[i] for i in idxs]
+            expected = _auc(band_scores, band_labels)
+            actual = out[band][name]
+            if math.isnan(expected):
+                assert math.isnan(actual)
+            else:
+                assert abs(actual - expected) < 1e-9
+
+
+def test_labels_computed_once_not_per_subset():
+    """The last 60 rows should not silently vanish from each band's AUC.
+
+    If we computed labels per-subset, slicing rows[band==X] then calling
+    _entry_lagged_label would drop the last 60 of THAT subset (not the
+    last 60 of the full series). The helper must NOT do that.
+    """
+    n = 200
+    # Half NONE, half BUY, alternating.
+    rows = [_row(10 + i, "NONE" if i % 2 == 0 else "BUY", 100.0 + i,
+                 _date_str(i)) for i in range(n)]
+    out = _within_band_aucs(rows)
+    # Every band should have non-NaN AUCs (since labels are computed once
+    # over the full 200-row series, BOTH bands have plenty of labeled rows).
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert not math.isnan(out["NONE"][h]), f"NONE[{h}] should be finite"
+        assert not math.isnan(out["BUY"][h]), f"BUY[{h}] should be finite"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_within_band_aucs.py -v`
+Expected: ImportError on `_within_band_aucs` — function not yet defined.
+
+- [ ] **Step 3: Implement `_within_band_aucs` in `regime_canary_form_sweep_full.py`**
+
+Place this function near `run_form_sweep_full` in `src/uw_scan/reports/regime_canary_form_sweep_full.py`:
+
+```python
+def _within_band_aucs(rows: list[dict], deps: CanaryFormSweepDeps) -> dict[str, dict[str, float]]:
+    """AUC of composite score vs forward labels, restricted to each band.
+
+    Labels are computed ONCE over the full row series (so the last 60 days
+    don't drop out of every band-subset), then filtered by band membership.
+    Returns NaN for bands with <2 distinct labels in the subset.
+
+    This preserves the "compute labels once, filter by index" invariant
+    from cmd_robustness — see _auc_for_indices around line 979.
+    """
+    out: dict[str, dict[str, float]] = {b: {} for b in ("NONE", "WATCH", "BUY", "STRONG_BUY")}
+    if not rows:
+        return out
+    composite_scores = [r["score"] for r in rows]
+    for name, h, thr in deps.label_specs:
+        labels_full = deps.entry_lagged_label(rows, h, thr)
+        for band in ("NONE", "WATCH", "BUY", "STRONG_BUY"):
+            idxs = [i for i, r in enumerate(rows) if r["band"] == band]
+            band_scores = [composite_scores[i] for i in idxs]
+            band_labels = [labels_full[i] for i in idxs]
+            out[band][name] = deps.auc(band_scores, band_labels)
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_within_band_aucs.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Milestone checkpoint**
+
+```bash
+git add src/uw_scan/reports/regime_canary_form_sweep_full.py tests/unit/test_within_band_aucs.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 3: `delete_runs_by_batch_id` repository method
+
+**Files:**
+- Modify: `src/uw_scan/storage/regime_backtest_repository.py`
+- Modify: `tests/integration/regime/test_canary_form_sweep_full.py` (create file with the first integration test)
+
+Cleanup-on-failure needs a way to remove all rows tagged with a given `batch_id`. The method does a `DELETE FROM regime_backtest_runs` scoped to **exactly the rows this command writes** (`indicator='canary'`, `run_scope='research'`, `params->>'phase'='form_sweep_full'`, and the matching `batch_id`). The scoping is defense against UUID4 collisions across indicators/phases — extraordinarily unlikely, but the cost of being explicit is one extra WHERE clause and the benefit is a deletion contract you can actually reason about ("this method only deletes form_sweep_full research runs for canary"). The migration 057 schema has `ON DELETE CASCADE` for `regime_backtest_daily.run_id → regime_backtest_runs.id`, so daily rows are cleaned up automatically.
+
+- [ ] **Step 1: Verify CASCADE behavior in migration**
+
+Run: `grep -A2 "CONSTRAINT.*run_id\|REFERENCES.*regime_backtest_runs" $(find . -path ./node_modules -prune -o -name "057_*.sql" -print 2>/dev/null) | head -10`
+Expected output contains `ON DELETE CASCADE`. If it does NOT, abort and surface to the user — the spec assumes CASCADE; without it the cleanup helper needs an explicit `DELETE FROM regime_backtest_daily WHERE run_id IN (...)` first.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/integration/regime/test_canary_form_sweep_full.py
+"""Integration tests for canary --form-sweep-full and its renderer.
+
+All tests use the synthetic vol-complex fixture in
+_canary_form_sweep_fixture.py and the project's pytest-postgresql fixture
+(real Postgres, migrations applied per tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+
+def test_delete_runs_by_batch_id_removes_rows_and_cascades_daily(
+    seeded_db_empty_cards,
+):
+    """Insert a 4-row form_sweep_full batch + daily rows, then delete
+    by batch_id. All runs AND daily rows must be gone."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    batch_id = str(uuid.uuid4())
+
+    inserted_run_ids: list[int] = []
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        run_id = repo.insert_run(
+            indicator="canary",
+            composite_version="1",
+            start_date=date(2011, 2, 8),
+            end_date=date(2026, 5, 21),
+            window_days=350,
+            n_days=100,
+            params={"score_form": form, "phase": "form_sweep_full",
+                    "batch_id": batch_id, "purpose": "candidate_discovery_not_validation"},
+            summary={"is_winning_form": False, "score_form": form,
+                     "batch_id": batch_id, "phase": "form_sweep_full"},
+            run_scope="research",
+        )
+        inserted_run_ids.append(run_id)
+        repo.bulk_insert_daily(run_id, [
+            {"trade_date": date(2024, 1, 2), "score": 20.0, "level": "NONE",
+             "payload": {"raw_score": 20.0}},
+        ])
+
+    # Verify rows exist
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s", (batch_id,))
+        assert cur.fetchone()[0] == 4
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily "
+            f"WHERE run_id = ANY(%s)", (inserted_run_ids,))
+        assert cur.fetchone()[0] == 4
+
+    # Delete by batch_id
+    n_deleted = repo.delete_runs_by_batch_id(batch_id)
+    assert n_deleted == 4
+
+    # Verify rows are gone (runs AND daily via CASCADE)
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s", (batch_id,))
+        assert cur.fetchone()[0] == 0
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily "
+            f"WHERE run_id = ANY(%s)", (inserted_run_ids,))
+        assert cur.fetchone()[0] == 0
+
+
+def test_delete_runs_by_batch_id_returns_zero_when_no_match(seeded_db_empty_cards):
+    """Calling with an unknown batch_id is a no-op returning 0."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    n = repo.delete_runs_by_batch_id("00000000-0000-0000-0000-000000000000")
+    assert n == 0
+
+
+def test_delete_runs_by_batch_id_scoped_to_canary_research_form_sweep_full(
+    seeded_db_empty_cards,
+):
+    """A row with the same batch_id but a DIFFERENT indicator/scope/phase
+    must NOT be deleted. Defends against UUID4 collisions and accidental
+    over-scoping if the method is reused without thinking."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    batch_id = str(uuid.uuid4())
+
+    # Three "lookalike" rows that share batch_id but each violates exactly
+    # one of the three scope filters — none should be deleted.
+    lookalikes = [
+        # Wrong indicator
+        dict(indicator="vcg", composite_version="1",
+             start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+             window_days=350, n_days=10,
+             params={"phase": "form_sweep_full", "batch_id": batch_id},
+             summary={"phase": "form_sweep_full"}, run_scope="research"),
+        # Wrong run_scope
+        dict(indicator="canary", composite_version="1",
+             start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+             window_days=350, n_days=10,
+             params={"phase": "form_sweep_full", "batch_id": batch_id},
+             summary={"phase": "form_sweep_full"}, run_scope="production"),
+        # Wrong phase
+        dict(indicator="canary", composite_version="1",
+             start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+             window_days=350, n_days=10,
+             params={"phase": "calibrate", "batch_id": batch_id},
+             summary={"phase": "calibrate"}, run_scope="research"),
+    ]
+    lookalike_ids = [repo.insert_run(**spec) for spec in lookalikes]
+
+    # One target row that matches all three scope filters — should be deleted.
+    target_id = repo.insert_run(
+        indicator="canary", composite_version="1",
+        start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+        window_days=350, n_days=10,
+        params={"score_form": "linear", "phase": "form_sweep_full",
+                "batch_id": batch_id,
+                "purpose": "candidate_discovery_not_validation"},
+        summary={"is_winning_form": False, "score_form": "linear",
+                 "batch_id": batch_id, "phase": "form_sweep_full"},
+        run_scope="research",
+    )
+
+    n_deleted = repo.delete_runs_by_batch_id(batch_id)
+    assert n_deleted == 1, "only the in-scope target row should be deleted"
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id FROM {db_schema}.regime_backtest_runs "
+            f"WHERE id = ANY(%s)", (lookalike_ids,))
+        remaining = [r[0] for r in cur.fetchall()]
+        assert sorted(remaining) == sorted(lookalike_ids), \
+            "lookalike rows must remain — scoping violation"
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE id = %s", (target_id,))
+        assert cur.fetchone()[0] == 0
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/integration/regime/test_canary_form_sweep_full.py -v -k delete_runs`
+Expected: AttributeError on `delete_runs_by_batch_id` — method not yet defined.
+
+- [ ] **Step 4: Implement `delete_runs_by_batch_id` in repository**
+
+Append to `src/uw_scan/storage/regime_backtest_repository.py` (after the last existing method, e.g. after `mark_run_completed`):
+
+```python
+    def delete_runs_by_batch_id(self, batch_id: str) -> int:
+        """Delete canary form_sweep_full research runs with given batch_id.
+
+        Scoped intentionally narrow — only `indicator='canary'`,
+        `run_scope='research'`, `params->>'phase'='form_sweep_full'` rows
+        are affected. This is the cleanup-on-failure path for
+        `cmd_form_sweep_full`; it should never touch any other indicator,
+        scope, or phase even on a UUID4 collision.
+
+        Daily rows are removed by `ON DELETE CASCADE` (migration 057).
+        Returns the number of run rows deleted (0 if no match).
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {self._schema}.regime_backtest_runs "
+                "WHERE indicator = 'canary' "
+                "  AND run_scope = 'research' "
+                "  AND params->>'phase' = 'form_sweep_full' "
+                "  AND params->>'batch_id' = %s",
+                (batch_id,),
+            )
+            deleted = cur.rowcount
+        self._conn.commit()
+        return deleted
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/regime/test_canary_form_sweep_full.py -v -k delete_runs`
+Expected: 3 passed (basic delete, no-op-on-unknown, scoped-to-canary-research-form-sweep-full).
+
+- [ ] **Step 6: Milestone checkpoint**
+
+```bash
+git add src/uw_scan/storage/regime_backtest_repository.py tests/integration/regime/test_canary_form_sweep_full.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 4: `cmd_form_sweep_full` wrapper + focused core implementation + `--form-sweep-full` CLI flag
+
+**Files:**
+- Create: `src/uw_scan/reports/regime_canary_form_sweep_full.py` (focused command implementation)
+- Modify: `scripts/backtest_canary.py` (add thin `cmd_form_sweep_full` wrapper, `--form-sweep-full` argparse flag, mutual-exclusion check, dispatch branch)
+- Modify: `tests/integration/regime/test_canary_form_sweep_full.py` (add 3 happy-path tests)
+- Create: `tests/unit/test_canary_form_sweep_cli.py` (custom mutual-exclusion guard test)
+
+This is the centerpiece. The focused implementation follows the "compute all in memory first, then persist with cleanup-on-failure" pattern from spec §4.2. `scripts/backtest_canary.py` stays thin because it is already past the repo's 1,000-line split threshold.
+
+- [ ] **Step 1: Write the failing happy-path tests**
+
+Append to `tests/integration/regime/test_canary_form_sweep_full.py`:
+
+```python
+def test_cmd_form_sweep_full_persists_4_rows_sharing_batch_id(seeded_db_empty_cards):
+    """Run the script's wrapper. Assert: 4 research rows, same batch_id, same generated_at."""
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT params->>'batch_id', summary->>'generated_at', "
+            f"       params->>'score_form', summary->>'is_winning_form', run_scope "
+            f"FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'")
+        rows = cur.fetchall()
+
+    assert len(rows) == 4
+    batch_ids = {r[0] for r in rows}
+    gen_ats = {r[1] for r in rows}
+    forms = {r[2] for r in rows}
+    is_winning = {r[3] for r in rows}
+    run_scopes = {r[4] for r in rows}
+    assert len(batch_ids) == 1, f"all 4 rows must share batch_id, got {batch_ids}"
+    assert len(gen_ats) == 1, f"all 4 rows must share generated_at, got {gen_ats}"
+    assert forms == {"linear", "convex", "concave", "sigmoid"}
+    assert is_winning == {"false"}, f"is_winning_form must be false for all, got {is_winning}"
+    assert run_scopes == {"research"}, f"run_scope must be research for all, got {run_scopes}"
+
+
+def test_cmd_form_sweep_full_writes_daily_rows(seeded_db_empty_cards):
+    """Each form's run has exactly `n_days` corresponding regime_backtest_daily rows.
+
+    The looser '> 0' check would pass on a buggy implementation that writes
+    one daily row per form (e.g. only the first row of each form's series).
+    Asserting equality to the run's `n_days` catches that.
+    """
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        # Per-form: actual daily count == the run's declared n_days. The
+        # n_days value is set by run_form_sweep_full to the size of the
+        # computed eval series for that form, so this asserts the persistence
+        # path materialises exactly the rows it claims it computed.
+        cur.execute(
+            f"SELECT r.params->>'score_form', r.n_days, COUNT(d.trade_date) "
+            f"FROM {db_schema}.regime_backtest_runs r "
+            f"LEFT JOIN {db_schema}.regime_backtest_daily d ON d.run_id = r.id "
+            f"WHERE r.params->>'phase' = 'form_sweep_full' "
+            f"GROUP BY r.params->>'score_form', r.n_days")
+        rows = cur.fetchall()
+    assert len(rows) == 4, f"expected 4 form rows, got {len(rows)}"
+    seen_forms: set[str] = set()
+    for form, n_days, daily_count in rows:
+        seen_forms.add(form)
+        assert n_days > 0, f"{form} run.n_days must be > 0, got {n_days}"
+        assert daily_count == n_days, (
+            f"{form}: daily-row count {daily_count} != run.n_days {n_days} "
+            f"— persistence is not writing every computed eval row"
+        )
+    assert seen_forms == {"linear", "convex", "concave", "sigmoid"}
+
+
+def test_cmd_form_sweep_full_summary_schema(seeded_db_empty_cards):
+    """summary JSONB has all the spec-required keys."""
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT summary FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full' LIMIT 1")
+        summary = cur.fetchone()[0]
+    # Required top-level keys
+    for key in ("is_winning_form", "score_form", "phase", "source",
+                "batch_id", "generated_at", "n_days", "aucs", "auc_ci95",
+                "band_distribution", "within_band_aucs", "vol_only_gap"):
+        assert key in summary, f"summary missing key: {key}"
+    # aucs has all 3 series × 3 horizons
+    for series in ("composite", "vol_only", "speed_only"):
+        assert series in summary["aucs"]
+        for horizon in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+            assert horizon in summary["aucs"][series], \
+                f"aucs.{series}.{horizon} missing"
+    # band_distribution has all 4 bands
+    for band in ("NONE", "WATCH", "BUY", "STRONG_BUY"):
+        assert band in summary["band_distribution"]
+
+
+def test_cmd_form_sweep_full_prints_renderer_output(seeded_db_empty_cards, capsys):
+    """After persistence, the command must call the renderer and print its
+    output to stdout. A buggy implementation that persists correctly but
+    skips the print would otherwise pass every DB-only test.
+
+    Asserts: the canonical header row, all four form labels, the
+    Observations section header, and the "What this run does NOT decide"
+    footer all appear in stdout.
+    """
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    captured = capsys.readouterr()
+    stdout = captured.out
+    # Header: at least the four canonical form labels appear in stdout, in order.
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        assert form in stdout, f"renderer output missing form row '{form}'"
+    li = stdout.index("linear")
+    cv = stdout.index("convex")
+    cc = stdout.index("concave")
+    sg = stdout.index("sigmoid")
+    assert li < cv < cc < sg, (
+        f"form rows must appear in canonical order, got positions "
+        f"linear={li}, convex={cv}, concave={cc}, sigmoid={sg}"
+    )
+    # Observations + footer must both appear.
+    assert "Observations" in stdout, "renderer output missing Observations section"
+    assert "What this run does NOT decide" in stdout, (
+        "renderer footer missing — guardrail prose against misuse"
+    )
+
+
+def test_cmd_form_sweep_full_does_not_persist_when_compute_fails_mid_run(
+    seeded_db_empty_cards, monkeypatch,
+):
+    """Compute-all-before-persist invariant (spec §4.2 / AC-13).
+
+    Patches `deps.compute_canary_series` to raise on the *third* invocation
+    (= third form). Asserts: zero `form_sweep_full` rows are persisted,
+    proving the implementation does not interleave compute and persist.
+    """
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from uw_scan.reports import regime_canary_form_sweep_full as impl_mod
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    # Patch the deps factory the wrapper uses, so the patched function rides
+    # through the DI dataclass.
+    real_run = impl_mod.run_form_sweep_full
+    call_count = {"compute": 0}
+
+    def make_failing_run(conn, *, schema, deps):
+        real_compute = deps.compute_canary_series
+
+        def patched_compute(*args, **kwargs):
+            call_count["compute"] += 1
+            if call_count["compute"] == 3:
+                raise RuntimeError(
+                    "synthetic failure on form 3 — compute-before-persist test"
+                )
+            return real_compute(*args, **kwargs)
+
+        from dataclasses import replace
+        patched_deps = replace(deps, compute_canary_series=patched_compute)
+        return real_run(conn, schema=schema, deps=patched_deps)
+
+    monkeypatch.setattr(impl_mod, "run_form_sweep_full", make_failing_run)
+
+    with pytest.raises(RuntimeError, match="synthetic failure on form 3"):
+        cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    # Zero form_sweep_full rows must remain — proves the implementation
+    # finished computing forms 1 and 2 in memory but did not write them
+    # to the DB before form 3's compute failed. (Cleanup also covers
+    # this, so the row count alone is necessary but not sufficient; the
+    # call_count below proves compute reached form 3.)
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, (
+            "compute-before-persist violated: rows for forms 1/2 leaked "
+            "into the DB before form 3's compute failed"
+        )
+    assert call_count["compute"] == 3, (
+        f"expected compute to be called 3 times before failing, got {call_count['compute']}"
+    )
+```
+
+Also create `tests/unit/test_canary_form_sweep_cli.py`:
+
+```python
+"""Unit tests for canary backtest CLI guardrails."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from scripts import backtest_canary
+
+
+def test_form_sweep_full_is_mutually_exclusive(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["backtest_canary.py", "--form-sweep", "--form-sweep-full"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        backtest_canary.main()
+    assert exc.value.code == 2
+    assert "only one of --calibrate" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_canary_form_sweep_cli.py tests/integration/regime/test_canary_form_sweep_full.py -v -k form_sweep_full`
+Expected: failing tests until `--form-sweep-full`, the mutual-exclusion error, and `cmd_form_sweep_full` exist.
+
+- [ ] **Step 3: Implement focused command module + thin script wrapper**
+
+Create `src/uw_scan/reports/regime_canary_form_sweep_full.py`. It owns the full-history implementation and `_within_band_aucs`; it must not import `scripts.backtest_canary`. Instead, define a small dependency container and receive existing helpers from the script wrapper:
+
+```python
+@dataclass(frozen=True)
+class CanaryFormSweepDeps:
+    compute_canary_series: Callable[..., dict]
+    aucs_for_rows: Callable[[list[dict]], dict[str, dict[str, float]]]
+    band_counts: Callable[[list[dict]], dict[str, int]]
+    block_bootstrap_auc_ci: Callable[..., tuple[float, float]]
+    clean_nans: Callable[[Any], Any]
+    entry_lagged_label: Callable[[list[dict], int, float], list]
+    auc: Callable[[list[float], list], float]
+    label_specs: list[tuple[str, int, float]]
+    composite_version: int
+```
+
+The module exposes:
+
+```python
+def _within_band_aucs(rows: list[dict], deps: CanaryFormSweepDeps) -> dict[str, dict[str, float]]:
+    """AUC of composite score vs forward labels, restricted to each band.
+
+    Labels are computed once over the full row series, then filtered by band.
+    Returns NaN for bands with <2 distinct labels in the subset.
+    """
+
+
+def run_form_sweep_full(conn, *, schema: str, deps: CanaryFormSweepDeps) -> None:
+    """Full-history score-form sweep against canary_snapshots range.
+
+    Candidate discovery only. DO NOT:
+      - declare a winning form
+      - write to canary-calibration-v1.json
+      - set summary.is_winning_form=True
+      - read or modify the OOS gate's LAST_KNOWN_AUC_* constants
+    """
+```
+
+Implementation requirements inside `run_form_sweep_full`:
+
+- Load calibration with `load_calibration()`.
+- Resolve `snap_min`, `snap_max`, and `snap_count` from `{schema}.canary_snapshots`.
+- Compute all four forms in memory before persisting any row.
+- Persist with `RegimeBacktestRepository.insert_run(..., run_scope="research")`; this argument is mandatory.
+- Use params literals: `phase="form_sweep_full"`, `batch_id=<uuid4>`, `purpose="candidate_discovery_not_validation"`, `min_aligned_bars=350`, `window_semantics="warmup_requirement_not_eval_window"`.
+- Use summary literals: `is_winning_form=False`, `phase="form_sweep_full"`, `source="form_sweep_full"`, shared `batch_id`, shared `generated_at`.
+- Convert eval rows before `bulk_insert_daily`: `trade_date=r["date"]`, `score=r["score"]`, `level=r["band"]`, and payload keys `raw_score`, `tactical`, `structural`, `speed`, `warning_state`. Do not pass raw eval rows directly; `RegimeBacktestRepository.bulk_insert_daily` expects `trade_date`.
+- On any exception during persistence, **preserve the original exception** and then attempt cleanup. The naive "cleanup then re-raise" pattern silently swaps the original failure for any failure that happens inside cleanup (the second `raise` shadows the first). Required shape (see Step 3 implementation block for the exact code):
+
+  ```python
+  except Exception as original:
+      # Real Postgres errors leave the transaction in InFailedSqlTransaction;
+      # rollback() must run BEFORE the DELETE, or the delete itself errors.
+      try:
+          conn.rollback()
+      except Exception as rollback_err:
+          # Best-effort. Log and continue so the original exception still wins.
+          log.exception("rollback failed during form_sweep_full cleanup: %s", rollback_err)
+      try:
+          deps.repo.delete_runs_by_batch_id(batch_id)
+      except Exception as cleanup_err:
+          # Cleanup failure is logged but does NOT replace the original.
+          log.exception(
+              "delete_runs_by_batch_id(%s) failed during cleanup: %s",
+              batch_id, cleanup_err,
+          )
+      raise original  # `raise` (bare) also preserves the original — both forms are valid.
+  ```
+
+  The intent: a partial-batch row in the DB is bad, but obscuring the root cause is worse — debugging a `ProgrammingError` from a fictional `definitely_missing_table` is much harder if you only see "delete_runs_by_batch_id failed because the transaction is aborted."
+- After success, reload rows with `WHERE params->>'batch_id' = %s AND run_scope = 'research' AND completed_at IS NOT NULL`, assert exactly four rows, and print `render_canary_form_sweep_compare(run_dicts)`.
+
+Then add only this wrapper to `scripts/backtest_canary.py` near `cmd_form_sweep`:
+
+```python
+def cmd_form_sweep_full(conn, *, schema: str) -> None:
+    from uw_scan.reports.regime_canary_form_sweep_full import (
+        CanaryFormSweepDeps,
+        run_form_sweep_full,
+    )
+
+    deps = CanaryFormSweepDeps(
+        compute_canary_series=_compute_canary_series,
+        aucs_for_rows=_aucs_for_rows,
+        band_counts=_band_counts,
+        block_bootstrap_auc_ci=_block_bootstrap_auc_ci,
+        clean_nans=_clean_nans,
+        entry_lagged_label=_entry_lagged_label,
+        auc=_auc,
+        label_specs=LABEL_SPECS,
+        composite_version=COMPOSITE_VERSION,
+    )
+    run_form_sweep_full(conn, schema=schema, deps=deps)
+```
+
+- [ ] **Step 4: Wire `--form-sweep-full` into argparse + main()**
+
+Modify `scripts/backtest_canary.py` around lines 1070-1114. Find:
+
+```python
+def main():
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--calibrate", action="store_true")
+    parser.add_argument("--form-sweep", action="store_true")
+    parser.add_argument("--report", action="store_true")
+    parser.add_argument(
+        "--walk-forward",
+        action="store_true",
+        help="6-window expanding-train walk-forward (frozen v1 calibration)",
+    )
+    parser.add_argument(
+        "--robustness",
+        action="store_true",
+        help="full-dataset robustness report (exclusion regimes, by-year, by-band)",
+    )
+    parser.add_argument("--write-summary", action="store_true")
+    parser.add_argument("--form", choices=("linear", "convex", "concave", "sigmoid"))
+    args = parser.parse_args()
+```
+
+Replace with:
+
+```python
+def main():
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--calibrate", action="store_true")
+    parser.add_argument("--form-sweep", action="store_true")
+    parser.add_argument(
+        "--form-sweep-full",
+        action="store_true",
+        help="candidate discovery: sweep all 4 forms against full canary_snapshots range",
+    )
+    parser.add_argument("--report", action="store_true")
+    parser.add_argument(
+        "--walk-forward",
+        action="store_true",
+        help="6-window expanding-train walk-forward (frozen v1 calibration)",
+    )
+    parser.add_argument(
+        "--robustness",
+        action="store_true",
+        help="full-dataset robustness report (exclusion regimes, by-year, by-band)",
+    )
+    parser.add_argument("--write-summary", action="store_true")
+    parser.add_argument("--form", choices=("linear", "convex", "concave", "sigmoid"))
+    args = parser.parse_args()
+
+    # CLI-level mutual exclusion (G-1) — argparse doesn't use a group here.
+    mode_flags = [args.calibrate, args.form_sweep, args.form_sweep_full,
+                  args.report, args.walk_forward, args.robustness]
+    if sum(bool(f) for f in mode_flags) > 1:
+        parser.error(
+            "only one of --calibrate/--form-sweep/--form-sweep-full/--report/"
+            "--walk-forward/--robustness may be specified"
+        )
+
+    if args.form_sweep_full and args.form is not None:
+        log.warning("--form is ignored under --form-sweep-full (sweep iterates all 4 forms)")
+```
+
+Then add the dispatch branch to the existing `if/elif` chain in `main()` — insert AFTER the `--form-sweep` branch and BEFORE the `--report` branch:
+
+```python
+        if args.form_sweep:
+            cmd_form_sweep(conn, write_summary=args.write_summary, schema=schema)
+            return
+        if args.form_sweep_full:
+            cmd_form_sweep_full(conn, schema=schema)
+            return
+        if args.report:
+            ...
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_canary_form_sweep_cli.py tests/integration/regime/test_canary_form_sweep_full.py -v -k form_sweep_full`
+Expected: 6 passed (mutually_exclusive, persists_4_rows, writes_daily, summary_schema, prints_renderer_output, does_not_persist_when_compute_fails_mid_run). Plus the 3 delete tests from Task 3 still pass.
+
+- [ ] **Step 6: Milestone checkpoint**
+
+```bash
+git add scripts/backtest_canary.py src/uw_scan/reports/regime_canary_form_sweep_full.py tests/unit/test_canary_form_sweep_cli.py tests/integration/regime/test_canary_form_sweep_full.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 5: Cleanup-on-failure test (atomicity guarantee — AC-13)
+
+**Files:**
+- Modify: `tests/integration/regime/test_canary_form_sweep_full.py` (add atomicity test)
+
+The command's `try/except` must clean up via `delete_runs_by_batch_id` on failure. This test asserts the invariant by monkey-patching `bulk_insert_daily` to trigger a real Postgres error on the third call, which leaves the transaction aborted unless the implementation calls `conn.rollback()` before cleanup.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/regime/test_canary_form_sweep_full.py`:
+
+```python
+def test_form_sweep_full_cleanup_on_failure(seeded_db_empty_cards, monkeypatch):
+    """Simulate a real DB failure on the 3rd form's bulk_insert_daily call.
+    Assert: rollback happens and zero failed-batch rows remain afterwards."""
+    from pathlib import Path
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    calib_path = Path(__file__).parents[3] / "docs/research/regime/canary-calibration-v1.json"
+    before_calib_bytes = calib_path.read_bytes()
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    real_bulk = RegimeBacktestRepository.bulk_insert_daily
+    call_count = {"n": 0}
+
+    def fail_on_third_call(self, run_id, rows):
+        call_count["n"] += 1
+        if call_count["n"] == 3:
+            with self._conn.cursor() as cur:
+                cur.execute("INSERT INTO definitely_missing_table VALUES (1)")
+        return real_bulk(self, run_id, rows)
+
+    monkeypatch.setattr(
+        RegimeBacktestRepository, "bulk_insert_daily", fail_on_third_call
+    )
+
+    with pytest.raises(Exception):
+        cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    # Assert: zero rows remain for ANY form_sweep_full batch (the only batch
+    # was the failed one — cleanup must have removed it).
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, \
+            "cleanup-on-failure must remove all rows for failed batch_id"
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily d "
+            f"JOIN {db_schema}.regime_backtest_runs r ON d.run_id = r.id "
+            f"WHERE r.params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, "daily rows must cascade-delete"
+    assert calib_path.read_bytes() == before_calib_bytes, "calibration file changed on failure"
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes — depends on Task 4)**
+
+Run: `uv run pytest tests/integration/regime/test_canary_form_sweep_full.py -v -k cleanup_on_failure`
+Expected: PASS. If it fails with `InFailedSqlTransaction`, add `conn.rollback()` before `delete_runs_by_batch_id(batch_id)` in `run_form_sweep_full`.
+
+- [ ] **Step 3: Milestone checkpoint**
+
+```bash
+git add tests/integration/regime/test_canary_form_sweep_full.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 6: `render_canary_form_sweep_compare` renderer + unit tests
+
+**Files:**
+- Create: `src/uw_scan/reports/regime_canary_backtest_report.py`
+- Create: `tests/unit/test_canary_form_sweep_renderer.py`
+
+Pure function. Takes 4 row dicts (each shaped like a `regime_backtest_runs` row), returns markdown string. Mirrors the layout of `regime_backtest_report.py` (CRI) and `regime_vcg_backtest_report.py` (VCG).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_canary_form_sweep_renderer.py
+"""Unit tests for render_canary_form_sweep_compare."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from uw_scan.reports.regime_canary_backtest_report import (
+    render_canary_form_sweep_compare,
+)
+
+
+def _mk_run(*, run_id: int, form: str, batch_id: str = "batch-1",
+            composite_60d: float = 0.620, vol_60d: float = 0.640,
+            watch_pct: float = 39.3, buy_band_60d: float = 0.348,
+            buy_pct: float = 5.5, strong_buy_pct: float = 0.0) -> dict:
+    """Minimal row shape consumed by the renderer."""
+    return {
+        "id": run_id,
+        "run_scope": "research",
+        "start_date": date(2011, 2, 8),
+        "end_date": date(2026, 5, 21),
+        "composite_version": "1",
+        "params": {"score_form": form, "phase": "form_sweep_full",
+                   "batch_id": batch_id},
+        "summary": {
+            "is_winning_form": False,
+            "score_form": form,
+            "batch_id": batch_id,
+            "n_days": 3843,
+            "aucs": {
+                "composite":  {"up5d_2pct": 0.620, "up20d_5pct": 0.627, "up60d_10pct": composite_60d},
+                "vol_only":   {"up5d_2pct": 0.626, "up20d_5pct": 0.639, "up60d_10pct": vol_60d},
+                "speed_only": {"up5d_2pct": 0.470, "up20d_5pct": 0.465, "up60d_10pct": 0.430},
+            },
+            "band_distribution": {
+                "NONE": int(3843 * (1 - watch_pct/100 - buy_pct/100 - strong_buy_pct/100)),
+                "WATCH": int(3843 * watch_pct/100),
+                "BUY": int(3843 * buy_pct/100),
+                "STRONG_BUY": int(3843 * strong_buy_pct/100),
+            },
+            "within_band_aucs": {
+                "NONE":  {"up5d_2pct": 0.581, "up20d_5pct": 0.601, "up60d_10pct": 0.586},
+                "WATCH": {"up5d_2pct": 0.559, "up20d_5pct": 0.633, "up60d_10pct": 0.609},
+                "BUY":   {"up5d_2pct": 0.447, "up20d_5pct": 0.431, "up60d_10pct": buy_band_60d},
+                "STRONG_BUY": {"up5d_2pct": None, "up20d_5pct": None, "up60d_10pct": None},
+            },
+            "vol_only_gap": {
+                "up5d_2pct": 0.006, "up20d_5pct": 0.012,
+                "up60d_10pct": vol_60d - composite_60d,
+            },
+        },
+    }
+
+
+def _full_set(batch_id: str = "batch-1") -> list[dict]:
+    return [
+        _mk_run(run_id=27, form="linear", batch_id=batch_id),
+        _mk_run(run_id=28, form="convex", batch_id=batch_id),
+        _mk_run(run_id=29, form="concave", batch_id=batch_id),
+        _mk_run(run_id=30, form="sigmoid", batch_id=batch_id),
+    ]
+
+
+def test_canonical_form_ordering():
+    """Output rows always: linear → convex → concave → sigmoid, regardless of input order."""
+    runs = [_mk_run(run_id=i, form=f) for i, f in
+            enumerate(("sigmoid", "concave", "linear", "convex"), start=100)]
+    out = render_canary_form_sweep_compare(runs)
+    li = out.index("| linear ")
+    cv = out.index("| convex ")
+    cc = out.index("| concave")
+    sg = out.index("| sigmoid")
+    assert li < cv < cc < sg, f"unexpected order: linear={li} convex={cv} concave={cc} sigmoid={sg}"
+
+
+def test_missing_form_raises():
+    """3 rows (sigmoid missing) — length check fires first with 'got 3'.
+
+    The renderer validates length BEFORE form-set, so the error is the
+    `need exactly 4 rows, got 3` message rather than a form-specific one.
+    The form-set check (one canonical form replaced by a duplicate) is
+    covered separately by `test_duplicate_form_raises`.
+    """
+    runs = _full_set()[:3]  # missing sigmoid
+    with pytest.raises(ValueError, match=r"got 3"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_duplicate_form_raises():
+    runs = _full_set()
+    runs[1] = _mk_run(run_id=99, form="linear")  # 2 linears now
+    with pytest.raises(ValueError, match="linear|duplicate"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_fewer_than_4_rows_raises():
+    with pytest.raises(ValueError, match="4"):
+        render_canary_form_sweep_compare(_full_set()[:2])
+
+
+def test_mismatched_batch_id_raises():
+    runs = _full_set("batch-1")
+    runs[2] = _mk_run(run_id=99, form="concave", batch_id="batch-2")
+    with pytest.raises(ValueError, match="batch_id"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_non_research_scope_raises():
+    runs = _full_set()
+    runs[0]["run_scope"] = "production"
+    with pytest.raises(ValueError, match="research"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_footer_present():
+    out = render_canary_form_sweep_compare(_full_set())
+    assert "What this run does NOT decide" in out
+    assert "candidate-discovery" in out.lower() or "candidate discovery" in out.lower()
+
+
+def test_observation_watch_overfire():
+    """WATCH% > 30 in linear (default fixture has 39.3) — should appear in observations."""
+    out = render_canary_form_sweep_compare(_full_set())
+    # Find the WATCH overfire line and verify linear is mentioned
+    lines = [l for l in out.splitlines() if "WATCH% above 30%" in l]
+    assert lines, "expected WATCH% above 30% observation line"
+    assert "linear" in lines[0]
+
+
+def test_observation_buy_band_inversion():
+    """BUY-band 60d AUC < 0.50 in linear (default 0.348) — should appear."""
+    out = render_canary_form_sweep_compare(_full_set())
+    lines = [l for l in out.splitlines() if "BUY-band 60d AUC below 0.50" in l]
+    assert lines
+    assert "linear" in lines[0]
+
+
+def test_observation_composite_improves_over_linear():
+    """If convex 60d AUC > linear 60d by >=0.02, it should be listed."""
+    runs = [
+        _mk_run(run_id=27, form="linear", composite_60d=0.620),
+        _mk_run(run_id=28, form="convex", composite_60d=0.650),  # +0.030
+        _mk_run(run_id=29, form="concave", composite_60d=0.610),
+        _mk_run(run_id=30, form="sigmoid", composite_60d=0.620),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines()
+             if "Composite 60d AUC improves over linear" in l]
+    assert lines
+    assert "convex" in lines[0]
+    # concave should NOT appear (it got worse)
+    assert "concave" not in lines[0]
+
+
+def test_observation_watch_reduce_without_auc_loss():
+    """If sigmoid has WATCH%-5pp AND 60d AUC within 0.01 of linear, list it."""
+    runs = [
+        _mk_run(run_id=27, form="linear", watch_pct=39.3, composite_60d=0.620),
+        _mk_run(run_id=28, form="convex", watch_pct=39.0, composite_60d=0.620),
+        _mk_run(run_id=29, form="concave", watch_pct=39.5, composite_60d=0.620),
+        _mk_run(run_id=30, form="sigmoid", watch_pct=33.0,  # -6.3pp
+                composite_60d=0.615),  # -0.005 — within 0.01
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines()
+             if "WATCH% reduced by" in l]
+    assert lines
+    assert "sigmoid" in lines[0]
+
+
+def test_observation_vol_only_gap():
+    """Vol-only gap ≥ +0.02 (= vol_only_60d - composite_60d ≥ 0.02): listed.
+
+    Construct convex so that vol_only beats composite by >= 0.02 at the 60d
+    horizon; the other three forms have neutral gap. Only `convex` should
+    appear, and `none` should not be used.
+    """
+    runs = [
+        _mk_run(run_id=27, form="linear",  composite_60d=0.620, vol_60d=0.625),
+        _mk_run(run_id=28, form="convex",  composite_60d=0.620, vol_60d=0.650),  # gap +0.030
+        _mk_run(run_id=29, form="concave", composite_60d=0.620, vol_60d=0.625),
+        _mk_run(run_id=30, form="sigmoid", composite_60d=0.620, vol_60d=0.625),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines() if "Vol-only gap (60d) ≥ +0.02 in" in l]
+    assert lines, "expected vol-only gap observation line"
+    assert "convex" in lines[0]
+    assert "linear" not in lines[0]
+    assert "concave" not in lines[0]
+    assert "sigmoid" not in lines[0]
+
+
+def test_observation_buy_pct_zero():
+    """BUY% at exactly 0 (band never fires): listed.
+
+    Forms with `buy_pct=0` should match; forms with non-zero BUY% should not.
+    Asserts the rule's truthiness AND that `linear` (buy_pct=5.5 in the
+    default fixture) is NOT in the matching list.
+    """
+    runs = [
+        _mk_run(run_id=27, form="linear",  buy_pct=5.5),
+        _mk_run(run_id=28, form="convex",  buy_pct=0.0),  # band never fires
+        _mk_run(run_id=29, form="concave", buy_pct=0.0),
+        _mk_run(run_id=30, form="sigmoid", buy_pct=2.0),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines()
+             if "BUY% at exactly 0 (band never fires) in" in l]
+    assert lines, "expected BUY%=0 observation line"
+    assert "convex" in lines[0]
+    assert "concave" in lines[0]
+    assert "linear" not in lines[0]
+    assert "sigmoid" not in lines[0]
+
+
+def test_observation_strong_buy_pct_zero():
+    """STRONG_BUY% at exactly 0: listed.
+
+    Default fixture has STRONG_BUY%=0 for ALL forms, so the matching set
+    should be all four forms (and `none` should NOT appear).
+    """
+    out = render_canary_form_sweep_compare(_full_set())
+    lines = [l for l in out.splitlines()
+             if "STRONG_BUY% at exactly 0 (band never fires) in" in l]
+    assert lines, "expected STRONG_BUY%=0 observation line"
+    # All four forms match because the default fixture has strong_buy_pct=0.
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        assert form in lines[0], f"{form} missing from STRONG_BUY%=0 line"
+
+
+def test_observation_none_when_no_form_matches():
+    """Rule that has zero matches must print `none` (not an empty list)."""
+    # All forms strictly below 30% WATCH AND above 0.50 BUY-band 60d AUC,
+    # AND zero vol-only gap, AND non-zero BUY%, AND non-zero STRONG_BUY%
+    # — none of the six per-form rules should trigger.
+    runs = [
+        _mk_run(run_id=27, form="linear",  watch_pct=25.0, buy_band_60d=0.60,
+                composite_60d=0.620, vol_60d=0.620,
+                buy_pct=5.0, strong_buy_pct=3.0),
+        _mk_run(run_id=28, form="convex",  watch_pct=24.0, buy_band_60d=0.60,
+                composite_60d=0.620, vol_60d=0.620,
+                buy_pct=5.0, strong_buy_pct=3.0),
+        _mk_run(run_id=29, form="concave", watch_pct=23.0, buy_band_60d=0.60,
+                composite_60d=0.620, vol_60d=0.620,
+                buy_pct=5.0, strong_buy_pct=3.0),
+        _mk_run(run_id=30, form="sigmoid", watch_pct=22.0, buy_band_60d=0.60,
+                composite_60d=0.620, vol_60d=0.620,
+                buy_pct=5.0, strong_buy_pct=3.0),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    # Every per-form rule line should end with "none".
+    for label in (
+        "WATCH% above 30% in",
+        "BUY-band 60d AUC below 0.50 in",
+        "Vol-only gap (60d) ≥ +0.02 in",
+        "BUY% at exactly 0 (band never fires) in",
+        "STRONG_BUY% at exactly 0 (band never fires) in",
+    ):
+        matching = [l for l in out.splitlines() if label in l]
+        assert matching, f"missing observation line for: {label}"
+        assert "none" in matching[0], (
+            f"rule '{label}' should report 'none' when no form matches, "
+            f"got: {matching[0]!r}"
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_canary_form_sweep_renderer.py -v`
+Expected: ImportError — module not yet created.
+
+- [ ] **Step 3: Implement the renderer module**
+
+Create `src/uw_scan/reports/regime_canary_backtest_report.py`:
+
+```python
+"""Pure renderer: canary form_sweep_full runs -> markdown table.
+
+Mirrors regime_backtest_report.py (CRI) and regime_vcg_backtest_report.py (VCG):
+pure function, no I/O, no DB. The __main__ block at the bottom adds a CLI
+entry point that DOES touch the DB (via a module-private loader).
+
+This renderer's primary defense against misuse is the fixed
+"What this run does NOT decide" footer — see spec
+docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md §4.3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from io import StringIO
+from typing import Any
+
+import psycopg
+from uw_scan.config import Settings
+
+CANONICAL_FORMS = ("linear", "convex", "concave", "sigmoid")
+
+
+def render_canary_form_sweep_compare(runs: list[dict]) -> str:
+    """Render a 4-form comparison table from form_sweep_full runs.
+
+    `runs` is a list of regime_backtest_runs row dicts, each with
+    params.phase='form_sweep_full'. Caller is responsible for filtering
+    and loading; this function does not touch the DB.
+
+    Sort order in output: linear, convex, concave, sigmoid (canonical,
+    not by id).
+
+    Raises ValueError if:
+      - fewer than 4 rows provided
+      - any form is missing or duplicated
+      - rows do not all share the same batch_id and composite_version
+      - any row is not params.phase='form_sweep_full' or run_scope='research'
+    """
+    if len(runs) != 4:
+        raise ValueError(f"need exactly 4 rows, got {len(runs)}")
+
+    by_form: dict[str, dict] = {}
+    for r in runs:
+        if r.get("run_scope") != "research":
+            raise ValueError(f"form_sweep_full rows must be research scoped, got {r.get('run_scope')!r}")
+        if r["params"].get("phase") != "form_sweep_full":
+            raise ValueError(f"expected params.phase=form_sweep_full, got {r['params'].get('phase')!r}")
+        form = r["params"]["score_form"]
+        if form not in CANONICAL_FORMS:
+            raise ValueError(f"unknown score_form: {form}")
+        if form in by_form:
+            raise ValueError(f"duplicate score_form: {form}")
+        by_form[form] = r
+
+    for form in CANONICAL_FORMS:
+        if form not in by_form:
+            raise ValueError(f"missing score_form: {form}")
+
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    if len(batch_ids) != 1:
+        raise ValueError(f"all rows must share batch_id, got {batch_ids}")
+    composite_versions = {str(r["composite_version"]) for r in runs}
+    if len(composite_versions) != 1:
+        raise ValueError(f"all rows must share composite_version, got {composite_versions}")
+
+    sample = by_form["linear"]
+    out = StringIO()
+    out.write("# Canary form-sweep — candidate discovery\n")
+    out.write(f"Window: {sample['start_date'].isoformat()} → "
+              f"{sample['end_date'].isoformat()} "
+              f"({sample['summary']['n_days']:,} days)\n")
+    out.write(f"Composite version: {sample['composite_version']}\n")
+    out.write(f"Batch id: {next(iter(batch_ids))}\n")
+    out.write(f"Run ids: {', '.join(str(by_form[f]['id']) for f in CANONICAL_FORMS)}\n")
+    out.write("\n")
+
+    out.write(
+        "| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | "
+        "STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |\n"
+    )
+    out.write(
+        "|---------|-------:|--------:|--------:|------:|-------:|-----:|"
+        "------------:|-----------------:|-------------------:|\n"
+    )
+    for form in CANONICAL_FORMS:
+        s = by_form[form]["summary"]
+        n = s["n_days"]
+        bd = s["band_distribution"]
+        pct = lambda x: 100.0 * bd[x] / n if n else 0.0  # noqa: E731
+        wb = s["within_band_aucs"]["BUY"].get("up60d_10pct")
+        buy_band_str = f"{wb:.3f}" if wb is not None else "  nan"
+        gap = s["vol_only_gap"]["up60d_10pct"]
+        gap_str = ("+" if gap >= 0 else "") + f"{gap:.3f}"
+        out.write(
+            f"| {form:<7} | {s['aucs']['composite']['up5d_2pct']:>6.3f} | "
+            f"{s['aucs']['composite']['up20d_5pct']:>7.3f} | "
+            f"{s['aucs']['composite']['up60d_10pct']:>7.3f} | "
+            f"{pct('NONE'):>5.1f} | {pct('WATCH'):>6.1f} | "
+            f"{pct('BUY'):>4.1f} | {pct('STRONG_BUY'):>11.1f} | "
+            f"{buy_band_str:>16} | {gap_str:>18} |\n"
+        )
+    out.write("\n")
+
+    out.write("## Observations\n\n")
+    linear_summary = by_form["linear"]["summary"]
+
+    def forms_where(predicate) -> str:
+        matched = [f for f in CANONICAL_FORMS if predicate(by_form[f]["summary"])]
+        return ", ".join(matched) if matched else "none"
+
+    rules = [
+        ("WATCH% above 30% in",
+         lambda s: 100.0 * s["band_distribution"]["WATCH"] / s["n_days"] > 30.0,
+         "  (over-broad WATCH band)"),
+        ("BUY-band 60d AUC below 0.50 in",
+         lambda s: (s["within_band_aucs"]["BUY"].get("up60d_10pct") is not None
+                    and s["within_band_aucs"]["BUY"]["up60d_10pct"] < 0.50),
+         "  (regression-to-mean signature)"),
+        ("Vol-only gap (60d) ≥ +0.02 in",
+         lambda s: s["vol_only_gap"]["up60d_10pct"] >= 0.02,
+         "  (speed layer net-negative for rank)"),
+        ("BUY% at exactly 0 (band never fires) in",
+         lambda s: s["band_distribution"]["BUY"] == 0,
+         ""),
+        ("STRONG_BUY% at exactly 0 (band never fires) in",
+         lambda s: s["band_distribution"]["STRONG_BUY"] == 0,
+         ""),
+        ("Composite 60d AUC improves over linear by ≥ +0.02 in",
+         lambda s: (s["score_form"] != "linear"
+                    and s["aucs"]["composite"]["up60d_10pct"]
+                        - linear_summary["aucs"]["composite"]["up60d_10pct"] >= 0.02),
+         "  (deserves v2-C planning)"),
+        ("WATCH% reduced by ≥ 5 percentage points vs linear "
+         "AND 60d AUC does not fall by more than 0.01 in",
+         lambda s: (s["score_form"] != "linear"
+                    and (100.0 * linear_summary["band_distribution"]["WATCH"]
+                         / linear_summary["n_days"]
+                         - 100.0 * s["band_distribution"]["WATCH"] / s["n_days"]) >= 5.0
+                    and (linear_summary["aucs"]["composite"]["up60d_10pct"]
+                         - s["aucs"]["composite"]["up60d_10pct"]) <= 0.01),
+         "  (practical v2-C candidate)"),
+    ]
+    for label, predicate, suffix in rules:
+        out.write(f"- {label}: {forms_where(predicate)}{suffix}\n")
+    out.write("\n")
+
+    out.write("## What this run does NOT decide\n\n")
+    out.write(
+        "This is candidate-discovery output. No form is declared "
+        '"winning". Any v2 calibration change must reserve a fresh '
+        "holdout window for OOS validation.\n"
+    )
+    return out.getvalue()
+
+
+# ----------------------------------------------------------------------
+# CLI entry point — DOES touch DB. Module-private loader pulls 4 rows.
+# ----------------------------------------------------------------------
+
+def _load_latest_complete_batch(conn, schema: str) -> list[dict]:
+    """Load 4 rows from the most-recent complete form_sweep_full batch.
+
+    "Complete" = exactly 4 rows AND covers all four CANONICAL_FORMS.
+    Incomplete batches are skipped.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH ranked_batches AS (
+              SELECT params->>'batch_id' AS batch_id,
+                     MAX(created_at) AS latest,
+                     COUNT(*) AS n_rows,
+                     array_agg(params->>'score_form' ORDER BY params->>'score_form')
+                       AS forms
+              FROM {schema}.regime_backtest_runs
+              WHERE indicator = 'canary'
+                AND run_scope = 'research'
+                AND completed_at IS NOT NULL
+                AND params->>'phase' = 'form_sweep_full'
+              GROUP BY params->>'batch_id'
+            )
+            SELECT batch_id FROM ranked_batches
+            WHERE n_rows = 4
+              AND forms = ARRAY['concave','convex','linear','sigmoid']
+            ORDER BY latest DESC
+            LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise ValueError("no complete form_sweep_full batch found")
+        batch_id = row[0]
+        # Repeat the same scope filters used to select the batch. Without
+        # `indicator='canary'` and `params->>'phase'='form_sweep_full'`, a
+        # row from a different indicator or phase sharing this batch_id
+        # (UUID4 collision) could leak in and break the renderer's
+        # CANONICAL_FORMS validation in a confusing way.
+        cur.execute(
+            f"SELECT id, params, summary, start_date, end_date, composite_version, run_scope "
+            f"FROM {schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s "
+            f"AND indicator = 'canary' "
+            f"AND run_scope = 'research' "
+            f"AND completed_at IS NOT NULL "
+            f"AND params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'",
+            (batch_id,),
+        )
+        return [
+            {"id": r[0], "params": r[1], "summary": r[2],
+             "start_date": r[3], "end_date": r[4], "composite_version": r[5],
+             "run_scope": r[6]}
+            for r in cur.fetchall()
+        ]
+
+
+def _load_specific_runs(conn, schema: str, run_ids: list[int]) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id, params, summary, start_date, end_date, composite_version, run_scope "
+            f"FROM {schema}.regime_backtest_runs "
+            f"WHERE id = ANY(%s) "
+            f"AND indicator = 'canary' "
+            f"AND run_scope = 'research' "
+            f"AND completed_at IS NOT NULL "
+            f"AND params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'",
+            (run_ids,),
+        )
+        return [
+            {"id": r[0], "params": r[1], "summary": r[2],
+             "start_date": r[3], "end_date": r[4], "composite_version": r[5],
+             "run_scope": r[6]}
+            for r in cur.fetchall()
+        ]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--mode", default="form_sweep_compare",
+                   choices=("form_sweep_compare",),
+                   help="rendering mode (currently only form_sweep_compare)")
+    p.add_argument("--runs", default=None,
+                   help="comma-separated run ids; if omitted, load latest complete batch")
+    args = p.parse_args()
+
+    settings = Settings.from_env()
+    schema = settings.db_schema
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        if args.runs:
+            run_ids = [int(s) for s in args.runs.split(",")]
+            runs = _load_specific_runs(conn, schema, run_ids)
+        else:
+            runs = _load_latest_complete_batch(conn, schema)
+    print(render_canary_form_sweep_compare(runs))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_canary_form_sweep_renderer.py -v`
+Expected: 15 passed (canonical_form_ordering, missing_form_raises, duplicate_form_raises, fewer_than_4_rows_raises, mismatched_batch_id_raises, non_research_scope_raises, footer_present, observation_watch_overfire, observation_buy_band_inversion, observation_composite_improves_over_linear, observation_watch_reduce_without_auc_loss, observation_vol_only_gap, observation_buy_pct_zero, observation_strong_buy_pct_zero, observation_none_when_no_form_matches).
+
+- [ ] **Step 5: Milestone checkpoint**
+
+```bash
+git add src/uw_scan/reports/regime_canary_backtest_report.py tests/unit/test_canary_form_sweep_renderer.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 7: Renderer batch loading + integration tests
+
+**Files:**
+- Modify: `tests/integration/regime/test_canary_form_sweep_full.py`
+
+The renderer's `_load_latest_complete_batch` was implemented in Task 6 but is untested against a real DB. Add 2 integration tests: picks-latest-complete-batch, skips-incomplete-batch.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/regime/test_canary_form_sweep_full.py`:
+
+```python
+def test_form_sweep_full_renderer_picks_latest_complete_batch(seeded_db_empty_cards):
+    """Two complete batches, different created_at — loader picks the latest."""
+    from uw_scan.reports.regime_canary_backtest_report import _load_latest_complete_batch
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+
+    def insert_batch(batch_id: str):
+        for form in ("linear", "convex", "concave", "sigmoid"):
+            run_id = repo.insert_run(
+                indicator="canary", composite_version="1",
+                start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+                window_days=350, n_days=100,
+                params={"score_form": form, "phase": "form_sweep_full",
+                        "batch_id": batch_id},
+                summary={"is_winning_form": False, "score_form": form,
+                         "batch_id": batch_id, "phase": "form_sweep_full",
+                         "n_days": 100,
+                         "aucs": {"composite": {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                                  "vol_only":  {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                                  "speed_only":{"up5d_2pct": 0.5, "up20d_5pct": 0.5, "up60d_10pct": 0.5}},
+                         "band_distribution": {"NONE": 60, "WATCH": 30, "BUY": 10, "STRONG_BUY": 0},
+                         "within_band_aucs": {"NONE": {"up60d_10pct": 0.55},
+                                              "WATCH": {"up60d_10pct": 0.55},
+                                              "BUY": {"up60d_10pct": 0.45},
+                                              "STRONG_BUY": {"up60d_10pct": None}},
+                         "vol_only_gap": {"up5d_2pct": 0.0, "up20d_5pct": 0.0, "up60d_10pct": 0.0}},
+                run_scope="research",
+            )
+            repo.mark_run_completed(run_id)
+
+    # Earlier batch
+    insert_batch("batch-A")
+    # Later batch (later created_at by virtue of insertion order)
+    insert_batch("batch-B")
+
+    runs = _load_latest_complete_batch(db_conn, db_schema)
+    assert len(runs) == 4
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    assert batch_ids == {"batch-B"}, f"expected batch-B, got {batch_ids}"
+
+
+def test_renderer_skips_incomplete_batch(seeded_db_empty_cards):
+    """Earlier complete batch + later incomplete (3 rows) batch — loader returns the earlier."""
+    from uw_scan.reports.regime_canary_backtest_report import _load_latest_complete_batch
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+
+    def insert_run_for(batch_id: str, form: str, *, completed: bool = True):
+        run_id = repo.insert_run(
+            indicator="canary", composite_version="1",
+            start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+            window_days=350, n_days=100,
+            params={"score_form": form, "phase": "form_sweep_full",
+                    "batch_id": batch_id},
+            summary={"is_winning_form": False, "score_form": form,
+                     "batch_id": batch_id, "phase": "form_sweep_full",
+                     "n_days": 100,
+                     "aucs": {"composite": {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                              "vol_only":  {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                              "speed_only":{"up5d_2pct": 0.5, "up20d_5pct": 0.5, "up60d_10pct": 0.5}},
+                     "band_distribution": {"NONE": 60, "WATCH": 30, "BUY": 10, "STRONG_BUY": 0},
+                     "within_band_aucs": {"NONE": {"up60d_10pct": 0.55},
+                                          "WATCH": {"up60d_10pct": 0.55},
+                                          "BUY": {"up60d_10pct": 0.45},
+                                          "STRONG_BUY": {"up60d_10pct": None}},
+                     "vol_only_gap": {"up5d_2pct": 0.0, "up20d_5pct": 0.0, "up60d_10pct": 0.0}},
+            run_scope="research",
+        )
+        if completed:
+            repo.mark_run_completed(run_id)
+
+    # Earlier complete batch
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        insert_run_for("batch-complete", form)
+    # Later batch but only 3 completed forms (simulated mid-run failure that didn't cleanup)
+    for form in ("linear", "convex", "concave"):
+        insert_run_for("batch-partial", form)
+
+    runs = _load_latest_complete_batch(db_conn, db_schema)
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    assert batch_ids == {"batch-complete"}, \
+        f"loader must skip incomplete batches, got {batch_ids}"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/regime/test_canary_form_sweep_full.py -v -k "picks_latest_complete_batch or skips_incomplete_batch"`
+Expected: 2 passed.
+
+- [ ] **Step 3: Milestone checkpoint**
+
+```bash
+git add tests/integration/regime/test_canary_form_sweep_full.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 8: Downstream-invisibility tests (OOS gate, validation API, calibration file)
+
+**Files:**
+- Modify: `tests/integration/regime/test_canary_form_sweep_full.py`
+
+These are the spec's §4.4 G-4 guardrail tests. They prove form_sweep_full rows are invisible to v1 production surfaces.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/integration/regime/test_canary_form_sweep_full.py`:
+
+```python
+def test_form_sweep_full_does_not_write_calibration_file(
+    seeded_db_empty_cards,
+):
+    """canary-calibration-v1.json byte content unchanged after run."""
+    import hashlib
+    from pathlib import Path
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    calib_path = Path(__file__).parent.parent.parent.parent / (
+        "docs/research/regime/canary-calibration-v1.json")
+    assert calib_path.exists(), f"calibration file not found at {calib_path}"
+
+    before_bytes = calib_path.read_bytes()
+    before_hash = hashlib.sha256(before_bytes).hexdigest()
+    before_mtime = calib_path.stat().st_mtime
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    after_bytes = calib_path.read_bytes()
+    after_hash = hashlib.sha256(after_bytes).hexdigest()
+    after_mtime = calib_path.stat().st_mtime
+
+    assert before_bytes == after_bytes, "calibration file content changed"
+    assert before_hash == after_hash, "calibration SHA-256 mismatch"
+    assert before_mtime == after_mtime, "calibration mtime changed"
+
+
+def test_form_sweep_full_invisible_to_oos_gate(seeded_db_empty_cards):
+    """Production find_latest_run does not return any research-scoped form_sweep_full row."""
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    # Seed a pre-existing v1 winning run (mimicking what the OOS gate looks at)
+    winning_run_id = repo.insert_run(
+        indicator="canary", composite_version="1",
+        start_date=date(2020, 1, 2), end_date=date(2026, 5, 21),
+        window_days=350, n_days=1605,
+        params={"score_form": "linear", "phase": "final_oos_report"},
+        summary={"is_winning_form": True, "score_form": "linear"},
+    )
+    repo.mark_run_completed(winning_run_id)
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    # find_latest_run defaults to run_scope='production', so research rows are invisible.
+    latest = repo.find_latest_run("canary", composite_version="1")
+    assert latest is not None
+    assert latest["id"] == winning_run_id, (
+        f"find_latest_run returned {latest['id']}; expected pre-existing v1 run "
+        f"{winning_run_id}. form_sweep_full rows must be research scoped."
+    )
+
+
+def test_form_sweep_full_invisible_to_validation_api(
+    seeded_db_empty_cards,
+):
+    """The /api/regime/canary/validation router function returns the same
+    row before and after a form_sweep_full run."""
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_vol_index, seed_canary_snapshots)
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from uw_scan.api.routers.regime import get_canary_validation
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    pre_winning_id = repo.insert_run(
+        indicator="canary", composite_version="1",
+        start_date=date(2020, 1, 2), end_date=date(2026, 5, 21),
+        window_days=350, n_days=1605,
+        params={"score_form": "linear", "phase": "final_oos_report"},
+        summary={"is_winning_form": True, "score_form": "linear"},
+    )
+    repo.mark_run_completed(pre_winning_id)
+
+    # Capture the actual router response the API would serialize.
+    before = get_canary_validation(repo=seeded_db_empty_cards).model_dump_json()
+    assert f'"run_id":{pre_winning_id}' in before
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    after = get_canary_validation(repo=seeded_db_empty_cards).model_dump_json()
+    assert before == after, "validation API payload changed across form_sweep_full"
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/integration/regime/test_canary_form_sweep_full.py -v -k "does_not_write_calibration or invisible_to_oos_gate or invisible_to_validation_api"`
+Expected: 3 passed.
+
+- [ ] **Step 3: Milestone checkpoint**
+
+```bash
+git add tests/integration/regime/test_canary_form_sweep_full.py
+# Commit only after the user-approved milestone trigger.
+```
+
+---
+
+## Task 9: Final verification + live smoke
+
+**Files:**
+- No code changes. This task verifies the complete suite passes and runs a manual smoke against the real DB.
+
+- [ ] **Step 1: Run all tests added in this PR**
+
+```bash
+uv run pytest tests/unit/test_within_band_aucs.py \
+              tests/unit/test_canary_form_sweep_cli.py \
+              tests/unit/test_canary_form_sweep_renderer.py \
+              tests/integration/regime/test_canary_form_sweep_full.py -v
+```
+
+Expected: **35 passed total**:
+- 5 unit tests in `test_within_band_aucs.py`
+- 1 unit test in `test_canary_form_sweep_cli.py`
+- 15 unit tests in `test_canary_form_sweep_renderer.py` (4 new observation rules: vol_only_gap, buy_pct_zero, strong_buy_pct_zero, none_when_no_form_matches)
+- 14 integration tests in `test_canary_form_sweep_full.py`:
+  - 3 `delete_runs_by_batch_id` (Task 3 — includes scope-correctness test)
+  - 5 happy-path persistence (Task 4 — includes capsys stdout + compute-before-persist)
+  - 1 cleanup-on-failure (Task 5)
+  - 2 renderer picks-latest / skips-incomplete (Task 7)
+  - 3 downstream invisibility (Task 8)
+
+- [ ] **Step 2: Run the existing OOS gate test to confirm non-regression**
+
+```bash
+uv run pytest tests/integration/regime/test_canary_oos_gate.py -v
+```
+
+Expected: existing OOS gate test passes (no regressions). This is AC-11.
+
+- [ ] **Step 3: Run the live `--form-sweep-full` against the real DB**
+
+```bash
+uv run python scripts/backtest_canary.py --form-sweep-full
+```
+
+Expected output (final paragraph of the stdout):
+
+```
+# Canary form-sweep — candidate discovery
+Window: 2011-02-08 → 2026-05-21 (3,843 days)
+Composite version: 1
+Batch id: <uuid>
+Run ids: <r1>, <r2>, <r3>, <r4>
+
+| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |
+| linear  |  0.620 |   0.627 |   0.619 | ...   | ...    | ...  |     ...     |      ...         |      ...           |
+| convex  |  ...   |   ...   |   ...   | ...   | ...    | ...  |     ...     |      ...         |      ...           |
+| concave |  ...   |   ...   |   ...   | ...   | ...    | ...  |     ...     |      ...         |      ...           |
+| sigmoid |  ...   |   ...   |   ...   | ...   | ...    | ...  |     ...     |      ...         |      ...           |
+
+## Observations
+- ...
+
+## What this run does NOT decide
+This is candidate-discovery output. No form is declared "winning". ...
+```
+
+Exit code: 0. 4 new rows in `regime_backtest_runs` for the new batch.
+
+- [ ] **Step 4: Verify renderer re-render works on demand**
+
+```bash
+uv run python -m uw_scan.reports.regime_canary_backtest_report
+```
+
+Expected: identical table to Step 3's stdout (auto-loads the same batch).
+
+- [ ] **Step 5: Run `/codex-review --diff` (AC-12)**
+
+This is interactive — the user invokes it. Surface to the user:
+
+> "All tests pass. Live smoke completed; 4 form_sweep_full rows persisted under batch_id=<uuid>. Recommend running `/codex-review --diff` (or `/review-cycle`) before opening PR."
+
+- [ ] **Step 6: Stage for PR**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: 8 commits visible (one per task above that committed code; Task 9 is verification-only and may not need its own commit).
+
+---
+
+## Spec Coverage Map
+
+Verifying every spec section maps to at least one task:
+
+| Spec section | Tasks |
+|---|---|
+| §1 TL;DR / motivation | Task 4 (the change itself) |
+| §2 Goals G1-G3 | Task 4 (the change), Task 6 (renderer stdout) |
+| §2 Goals G4 (invisibility) | Task 8 |
+| §3 Architecture (two new units) | Task 4 (cmd + helper), Task 6 (renderer) |
+| §4.1 CLI surface | Task 4 (argparse + dispatch) |
+| §4.2 Persistence shape (params + summary) | Task 4 (Step 3 dict literals) |
+| §4.2 Atomicity / cleanup-on-failure | Task 3 (repo method), Task 4 (try/except), Task 5 (assertion test) |
+| §4.2 `_within_band_aucs` helper | Task 2 |
+| §4.3 Renderer pure function | Task 6 |
+| §4.3 Renderer CLI entry point | Task 6 (main() + __main__) |
+| §4.3 Loader by batch_id | Task 6 (`_load_latest_complete_batch`), Task 7 (integration tests) |
+| §4.4 G-1 mutual exclusion | Task 4 (CLI unit test + Step 4 count-check) |
+| §4.4 G-2 function isolation | Task 4 (Step 3 docstring + no calibration write) |
+| §4.4 G-3 persistence locks | Task 4 (Step 3 hardcoded literals) |
+| §4.4 G-4 downstream invisibility | Task 8 |
+| §4.4 G-5 re-run / version safety | Task 4 (Step 3 batch_id), Task 6 (loader) |
+| §4.4 G-6 batch atomicity | Task 5 |
+| §4.5 Unit tests | Task 2 (within_band), Task 6 (renderer) |
+| §4.5 Integration tests | Tasks 3, 4, 5, 7, 8 |
+| §5 Acceptance criteria AC-1..AC-13 | Task 9 (verification) |
+
+**Gaps**: none — every spec section has at least one implementing task.
+
+---
+
+## Notes for the implementer
+
+- **Branch name**: `feat/canary-form-sweep-full` (per the prerequisite section).
+- **Commit style**: Conventional commits (`type(scope): subject`) when the user explicitly approves a milestone commit. Until then, task-end snippets are staging/checkpoint guidance only.
+- **Never commit without explicit user request** — the user has a standing rule about this. If you encounter ambiguity about a milestone boundary, stop and ask.
+- **No bare `python` / `pip` / `pytest`** — use `uv run` for all Python invocations per the project's `uv`-only rule.
+- **Module size budget**: `scripts/backtest_canary.py` currently sits at ~1,120 lines. Do not add the new command body there. Keep the script change to the wrapper/argparse wiring and put the implementation in `src/uw_scan/reports/regime_canary_form_sweep_full.py`.
+- **Connection autocommit**: existing repository methods commit per call. `cmd_form_sweep_full` relies on this; if you find yourself changing the repository to be non-committing, stop — that's out of scope per the spec.
+- **If the migration 057 CASCADE check (Task 3 Step 1) fails**, surface immediately — do NOT silently work around it. The cleanup helper would need an explicit `DELETE FROM regime_backtest_daily ...` first.

--- a/docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md
+++ b/docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md
@@ -1,0 +1,654 @@
+# Canary Full-History Form-Sweep — Design Spec
+
+**Date**: 2026-05-27
+**Status**: design — implementation plan not yet started
+**Author intent**: candidate discovery for v2 score-form, not selection of a new production form
+**Parent docs**:
+- `docs/research/regime/canary-next-steps-2026-05-27.md` (Phase A, item #1)
+- `docs/research/regime/canary-5yr-executive-summary.md` (§10 — v2-A/B/C/D motivation)
+- `docs/research/regime/canary-methodology.md` (composite math + calibration discipline)
+- `docs/superpowers/specs/2026-05-26-5pct-canary-indicator-design.md` (v1 spec; this is its first measurement-only follow-up)
+
+---
+
+## TL;DR
+
+The v1 canary form (`linear`) was picked by `cmd_form_sweep` running against `VALID_START=2015-01-01..VALID_END=2019-12-31` (5 years, mild vol regime). We now have 3,843 rows across 15+ years in `canary_snapshots`. Re-running the form-sweep against the full backfilled dataset can identify whether non-linear forms deserve v2 candidate work — at near-zero cost, since `_compute_canary_series` already recomputes from `vol_index_daily` and `_aucs_for_rows` already produces composite/speed-only/vol-only AUCs. (The full dataset cannot "confirm" the production form: any v2 form change still requires a fresh holdout window for OOS validation.)
+
+This spec adds a new CLI subcommand `--form-sweep-full` that runs that measurement. It produces 4 rows in `regime_backtest_runs` (one per form), each tagged `run_scope='research'` (the keystone invisibility lock — same mechanism VCG already uses), `phase='form_sweep_full'`, `is_winning_form=False`, and a shared `batch_id` (UUID per invocation) so re-runs and partial failures cannot be confused with each other. Six guardrails — CLI-level mutual exclusion, function isolation, persistence locks anchored on `run_scope='research'`, downstream-invisibility, batch-atomicity (cleanup-on-failure), and re-run/version safety — prevent the output from accidentally being treated as a production form selection.
+
+A new focused implementation module in `src/uw_scan/reports/regime_canary_form_sweep_full.py` runs the measurement, while `scripts/backtest_canary.py` stays as a thin CLI dispatcher. A new pure-function renderer in `src/uw_scan/reports/regime_canary_backtest_report.py` prints a 4-row comparison table to stdout, with a fixed "What this run does NOT decide" footer.
+
+**Scope budget**: ~300-360 LOC new code across 3 source files (thin `scripts/backtest_canary.py` wrapper + new `src/uw_scan/reports/regime_canary_form_sweep_full.py` + new `src/uw_scan/reports/regime_canary_backtest_report.py`) + 1 new repository method (`RegimeBacktestRepository.delete_runs_by_batch_id`) + 4 test files (11 integration tests + 17 unit tests). ~20-30s of new test runtime.
+
+---
+
+## 1. Motivation
+
+### What v1 left unresolved
+
+After PR #83 (v1 canary indicator) merged, three findings in `canary-5yr-executive-summary.md` §9 demanded follow-up:
+
+- **WATCH band overfires**: 31-39% of all days vs. design intent of ~25%
+- **Within-BUY band is anti-predictive**: AUC 0.35-0.45 across all horizons (regression-to-mean signature)
+- **Vol-only beats composite by 0.01-0.04 AUC** at every horizon × every subset
+
+The roadmap memo (`canary-next-steps-2026-05-27.md`) rank-ordered the follow-ups. Phase A item #1 — re-run `--form-sweep` against the full 2011-2026 dataset — is the highest-information, smallest-code change available. If a non-`linear` form compresses middle scores into NONE (which `convex` or `sigmoid` could do mechanically), the WATCH-overfire problem may have a candidate fix, pending v2 holdout validation.
+
+### Why this is "discovery, not validation"
+
+The full 2011-2026 dataset is the **same data** the v1 walk-forward judged against (run ids 19-24). Picking a winning form from it and then re-evaluating against any subset of it would be circular — the walk-forward result is the empirical anchor we just bought. Any v2 calibration change requires a reserved holdout window that this run cannot supply.
+
+Therefore: this run **discovers candidates**. Any candidate must be re-validated under its own spec, with a reserved holdout, before it can change `canary-calibration-v1.json`.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+- G1. Evaluate all 4 supported score forms (`linear`, `convex`, `concave`, `sigmoid`) against the full backfilled `canary_snapshots` range.
+- G2. Persist diagnostic AUC + band-distribution + within-band-rank + vol-only-gap metrics in `regime_backtest_runs.summary` so the result is re-renderable from DB.
+- G3. Print a 4-row comparison table to stdout at end of run, with mechanical "Observations" flags on surprising patterns and a fixed "this is not a decision" footer.
+- G4. Make it **impossible** for the run to silently change v1 production behavior (validation panel, OOS gate, calibration JSON).
+
+### Non-goals
+
+- NG1. Selecting or declaring a winning form.
+- NG2. Updating `canary-calibration-v1.json`.
+- NG3. Bumping `COMPOSITE_VERSION`.
+- NG4. Changing band thresholds (NONE/WATCH/BUY/STRONG_BUY).
+- NG5. Adding a UI surface for the result (validation panel changes are out of scope).
+- NG6. Modifying `cmd_form_sweep` (the existing 2015-2019 selection-mode function) — it remains untouched so any historical re-runs reproduce.
+- NG7. Adding new API endpoints.
+
+---
+
+## 3. Architecture overview
+
+```
+                      ┌──────────────────────────────┐
+   scripts/           │  --form-sweep-full           │
+   backtest_canary.py │  thin wrapper + argparse     │
+                      └──────────────┬───────────────┘
+                                     │ delegates
+                                     ▼
+                      ┌──────────────────────────────┐
+                      │ src/uw_scan/reports/         │
+                      │ regime_canary_form_sweep_    │
+                      │ full.py                      │
+                      └──────────────────────────────┘
+                              │
+                              │ reads (read-only)
+                              ▼
+              ┌─────────────────────────────────┐
+              │ uw_scan.vol_index_daily         │
+              │ uw_scan.canary_snapshots (MIN/  │
+              │   MAX(data_date) for window)    │
+              └─────────────────────────────────┘
+                              │
+                              │ 4× recompute via _compute_canary_series
+                              ▼
+                      ┌──────────────────────────────┐
+                      │ For each form:               │
+                      │   linear / convex /          │
+                      │   concave / sigmoid          │
+                      │                              │
+                      │ → aucs (composite/speed/vol) │
+                      │ → band_distribution          │
+                      │ → within_band_aucs           │
+                      │ → vol_only_gap               │
+                      │ → auc_ci95 (block-bootstrap) │
+                      └──────────────────────────────┘
+                              │
+                              │ INSERT (×4 rows + daily)
+                              ▼
+              ┌─────────────────────────────────┐
+              │ uw_scan.regime_backtest_runs    │
+	              │   run_scope='research'          │
+	              │   params.phase='form_sweep_full'│
+	              │   summary.is_winning_form=False │
+              │ uw_scan.regime_backtest_daily   │
+              └─────────────────────────────────┘
+                              │
+                              │ stdout (immediate) + on-demand re-render
+                              ▼
+                      ┌──────────────────────────────┐
+                      │ src/uw_scan/reports/         │
+                      │ regime_canary_backtest_      │
+                      │ report.py (new)              │
+                      │                              │
+                      │ render_canary_form_sweep_    │
+                      │ compare(runs) -> str         │
+                      └──────────────────────────────┘
+```
+
+Three new or changed code units. All stay narrow:
+- `scripts/backtest_canary.py` only adds the `--form-sweep-full` flag, mutual-exclusion check, and a small `cmd_form_sweep_full` wrapper that delegates to `regime_canary_form_sweep_full.py`. This satisfies the repo's module-size rule: `scripts/backtest_canary.py` is already >1,000 lines, so the new command body is not added there.
+- `regime_canary_form_sweep_full.py` owns the new command body and `_within_band_aucs`. Existing helpers — `_compute_canary_series`, `_aucs_for_rows`, `_band_counts`, `_block_bootstrap_auc_ci`, `_clean_nans`, `_entry_lagged_label`, `_auc`, `LABEL_SPECS`, `COMPOSITE_VERSION` — are passed in from the script wrapper as explicit dependencies, so the package module does not import the script.
+- `regime_canary_backtest_report.py` is a new module, sibling to `regime_backtest_report.py` (CRI) and `regime_vcg_backtest_report.py` (VCG), matching the project's "one renderer per indicator" convention.
+
+---
+
+## 4. Detailed design
+
+### 4.1 CLI surface
+
+Single boolean flag — no overrides:
+
+```bash
+uv run python scripts/backtest_canary.py --form-sweep-full
+```
+
+**Window resolution** (computed at run time, not hardcoded):
+- `start = MIN(canary_snapshots.data_date)`
+- `end = MAX(canary_snapshots.data_date)`
+- Logged at run start: `INFO form-sweep-full window: 2011-02-08 → 2026-05-21 (3,843 days)`
+
+**Argparse**:
+- `--form-sweep-full` is added as a new boolean alongside the existing top-level mode flags (`--calibrate`, `--form-sweep`, `--report`, `--walk-forward`, `--robustness`). The existing argparse setup at `scripts/backtest_canary.py:1072-1088` does NOT use `add_mutually_exclusive_group` — it uses an `if/elif/return` chain in `main()`. Mutual exclusion is therefore enforced by an explicit count-check at the top of `main()`: if more than one top-level mode flag is True, call `parser.error("only one of --calibrate/--form-sweep/--form-sweep-full/--report/--walk-forward/--robustness may be specified")` and exit with code 2.
+- `--form linear|convex|concave|sigmoid` (existing per-form override) has no effect when `--form-sweep-full` is set (the sweep iterates all four forms regardless). If `--form` is passed alongside `--form-sweep-full`, a warning is logged at run start (`WARNING --form is ignored under --form-sweep-full`) so the user knows their flag had no effect.
+
+**Exit codes**:
+- `0` on success: all 4 form rows persisted + comparison logged.
+- `1` on failure: snapshot table empty, any form computation errors, OR any of the 4 inserts fails. Fail loud — no partial-state runs.
+
+**End-of-run output**: the script calls `render_canary_form_sweep_compare(runs)` after persisting and prints to stdout. The user sees the table without a separate command.
+
+### 4.2 Persistence shape
+
+Each of the 4 runs writes **one row to `regime_backtest_runs`** and **~3,843 daily rows to `regime_backtest_daily`**.
+
+#### `regime_backtest_runs` row (×4, all sharing the same `batch_id`)
+
+| Column | Value |
+|---|---|
+| `indicator` | `"canary"` |
+| `composite_version` | `"1"` (mirrors `cmd_form_sweep` convention; varying `score_form` does not bump the version) |
+| `run_scope` | **`"research"`** (keystone invisibility lock — see §4.4 G-3. `find_latest_run` filters `WHERE run_scope=%s` defaulting to `'production'`, so research-scoped rows are invisible to the OOS gate and `/api/regime/canary/validation`. Convention matches VCG research runs at `scripts/backtest_vcg.py:434, 438`.) |
+| `start_date` | `MIN(canary_snapshots.data_date)` |
+| `end_date` | `MAX(canary_snapshots.data_date)` |
+| `window_days` | `350` (kept for column consistency with other canary runs; semantic meaning clarified in `params` below) |
+| `n_days` | length of eval_rows |
+| `params` | see schema below |
+| `summary` | JSONB — schema below |
+
+#### `params` JSONB schema
+
+```json
+{
+  "score_form": "<linear|convex|concave|sigmoid>",
+  "phase": "form_sweep_full",
+  "batch_id": "<uuid4 — same value across all 4 rows from one invocation>",
+  "purpose": "candidate_discovery_not_validation",
+  "min_aligned_bars": 350,
+  "window_semantics": "warmup_requirement_not_eval_window"
+}
+```
+
+The `batch_id` is generated **once** at run start via `uuid.uuid4()` and reused for all 4 form rows in that invocation. It is the primary grouping key the renderer uses to fetch a coherent set; `start_date`/`end_date`/`composite_version` are informational columns kept consistent with other run types but are NOT used as the renderer's grouping key (see §4.3).
+
+`purpose` is a fixed string that future SQL queries can filter on (`params->>'purpose' = 'candidate_discovery_not_validation'`) to distinguish these rows from any future production-selection runs at a glance.
+
+`min_aligned_bars` and `window_semantics` make the `window_days=350` column readable without grepping the script — they spell out that 350 is the warm-up gate, not an evaluation length.
+
+#### `summary` JSONB schema
+
+```json
+{
+  "is_winning_form": false,
+  "score_form": "<linear|convex|concave|sigmoid>",
+  "phase": "form_sweep_full",
+  "source": "form_sweep_full",
+  "batch_id": "<same uuid4 as in params.batch_id>",
+  "generated_at": "<ISO-8601 UTC timestamp at run start, shared across all 4 rows>",
+  "n_days": 3843,
+  "aucs": {
+    "composite":  {"up5d_2pct": 0.620, "up20d_5pct": 0.627, "up60d_10pct": 0.619},
+    "vol_only":   {"up5d_2pct": 0.626, "up20d_5pct": 0.639, "up60d_10pct": 0.642},
+    "speed_only": {"up5d_2pct": 0.470, "up20d_5pct": 0.465, "up60d_10pct": 0.430}
+  },
+  "auc_ci95": {
+    "up5d_2pct":   [lo, hi],
+    "up20d_5pct":  [lo, hi],
+    "up60d_10pct": [lo, hi]
+  },
+  "band_distribution": {"NONE": 2121, "WATCH": 1511, "BUY": 211, "STRONG_BUY": 0},
+  "within_band_aucs": {
+    "NONE":  {"up5d_2pct": 0.581, "up20d_5pct": 0.601, "up60d_10pct": 0.586},
+    "WATCH": {"up5d_2pct": 0.559, "up20d_5pct": 0.633, "up60d_10pct": 0.609},
+    "BUY":   {"up5d_2pct": 0.447, "up20d_5pct": 0.431, "up60d_10pct": 0.348}
+  },
+  "vol_only_gap": {
+    "up5d_2pct": 0.006, "up20d_5pct": 0.012, "up60d_10pct": 0.023
+  }
+}
+```
+
+Notes:
+- `is_winning_form: false` is **hardcoded in the dict literal** — not computed, not conditional. The form-selection logic from `cmd_form_sweep` (lines 473-487) is **not** copied into the new function.
+- `auc_ci95` uses `_block_bootstrap_auc_ci(block_size=20, iters=1000)` against composite scores only (matches `cmd_walk_forward` convention).
+- `within_band_aucs` is computed by a new `_within_band_aucs` helper (~25 LOC, placed near `_aucs_for_rows`). NaN AUCs (e.g. STRONG_BUY band with zero observations) cleaned to `null` via existing `_clean_nans`.
+- `vol_only_gap` is derived (`vol_only - composite` per horizon). Stored explicitly so renderer doesn't recompute. Positive = vol-only better than composite at that horizon.
+- `phase: "form_sweep_full"` is duplicated into the summary for ad-hoc SQL filtering (`summary->>'phase' = 'form_sweep_full'`) without a JSON-path into params.
+
+#### `regime_backtest_daily` rows (×4 sets)
+
+Same shape as existing `cmd_form_sweep` daily writes at `scripts/backtest_canary.py:453-470`:
+
+```json
+{
+  "trade_date": "2011-02-08",
+  "score": 18.43,
+  "level": "NONE",
+  "payload": {
+    "raw_score": 18.43,
+    "tactical": 5.12,
+    "structural": 11.31,
+    "speed": 2.0,
+    "warning_state": "NONE"
+  }
+}
+```
+
+Volume: 4 forms × ~3,843 rows = ~15,372 daily rows. Lets us drill down later without re-running.
+
+#### Persistence atomicity (cleanup-on-failure)
+
+`RegimeBacktestRepository.insert_run`, `bulk_insert_daily`, and `mark_run_completed` each call `self._conn.commit()` internally (verified at `src/uw_scan/storage/regime_backtest_repository.py:115, 137, 146`). A single-transaction wrap of all 4 form persistences (Option A) would require refactoring the repository to accept a non-committing mode — out of this spec's scope.
+
+Therefore the script uses **Option B: cleanup-on-failure**, with `batch_id` as the cleanup key:
+
+```python
+import uuid
+
+def cmd_form_sweep_full(conn, *, schema: str) -> None:
+    batch_id = str(uuid.uuid4())
+    generated_at = datetime.now(timezone.utc).isoformat()
+    bt_repo = RegimeBacktestRepository(conn, schema=schema)
+
+    # Phase 1 (in-memory): compute all 4 form series + summaries.
+    # Any failure here is pre-persistence — no rows yet exist, so no cleanup needed.
+    per_form: dict[str, dict] = {}
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        series = _compute_canary_series(conn, cal, form=form, start=..., end=..., schema=schema)
+        per_form[form] = _build_summary_dict(series, form, batch_id, generated_at)
+
+    # Phase 2 (persistence): insert all 4 runs + daily rows. On ANY failure,
+    # cleanup all rows tagged with this batch_id and re-raise so the
+    # process exits non-zero.
+    try:
+        for form, payload in per_form.items():
+            run_id = bt_repo.insert_run(..., run_scope="research")  # commits
+            bt_repo.bulk_insert_daily(run_id, payload["daily"])  # commits
+            bt_repo.mark_run_completed(run_id)  # commits
+    except Exception:
+        log.exception("form_sweep_full persistence failed; cleaning up batch_id=%s", batch_id)
+        conn.rollback()  # required if the failed DB statement left the transaction aborted
+        _cleanup_batch(conn, schema=schema, batch_id=batch_id)
+        raise
+```
+
+The `_cleanup_batch` helper is a new method on `RegimeBacktestRepository`:
+
+```python
+def delete_runs_by_batch_id(self, batch_id: str) -> int:
+    """Delete all regime_backtest_runs (and CASCADE to daily) tagged with batch_id.
+
+    Returns the number of run rows deleted. Used by form_sweep_full's
+    cleanup-on-failure path.
+    """
+```
+
+The migration that creates `regime_backtest_daily` already has `ON DELETE CASCADE` for `run_id` (per the closure memo's cookbook); the cleanup is a single `DELETE FROM regime_backtest_runs WHERE params->>'batch_id' = %s`. If the FK does not cascade in the current schema, the implementation plan must verify and add an explicit daily-delete first.
+
+**Invariant**: after `cmd_form_sweep_full` returns (whether success or failure), the DB contains either exactly 0 rows OR exactly 4 rows for the script's `batch_id`. Never 1, 2, or 3.
+
+#### New helper
+
+```python
+def _within_band_aucs(rows: list[dict]) -> dict[str, dict[str, float]]:
+    """AUC of composite score vs forward labels, restricted to each band.
+
+    Labels are computed once over the full row series (so the last 60 days
+    don't drop out of every band-subset), then filtered by band membership.
+    Returns NaN for bands with <2 distinct labels in the subset.
+
+    This preserves the "compute labels once, filter by index" fix from the
+    v1 robustness work — see scripts/backtest_canary.py:_auc_for_indices.
+    """
+```
+
+Placed in `regime_canary_form_sweep_full.py`. ~25 LOC. Reuses `_entry_lagged_label` + `_auc` through explicit dependency injection from the script wrapper.
+
+### 4.3 Renderer
+
+New module: `src/uw_scan/reports/regime_canary_backtest_report.py`.
+
+Pure function, no I/O:
+
+```python
+def render_canary_form_sweep_compare(runs: list[dict]) -> str:
+    """Render a 4-form comparison table from form_sweep_full runs.
+
+    `runs` is a list of regime_backtest_runs row dicts, each with
+    params.phase='form_sweep_full'. Caller is responsible for filtering
+    and loading; this function does not touch the DB.
+
+    Sort order in output: linear, convex, concave, sigmoid (canonical,
+    not by id).
+
+    Raises ValueError if:
+      - fewer than 4 rows provided
+      - any form appears more than once
+      - any required score_form is missing
+    """
+```
+
+#### Output format
+
+```markdown
+# Canary form-sweep — candidate discovery
+Window: 2011-02-08 → 2026-05-21 (3,843 days)
+Composite version: 1
+Run ids: 27, 28, 29, 30
+
+| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |
+|---------|-------:|--------:|--------:|------:|-------:|-----:|------------:|-----------------:|-------------------:|
+| linear  |  0.620 |   0.627 |   0.619 |  55.2 |   39.3 |  5.5 |         0.0 |            0.348 |             +0.023 |
+| convex  |  ...   |   ...   |   ...   |  ...  |   ...  |  ... |         ... |            ...   |             ...    |
+| concave |  ...   |   ...   |   ...   |  ...  |   ...  |  ... |         ... |            ...   |             ...    |
+| sigmoid |  ...   |   ...   |   ...   |  ...  |   ...  |  ... |         ... |            ...   |             ...    |
+
+## Observations
+
+- WATCH% above 30% in: <list of forms>
+- BUY-band 60d AUC below 0.50 in: <list of forms>  (regression-to-mean signature)
+- Vol-only gap (60d) ≥ +0.02 in: <list of forms>  (speed layer net-negative for rank)
+- BUY% at exactly 0 (band never fires) in: <list of forms>
+- STRONG_BUY% at exactly 0 (band never fires) in: <list of forms>
+- Composite 60d AUC improves over linear by ≥ +0.02 in: <list of forms>  (deserves v2-C planning)
+- WATCH% reduced by ≥ 5 percentage points vs linear AND 60d AUC does not fall by more than 0.01 in: <list of forms>  (practical v2-C candidate)
+
+## What this run does NOT decide
+
+This is candidate-discovery output. No form is declared "winning". Any v2
+calibration change must reserve a fresh holdout window for OOS validation.
+```
+
+The **Observations** block is mechanical — it lists forms that match each rule. It never names a winner. The `<list of forms>` slots in the example above are render-time substitutions; the renderer fills them with comma-joined form names (e.g. "convex, sigmoid") or "none" when no form matches the rule.
+
+The **What this run does NOT decide** footer is a fixed string in the renderer source, defending against the human-cognitive bias to read a table and conclude "highest number wins."
+
+#### CLI entry point
+
+`__main__` block in the renderer module. `--mode` defaults to `form_sweep_compare` (currently the only supported mode); `--runs` is optional.
+
+```bash
+# Default — implicit --mode form_sweep_compare, auto-loads latest 4 rows
+uv run python -m uw_scan.reports.regime_canary_backtest_report
+
+# Explicit mode + specific row ids
+uv run python -m uw_scan.reports.regime_canary_backtest_report \
+    --mode form_sweep_compare --runs 27,28,29,30
+```
+
+Without `--runs`: loads the **latest complete `batch_id`** — defined as the most-recent `params->>'batch_id'` whose row-count for `params->>'phase' = 'form_sweep_full'` equals exactly 4 AND covers all four score forms. The "latest" is determined by `MAX(created_at)` among rows in that batch.
+
+Concretely the loader's logic:
+
+```sql
+-- Identify the latest fully-complete research batch.
+-- All filters are necessary: an in-progress batch with completed_at IS NULL,
+-- or a stray production-scoped row with the same batch_id, would otherwise
+-- be selectable and break the renderer's all-four-forms contract.
+WITH ranked_batches AS (
+  SELECT params->>'batch_id' AS batch_id,
+         MAX(created_at) AS latest,
+         COUNT(*) AS n_rows,
+         array_agg(params->>'score_form' ORDER BY params->>'score_form') AS forms
+  FROM uw_scan.regime_backtest_runs
+  WHERE indicator = 'canary'
+    AND run_scope = 'research'
+    AND completed_at IS NOT NULL
+    AND params->>'phase' = 'form_sweep_full'
+  GROUP BY params->>'batch_id'
+)
+SELECT batch_id FROM ranked_batches
+WHERE n_rows = 4
+  AND forms = ARRAY['concave','convex','linear','sigmoid']
+ORDER BY latest DESC
+LIMIT 1;
+```
+
+Incomplete batches (n_rows < 4 OR missing forms — i.e. an in-progress run, or a failed run whose cleanup somehow didn't complete) are **skipped, not rendered**. The loader falls through to the next-latest complete batch. If no complete batch exists, the renderer raises `ValueError("no complete form_sweep_full batch found")` — never renders partial state.
+
+With `--runs <id>,<id>,<id>,<id>`: load exactly those four rows (use case: render an **explicit, non-latest batch** — e.g., re-render an older batch for documentation, or render a specific batch_id when multiple completed batches exist on the same day). Renderer still validates: all 4 rows must share the same `batch_id`, the same `composite_version`, and cover all four `score_form` values; otherwise raises.
+
+`--runs` does **not** support cross-batch or cross-version comparison. Comparing v1 vs v2 candidate forms, or comparing two distinct batches over time, requires a separate comparison mode (out of scope for this design; would be a `form_sweep_cross_batch` follow-up).
+
+Errors if fewer than 4 rows match, any form is missing, any form appears more than once, or rows span multiple `batch_id` / `composite_version` values. No partial-state rendering.
+
+#### Where the renderer is called
+
+1. **End of `cmd_form_sweep_full`**: after the 4 inserts, calls `render_canary_form_sweep_compare(runs)` and prints to stdout.
+2. **Later, on demand**: via the `python -m` entry point.
+
+#### What this renderer is NOT
+
+- Not used by `/api/regime/canary/validation`. That endpoint calls `find_latest_run(..., run_scope='production')` and then post-filters in Python on `summary.is_winning_form` (`src/uw_scan/api/routers/regime.py:407-435`, line 420). Because `cmd_form_sweep_full` writes with `run_scope='research'`, those rows are filtered out at the SQL layer by `find_latest_run` — they never reach the Python post-filter. `run_scope='research'` is the **keystone**; `is_winning_form=false` is defense-in-depth only.
+- Not a generalization of the existing CRI / VCG renderers.
+- Not coupled to `canary_snapshots` — works purely off `regime_backtest_runs` rows.
+
+### 4.4 Guardrails
+
+Five categories enforcing "candidate discovery, not selection" in code.
+
+#### G-1. CLI-level mutual exclusion
+
+The existing argparse setup does NOT use `add_mutually_exclusive_group`; it uses an `if/elif/return` chain in `main()` (`scripts/backtest_canary.py:1092-1114`). Exclusion is enforced by an explicit count-check at the top of `main()`:
+
+```python
+mode_flags = [args.calibrate, args.form_sweep, args.form_sweep_full,
+              args.report, args.walk_forward, args.robustness]
+if sum(bool(f) for f in mode_flags) > 1:
+    parser.error("only one of --calibrate/--form-sweep/--form-sweep-full/"
+                 "--report/--walk-forward/--robustness may be specified")
+```
+
+`--form X` has no effect under `--form-sweep-full` (the sweep iterates all four forms by design). If `--form` is passed alongside, a warning is logged at run start so the user knows the flag had no effect.
+
+#### G-2. Function-level isolation
+
+`cmd_form_sweep_full` is a thin wrapper, and the full-history implementation lives outside `cmd_form_sweep`. They share read-only helpers through explicit dependencies; **zero shared mutable state**.
+
+`cmd_form_sweep_full` is forbidden — by absence-of-code, reviewable in diff — from:
+- Calling `CALIB_PATH.write_text(...)` (the way `cmd_form_sweep` rewrites the calibration JSON at lines 489-491)
+- Computing or storing a "winner"
+- Setting `summary["is_winning_form"] = True` under any condition
+
+A header docstring on the wrapper and implementation entry point makes this explicit:
+
+```python
+def cmd_form_sweep_full(conn, *, schema: str) -> None:
+    """Full-history score-form sweep against canary_snapshots range.
+
+    Candidate discovery only. DO NOT:
+      - declare a winning form
+      - write to canary-calibration-v1.json
+      - set summary.is_winning_form=True
+      - read or modify the OOS gate's LAST_KNOWN_AUC_* constants
+
+    Any v2 calibration change requires a new spec and a reserved holdout
+    window — not the data this run evaluates against.
+    """
+```
+
+#### G-3. Persistence-level locks
+
+The **keystone invisibility lock** is the dedicated `regime_backtest_runs.run_scope` column introduced in migration 059 (the same mechanism VCG already uses for its research runs):
+
+- `run_scope: "research"` — hardcoded literal in the `insert_run(...)` call. `RegimeBacktestRepository.find_latest_run` (`src/uw_scan/storage/regime_backtest_repository.py:148-211`) filters `WHERE run_scope = %s` defaulting to `"production"`, so research-scoped rows are invisible to the OOS gate and `/api/regime/canary/validation` by construction. This is THE mechanism that prevents form_sweep_full output from being mistaken for a production form selection.
+
+Additional persistence locks (defense in depth, none of which are the keystone — `run_scope` is):
+
+- `summary.is_winning_form: False` is a hardcoded literal. Not a visibility filter, but a renderer/SQL-introspection convenience: any future query that asks "which run is the production form?" can also filter on this for redundancy.
+- `params["phase"]: "form_sweep_full"` is a hardcoded literal.
+- `composite_version` is `str(COMPOSITE_VERSION)` (imported constant; no CLI override).
+
+#### G-4. Downstream-effect isolation
+
+Three integration tests prove form_sweep_full rows do NOT bleed into v1 production surfaces. The mechanism is `run_scope='research'` (see G-3) — `find_latest_run` defaults to `run_scope='production'`, so research-scoped rows are filtered out at the SQL level, not at the Python level.
+
+| Test | Asserts |
+|---|---|
+| `test_form_sweep_full_invisible_to_oos_gate` | `RegimeBacktestRepository.find_latest_run("canary", composite_version="1")` does not return a form_sweep_full row |
+| `test_form_sweep_full_invisible_to_validation_api` | `GET /api/regime/canary/validation` payload unchanged before/after `cmd_form_sweep_full` |
+| `test_form_sweep_full_does_not_write_calibration_file` | `canary-calibration-v1.json` mtime + SHA-256 unchanged after the run |
+
+#### G-5. Re-run + version safety
+
+Each invocation generates a fresh `batch_id` (UUID4) and appends 4 new rows tagged with it. No idempotent overwrite. Old batches remain available for cross-run comparison; cleanup happens via the cross-roadmap `archived_at` migration (out of scope here).
+
+Renderer groups by `batch_id` (see §4.3). A future `COMPOSITE_VERSION` bump produces a new batch whose rows have a different `composite_version` column value; the loader's "latest complete batch" logic will naturally pick the v2 batch once it exists, and the `--runs` override lets users explicitly load a v1 batch for historical comparison.
+
+Startup log surfaces existing batches so re-running isn't silent:
+
+```text
+INFO existing form_sweep_full batches: 1 (most recent batch=<uuid>, 4 rows, completed 2026-05-27 14:32 UTC)
+INFO this invocation will create a new batch_id=<uuid>
+```
+
+#### G-6. Batch atomicity (cleanup-on-failure)
+
+Per §4.2 ("Persistence atomicity"), if any persistence step fails partway through the 4 form inserts, all rows tagged with the script's `batch_id` are explicitly deleted before the script exits non-zero. The DB-level invariant is:
+
+> After `cmd_form_sweep_full` returns or raises, the count of `regime_backtest_runs` rows with `params->>'batch_id' = <script's batch_id>` is either exactly 0 or exactly 4. Never any other value.
+
+This is enforced by:
+
+1. The script's `try/except` wrapper around the Phase 2 (persistence) loop in `cmd_form_sweep_full` — calls `_cleanup_batch` on any exception and re-raises.
+2. The renderer's "load latest complete batch" logic (§4.3) — even if cleanup were to fail (e.g. DB outage between insert and cleanup), the renderer would skip the incomplete batch and load the previous complete one. Defense in depth.
+3. An integration test that simulates a mid-run failure and asserts row-count = 0 for the failed `batch_id` (see §4.5).
+
+### 4.5 Testing strategy
+
+Five test buckets, total ~20-30s of runtime added.
+
+#### Unit (no DB)
+
+| File | Cases |
+|---|---|
+| `tests/unit/test_within_band_aucs.py` | 5 cases for `_within_band_aucs` (empty rows, empty band, all-same-label, normal, label-once-filter-by-index invariant) |
+| `tests/unit/test_canary_form_sweep_cli.py` | 1 case proving the custom `--form-sweep-full` mutual-exclusion guard exits before DB/config loading |
+| `tests/unit/test_canary_form_sweep_renderer.py` | 11 cases for `render_canary_form_sweep_compare` (canonical form ordering; missing form raises; duplicate form raises; <4 rows raises; mismatched `batch_id` across rows raises; non-research `run_scope` raises; footer present; **all 7 observations flag correctly** including the two new rules — composite-improves-over-linear, WATCH-reduce-without-AUC-loss) |
+
+String-contains assertions on renderer output; no full-string snapshot (numbers will drift).
+
+#### Integration (real Postgres via pytest-postgresql)
+
+All in `tests/integration/regime/test_canary_form_sweep_full.py`:
+
+| Test | Asserts |
+|---|---|
+| `test_delete_runs_by_batch_id_removes_rows_and_cascades_daily` | Repository cleanup deletes all runs for a `batch_id` and cascades `regime_backtest_daily` rows |
+| `test_delete_runs_by_batch_id_returns_zero_when_no_match` | Repository cleanup is a no-op returning 0 for an unknown `batch_id` |
+| `test_cmd_form_sweep_full_persists_4_rows_sharing_batch_id` | 4 research rows persisted, all forms present, all share one `batch_id` and `generated_at`, all `is_winning_form=false` |
+| `test_cmd_form_sweep_full_writes_daily_rows` | Each form's run has at least one `regime_backtest_daily` row |
+| `test_cmd_form_sweep_full_summary_schema` | `summary` JSONB has all required top-level keys and AUC/band subkeys |
+| `test_form_sweep_full_cleanup_on_failure` | Monkey-patch `RegimeBacktestRepository.bulk_insert_daily` to trigger a real database error on the 3rd form's call, proving `conn.rollback()` happens before cleanup. After `cmd_form_sweep_full` raises, assert: zero rows with the failed `batch_id` in both `regime_backtest_runs` and `regime_backtest_daily`. Calibration JSON also unchanged. |
+| `test_form_sweep_full_renderer_picks_latest_complete_batch` | Inject batch A (4 rows complete) + batch B (4 rows complete, later created_at); loader returns batch B's 4 rows |
+| `test_renderer_skips_incomplete_batch` | Inject batch A (4 rows complete, earlier) + batch B (3 rows only — simulated mid-run-failure-without-cleanup, later created_at); loader returns batch A's 4 rows, NOT batch B |
+| `test_form_sweep_full_does_not_write_calibration_file` | Calibration JSON mtime + SHA-256 unchanged |
+| `test_form_sweep_full_invisible_to_oos_gate` | Find-latest-winning returns the pre-existing v1 row, not a form_sweep_full row |
+| `test_form_sweep_full_invisible_to_validation_api` | Validation API payload unchanged |
+
+Synthetic vol-complex fixture (400 days × 5 symbols) lives at `tests/integration/regime/_canary_form_sweep_fixture.py` per the colocation rule.
+
+#### Explicitly skipped
+
+| Skipped | Why |
+|---|---|
+| Generic argparse parsing | Upstream `argparse` behavior is not retested; the custom mutual-exclusion guard is covered by `tests/unit/test_canary_form_sweep_cli.py` |
+| Frontend tests | No UI change; validation panel invisibility covered by §G-4 |
+| OpenAPI / API contract tests | No new API endpoint |
+| Performance / load | Runs once per investigation, not in hot path |
+| Block-bootstrap reproducibility | `_block_bootstrap_auc_ci` already uses `seed=42`; covered by existing tests |
+| Mocked-DB tests | Project policy bans mocked DB (`tests/CLAUDE.md`) |
+| Explicit "OOS gate still passes" non-regression | §G-4 invisibility test already proves the gate cannot see form_sweep_full rows; redundant |
+
+---
+
+## 5. Acceptance criteria
+
+The change is shippable when ALL of the following hold:
+
+| # | Criterion |
+|---|---|
+| AC-1 | `uv run python scripts/backtest_canary.py --form-sweep-full` runs to completion without errors against the production-shaped DB |
+| AC-2 | 4 new rows present in `regime_backtest_runs` with `params->>'phase' = 'form_sweep_full'`, one per `score_form` value, all sharing the **same `params->>'batch_id'`** (UUID, non-null) and the same `summary->>'generated_at'` |
+| AC-3 | Each new row's `summary` matches the §4.2 schema (all fields present, no NaN tokens in JSONB) |
+| AC-4 | `run_scope = 'research'` and `summary->>'is_winning_form' = 'false'` for all 4 new rows |
+| AC-5 | `canary-calibration-v1.json` mtime + SHA-256 are unchanged after the run |
+| AC-6 | `RegimeBacktestRepository.find_latest_run("canary", composite_version="1")` returns the pre-existing v1 winning row (run id 18 or equivalent), not a form_sweep_full row |
+| AC-7 | `GET /api/regime/canary/validation` payload is byte-identical before and after the run |
+| AC-8 | Stdout shows the 4-form comparison table + "Observations" block + "What this run does NOT decide" footer |
+| AC-9 | `uv run python -m uw_scan.reports.regime_canary_backtest_report` (no additional args; `--mode` defaults to `form_sweep_compare`) reproduces the same table by loading the latest complete `batch_id` |
+| AC-10 | All 11 integration tests + 3 unit test files pass (`uv run pytest tests/unit/test_within_band_aucs.py tests/unit/test_canary_form_sweep_cli.py tests/unit/test_canary_form_sweep_renderer.py tests/integration/regime/test_canary_form_sweep_full.py`) |
+| AC-11 | Existing OOS gate test (`tests/integration/regime/test_canary_oos_gate.py`) continues to pass |
+| AC-12 | `/review-cycle` runs cleanly on the final change (multi-pass review per the project's review discipline; wraps `/codex-review` plus adversarial + assumption-verification passes) |
+| AC-13 | **Atomicity invariant**: after `cmd_form_sweep_full` returns or raises, the count of `regime_backtest_runs` rows with `params->>'batch_id' = <script's batch_id>` is either exactly 0 (failure path with successful cleanup) or exactly 4 (success path). Asserted by `test_form_sweep_full_cleanup_on_failure` for the failure path and by `test_cmd_form_sweep_full_persists_4_rows_sharing_batch_id` for the success path. |
+
+---
+
+## 6. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Output is read as "X is the winner" and someone manually edits the calibration JSON | G-2 (function isolation), G-3 (hardcoded `is_winning_form=false`), G-4 (downstream-invisibility tests), renderer footer "What this run does NOT decide" |
+| Future contributor refactors `cmd_form_sweep` and the changes bleed into `cmd_form_sweep_full` | Separate functions, separate test files. Any shared-helper change has to pass both test suites. |
+| `COMPOSITE_VERSION` bumps later and form_sweep_full rows from v1 silently mix into v2 comparisons | G-5: each invocation generates a fresh `batch_id` at a single `COMPOSITE_VERSION`, so cross-version mixing inside a single batch is structurally impossible. The renderer's "latest complete batch" loader picks the v2 batch once it exists. `--runs` override is required to explicitly compare a v1 batch vs a v2 batch. |
+| Mid-run failure leaves partial rows that contaminate later loads | G-6: cleanup-on-failure via `_cleanup_batch(batch_id)`. Renderer "skip incomplete batches" provides defense in depth. Tested by `test_form_sweep_full_cleanup_on_failure` + `test_renderer_skips_incomplete_batch`. |
+| Re-running creates DB bloat | Each run = 4 rows + ~15K daily rows. Modest. `archived_at` migration (cross-roadmap) provides cleanup once it lands. |
+| Block-bootstrap CI on 3,843-day series is slow | `iters=1000, block_size=20` — same parameters used by walk-forward (run id ranges 19-24 each completed in <1 min). 4 forms × 3 horizons = 12 CIs total. Total ~30s additional. |
+| Synthetic vol-complex fixture for end-to-end test is coherent enough to run but unrealistic enough to mislead | The end-to-end test only verifies **shape** (4 rows, correct fields, no errors), not specific AUC values. AUC correctness is covered separately by `_aucs_for_rows` tests (existing) and `_within_band_aucs` unit tests. |
+| Renderer's "Observations" rules calcify and become misleading later | Rules are hardcoded thresholds (30%, 0.50, +0.02) — easy to read and change in one file. Each rule has a comment explaining the threshold's basis. |
+
+---
+
+## 7. Out of scope (deferred to future specs)
+
+- v2-A architecture change (drop speed from composite, expose `vol_resolution_score` / `speed_state` / `display_score` separately)
+- v2-B band threshold changes (lower STRONG_BUY)
+- v2-C calibration retune (depends on this run's output)
+- v2-D capitulation scorer
+- UI window picker on validation panel
+- `regime_backtest_runs.archived_at` migration (cross-roadmap with VCG)
+- Form-sweep against indicators other than canary
+
+Any of these may eventually consume this spec's output, but none are part of this implementation.
+
+---
+
+## 8. Open questions
+
+None blocking implementation. Two non-blocking questions to revisit when the run output is in:
+
+- Should the renderer's "Observations" rules become tunable (config file) once a v2 calibration is shipped? Today they're hardcoded; that's correct for v1's frozen-baseline posture.
+- Should there be a sibling sweep against the **walk-forward windows** (WF-1..WF-6 from `canary-5yr-executive-summary.md` §8) rather than the full dataset? Likely a separate follow-up spec if the form_sweep_full result is ambiguous.
+
+---
+
+## 9. References
+
+- v1 design spec: `docs/superpowers/specs/2026-05-26-5pct-canary-indicator-design.md`
+- v1 executive summary: `docs/research/regime/canary-5yr-executive-summary.md`
+- Roadmap: `docs/research/regime/canary-next-steps-2026-05-27.md`
+- Methodology: `docs/research/regime/canary-methodology.md`
+- Existing form-sweep: `scripts/backtest_canary.py:408-493`
+- Existing canary series compute: `scripts/backtest_canary.py:175-279`
+- Existing AUC helpers: `scripts/backtest_canary.py:662-719`
+- Existing CRI renderer (pattern): `src/uw_scan/reports/regime_backtest_report.py`
+- Existing VCG renderer (pattern): `src/uw_scan/reports/regime_vcg_backtest_report.py`
+- Test conventions: `tests/CLAUDE.md`
+- Research workspace conventions: `docs/research/regime/CLAUDE.md`

--- a/scripts/backtest_canary.py
+++ b/scripts/backtest_canary.py
@@ -492,6 +492,33 @@ def cmd_form_sweep(conn, *, write_summary: bool, schema: str) -> None:
     CALIB_PATH.write_text(json.dumps(cal_raw, indent=2) + "\n")
 
 
+def cmd_form_sweep_full(conn, *, schema: str) -> None:
+    """Full-history candidate-discovery sweep across all 4 score forms.
+
+    Thin wrapper — delegates to
+    `uw_scan.reports.regime_canary_form_sweep_full.run_form_sweep_full`.
+    Passes existing helpers through a dependency container so the
+    package module does not import this script.
+    """
+    from uw_scan.reports.regime_canary_form_sweep_full import (
+        CanaryFormSweepDeps,
+        run_form_sweep_full,
+    )
+
+    deps = CanaryFormSweepDeps(
+        compute_canary_series=_compute_canary_series,
+        aucs_for_rows=_aucs_for_rows,
+        band_counts=_band_counts,
+        block_bootstrap_auc_ci=_block_bootstrap_auc_ci,
+        clean_nans=_clean_nans,
+        entry_lagged_label=_entry_lagged_label,
+        auc=_auc,
+        label_specs=LABEL_SPECS,
+        composite_version=COMPOSITE_VERSION,
+    )
+    run_form_sweep_full(conn, schema=schema, deps=deps)
+
+
 def cmd_report(conn, *, form, write_summary: bool, schema: str) -> None:
     from uw_scan.cards.canary_calibration import load_calibration
     from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
@@ -1072,6 +1099,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--calibrate", action="store_true")
     parser.add_argument("--form-sweep", action="store_true")
+    parser.add_argument(
+        "--form-sweep-full",
+        action="store_true",
+        help="candidate discovery: sweep all 4 forms against full canary_snapshots range",
+    )
     parser.add_argument("--report", action="store_true")
     parser.add_argument(
         "--walk-forward",
@@ -1087,6 +1119,26 @@ def main():
     parser.add_argument("--form", choices=("linear", "convex", "concave", "sigmoid"))
     args = parser.parse_args()
 
+    # CLI-level mutual exclusion (G-1) — argparse doesn't use a group here.
+    mode_flags = [
+        args.calibrate,
+        args.form_sweep,
+        args.form_sweep_full,
+        args.report,
+        args.walk_forward,
+        args.robustness,
+    ]
+    if sum(bool(f) for f in mode_flags) > 1:
+        parser.error(
+            "only one of --calibrate/--form-sweep/--form-sweep-full/--report/"
+            "--walk-forward/--robustness may be specified"
+        )
+
+    if args.form_sweep_full and args.form is not None:
+        log.warning(
+            "--form is ignored under --form-sweep-full (sweep iterates all 4 forms)"
+        )
+
     settings = Settings.from_env()
     schema = settings.db_schema
     with connect(settings.db_dsn()) as conn:
@@ -1095,6 +1147,9 @@ def main():
             return
         if args.form_sweep:
             cmd_form_sweep(conn, write_summary=args.write_summary, schema=schema)
+            return
+        if args.form_sweep_full:
+            cmd_form_sweep_full(conn, schema=schema)
             return
         if args.report:
             cmd_report(

--- a/src/uw_scan/reports/regime_canary_backtest_report.py
+++ b/src/uw_scan/reports/regime_canary_backtest_report.py
@@ -1,0 +1,316 @@
+"""Pure renderer: canary form_sweep_full runs -> markdown table.
+
+Mirrors regime_backtest_report.py (CRI) and regime_vcg_backtest_report.py (VCG):
+pure function, no I/O, no DB. The __main__ block at the bottom adds a CLI
+entry point that DOES touch the DB (via a module-private loader).
+
+This renderer's primary defense against misuse is the fixed
+"What this run does NOT decide" footer — see spec
+docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md §4.3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from io import StringIO
+
+import psycopg
+
+from uw_scan.config import Settings
+
+CANONICAL_FORMS = ("linear", "convex", "concave", "sigmoid")
+
+
+def render_canary_form_sweep_compare(runs: list[dict]) -> str:
+    """Render a 4-form comparison table from form_sweep_full runs.
+
+    `runs` is a list of regime_backtest_runs row dicts, each with
+    params.phase='form_sweep_full'. Caller is responsible for filtering
+    and loading; this function does not touch the DB.
+
+    Sort order in output: linear, convex, concave, sigmoid (canonical,
+    not by id).
+
+    Raises ValueError if:
+      - fewer than 4 rows provided
+      - any form is missing or duplicated
+      - rows do not all share the same batch_id and composite_version
+      - any row is not params.phase='form_sweep_full' or run_scope='research'
+    """
+    if len(runs) != 4:
+        raise ValueError(f"need exactly 4 rows, got {len(runs)}")
+
+    by_form: dict[str, dict] = {}
+    for r in runs:
+        if r.get("run_scope") != "research":
+            raise ValueError(
+                f"form_sweep_full rows must be research scoped, got {r.get('run_scope')!r}"
+            )
+        if r["params"].get("phase") != "form_sweep_full":
+            raise ValueError(
+                f"expected params.phase=form_sweep_full, got {r['params'].get('phase')!r}"
+            )
+        form = r["params"]["score_form"]
+        if form not in CANONICAL_FORMS:
+            raise ValueError(f"unknown score_form: {form}")
+        if form in by_form:
+            raise ValueError(f"duplicate score_form: {form}")
+        by_form[form] = r
+
+    for form in CANONICAL_FORMS:
+        if form not in by_form:
+            raise ValueError(f"missing score_form: {form}")
+
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    if len(batch_ids) != 1:
+        raise ValueError(f"all rows must share batch_id, got {batch_ids}")
+    composite_versions = {str(r["composite_version"]) for r in runs}
+    if len(composite_versions) != 1:
+        raise ValueError(
+            f"all rows must share composite_version, got {composite_versions}"
+        )
+
+    sample = by_form["linear"]
+    out = StringIO()
+    out.write("# Canary form-sweep — candidate discovery\n")
+    out.write(
+        f"Window: {sample['start_date'].isoformat()} → "
+        f"{sample['end_date'].isoformat()} "
+        f"({sample['summary']['n_days']:,} days)\n"
+    )
+    out.write(f"Composite version: {sample['composite_version']}\n")
+    out.write(f"Batch id: {next(iter(batch_ids))}\n")
+    out.write(f"Run ids: {', '.join(str(by_form[f]['id']) for f in CANONICAL_FORMS)}\n")
+    out.write("\n")
+
+    out.write(
+        "| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | "
+        "STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |\n"
+    )
+    out.write(
+        "|---------|-------:|--------:|--------:|------:|-------:|-----:|"
+        "------------:|-----------------:|-------------------:|\n"
+    )
+    for form in CANONICAL_FORMS:
+        s = by_form[form]["summary"]
+        n = s["n_days"]
+        bd = s["band_distribution"]
+
+        def pct(b: str, _n: int = n, _bd: dict = bd) -> float:
+            return 100.0 * _bd[b] / _n if _n else 0.0
+
+        wb = s["within_band_aucs"]["BUY"].get("up60d_10pct")
+        buy_band_str = f"{wb:.3f}" if wb is not None else "  nan"
+        gap = s["vol_only_gap"]["up60d_10pct"]
+        gap_str = ("+" if gap >= 0 else "") + f"{gap:.3f}"
+        out.write(
+            f"| {form:<7} | {s['aucs']['composite']['up5d_2pct']:>6.3f} | "
+            f"{s['aucs']['composite']['up20d_5pct']:>7.3f} | "
+            f"{s['aucs']['composite']['up60d_10pct']:>7.3f} | "
+            f"{pct('NONE'):>5.1f} | {pct('WATCH'):>6.1f} | "
+            f"{pct('BUY'):>4.1f} | {pct('STRONG_BUY'):>11.1f} | "
+            f"{buy_band_str:>16} | {gap_str:>18} |\n"
+        )
+    out.write("\n")
+
+    out.write("## Observations\n\n")
+    linear_summary = by_form["linear"]["summary"]
+
+    def forms_where(predicate) -> str:
+        matched = [f for f in CANONICAL_FORMS if predicate(by_form[f]["summary"])]
+        return ", ".join(matched) if matched else "none"
+
+    rules = [
+        (
+            "WATCH% above 30% in",
+            lambda s: 100.0 * s["band_distribution"]["WATCH"] / s["n_days"] > 30.0,
+            "  (over-broad WATCH band)",
+        ),
+        (
+            "BUY-band 60d AUC below 0.50 in",
+            lambda s: (
+                s["within_band_aucs"]["BUY"].get("up60d_10pct") is not None
+                and s["within_band_aucs"]["BUY"]["up60d_10pct"] < 0.50
+            ),
+            "  (regression-to-mean signature)",
+        ),
+        (
+            "Vol-only gap (60d) ≥ +0.02 in",
+            lambda s: s["vol_only_gap"]["up60d_10pct"] >= 0.02,
+            "  (speed layer net-negative for rank)",
+        ),
+        (
+            "BUY% at exactly 0 (band never fires) in",
+            lambda s: s["band_distribution"]["BUY"] == 0,
+            "",
+        ),
+        (
+            "STRONG_BUY% at exactly 0 (band never fires) in",
+            lambda s: s["band_distribution"]["STRONG_BUY"] == 0,
+            "",
+        ),
+        (
+            "Composite 60d AUC improves over linear by ≥ +0.02 in",
+            lambda s: (
+                s["score_form"] != "linear"
+                and s["aucs"]["composite"]["up60d_10pct"]
+                - linear_summary["aucs"]["composite"]["up60d_10pct"]
+                >= 0.02
+            ),
+            "  (deserves v2-C planning)",
+        ),
+        (
+            "WATCH% reduced by ≥ 5 percentage points vs linear "
+            "AND 60d AUC does not fall by more than 0.01 in",
+            lambda s: (
+                s["score_form"] != "linear"
+                and (
+                    100.0
+                    * linear_summary["band_distribution"]["WATCH"]
+                    / linear_summary["n_days"]
+                    - 100.0 * s["band_distribution"]["WATCH"] / s["n_days"]
+                )
+                >= 5.0
+                and (
+                    linear_summary["aucs"]["composite"]["up60d_10pct"]
+                    - s["aucs"]["composite"]["up60d_10pct"]
+                )
+                <= 0.01
+            ),
+            "  (practical v2-C candidate)",
+        ),
+    ]
+    for label, predicate, suffix in rules:
+        out.write(f"- {label}: {forms_where(predicate)}{suffix}\n")
+    out.write("\n")
+
+    out.write("## What this run does NOT decide\n\n")
+    out.write(
+        "This is candidate-discovery output. No form is declared "
+        '"winning". Any v2 calibration change must reserve a fresh '
+        "holdout window for OOS validation.\n"
+    )
+    return out.getvalue()
+
+
+# ----------------------------------------------------------------------
+# CLI entry point — DOES touch DB. Module-private loader pulls 4 rows.
+# ----------------------------------------------------------------------
+
+
+def _load_latest_complete_batch(conn, schema: str) -> list[dict]:
+    """Load 4 rows from the most-recent complete form_sweep_full batch.
+
+    "Complete" = exactly 4 rows AND covers all four CANONICAL_FORMS.
+    Incomplete batches are skipped.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            WITH ranked_batches AS (
+              SELECT params->>'batch_id' AS batch_id,
+                     MAX(created_at) AS latest,
+                     COUNT(*) AS n_rows,
+                     array_agg(params->>'score_form' ORDER BY params->>'score_form')
+                       AS forms
+              FROM {schema}.regime_backtest_runs
+              WHERE indicator = 'canary'
+                AND run_scope = 'research'
+                AND completed_at IS NOT NULL
+                AND params->>'phase' = 'form_sweep_full'
+              GROUP BY params->>'batch_id'
+            )
+            SELECT batch_id FROM ranked_batches
+            WHERE n_rows = 4
+              AND forms = ARRAY['concave','convex','linear','sigmoid']
+            ORDER BY latest DESC
+            LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise ValueError("no complete form_sweep_full batch found")
+        batch_id = row[0]
+        cur.execute(
+            f"SELECT id, params, summary, start_date, end_date, composite_version, run_scope "
+            f"FROM {schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s "
+            f"AND indicator = 'canary' "
+            f"AND run_scope = 'research' "
+            f"AND completed_at IS NOT NULL "
+            f"AND params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'",
+            (batch_id,),
+        )
+        return [
+            {
+                "id": r[0],
+                "params": r[1],
+                "summary": r[2],
+                "start_date": r[3],
+                "end_date": r[4],
+                "composite_version": r[5],
+                "run_scope": r[6],
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def _load_specific_runs(conn, schema: str, run_ids: list[int]) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id, params, summary, start_date, end_date, composite_version, run_scope "
+            f"FROM {schema}.regime_backtest_runs "
+            f"WHERE id = ANY(%s) "
+            f"AND indicator = 'canary' "
+            f"AND run_scope = 'research' "
+            f"AND completed_at IS NOT NULL "
+            f"AND params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'",
+            (run_ids,),
+        )
+        return [
+            {
+                "id": r[0],
+                "params": r[1],
+                "summary": r[2],
+                "start_date": r[3],
+                "end_date": r[4],
+                "composite_version": r[5],
+                "run_scope": r[6],
+            }
+            for r in cur.fetchall()
+        ]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--mode",
+        default="form_sweep_compare",
+        choices=("form_sweep_compare",),
+        help="rendering mode (currently only form_sweep_compare)",
+    )
+    p.add_argument(
+        "--runs",
+        default=None,
+        help="comma-separated run ids; if omitted, load latest complete batch",
+    )
+    args = p.parse_args()
+
+    settings = Settings.from_env()
+    schema = settings.db_schema
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        if args.runs:
+            run_ids = [int(s) for s in args.runs.split(",")]
+            runs = _load_specific_runs(conn, schema, run_ids)
+        else:
+            runs = _load_latest_complete_batch(conn, schema)
+    print(render_canary_form_sweep_compare(runs))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/uw_scan/reports/regime_canary_backtest_report.py
+++ b/src/uw_scan/reports/regime_canary_backtest_report.py
@@ -100,17 +100,27 @@ def render_canary_form_sweep_compare(runs: list[dict]) -> str:
         def pct(b: str, _n: int = n, _bd: dict = bd) -> float:
             return 100.0 * _bd[b] / _n if _n else 0.0
 
+        def _fmt(v: float | None, width: int) -> str:
+            """`{v:>W.3f}` but renders None as a right-justified 'nan'."""
+            if v is None:
+                return "nan".rjust(width)
+            return f"{v:>{width}.3f}"
+
         wb = s["within_band_aucs"]["BUY"].get("up60d_10pct")
-        buy_band_str = f"{wb:.3f}" if wb is not None else "  nan"
+        buy_band_str = _fmt(wb, 16)
         gap = s["vol_only_gap"]["up60d_10pct"]
-        gap_str = ("+" if gap >= 0 else "") + f"{gap:.3f}"
+        if gap is None:
+            gap_str = "nan".rjust(18)
+        else:
+            gap_str = (("+" if gap >= 0 else "") + f"{gap:.3f}").rjust(18)
+        c = s["aucs"]["composite"]
         out.write(
-            f"| {form:<7} | {s['aucs']['composite']['up5d_2pct']:>6.3f} | "
-            f"{s['aucs']['composite']['up20d_5pct']:>7.3f} | "
-            f"{s['aucs']['composite']['up60d_10pct']:>7.3f} | "
+            f"| {form:<7} | {_fmt(c['up5d_2pct'], 6)} | "
+            f"{_fmt(c['up20d_5pct'], 7)} | "
+            f"{_fmt(c['up60d_10pct'], 7)} | "
             f"{pct('NONE'):>5.1f} | {pct('WATCH'):>6.1f} | "
             f"{pct('BUY'):>4.1f} | {pct('STRONG_BUY'):>11.1f} | "
-            f"{buy_band_str:>16} | {gap_str:>18} |\n"
+            f"{buy_band_str} | {gap_str} |\n"
         )
     out.write("\n")
 
@@ -137,7 +147,10 @@ def render_canary_form_sweep_compare(runs: list[dict]) -> str:
         ),
         (
             "Vol-only gap (60d) ≥ +0.02 in",
-            lambda s: s["vol_only_gap"]["up60d_10pct"] >= 0.02,
+            lambda s: (
+                s["vol_only_gap"]["up60d_10pct"] is not None
+                and s["vol_only_gap"]["up60d_10pct"] >= 0.02
+            ),
             "  (speed layer net-negative for rank)",
         ),
         (
@@ -154,6 +167,8 @@ def render_canary_form_sweep_compare(runs: list[dict]) -> str:
             "Composite 60d AUC improves over linear by ≥ +0.02 in",
             lambda s: (
                 s["score_form"] != "linear"
+                and s["aucs"]["composite"]["up60d_10pct"] is not None
+                and linear_summary["aucs"]["composite"]["up60d_10pct"] is not None
                 and s["aucs"]["composite"]["up60d_10pct"]
                 - linear_summary["aucs"]["composite"]["up60d_10pct"]
                 >= 0.02
@@ -165,6 +180,8 @@ def render_canary_form_sweep_compare(runs: list[dict]) -> str:
             "AND 60d AUC does not fall by more than 0.01 in",
             lambda s: (
                 s["score_form"] != "linear"
+                and s["aucs"]["composite"]["up60d_10pct"] is not None
+                and linear_summary["aucs"]["composite"]["up60d_10pct"] is not None
                 and (
                     100.0
                     * linear_summary["band_distribution"]["WATCH"]

--- a/src/uw_scan/reports/regime_canary_form_sweep_full.py
+++ b/src/uw_scan/reports/regime_canary_form_sweep_full.py
@@ -1,0 +1,60 @@
+"""Canary form-sweep-full: candidate discovery over all 4 score forms.
+
+This module owns the focused implementation of `--form-sweep-full`. The
+script `scripts/backtest_canary.py` exposes only a thin wrapper that
+delegates here through the `CanaryFormSweepDeps` container, so the
+script stays under its 1,000-line split threshold.
+
+Candidate discovery only — no winning form is declared, no calibration
+file is written, no production surface is touched. See
+docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class CanaryFormSweepDeps:
+    """Dependency container — receives the script's helpers without
+    introducing a back-import from the package into the script."""
+
+    compute_canary_series: Callable[..., dict]
+    aucs_for_rows: Callable[[list[dict]], dict[str, dict[str, float]]]
+    band_counts: Callable[[list[dict]], dict[str, int]]
+    block_bootstrap_auc_ci: Callable[..., tuple[float, float]]
+    clean_nans: Callable[[Any], Any]
+    entry_lagged_label: Callable[[list[dict], int, float], list]
+    auc: Callable[[list[float], list], float]
+    label_specs: list[tuple[str, int, float]]
+    composite_version: int
+
+
+def _within_band_aucs(
+    rows: list[dict], deps: CanaryFormSweepDeps
+) -> dict[str, dict[str, float]]:
+    """AUC of composite score vs forward labels, restricted to each band.
+
+    Labels are computed ONCE over the full row series (so the last 60 days
+    don't drop out of every band-subset), then filtered by band membership.
+    Returns NaN for bands with <2 distinct labels in the subset.
+
+    This preserves the "compute labels once, filter by index" invariant
+    from cmd_robustness — see _auc_for_indices around line 979.
+    """
+    out: dict[str, dict[str, float]] = {
+        b: {} for b in ("NONE", "WATCH", "BUY", "STRONG_BUY")
+    }
+    if not rows:
+        return out
+    composite_scores = [r["score"] for r in rows]
+    for name, h, thr in deps.label_specs:
+        labels_full = deps.entry_lagged_label(rows, h, thr)
+        for band in ("NONE", "WATCH", "BUY", "STRONG_BUY"):
+            idxs = [i for i, r in enumerate(rows) if r["band"] == band]
+            band_scores = [composite_scores[i] for i in idxs]
+            band_labels = [labels_full[i] for i in idxs]
+            out[band][name] = deps.auc(band_scores, band_labels)
+    return out

--- a/src/uw_scan/reports/regime_canary_form_sweep_full.py
+++ b/src/uw_scan/reports/regime_canary_form_sweep_full.py
@@ -12,8 +12,15 @@ docs/superpowers/specs/2026-05-27-canary-form-sweep-full-design.md.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Callable
+from uuid import uuid4
+
+log = logging.getLogger(__name__)
+
+CANONICAL_FORMS = ("linear", "convex", "concave", "sigmoid")
 
 
 @dataclass(frozen=True)
@@ -58,3 +65,195 @@ def _within_band_aucs(
             band_labels = [labels_full[i] for i in idxs]
             out[band][name] = deps.auc(band_scores, band_labels)
     return out
+
+
+def run_form_sweep_full(conn, *, schema: str, deps: CanaryFormSweepDeps) -> None:
+    """Full-history score-form sweep against canary_snapshots range.
+
+    Candidate discovery only. DO NOT:
+      - declare a winning form
+      - write to canary-calibration-v1.json
+      - set summary.is_winning_form=True
+      - read or modify the OOS gate's LAST_KNOWN_AUC_* constants
+    """
+    from uw_scan.cards.canary_calibration import load_calibration
+    from uw_scan.reports.regime_canary_backtest_report import (
+        render_canary_form_sweep_compare,
+    )
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    cal = load_calibration()
+    bt_repo = RegimeBacktestRepository(conn, schema=schema)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT MIN(data_date), MAX(data_date), COUNT(*) "
+            f"FROM {schema}.canary_snapshots"
+        )
+        snap_min, snap_max, snap_count = cur.fetchone()
+    if not snap_min:
+        raise RuntimeError("canary_snapshots is empty — cannot run form-sweep-full")
+    log.info(
+        "form_sweep_full: snap range %s → %s (%d rows)",
+        snap_min,
+        snap_max,
+        snap_count,
+    )
+
+    batch_id = str(uuid4())
+    generated_at = datetime.now(timezone.utc).isoformat()
+
+    # Phase 1: compute eval rows for all four forms in memory. NO DB writes.
+    per_form: dict[str, dict] = {}
+    for form in CANONICAL_FORMS:
+        series = deps.compute_canary_series(
+            conn,
+            cal,
+            form=form,
+            start=snap_min,
+            end=snap_max,
+            schema=schema,
+        )
+        per_form[form] = {"eval_rows": series["eval_rows"]}
+
+    # Phase 2: compute summaries in memory. Still NO DB writes.
+    for form, payload in per_form.items():
+        eval_rows = payload["eval_rows"]
+        aucs = deps.aucs_for_rows(eval_rows)
+        composite_scores = [r["score"] for r in eval_rows]
+        auc_ci95: dict[str, list[float]] = {}
+        for name, h, thr in deps.label_specs:
+            labels = deps.entry_lagged_label(eval_rows, h, thr)
+            lo, hi = deps.block_bootstrap_auc_ci(composite_scores, labels)
+            auc_ci95[name] = [lo, hi]
+        band_dist = deps.band_counts(eval_rows)
+        within_band = _within_band_aucs(eval_rows, deps)
+        vol_only_gap = {
+            name: (
+                aucs["vol_only"].get(name, float("nan"))
+                - aucs["composite"].get(name, float("nan"))
+            )
+            for name, _, _ in deps.label_specs
+        }
+        payload.update(
+            {
+                "aucs": aucs,
+                "auc_ci95": auc_ci95,
+                "band_distribution": band_dist,
+                "within_band_aucs": within_band,
+                "vol_only_gap": vol_only_gap,
+                "n_days": len(eval_rows),
+            }
+        )
+
+    # Phase 3: persist. On ANY exception, rollback + delete-by-batch_id;
+    # the original exception is preserved (Python's last-raise-wins would
+    # otherwise mask the root cause with a cleanup-time error).
+    try:
+        for form, payload in per_form.items():
+            eval_rows = payload["eval_rows"]
+            if not eval_rows:
+                raise RuntimeError(f"form_sweep_full: form={form} produced 0 eval rows")
+            summary = deps.clean_nans(
+                {
+                    "is_winning_form": False,
+                    "score_form": form,
+                    "phase": "form_sweep_full",
+                    "source": "form_sweep_full",
+                    "batch_id": batch_id,
+                    "generated_at": generated_at,
+                    "n_days": payload["n_days"],
+                    "aucs": payload["aucs"],
+                    "auc_ci95": payload["auc_ci95"],
+                    "band_distribution": payload["band_distribution"],
+                    "within_band_aucs": payload["within_band_aucs"],
+                    "vol_only_gap": payload["vol_only_gap"],
+                }
+            )
+            params = {
+                "score_form": form,
+                "phase": "form_sweep_full",
+                "batch_id": batch_id,
+                "purpose": "candidate_discovery_not_validation",
+                "min_aligned_bars": 350,
+                "window_semantics": "warmup_requirement_not_eval_window",
+            }
+            run_id = bt_repo.insert_run(
+                indicator="canary",
+                composite_version=str(deps.composite_version),
+                start_date=eval_rows[0]["date"],
+                end_date=eval_rows[-1]["date"],
+                window_days=350,
+                n_days=payload["n_days"],
+                params=params,
+                summary=summary,
+                run_scope="research",
+            )
+            bt_repo.bulk_insert_daily(
+                run_id,
+                [
+                    {
+                        "trade_date": r["date"],
+                        "score": r["score"],
+                        "level": r["band"],
+                        "payload": {
+                            "raw_score": r["score"],
+                            "tactical": r["tactical"],
+                            "structural": r["structural"],
+                            "speed": r["speed"],
+                            "warning_state": r["warning_state"],
+                        },
+                    }
+                    for r in eval_rows
+                ],
+            )
+            bt_repo.mark_run_completed(run_id)
+    except Exception as original:
+        # Real Postgres errors leave the transaction in InFailedSqlTransaction;
+        # rollback() must run BEFORE the DELETE, or the delete itself errors.
+        try:
+            conn.rollback()
+        except Exception as rollback_err:
+            log.exception(
+                "rollback failed during form_sweep_full cleanup: %s",
+                rollback_err,
+            )
+        try:
+            bt_repo.delete_runs_by_batch_id(batch_id)
+        except Exception as cleanup_err:
+            log.exception(
+                "delete_runs_by_batch_id(%s) failed during cleanup: %s",
+                batch_id,
+                cleanup_err,
+            )
+        raise original
+
+    # Phase 4: reload, validate, render.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id, params, summary, start_date, end_date, "
+            f"       composite_version, run_scope "
+            f"FROM {schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s "
+            f"  AND run_scope = 'research' "
+            f"  AND completed_at IS NOT NULL "
+            f"ORDER BY params->>'score_form'",
+            (batch_id,),
+        )
+        run_dicts = [
+            {
+                "id": r[0],
+                "params": r[1],
+                "summary": r[2],
+                "start_date": r[3],
+                "end_date": r[4],
+                "composite_version": r[5],
+                "run_scope": r[6],
+            }
+            for r in cur.fetchall()
+        ]
+    if len(run_dicts) != 4:
+        raise RuntimeError(
+            f"form_sweep_full: expected 4 persisted rows, got {len(run_dicts)}"
+        )
+    print(render_canary_form_sweep_compare(run_dicts))

--- a/src/uw_scan/storage/regime_backtest_repository.py
+++ b/src/uw_scan/storage/regime_backtest_repository.py
@@ -145,6 +145,31 @@ class RegimeBacktestRepository:
             )
         self._conn.commit()
 
+    def delete_runs_by_batch_id(self, batch_id: str) -> int:
+        """Delete canary form_sweep_full research runs with given batch_id.
+
+        Scoped intentionally narrow — only `indicator='canary'`,
+        `run_scope='research'`, `params->>'phase'='form_sweep_full'` rows
+        are affected. This is the cleanup-on-failure path for
+        `cmd_form_sweep_full`; it should never touch any other indicator,
+        scope, or phase even on a UUID4 collision.
+
+        Daily rows are removed by ON DELETE CASCADE (migration 057).
+        Returns the number of run rows deleted (0 if no match).
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {self._schema}.regime_backtest_runs "
+                "WHERE indicator = 'canary' "
+                "  AND run_scope = 'research' "
+                "  AND params->>'phase' = 'form_sweep_full' "
+                "  AND params->>'batch_id' = %s",
+                (batch_id,),
+            )
+            deleted = cur.rowcount
+        self._conn.commit()
+        return deleted
+
     def find_latest_run(
         self,
         indicator: Literal["cri", "vcg", "canary"],

--- a/tests/integration/regime/_canary_form_sweep_fixture.py
+++ b/tests/integration/regime/_canary_form_sweep_fixture.py
@@ -1,0 +1,108 @@
+"""Synthetic vol-complex fixture for canary form-sweep-full integration tests.
+
+Seeds 600 trading days × 5 symbols into vol_index_daily (enough to clear the
+350-bar MIN_ALIGNED_BARS warm-up with ~250 bars beyond) plus 200 days into
+canary_snapshots so the MIN/MAX(data_date) window supports 60d forward labels
+(60d AUC requires at least 60 buffer rows past the eval region).
+
+Coherent but not realistic — designed to make the scoring pipeline run
+without raising, NOT to produce meaningful AUC values. Tests in this PR
+assert SHAPE (4 rows, batch_id present, etc.), not numeric correctness.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import numpy as np
+
+
+def _trading_days(start: date, n: int) -> list[date]:
+    """n consecutive Mon-Fri days starting from `start` (skip Sat/Sun)."""
+    out: list[date] = []
+    d = start
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def seed_vol_index(conn, *, schema: str, n_days: int = 600) -> list[date]:
+    """Insert n_days × {VIX, VVIX, VIX3M, COR1M, SPX} into vol_index_daily.
+
+    Default is 600 (≥ 350 warm-up + ≥ 200 evaluable). Returns the list of
+    trading dates (oldest first).
+    """
+    rng = np.random.default_rng(seed=42)
+    dates = _trading_days(date(2010, 1, 4), n_days)
+
+    spx = 1000.0 * np.cumprod(1 + rng.normal(0.0003, 0.01, n_days))
+    vix = np.clip(15 + 5 * rng.standard_normal(n_days), 10, 50)
+    vvix = np.clip(95 + 10 * rng.standard_normal(n_days), 70, 130)
+    vix3m = vix * 1.05 + rng.normal(0, 0.5, n_days)
+    cor1m = np.clip(50 + 8 * rng.standard_normal(n_days), 30, 70)
+
+    rows = []
+    for i, d in enumerate(dates):
+        for sym, arr in (
+            ("SPX", spx),
+            ("VIX", vix),
+            ("VVIX", vvix),
+            ("VIX3M", vix3m),
+            ("COR1M", cor1m),
+        ):
+            rows.append((sym, d, Decimal(str(round(float(arr[i]), 4)))))
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO {schema}.vol_index_daily "
+            "(symbol, trade_date, close) VALUES (%s, %s, %s) "
+            "ON CONFLICT (symbol, trade_date) DO NOTHING",
+            rows,
+        )
+    conn.commit()
+    return dates
+
+
+def seed_canary_snapshots(
+    conn, *, schema: str, dates: list[date], n_snapshots: int = 200
+) -> tuple[date, date]:
+    """Insert n_snapshots synthetic canary_snapshots rows.
+
+    Default is 200 so that the form-sweep-full's 60d AUC labels are finite
+    (200 - 60 = 140 evaluable rows per band). Uses the LAST n_snapshots from
+    `dates` (i.e. the most recent slice). Returns (min_date, max_date).
+    """
+    seed_dates = dates[-n_snapshots:]
+    rows = []
+    for d in seed_dates:
+        rows.append(
+            (
+                d,
+                1,  # composite_version
+                "linear",  # score_form
+                Decimal("20.0"),  # score
+                Decimal("20.0"),  # raw_score
+                "NONE",  # band
+                Decimal("5.0"),  # tactical_score
+                Decimal("10.0"),  # structural_score
+                0,  # speed_score (constraint allows 0, 8, or 20)
+                "NONE",  # warning_state
+                "abc123",  # payload_hash (any string)
+                '{"inputs": {"spx_close": 1500.0}}',  # payload JSONB
+            )
+        )
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"INSERT INTO {schema}.canary_snapshots "
+            "(data_date, composite_version, score_form, score, raw_score, "
+            " band, tactical_score, structural_score, speed_score, "
+            " warning_state, payload_hash, payload) "
+            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb) "
+            "ON CONFLICT (data_date, composite_version) DO NOTHING",
+            rows,
+        )
+    conn.commit()
+    return (seed_dates[0], seed_dates[-1])

--- a/tests/integration/regime/test_canary_form_sweep_full.py
+++ b/tests/integration/regime/test_canary_form_sweep_full.py
@@ -455,3 +455,197 @@ def test_form_sweep_full_cleanup_on_failure(seeded_db_empty_cards, monkeypatch):
     assert calib_path.read_bytes() == before_calib_bytes, (
         "calibration file changed on failure"
     )
+
+
+def test_form_sweep_full_renderer_picks_latest_complete_batch(seeded_db_empty_cards):
+    """Two complete batches, different created_at — loader picks the latest."""
+    from uw_scan.reports.regime_canary_backtest_report import (
+        _load_latest_complete_batch,
+    )
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+
+    def insert_batch(batch_id: str):
+        for form in ("linear", "convex", "concave", "sigmoid"):
+            run_id = repo.insert_run(
+                indicator="canary", composite_version="1",
+                start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+                window_days=350, n_days=100,
+                params={"score_form": form, "phase": "form_sweep_full",
+                        "batch_id": batch_id},
+                summary={"is_winning_form": False, "score_form": form,
+                         "batch_id": batch_id, "phase": "form_sweep_full",
+                         "n_days": 100,
+                         "aucs": {"composite": {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                                  "vol_only":  {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                                  "speed_only":{"up5d_2pct": 0.5, "up20d_5pct": 0.5, "up60d_10pct": 0.5}},
+                         "band_distribution": {"NONE": 60, "WATCH": 30, "BUY": 10, "STRONG_BUY": 0},
+                         "within_band_aucs": {"NONE": {"up60d_10pct": 0.55},
+                                              "WATCH": {"up60d_10pct": 0.55},
+                                              "BUY": {"up60d_10pct": 0.45},
+                                              "STRONG_BUY": {"up60d_10pct": None}},
+                         "vol_only_gap": {"up5d_2pct": 0.0, "up20d_5pct": 0.0, "up60d_10pct": 0.0}},
+                run_scope="research",
+            )
+            repo.mark_run_completed(run_id)
+
+    insert_batch("batch-A")
+    insert_batch("batch-B")
+
+    runs = _load_latest_complete_batch(db_conn, db_schema)
+    assert len(runs) == 4
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    assert batch_ids == {"batch-B"}, f"expected batch-B, got {batch_ids}"
+
+
+def test_renderer_skips_incomplete_batch(seeded_db_empty_cards):
+    """Earlier complete batch + later incomplete (3 rows) batch — loader returns the earlier."""
+    from uw_scan.reports.regime_canary_backtest_report import (
+        _load_latest_complete_batch,
+    )
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+
+    def insert_run_for(batch_id: str, form: str, *, completed: bool = True):
+        run_id = repo.insert_run(
+            indicator="canary", composite_version="1",
+            start_date=date(2011, 2, 8), end_date=date(2026, 5, 21),
+            window_days=350, n_days=100,
+            params={"score_form": form, "phase": "form_sweep_full",
+                    "batch_id": batch_id},
+            summary={"is_winning_form": False, "score_form": form,
+                     "batch_id": batch_id, "phase": "form_sweep_full",
+                     "n_days": 100,
+                     "aucs": {"composite": {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                              "vol_only":  {"up5d_2pct": 0.6, "up20d_5pct": 0.6, "up60d_10pct": 0.6},
+                              "speed_only":{"up5d_2pct": 0.5, "up20d_5pct": 0.5, "up60d_10pct": 0.5}},
+                     "band_distribution": {"NONE": 60, "WATCH": 30, "BUY": 10, "STRONG_BUY": 0},
+                     "within_band_aucs": {"NONE": {"up60d_10pct": 0.55},
+                                          "WATCH": {"up60d_10pct": 0.55},
+                                          "BUY": {"up60d_10pct": 0.45},
+                                          "STRONG_BUY": {"up60d_10pct": None}},
+                     "vol_only_gap": {"up5d_2pct": 0.0, "up20d_5pct": 0.0, "up60d_10pct": 0.0}},
+            run_scope="research",
+        )
+        if completed:
+            repo.mark_run_completed(run_id)
+
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        insert_run_for("batch-complete", form)
+    for form in ("linear", "convex", "concave"):
+        insert_run_for("batch-partial", form)
+
+    runs = _load_latest_complete_batch(db_conn, db_schema)
+    batch_ids = {r["params"]["batch_id"] for r in runs}
+    assert batch_ids == {"batch-complete"}, (
+        f"loader must skip incomplete batches, got {batch_ids}"
+    )
+
+
+def test_form_sweep_full_does_not_write_calibration_file(seeded_db_empty_cards):
+    """canary-calibration-v1.json byte content unchanged after run."""
+    import hashlib
+    from pathlib import Path
+
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    calib_path = (
+        Path(__file__).parents[3]
+        / "docs/research/regime/canary-calibration-v1.json"
+    )
+    assert calib_path.exists(), f"calibration file not found at {calib_path}"
+
+    before_bytes = calib_path.read_bytes()
+    before_hash = hashlib.sha256(before_bytes).hexdigest()
+    before_mtime = calib_path.stat().st_mtime
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    after_bytes = calib_path.read_bytes()
+    after_hash = hashlib.sha256(after_bytes).hexdigest()
+    after_mtime = calib_path.stat().st_mtime
+
+    assert before_bytes == after_bytes, "calibration file content changed"
+    assert before_hash == after_hash, "calibration SHA-256 mismatch"
+    assert before_mtime == after_mtime, "calibration mtime changed"
+
+
+def test_form_sweep_full_invisible_to_oos_gate(seeded_db_empty_cards):
+    """Production find_latest_run does not return any research-scoped form_sweep_full row."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    winning_run_id = repo.insert_run(
+        indicator="canary", composite_version="1",
+        start_date=date(2020, 1, 2), end_date=date(2026, 5, 21),
+        window_days=350, n_days=1605,
+        params={"score_form": "linear", "phase": "final_oos_report"},
+        summary={"is_winning_form": True, "score_form": "linear"},
+    )
+    repo.mark_run_completed(winning_run_id)
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    latest = repo.find_latest_run("canary", composite_version="1")
+    assert latest is not None
+    assert latest["id"] == winning_run_id, (
+        f"find_latest_run returned {latest['id']}; expected pre-existing v1 run "
+        f"{winning_run_id}. form_sweep_full rows must be research scoped."
+    )
+
+
+def test_form_sweep_full_invisible_to_validation_api(seeded_db_empty_cards):
+    """The /api/regime/canary/validation router function returns the same
+    row before and after a form_sweep_full run."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+    from uw_scan.api.routers.regime import get_canary_validation
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    pre_winning_id = repo.insert_run(
+        indicator="canary", composite_version="1",
+        start_date=date(2020, 1, 2), end_date=date(2026, 5, 21),
+        window_days=350, n_days=1605,
+        params={"score_form": "linear", "phase": "final_oos_report"},
+        summary={"is_winning_form": True, "score_form": "linear"},
+    )
+    repo.mark_run_completed(pre_winning_id)
+
+    before = get_canary_validation(repo=seeded_db_empty_cards).model_dump_json()
+    assert f'"run_id":{pre_winning_id}' in before
+
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    after = get_canary_validation(repo=seeded_db_empty_cards).model_dump_json()
+    assert before == after, "validation API payload changed across form_sweep_full"

--- a/tests/integration/regime/test_canary_form_sweep_full.py
+++ b/tests/integration/regime/test_canary_form_sweep_full.py
@@ -196,3 +196,204 @@ def test_delete_runs_by_batch_id_scoped_to_canary_research_form_sweep_full(
             (target_id,),
         )
         assert cur.fetchone()[0] == 0
+
+
+def test_cmd_form_sweep_full_persists_4_rows_sharing_batch_id(seeded_db_empty_cards):
+    """Run the script's wrapper. Assert: 4 research rows, same batch_id, same generated_at."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT params->>'batch_id', summary->>'generated_at', "
+            f"       params->>'score_form', summary->>'is_winning_form', run_scope "
+            f"FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full' "
+            f"ORDER BY params->>'score_form'"
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 4
+    batch_ids = {r[0] for r in rows}
+    gen_ats = {r[1] for r in rows}
+    forms = {r[2] for r in rows}
+    is_winning = {r[3] for r in rows}
+    run_scopes = {r[4] for r in rows}
+    assert len(batch_ids) == 1, f"all 4 rows must share batch_id, got {batch_ids}"
+    assert len(gen_ats) == 1, f"all 4 rows must share generated_at, got {gen_ats}"
+    assert forms == {"linear", "convex", "concave", "sigmoid"}
+    assert is_winning == {"false"}, f"is_winning_form must be false for all, got {is_winning}"
+    assert run_scopes == {"research"}, f"run_scope must be research for all, got {run_scopes}"
+
+
+def test_cmd_form_sweep_full_writes_daily_rows(seeded_db_empty_cards):
+    """Each form's run has exactly `n_days` corresponding regime_backtest_daily rows."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT r.params->>'score_form', r.n_days, COUNT(d.trade_date) "
+            f"FROM {db_schema}.regime_backtest_runs r "
+            f"LEFT JOIN {db_schema}.regime_backtest_daily d ON d.run_id = r.id "
+            f"WHERE r.params->>'phase' = 'form_sweep_full' "
+            f"GROUP BY r.params->>'score_form', r.n_days"
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 4, f"expected 4 form rows, got {len(rows)}"
+    seen_forms: set[str] = set()
+    for form, n_days, daily_count in rows:
+        seen_forms.add(form)
+        assert n_days > 0, f"{form} run.n_days must be > 0, got {n_days}"
+        assert daily_count == n_days, (
+            f"{form}: daily-row count {daily_count} != run.n_days {n_days} "
+            f"— persistence is not writing every computed eval row"
+        )
+    assert seen_forms == {"linear", "convex", "concave", "sigmoid"}
+
+
+def test_cmd_form_sweep_full_summary_schema(seeded_db_empty_cards):
+    """summary JSONB has all the spec-required keys."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT summary FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full' LIMIT 1"
+        )
+        summary = cur.fetchone()[0]
+    for key in ("is_winning_form", "score_form", "phase", "source",
+                "batch_id", "generated_at", "n_days", "aucs", "auc_ci95",
+                "band_distribution", "within_band_aucs", "vol_only_gap"):
+        assert key in summary, f"summary missing key: {key}"
+    for series in ("composite", "vol_only", "speed_only"):
+        assert series in summary["aucs"]
+        for horizon in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+            assert horizon in summary["aucs"][series], \
+                f"aucs.{series}.{horizon} missing"
+    for band in ("NONE", "WATCH", "BUY", "STRONG_BUY"):
+        assert band in summary["band_distribution"]
+
+
+def test_cmd_form_sweep_full_prints_renderer_output(seeded_db_empty_cards, capsys):
+    """After persistence, the command must call the renderer and print its
+    output to stdout. A buggy implementation that persists correctly but
+    skips the print would otherwise pass every DB-only test."""
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    captured = capsys.readouterr()
+    stdout = captured.out
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        assert form in stdout, f"renderer output missing form row '{form}'"
+    li = stdout.index("linear")
+    cv = stdout.index("convex")
+    cc = stdout.index("concave")
+    sg = stdout.index("sigmoid")
+    assert li < cv < cc < sg, (
+        f"form rows must appear in canonical order, got positions "
+        f"linear={li}, convex={cv}, concave={cc}, sigmoid={sg}"
+    )
+    assert "Observations" in stdout, "renderer output missing Observations section"
+    assert "What this run does NOT decide" in stdout, (
+        "renderer footer missing — guardrail prose against misuse"
+    )
+
+
+def test_cmd_form_sweep_full_does_not_persist_when_compute_fails_mid_run(
+    seeded_db_empty_cards, monkeypatch,
+):
+    """Compute-all-before-persist invariant (spec §4.2 / AC-13).
+
+    Patches `deps.compute_canary_series` to raise on the *third* invocation
+    (= third form). Asserts: zero `form_sweep_full` rows are persisted.
+    """
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+    from uw_scan.reports import regime_canary_form_sweep_full as impl_mod
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    real_run = impl_mod.run_form_sweep_full
+    call_count = {"compute": 0}
+
+    def make_failing_run(conn, *, schema, deps):
+        real_compute = deps.compute_canary_series
+
+        def patched_compute(*args, **kwargs):
+            call_count["compute"] += 1
+            if call_count["compute"] == 3:
+                raise RuntimeError(
+                    "synthetic failure on form 3 — compute-before-persist test"
+                )
+            return real_compute(*args, **kwargs)
+
+        from dataclasses import replace
+        patched_deps = replace(deps, compute_canary_series=patched_compute)
+        return real_run(conn, schema=schema, deps=patched_deps)
+
+    monkeypatch.setattr(impl_mod, "run_form_sweep_full", make_failing_run)
+
+    with pytest.raises(RuntimeError, match="synthetic failure on form 3"):
+        cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, (
+            "compute-before-persist violated: rows for forms 1/2 leaked "
+            "into the DB before form 3's compute failed"
+        )
+    assert call_count["compute"] == 3, (
+        f"expected compute to be called 3 times before failing, "
+        f"got {call_count['compute']}"
+    )

--- a/tests/integration/regime/test_canary_form_sweep_full.py
+++ b/tests/integration/regime/test_canary_form_sweep_full.py
@@ -397,3 +397,61 @@ def test_cmd_form_sweep_full_does_not_persist_when_compute_fails_mid_run(
         f"expected compute to be called 3 times before failing, "
         f"got {call_count['compute']}"
     )
+
+
+def test_form_sweep_full_cleanup_on_failure(seeded_db_empty_cards, monkeypatch):
+    """Simulate a real DB failure on the 3rd form's bulk_insert_daily call.
+    Assert: rollback happens and zero failed-batch rows remain afterwards."""
+    from pathlib import Path
+
+    from scripts.backtest_canary import cmd_form_sweep_full
+    from tests.integration.regime._canary_form_sweep_fixture import (
+        seed_canary_snapshots,
+        seed_vol_index,
+    )
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    calib_path = (
+        Path(__file__).parents[3]
+        / "docs/research/regime/canary-calibration-v1.json"
+    )
+    before_calib_bytes = calib_path.read_bytes()
+    dates = seed_vol_index(db_conn, schema=db_schema, n_days=600)
+    seed_canary_snapshots(db_conn, schema=db_schema, dates=dates, n_snapshots=200)
+
+    real_bulk = RegimeBacktestRepository.bulk_insert_daily
+    call_count = {"n": 0}
+
+    def fail_on_third_call(self, run_id, rows):
+        call_count["n"] += 1
+        if call_count["n"] == 3:
+            with self._conn.cursor() as cur:
+                cur.execute("INSERT INTO definitely_missing_table VALUES (1)")
+        return real_bulk(self, run_id, rows)
+
+    monkeypatch.setattr(
+        RegimeBacktestRepository, "bulk_insert_daily", fail_on_third_call,
+    )
+
+    with pytest.raises(Exception):
+        cmd_form_sweep_full(db_conn, schema=db_schema)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, (
+            "cleanup-on-failure must remove all rows for failed batch_id"
+        )
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily d "
+            f"JOIN {db_schema}.regime_backtest_runs r ON d.run_id = r.id "
+            f"WHERE r.params->>'phase' = 'form_sweep_full'"
+        )
+        assert cur.fetchone()[0] == 0, "daily rows must cascade-delete"
+    assert calib_path.read_bytes() == before_calib_bytes, (
+        "calibration file changed on failure"
+    )

--- a/tests/integration/regime/test_canary_form_sweep_full.py
+++ b/tests/integration/regime/test_canary_form_sweep_full.py
@@ -1,0 +1,198 @@
+"""Integration tests for canary --form-sweep-full and its renderer.
+
+All tests use the synthetic vol-complex fixture in
+_canary_form_sweep_fixture.py and the project's pytest-postgresql fixture
+(real Postgres, migrations applied per tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+
+
+def test_delete_runs_by_batch_id_removes_rows_and_cascades_daily(
+    seeded_db_empty_cards,
+):
+    """Insert a 4-row form_sweep_full batch + daily rows, then delete
+    by batch_id. All runs AND daily rows must be gone."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    batch_id = str(uuid.uuid4())
+
+    inserted_run_ids: list[int] = []
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        run_id = repo.insert_run(
+            indicator="canary",
+            composite_version="1",
+            start_date=date(2011, 2, 8),
+            end_date=date(2026, 5, 21),
+            window_days=350,
+            n_days=100,
+            params={
+                "score_form": form,
+                "phase": "form_sweep_full",
+                "batch_id": batch_id,
+                "purpose": "candidate_discovery_not_validation",
+            },
+            summary={
+                "is_winning_form": False,
+                "score_form": form,
+                "batch_id": batch_id,
+                "phase": "form_sweep_full",
+            },
+            run_scope="research",
+        )
+        inserted_run_ids.append(run_id)
+        repo.bulk_insert_daily(
+            run_id,
+            [
+                {
+                    "trade_date": date(2024, 1, 2),
+                    "score": 20.0,
+                    "level": "NONE",
+                    "payload": {"raw_score": 20.0},
+                },
+            ],
+        )
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s",
+            (batch_id,),
+        )
+        assert cur.fetchone()[0] == 4
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily "
+            f"WHERE run_id = ANY(%s)",
+            (inserted_run_ids,),
+        )
+        assert cur.fetchone()[0] == 4
+
+    n_deleted = repo.delete_runs_by_batch_id(batch_id)
+    assert n_deleted == 4
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs "
+            f"WHERE params->>'batch_id' = %s",
+            (batch_id,),
+        )
+        assert cur.fetchone()[0] == 0
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_daily "
+            f"WHERE run_id = ANY(%s)",
+            (inserted_run_ids,),
+        )
+        assert cur.fetchone()[0] == 0
+
+
+def test_delete_runs_by_batch_id_returns_zero_when_no_match(seeded_db_empty_cards):
+    """Calling with an unknown batch_id is a no-op returning 0."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    n = repo.delete_runs_by_batch_id("00000000-0000-0000-0000-000000000000")
+    assert n == 0
+
+
+def test_delete_runs_by_batch_id_scoped_to_canary_research_form_sweep_full(
+    seeded_db_empty_cards,
+):
+    """A row with the same batch_id but a DIFFERENT indicator/scope/phase
+    must NOT be deleted. Defends against UUID4 collisions and accidental
+    over-scoping if the method is reused without thinking."""
+    from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
+
+    db_conn = seeded_db_empty_cards.conn
+    db_schema = seeded_db_empty_cards._schema
+    repo = RegimeBacktestRepository(db_conn, schema=db_schema)
+    batch_id = str(uuid.uuid4())
+
+    lookalikes = [
+        # Wrong indicator
+        dict(
+            indicator="vcg",
+            composite_version="1",
+            start_date=date(2011, 2, 8),
+            end_date=date(2026, 5, 21),
+            window_days=350,
+            n_days=10,
+            params={"phase": "form_sweep_full", "batch_id": batch_id},
+            summary={"phase": "form_sweep_full"},
+            run_scope="research",
+        ),
+        # Wrong run_scope
+        dict(
+            indicator="canary",
+            composite_version="1",
+            start_date=date(2011, 2, 8),
+            end_date=date(2026, 5, 21),
+            window_days=350,
+            n_days=10,
+            params={"phase": "form_sweep_full", "batch_id": batch_id},
+            summary={"phase": "form_sweep_full"},
+            run_scope="production",
+        ),
+        # Wrong phase
+        dict(
+            indicator="canary",
+            composite_version="1",
+            start_date=date(2011, 2, 8),
+            end_date=date(2026, 5, 21),
+            window_days=350,
+            n_days=10,
+            params={"phase": "calibrate", "batch_id": batch_id},
+            summary={"phase": "calibrate"},
+            run_scope="research",
+        ),
+    ]
+    lookalike_ids = [repo.insert_run(**spec) for spec in lookalikes]
+
+    target_id = repo.insert_run(
+        indicator="canary",
+        composite_version="1",
+        start_date=date(2011, 2, 8),
+        end_date=date(2026, 5, 21),
+        window_days=350,
+        n_days=10,
+        params={
+            "score_form": "linear",
+            "phase": "form_sweep_full",
+            "batch_id": batch_id,
+            "purpose": "candidate_discovery_not_validation",
+        },
+        summary={
+            "is_winning_form": False,
+            "score_form": "linear",
+            "batch_id": batch_id,
+            "phase": "form_sweep_full",
+        },
+        run_scope="research",
+    )
+
+    n_deleted = repo.delete_runs_by_batch_id(batch_id)
+    assert n_deleted == 1, "only the in-scope target row should be deleted"
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT id FROM {db_schema}.regime_backtest_runs WHERE id = ANY(%s)",
+            (lookalike_ids,),
+        )
+        remaining = [r[0] for r in cur.fetchall()]
+        assert sorted(remaining) == sorted(lookalike_ids), (
+            "lookalike rows must remain — scoping violation"
+        )
+        cur.execute(
+            f"SELECT COUNT(*) FROM {db_schema}.regime_backtest_runs WHERE id = %s",
+            (target_id,),
+        )
+        assert cur.fetchone()[0] == 0

--- a/tests/unit/test_canary_form_sweep_cli.py
+++ b/tests/unit/test_canary_form_sweep_cli.py
@@ -1,0 +1,21 @@
+"""Unit tests for canary backtest CLI guardrails."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from scripts import backtest_canary
+
+
+def test_form_sweep_full_is_mutually_exclusive(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["backtest_canary.py", "--form-sweep", "--form-sweep-full"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        backtest_canary.main()
+    assert exc.value.code == 2
+    assert "only one of --calibrate" in capsys.readouterr().err

--- a/tests/unit/test_canary_form_sweep_renderer.py
+++ b/tests/unit/test_canary_form_sweep_renderer.py
@@ -1,0 +1,313 @@
+"""Unit tests for render_canary_form_sweep_compare."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from uw_scan.reports.regime_canary_backtest_report import (
+    render_canary_form_sweep_compare,
+)
+
+
+def _mk_run(
+    *,
+    run_id: int,
+    form: str,
+    batch_id: str = "batch-1",
+    composite_60d: float = 0.620,
+    vol_60d: float = 0.640,
+    watch_pct: float = 39.3,
+    buy_band_60d: float = 0.348,
+    buy_pct: float = 5.5,
+    strong_buy_pct: float = 0.0,
+) -> dict:
+    """Minimal row shape consumed by the renderer."""
+    n_days = 3843
+    return {
+        "id": run_id,
+        "run_scope": "research",
+        "start_date": date(2011, 2, 8),
+        "end_date": date(2026, 5, 21),
+        "composite_version": "1",
+        "params": {
+            "score_form": form,
+            "phase": "form_sweep_full",
+            "batch_id": batch_id,
+        },
+        "summary": {
+            "is_winning_form": False,
+            "score_form": form,
+            "batch_id": batch_id,
+            "n_days": n_days,
+            "aucs": {
+                "composite": {
+                    "up5d_2pct": 0.620,
+                    "up20d_5pct": 0.627,
+                    "up60d_10pct": composite_60d,
+                },
+                "vol_only": {
+                    "up5d_2pct": 0.626,
+                    "up20d_5pct": 0.639,
+                    "up60d_10pct": vol_60d,
+                },
+                "speed_only": {
+                    "up5d_2pct": 0.470,
+                    "up20d_5pct": 0.465,
+                    "up60d_10pct": 0.430,
+                },
+            },
+            "band_distribution": {
+                "NONE": int(
+                    n_days
+                    * (1 - watch_pct / 100 - buy_pct / 100 - strong_buy_pct / 100)
+                ),
+                "WATCH": int(n_days * watch_pct / 100),
+                "BUY": int(n_days * buy_pct / 100),
+                "STRONG_BUY": int(n_days * strong_buy_pct / 100),
+            },
+            "within_band_aucs": {
+                "NONE": {"up5d_2pct": 0.581, "up20d_5pct": 0.601, "up60d_10pct": 0.586},
+                "WATCH": {
+                    "up5d_2pct": 0.559,
+                    "up20d_5pct": 0.633,
+                    "up60d_10pct": 0.609,
+                },
+                "BUY": {
+                    "up5d_2pct": 0.447,
+                    "up20d_5pct": 0.431,
+                    "up60d_10pct": buy_band_60d,
+                },
+                "STRONG_BUY": {
+                    "up5d_2pct": None,
+                    "up20d_5pct": None,
+                    "up60d_10pct": None,
+                },
+            },
+            "vol_only_gap": {
+                "up5d_2pct": 0.006,
+                "up20d_5pct": 0.012,
+                "up60d_10pct": vol_60d - composite_60d,
+            },
+        },
+    }
+
+
+def _full_set(batch_id: str = "batch-1") -> list[dict]:
+    return [
+        _mk_run(run_id=27, form="linear", batch_id=batch_id),
+        _mk_run(run_id=28, form="convex", batch_id=batch_id),
+        _mk_run(run_id=29, form="concave", batch_id=batch_id),
+        _mk_run(run_id=30, form="sigmoid", batch_id=batch_id),
+    ]
+
+
+def test_canonical_form_ordering():
+    """Output rows always: linear → convex → concave → sigmoid, regardless of input order."""
+    runs = [
+        _mk_run(run_id=i, form=f)
+        for i, f in enumerate(("sigmoid", "concave", "linear", "convex"), start=100)
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    li = out.index("| linear ")
+    cv = out.index("| convex ")
+    cc = out.index("| concave")
+    sg = out.index("| sigmoid")
+    assert li < cv < cc < sg, (
+        f"unexpected order: linear={li} convex={cv} concave={cc} sigmoid={sg}"
+    )
+
+
+def test_missing_form_raises():
+    """3 rows (sigmoid missing) — length check fires first with 'got 3'."""
+    runs = _full_set()[:3]  # missing sigmoid
+    with pytest.raises(ValueError, match=r"got 3"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_duplicate_form_raises():
+    runs = _full_set()
+    runs[1] = _mk_run(run_id=99, form="linear")  # 2 linears now
+    with pytest.raises(ValueError, match="linear|duplicate"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_fewer_than_4_rows_raises():
+    with pytest.raises(ValueError, match="4"):
+        render_canary_form_sweep_compare(_full_set()[:2])
+
+
+def test_mismatched_batch_id_raises():
+    runs = _full_set("batch-1")
+    runs[2] = _mk_run(run_id=99, form="concave", batch_id="batch-2")
+    with pytest.raises(ValueError, match="batch_id"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_non_research_scope_raises():
+    runs = _full_set()
+    runs[0]["run_scope"] = "production"
+    with pytest.raises(ValueError, match="research"):
+        render_canary_form_sweep_compare(runs)
+
+
+def test_footer_present():
+    out = render_canary_form_sweep_compare(_full_set())
+    assert "What this run does NOT decide" in out
+    assert "candidate-discovery" in out.lower() or "candidate discovery" in out.lower()
+
+
+def test_observation_watch_overfire():
+    """WATCH% > 30 in linear (default fixture has 39.3) — should appear in observations."""
+    out = render_canary_form_sweep_compare(_full_set())
+    lines = [l for l in out.splitlines() if "WATCH% above 30%" in l]
+    assert lines, "expected WATCH% above 30% observation line"
+    assert "linear" in lines[0]
+
+
+def test_observation_buy_band_inversion():
+    """BUY-band 60d AUC < 0.50 in linear (default 0.348) — should appear."""
+    out = render_canary_form_sweep_compare(_full_set())
+    lines = [l for l in out.splitlines() if "BUY-band 60d AUC below 0.50" in l]
+    assert lines
+    assert "linear" in lines[0]
+
+
+def test_observation_composite_improves_over_linear():
+    """If convex 60d AUC > linear 60d by >=0.02, it should be listed."""
+    runs = [
+        _mk_run(run_id=27, form="linear", composite_60d=0.620),
+        _mk_run(run_id=28, form="convex", composite_60d=0.650),  # +0.030
+        _mk_run(run_id=29, form="concave", composite_60d=0.610),
+        _mk_run(run_id=30, form="sigmoid", composite_60d=0.620),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [
+        l for l in out.splitlines() if "Composite 60d AUC improves over linear" in l
+    ]
+    assert lines
+    assert "convex" in lines[0]
+    assert "concave" not in lines[0]
+
+
+def test_observation_watch_reduce_without_auc_loss():
+    """If sigmoid has WATCH%-5pp AND 60d AUC within 0.01 of linear, list it."""
+    runs = [
+        _mk_run(run_id=27, form="linear", watch_pct=39.3, composite_60d=0.620),
+        _mk_run(run_id=28, form="convex", watch_pct=39.0, composite_60d=0.620),
+        _mk_run(run_id=29, form="concave", watch_pct=39.5, composite_60d=0.620),
+        _mk_run(run_id=30, form="sigmoid", watch_pct=33.0, composite_60d=0.615),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines() if "WATCH% reduced by" in l]
+    assert lines
+    assert "sigmoid" in lines[0]
+
+
+def test_observation_vol_only_gap():
+    """Vol-only gap ≥ +0.02 (= vol_only_60d - composite_60d ≥ 0.02): listed."""
+    runs = [
+        _mk_run(run_id=27, form="linear", composite_60d=0.620, vol_60d=0.625),
+        _mk_run(run_id=28, form="convex", composite_60d=0.620, vol_60d=0.650),
+        _mk_run(run_id=29, form="concave", composite_60d=0.620, vol_60d=0.625),
+        _mk_run(run_id=30, form="sigmoid", composite_60d=0.620, vol_60d=0.625),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [l for l in out.splitlines() if "Vol-only gap (60d) ≥ +0.02 in" in l]
+    assert lines, "expected vol-only gap observation line"
+    assert "convex" in lines[0]
+    assert "linear" not in lines[0]
+    assert "concave" not in lines[0]
+    assert "sigmoid" not in lines[0]
+
+
+def test_observation_buy_pct_zero():
+    """BUY% at exactly 0 (band never fires): listed."""
+    runs = [
+        _mk_run(run_id=27, form="linear", buy_pct=5.5),
+        _mk_run(run_id=28, form="convex", buy_pct=0.0),
+        _mk_run(run_id=29, form="concave", buy_pct=0.0),
+        _mk_run(run_id=30, form="sigmoid", buy_pct=2.0),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    lines = [
+        l for l in out.splitlines() if "BUY% at exactly 0 (band never fires) in" in l
+    ]
+    assert lines, "expected BUY%=0 observation line"
+    assert "convex" in lines[0]
+    assert "concave" in lines[0]
+    assert "linear" not in lines[0]
+    assert "sigmoid" not in lines[0]
+
+
+def test_observation_strong_buy_pct_zero():
+    """STRONG_BUY% at exactly 0: listed."""
+    out = render_canary_form_sweep_compare(_full_set())
+    lines = [
+        l
+        for l in out.splitlines()
+        if "STRONG_BUY% at exactly 0 (band never fires) in" in l
+    ]
+    assert lines, "expected STRONG_BUY%=0 observation line"
+    for form in ("linear", "convex", "concave", "sigmoid"):
+        assert form in lines[0], f"{form} missing from STRONG_BUY%=0 line"
+
+
+def test_observation_none_when_no_form_matches():
+    """Rule that has zero matches must print `none`."""
+    runs = [
+        _mk_run(
+            run_id=27,
+            form="linear",
+            watch_pct=25.0,
+            buy_band_60d=0.60,
+            composite_60d=0.620,
+            vol_60d=0.620,
+            buy_pct=5.0,
+            strong_buy_pct=3.0,
+        ),
+        _mk_run(
+            run_id=28,
+            form="convex",
+            watch_pct=24.0,
+            buy_band_60d=0.60,
+            composite_60d=0.620,
+            vol_60d=0.620,
+            buy_pct=5.0,
+            strong_buy_pct=3.0,
+        ),
+        _mk_run(
+            run_id=29,
+            form="concave",
+            watch_pct=23.0,
+            buy_band_60d=0.60,
+            composite_60d=0.620,
+            vol_60d=0.620,
+            buy_pct=5.0,
+            strong_buy_pct=3.0,
+        ),
+        _mk_run(
+            run_id=30,
+            form="sigmoid",
+            watch_pct=22.0,
+            buy_band_60d=0.60,
+            composite_60d=0.620,
+            vol_60d=0.620,
+            buy_pct=5.0,
+            strong_buy_pct=3.0,
+        ),
+    ]
+    out = render_canary_form_sweep_compare(runs)
+    for label in (
+        "WATCH% above 30% in",
+        "BUY-band 60d AUC below 0.50 in",
+        "Vol-only gap (60d) ≥ +0.02 in",
+        "BUY% at exactly 0 (band never fires) in",
+        "STRONG_BUY% at exactly 0 (band never fires) in",
+    ):
+        matching = [l for l in out.splitlines() if label in l]
+        assert matching, f"missing observation line for: {label}"
+        assert "none" in matching[0], (
+            f"rule '{label}' should report 'none' when no form matches, "
+            f"got: {matching[0]!r}"
+        )

--- a/tests/unit/test_canary_form_sweep_renderer.py
+++ b/tests/unit/test_canary_form_sweep_renderer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
+
 from uw_scan.reports.regime_canary_backtest_report import (
     render_canary_form_sweep_compare,
 )
@@ -160,7 +161,7 @@ def test_footer_present():
 def test_observation_watch_overfire():
     """WATCH% > 30 in linear (default fixture has 39.3) — should appear in observations."""
     out = render_canary_form_sweep_compare(_full_set())
-    lines = [l for l in out.splitlines() if "WATCH% above 30%" in l]
+    lines = [line for line in out.splitlines() if "WATCH% above 30%" in line]
     assert lines, "expected WATCH% above 30% observation line"
     assert "linear" in lines[0]
 
@@ -168,7 +169,7 @@ def test_observation_watch_overfire():
 def test_observation_buy_band_inversion():
     """BUY-band 60d AUC < 0.50 in linear (default 0.348) — should appear."""
     out = render_canary_form_sweep_compare(_full_set())
-    lines = [l for l in out.splitlines() if "BUY-band 60d AUC below 0.50" in l]
+    lines = [line for line in out.splitlines() if "BUY-band 60d AUC below 0.50" in line]
     assert lines
     assert "linear" in lines[0]
 
@@ -183,7 +184,9 @@ def test_observation_composite_improves_over_linear():
     ]
     out = render_canary_form_sweep_compare(runs)
     lines = [
-        l for l in out.splitlines() if "Composite 60d AUC improves over linear" in l
+        line
+        for line in out.splitlines()
+        if "Composite 60d AUC improves over linear" in line
     ]
     assert lines
     assert "convex" in lines[0]
@@ -199,7 +202,7 @@ def test_observation_watch_reduce_without_auc_loss():
         _mk_run(run_id=30, form="sigmoid", watch_pct=33.0, composite_60d=0.615),
     ]
     out = render_canary_form_sweep_compare(runs)
-    lines = [l for l in out.splitlines() if "WATCH% reduced by" in l]
+    lines = [line for line in out.splitlines() if "WATCH% reduced by" in line]
     assert lines
     assert "sigmoid" in lines[0]
 
@@ -213,7 +216,9 @@ def test_observation_vol_only_gap():
         _mk_run(run_id=30, form="sigmoid", composite_60d=0.620, vol_60d=0.625),
     ]
     out = render_canary_form_sweep_compare(runs)
-    lines = [l for l in out.splitlines() if "Vol-only gap (60d) ≥ +0.02 in" in l]
+    lines = [
+        line for line in out.splitlines() if "Vol-only gap (60d) ≥ +0.02 in" in line
+    ]
     assert lines, "expected vol-only gap observation line"
     assert "convex" in lines[0]
     assert "linear" not in lines[0]
@@ -231,7 +236,9 @@ def test_observation_buy_pct_zero():
     ]
     out = render_canary_form_sweep_compare(runs)
     lines = [
-        l for l in out.splitlines() if "BUY% at exactly 0 (band never fires) in" in l
+        line
+        for line in out.splitlines()
+        if "BUY% at exactly 0 (band never fires) in" in line
     ]
     assert lines, "expected BUY%=0 observation line"
     assert "convex" in lines[0]
@@ -244,9 +251,9 @@ def test_observation_strong_buy_pct_zero():
     """STRONG_BUY% at exactly 0: listed."""
     out = render_canary_form_sweep_compare(_full_set())
     lines = [
-        l
-        for l in out.splitlines()
-        if "STRONG_BUY% at exactly 0 (band never fires) in" in l
+        line
+        for line in out.splitlines()
+        if "STRONG_BUY% at exactly 0 (band never fires) in" in line
     ]
     assert lines, "expected STRONG_BUY%=0 observation line"
     for form in ("linear", "convex", "concave", "sigmoid"):
@@ -305,7 +312,7 @@ def test_observation_none_when_no_form_matches():
         "BUY% at exactly 0 (band never fires) in",
         "STRONG_BUY% at exactly 0 (band never fires) in",
     ):
-        matching = [l for l in out.splitlines() if label in l]
+        matching = [line for line in out.splitlines() if label in line]
         assert matching, f"missing observation line for: {label}"
         assert "none" in matching[0], (
             f"rule '{label}' should report 'none' when no form matches, "

--- a/tests/unit/test_within_band_aucs.py
+++ b/tests/unit/test_within_band_aucs.py
@@ -1,0 +1,142 @@
+"""Unit tests for _within_band_aucs."""
+
+import math
+
+import pytest
+
+from scripts import backtest_canary as canary_backtest
+from uw_scan.reports.regime_canary_form_sweep_full import (
+    CanaryFormSweepDeps,
+)
+from uw_scan.reports.regime_canary_form_sweep_full import (
+    _within_band_aucs as _impl_within_band_aucs,
+)
+
+
+def _deps() -> CanaryFormSweepDeps:
+    return CanaryFormSweepDeps(
+        compute_canary_series=canary_backtest._compute_canary_series,
+        aucs_for_rows=canary_backtest._aucs_for_rows,
+        band_counts=canary_backtest._band_counts,
+        block_bootstrap_auc_ci=canary_backtest._block_bootstrap_auc_ci,
+        clean_nans=canary_backtest._clean_nans,
+        entry_lagged_label=canary_backtest._entry_lagged_label,
+        auc=canary_backtest._auc,
+        label_specs=canary_backtest.LABEL_SPECS,
+        composite_version=canary_backtest.COMPOSITE_VERSION,
+    )
+
+
+def _within_band_aucs(rows: list[dict]) -> dict[str, dict[str, float]]:
+    return _impl_within_band_aucs(rows, _deps())
+
+
+def _row(score: float, band: str, spx: float, date_str: str = "2020-01-01") -> dict:
+    """Minimal row shape for the helper. Only fields actually read."""
+    from datetime import date
+
+    return {
+        "score": score,
+        "band": band,
+        "spx": spx,
+        "date": date.fromisoformat(date_str),
+    }
+
+
+def _date_str(offset: int) -> str:
+    from datetime import date, timedelta
+
+    return (date(2020, 1, 1) + timedelta(days=offset)).isoformat()
+
+
+def test_empty_rows_returns_empty():
+    out = _within_band_aucs([])
+    assert out == {"NONE": {}, "WATCH": {}, "BUY": {}, "STRONG_BUY": {}}
+
+
+def test_band_with_no_rows_returns_nan():
+    # All rows in NONE band — WATCH/BUY/STRONG_BUY should return NaN per horizon.
+    rows = [_row(10, "NONE", 100.0 + i, _date_str(i)) for i in range(80)]
+    out = _within_band_aucs(rows)
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert math.isnan(out["WATCH"][h])
+        assert math.isnan(out["BUY"][h])
+
+
+def test_all_same_label_returns_nan():
+    # Construct so forward labels are all 0 (no >2% moves) — AUC is undefined.
+    rows = [_row(50, "BUY", 100.0, _date_str(i)) for i in range(80)]
+    out = _within_band_aucs(rows)
+    # BUY band's AUCs all NaN because positive class is empty.
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert math.isnan(out["BUY"][h])
+
+
+def test_normal_case_matches_filtered_auc():
+    """Normal: 3 bands populated, labels computed once over full series."""
+    from scripts.backtest_canary import LABEL_SPECS, _auc, _entry_lagged_label
+
+    rng = __import__("numpy").random.default_rng(seed=1)
+    n = 100
+    bands = ["NONE"] * 40 + ["WATCH"] * 40 + ["BUY"] * 20
+    rng.shuffle(bands)
+    spx_path = 100.0 + __import__("numpy").cumsum(rng.normal(0.001, 0.01, n))
+    rows = [
+        _row(
+            float(i + rng.standard_normal()), bands[i], float(spx_path[i]), _date_str(i)
+        )
+        for i in range(n)
+    ]
+    out = _within_band_aucs(rows)
+    # Recompute reference per-band by hand and confirm equality.
+    for band in ("NONE", "WATCH", "BUY"):
+        idxs = [i for i, r in enumerate(rows) if r["band"] == band]
+        for name, h, thr in LABEL_SPECS:
+            labels_full = _entry_lagged_label(rows, h, thr)
+            band_scores = [rows[i]["score"] for i in idxs]
+            band_labels = [labels_full[i] for i in idxs]
+            expected = _auc(band_scores, band_labels)
+            actual = out[band][name]
+            if math.isnan(expected):
+                assert math.isnan(actual)
+            else:
+                assert abs(actual - expected) < 1e-9
+
+
+def test_labels_computed_once_not_per_subset():
+    """The last 60 rows should not silently vanish from each band's AUC.
+
+    If we computed labels per-subset, slicing rows[band==X] then calling
+    _entry_lagged_label would drop the last 60 of THAT subset (not the
+    last 60 of the full series). The helper must NOT do that.
+
+    SPX path uses seeded RNG so forward returns straddle thresholds
+    (mixed 0/1 labels) — a monotonic path would give all-1 labels and
+    NaN AUCs regardless of how labels are computed.
+    """
+    import math as _m
+
+    import numpy as np
+
+    n = 200
+    rng = np.random.default_rng(seed=7)
+    # Deterministic sinusoidal path with slight upward drift — guarantees
+    # forward returns straddle the 2%/5%/10% thresholds at all 3 horizons.
+    spx_path = [100.0 + 8.0 * _m.sin(i / 7.0) + 0.05 * i for i in range(n)]
+    # Half NONE, half BUY, alternating; score = i+jitter so within-band AUCs
+    # are well-defined.
+    rows = [
+        _row(
+            float(i + rng.standard_normal()),
+            "NONE" if i % 2 == 0 else "BUY",
+            float(spx_path[i]),
+            _date_str(i),
+        )
+        for i in range(n)
+    ]
+    out = _within_band_aucs(rows)
+    # Every band should have non-NaN AUCs (since labels are computed once
+    # over the full 200-row series, BOTH bands have plenty of labeled rows).
+    for h in ("up5d_2pct", "up20d_5pct", "up60d_10pct"):
+        assert not math.isnan(out["NONE"][h]), f"NONE[{h}] should be finite"
+        assert not math.isnan(out["BUY"][h]), f"BUY[{h}] should be finite"

--- a/tests/unit/test_within_band_aucs.py
+++ b/tests/unit/test_within_band_aucs.py
@@ -2,8 +2,6 @@
 
 import math
 
-import pytest
-
 from scripts import backtest_canary as canary_backtest
 from uw_scan.reports.regime_canary_form_sweep_full import (
     CanaryFormSweepDeps,


### PR DESCRIPTION
## Summary

Adds `--form-sweep-full`: a research-only candidate-discovery sweep across all four score forms (`linear` / `convex` / `concave` / `sigmoid`) over the full `canary_snapshots` window (2011-02-08 → 2026-05-21, 3,843 days each).

**The result is a successful negative**: no alternative form solves the v1 pathology. The score-form hypothesis is rejected, redirecting v2-C from "swap to convex/concave/sigmoid" to "band / ordinal-regime redesign." No score form is changed, no calibration JSON is touched, no `COMPOSITE_VERSION` bump.

## What this PR adds

- **Worker** `src/uw_scan/reports/regime_canary_form_sweep_full.py` — 4-phase pipeline (snap-range resolve → in-memory compute for all 4 forms → atomic persist with cleanup-on-failure → reload + render). Uses a frozen `CanaryFormSweepDeps` dataclass so the package never back-imports the script.
- **Pure renderer** `src/uw_scan/reports/regime_canary_backtest_report.py::render_canary_form_sweep_compare` + standalone CLI `python -m uw_scan.reports.regime_canary_backtest_report` for re-rendering the latest complete batch without recompute.
- **Repo method** `RegimeBacktestRepository.delete_runs_by_batch_id` — scoped to `indicator='canary'` AND `run_scope='research'` AND `phase='form_sweep_full'`; cascade-deletes daily rows via FK.
- **CLI wiring** `cmd_form_sweep_full` + `--form-sweep-full` flag in `scripts/backtest_canary.py`, with mutual-exclusion across the 6 mode flags.
- **35 new tests** (5 helper-unit + 15 renderer-unit + 1 CLI-unit + 14 integration) — all passing.
- **Doc update** `docs/research/regime/canary-5yr-executive-summary.md` §13 records the verdict; §10 v2-A promoted; §10 v2-C reframed.

## Result

| Form    | AUC 5d | AUC 20d | AUC 60d | NONE% | WATCH% | BUY% | STRONG_BUY% | BUY-band 60d AUC | Vol-only gap (60d) |
|---------|-------:|--------:|--------:|------:|-------:|-----:|------------:|-----------------:|-------------------:|
| linear  |  0.620 |   0.627 |   0.619 |  55.2 |   39.3 |  5.5 |         0.0 |            0.348 |             +0.023 |
| convex  |  0.616 |   0.623 |   0.608 |  60.8 |   34.8 |  4.4 |         0.0 |            0.369 |             +0.027 |
| concave |  0.624 |   0.628 |   0.628 |  46.3 |   46.4 |  7.2 |         0.0 |            0.505 |             +0.020 |
| sigmoid |  0.623 |   0.632 |   0.627 |  56.0 |   38.4 |  5.6 |         0.0 |            0.340 |             +0.025 |

**Verdict (recorded in §13 of the exec summary):**

- Best 60d AUC is concave at 0.628 vs linear 0.619 — only +0.009, below the +0.02 promotion bar.
- WATCH overfire universal (all > 30%); concave makes it worse at 46.4%.
- STRONG_BUY band never fires in any form (0.0% across the board).
- BUY-band rank inversion (< 0.50) persists in linear, convex, sigmoid; concave clears 0.505 only by paying with massive WATCH expansion.
- **Vol-only gap survives every form (+0.020 to +0.027)** — strengthens v2-A independently of curvature.

## Downstream-invisibility evidence (multi-layer defense)

| Layer | Mechanism |
|---|---|
| Persistence | `run_scope='research'` set at write time; `find_latest_run` default is `production`, so form-sweep rows are invisible to all production queries. |
| Summary | `is_winning_form=false` hard-coded at write time. |
| Renderer | Fixed "What this run does NOT decide" footer embedded in markdown. |
| Calibration | Zero writes to `canary-calibration-v1.json`. MD5 unchanged before/after live run: `407024fadb7e7b46417f08f4d019d991`. |
| OOS gate | Reads only production-scope rows; integration test verifies the form-sweep batch is invisible to it. |

## Verification (re-run on this branch)

- `uv run pytest tests/unit/test_within_band_aucs.py tests/unit/test_canary_form_sweep_cli.py tests/unit/test_canary_form_sweep_renderer.py tests/integration/regime/test_canary_form_sweep_full.py -v` → **35 passed in 34.18s**
- `uv run pytest tests/integration/regime/test_canary_oos_gate.py -v` → **4 passed in 6.49s** (non-regression)
- Live smoke against working DB → batch `a71b88a4-7904-4653-aa70-611f24e9fbf1`, runs 27–30, all research-scoped, all `is_winning_form=false`.
- Production-scope query returns zero `form_sweep_full` rows.
- Standalone renderer `python -m uw_scan.reports.regime_canary_backtest_report` re-renders the same batch identically.

## Decisions taken from this result

- **Keep score form `linear`.** No change.
- **Do not touch calibration JSON.**
- **Do not bump `COMPOSITE_VERSION`.**
- **v2-A promoted** to top of v2 queue (vol predicts; speed contextualizes — survives all four forms).
- **v2-C reframed** from score-form change to band/ordinal-regime redesign (4 candidate directions listed in §10).
- **Do not run another form-selection step.** The negative result is the answer.

## Test plan

- [x] 35 form-sweep tests pass under real Postgres
- [x] 4 canary OOS-gate tests still pass (no regression)
- [x] Live smoke against working DB produces 4 research-scoped rows under one batch_id
- [x] Standalone renderer re-loads the same batch identically
- [x] Production-scope `find_latest_run` returns no `form_sweep_full` rows
- [x] `canary-calibration-v1.json` MD5 unchanged before/after live run

## Standing-rule compliance

- ✅ `uv` only (no bare `python`/`pytest`)
- ✅ Persisted analytical results to Postgres
- ✅ New `delete_runs_by_batch_id` lives in focused `regime_backtest_repository.py`, not `repository.py`
- ✅ No `Co-Authored-By: Claude` trailer on any of the 9 commits
- ✅ No secrets passed to subprocesses