### PR TITLE
feat(vcg-ui): drop V2-OVERRIDE pills + fold stress-history section

### DIFF
--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -539,43 +539,14 @@ export function VcgSubTabView({
               </span>
               <span
                 style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: "8px",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  fontWeight: 700,
+                  color: pctRankColor(sig.vvix_percentile_rank),
                 }}
+                data-testid="vcg-vvix-pct-rank"
               >
-                {sig.vix_percentile_rank != null &&
-                  sig.vvix_percentile_rank != null &&
-                  sig.vix_percentile_rank >= VOL_STRESS_THRESHOLD &&
-                  sig.vvix_percentile_rank >= VOL_STRESS_THRESHOLD && (
-                    <span
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "9px",
-                        fontWeight: 700,
-                        color: "#fff",
-                        background: "var(--fault, var(--negative))",
-                        padding: "1px 6px",
-                        borderRadius: "999px",
-                        letterSpacing: "0.08em",
-                      }}
-                      data-testid="vcg-vol-stress-override-badge"
-                      title="Both VIX and VVIX percentile ranks ≥ 0.95 — v2 absolute-vol-stress override is RISK_OFF"
-                    >
-                      V2 OVERRIDE
-                    </span>
-                  )}
-                <span
-                  style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "11px",
-                    fontWeight: 700,
-                    color: pctRankColor(sig.vvix_percentile_rank),
-                  }}
-                  data-testid="vcg-vvix-pct-rank"
-                >
-                  {formatPctRank(sig.vvix_percentile_rank)}
-                </span>
+                {formatPctRank(sig.vvix_percentile_rank)}
               </span>
             </div>
             <div

--- a/web/components/regime/vcg/VcgStressHistorySection.tsx
+++ b/web/components/regime/vcg/VcgStressHistorySection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import type { components } from "@/lib/types";
@@ -14,10 +15,15 @@ type VcgValidationResponse = components["schemas"]["VcgValidationResponse"];
  * the stress_history table. Kept separate from VcgSubTabView so that view
  * stays pure (props-only) and testable without HTTP mocking — only this
  * section owns the fetch.
