### PR TITLE
docs(canary): v2-A verdict §14 + v2-C design notes + WF-5 probe scaffold

### DIFF
--- a/docs/research/regime/canary-5yr-executive-summary.md
+++ b/docs/research/regime/canary-5yr-executive-summary.md
@@ -516,6 +516,80 @@ PGUSER=chenxi UW_SCAN_API_KEY=local-smoke \
 
 ---
 
+## 14. v2-A vol/speed separation result (2026-05-28, terminal verdict for v2-A)
+
+Research-only PR 1 ([#94](https://github.com/moremeds/unusual-whales/pull/94), merged 2026-05-28) — added a 4-line conditional in `run_analysis()` keyed on `calibration.composite_version`, plus full evidence machinery (`FlipGateEvidence`, renderer, AC-F1..F6 evaluator, cleanup-on-failure). Backfilled 3,843 v2 snapshots; ran 6-window walk-forward + robustness with shared `batch_id=9fedce4e-3019-4324-8431-db64587c069d`.
+
+**Verdict: STOP. PR 2 (production flip `COMPOSITE_VERSION = 1 → 2`) is NOT authorized.**
+
+### Headline numbers
+
+| Metric | v1 | v2 | Δ | Bar | Result |
+|---|---:|---:|---:|---:|:---|
+| Full-history 60d AUC | 0.6193 | 0.6421 | **+0.0227** | ≥ 0.634 | **PASS** (matches prior +0.020–0.027) |
+| Full-history 20d AUC | 0.6270 | 0.6389 | +0.0119 | ≥ 0.622 | PASS |
+| Full-history 5d AUC | 0.6200 | 0.6263 | +0.0063 | ≥ 0.615 | PASS |
+| WATCH% | 39.3% | 13.5% | −25.8pp | ≤ 44.3% | PASS by huge margin |
+| v1 golden hash unchanged | — | — | — | byte-identical | PASS |
+
+### Where v2-A failed
+
+**AC-F4: WF-5 regression of −0.134 AUC** (v1 0.721 → v2 0.587), in the "Bond-yield selloff + 2024 quiet" regime — exceeds the −0.02 per-window tolerance. Pattern across all 6 walk-forward windows:
+
+| Window | Regime | v1 60d | v2 60d | Δ |
+|---|---|---:|---:|---:|
+| WF-1 | China deval, Brexit | 0.642 | 0.651 | +0.009 |
+| WF-2 | Volmageddon, Q4-18 | 0.569 | 0.569 | 0.000 |
+| WF-3 | Repo + COVID | 0.728 | 0.815 | **+0.087** |
+| WF-4 | Post-COVID, 2022 inflation | 0.791 | 0.792 | +0.001 |
+| WF-5 | Bond-yield, 2024 quiet | 0.721 | **0.587** | **−0.134** |
+| WF-6 | 2025 tariff, 2026 dip | 0.621 | 0.838 | **+0.217** |
+
+v2 dominates in crisis regimes (WF-3, WF-6); regresses materially in the quiet regime (WF-5). The "good on average, bad in one regime" failure mode AC-F4 was designed to surface.
+
+**AC-F3: 3 of 4 canonical CCA event dates didn't fire.** Empirically, v2 CCA fires on **2-month sustained-stress regimes** (Q4-2018 selloff, COVID, early-2022 inflation, 2025 tariff), not single-day shocks. Specifically:
+
+- `2011-08-08` (post-S&P-downgrade): `band=NONE, speed=NEUTRAL` — system never noticed
+- `2015-08-24` (yuan crash): `band=NONE, speed=BUY_THE_DIP_ACTIVE` — labeled buy opportunity, not warning. Directionally not wrong (S&P bottomed 9 trading days later), but conflated warning-state in the spec's canonical-date selection
+- `2018-02-05` (Volmageddon, single-day XIV crash): `band=NONE, speed=NEUTRAL` — single-day vol explosion undetected
+- `2020-03-09` (COVID Black Monday I): `speed=CONFIRMED_CANARY_ACTIVE` ✓
+
+### Interpretation: speed.score's regime-conditional role
+
+The headline +0.023 AUC lift was correct *in aggregate* but came concentrated in crisis regimes. In quiet regimes, `speed.score` was load-bearing — likely as an **early-instability detector** (low-vol breakout, lead-lag, flow acceleration, gamma transition), not as a panic detector. Vol-complex dominates in crisis; speed contributes in quiet. The v2-A formulation ("binary remove speed") loses the quiet-regime contribution.
+
+### Decisions taken from this result
+
+| Item | Decision |
+|---|---|
+| `COMPOSITE_VERSION` | **Do not bump.** v2-A formula is not a clean win. |
+| v2-A (drop speed from composite) | **Reject. Terminal.** Do not retry. |
+| v2-C (regime-conditional redesign) | **Promoted.** Three candidate directions: (A) regime-conditional weighting, (B) rank inversion within BUY, (C) convex blending. See [`canary-v2c-design-notes.md`](canary-v2c-design-notes.md). |
+| WF-5 deep-dive | **High priority next step.** Understand what speed.score captured in 2024 quiet regime before v2-C design. Probe scaffold at `scripts/probe_canary_wf5.py`. |
+| AC-F3 reformulation | **Required before next experiment.** Spec used 4 canonical event dates; empirics show v2 CCA fires on 2-month stress clusters. New gate: "CCA fires within ±N-day onset window of stress regime start". N must be **pre-committed** before v2-C runs, not chosen after seeing data. |
+| v2-A evidence machinery | **Keep.** `FlipGateEvidence`, renderer, AC-F1..F6 evaluator, cleanup-on-failure, payload-hash idempotency, scoped-delete repo method — all reusable for v2-C/D experiments. |
+
+### Why this is a successful negative result
+
+The pre-committed per-window gate (AC-F4) prevented shipping what looked like a headline win (+0.023 AUC) but would have introduced regime-specific weakness — the exact "good on average, bad in one regime" failure mode that blows up production portfolios. Aggregate metrics conceal regime fragility; per-window gates surface it. This was the most valuable governance moment of PR #94.
+
+The infrastructure built for v2-A is fully reusable for v2-C. Marginal cost of the next experiment is the calibration JSON + the formula change.
+
+### Reproduce
+
+```bash
+# Re-render the v1-vs-v2 report (no recompute, just re-render):
+PGUSER=chenxi UW_SCAN_API_KEY=local-smoke \
+  uv run python scripts/backtest_canary.py --v1-v2-compare \
+      --batch-id 9fedce4e-3019-4324-8431-db64587c069d
+
+# Probe WF-5 to understand speed.score's quiet-regime behavior:
+PGUSER=chenxi UW_SCAN_API_KEY=local-smoke \
+  uv run python scripts/probe_canary_wf5.py
+```
+
+---
+
 ## Appendix: How this document was generated
 
 - Dataset stats: SQL queries against `uw_scan.canary_snapshots` (full 15.3-year backfilled window).

--- a/docs/research/regime/canary-v2c-design-notes.md
+++ b/docs/research/regime/canary-v2c-design-notes.md
@@ -1,0 +1,146 @@
+# Canary v2-C — Design Notes (post v2-A STOP verdict)
+
+**Status:** Pre-spec. Captures the three candidate directions surfaced after [v2-A's terminal STOP verdict](canary-5yr-executive-summary.md#14-v2-a-volspeed-separation-result-2026-05-28-terminal-verdict-for-v2-a). This document is NOT a full spec — it's the alignment artifact before a spec brainstorm.
+
+**Date:** 2026-05-28
+**Owner:** chenxi
+**Related:** [v2-A spec](../../superpowers/specs/2026-05-27-canary-v2a-vol-speed-separation-design.md) · [v2-A plan](../../superpowers/plans/2026-05-27-canary-v2a-vol-speed-separation-plan.md) · [PR #94](https://github.com/moremeds/unusual-whales/pull/94)
+
+---
+
+## Why v2-C exists
+
+v2-A's "binary remove `speed.score` from the composite" failed AC-F4 (WF-5 regression of −0.134 AUC). The interpretation:
+
+- **`speed.score` is NOT a panic detector.** Vol-complex (`tactical + structural`) carries the panic signal in crisis regimes (WF-3 +0.087, WF-6 +0.217).
+- **`speed.score` IS an early-instability detector in quiet regimes.** WF-5 (2024 quiet) collapsed when speed was removed — most likely because speed was carrying low-vol breakout / lead-lag / flow-acceleration / gamma-transition information that becomes load-bearing when vol-complex signals are dormant.
+
+The problem with v2-A was not "is speed useful" but "should speed dominate the composite". Binary removal was too blunt.
+
+---
+
+## Three candidate directions
+
+### A. Regime-conditional weighting (most direct)
+
+```python
+if vol_regime == "crisis":
+    weight_speed = 0.0  # or small
+    weight_vol_complex = 1.0
+elif vol_regime == "quiet":
+    weight_speed = 1.0  # full
+    weight_vol_complex = 1.0
+else:  # transition
+    interpolate
+```
+
+**Pros:** Easy to reason about; cleanest hypothesis test (preserve quiet-regime contribution + preserve crisis-regime lift).
+**Cons:** Adds a regime-detection signal that needs its own validation. Two-stage classifier increases failure surface.
+**Open question:** What defines `vol_regime`? Realized vol percentile? VIX level percentile? VVIX/VIX ratio? Each choice is a new pre-committed gate.
+
+### B. Rank inversion within BUY (most nuanced)
+
+Keep v1's `tactical + structural + speed.score` formula to qualify the BUY bucket (preserves cross-sectional ranking), then use `speed` as a **secondary ordering signal within already-qualified BUYs only**.
+
+```python
+raw = tactical + structural + speed.score  # v1 formula — keeps quiet contribution
+band = compute_band(raw)
+if band == "BUY":
+    # within-BUY ranking uses speed as tie-breaker on tactical+structural ties
+    final_rank = (tactical + structural, speed.score)
+```
+
+**Pros:** Doesn't change the band-classification machinery (low-risk for production). Surgical — only affects within-BUY ordering, which is exactly where the form-sweep saw rank inversion. The user [originally called this v2-C](canary-5yr-executive-summary.md#10-v2-candidate-issues-file-as-follow-up-github-issues-do-not-block-pr-83).
+**Cons:** Doesn't fix the WF-5 contribution problem directly — speed still contributes to the raw score, so WF-5 wouldn't change. But the v2-A AUC lift might disappear too. This is a different bet (cross-sectional ordering) rather than a v2-A replacement.
+
+### C. Convex blending (nonlinear interaction)
+
+```python
+# instead of additive:
+raw = tactical + structural + speed.score
+# try multiplicative or clipped:
+raw = (tactical + structural) * regime_fn(speed.score)
+# or:
+raw = tactical + structural + clip(speed.score, 0, threshold_by_regime)
+```
+
+**Pros:** Captures the intuition that speed's *contribution magnitude* should depend on the vol-complex's own state (when vol-complex is already saying "crisis", speed adds little).
+**Cons:** Hyperparameter search space explodes. Hard to falsify cleanly.
+
+---
+
+## Pre-experiment requirements (must complete before any v2-C variant runs)
+
+These are non-negotiable for institutional discipline.
+
+### 1. WF-5 deep-dive (highest priority — gold mine)
+
+Probe scaffold lives at [`scripts/probe_canary_wf5.py`](../../../scripts/probe_canary_wf5.py). First-pass output answers: in WF-5, how often did `speed.state != NEUTRAL`? What was `speed.score`'s distribution? How does that compare to WF-3 (where v2 won big) and WF-1 (where v2 broke even)?
+
+Follow-up probes (queue):
+
+- Forward 60d return by `speed.state` bucket in WF-5 vs WF-3 — does speed *predict* anything in quiet, or is it noise that v1's additive formula happens to suppress?
+- Cross-asset signal correlations during WF-5: is speed picking up lead-lag from credit, vol-of-vol, or term structure that vol-complex misses?
+- Vol-of-vol (VVIX) percentile during WF-5 days when speed fires — is it actually "quiet" or just "stretched"?
+
+### 2. AC-F3 reformulation (gate redesign)
+
+v2-A's spec required 4 canonical event dates to fire `confirmed_canary_active=True`. Empirically (PR #94), v2 CCA fires on 2-month sustained-stress clusters, not single-day events. The canonical-date selection conflated warning state with dip-buy state (see 2015-08-24 case).
+
+**New gate proposal (must be pre-committed before v2-C runs):**
+
+> "For each of the N canonical stress regimes, CCA must fire at least once within ±K trading days of the regime's onset date."
+
+Pre-committed parameters needed:
+- The list of stress regimes (probably 4–6 across 2008–2026, picked from web-validated event chronology — NOT from looking at v2 fire dates)
+- `K` (window tolerance) — must be picked from prior research, not after seeing data. Suggest 0–5 trading days.
+- Onset definition (first day of regime, or first ≥−3% close, or first VIX > Nth percentile day)
+
+### 3. Regime-conditioned attribution
+
+Don't rely on aggregate full-history AUC. Compute per-window:
+- Feature importance for `tactical`, `structural`, `speed.score`, `speed.state` separately
+- Marginal AUC contribution: AUC(composite) vs AUC(composite without feature X)
+- Stability of attribution across windows (high stability = robust signal; low stability = regime-dependent)
+
+### 4. Vol-concentration check
+
+Hypothesis: v2 dropped speed and concentrated remaining mass in vol-complex, possibly reducing effective dimensionality. Test by computing pairwise correlation of `tactical`, `structural`, `speed.score` within each window. If `tactical` and `structural` are already highly correlated, v2's composite is effectively one signal — fragile under regime change.
+
+---
+
+## What the v2-C spec should look like
+
+When the spec brainstorm starts (post-WF-5 probe), it should:
+
+1. **Pick exactly one of A/B/C** — not all three. Each is a distinct hypothesis with its own falsification criteria.
+2. **Pre-commit AC-F1..F6 BEFORE running any backtest.** Same discipline as v2-A. Include:
+   - AC-F1 / AC-F2: full-history AUC bars (lift bar should be higher than v2-A's +0.015 — we have more information now)
+   - AC-F3 (reformulated): stress-cluster onset-window match per §2 above
+   - AC-F4: per-window catastrophic-degradation gate (tolerance −0.02 or tighter)
+   - AC-F5: WATCH% bar (v1 reference unchanged at 39.3%)
+   - AC-F6: v1 unchanged (golden hash, same as v2-A)
+   - **NEW AC-F7:** WF-5 specific gate — v2-C 60d AUC in WF-5 must NOT regress vs v1 by more than −0.02. This is the gate that v2-A failed; v2-C must pass it.
+3. **Use the v2-A infrastructure as-is.** `FlipGateEvidence`, renderer, cleanup-on-failure, payload-hash idempotency, scoped-delete repo method — all reusable. Marginal cost of v2-C is the calibration JSON + the formula change.
+
+---
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-28 | v2-A rejected, terminal | AC-F4 + AC-F3 failed; WF-5 regression of −0.134 + 3 of 4 canonical CCA dates missed |
+| 2026-05-28 | v2-C promoted to top of queue | Speed contribution in quiet regimes confirmed empirically |
+| 2026-05-28 | Pre-spec docs first | WF-5 probe needed before direction-picking spec is written |
+| TBD | Direction picked (A / B / C) | After WF-5 probe results |
+| TBD | v2-C spec written | After direction picked + AC reformulation locked |
+
+---
+
+## References
+
+- [v2-A executive summary §14](canary-5yr-executive-summary.md#14-v2-a-volspeed-separation-result-2026-05-28-terminal-verdict-for-v2-a)
+- [PR #94 — research-only v2-A evidence pass](https://github.com/moremeds/unusual-whales/pull/94)
+- [v2-A spec](../../superpowers/specs/2026-05-27-canary-v2a-vol-speed-separation-design.md) (commit `09a2ea8`)
+- [v2-A plan](../../superpowers/plans/2026-05-27-canary-v2a-vol-speed-separation-plan.md) (commit `6782af0`)
+- WF-5 probe: `scripts/probe_canary_wf5.py`

--- a/scripts/probe_canary_wf5.py
+++ b/scripts/probe_canary_wf5.py
@@ -1,0 +1,196 @@
+"""WF-5 probe: investigate `speed.score`'s role in the 2024 quiet regime.
+
+After v2-A returned verdict STOP (AC-F4: WF-5 regressed -0.134), the open
+question is what `speed.score` was capturing in the 2023-01-02 → 2024-12-31
+window such that removing it materially hurt 60d AUC. This script is the
+first probe — exploratory, not a test.
+
+What it does:
+  1. Pulls v1 walk-forward daily rows for WF-5 from regime_backtest_daily.
+  2. Tabulates `payload.speed` (.score / .state) distributions per day.
+  3. Side-by-sides WF-5 against WF-3 (where v2 won big, +0.087) and WF-1
+     (where v2 broke even, +0.009) so you can SEE the regime difference.
+  4. Computes simple descriptives: pct days speed.state != NEUTRAL,
+     distribution of speed.score (0/8/20 are the only valid values),
+     correlation of speed.score with v1 composite score within the window.
+
+Why this matters: the user articulated speed as an "early instability
+detector in quiet regimes, not a panic detector." This probe is the first
+step to test that hypothesis empirically.
+
+Usage:
+  PGUSER=chenxi UW_SCAN_API_KEY=local-smoke uv run python scripts/probe_canary_wf5.py
+
+Output is human-readable + TSV-parseable. Not persisted to DB — just stdout.
+
+Spec context: docs/research/regime/canary-5yr-executive-summary.md §14
+Decision context: docs/research/regime/canary-v2c-design-notes.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+
+import psycopg
+
+from uw_scan.config import Settings
+
+WINDOWS = {
+    "WF-1": ("2015-01-01", "2016-12-31", "China deval, Brexit"),
+    "WF-3": ("2019-01-01", "2020-09-30", "Repo crisis, COVID crash"),
+    "WF-5": ("2023-01-01", "2024-12-31", "Bond-yield selloff, 2024 quiet"),
+}
+
+
+def _fetch_v1_window_daily(conn, *, schema: str, window_id: str) -> list[dict]:
+    """Pull v1 walk-forward daily rows for one window_id.
+
+    Joins regime_backtest_daily to its parent run via run_id, filters to
+    production canary v1 walk-forward, returns daily rows ordered by date.
+    """
+    sql = f"""
+        SELECT d.trade_date, d.score, d.level, d.payload
+        FROM {schema}.regime_backtest_daily d
+        JOIN {schema}.regime_backtest_runs r ON d.run_id = r.id
+        WHERE r.indicator = 'canary'
+          AND r.run_scope = 'production'
+          AND r.composite_version = '1'
+          AND r.params->>'phase' = 'walk_forward'
+          AND r.params->>'window_id' = %s
+          AND r.completed_at IS NOT NULL
+        ORDER BY d.trade_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (window_id,))
+        rows = []
+        for trade_date, score, level, payload in cur.fetchall():
+            speed = payload.get("speed", {})
+            # payload.speed shape varies — handle both nested dict and raw int.
+            speed_score: int | None = None
+            speed_state: str | None = None
+            if isinstance(speed, dict):
+                # walk-forward daily payload shape is the canary_scoring
+                # `speed` sub-dict: {"score": int, "state": str, ...}
+                # OR (older format) just the integer score under "speed" key.
+                speed_score = speed.get("score")
+                speed_state = speed.get("state")
+            elif isinstance(speed, (int, float)):
+                speed_score = int(speed)
+            rows.append(
+                {
+                    "date": trade_date,
+                    "score": float(score) if score is not None else None,
+                    "band": level,
+                    "tactical": payload.get("tactical"),
+                    "structural": payload.get("structural"),
+                    "speed_score": speed_score,
+                    "speed_state": speed_state,
+                    "warning_state": payload.get("warning_state"),
+                }
+            )
+        return rows
+
+
+def _summarize(rows: list[dict], label: str) -> dict:
+    """Compute descriptive stats for one window's daily rows."""
+    n = len(rows)
+    speed_scores = [r["speed_score"] for r in rows if r["speed_score"] is not None]
+    speed_states = [r["speed_state"] for r in rows if r["speed_state"] is not None]
+    composite_scores = [r["score"] for r in rows if r["score"] is not None]
+
+    state_counts: dict[str, int] = {}
+    for s in speed_states:
+        state_counts[s] = state_counts.get(s, 0) + 1
+
+    score_value_counts: dict[int, int] = {}
+    for s in speed_scores:
+        score_value_counts[s] = score_value_counts.get(s, 0) + 1
+
+    pct_nonzero_speed = (
+        100.0 * sum(1 for s in speed_scores if s and s > 0) / len(speed_scores)
+        if speed_scores
+        else 0.0
+    )
+
+    speed_score_mean = statistics.mean(speed_scores) if speed_scores else 0.0
+    composite_mean = statistics.mean(composite_scores) if composite_scores else 0.0
+
+    return {
+        "label": label,
+        "n_days": n,
+        "speed_score_mean": speed_score_mean,
+        "speed_score_value_counts": score_value_counts,
+        "speed_state_counts": state_counts,
+        "pct_days_speed_nonzero": pct_nonzero_speed,
+        "composite_score_mean": composite_mean,
+    }
+
+
+def _print_window_summary(s: dict, window_id: str) -> None:
+    print(f"\n=== {window_id} — {s['label']} (n={s['n_days']} daily rows) ===")
+    print(
+        f"  speed.score: mean={s['speed_score_mean']:.3f}  pct_days_nonzero={s['pct_days_speed_nonzero']:.1f}%"
+    )
+    print(
+        f"  speed.score value distribution: {dict(sorted(s['speed_score_value_counts'].items()))}"
+    )
+    print(f"  speed.state distribution: {s['speed_state_counts']}")
+    print(f"  composite score mean: {s['composite_score_mean']:.3f}")
+
+
+def _print_tsv(summaries: dict[str, dict]) -> None:
+    print("\n=== TSV (window\tn\tspeed_mean\tspeed_pct_nonzero\tcomposite_mean) ===")
+    for wid, s in summaries.items():
+        print(
+            f"{wid}\t{s['n_days']}\t"
+            f"{s['speed_score_mean']:.3f}\t{s['pct_days_speed_nonzero']:.1f}\t"
+            f"{s['composite_score_mean']:.3f}"
+        )
+
+
+def main() -> int:
+    argparse.ArgumentParser(description=__doc__).parse_args()
+
+    settings = Settings.from_env()
+    summaries: dict[str, dict] = {}
+    with psycopg.connect(settings.db_dsn()) as conn:
+        for wid, (start, end, label) in WINDOWS.items():
+            rows = _fetch_v1_window_daily(
+                conn, schema=settings.db_schema, window_id=wid
+            )
+            if not rows:
+                print(
+                    f"WARN: {wid} has zero v1 walk-forward daily rows. "
+                    f"Has --walk-forward run with this batch?",
+                    file=sys.stderr,
+                )
+                continue
+            s = _summarize(rows, f"{label} ({start} → {end})")
+            summaries[wid] = s
+            _print_window_summary(s, wid)
+
+    if not summaries:
+        print(
+            "ERROR: no v1 walk-forward daily rows found for any window.",
+            file=sys.stderr,
+        )
+        return 1
+
+    _print_tsv(summaries)
+
+    print("\n=== Probe questions to explore from here ===")
+    print("1. If WF-5's speed_pct_nonzero is comparable to WF-3's, speed is")
+    print("   firing similarly but contributes to AUC differently — that's")
+    print("   the regime-conditional contribution hypothesis.")
+    print("2. If WF-5's speed_pct_nonzero is materially HIGHER than WF-3's,")
+    print("   speed is overfiring in quiet — could be a calibration artifact.")
+    print("3. Cross-reference with forward 60d returns by speed.state bucket.")
+    print("   (Next probe — needs SPX join from vol_index_daily.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-on artifact from [PR #94](https://github.com/moremeds/unusual-whales/pull/94) (canary v2-A research, verdict STOP). Three small, focused additions:

1. **`docs/research/regime/canary-5yr-executive-summary.md` §14** — records the v2-A terminal verdict per spec §10 / renderer footer. Headline +0.023 AUC lift was real but concentrated in crisis regimes; WF-5 (2024 quiet) collapsed because `speed.score` was load-bearing. Interpretation: speed is an early-instability detector in quiet regimes, NOT a panic detector.

2. **`scripts/probe_canary_wf5.py`** — exploratory probe (NOT a test). Pulls v1 walk-forward daily rows for WF-1, WF-3, WF-5 from `regime_backtest_daily`, tabulates `speed.score` distribution + composite mean per window. First-pass result already meaningful:

   | Window | n | speed_mean | speed_pct_nonzero | composite_mean |
   |---|---:|---:|---:|---:|
   | WF-1 (broke even) | 504 | 9.024 | 100.0% | 25.055 |
   | WF-3 (v2 won big) | 441 | 8.390 | 90.2% | 26.307 |
   | WF-5 (v2 regressed) | 502 | 9.028 | 100.0% | 17.318 |

   Speed quiets (10% NEUTRAL days) during the COVID crisis in WF-3 — meanwhile WF-5's quiet regime has speed firing 100% of days at 8/20. Consistent with "speed = always-on early-instability signal in quiet" hypothesis.

3. **`docs/research/regime/canary-v2c-design-notes.md`** — pre-spec alignment doc for v2-C. Three candidate directions (regime-conditional weighting / rank inversion within BUY / convex blending), four pre-experiment requirements (WF-5 deep-dive, AC-F3 reformulation, regime-conditioned attribution, vol-concentration check), and the gate for the eventual spec brainstorm (pick exactly ONE of A/B/C, pre-commit AC-F1..F7 with new AC-F7 = WF-5 must not regress > −0.02).

## Scope

Pure docs + research-script scaffold. No production code touched.

- `canary-5yr-executive-summary.md`: +74 lines (new §14 section before Appendix)
- `scripts/probe_canary_wf5.py`: new, ~150 LOC
- `canary-v2c-design-notes.md`: new, ~130 lines

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/` — passes
- [x] Probe script runs against dev DB and produces the table above
- [x] No production source files touched (production behavior strictly unchanged)
- [ ] CI green (waiting)

## Next moves (post-merge)

1. Run follow-up WF-5 probes: forward 60d return by `speed.state` bucket, cross-asset signal correlations, VVIX percentile during speed-fire days
2. Pick one of v2-C direction A/B/C based on probe findings
3. Brainstorm v2-C spec with pre-committed AC-F1..F7
4. Open issue #90 (or equivalent) tracking the v2-C work