+ *
+ * The section header is a toggle: click to collapse / expand. Defaults open.
+ * The fetch still fires on mount regardless of fold state — the cost is a
+ * one-time GET, and pre-fetching keeps the count visible in the header.
  */
 export default function VcgStressHistorySection() {
   const [data, setData] = useState<VcgValidationResponse | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [open, setOpen] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -49,8 +55,27 @@ export default function VcgStressHistorySection() {
 
   return (
     <div className="section" data-testid="vcg-stress-history-section">
-      <div className="section-header">
-        <div className="section-title">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        data-testid="vcg-stress-history-toggle"
+        className="section-header"
+        style={{
+          width: "100%",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+          textAlign: "left",
+          color: "inherit",
+        }}
+      >
+        <div
+          className="section-title"
+          style={{ display: "flex", alignItems: "center", gap: "6px" }}
+        >
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
           PANIC / RISK-OFF / EDR History (all-time)
           {totalDays != null && (
             <span
@@ -65,14 +90,14 @@ export default function VcgStressHistorySection() {
             </span>
           )}
         </div>
-      </div>
-      {err && (
+      </button>
+      {open && err && (
         <div data-testid="vcg-stress-history-error">
           Stress history unavailable: {err}
         </div>
       )}
-      {!err && !data && <div>Loading…</div>}
-      {!err && data && (
+      {open && !err && !data && <div>Loading…</div>}
+      {open && !err && data && (
         <div className="section-body table-wrap">
           <VcgStressHistoryTable rows={rows} />
         </div>

--- a/web/components/regime/vcg/VcgStressHistoryTable.tsx
+++ b/web/components/regime/vcg/VcgStressHistoryTable.tsx
@@ -136,11 +136,6 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
       </thead>
       <tbody>
         {sorted.map((r) => {
-          const override =
-            r.vix_percentile_rank != null &&
-            r.vvix_percentile_rank != null &&
-            r.vix_percentile_rank >= VOL_STRESS_THRESHOLD &&
-            r.vvix_percentile_rank >= VOL_STRESS_THRESHOLD;
           return (
             <tr
               key={r.date}
@@ -164,20 +159,6 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
                     ? "RISK-OFF"
                     : r.interpretation}
                 </span>
-                {override && (
-                  <span
-                    style={{
-                      marginLeft: "6px",
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "9px",
-                      color: "var(--fault, var(--negative))",
-                      letterSpacing: "0.06em",
-                    }}
-                    title="VIX & VVIX percentile ranks both ≥ 0.95 — v2 absolute-vol-stress override"
-                  >
-                    V2-OVERRIDE
-                  </span>
-                )}
               </td>
               <td className="right">{formatSignedNumber(r.score)}</td>
               <td className="right">{formatSignedNumber(r.vcg_adj)}</td>

--- a/web/tests/unit/VcgStressHistoryTable.test.tsx
+++ b/web/tests/unit/VcgStressHistoryTable.test.tsx
@@ -61,19 +61,24 @@ describe("VcgStressHistoryTable", () => {
     expect(screen.queryByText("RISK-OFF")).not.toBeNull();
   });
 
-  it("flags PANIC rows whose VIX & VVIX percentile ranks both clear 0.95 with V2-OVERRIDE", () => {
+  it("colors percentile-rank cells red when v >= 0.95 (vol-stress threshold)", () => {
     const { container } = render(<VcgStressHistoryTable rows={ROWS} />);
-    const overrides = container.querySelectorAll(
-      '[title*="v2 absolute-vol-stress override"]',
-    );
-    // Only the 2024-01-15 PANIC row has both percentile ranks ≥ 0.95.
-    expect(overrides.length).toBe(1);
+    // 2024-01-15 PANIC row: both percentile ranks clear 0.95 → both cells red.
     const panicRow = container.querySelector(
       '[data-testid="vcg-stress-row-2024-01-15"]',
     );
-    expect(
-      panicRow?.querySelector('[title*="v2 absolute-vol-stress override"]'),
-    ).not.toBeNull();
+    const tds = panicRow?.querySelectorAll("td");
+    const vixCell = tds?.[7] as HTMLElement | undefined;
+    const vvixCell = tds?.[8] as HTMLElement | undefined;
+    expect(vixCell?.style.color).toContain("var(--fault");
+    expect(vvixCell?.style.color).toContain("var(--fault");
+    // 2024-06-10 EDR row: both ranks well under 0.95 → text-primary (not red).
+    const edrRow = container.querySelector(
+      '[data-testid="vcg-stress-row-2024-06-10"]',
+    );
+    const edrCells = edrRow?.querySelectorAll("td");
+    const edrVix = edrCells?.[7] as HTMLElement | undefined;
+    expect(edrVix?.style.color).toContain("var(--text-primary)");
   });
 
   it("toggles sort order on header click", () => {


### PR DESCRIPTION
## Summary
Follow-on UI polish for the VCG v2 stack shipped in #91.

- **Removed V2-OVERRIDE pills** — the explicit `V2 OVERRIDE` annotation on the VVIX 252d %ile row (Signal Detail card) and the inline `V2-OVERRIDE` text on stress-history rows. The red cell color when a percentile rank ≥ 0.95 already conveys the override condition; the extra pill was duplicative noise.
- **Foldable stress-history section** — the section header (PANIC / RISK-OFF / EDR History) is now a button toggle with a Chevron indicator (down = open, right = collapsed). Defaults open. Collapsing hides the table body but keeps `N stress days · M total` visible in the header. Lets users scan the VCG sub-tab without committing screen real estate to the 200+ row history.

## Test plan
- [x] `cd web && npm run typecheck` — tsc clean
- [x] `cd web && npm run test` — 352 / 352 pass (existing override-pill assertion in `VcgStressHistoryTable.test.tsx` replaced with a cell-color check)
- [ ] Visual smoke at `localhost:3001/regime` → VCG sub-tab: confirm pills removed, header toggle works, default open
- [ ] Confirm fold state doesn't break the existing fetch on mount (count remains accurate when collapsed)