### PR TITLE
feat(vcg-ui): forward-return columns + capitulation framing

### DIFF
--- a/docs/superpowers/plans/2026-05-28-vcg-ui-capitulation-framing-plan.md
+++ b/docs/superpowers/plans/2026-05-28-vcg-ui-capitulation-framing-plan.md
@@ -1,0 +1,1312 @@
+# VCG UI Capitulation-Framing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reframe VCG stress states in the regime UI from implicit "warning" framing to data-grounded "capitulation marker" framing, by surfacing realized forward SPX returns alongside each PANIC / RISK_OFF / EDR day.
+
+**Architecture:** Backend-additive only — extend `/api/regime/vcg-validation` response with three forward-return columns per stress day (`fwd_5d_pct`, `fwd_20d_pct`, `fwd_60d_pct`) plus an aggregate summary keyed by interpretation. Frontend-additive only — three small surface changes (table columns, summary line above table, Signal-Detail context row when current state is stress) plus one tooltip update. No changes to VCG signal math, classifier, or `COMPOSITE_VERSION`.
+
+**Tech Stack:** Python 3.13 via `uv`, psycopg 3, Pydantic v2, FastAPI; Next.js 16, React 19, TypeScript, Vitest.
+
+> **Standing-rule reminder (CLAUDE.md):** "Never commit without an explicit user request." The `Commit (milestone)` steps in this plan assume the user has already authorized milestone commits for this work. **If the user has not explicitly said "commit each milestone" for this plan, pause at the first commit step and ask** — staging-only is fine until then. Drafted-then-paused is the default; do not auto-commit.
+
+---
+
+## Design Context (read before starting)
+
+This plan implements the recommendation from the 2026-05-28 VCG forward-return probe series. The probe writeup lives in session-private research and is **not committed to `main`** as of this plan's authoring; the headline numbers and methodology are summarized inline below so the plan is self-contained. If the engineer wants the full probe note, ask the user — do not chase a dangling reference.
+
+**Empirical findings driving the UI change** (from `run_id=31`, 4,710 days, 18.5yr):
+
+| Interpretation | n | mean fwd 5d % | mean fwd 20d % | mean fwd 60d % | win% 20d |
+|---|---|---|---|---|---|
+| PANIC | 83 | +0.2 | **+2.88** | +2.29 | 53.0 |
+| RISK_OFF | 133 | +0.2 | +0.15 | **+3.04** | 67.7 |
+| NORMAL | 2,070 | — | +0.80 | +2.51 | 66.1 |
+
+**Implication:** VCG's stress states mark capitulation, not impending downside. Current UI red-pill framing implies "warning" — empirically false. The fix is **information addition** (add forward-return data so users see what historically happened), not redesign (no pill-color or layout change).
+
+**Why this is safe to ship:**
+- No change to VCG math, no `COMPOSITE_VERSION` bump.
+- Contract change is purely additive (optional fields), no breaking change for any existing client.
+- All new data is derived from already-persisted `regime_backtest_daily` and `vol_index_daily` rows — no new ingestion.
+
+**BOUNCE is out of scope** (n=5, dominated by 2008 GFC; including it would mislead). Current `stress_history` `Literal` excludes BOUNCE — keep it that way.
+
+---
+
+## File Structure
+
+**Architecture clarification (post-Pass-1):** the existing handler at `src/uw_scan/api/routers/regime_validation.py:288-348` does **Python-side iteration**, not SQL aggregation. The `regime_backtest_daily` table stores stress fields inside a JSONB `payload` column (see `migrations/057_regime_backtest_results.sql`); they are NOT first-class columns. SPX close lives in `vol_index_daily` with `WHERE symbol = 'SPX'` (column `close`, not `spx_close`). Forward-return computation therefore goes in a pure-function card util consumed by the handler — not into a new storage aggregate query.
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/uw_scan/api/models/regime_validation.py` | Modify | Add 3 optional fwd-return fields to `VcgStressHistoryEntry`; add `VcgStressHistorySummary` + `VcgStressHistorySummaryRow` models; add `stress_history_summary` field to `VcgValidationResponse` |
+| `src/uw_scan/cards/regime_forward_returns.py` | **Create** | Pure functions: `attach_forward_returns(entries, spx_series)` + `summarize_stress_returns(entries)`. No DB access. |
+| `src/uw_scan/api/routers/regime_validation.py` | Modify | Load SPX series via `VolIndexRepository`, pass through card util, attach to response. Existing Python iteration over `daily` is preserved. |
+| `src/uw_scan/storage/vol_index_repository.py` | Modify (only if needed) | Add `fetch_close_series(symbol)` returning the full date-ordered list, if `fetch_multi_history` proves insufficient |
+| `tests/unit/api/test_regime_validation_models.py` | Modify/Create | Test new optional fields default to None; test summary contract |
+| `tests/unit/cards/test_regime_forward_returns.py` | Create | Unit-test the pure card functions with synthetic SPX series + entries |
+| `tests/integration/api/test_regime_validation_endpoint.py` | Modify | Endpoint includes `stress_history_summary`; stress rows include the three fwd fields |
+| `tests/snapshots/openapi/vcg-validation.json` *(actual path found at exec time)* | Regenerate | After model change |
+| `web/lib/types.ts` | Regenerate | After OpenAPI change via `npm run gen:types` |
+| `web/components/regime/vcg/VcgStressHistoryTable.tsx` | Modify | Add 3 columns: `+5d %`, `+20d %`, `+60d %` with sign-based coloring; render `—` for null |
+| `web/components/regime/vcg/VcgStressHistorySection.tsx` | Modify | Add summary line above the foldable section header showing aggregate stats |
+| `web/components/regime/VcgSubTab.tsx` | Modify | Add "Historical (5d / 20d / 60d)" row to Signal Detail card when current `interpretation` is PANIC/RISK_OFF/EDR |
+| `web/components/regime/vcg/InterpretationPill.tsx` *(or wherever the pill lives — confirm at exec time)* | Modify | Add hover tooltip with one-line forward-return context per interpretation |
+| `web/tests/unit/VcgStressHistoryTable.test.tsx` | Modify | Add tests for new columns + null handling |
+| `web/tests/unit/VcgStressHistorySection.test.tsx` | Modify/Create | Test summary line rendering |
+| `web/tests/unit/VcgSubTab.test.tsx` | Modify/Create | Test Signal Detail historical row appears only in stress states |
+
+---
+
+## Tasks
+
+### Task 0: Set up worktree and branch
+
+**Files:** none yet.
+
+- [ ] **Step 1: Create worktree**
+
+Run from `/Users/chenxi/projects/unusual-whales`:
+```bash
+git fetch origin
+git worktree add -b feat/vcg-ui-capitulation-framing .worktrees/vcg-ui-capitulation-framing origin/main
+cd .worktrees/vcg-ui-capitulation-framing
+```
+Expected: new directory `.worktrees/vcg-ui-capitulation-framing/`; `git branch --show-current` prints `feat/vcg-ui-capitulation-framing`.
+
+- [ ] **Step 2: Verify environment**
+
+```bash
+uv sync --extra postgres
+cd web && npm install && cd ..
+```
+Expected: both succeed without errors. **All subsequent tasks run from inside the worktree.**
+
+- [ ] **Step 3: Confirm baseline tests pass before changing anything**
+
+```bash
+uv run pytest tests/unit -q 2>&1 | tail -5
+cd web && npm run typecheck && npm run test -- --run 2>&1 | tail -10 ; cd ..
+```
+Expected: green. If anything is red on origin/main, stop and surface it — do not start implementation on a red baseline.
+
+---
+
+### Task 1: Extend Pydantic models (additive only)
+
+**Files:**
+- Modify: `src/uw_scan/api/models/regime_validation.py`
+- Test: `tests/unit/api/test_regime_validation_models.py` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `tests/unit/api/test_regime_validation_models.py`:
+```python
+"""Contract tests for the regime-validation Pydantic models."""
+from uw_scan.api.models.regime_validation import (
+    VcgStressHistoryEntry,
+    VcgStressHistorySummary,
+    VcgStressHistorySummaryRow,
+    VcgValidationResponse,
+)
+
+
+def test_stress_history_entry_forward_return_fields_default_none() -> None:
+    entry = VcgStressHistoryEntry(date="2020-03-16", interpretation="PANIC")
+    assert entry.fwd_5d_pct is None
+    assert entry.fwd_20d_pct is None
+    assert entry.fwd_60d_pct is None
+
+
+def test_stress_history_summary_row_shape() -> None:
+    row = VcgStressHistorySummaryRow(
+        interpretation="PANIC",
+        n=83,
+        mean_fwd_5d_pct=0.20,
+        mean_fwd_20d_pct=2.88,
+        mean_fwd_60d_pct=2.29,
+        winrate_20d_pct=53.0,
+        winrate_60d_pct=41.0,
+    )
+    assert row.n == 83
+    assert row.mean_fwd_20d_pct == 2.88
+
+
+def test_validation_response_summary_optional() -> None:
+    """stress_history_summary must default to None so we don't break
+    existing clients before backfill."""
+    resp = VcgValidationResponse(
+        backtest_md="",
+        n_days=0,
+        composite_version="2",
+        credit_proxy="HY_OAS",
+        interpretation_distribution=[],
+        named_crash_window=[],
+    )
+    assert resp.stress_history_summary is None
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+```bash
+uv run pytest tests/unit/api/test_regime_validation_models.py -v
+```
+Expected: ImportError on `VcgStressHistorySummary` / `VcgStressHistorySummaryRow`.
+
+- [ ] **Step 3: Implement model additions**
+
+Edit `src/uw_scan/api/models/regime_validation.py`:
+
+a) Extend `VcgStressHistoryEntry` (after line 84 `vvix_percentile_rank`):
+```python
+    fwd_5d_pct: float | None = None
+    fwd_20d_pct: float | None = None
+    fwd_60d_pct: float | None = None
+```
+
+b) Add new types **before** `VcgValidationResponse`:
+```python
+class VcgStressHistorySummaryRow(BaseModel):
+    """Per-interpretation aggregate of realized forward SPX returns
+    across all stress days in the backtest run."""
+
+    interpretation: Literal["PANIC", "RISK_OFF", "EDR"]
+    n: int
+    mean_fwd_5d_pct: float | None = None
+    mean_fwd_20d_pct: float | None = None
+    mean_fwd_60d_pct: float | None = None
+    winrate_20d_pct: float | None = None  # % of fwd_20d_pct > 0
+    winrate_60d_pct: float | None = None
+
+
+class VcgStressHistorySummary(BaseModel):
+    """Aggregate forward-return stats for the stress_history table."""
+
+    by_interpretation: list[VcgStressHistorySummaryRow]
+```
+
+c) Add to `VcgValidationResponse` (after `stress_history` line 96):
+```python
+    stress_history_summary: VcgStressHistorySummary | None = None
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+uv run pytest tests/unit/api/test_regime_validation_models.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Sanity-check existing tests still pass**
+
+```bash
+uv run pytest tests/unit -q 2>&1 | tail -3
+```
+Expected: green.
+
+- [ ] **Step 6: Commit (milestone)**
+
+```bash
+git add src/uw_scan/api/models/regime_validation.py tests/unit/api/test_regime_validation_models.py
+git commit -m "feat(vcg-ui): add forward-return fields + summary contract"
+```
+
+---
+
+### Task 2: Pure-function card util for forward returns + summary
+
+**Why a card util, not a storage aggregate (verified 2026-05-28 against the real code):**
+
+The existing `/api/regime/vcg-validation` handler at `src/uw_scan/api/routers/regime_validation.py:288-348` does **Python-side iteration** over the daily rows returned by `RegimeBacktestRepository.fetch_daily_for_run(run_id)`. The `regime_backtest_daily` table (per `migrations/057_regime_backtest_results.sql`) has columns `(run_id, trade_date, score, level, payload JSONB)` — fields like `pi_panic`, `vix`, `vvix`, `vix_percentile_rank`, `vvix_percentile_rank` live **inside the `payload` JSONB**, not as first-class columns. The `level` column holds the interpretation string. SPX close lives in `vol_index_daily` filtered by `WHERE symbol = 'SPX'`, column `close`. There is no `spx_close` column.
+
+So forward-return computation goes in a pure-function card util at `src/uw_scan/cards/regime_forward_returns.py` (matching the project's "share util via cards/" feedback rule). The handler loads SPX series once via `VolIndexRepository.fetch_multi_history(["SPX"], 9000)`, passes the daily list + SPX series to the card util, and gets enriched entries + a summary back. No new SQL; no new storage module.
+
+**Files:**
+- Create: `src/uw_scan/cards/regime_forward_returns.py`
+- Test: `tests/unit/cards/test_regime_forward_returns.py`
+
+- [ ] **Step 1: Sanity-check the SPX data exists**
+
+```bash
+uv run python -c "from uw_scan.config import get_settings; from psycopg import connect; s = get_settings(); c = connect(s.postgres_dsn); cur = c.cursor(); cur.execute(\"SELECT COUNT(*), MIN(trade_date), MAX(trade_date) FROM uw_scan.vol_index_daily WHERE symbol='SPX'\"); print(cur.fetchone())"
+```
+Expected: a tuple like `(4710, datetime.date(2007, 11, 26), datetime.date(2026, 5, 27))` — i.e., SPX history spans the backtest period. If the count is implausibly small or the dates don't cover `run_id=31`'s span, **stop and surface to the user before continuing**.
+
+- [ ] **Step 2: Write the failing unit test**
+
+Create `tests/unit/cards/test_regime_forward_returns.py`:
+```python
+"""Pure-function tests for regime_forward_returns.
+
+Verifies the date-aligned LEAD-by-index logic on synthetic data (no DB).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from uw_scan.cards.regime_forward_returns import (
+    attach_forward_returns,
+    summarize_stress_returns,
+)
+
+
+def _spx_series(rows: list[tuple[str, float]]) -> list[tuple[date, float]]:
+    return [(date.fromisoformat(d), c) for d, c in rows]
+
+
+def test_attach_forward_returns_basic_lead_logic() -> None:
+    spx = _spx_series(
+        [
+            ("2026-01-02", 100.0),  # entry
+            ("2026-01-03", 101.0),
+            ("2026-01-04", 102.0),
+            ("2026-01-05", 103.0),
+            ("2026-01-06", 104.0),
+            ("2026-01-07", 105.0),  # +5d from entry
+        ]
+    )
+    entries = [{"date": "2026-01-02", "interpretation": "PANIC"}]
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] == 5.0  # (105 - 100) / 100 * 100
+
+
+def test_attach_forward_returns_null_at_tail() -> None:
+    """When entry date is within `horizon` of series tail, fwd return is None."""
+    spx = _spx_series([("2026-05-25", 100.0), ("2026-05-26", 101.0), ("2026-05-27", 102.0)])
+    entries = [{"date": "2026-05-27", "interpretation": "PANIC"}]
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] is None
+
+
+def test_attach_forward_returns_handles_missing_spx_date() -> None:
+    """If the entry date isn't in the SPX series (holiday alignment), return None."""
+    spx = _spx_series([("2026-01-02", 100.0), ("2026-01-09", 101.0)])
+    entries = [{"date": "2026-01-05", "interpretation": "PANIC"}]  # holiday
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] is None
+
+
+def test_summarize_stress_returns_groups_by_interpretation() -> None:
+    enriched = [
+        {"interpretation": "PANIC", "fwd_20d_pct": 5.0, "fwd_60d_pct": 8.0},
+        {"interpretation": "PANIC", "fwd_20d_pct": -3.0, "fwd_60d_pct": 2.0},
+        {"interpretation": "PANIC", "fwd_20d_pct": None, "fwd_60d_pct": None},
+        {"interpretation": "RISK_OFF", "fwd_20d_pct": 1.0, "fwd_60d_pct": 4.0},
+    ]
+    summary = summarize_stress_returns(enriched)
+    by = {row["interpretation"]: row for row in summary}
+
+    # PANIC: n=3 total, but means / winrates skip None
+    assert by["PANIC"]["n"] == 3
+    assert by["PANIC"]["mean_fwd_20d_pct"] == 1.0  # (5 + -3) / 2
+    assert by["PANIC"]["winrate_20d_pct"] == 50.0  # 1 of 2 non-null positive
+    # RISK_OFF: n=1
+    assert by["RISK_OFF"]["n"] == 1
+    assert by["RISK_OFF"]["mean_fwd_60d_pct"] == 4.0
+
+
+def test_summarize_stress_returns_handles_all_null_horizon() -> None:
+    """If every entry has None for a horizon, mean is None (not 0, not NaN)."""
+    enriched = [
+        {"interpretation": "PANIC", "fwd_20d_pct": None, "fwd_60d_pct": None},
+    ]
+    summary = summarize_stress_returns(enriched)
+    assert summary[0]["mean_fwd_20d_pct"] is None
+    assert summary[0]["winrate_20d_pct"] is None
+
+
+def test_attach_forward_returns_rejects_unsorted_spx_series() -> None:
+    """Defensive — silent wrong fwd returns from a refactored SQL
+    dropping ORDER BY is worse than a loud crash."""
+    import pytest
+
+    unsorted = _spx_series(
+        [("2026-01-03", 101.0), ("2026-01-02", 100.0)]  # out of order
+    )
+    with pytest.raises(ValueError, match="sorted ascending"):
+        attach_forward_returns([{"date": "2026-01-02", "interpretation": "PANIC"}], unsorted)
+
+
+def test_attach_forward_returns_empty_entries() -> None:
+    """Empty entry list returns empty list (no error)."""
+    spx = _spx_series([("2026-01-02", 100.0)])
+    assert attach_forward_returns([], spx) == []
+```
+
+- [ ] **Step 3: Run — verify failure**
+
+```bash
+uv run pytest tests/unit/cards/test_regime_forward_returns.py -v
+```
+Expected: ImportError (module doesn't exist yet).
+
+- [ ] **Step 4: Implement the card util**
+
+Create `src/uw_scan/cards/regime_forward_returns.py`:
+```python
+"""Pure helpers for projecting realized forward SPX returns onto VCG
+stress-history entries, and aggregating the result by interpretation.
+
+No DB access. The handler at api/routers/regime_validation.py loads the
+SPX series and the daily entries; this module enriches and summarizes.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Iterable
+
+# Default horizons match the UI columns (+5d, +20d, +60d).
+DEFAULT_HORIZONS: tuple[int, ...] = (5, 20, 60)
+
+
+def attach_forward_returns(
+    entries: list[dict[str, Any]],
+    spx_series: list[tuple[date, float]],
+    horizons: Iterable[int] = DEFAULT_HORIZONS,
+) -> list[dict[str, Any]]:
+    """Return a new list of entry dicts, each with `fwd_{H}d_pct` keys.
+
+    spx_series must be sorted ascending by trade_date. Each entry's date
+    is matched against the series; the close N trading days later is
+    looked up by index. Missing dates or tail-overhangs produce None.
+
+    Returns a shallow-copied list of dicts so the input is not mutated.
+
+    Raises ValueError if spx_series is not sorted ascending — defensive
+    check against a future SQL refactor dropping the ORDER BY in
+    VolIndexRepository.fetch_multi_history. Silent wrong fwd returns
+    are worse than a loud crash.
+    """
+    for i in range(len(spx_series) - 1):
+        if spx_series[i][0] > spx_series[i + 1][0]:
+            raise ValueError(
+                f"spx_series must be sorted ascending by date; "
+                f"index {i} ({spx_series[i][0]}) > index {i+1} ({spx_series[i+1][0]})"
+            )
+    date_to_index = {d: i for i, (d, _) in enumerate(spx_series)}
+    closes = [c for _, c in spx_series]
+    horizons = tuple(horizons)
+
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        enriched = dict(entry)  # shallow copy; do not mutate input
+        entry_date = _parse_date(entry.get("date"))
+        idx = date_to_index.get(entry_date) if entry_date else None
+        for h in horizons:
+            key = f"fwd_{h}d_pct"
+            if idx is None:
+                enriched[key] = None
+                continue
+            future_idx = idx + h
+            if future_idx >= len(closes):
+                enriched[key] = None
+                continue
+            base = closes[idx]
+            future = closes[future_idx]
+            if base is None or future is None or base == 0:
+                enriched[key] = None
+                continue
+            enriched[key] = (future - base) / base * 100.0
+        out.append(enriched)
+    return out
+
+
+def summarize_stress_returns(
+    enriched_entries: list[dict[str, Any]],
+    horizons: Iterable[int] = DEFAULT_HORIZONS,
+) -> list[dict[str, Any]]:
+    """Group entries by `interpretation`; for each group return
+    {interpretation, n, mean_fwd_{H}d_pct, winrate_{H}d_pct} for
+    H in horizons.
+
+    `n` is the total entry count (including those with None fwd values).
+    `mean_*` and `winrate_*` skip None values; if every value for a
+    horizon is None, the aggregate is None (not 0, not NaN).
+    """
+    horizons = tuple(horizons)
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for entry in enriched_entries:
+        interp = entry.get("interpretation")
+        if not interp:
+            continue
+        groups.setdefault(interp, []).append(entry)
+
+    out: list[dict[str, Any]] = []
+    for interp in sorted(groups):
+        rows = groups[interp]
+        row: dict[str, Any] = {"interpretation": interp, "n": len(rows)}
+        for h in horizons:
+            key = f"fwd_{h}d_pct"
+            values = [r[key] for r in rows if r.get(key) is not None]
+            row[f"mean_{key}"] = (
+                sum(values) / len(values) if values else None
+            )
+            if values:
+                wins = sum(1 for v in values if v > 0)
+                row[f"winrate_{h}d_pct"] = wins / len(values) * 100.0
+            else:
+                row[f"winrate_{h}d_pct"] = None
+        out.append(row)
+    return out
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+```
+
+> **Important — interpretation Literal narrowness:** the existing `VcgStressHistoryEntry.interpretation` is `Literal["PANIC", "RISK_OFF", "EDR"]`. `summarize_stress_returns` accepts arbitrary string interpretations but in production the handler only ever passes these three (the handler at `regime_validation.py:327` filters `stress_levels = {"PANIC", "RISK_OFF", "EDR"}`). Do NOT change the Literal in Task 1 to include BOUNCE — that is explicitly out of scope per the design context.
+
+- [ ] **Step 5: Verify tests pass**
+
+```bash
+uv run pytest tests/unit/cards/test_regime_forward_returns.py -v
+```
+Expected: green.
+
+- [ ] **Step 6: Sanity-check the broader unit suite still passes**
+
+```bash
+uv run pytest tests/unit -q 2>&1 | tail -3
+```
+Expected: green. (No existing test should reference `regime_forward_returns` yet.)
+
+- [ ] **Step 7: Commit (milestone — pending user authorization per top-of-plan note)**
+
+```bash
+git add src/uw_scan/cards/regime_forward_returns.py tests/unit/cards/test_regime_forward_returns.py
+git commit -m "feat(vcg-ui): pure card util for forward-return projection + summary"
+```
+
+---
+
+### Task 3: Wire the card util into the endpoint handler
+
+**Files:**
+- Modify: `src/uw_scan/api/routers/regime_validation.py` (handler at lines 288-348)
+- Test: `tests/integration/api/test_regime_validation_endpoint.py` (or whatever the existing endpoint test file is — confirm at exec time)
+
+- [ ] **Step 1: Read the existing handler and identify call sites**
+
+```bash
+grep -n "VcgValidationResponse\|stress_history\b\|fetch_daily_for_run" src/uw_scan/api/routers/regime_validation.py
+```
+Expected: confirms the handler structure — `rb.find_latest_run("vcg")` → `rb.fetch_daily_for_run(run["id"])` → Python-iter → `VcgValidationResponse(...)`.
+
+- [ ] **Step 2: Write the failing endpoint integration test**
+
+Add to the existing endpoint test file (or create `tests/integration/api/test_regime_validation_endpoint.py` if absent):
+```python
+def test_vcg_validation_includes_stress_history_summary(test_client) -> None:
+    """The endpoint must expose stress_history_summary and per-entry
+    forward-return fields. Values may be null (no SPX data, recent
+    tail) — structural check only."""
+    resp = test_client.get("/api/regime/vcg-validation")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Summary structure
+    assert "stress_history_summary" in body
+    summary = body["stress_history_summary"]
+    assert summary is not None
+    assert "by_interpretation" in summary
+
+    # Per-entry structure
+    sh = body["stress_history"]
+    assert sh, "expected non-empty stress_history in seeded backtest"
+    first = sh[0]
+    for key in ("fwd_5d_pct", "fwd_20d_pct", "fwd_60d_pct"):
+        assert key in first, f"missing {key} on stress_history entry"
+
+
+def test_vcg_validation_summary_values_match_published_probes(test_client) -> None:
+    """Numeric check against the published probe note values.
+    Gated by env flag — only runs when the local DB has the production
+    backtest (run_id=31, 4,710 days). CI seeds do not satisfy this."""
+    import os
+    if os.getenv("VCG_FULL_BACKTEST_AVAILABLE") != "1":
+        import pytest
+        pytest.skip("requires production backtest fixture (set VCG_FULL_BACKTEST_AVAILABLE=1 locally)")
+    import math
+
+    resp = test_client.get("/api/regime/vcg-validation")
+    body = resp.json()
+    by = {row["interpretation"]: row for row in body["stress_history_summary"]["by_interpretation"]}
+
+    # Published probe values (docs/research/regime/vcg-forward-return-probes-2026-05-28.md):
+    assert by["PANIC"]["n"] == 83
+    assert math.isclose(by["PANIC"]["mean_fwd_20d_pct"], 2.88, abs_tol=0.05)
+    assert by["RISK_OFF"]["n"] == 133
+    assert math.isclose(by["RISK_OFF"]["mean_fwd_60d_pct"], 3.04, abs_tol=0.05)
+```
+
+> **Why split into two tests:** the structural test runs on any fixture (including CI-seeded small datasets); the numeric-match test is gated behind `VCG_FULL_BACKTEST_AVAILABLE=1` so the brittle probe values don't fail CI on small seeds. Local devs running against the production warm-store get the full check.
+
+- [ ] **Step 3: Run — verify structural test fails**
+
+```bash
+uv run pytest tests/integration/api/test_regime_validation_endpoint.py -v -k stress_history_summary
+```
+Expected: KeyError or schema-validation failure (the response model doesn't have `stress_history_summary` populated yet, and entries lack fwd keys).
+
+- [ ] **Step 4: Wire the card util into the handler**
+
+Edit `src/uw_scan/api/routers/regime_validation.py`.
+
+**Step 4a — add imports at module top** (NOT inside the function body):
+```python
+from uw_scan.api.models.regime_validation import (
+    ...,  # existing imports
+    VcgStressHistorySummary,
+    VcgStressHistorySummaryRow,
+)
+from uw_scan.cards.regime_forward_returns import (
+    attach_forward_returns,
+    summarize_stress_returns,
+)
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+```
+
+**Step 4b — add enrichment block** after the existing `stress_history` Python loop ends (around line 348) but before the `return VcgValidationResponse(...)` (line 349):
+
+```python
+# Forward-return enrichment. Skip the SPX load entirely if no stress
+# days were emitted in this run — common for runs early in calibration
+# work, no point spending the query.
+stress_history_summary: VcgStressHistorySummary | None = None
+if stress_history:
+    # VolIndexRepository instantiation follows the existing pattern at
+    # line 289 (`RegimeBacktestRepository(repo.conn, schema=repo._schema)`).
+    # `repo._schema` is technically private but every router in this file
+    # accesses it the same way; do not break the convention here.
+    vix_repo = VolIndexRepository(repo.conn, schema=repo._schema)
+    # 9000-day window covers the full 18.5yr backtest with headroom.
+    spx_rows = vix_repo.fetch_multi_history(["SPX"], 9000).get("SPX", [])
+    spx_series = [(r["trade_date"], r["close"]) for r in spx_rows]
+
+    # Convert VcgStressHistoryEntry → plain dicts for the (intentionally
+    # Pydantic-naive) card util, enrich, then rebind stress_history to
+    # the typed-reconstructed list. Original entries get GC'd.
+    entry_dicts = [e.model_dump() for e in stress_history]
+    enriched_dicts = attach_forward_returns(entry_dicts, spx_series)
+    stress_history = [VcgStressHistoryEntry(**d) for d in enriched_dicts]
+
+    # summarize_stress_returns inherits the handler's stress filter
+    # (PANIC/RISK_OFF/EDR) implicitly via VcgStressHistorySummaryRow's
+    # `Literal["PANIC","RISK_OFF","EDR"]` — passing any other
+    # interpretation here would raise Pydantic ValidationError, which
+    # is the right behavior if the stress set ever expands.
+    summary_rows = summarize_stress_returns(enriched_dicts)
+    stress_history_summary = VcgStressHistorySummary(
+        by_interpretation=[
+            VcgStressHistorySummaryRow(
+                interpretation=row["interpretation"],
+                n=row["n"],
+                mean_fwd_5d_pct=row.get("mean_fwd_5d_pct"),
+                mean_fwd_20d_pct=row.get("mean_fwd_20d_pct"),
+                mean_fwd_60d_pct=row.get("mean_fwd_60d_pct"),
+                winrate_20d_pct=row.get("winrate_20d_pct"),
+                winrate_60d_pct=row.get("winrate_60d_pct"),
+            )
+            for row in summary_rows
+        ]
+    )
+```
+
+**Step 4c — pass through to response:** Add `stress_history_summary=stress_history_summary` to the `VcgValidationResponse(...)` call. The field is `Optional` per Task 1; when `stress_history` is empty, it stays `None` and the frontend conditional renders nothing.
+
+> **Why convert to dicts and back:** the card util is pure-Python on dicts for testability (no Pydantic dependency in `cards/`). The cost is two `model_dump()` + `VcgStressHistoryEntry(**d)` round-trips per request; on a stress_history of ~265 entries this is sub-millisecond. If profiling later shows this is hot, refactor the card util to take Pydantic models directly.
+
+- [ ] **Step 5: Verify structural test passes**
+
+```bash
+uv run pytest tests/integration/api/test_regime_validation_endpoint.py -v -k stress_history_summary
+```
+Expected: PASS.
+
+- [ ] **Step 6: Verify numeric-match test passes against production DB**
+
+```bash
+VCG_FULL_BACKTEST_AVAILABLE=1 uv run pytest tests/integration/api/test_regime_validation_endpoint.py -v -k summary_values_match
+```
+Expected: PASS if you're running against the warm-store with `run_id=31`. If you're on a CI-seeded small DB, the test will SKIP (which is intentional).
+
+If the numeric check fails with mean_fwd_20d_pct deviating from 2.88 by more than 0.05, **stop**: re-derive the probe value from a direct SQL query before adjusting the test. Do not loosen the tolerance.
+
+- [ ] **Step 7: Sanity-check broader integration suite still passes**
+
+```bash
+uv run pytest tests/integration -q -m "not live and not slow" 2>&1 | tail -3
+```
+Expected: green.
+
+- [ ] **Step 8: Commit (milestone — pending user authorization)**
+
+```bash
+git add src/uw_scan/api/routers/regime_validation.py tests/integration/api/test_regime_validation_endpoint.py
+git commit -m "feat(vcg-ui): expose stress_history_summary + fwd returns on /vcg-validation"
+```
+
+---
+
+### Task 4: Regenerate OpenAPI snapshot + frontend types
+
+**Files:**
+- Regenerate: OpenAPI snapshot (path varies — see snapshot test)
+- Regenerate: `web/lib/types.ts`
+
+- [ ] **Step 1: Find snapshot test path**
+
+```bash
+grep -rn "openapi" tests/unit/ tests/integration/ 2>/dev/null | grep -i snapshot | head -5
+```
+
+- [ ] **Step 2: Run snapshot test in update mode**
+
+If the project uses `pytest --snapshot-update`:
+```bash
+uv run pytest tests/<snapshot-path> --snapshot-update -v
+```
+Otherwise, run the regeneration script referenced by the existing snapshot test (look for a `regenerate` or `--update` flag).
+
+- [ ] **Step 3: Regenerate web types**
+
+```bash
+cd web && npm run gen:types && cd ..
+git diff --stat web/lib/types.ts
+```
+Expected: diff shows `VcgStressHistoryEntry` gained 3 fields and `VcgValidationResponse` gained `stress_history_summary`. Verify no unrelated drift.
+
+- [ ] **Step 4: Verify frontend typecheck still passes**
+
+```bash
+cd web && npm run typecheck 2>&1 | tail -3
+```
+Expected: green (existing call sites are unaffected because the new fields are optional).
+
+- [ ] **Step 5: Commit (milestone)**
+
+```bash
+git add tests/<snapshot-path>/* web/lib/types.ts
+git commit -m "chore(openapi): regenerate snapshot + types for stress-history forward returns"
+```
+
+---
+
+### Task 5: Add forward-return columns to `VcgStressHistoryTable`
+
+**Files:**
+- Modify: `web/components/regime/vcg/VcgStressHistoryTable.tsx`
+- Modify: `web/tests/unit/VcgStressHistoryTable.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/tests/unit/VcgStressHistoryTable.test.tsx`:
+```typescript
+it("renders +5d / +20d / +60d forward-return cells with sign coloring", () => {
+  const rows: Row[] = [
+    {
+      date: "2020-03-16",
+      interpretation: "PANIC",
+      score: -3.2, vcg_adj: -3.2, pi_panic: 1.5, sign_ok: true,
+      vix: 80, vvix: 130,
+      vix_percentile_rank: 0.99, vvix_percentile_rank: 0.99,
+      fwd_5d_pct: -8.5,
+      fwd_20d_pct: 15.3,
+      fwd_60d_pct: 22.1,
+    },
+  ];
+  const { container } = render(<VcgStressHistoryTable rows={rows} />);
+  const row = container.querySelector('[data-testid="vcg-stress-row-2020-03-16"]');
+  const cells = row?.querySelectorAll("td");
+  // Columns 9, 10, 11 are +5d / +20d / +60d
+  expect(cells?.[9]?.textContent).toMatch(/-8\.5/);
+  expect(cells?.[10]?.textContent).toMatch(/\+15\.3/);
+  expect(cells?.[11]?.textContent).toMatch(/\+22\.1/);
+  // Negative fwd_5d should be red; positive should be green
+  expect((cells?.[9] as HTMLElement).style.color).toContain("var(--fault");
+  expect((cells?.[10] as HTMLElement).style.color).toContain("var(--ok");
+});
+
+it("renders '—' for null forward-return cells (recent days)", () => {
+  const rows: Row[] = [
+    {
+      date: "2026-05-27",
+      interpretation: "RISK_OFF",
+      score: -1.9, vcg_adj: -1.9, pi_panic: 0, sign_ok: true,
+      vix: 25, vvix: 110,
+      vix_percentile_rank: 0.7, vvix_percentile_rank: 0.6,
+      fwd_5d_pct: 0.5,
+      fwd_20d_pct: null,
+      fwd_60d_pct: null,
+    },
+  ];
+  const { container } = render(<VcgStressHistoryTable rows={rows} />);
+  const row = container.querySelector('[data-testid="vcg-stress-row-2026-05-27"]');
+  const cells = row?.querySelectorAll("td");
+  expect(cells?.[10]?.textContent).toBe("—");
+  expect(cells?.[11]?.textContent).toBe("—");
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+cd web && npm run test -- --run VcgStressHistoryTable 2>&1 | tail -15 ; cd ..
+```
+Expected: assertions on cells[9..11] fail because the columns don't exist yet.
+
+- [ ] **Step 3: Read existing component and add 3 columns**
+
+Open `web/components/regime/vcg/VcgStressHistoryTable.tsx`. Locate the `<thead>` and add three columns at the end of the header row:
+```tsx
+<th
+  scope="col"
+  onClick={() => toggleSort("fwd_5d_pct")}
+  style={{ cursor: "pointer", textAlign: "right" }}
+>
+  +5d %
+</th>
+<th
+  scope="col"
+  onClick={() => toggleSort("fwd_20d_pct")}
+  style={{ cursor: "pointer", textAlign: "right" }}
+>
+  +20d %
+</th>
+<th
+  scope="col"
+  onClick={() => toggleSort("fwd_60d_pct")}
+  style={{ cursor: "pointer", textAlign: "right" }}
+>
+  +60d %
+</th>
+```
+
+Add a helper inside the component (or import from a shared util):
+```tsx
+function renderFwdCell(value: number | null | undefined) {
+  if (value == null || Number.isNaN(value)) {
+    return <td style={{ textAlign: "right", color: "var(--text-muted)" }}>—</td>;
+  }
+  const color = value > 0 ? "var(--ok-fg)" : value < 0 ? "var(--fault-fg)" : "var(--text-primary)";
+  const sign = value > 0 ? "+" : "";
+  return (
+    <td style={{ textAlign: "right", color, fontFamily: "var(--font-mono)" }}>
+      {sign}
+      {value.toFixed(1)}
+    </td>
+  );
+}
+```
+
+In the `<tbody>` row mapping, append after the existing cells:
+```tsx
+{renderFwdCell(row.fwd_5d_pct)}
+{renderFwdCell(row.fwd_20d_pct)}
+{renderFwdCell(row.fwd_60d_pct)}
+```
+
+> If the existing component uses different CSS-var names for green/red (e.g. `--text-positive` instead of `--ok-fg`), use the existing convention — `grep` the file for current sign-coloring before adding.
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+cd web && npm run test -- --run VcgStressHistoryTable 2>&1 | tail -5 ; cd ..
+```
+Expected: green.
+
+- [ ] **Step 5: Commit (milestone)**
+
+```bash
+git add web/components/regime/vcg/VcgStressHistoryTable.tsx web/tests/unit/VcgStressHistoryTable.test.tsx
+git commit -m "feat(vcg-ui): add forward-return columns to stress-history table"
+```
+
+---
+
+### Task 6: Add summary line above the stress-history section
+
+**Files:**
+- Modify: `web/components/regime/vcg/VcgStressHistorySection.tsx`
+- Create/modify: `web/tests/unit/VcgStressHistorySection.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+Create `web/tests/unit/VcgStressHistorySection.test.tsx` (or extend if it exists):
+```typescript
+/* @vitest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import VcgStressHistorySection from "@/components/regime/vcg/VcgStressHistorySection";
+
+const FIXTURE = {
+  backtest_md: "",
+  n_days: 4710,
+  composite_version: "2",
+  credit_proxy: "HY_OAS",
+  interpretation_distribution: [],
+  named_crash_window: [],
+  stress_history: [],
+  stress_history_summary: {
+    by_interpretation: [
+      {
+        interpretation: "PANIC",
+        n: 83,
+        mean_fwd_5d_pct: 0.2,
+        mean_fwd_20d_pct: 2.88,
+        mean_fwd_60d_pct: 2.29,
+        winrate_20d_pct: 53.0,
+        winrate_60d_pct: 41.0,
+      },
+      {
+        interpretation: "RISK_OFF",
+        n: 133,
+        mean_fwd_5d_pct: 0.2,
+        mean_fwd_20d_pct: 0.15,
+        mean_fwd_60d_pct: 3.04,
+        winrate_20d_pct: 67.7,
+        winrate_60d_pct: 74.4,
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => FIXTURE,
+  } as Response);
+});
+
+describe("VcgStressHistorySection summary line", () => {
+  it("renders aggregate stats for PANIC and RISK_OFF", async () => {
+    render(<VcgStressHistorySection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("vcg-stress-summary")).toBeDefined();
+    });
+    const summary = screen.getByTestId("vcg-stress-summary");
+    expect(summary.textContent).toMatch(/83 historical PANIC/);
+    expect(summary.textContent).toMatch(/\+2\.88/);
+    expect(summary.textContent).toMatch(/133 RISK_OFF/);
+    expect(summary.textContent).toMatch(/\+3\.04/);
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+```bash
+cd web && npm run test -- --run VcgStressHistorySection 2>&1 | tail -10 ; cd ..
+```
+Expected: `vcg-stress-summary` testid not found.
+
+- [ ] **Step 3: Add the summary line**
+
+Edit `web/components/regime/vcg/VcgStressHistorySection.tsx`. Before the `<button ... section-header>` element (around line 58), add:
+
+```tsx
+{data?.stress_history_summary && (
+  <div
+    data-testid="vcg-stress-summary"
+    style={{
+      fontSize: "11px",
+      fontFamily: "var(--font-mono)",
+      color: "var(--text-secondary)",
+      marginBottom: "8px",
+      lineHeight: 1.5,
+    }}
+  >
+    {data.stress_history_summary.by_interpretation.map((row) => (
+      <div key={row.interpretation}>
+        Across {row.n} historical {row.interpretation} events, mean 20d
+        forward SPX return was{" "}
+        <span
+          style={{
+            color:
+              (row.mean_fwd_20d_pct ?? 0) > 0
+                ? "var(--ok-fg)"
+                : "var(--fault-fg)",
+          }}
+        >
+          {(row.mean_fwd_20d_pct ?? 0) >= 0 ? "+" : ""}
+          {row.mean_fwd_20d_pct?.toFixed(2)}%
+        </span>{" "}
+        ({row.winrate_20d_pct?.toFixed(0)}% positive).
+      </div>
+    ))}
+  </div>
+)}
+```
+
+> Filter out EDR from the rendered summary lines if it adds noise (the user's design called out PANIC + RISK_OFF specifically). Add `.filter(r => r.interpretation !== "EDR")` if so.
+
+- [ ] **Step 4: Verify test passes**
+
+```bash
+cd web && npm run test -- --run VcgStressHistorySection 2>&1 | tail -5 ; cd ..
+```
+Expected: green.
+
+- [ ] **Step 5: Commit (milestone)**
+
+```bash
+git add web/components/regime/vcg/VcgStressHistorySection.tsx web/tests/unit/VcgStressHistorySection.test.tsx
+git commit -m "feat(vcg-ui): summary line above stress-history table"
+```
+
+---
+
+### Task 7: Historical-context row in Signal Detail card
+
+**Architecture discovery (Pass 6, 2026-05-28):** `VcgSubTab.tsx` uses `useVcg()` (hits `/api/regime/vcg` — current state) and renders `<VcgStressHistorySection />` (which independently fetches `/api/regime/vcg-validation`). The two components do NOT share the validation response. The "Signal Detail historical row" requires the validation summary, so we have three options:
+
+- **Option A (faithful to original design):** VcgSubTab adds a second `useEffect` to fetch `/api/regime/vcg-validation`'s `stress_history_summary`. Cost: extra HTTP roundtrip per page load. Benefit: row appears in Signal Detail card next to current state — strongest UX signal when user is currently in stress.
+- **Option B (lift state up):** Move VcgStressHistorySection's fetch into VcgSubTab and pass the response down. Cost: bigger refactor of an already-shipped component. Benefit: one fetch, one source of truth.
+- **Option C (MVP — recommended):** **Skip the Signal Detail row.** The summary line in StressHistorySection (Task 6) already conveys the historical context. The row was an upsell for "you're in a stress state RIGHT NOW" — but the user can see the same data by scrolling to the stress-history section. Cost: weaker UX coupling. Benefit: zero architectural change, ships faster.
+
+> **Recommendation:** Default to Option C for the first ship. Re-evaluate Option A in a follow-up PR if user testing shows people miss the historical context when in a stress state.
+
+**If Option C is chosen, SKIP this entire task — proceed to Task 8.** If Option A is chosen, follow the steps below.
+
+**Files (Option A only):**
+- Modify: `web/components/regime/VcgSubTab.tsx`
+- Create/modify: `web/tests/unit/VcgSubTab.test.tsx`
+
+- [ ] **Step 1: Read existing Signal Detail layout**
+
+```bash
+grep -n "Signal Detail\|signal-detail\|interpretation" web/components/regime/VcgSubTab.tsx | head -20
+```
+
+Identify the current `interpretation` source. Per `useVcg.ts`, it lives in the `VcgResponse` from `/api/regime/vcg`. The new row should appear only when `currentInterpretation in {"PANIC", "RISK_OFF", "EDR"}`. The summary data needs a separate fetch — add a `useEffect` similar to the one in `VcgStressHistorySection.tsx:28-51` (fetch `regimeApi.vcgValidation()`, store in state).
+
+- [ ] **Step 2: Write failing test**
+
+Create `web/tests/unit/VcgSubTab.test.tsx`:
+```typescript
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+// Import as default or named depending on file's actual export
+import VcgSubTab from "@/components/regime/VcgSubTab";
+
+const summaryFixture = {
+  by_interpretation: [
+    {
+      interpretation: "PANIC",
+      n: 83,
+      mean_fwd_5d_pct: 0.2,
+      mean_fwd_20d_pct: 2.88,
+      mean_fwd_60d_pct: 2.29,
+      winrate_20d_pct: 53.0,
+      winrate_60d_pct: 41.0,
+    },
+  ],
+};
+
+describe("VcgSubTab Signal Detail historical context", () => {
+  it("renders historical-fwd row when current interpretation is PANIC", () => {
+    render(
+      <VcgSubTab
+        currentState={{ interpretation: "PANIC", /* other required props */ }}
+        stressHistorySummary={summaryFixture}
+      />
+    );
+    const row = screen.queryByTestId("vcg-signal-detail-historical");
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toMatch(/\+0\.2.*\+2\.88.*\+2\.29/);
+    expect(row?.textContent).toMatch(/n=83/);
+  });
+
+  it("does NOT render historical-fwd row when current interpretation is NORMAL", () => {
+    render(
+      <VcgSubTab
+        currentState={{ interpretation: "NORMAL" }}
+        stressHistorySummary={summaryFixture}
+      />
+    );
+    expect(screen.queryByTestId("vcg-signal-detail-historical")).toBeNull();
+  });
+});
+```
+
+> **Calibrate the test props to the actual `VcgSubTab` prop shape during execution** — the component is a real page wiring, and the prop names will differ. The two behaviors that must hold are: (1) row appears for PANIC/RISK_OFF/EDR, (2) row hides for NORMAL/SUPPRESSED.
+
+- [ ] **Step 3: Add the historical-context row**
+
+In `VcgSubTab.tsx`, in the Signal Detail card JSX, find where current `interpretation` is rendered. Just below it, conditionally render:
+
+```tsx
+{(["PANIC", "RISK_OFF", "EDR"].includes(currentInterpretation) &&
+  stressSummary?.by_interpretation.find(
+    (r) => r.interpretation === currentInterpretation,
+  )) && (() => {
+  const row = stressSummary!.by_interpretation.find(
+    (r) => r.interpretation === currentInterpretation,
+  )!;
+  const fmt = (v: number | null | undefined) =>
+    v == null ? "—" : `${v >= 0 ? "+" : ""}${v.toFixed(1)}%`;
+  return (
+    <div
+      data-testid="vcg-signal-detail-historical"
+      style={{
+        marginTop: "4px",
+        fontSize: "11px",
+        color: "var(--text-secondary)",
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      Historical fwd (5d / 20d / 60d): {fmt(row.mean_fwd_5d_pct)} /{" "}
+      {fmt(row.mean_fwd_20d_pct)} / {fmt(row.mean_fwd_60d_pct)} (n={row.n},{" "}
+      {row.winrate_20d_pct?.toFixed(0)}% pos 20d)
+    </div>
+  );
+})()}
+```
+
+- [ ] **Step 4: Verify test passes**
+
+```bash
+cd web && npm run test -- --run VcgSubTab 2>&1 | tail -5 ; cd ..
+```
+Expected: green.
+
+- [ ] **Step 5: Commit (milestone)**
+
+```bash
+git add web/components/regime/VcgSubTab.tsx web/tests/unit/VcgSubTab.test.tsx
+git commit -m "feat(vcg-ui): historical-fwd row in Signal Detail card"
+```
+
+---
+
+### Task 8: Interpretation-pill tooltip
+
+**Files:**
+- Locate: `grep -rn "interpretation\b.*PANIC\|pill" web/components/regime/ | head` to find the pill component
+- Modify: that pill component
+- Modify/Create: unit test for the pill
+
+- [ ] **Step 1: Find the existing pill component**
+
+```bash
+grep -rln "PANIC\|RISK_OFF" web/components/regime/ | head -5
+grep -n "interpretation" web/components/regime/vcg/VcgStressHistoryTable.tsx | head -5
+```
+
+The pill is rendered inline in the table; identify whether it's a dedicated component or inline JSX with a `getInterpretationStyle()` helper. If inline, factor a tiny `InterpretationPill.tsx` component **only if** the same JSX is duplicated in 3+ places. Otherwise, modify in place.
+
+- [ ] **Step 2: Write failing test**
+
+Add to the appropriate test file (or extend `VcgStressHistoryTable.test.tsx`):
+```typescript
+it("interpretation pill has tooltip with historical forward-return summary", () => {
+  const rows: Row[] = [
+    {
+      date: "2020-03-16",
+      interpretation: "PANIC",
+      score: -3.2, vcg_adj: -3.2, pi_panic: 1.5, sign_ok: true,
+      vix: 80, vvix: 130,
+      vix_percentile_rank: 0.99, vvix_percentile_rank: 0.99,
+      fwd_5d_pct: -8.5, fwd_20d_pct: 15.3, fwd_60d_pct: 22.1,
+    },
+  ];
+  const { container } = render(<VcgStressHistoryTable rows={rows} />);
+  const pill = container.querySelector('[data-testid="interpretation-pill-PANIC"]');
+  expect(pill?.getAttribute("title")).toMatch(/capitulation/i);
+  expect(pill?.getAttribute("title")).toMatch(/\+2\.88|forward 20d/);
+});
+```
+
+- [ ] **Step 3: Run — verify fail**
+
+```bash
+cd web && npm run test -- --run interpretation-pill 2>&1 | tail -5 ; cd ..
+```
+Expected: testid missing or title attribute missing.
+
+- [ ] **Step 4: Add tooltip + testid to pill**
+
+Update the pill rendering. Replace the existing pill `<span>` with:
+```tsx
+<span
+  data-testid={`interpretation-pill-${row.interpretation}`}
+  title={
+    row.interpretation === "PANIC"
+      ? "PANIC — acute stress capitulation marker. Historical 20d forward SPX: +2.88% mean (n=83, 53% positive). Marks capitulation moments, not future drawdowns."
+      : row.interpretation === "RISK_OFF"
+      ? "RISK_OFF — sustained vol-complex stress. Historical 60d forward SPX: +3.04% mean (n=133, 74% positive). Indistinguishable from baseline drift at 60d."
+      : row.interpretation === "EDR"
+      ? "EDR — elevated daily risk. Subset of stress days that did not meet PANIC/RISK_OFF thresholds."
+      : undefined
+  }
+  style={existingPillStyle}
+>
+  {label}
+</span>
+```
+
+> Keep all existing styling unchanged. The tooltip is `title` for a no-dep solution. If the repo has a tooltip primitive (look for `Tooltip` in `web/components/ui/`), prefer that over `title` for a richer experience — but `title` is acceptable for v1.
+
+- [ ] **Step 5: Verify test passes**
+
+```bash
+cd web && npm run test -- --run VcgStressHistoryTable 2>&1 | tail -5 ; cd ..
+```
+Expected: green, including the new tooltip test.
+
+- [ ] **Step 6: Commit (milestone)**
+
+```bash
+git add web/components/regime/
+git commit -m "feat(vcg-ui): tooltip on interpretation pills with historical context"
+```
+
+---
+
+### Task 9: Browser verification
+
+**Files:** none changed; this is verification only.
+
+- [ ] **Step 1: Start dev stack**
+
+```bash
+bash scripts/dev.sh &
+# Wait for web on :3001 and API on :8400
+sleep 15
+```
+
+- [ ] **Step 2: Open `/regime` in browser**
+
+```bash
+open http://localhost:3001/regime
+```
+Manually confirm in the VCG sub-tab:
+- The "PANIC / RISK-OFF / EDR History (all-time)" section header still works (still folds/unfolds).
+- Above it, the summary line(s) render: "Across 83 historical PANIC events, mean 20d forward SPX return was +2.88% (53% positive)."
+- Inside the table, three new columns appear at the right: `+5d %`, `+20d %`, `+60d %`. Positive values are green, negative are red, recent days show `—` for `+60d %`.
+- Hovering a PANIC pill shows the tooltip text.
+- If the Signal Detail card currently shows a stress state, the "Historical fwd" row appears underneath the interpretation.
+
+- [ ] **Step 3: Take a "before/after" screenshot for the PR**
+
+```bash
+mkdir -p output/playwright
+# Use Playwright or browser screenshot tooling
+# Save to:
+#   output/playwright/2026-05-28-vcg-stress-history-with-fwd-returns.png
+```
+
+- [ ] **Step 4: Sanity-check the API directly**
+
+```bash
+curl -s http://localhost:8400/api/regime/vcg-validation | jq '.stress_history_summary, .stress_history[0]'
+```
+Expected: `stress_history_summary` populated with 2-3 rows (PANIC/RISK_OFF/EDR); first stress_history row has `fwd_5d_pct`, `fwd_20d_pct`, `fwd_60d_pct` keys (may be null on recent days).
+
+- [ ] **Step 5: Stop dev stack**
+
+```bash
+# Find and kill the dev.sh process group
+ps aux | grep -E "dev\.sh|next dev|uvicorn" | grep -v grep
+# kill <pids>
+```
+
+---
+
+### Task 10: Final verification + PR
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+uv run pytest tests/unit -q && uv run pytest tests/integration -q -m "not live and not slow"
+cd web && npm run typecheck && npm run test -- --run ; cd ..
+```
+Expected: all green.
+
+- [ ] **Step 2: Confirm OpenAPI snapshot, types, and frontend are in sync**
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+```
+Expected: no unstaged or untracked changes; diff stat shows the 10-15 files touched.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/vcg-ui-capitulation-framing
+gh pr create --title "feat(vcg-ui): forward-return columns + capitulation framing" --body "$(cat <<'EOF'
+## Summary
+- Reframes the VCG stress-history UI to show what historically happened *after* each PANIC / RISK_OFF / EDR day, instead of relying on red-pill framing that implies "warning."
+- Backend-additive: `VcgStressHistoryEntry` gains `fwd_5d_pct`, `fwd_20d_pct`, `fwd_60d_pct`; `VcgValidationResponse` gains optional `stress_history_summary`. No `COMPOSITE_VERSION` bump.
+- Frontend-additive: 3 columns on the stress-history table, 1 summary line above, 1 historical-fwd row in the Signal Detail card when current state is stress, 1 tooltip on the interpretation pill.
+- Grounded in 13 forward-return probes documented at `docs/research/regime/vcg-forward-return-probes-2026-05-28.md` (PANIC mean 20d = +2.88%, RISK_OFF mean 60d = +3.04%).
+
+## Test plan
+- [ ] `uv run pytest tests/unit tests/integration -m "not live and not slow"` green
+- [ ] `cd web && npm run typecheck && npm run test -- --run` green
+- [ ] Manual: open `/regime` VCG sub-tab — new columns + summary + tooltip render correctly
+- [ ] Manual: open `/regime` VCG sub-tab — Signal Detail card shows historical-fwd row only when current state is PANIC/RISK_OFF/EDR
+
+## What this does NOT change
+- VCG signal math, classifier, cascade logic, `COMPOSITE_VERSION`
+- Stress state assignment for any historical day
+- Other regime indicators (CRI, Canary, GEX cockpit)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for CI to be green, then merge via `gh pr merge`**
+
+Do **not** `git push origin main` directly — per project standing rule, always merge via PR.
+
+---
+
+## Standing-rule checklist (run before declaring done)
+
+- [ ] **`uv` only** — no bare `python`/`pip`/`pytest` in any task command. ✅ (all backend commands use `uv run pytest`).
+- [ ] **Persist analytical results to Postgres** — no in-memory caching introduced; results derive from already-persisted `regime_backtest_daily` + `vol_index_daily`.
+- [ ] **No naked shorts** — N/A (UI-only).
+- [ ] **Data source priority** — N/A (no new external data; SPX comes from existing `vol_index_daily`).
+- [ ] **No secrets to Codex subprocesses** — N/A.
+- [ ] **No commit without explicit user request** — every commit step is gated by user approval at the start of the work; do not auto-commit during subagent execution.
+- [ ] **PR before merge to main** — Task 10 Step 3 opens a PR; never `git push origin main`.
+- [ ] **Branch name** — `feat/vcg-ui-capitulation-framing` ✅.
+- [ ] **No `Co-Authored-By: Claude`** trailer in any commit.
+- [ ] **Migrations idempotent** — N/A (no migrations).
+- [ ] **Module size budget <500 lines** — `regime_validation.py` model file currently 96 lines; +25 lines stays well under budget. Storage module: check at exec time (likely already large; if storage module is >1000 lines, propose splitting **before** appending).
+- [ ] **API contract identity preserved** — change is purely additive (new optional fields), no rename/removal; existing OpenAPI component names unchanged.
+- [ ] **`/api/regime/vcg-validation` 503 contract still honored** — when no completed VCG run exists, endpoint still returns 503 unchanged; `stress_history_summary` is only computed when the run exists.
+- [ ] **Screenshots under `output/playwright/`** ✅ (Task 9 Step 3).
+- [ ] **Worktree under `.worktrees/`** ✅ (Task 0 Step 1).
+- [ ] **No code review skipped** — `/review-cycle` runs on this plan (per user request) and on the diff before merge.
+
+---
+
+## Out of scope (do NOT do in this PR)
+
+- Adding BOUNCE to `stress_history` — n=5, dominated by 2008 GFC; would mislead.
+- Changing pill colors — surface change only, no math implication.
+- Materializing forward returns into `regime_backtest_daily` — query-time computation is cheap enough and reversible.
+- Bumping `COMPOSITE_VERSION` — math is unchanged.
+- Updating the methodology doc — already calls VCG "descriptive, not predictive"; UI is catching up to the doc, not the other way around.
+- Adding forward-return-based filtering or sorting controls — wait for user demand.

--- a/src/uw_scan/api/models/regime_validation.py
+++ b/src/uw_scan/api/models/regime_validation.py
@@ -82,6 +82,28 @@ class VcgStressHistoryEntry(BaseModel):
     vvix: float | None = None
     vix_percentile_rank: float | None = None
     vvix_percentile_rank: float | None = None
+    fwd_5d_pct: float | None = None
+    fwd_20d_pct: float | None = None
+    fwd_60d_pct: float | None = None
+
+
+class VcgStressHistorySummaryRow(BaseModel):
+    """Per-interpretation aggregate of realized forward SPX returns
+    across all stress days in the backtest run."""
+
+    interpretation: Literal["PANIC", "RISK_OFF", "EDR"]
+    n: int
+    mean_fwd_5d_pct: float | None = None
+    mean_fwd_20d_pct: float | None = None
+    mean_fwd_60d_pct: float | None = None
+    winrate_20d_pct: float | None = None
+    winrate_60d_pct: float | None = None
+
+
+class VcgStressHistorySummary(BaseModel):
+    """Aggregate forward-return stats for the stress_history table."""
+
+    by_interpretation: list[VcgStressHistorySummaryRow]
 
 
 class VcgValidationResponse(BaseModel):
@@ -94,3 +116,4 @@ class VcgValidationResponse(BaseModel):
     interpretation_distribution: list[VcgInterpretationCount]
     named_crash_window: list[VcgNamedCrashEvent]
     stress_history: list[VcgStressHistoryEntry] = []
+    stress_history_summary: VcgStressHistorySummary | None = None

--- a/src/uw_scan/api/routers/regime_validation.py
+++ b/src/uw_scan/api/routers/regime_validation.py
@@ -35,7 +35,13 @@ from uw_scan.api.models.regime_validation import (
     VcgNamedCrashEvent,
     VcgNamedCrashOffset,
     VcgStressHistoryEntry,
+    VcgStressHistorySummary,
+    VcgStressHistorySummaryRow,
     VcgValidationResponse,
+)
+from uw_scan.cards.regime_forward_returns import (
+    attach_forward_returns,
+    summarize_stress_returns,
 )
 from uw_scan.reports.regime_backtest_report import (
     NAMED_CRASH_DATES,
@@ -45,6 +51,7 @@ from uw_scan.reports.regime_vcg_backtest_report import render_vcg_backtest_markd
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.regime_backtest_repository import RegimeBacktestRepository
 from uw_scan.storage.repository import Repository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 logger = logging.getLogger(__name__)
 
@@ -346,6 +353,36 @@ def get_vcg_validation(
                 vvix_percentile_rank=payload.get("vvix_percentile_rank"),
             )
         )
+    # Forward-return enrichment. Skip the SPX load entirely if no stress
+    # days were emitted in this run — common for runs early in calibration
+    # work, no point spending the query.
+    stress_history_summary: VcgStressHistorySummary | None = None
+    if stress_history:
+        # 9000-day window covers the full 18.5yr backtest with headroom.
+        vix_repo = VolIndexRepository(repo.conn, schema=repo._schema)
+        spx_rows = vix_repo.fetch_multi_history(["SPX"], 9000).get("SPX", [])
+        spx_series = [(r["trade_date"], r["close"]) for r in spx_rows]
+
+        entry_dicts = [e.model_dump() for e in stress_history]
+        enriched_dicts = attach_forward_returns(entry_dicts, spx_series)
+        stress_history = [VcgStressHistoryEntry(**d) for d in enriched_dicts]
+
+        summary_rows = summarize_stress_returns(enriched_dicts)
+        stress_history_summary = VcgStressHistorySummary(
+            by_interpretation=[
+                VcgStressHistorySummaryRow(
+                    interpretation=row["interpretation"],
+                    n=row["n"],
+                    mean_fwd_5d_pct=row.get("mean_fwd_5d_pct"),
+                    mean_fwd_20d_pct=row.get("mean_fwd_20d_pct"),
+                    mean_fwd_60d_pct=row.get("mean_fwd_60d_pct"),
+                    winrate_20d_pct=row.get("winrate_20d_pct"),
+                    winrate_60d_pct=row.get("winrate_60d_pct"),
+                )
+                for row in summary_rows
+            ]
+        )
+
     return VcgValidationResponse(
         backtest_md=render_vcg_backtest_markdown(run, daily),
         n_days=len(daily),
@@ -361,4 +398,5 @@ def get_vcg_validation(
         ],
         named_crash_window=events,
         stress_history=stress_history,
+        stress_history_summary=stress_history_summary,
     )

--- a/src/uw_scan/cards/regime_forward_returns.py
+++ b/src/uw_scan/cards/regime_forward_returns.py
@@ -1,0 +1,116 @@
+"""Pure helpers for projecting realized forward SPX returns onto VCG
+stress-history entries, and aggregating the result by interpretation.
+
+No DB access. The handler at api/routers/regime_validation.py loads the
+SPX series and the daily entries; this module enriches and summarizes.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Iterable
+
+# Default horizons match the UI columns (+5d, +20d, +60d).
+DEFAULT_HORIZONS: tuple[int, ...] = (5, 20, 60)
+
+
+def attach_forward_returns(
+    entries: list[dict[str, Any]],
+    spx_series: list[tuple[date, float]],
+    horizons: Iterable[int] = DEFAULT_HORIZONS,
+) -> list[dict[str, Any]]:
+    """Return a new list of entry dicts, each with `fwd_{H}d_pct` keys.
+
+    spx_series must be sorted ascending by trade_date. Each entry's date
+    is matched against the series; the close N trading days later is
+    looked up by index. Missing dates or tail-overhangs produce None.
+
+    Returns a shallow-copied list of dicts so the input is not mutated.
+
+    Raises ValueError if spx_series is not sorted ascending — defensive
+    check against a future SQL refactor dropping the ORDER BY in
+    VolIndexRepository.fetch_multi_history. Silent wrong fwd returns
+    are worse than a loud crash.
+    """
+    for i in range(len(spx_series) - 1):
+        if spx_series[i][0] > spx_series[i + 1][0]:
+            raise ValueError(
+                f"spx_series must be sorted ascending by date; "
+                f"index {i} ({spx_series[i][0]}) > index {i + 1} ({spx_series[i + 1][0]})"
+            )
+    date_to_index = {d: i for i, (d, _) in enumerate(spx_series)}
+    closes = [c for _, c in spx_series]
+    horizons = tuple(horizons)
+
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        enriched = dict(entry)  # shallow copy; do not mutate input
+        entry_date = _parse_date(entry.get("date"))
+        idx = date_to_index.get(entry_date) if entry_date else None
+        for h in horizons:
+            key = f"fwd_{h}d_pct"
+            if idx is None:
+                enriched[key] = None
+                continue
+            future_idx = idx + h
+            if future_idx >= len(closes):
+                enriched[key] = None
+                continue
+            base = closes[idx]
+            future = closes[future_idx]
+            if base is None or future is None or base == 0:
+                enriched[key] = None
+                continue
+            enriched[key] = (future - base) / base * 100.0
+        out.append(enriched)
+    return out
+
+
+def summarize_stress_returns(
+    enriched_entries: list[dict[str, Any]],
+    horizons: Iterable[int] = DEFAULT_HORIZONS,
+) -> list[dict[str, Any]]:
+    """Group entries by `interpretation`; for each group return
+    {interpretation, n, mean_fwd_{H}d_pct, winrate_{H}d_pct} for
+    H in horizons.
+
+    `n` is the total entry count (including those with None fwd values).
+    `mean_*` and `winrate_*` skip None values; if every value for a
+    horizon is None, the aggregate is None (not 0, not NaN).
+    """
+    horizons = tuple(horizons)
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for entry in enriched_entries:
+        interp = entry.get("interpretation")
+        if not interp:
+            continue
+        groups.setdefault(interp, []).append(entry)
+
+    out: list[dict[str, Any]] = []
+    for interp in sorted(groups):
+        rows = groups[interp]
+        row: dict[str, Any] = {"interpretation": interp, "n": len(rows)}
+        for h in horizons:
+            key = f"fwd_{h}d_pct"
+            values = [r[key] for r in rows if r.get(key) is not None]
+            row[f"mean_{key}"] = sum(values) / len(values) if values else None
+            if values:
+                wins = sum(1 for v in values if v > 0)
+                row[f"winrate_{h}d_pct"] = wins / len(values) * 100.0
+            else:
+                row[f"winrate_{h}d_pct"] = None
+        out.append(row)
+    return out
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            return None
+    return None

--- a/src/uw_scan/cards/regime_forward_returns.py
+++ b/src/uw_scan/cards/regime_forward_returns.py
@@ -7,8 +7,11 @@ SPX series and the daily entries; this module enriches and summarizes.
 
 from __future__ import annotations
 
+import logging
 from datetime import date
 from typing import Any, Iterable
+
+log = logging.getLogger(__name__)
 
 # Default horizons match the UI columns (+5d, +20d, +60d).
 DEFAULT_HORIZONS: tuple[int, ...] = (5, 20, 60)
@@ -111,6 +114,7 @@ def _parse_date(value: Any) -> date | None:
     if isinstance(value, str):
         try:
             return date.fromisoformat(value)
-        except ValueError:
+        except ValueError as exc:
+            log.debug("date.fromisoformat failed: %s", repr(exc))
             return None
     return None

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -14642,6 +14642,39 @@
             "title": "Date",
             "type": "string"
           },
+          "fwd_20d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fwd 20D Pct"
+          },
+          "fwd_5d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fwd 5D Pct"
+          },
+          "fwd_60d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fwd 60D Pct"
+          },
           "interpretation": {
             "enum": [
               "PANIC",
@@ -14747,6 +14780,102 @@
         "title": "VcgStressHistoryEntry",
         "type": "object"
       },
+      "VcgStressHistorySummary": {
+        "description": "Aggregate forward-return stats for the stress_history table.",
+        "properties": {
+          "by_interpretation": {
+            "items": {
+              "$ref": "#/components/schemas/VcgStressHistorySummaryRow"
+            },
+            "title": "By Interpretation",
+            "type": "array"
+          }
+        },
+        "required": [
+          "by_interpretation"
+        ],
+        "title": "VcgStressHistorySummary",
+        "type": "object"
+      },
+      "VcgStressHistorySummaryRow": {
+        "description": "Per-interpretation aggregate of realized forward SPX returns\nacross all stress days in the backtest run.",
+        "properties": {
+          "interpretation": {
+            "enum": [
+              "PANIC",
+              "RISK_OFF",
+              "EDR"
+            ],
+            "title": "Interpretation",
+            "type": "string"
+          },
+          "mean_fwd_20d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Fwd 20D Pct"
+          },
+          "mean_fwd_5d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Fwd 5D Pct"
+          },
+          "mean_fwd_60d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Fwd 60D Pct"
+          },
+          "n": {
+            "title": "N",
+            "type": "integer"
+          },
+          "winrate_20d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Winrate 20D Pct"
+          },
+          "winrate_60d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Winrate 60D Pct"
+          }
+        },
+        "required": [
+          "interpretation",
+          "n"
+        ],
+        "title": "VcgStressHistorySummaryRow",
+        "type": "object"
+      },
       "VcgValidationResponse": {
         "description": "Latest completed VCG backtest run rendered + structured.",
         "properties": {
@@ -14787,6 +14916,16 @@
             },
             "title": "Stress History",
             "type": "array"
+          },
+          "stress_history_summary": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VcgStressHistorySummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [

--- a/tests/integration/api/test_regime_vcg_validation_endpoint.py
+++ b/tests/integration/api/test_regime_vcg_validation_endpoint.py
@@ -65,6 +65,72 @@ def test_vcg_validation_stress_history_contract(seed_vcg_backtest_run, client) -
     assert panic["sign_ok"] is True
 
 
+def test_vcg_validation_includes_stress_history_summary(
+    seed_vcg_backtest_run, client
+) -> None:
+    """The endpoint must expose stress_history_summary and per-entry
+    forward-return fields. Values may be null on a fresh test DB with no
+    SPX vol_index_daily rows — structural check only."""
+    resp = client.get("/api/regime/vcg-validation")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Per-entry structure: every stress row carries the three fwd keys.
+    sh = body["stress_history"]
+    assert sh, "expected non-empty stress_history in seeded backtest"
+    for row in sh:
+        for key in ("fwd_5d_pct", "fwd_20d_pct", "fwd_60d_pct"):
+            assert key in row, f"missing {key} on stress_history entry {row['date']}"
+
+    # Summary structure: non-None when stress_history is non-empty.
+    assert "stress_history_summary" in body
+    summary = body["stress_history_summary"]
+    assert summary is not None
+    assert "by_interpretation" in summary
+    assert len(summary["by_interpretation"]) >= 1
+    for row in summary["by_interpretation"]:
+        for key in (
+            "interpretation",
+            "n",
+            "mean_fwd_5d_pct",
+            "mean_fwd_20d_pct",
+            "mean_fwd_60d_pct",
+            "winrate_20d_pct",
+            "winrate_60d_pct",
+        ):
+            assert key in row
+
+
+def test_vcg_validation_summary_values_match_published_probes(
+    seed_vcg_backtest_run, client
+) -> None:
+    """Numeric check against the published probe note values.
+    Gated by env flag — only runs when the local DB has the production
+    backtest (run_id=31, 4,710 days). CI seeds do not satisfy this."""
+    import math
+    import os
+
+    if os.getenv("VCG_FULL_BACKTEST_AVAILABLE") != "1":
+        import pytest
+
+        pytest.skip(
+            "requires production backtest fixture (set VCG_FULL_BACKTEST_AVAILABLE=1 locally)"
+        )
+
+    resp = client.get("/api/regime/vcg-validation")
+    body = resp.json()
+    by = {
+        row["interpretation"]: row
+        for row in body["stress_history_summary"]["by_interpretation"]
+    }
+
+    # Published probe values (docs/research/regime/vcg-forward-return-probes-2026-05-28.md):
+    assert by["PANIC"]["n"] == 83
+    assert math.isclose(by["PANIC"]["mean_fwd_20d_pct"], 2.88, abs_tol=0.05)
+    assert by["RISK_OFF"]["n"] == 133
+    assert math.isclose(by["RISK_OFF"]["mean_fwd_60d_pct"], 3.04, abs_tol=0.05)
+
+
 def test_vcg_validation_503_when_no_completed_run(
     seeded_db_empty_cards, client
 ) -> None:

--- a/tests/unit/api/test_regime_validation_models.py
+++ b/tests/unit/api/test_regime_validation_models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from uw_scan.api.models.regime_validation import (
     VcgStressHistoryEntry,
-    VcgStressHistorySummary,
     VcgStressHistorySummaryRow,
     VcgValidationResponse,
 )

--- a/tests/unit/api/test_regime_validation_models.py
+++ b/tests/unit/api/test_regime_validation_models.py
@@ -1,0 +1,45 @@
+"""Contract tests for the regime-validation Pydantic models."""
+
+from __future__ import annotations
+
+from uw_scan.api.models.regime_validation import (
+    VcgStressHistoryEntry,
+    VcgStressHistorySummary,
+    VcgStressHistorySummaryRow,
+    VcgValidationResponse,
+)
+
+
+def test_stress_history_entry_forward_return_fields_default_none() -> None:
+    entry = VcgStressHistoryEntry(date="2020-03-16", interpretation="PANIC")
+    assert entry.fwd_5d_pct is None
+    assert entry.fwd_20d_pct is None
+    assert entry.fwd_60d_pct is None
+
+
+def test_stress_history_summary_row_shape() -> None:
+    row = VcgStressHistorySummaryRow(
+        interpretation="PANIC",
+        n=83,
+        mean_fwd_5d_pct=0.20,
+        mean_fwd_20d_pct=2.88,
+        mean_fwd_60d_pct=2.29,
+        winrate_20d_pct=53.0,
+        winrate_60d_pct=41.0,
+    )
+    assert row.n == 83
+    assert row.mean_fwd_20d_pct == 2.88
+
+
+def test_validation_response_summary_optional() -> None:
+    """stress_history_summary must default to None so we don't break
+    existing clients before backfill."""
+    resp = VcgValidationResponse(
+        backtest_md="",
+        n_days=0,
+        composite_version="2",
+        credit_proxy="HY_OAS",
+        interpretation_distribution=[],
+        named_crash_window=[],
+    )
+    assert resp.stress_history_summary is None

--- a/tests/unit/cards/test_regime_forward_returns.py
+++ b/tests/unit/cards/test_regime_forward_returns.py
@@ -1,0 +1,105 @@
+"""Pure-function tests for regime_forward_returns.
+
+Verifies the date-aligned LEAD-by-index logic on synthetic data (no DB).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from uw_scan.cards.regime_forward_returns import (
+    attach_forward_returns,
+    summarize_stress_returns,
+)
+
+
+def _spx_series(rows: list[tuple[str, float]]) -> list[tuple[date, float]]:
+    return [(date.fromisoformat(d), c) for d, c in rows]
+
+
+def test_attach_forward_returns_basic_lead_logic() -> None:
+    spx = _spx_series(
+        [
+            ("2026-01-02", 100.0),  # entry
+            ("2026-01-03", 101.0),
+            ("2026-01-04", 102.0),
+            ("2026-01-05", 103.0),
+            ("2026-01-06", 104.0),
+            ("2026-01-07", 105.0),  # +5d from entry
+        ]
+    )
+    entries = [{"date": "2026-01-02", "interpretation": "PANIC"}]
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] == 5.0  # (105 - 100) / 100 * 100
+
+
+def test_attach_forward_returns_null_at_tail() -> None:
+    """When entry date is within `horizon` of series tail, fwd return is None."""
+    spx = _spx_series(
+        [("2026-05-25", 100.0), ("2026-05-26", 101.0), ("2026-05-27", 102.0)]
+    )
+    entries = [{"date": "2026-05-27", "interpretation": "PANIC"}]
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] is None
+
+
+def test_attach_forward_returns_handles_missing_spx_date() -> None:
+    """If the entry date isn't in the SPX series (holiday alignment), return None."""
+    spx = _spx_series([("2026-01-02", 100.0), ("2026-01-09", 101.0)])
+    entries = [{"date": "2026-01-05", "interpretation": "PANIC"}]  # holiday
+
+    enriched = attach_forward_returns(entries, spx, horizons=(5,))
+
+    assert enriched[0]["fwd_5d_pct"] is None
+
+
+def test_summarize_stress_returns_groups_by_interpretation() -> None:
+    enriched = [
+        {"interpretation": "PANIC", "fwd_20d_pct": 5.0, "fwd_60d_pct": 8.0},
+        {"interpretation": "PANIC", "fwd_20d_pct": -3.0, "fwd_60d_pct": 2.0},
+        {"interpretation": "PANIC", "fwd_20d_pct": None, "fwd_60d_pct": None},
+        {"interpretation": "RISK_OFF", "fwd_20d_pct": 1.0, "fwd_60d_pct": 4.0},
+    ]
+    summary = summarize_stress_returns(enriched)
+    by = {row["interpretation"]: row for row in summary}
+
+    # PANIC: n=3 total, but means / winrates skip None
+    assert by["PANIC"]["n"] == 3
+    assert by["PANIC"]["mean_fwd_20d_pct"] == 1.0  # (5 + -3) / 2
+    assert by["PANIC"]["winrate_20d_pct"] == 50.0  # 1 of 2 non-null positive
+    # RISK_OFF: n=1
+    assert by["RISK_OFF"]["n"] == 1
+    assert by["RISK_OFF"]["mean_fwd_60d_pct"] == 4.0
+
+
+def test_summarize_stress_returns_handles_all_null_horizon() -> None:
+    """If every entry has None for a horizon, mean is None (not 0, not NaN)."""
+    enriched = [
+        {"interpretation": "PANIC", "fwd_20d_pct": None, "fwd_60d_pct": None},
+    ]
+    summary = summarize_stress_returns(enriched)
+    assert summary[0]["mean_fwd_20d_pct"] is None
+    assert summary[0]["winrate_20d_pct"] is None
+
+
+def test_attach_forward_returns_rejects_unsorted_spx_series() -> None:
+    """Defensive — silent wrong fwd returns from a refactored SQL
+    dropping ORDER BY is worse than a loud crash."""
+    unsorted = _spx_series(
+        [("2026-01-03", 101.0), ("2026-01-02", 100.0)]  # out of order
+    )
+    with pytest.raises(ValueError, match="sorted ascending"):
+        attach_forward_returns(
+            [{"date": "2026-01-02", "interpretation": "PANIC"}], unsorted
+        )
+
+
+def test_attach_forward_returns_empty_entries() -> None:
+    """Empty entry list returns empty list (no error)."""
+    spx = _spx_series([("2026-01-02", 100.0)])
+    assert attach_forward_returns([], spx) == []

--- a/web/components/regime/vcg/VcgStressHistorySection.tsx
+++ b/web/components/regime/vcg/VcgStressHistorySection.tsx
@@ -55,6 +55,49 @@ export default function VcgStressHistorySection() {
 
   return (
     <div className="section" data-testid="vcg-stress-history-section">
+      {data?.stress_history_summary && (
+        <div
+          data-testid="vcg-stress-summary"
+          style={{
+            fontSize: "11px",
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-secondary)",
+            marginBottom: "8px",
+            lineHeight: 1.5,
+          }}
+        >
+          {data.stress_history_summary.by_interpretation
+            .filter((row) => row.interpretation !== "EDR")
+            .map((row) => {
+              const mean20 = row.mean_fwd_20d_pct ?? 0;
+              const mean60 = row.mean_fwd_60d_pct ?? 0;
+              return (
+                <div key={row.interpretation}>
+                  Across {row.n} historical {row.interpretation} events, mean
+                  20d forward SPX return was{" "}
+                  <span
+                    style={{
+                      color: mean20 > 0 ? "var(--positive)" : "var(--negative)",
+                    }}
+                  >
+                    {mean20 >= 0 ? "+" : ""}
+                    {row.mean_fwd_20d_pct?.toFixed(2)}%
+                  </span>{" "}
+                  ({row.winrate_20d_pct?.toFixed(0)}% positive); 60d{" "}
+                  <span
+                    style={{
+                      color: mean60 > 0 ? "var(--positive)" : "var(--negative)",
+                    }}
+                  >
+                    {mean60 >= 0 ? "+" : ""}
+                    {row.mean_fwd_60d_pct?.toFixed(2)}%
+                  </span>{" "}
+                  ({row.winrate_60d_pct?.toFixed(0)}% positive).
+                </div>
+              );
+            })}
+        </div>
+      )}
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/web/components/regime/vcg/VcgStressHistoryTable.tsx
+++ b/web/components/regime/vcg/VcgStressHistoryTable.tsx
@@ -33,6 +33,19 @@ function interpretationColor(interp: VcgStressEntry["interpretation"]): string {
   }
 }
 
+function interpretationTooltip(
+  interp: VcgStressEntry["interpretation"],
+): string | undefined {
+  switch (interp) {
+    case "PANIC":
+      return "PANIC — acute stress capitulation marker. Historical 20d forward SPX: +2.88% mean (n=83, 53% positive). Marks capitulation moments, not future drawdowns.";
+    case "RISK_OFF":
+      return "RISK_OFF — sustained vol-complex stress. Historical 60d forward SPX: +3.04% mean (n=133, 74% positive). Indistinguishable from baseline drift at 60d.";
+    case "EDR":
+      return "EDR — elevated daily risk. Subset of stress days that did not meet PANIC/RISK_OFF thresholds.";
+  }
+}
+
 function sortIndicator(
   col: SortCol,
   activeCol: SortCol | null,
@@ -165,6 +178,8 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
               <td>
                 <span
                   className="pill"
+                  data-testid={`interpretation-pill-${r.interpretation}`}
+                  title={interpretationTooltip(r.interpretation)}
                   style={{
                     background: interpretationColor(r.interpretation),
                     color: "#fff",
@@ -172,6 +187,7 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
                     fontWeight: 700,
                     padding: "1px 6px",
                     borderRadius: "999px",
+                    cursor: "help",
                   }}
                 >
                   {r.interpretation === "RISK_OFF"

--- a/web/components/regime/vcg/VcgStressHistoryTable.tsx
+++ b/web/components/regime/vcg/VcgStressHistoryTable.tsx
@@ -14,7 +14,10 @@ type SortCol =
   | "vix"
   | "vvix"
   | "vix_percentile_rank"
-  | "vvix_percentile_rank";
+  | "vvix_percentile_rank"
+  | "fwd_5d_pct"
+  | "fwd_20d_pct"
+  | "fwd_60d_pct";
 type SortDir = "asc" | "desc";
 
 const VOL_STRESS_THRESHOLD = 0.95;
@@ -63,6 +66,19 @@ function sortRows(
 function fmtPctRank(v: number | null | undefined): string {
   if (v == null || !Number.isFinite(v)) return "—";
   return `${(v * 100).toFixed(1)}%`;
+}
+
+function fwdReturnColor(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "var(--text-muted)";
+  if (v > 0) return "var(--positive)";
+  if (v < 0) return "var(--negative)";
+  return "var(--text-primary)";
+}
+
+function fmtFwdReturn(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v.toFixed(1)}`;
 }
 
 function pctRankColor(v: number | null | undefined): string {
@@ -116,6 +132,9 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
               ["vvix", "VVIX", true],
               ["vix_percentile_rank", "VIX %ile", true],
               ["vvix_percentile_rank", "VVIX %ile", true],
+              ["fwd_5d_pct", "+5d %", true],
+              ["fwd_20d_pct", "+20d %", true],
+              ["fwd_60d_pct", "+60d %", true],
             ] as [SortCol, string, boolean][]
           ).map(([col, label, isRight]) => (
             <th
@@ -183,13 +202,31 @@ export function VcgStressHistoryTable({ rows }: { rows: VcgStressEntry[] }) {
               >
                 {fmtPctRank(r.vvix_percentile_rank)}
               </td>
+              <td
+                className="right"
+                style={{ color: fwdReturnColor(r.fwd_5d_pct) }}
+              >
+                {fmtFwdReturn(r.fwd_5d_pct)}
+              </td>
+              <td
+                className="right"
+                style={{ color: fwdReturnColor(r.fwd_20d_pct) }}
+              >
+                {fmtFwdReturn(r.fwd_20d_pct)}
+              </td>
+              <td
+                className="right"
+                style={{ color: fwdReturnColor(r.fwd_60d_pct) }}
+              >
+                {fmtFwdReturn(r.fwd_60d_pct)}
+              </td>
             </tr>
           );
         })}
         {rows.length === 0 && (
           <tr>
             <td
-              colSpan={9}
+              colSpan={12}
               style={{ textAlign: "center", color: "var(--text-muted)" }}
             >
               No stress-state days in the current backtest run.

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4,6 +4,176 @@
  */
 
 export interface paths {
+    "/api/cockpit/{ticker}/dealer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Dealer */
+        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/flow-im": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Flow Im */
+        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit State */
+        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/surface": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Surface */
+        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/vrp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Vrp */
+        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/gauge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gauge */
+        get: operations["get_gauge_api_gold_gauge_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/inputs/{series_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Input Series */
+        get: operations["get_input_series_api_gold_inputs__series_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/lenses/{lens_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Lens */
+        get: operations["get_lens_api_gold_lenses__lens_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Replay */
+        get: operations["get_replay_api_gold_replay_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get State */
+        get: operations["get_state_api_gold_state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -55,40 +225,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist": {
+    "/api/jobs/{job_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Watchlist */
-        get: operations["get_watchlist_api_watchlist_get"];
-        put?: never;
-        /** Post Watchlist */
-        post: operations["post_watchlist_api_watchlist_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/queue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Watchlist Queue
-         * @description Lightweight queue snapshot for the dashboard's QueueProgress widget.
-         *
-         *     Returns only the rescan-queue summary — no card joins, no meta. Designed
-         *     for the 2.5s polling loop in QueueProgress so the dashboard doesn't
-         *     refetch the full watchlist payload every tick.
-         */
-        get: operations["get_watchlist_queue_api_watchlist_queue_get"];
+        /** Get Job */
+        get: operations["get_job_api_jobs__job_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -97,7 +242,221 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist/{ticker}": {
+    "/api/ohlc/{ticker}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Ohlc */
+        get: operations["get_ohlc_api_ohlc__ticker__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Endpoints */
+        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Requests */
+        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Summary */
+        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/tickers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Tickers */
+        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rates/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Rates Snapshot */
+        get: operations["rates_snapshot_api_rates_snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime */
+        get: operations["get_regime_api_regime_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Canary Latest */
+        get: operations["get_canary_latest_api_regime_canary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Canary History */
+        get: operations["get_canary_history_api_regime_canary_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary/validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Canary Validation
+         * @description v0.4 patch I4 + C6: use the existing `find_latest_run` (which already
+         *     filters on `completed_at IS NOT NULL`) and post-filter for the winning
+         *     form in summary JSON. composite_version is stringified at the DB boundary.
+         */
+        get: operations["get_canary_validation_api_regime_canary_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/dealer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dealer Regime
+         * @description Per-ticker dealer Greek regime — feeds the Magnet/Gamma summary bar
+         *     and the Volatility tab regime panel. Uses the same `gather_inputs`
+         *     helper the report assembler uses so both paths see the same upstream.
+         */
+        get: operations["get_dealer_regime_api_regime_dealer_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gex */
+        get: operations["get_gex_api_regime_gex_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex/scan": {
         parameters: {
             query?: never;
             header?: never;
@@ -106,13 +465,201 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post?: never;
-        /** Delete Watchlist */
-        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
+        /**
+         * Trigger Gex Scan
+         * @description Run a GEX scan synchronously against UW and persist.
+         */
+        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        delete?: never;
         options?: never;
         head?: never;
-        /** Patch Watchlist */
-        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/guidance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Guidance */
+        get: operations["get_guidance_api_regime_guidance_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Cri Scan
+         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_cri_scan_api_regime_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Validation
+         * @description Latest completed CRI backtest run, rendered to markdown.
+         *
+         *     Source of truth is uw_scan.regime_backtest_runs. The previous file
+         *     fallback (cri-backtest.md/.csv + oos-summary.json on disk) was removed
+         *     after the prod gate in
+         *     docs/superpowers/archive/specs/2026-05-24-regime-research-closure-design.md §10.4
+         *     was satisfied. If no completed run exists at the current
+         *     cri_scorers.COMPOSITE_VERSION, returns 503 — operators should run
+         *     scripts/backtest_cri.py to seed the table.
+         */
+        get: operations["get_validation_api_regime_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg */
+        get: operations["get_vcg_api_regime_vcg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg-validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vcg Validation
+         * @description Latest completed VCG backtest run, rendered to markdown + structured.
+         *
+         *     Source of truth is uw_scan.regime_backtest_runs (migration 057). Returns
+         *     503 with an actionable message if no completed run exists at the current
+         *     vcg_scoring.COMPOSITE_VERSION — operators should run scripts/backtest_vcg.py.
+         *
+         *     Persisted JSON shape (from scripts/backtest_vcg.py):
+         *         summary.extras.named_crash_window: dict[iso_str, list[dict]] where
+         *         each inner dict has offset_d (NOT offset_days), vcg, vcg_adj, beta1,
+         *         beta2, sign_ok, interpretation, vix. Event labels live in
+         *         NAMED_CRASH_DATES, not the persisted JSON.
+         */
+        get: operations["get_vcg_validation_api_regime_vcg_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Vcg Scan
+         * @description Run a VCG scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vol-backdrop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vol Backdrop */
+        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scanner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Scanner */
+        get: operations["get_scanner_api_scanner_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scanner/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Scanner Discover
+         * @description Pull market-wide flow alerts, run DCF per ticker, exclude watchlist, top-N.
+         */
+        get: operations["get_scanner_discover_api_scanner_discover_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/stock/{ticker}": {
@@ -181,247 +728,6 @@ export interface paths {
         };
         /** Get Specific Run */
         get: operations["get_specific_run_api_stock__ticker__runs__run_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ohlc/{ticker}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ohlc */
-        get: operations["get_ohlc_api_ohlc__ticker__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit State */
-        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/dealer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Dealer */
-        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/surface": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Surface */
-        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/flow-im": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Flow Im */
-        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/vrp": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Vrp */
-        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/{ticker}/rescan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Enqueue Rescan */
-        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/rescan-all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enqueue Rescan All
-         * @description Enqueue a rescan job for every active watchlist ticker.
-         */
-        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Job */
-        get: operations["get_job_api_jobs__job_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/stock/{ticker}/volatility/series": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Volatility Series */
-        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Summary */
-        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/endpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Endpoints */
-        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/tickers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Tickers */
-        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/requests": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Requests */
-        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -518,6 +824,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/stock/{ticker}/volatility/series": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Volatility Series */
+        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/trade-insights/priors": {
         parameters: {
             query?: never;
@@ -551,15 +874,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex": {
+    "/api/watchlist": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Gex */
-        get: operations["get_gex_api_regime_gex_get"];
+        /** Get Watchlist */
+        get: operations["get_watchlist_api_watchlist_get"];
+        put?: never;
+        /** Post Watchlist */
+        post: operations["post_watchlist_api_watchlist_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Watchlist Queue
+         * @description Lightweight queue snapshot for the dashboard's QueueProgress widget.
+         *
+         *     Returns only the rescan-queue summary — no card joins, no meta. Designed
+         *     for the 2.5s polling loop in QueueProgress so the dashboard doesn't
+         *     refetch the full watchlist payload every tick.
+         */
+        get: operations["get_watchlist_queue_api_watchlist_queue_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -568,7 +916,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex/scan": {
+    "/api/watchlist/rescan-all": {
         parameters: {
             query?: never;
             header?: never;
@@ -578,51 +926,17 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Trigger Gex Scan
-         * @description Run a GEX scan synchronously against UW and persist.
+         * Enqueue Rescan All
+         * @description Enqueue a rescan job for every active watchlist ticker.
          */
-        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/regime/vol-backdrop": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vol Backdrop */
-        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Regime */
-        get: operations["get_regime_api_regime_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/scan": {
+    "/api/watchlist/{ticker}": {
         parameters: {
             query?: never;
             header?: never;
@@ -631,35 +945,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Trigger Cri Scan
-         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
-         */
-        post: operations["trigger_cri_scan_api_regime_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg */
-        get: operations["get_vcg_api_regime_vcg_get"];
-        put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Watchlist */
+        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Patch Watchlist */
+        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
         trace?: never;
     };
-    "/api/regime/vcg/scan": {
+    "/api/watchlist/{ticker}/rescan": {
         parameters: {
             query?: never;
             header?: never;
@@ -668,303 +963,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Trigger Vcg Scan
-         * @description Run a VCG scan synchronously off the warm store; persist a snapshot.
-         */
-        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/dealer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Dealer Regime
-         * @description Per-ticker dealer Greek regime — feeds the Magnet/Gamma summary bar
-         *     and the Volatility tab regime panel. Uses the same `gather_inputs`
-         *     helper the report assembler uses so both paths see the same upstream.
-         */
-        get: operations["get_dealer_regime_api_regime_dealer_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Canary Latest */
-        get: operations["get_canary_latest_api_regime_canary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Canary History */
-        get: operations["get_canary_history_api_regime_canary_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary/validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Canary Validation
-         * @description v0.4 patch I4 + C6: use the existing `find_latest_run` (which already
-         *     filters on `completed_at IS NOT NULL`) and post-filter for the winning
-         *     form in summary JSON. composite_version is stringified at the DB boundary.
-         */
-        get: operations["get_canary_validation_api_regime_canary_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/guidance": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Guidance */
-        get: operations["get_guidance_api_regime_guidance_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Validation
-         * @description Latest completed CRI backtest run, rendered to markdown.
-         *
-         *     Source of truth is uw_scan.regime_backtest_runs. The previous file
-         *     fallback (cri-backtest.md/.csv + oos-summary.json on disk) was removed
-         *     after the prod gate in
-         *     docs/superpowers/archive/specs/2026-05-24-regime-research-closure-design.md §10.4
-         *     was satisfied. If no completed run exists at the current
-         *     cri_scorers.COMPOSITE_VERSION, returns 503 — operators should run
-         *     scripts/backtest_cri.py to seed the table.
-         */
-        get: operations["get_validation_api_regime_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg-validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Vcg Validation
-         * @description Latest completed VCG backtest run, rendered to markdown + structured.
-         *
-         *     Source of truth is uw_scan.regime_backtest_runs (migration 057). Returns
-         *     503 with an actionable message if no completed run exists at the current
-         *     vcg_scoring.COMPOSITE_VERSION — operators should run scripts/backtest_vcg.py.
-         *
-         *     Persisted JSON shape (from scripts/backtest_vcg.py):
-         *         summary.extras.named_crash_window: dict[iso_str, list[dict]] where
-         *         each inner dict has offset_d (NOT offset_days), vcg, vcg_adj, beta1,
-         *         beta2, sign_ok, interpretation, vix. Event labels live in
-         *         NAMED_CRASH_DATES, not the persisted JSON.
-         */
-        get: operations["get_vcg_validation_api_regime_vcg_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/gauge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Gauge */
-        get: operations["get_gauge_api_gold_gauge_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/inputs/{series_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Input Series */
-        get: operations["get_input_series_api_gold_inputs__series_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get State */
-        get: operations["get_state_api_gold_state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/lenses/{lens_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Lens */
-        get: operations["get_lens_api_gold_lenses__lens_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/replay": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Replay */
-        get: operations["get_replay_api_gold_replay_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/rates/snapshot": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Rates Snapshot */
-        get: operations["rates_snapshot_api_rates_snapshot_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scanner": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Scanner */
-        get: operations["get_scanner_api_scanner_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scanner/discover": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Scanner Discover
-         * @description Pull market-wide flow alerts, run DCF per ticker, exclude watchlist, top-N.
-         */
-        get: operations["get_scanner_discover_api_scanner_discover_get"];
-        put?: never;
-        post?: never;
+        /** Enqueue Rescan */
+        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -977,11 +977,15 @@ export interface components {
     schemas: {
         /** BenchmarkCurrentResponse */
         BenchmarkCurrentResponse: {
+            bottleneck?: components["schemas"]["BenchmarkReasonResponse"] | null;
             /**
              * Captured At
              * Format: date-time
              */
             captured_at: string;
+            metrics: components["schemas"]["BenchmarkMetricsResponse"];
+            /** Reasons */
+            reasons?: components["schemas"]["BenchmarkReasonResponse"][];
             /** Score */
             score: number;
             /**
@@ -990,10 +994,6 @@ export interface components {
              */
             status: "OK" | "DEGRADED" | "CRITICAL";
             subscores: components["schemas"]["BenchmarkSubscoresResponse"];
-            metrics: components["schemas"]["BenchmarkMetricsResponse"];
-            bottleneck?: components["schemas"]["BenchmarkReasonResponse"] | null;
-            /** Reasons */
-            reasons?: components["schemas"]["BenchmarkReasonResponse"][];
         };
         /** BenchmarkHistoryResponse */
         BenchmarkHistoryResponse: {
@@ -1002,83 +1002,88 @@ export interface components {
         };
         /** BenchmarkMetricsResponse */
         BenchmarkMetricsResponse: {
-            /** Watchlist Size */
-            watchlist_size?: number | null;
-            /** Scanner Fresh Count */
-            scanner_fresh_count?: number | null;
-            /** Scanner Stale Count */
-            scanner_stale_count?: number | null;
-            /** Scanner Dead Count */
-            scanner_dead_count?: number | null;
-            /** Scanner Never Scanned Count */
-            scanner_never_scanned_count?: number | null;
+            /** Failing Record Tables */
+            failing_record_tables?: string[];
             /** Last Full Scan Age Seconds */
             last_full_scan_age_seconds?: number | null;
+            /** Massive Worker Expected Count */
+            massive_worker_expected_count?: number | null;
+            /** Massive Worker Online Count */
+            massive_worker_online_count?: number | null;
+            /** Oldest Queue Age Seconds */
+            oldest_queue_age_seconds?: number | null;
+            /** Queue Depth */
+            queue_depth?: number | null;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
             /** Scan Duration Avg Seconds */
             scan_duration_avg_seconds?: number | null;
             /** Scan Duration P95 Seconds */
             scan_duration_p95_seconds?: number | null;
-            /** Queue Depth */
-            queue_depth?: number | null;
-            /** Oldest Queue Age Seconds */
-            oldest_queue_age_seconds?: number | null;
-            /** Queue Drain Rate Per Minute */
-            queue_drain_rate_per_minute?: number | null;
-            /** Uw Latency P95 Ms */
-            uw_latency_p95_ms?: number | null;
+            /** Scanner Dead Count */
+            scanner_dead_count?: number | null;
+            /** Scanner Fresh Count */
+            scanner_fresh_count?: number | null;
+            /** Scanner Never Scanned Count */
+            scanner_never_scanned_count?: number | null;
+            /** Scanner Stale Count */
+            scanner_stale_count?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
             /** Uw Http 429 */
             uw_http_429?: number | null;
             /** Uw Http 4Xx */
             uw_http_4xx?: number | null;
             /** Uw Http 5Xx */
             uw_http_5xx?: number | null;
-            /** Requests Per Minute */
-            requests_per_minute?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Uw Worker Online Count */
-            uw_worker_online_count?: number | null;
+            /** Uw Latency P95 Ms */
+            uw_latency_p95_ms?: number | null;
             /** Uw Worker Expected Count */
             uw_worker_expected_count?: number | null;
-            /** Massive Worker Online Count */
-            massive_worker_online_count?: number | null;
-            /** Massive Worker Expected Count */
-            massive_worker_expected_count?: number | null;
+            /** Uw Worker Online Count */
+            uw_worker_online_count?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
             /** Ws Tick Age Seconds */
             ws_tick_age_seconds?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
-            /** Failing Record Tables */
-            failing_record_tables?: string[];
         };
         /** BenchmarkReasonResponse */
         BenchmarkReasonResponse: {
             /** Component */
             component: string;
+            /** Message */
+            message: string;
+            /** Penalty */
+            penalty: number;
             /**
              * Severity
              * @enum {string}
              */
             severity: "degraded" | "critical";
-            /** Message */
-            message: string;
-            /** Penalty */
-            penalty: number;
         };
         /** BenchmarkSnapshotResponse */
         BenchmarkSnapshotResponse: {
-            /** Id */
-            id: number;
-            /**
-             * Captured At
-             * Format: date-time
-             */
-            captured_at: string;
             /**
              * Capture Bucket
              * Format: date-time
              */
             capture_bucket: string;
+            /**
+             * Captured At
+             * Format: date-time
+             */
+            captured_at: string;
+            /** Details Jsonb */
+            details_jsonb?: {
+                [key: string]: unknown;
+            };
+            /** Id */
+            id: number;
+            metrics: components["schemas"]["BenchmarkMetricsResponse"];
             /** Score */
             score: number;
             /**
@@ -1087,26 +1092,21 @@ export interface components {
              */
             status: "OK" | "DEGRADED" | "CRITICAL";
             subscores: components["schemas"]["BenchmarkSubscoresResponse"];
-            metrics: components["schemas"]["BenchmarkMetricsResponse"];
-            /** Details Jsonb */
-            details_jsonb?: {
-                [key: string]: unknown;
-            };
         };
         /** BenchmarkSubscoresResponse */
         BenchmarkSubscoresResponse: {
-            /** Freshness */
-            freshness: number;
             /** Coverage */
             coverage: number;
-            /** Throughput */
-            throughput: number;
-            /** Provider */
-            provider: number;
-            /** Worker */
-            worker: number;
+            /** Freshness */
+            freshness: number;
             /** Persistence */
             persistence: number;
+            /** Provider */
+            provider: number;
+            /** Throughput */
+            throughput: number;
+            /** Worker */
+            worker: number;
         };
         /** CanaryHistoryResponse */
         CanaryHistoryResponse: {
@@ -1116,76 +1116,78 @@ export interface components {
         /** CanaryHistoryRow */
         CanaryHistoryRow: {
             /**
+             * Band
+             * @enum {string}
+             */
+            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
+            /**
              * Data Date
              * Format: date
              */
             data_date: string;
             /** Score */
             score: number;
-            /**
-             * Band
-             * @enum {string}
-             */
-            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
-            /** Tactical Score */
-            tactical_score: number;
-            /** Structural Score */
-            structural_score: number;
             /** Speed Score */
             speed_score: number;
+            /** Spx Close */
+            spx_close?: number | null;
+            /** Structural Score */
+            structural_score: number;
+            /** Tactical Score */
+            tactical_score: number;
             /**
              * Warning State
              * @enum {string}
              */
             warning_state: "NONE" | "CONFIRMED_CANARY_ACTIVE" | "BUY_THE_DIP_ACTIVE" | "BOTH_ACTIVE_AMBIGUOUS";
-            /** Spx Close */
-            spx_close?: number | null;
         };
         /** CanaryLatestResponse */
         CanaryLatestResponse: {
+            /**
+             * Band
+             * @enum {string}
+             */
+            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
+            /** Composite Version */
+            composite_version: number;
             /**
              * Data Date
              * Format: date
              */
             data_date: string;
-            /** Composite Version */
-            composite_version: number;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+            /** Raw Score */
+            raw_score: number;
+            /** Score */
+            score: number;
             /**
              * Score Form
              * @enum {string}
              */
             score_form: "linear" | "convex" | "concave" | "sigmoid";
-            /** Score */
-            score: number;
-            /** Raw Score */
-            raw_score: number;
-            /**
-             * Band
-             * @enum {string}
-             */
-            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
-            /** Tactical Score */
-            tactical_score: number;
-            /** Structural Score */
-            structural_score: number;
             /** Speed Score */
             speed_score: number;
+            /** Structural Score */
+            structural_score: number;
+            /** Tactical Score */
+            tactical_score: number;
             /**
              * Warning State
              * @enum {string}
              */
             warning_state: "NONE" | "CONFIRMED_CANARY_ACTIVE" | "BUY_THE_DIP_ACTIVE" | "BOTH_ACTIVE_AMBIGUOUS";
-            /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
         };
         /** CanaryValidationResponse */
         CanaryValidationResponse: {
-            /** Run Id */
-            run_id: number;
             /** Composite Version */
             composite_version: number;
+            /** Rendered Markdown */
+            rendered_markdown: string;
+            /** Run Id */
+            run_id: number;
             /**
              * Score Form
              * @enum {string}
@@ -1195,87 +1197,78 @@ export interface components {
             summary: {
                 [key: string]: unknown;
             };
-            /** Rendered Markdown */
-            rendered_markdown: string;
         };
         /** CandidateStructure */
         CandidateStructure: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Thesis */
-            thesis: string;
-            /** Expression Type */
-            expression_type: string;
-            /**
-             * Legs
-             * @default []
-             */
-            legs: components["schemas"]["InsightLeg"][];
-            /** Net Credit Debit */
-            net_credit_debit?: string | null;
-            /** Max Profit */
-            max_profit?: string | null;
-            /** Max Loss */
-            max_loss?: string | null;
             /**
              * Breakevens
              * @default []
              */
             breakevens: string[];
             /**
-             * Profit Zone
+             * Dte Band
              * @default
              */
-            profit_zone: string;
+            dte_band: string;
             /**
              * Edge Source
              * @default
              */
             edge_source: string;
             /**
+             * Expression Delta
+             * @default
+             */
+            expression_delta: string;
+            /** Expression Type */
+            expression_type: string;
+            /** Idea Id */
+            idea_id: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["InsightLeg"][];
+            /** Max Loss */
+            max_loss?: string | null;
+            /** Max Profit */
+            max_profit?: string | null;
+            /** Net Credit Debit */
+            net_credit_debit?: string | null;
+            /**
+             * Profit Zone
+             * @default
+             */
+            profit_zone: string;
+            /** Rank */
+            rank: number;
+            /**
              * Risk Flags
              * @default []
              */
             risk_flags: string[];
-            /** Rank */
-            rank: number;
             /**
              * Status
              * @default candidate
              */
             status: string;
-            /**
-             * Dte Band
-             * @default
-             */
-            dte_band: string;
-            /**
-             * Expression Delta
-             * @default
-             */
-            expression_delta: string;
+            /** Structure */
+            structure: string;
+            /** Thesis */
+            thesis: string;
         };
         /** ChainFlowReadRow */
         ChainFlowReadRow: {
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
             /** Call Open Interest */
             call_open_interest?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
             /** Call Put Volume Ratio */
             call_put_volume_ratio?: string | null;
-            /**
-             * Volume Oi Note
-             * @default
-             */
-            volume_oi_note: string;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
             /**
              * Read
              * @default
@@ -1286,99 +1279,104 @@ export interface components {
              * @default false
              */
             requires_t1_oi_confirmation: boolean;
+            /** Strike */
+            strike: string;
+            /**
+             * Volume Oi Note
+             * @default
+             */
+            volume_oi_note: string;
         };
         /** ClosestLevel */
         ClosestLevel: {
-            /** Label */
-            label: string;
             /** Direction */
             direction?: ("up" | "down" | "flip") | null;
-            /** Role */
-            role?: ("support" | "resistance" | "accelerator" | "flip") | null;
-            /** Strike */
-            strike: number;
             /** Distance Pct */
             distance_pct: number;
             /** Gamma */
             gamma?: number | null;
+            /** Label */
+            label: string;
             /**
              * Rank Kind
              * @default nearest
              * @enum {string}
              */
             rank_kind: "nearest" | "dominant";
+            /** Role */
+            role?: ("support" | "resistance" | "accelerator" | "flip") | null;
+            /** Strike */
+            strike: number;
         };
         /** CockpitDealerMetrics */
         CockpitDealerMetrics: {
-            /** Pin Candidate Strike */
-            pin_candidate_strike?: string | null;
-            /** Pin Candidate Expiry */
-            pin_candidate_expiry?: string | null;
-            /** Pin Source Date */
-            pin_source_date?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
-            /** Pin Regime Flag */
-            pin_regime_flag?: boolean | null;
-            /** Dealer Net Vanna Proxy */
-            dealer_net_vanna_proxy?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
+            /** Charm Stress Override */
+            charm_stress_override?: boolean | null;
             /** Dealer Net Charm Proxy */
             dealer_net_charm_proxy?: string | null;
+            /** Dealer Net Vanna Proxy */
+            dealer_net_vanna_proxy?: string | null;
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /** Flow Call Premium 3D */
+            flow_call_premium_3d?: string | null;
             /** Flow Color Lookback 3D */
             flow_color_lookback_3d?: ("put_heavy" | "call_heavy" | "neutral") | null;
             /** Flow Put Premium 3D */
             flow_put_premium_3d?: string | null;
-            /** Flow Call Premium 3D */
-            flow_call_premium_3d?: string | null;
+            /** Gamma Regime */
+            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
             /** Iv 30D Delta 5D */
             iv_30d_delta_5d?: string | null;
             /** Net Gamma */
             net_gamma?: string | null;
             /** Net Gamma Sign */
             net_gamma_sign?: ("positive" | "negative" | "neutral") | null;
-            /** Gamma Regime */
-            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
+            /** Pin Candidate Expiry */
+            pin_candidate_expiry?: string | null;
+            /** Pin Candidate Strike */
+            pin_candidate_strike?: string | null;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Pin Regime Flag */
+            pin_regime_flag?: boolean | null;
+            /** Pin Source Date */
+            pin_source_date?: string | null;
             /** Vanna Conditional Reading */
             vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
             /** Vanna Oi Change Bias */
             vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /** Charm Stress Override */
-            charm_stress_override?: boolean | null;
         };
         /** CockpitDealerPoint */
         CockpitDealerPoint: {
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Vanna */
-            call_vanna?: string | null;
-            /** Put Vanna */
-            put_vanna?: string | null;
-            /** Call Charm */
-            call_charm?: string | null;
-            /** Put Charm */
-            put_charm?: string | null;
-            /** Exposure Call Vanna */
-            exposure_call_vanna?: string | null;
-            /** Exposure Put Vanna */
-            exposure_put_vanna?: string | null;
             /** Exposure Call Charm */
             exposure_call_charm?: string | null;
+            /** Exposure Call Vanna */
+            exposure_call_vanna?: string | null;
             /** Exposure Put Charm */
             exposure_put_charm?: string | null;
+            /** Exposure Put Vanna */
+            exposure_put_vanna?: string | null;
+            /** Put Charm */
+            put_charm?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** CockpitDealerResponse */
         CockpitDealerResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1387,99 +1385,99 @@ export interface components {
             metrics?: components["schemas"]["CockpitDealerMetrics"];
             /** Points */
             points?: components["schemas"]["CockpitDealerPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitFlowAlert */
         CockpitFlowAlert: {
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
             /** Alert Id */
             alert_id: string;
-            /** Option Chain */
-            option_chain?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Option Type */
-            option_type?: string | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Option Type */
+            option_type?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Volume */
+            volume?: number | null;
         };
         /** CockpitFlowImResponse */
         CockpitFlowImResponse: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
             /** Alerts */
             alerts?: components["schemas"]["CockpitFlowAlert"][];
             /** Implied Moves */
             implied_moves?: components["schemas"]["CockpitImPoint"][];
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitImPoint */
         CockpitImPoint: {
+            /** Days */
+            days: number;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Days */
-            days: number;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
             /** Percentile */
             percentile?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitSkewPoint */
         CockpitSkewPoint: {
+            /** Expiry */
+            expiry?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Expiry */
-            expiry?: string | null;
             /** Risk Reversal */
             risk_reversal?: string | null;
         };
         /** CockpitStateResponse */
         CockpitStateResponse: {
-            state: components["schemas"]["MatrixState"];
             freshness: components["schemas"]["MatrixSourceFreshness"];
+            state: components["schemas"]["MatrixState"];
         };
         /** CockpitSurfaceResponse */
         CockpitSurfaceResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1489,43 +1487,43 @@ export interface components {
             skew?: components["schemas"]["CockpitSkewPoint"][];
             /** Term */
             term?: components["schemas"]["CockpitTermPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitTermPoint */
         CockpitTermPoint: {
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
             /** Implied Move Expected Abs */
             implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitVrpPoint */
         CockpitVrpPoint: {
+            /** Iv */
+            iv?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Iv */
-            iv?: string | null;
             /** Rv */
             rv?: string | null;
             /** Vrp */
             vrp?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
         };
         /** CockpitVrpResponse */
         CockpitVrpResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1533,9 +1531,12 @@ export interface components {
             market_date: string;
             /** Points */
             points?: components["schemas"]["CockpitVrpPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CrashTriggerBlock */
         CrashTriggerBlock: {
+            conditions?: components["schemas"]["CrashTriggerConditions"];
             /**
              * Fired
              * @default false
@@ -1546,66 +1547,55 @@ export interface components {
              * @default false
              */
             triggered: boolean;
-            conditions?: components["schemas"]["CrashTriggerConditions"];
             values?: components["schemas"]["CrashTriggerValues"];
         };
         /** CrashTriggerConditions */
         CrashTriggerConditions: {
             /**
-             * Spx Below 100D Ma
+             * Cor1M Gt 60
              * @default false
              */
-            spx_below_100d_ma: boolean;
+            cor1m_gt_60: boolean;
             /**
              * Realized Vol Gt 25
              * @default false
              */
             realized_vol_gt_25: boolean;
             /**
-             * Cor1M Gt 60
+             * Spx Below 100D Ma
              * @default false
              */
-            cor1m_gt_60: boolean;
+            spx_below_100d_ma: boolean;
         };
         /** CrashTriggerValues */
         CrashTriggerValues: {
-            /** Realized Vol */
-            realized_vol?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
         };
         /** CriBlock */
         CriBlock: {
-            /**
-             * Score
-             * @default 0
-             */
-            score: number;
+            components?: components["schemas"]["CriComponents"];
+            /** Composite Version */
+            composite_version?: (1 | 2 | 3) | null;
             /**
              * Level
              * @default LOW
              * @enum {string}
              */
             level: "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
-            /** Composite Version */
-            composite_version?: (1 | 2 | 3) | null;
-            components?: components["schemas"]["CriComponents"];
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
         };
         /**
          * CriComponents
          * @description Four 0-25 component scores summed into the composite 0-100.
          */
         CriComponents: {
-            /**
-             * Vix
-             * @default 0
-             */
-            vix: number;
-            /**
-             * Vvix
-             * @default 0
-             */
-            vvix: number;
             /**
              * Correlation
              * @default 0
@@ -1616,133 +1606,143 @@ export interface components {
              * @default 0
              */
             momentum: number;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
         };
         /** CriHistoryEntry */
         CriHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Date */
+            date: string;
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
             /** Realized Vol */
             realized_vol?: number | null;
             /** Spx Vs Ma Pct */
             spx_vs_ma_pct?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Vix */
+            vix?: number | null;
             /** Vix 5D Roc */
             vix_5d_roc?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix 5D Roc */
             vvix_5d_roc?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Pullback 20D Pct */
-            pullback_20d_pct?: number | null;
         };
         /**
          * CriResponse
          * @description Crash Risk Indicator snapshot (latest scan).
          */
         CriResponse: {
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Spx 100D Ma */
+            spx_100d_ma?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+            /** Spx Source */
+            spx_source?: ("SPX" | "SPY") | null;
+            /** Spy */
+            spy?: number | null;
+            /** Spy Closes */
+            spy_closes?: number[];
             /**
              * Status
              * @default empty
              * @enum {string}
              */
             status: "ok" | "empty";
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Date */
-            date?: string | null;
             /** Vix */
             vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
             /** Vix 5D Roc */
             vix_5d_roc?: number | null;
+            /** Vix Delta 3D */
+            vix_delta_3d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix 5D Roc */
             vvix_5d_roc?: number | null;
             /** Vvix Vix Ratio */
             vvix_vix_ratio?: number | null;
-            /** Spx 100D Ma */
-            spx_100d_ma?: number | null;
-            /** Spx Distance Pct */
-            spx_distance_pct?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
-            /** Cor1M Previous Close */
-            cor1m_previous_close?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Realized Vol */
-            realized_vol?: number | null;
-            /** Vix3M */
-            vix3m?: number | null;
-            /** Vrp */
-            vrp?: number | null;
-            /** Vix Zscore 30D */
-            vix_zscore_30d?: number | null;
-            /** Vix Vix3M Ratio */
-            vix_vix3m_ratio?: number | null;
-            /** Pullback 20D Pct */
-            pullback_20d_pct?: number | null;
-            /** Vix Delta 3D */
-            vix_delta_3d?: number | null;
-            /** Spx Source */
-            spx_source?: ("SPX" | "SPY") | null;
-            cri?: components["schemas"]["CriBlock"];
-            cta?: components["schemas"]["CtaBlock"];
-            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
-            /** History */
-            history?: components["schemas"]["CriHistoryEntry"][];
-            /** Spy Closes */
-            spy_closes?: number[];
         };
         /**
          * CriScanResponse
          * @description Response body for POST /api/regime/scan.
          */
         CriScanResponse: {
-            /**
-             * Status
-             * @default ok
-             * @enum {string}
-             */
-            status: "ok" | "skipped";
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default cri
              * @constant
              */
             scanner: "cri";
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
         };
         /** CtaBlock */
         CtaBlock: {
-            /** Realized Vol */
-            realized_vol?: number | null;
+            /** Est Selling Bn */
+            est_selling_bn?: number | null;
             /** Exposure Pct */
             exposure_pct?: number | null;
-            /** Forced Reduction Pct */
-            forced_reduction_pct?: number | null;
             /**
              * Forced Reduction
              * @default false
              */
             forced_reduction: boolean;
-            /** Est Selling Bn */
-            est_selling_bn?: number | null;
+            /** Forced Reduction Pct */
+            forced_reduction_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
             /** Selling Usd B */
             selling_usd_b?: number | null;
         };
@@ -1755,49 +1755,69 @@ export interface components {
          */
         DealerRegime: {
             /**
-             * Label
-             * @default neutral
-             */
-            label: string;
-            /**
-             * Score
+             * Charm Score
              * @default 0
              */
-            score: string;
+            charm_score: string;
             /**
              * Gamma Score
              * @default 0
              */
             gamma_score: string;
             /**
-             * Vanna Score
-             * @default 0
-             */
-            vanna_score: string;
-            /**
-             * Charm Score
-             * @default 0
-             */
-            charm_score: string;
-            /**
              * Headline
              * @default
              */
             headline: string;
             /**
-             * Subtitle
-             * @default
+             * Label
+             * @default neutral
              */
-            subtitle: string;
-            /** Prev Close Net Gex */
-            prev_close_net_gex?: string | null;
+            label: string;
             /** Odte Net Gex */
             odte_net_gex?: string | null;
             /** Odte Share Pct */
             odte_share_pct?: string | null;
+            /** Prev Close Net Gex */
+            prev_close_net_gex?: string | null;
+            /**
+             * Score
+             * @default 0
+             */
+            score: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /**
+             * Vanna Score
+             * @default 0
+             */
+            vanna_score: string;
         };
         /** DealerRegimeResponse */
         DealerRegimeResponse: {
+            /** Closest Levels */
+            closest_levels?: components["schemas"]["ClosestLevel"][];
+            /** Gamma Decay */
+            gamma_decay?: components["schemas"]["GammaDecayBucket"][];
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Odte Gex */
+            odte_gex?: number | null;
+            /** Odte Share Pct */
+            odte_share_pct?: number | null;
+            /** Prev Close Net Gex */
+            prev_close_net_gex?: number | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            signal?: components["schemas"]["DealerRegimeSignal"];
+            /** Spot */
+            spot?: number | null;
             /**
              * Status
              * @default empty
@@ -1809,32 +1829,27 @@ export interface components {
              * @default
              */
             ticker: string;
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Spot */
-            spot?: number | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Prev Close Net Gex */
-            prev_close_net_gex?: number | null;
-            signal?: components["schemas"]["DealerRegimeSignal"];
-            /** Closest Levels */
-            closest_levels?: components["schemas"]["ClosestLevel"][];
-            /** Odte Gex */
-            odte_gex?: number | null;
-            /** Odte Share Pct */
-            odte_share_pct?: number | null;
-            /** Gamma Decay */
-            gamma_decay?: components["schemas"]["GammaDecayBucket"][];
         };
         /**
          * DealerRegimeSignal
          * @description Per-ticker dealer regime classification (Γ-driven, with V/C support).
          */
         DealerRegimeSignal: {
+            /**
+             * Charm Score
+             * @default 0
+             */
+            charm_score: number;
+            /**
+             * Gamma Score
+             * @default 0
+             */
+            gamma_score: number;
+            /**
+             * Headline
+             * @default
+             */
+            headline: string;
             /**
              * Label
              * @default neutral
@@ -1847,30 +1862,15 @@ export interface components {
              */
             score: number;
             /**
-             * Gamma Score
-             * @default 0
+             * Subtitle
+             * @default
              */
-            gamma_score: number;
+            subtitle: string;
             /**
              * Vanna Score
              * @default 0
              */
             vanna_score: number;
-            /**
-             * Charm Score
-             * @default 0
-             */
-            charm_score: number;
-            /**
-             * Headline
-             * @default
-             */
-            headline: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
         };
         /**
          * DiscoveryCandidate
@@ -1880,9 +1880,8 @@ export interface components {
          *     requires a deep scan. Promote to the watchlist to get those.
          */
         DiscoveryCandidate: {
-            /** Ticker */
-            ticker: string;
-            hit: components["schemas"]["ScannerSignalHit"];
+            /** Alert Count */
+            alert_count: number;
             /**
              * Bias
              * @enum {string}
@@ -1890,17 +1889,25 @@ export interface components {
             bias: "bullish" | "bearish" | "neutral" | "mixed";
             /** Bias Strength */
             bias_strength?: ("strong" | "moderate" | "weak") | null;
-            /** Alert Count */
-            alert_count: number;
-            /** Sector */
-            sector?: string | null;
+            hit: components["schemas"]["ScannerSignalHit"];
             /** Latest Alert At */
             latest_alert_at?: string | null;
+            /** Sector */
+            sector?: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** DiscoveryResponse */
         DiscoveryResponse: {
+            /** Alerts Pulled */
+            alerts_pulled: number;
             /** Candidates */
             candidates: components["schemas"]["DiscoveryCandidate"][];
+            /**
+             * Earnings Unknown Dropped
+             * @default 0
+             */
+            earnings_unknown_dropped: number;
             /**
              * Fetched At
              * Format: date-time
@@ -1912,13 +1919,6 @@ export interface components {
              * @constant
              */
             source: "market_wide_flow_alerts";
-            /** Alerts Pulled */
-            alerts_pulled: number;
-            /**
-             * Earnings Unknown Dropped
-             * @default 0
-             */
-            earnings_unknown_dropped: number;
         };
         /** DivergencePoint */
         DivergencePoint: {
@@ -1939,143 +1939,143 @@ export interface components {
          *     persisted to uw_scan.exposures_summary.
          */
         ExposuresSummaryRow: {
+            /** Charm Above Sum */
+            charm_above_sum?: string | null;
+            /** Charm Below Sum */
+            charm_below_sum?: string | null;
+            /** Charm Flip */
+            charm_flip?: string | null;
+            /** Charm Headline */
+            charm_headline?: string | null;
+            /** Charm Imbalance Pct */
+            charm_imbalance_pct?: string | null;
+            /** Charm Pin Strike */
+            charm_pin_strike?: string | null;
+            /** Charm Signal Quality */
+            charm_signal_quality?: string | null;
+            /** Charm Subtitle */
+            charm_subtitle?: string | null;
+            /** Delta Shock 1Pt Iv */
+            delta_shock_1pt_iv?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Spot */
-            spot?: string | null;
+            /** Net Charm */
+            net_charm?: string | null;
             /** Net Vanna */
             net_vanna?: string | null;
+            /** Spot */
+            spot?: string | null;
             /** Top Vanna Strike */
             top_vanna_strike?: string | null;
             /** Top Vanna Value */
             top_vanna_value?: string | null;
-            /** Delta Shock 1Pt Iv */
-            delta_shock_1pt_iv?: string | null;
-            /** Vanna Regime */
-            vanna_regime?: string | null;
             /** Vanna Flip */
             vanna_flip?: string | null;
             /** Vanna Headline */
             vanna_headline?: string | null;
+            /** Vanna Regime */
+            vanna_regime?: string | null;
             /** Vanna Subtitle */
             vanna_subtitle?: string | null;
-            /** Net Charm */
-            net_charm?: string | null;
-            /** Charm Pin Strike */
-            charm_pin_strike?: string | null;
-            /** Charm Above Sum */
-            charm_above_sum?: string | null;
-            /** Charm Below Sum */
-            charm_below_sum?: string | null;
-            /** Charm Imbalance Pct */
-            charm_imbalance_pct?: string | null;
-            /** Charm Signal Quality */
-            charm_signal_quality?: string | null;
-            /** Charm Flip */
-            charm_flip?: string | null;
-            /** Charm Headline */
-            charm_headline?: string | null;
-            /** Charm Subtitle */
-            charm_subtitle?: string | null;
         };
         /** FlowAlert */
         FlowAlert: {
-            /** Id */
-            id: string;
-            /** Ticker */
-            ticker: string;
-            /** Option Chain */
-            option_chain?: string | null;
-            /** Type */
-            type?: string | null;
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Price */
-            price?: string | null;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            /** Total Size */
-            total_size?: number | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Volume Oi Ratio */
-            volume_oi_ratio?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Iv Start */
-            iv_start?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Id */
+            id: string;
+            /** Issue Type */
+            issue_type?: string | null;
             /** Iv End */
             iv_end?: string | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
+            /** Iv Start */
+            iv_start?: string | null;
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Price */
+            price?: string | null;
             /** Rule Id */
             rule_id?: string | null;
             /** Sector */
             sector?: string | null;
-            /** Issue Type */
-            issue_type?: string | null;
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Ticker */
+            ticker: string;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Total Size */
+            total_size?: number | null;
+            /** Type */
+            type?: string | null;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            /** Volume */
+            volume?: number | null;
+            /** Volume Oi Ratio */
+            volume_oi_ratio?: string | null;
         };
         /** FlowSnapshot */
         FlowSnapshot: {
-            /** Ticker */
-            ticker: string;
+            /** Ask Side Premium */
+            ask_side_premium: string;
+            /** Bear Premium */
+            bear_premium: string;
+            /** Bid Side Premium */
+            bid_side_premium: string;
+            /** Bull Premium */
+            bull_premium: string;
             /** Flow Count */
             flow_count: number;
-            /**
-             * Flow Count Is Limited
-             * @default false
-             */
-            flow_count_is_limited: boolean;
             /** Flow Count 30D Avg */
             flow_count_30d_avg?: string | null;
-            /** Flow Count Vs 30D Avg */
-            flow_count_vs_30d_avg?: string | null;
             /**
              * Flow Count 30D Days
              * @default 0
              */
             flow_count_30d_days: number;
-            /** Top Alert Rule */
-            top_alert_rule?: string | null;
+            /**
+             * Flow Count Is Limited
+             * @default false
+             */
+            flow_count_is_limited: boolean;
+            /** Flow Count Vs 30D Avg */
+            flow_count_vs_30d_avg?: string | null;
             /** Net Premium */
             net_premium: string;
-            /** Bull Premium */
-            bull_premium: string;
-            /** Bear Premium */
-            bear_premium: string;
-            /** Ask Side Premium */
-            ask_side_premium: string;
-            /** Bid Side Premium */
-            bid_side_premium: string;
+            /** Ticker */
+            ticker: string;
+            /** Top Alert Rule */
+            top_alert_rule?: string | null;
             /**
              * Top Alerts
              * @default []
@@ -2084,18 +2084,18 @@ export interface components {
         };
         /** GammaBlock */
         GammaBlock: {
+            /** Expiring Date */
+            expiring_date?: string | null;
+            /** Expiring Pct */
+            expiring_pct?: string | null;
             /** Flip Distance */
             flip_distance?: string | null;
             /** Flip Price */
             flip_price?: string | null;
-            /** Per 1Pct Move */
-            per_1pct_move?: string | null;
             /** Max Strike */
             max_strike?: string | null;
-            /** Expiring Pct */
-            expiring_pct?: string | null;
-            /** Expiring Date */
-            expiring_date?: string | null;
+            /** Per 1Pct Move */
+            per_1pct_move?: string | null;
         };
         /** GammaDecayBucket */
         GammaDecayBucket: {
@@ -2103,49 +2103,49 @@ export interface components {
             dte: number;
             /** Expiry */
             expiry: string;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Share Pct */
-            share_pct?: number | null;
             /** Gross Abs Gex */
             gross_abs_gex?: number | null;
             /** Gross Share Pct */
             gross_share_pct?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Share Pct */
+            share_pct?: number | null;
         };
         /** GexBias */
         GexBias: {
-            /** Direction */
-            direction?: string | null;
-            /** Reasons */
-            reasons?: string[];
             /** Days Above Flip */
             days_above_flip?: number | null;
+            /** Direction */
+            direction?: string | null;
             /** Flip Migration */
             flip_migration?: components["schemas"]["GexFlipMigrationEntry"][];
+            /** Reasons */
+            reasons?: string[];
         };
         /** GexBucket */
         GexBucket: {
-            /** Strike */
-            strike?: number | null;
             /** Call Gex */
             call_gex?: number | null;
-            /** Put Gex */
-            put_gex?: number | null;
             /** Net Gex */
             net_gex?: number | null;
             /** Pct From Spot */
             pct_from_spot?: number | null;
+            /** Put Gex */
+            put_gex?: number | null;
+            /** Strike */
+            strike?: number | null;
             /** Tag */
             tag?: string | null;
         };
         /** GexExpectedRange */
         GexExpectedRange: {
-            /** Low */
-            low?: number | null;
             /** High */
             high?: number | null;
             /** Iv 1D */
             iv_1d?: number | null;
+            /** Low */
+            low?: number | null;
         };
         /** GexFlipMigrationEntry */
         GexFlipMigrationEntry: {
@@ -2156,31 +2156,31 @@ export interface components {
         };
         /** GexHistoryEntry */
         GexHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Gex Flip */
-            gex_flip?: number | null;
-            /** Spot */
-            spot?: number | null;
             /** Atm Iv */
             atm_iv?: number | null;
-            /** Vol Pc */
-            vol_pc?: number | null;
             /** Bias */
             bias?: string | null;
+            /** Date */
+            date: string;
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Spot */
+            spot?: number | null;
+            /** Vol Pc */
+            vol_pc?: number | null;
         };
         /** GexIvData */
         GexIvData: {
+            /** Hv30 */
+            hv30?: number | null;
             /** Iv30D */
             iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: number | null;
-            /** Hv30 */
-            hv30?: number | null;
             /** Mq Iv30D */
             mq_iv30d?: number | null;
             /** Mq Iv Rank */
@@ -2190,130 +2190,130 @@ export interface components {
         };
         /** GexLevels */
         GexLevels: {
-            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
         };
         /** GexMqLevels */
         GexMqLevels: {
-            /** Source Date */
-            source_date?: string | null;
-            /** Spot */
-            spot?: number | null;
-            /** Hvl */
-            hvl?: number | null;
-            /** Call Resistance All */
-            call_resistance_all?: number | null;
             /** Call Resistance 0Dte */
             call_resistance_0dte?: number | null;
-            /** Put Support All */
-            put_support_all?: number | null;
-            /** Put Support 0Dte */
-            put_support_0dte?: number | null;
+            /** Call Resistance All */
+            call_resistance_all?: number | null;
+            /** Distance To Hvl Pct */
+            distance_to_hvl_pct?: string | null;
             /** Expected High */
             expected_high?: number | null;
             /** Expected Low */
             expected_low?: number | null;
-            /** Distance To Hvl Pct */
-            distance_to_hvl_pct?: string | null;
-            /** Iv30D */
-            iv30d?: number | null;
             /** Hv30 */
             hv30?: number | null;
+            /** Hvl */
+            hvl?: number | null;
+            /** Iv30D */
+            iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: string | null;
+            /** Put Support 0Dte */
+            put_support_0dte?: number | null;
+            /** Put Support All */
+            put_support_all?: number | null;
+            /** Source Date */
+            source_date?: string | null;
+            /** Spot */
+            spot?: number | null;
             /** Top Gex Strikes */
             top_gex_strikes?: number[];
         };
         /** GexResponse */
         GexResponse: {
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
+            /** Atm Iv */
+            atm_iv?: number | null;
+            bias?: components["schemas"]["GexBias"];
+            /** Close */
+            close?: number | null;
+            /** Data Date */
+            data_date?: string | null;
+            /** Day Change */
+            day_change?: number | null;
+            /** Day Change Pct */
+            day_change_pct?: number | null;
+            expected_range?: components["schemas"]["GexExpectedRange"];
+            /** History */
+            history?: components["schemas"]["GexHistoryEntry"][];
+            iv?: components["schemas"]["GexIvData"] | null;
+            levels?: components["schemas"]["GexLevels"];
             /**
              * Market Open
              * @default false
              */
             market_open: boolean;
+            /** Market Time */
+            market_time?: string | null;
+            mq?: components["schemas"]["GexMqLevels"] | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Prev Close */
+            prev_close?: number | null;
+            /** Profile */
+            profile?: components["schemas"]["GexBucket"][];
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            source_delta?: components["schemas"]["GexSourceDelta"] | null;
+            /** Spot */
+            spot?: number | null;
+            /** Spot Source */
+            spot_source?: string | null;
+            /** Tape Time */
+            tape_time?: string | null;
             /**
              * Ticker
              * @default SPX
              */
             ticker: string;
-            /** Spot */
-            spot?: number | null;
-            /** Close */
-            close?: number | null;
-            /** Prev Close */
-            prev_close?: number | null;
-            /** Market Time */
-            market_time?: string | null;
-            /** Tape Time */
-            tape_time?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /** Day Change */
-            day_change?: number | null;
-            /** Day Change Pct */
-            day_change_pct?: number | null;
-            /** Data Date */
-            data_date?: string | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Atm Iv */
-            atm_iv?: number | null;
             /** Vol Pc */
             vol_pc?: number | null;
-            levels?: components["schemas"]["GexLevels"];
-            /** Profile */
-            profile?: components["schemas"]["GexBucket"][];
-            expected_range?: components["schemas"]["GexExpectedRange"];
-            bias?: components["schemas"]["GexBias"];
-            /** History */
-            history?: components["schemas"]["GexHistoryEntry"][];
-            iv?: components["schemas"]["GexIvData"] | null;
-            mq?: components["schemas"]["GexMqLevels"] | null;
-            source_delta?: components["schemas"]["GexSourceDelta"] | null;
         };
         /** GexSourceDelta */
         GexSourceDelta: {
-            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
             call_wall_vs_resistance_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
         };
         /** GexSourceDeltaEntry */
         GexSourceDeltaEntry: {
-            /** Uw */
-            uw?: number | null;
-            /** Mq */
-            mq?: number | null;
             /** Delta */
             delta?: number | null;
+            /** Mq */
+            mq?: number | null;
+            /** Uw */
+            uw?: number | null;
         };
         /** GoldCbCountryHistory */
         GoldCbCountryHistory: {
+            /** Bucket */
+            bucket: string;
             /** Country Iso3 */
             country_iso3: string;
             /** Country Name */
             country_name: string;
-            /** Bucket */
-            bucket: string;
-            /** Latest Reserves T */
-            latest_reserves_t?: string | null;
             /**
              * History
              * @default []
              */
             history: components["schemas"]["GoldHistoryPoint"][];
+            /** Latest Reserves T */
+            latest_reserves_t?: string | null;
         };
         /** GoldCorrelationBand */
         GoldCorrelationBand: {
@@ -2356,19 +2356,8 @@ export interface components {
         };
         /** GoldCyclicalPostureModel */
         GoldCyclicalPostureModel: {
-            /** Zone Label */
-            zone_label?: string | null;
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
             /** Cpi Yoy */
             cpi_yoy?: string | null;
-            /** T5Yifr */
-            t5yifr?: string | null;
-            /** T5Yifr Pct 52W */
-            t5yifr_pct_52w?: string | null;
             /** Dfii10 */
             dfii10?: string | null;
             /** Dfii10 60D Change Bps */
@@ -2377,10 +2366,6 @@ export interface components {
             dxy?: string | null;
             /** Dxy 60D Sigma */
             dxy_60d_sigma?: string | null;
-            /** Gpr Value */
-            gpr_value?: string | null;
-            /** Gpr Pct 52W */
-            gpr_pct_52w?: string | null;
             /**
              * Factors
              * @default {}
@@ -2388,9 +2373,24 @@ export interface components {
             factors: {
                 [key: string]: number;
             };
-            two_force_text: components["schemas"]["GoldTwoForceText"];
+            /** Gpr Pct 52W */
+            gpr_pct_52w?: string | null;
+            /** Gpr Value */
+            gpr_value?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** T5Yifr */
+            t5yifr?: string | null;
+            /** T5Yifr Pct 52W */
+            t5yifr_pct_52w?: string | null;
+            two_force_text: components["schemas"]["GoldTwoForceText"];
+            /** Zone Label */
+            zone_label?: string | null;
         };
         /**
          * GoldDataFreshnessSource
@@ -2415,15 +2415,15 @@ export interface components {
          * @description One row of the Tier 5 lens-decomposition bars.
          */
         GoldDecompositionRow: {
+            /** Contribution */
+            contribution: string;
+            /** Factor */
+            factor: string;
             /**
              * Lens
              * @enum {string}
              */
             lens: "L1" | "L2" | "L3";
-            /** Factor */
-            factor: string;
-            /** Contribution */
-            contribution: string;
         };
         /** GoldGaugeResponse */
         GoldGaugeResponse: {
@@ -2433,16 +2433,16 @@ export interface components {
         };
         /** GoldGaugeState */
         GoldGaugeState: {
-            /** Corr 60D */
-            corr_60d?: string | null;
             /** Corr 126D */
             corr_126d?: string | null;
             /** Corr 252D */
             corr_252d?: string | null;
-            /** Corr 504D */
-            corr_504d?: string | null;
             /** Corr 252D Returns */
             corr_252d_returns?: string | null;
+            /** Corr 504D */
+            corr_504d?: string | null;
+            /** Corr 60D */
+            corr_60d?: string | null;
             /**
              * State
              * @enum {string}
@@ -2451,13 +2451,13 @@ export interface components {
         };
         /** GoldGaugeTimeSeriesPoint */
         GoldGaugeTimeSeriesPoint: {
+            /** Corr 252D */
+            corr_252d: string | null;
             /**
              * Obs Date
              * Format: date
              */
             obs_date: string;
-            /** Corr 252D */
-            corr_252d: string | null;
         };
         /** GoldHistoryPoint */
         GoldHistoryPoint: {
@@ -2472,45 +2472,49 @@ export interface components {
         /** GoldInputProvenance */
         GoldInputProvenance: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /**
              * As Of
              * Format: date-time
              */
             as_of: string;
+            /**
+             * Obs Date
+             * Format: date
+             */
+            obs_date: string;
         };
         /** GoldInputSeriesPoint */
         GoldInputSeriesPoint: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /** Value */
-            value: string;
-            /**
              * As Of
              * Format: date-time
              */
             as_of: string;
+            /**
+             * Obs Date
+             * Format: date
+             */
+            obs_date: string;
             /** Release Date */
             release_date?: string | null;
+            /** Value */
+            value: string;
         };
         /** GoldInputSeriesResponse */
         GoldInputSeriesResponse: {
-            /** Series Id */
-            series_id: string;
             /** Points */
             points: components["schemas"]["GoldInputSeriesPoint"][];
+            /** Series Id */
+            series_id: string;
         };
         /**
          * GoldLensResponse
          * @description Detail payload for one lens (richer than the summary in GoldStateResponse).
          */
         GoldLensResponse: {
+            /** Detail */
+            detail: {
+                [key: string]: components["schemas"]["GoldInputSeriesPoint"][];
+            };
             /**
              * Lens Id
              * @enum {string}
@@ -2518,24 +2522,20 @@ export interface components {
             lens_id: "structural" | "cyclical" | "valuation";
             /** Posture */
             posture: components["schemas"]["GoldStructuralPostureModel"] | components["schemas"]["GoldCyclicalPostureModel"] | components["schemas"]["GoldValuationPostureModel"];
-            /** Detail */
-            detail: {
-                [key: string]: components["schemas"]["GoldInputSeriesPoint"][];
-            };
         };
         /**
          * GoldSpotTile
          * @description XAU/USD snapshot used by the Tier 1 KPI strip.
          */
         GoldSpotTile: {
-            /** Last */
-            last: string;
             /** Delta Abs */
             delta_abs: string;
             /** Delta Pct */
             delta_pct: string;
             /** High */
             high: string;
+            /** Last */
+            last: string;
             /** Low */
             low: string;
             /** Open */
@@ -2544,24 +2544,19 @@ export interface components {
         /** GoldStateResponse */
         GoldStateResponse: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /**
              * Computed At
              * Format: date-time
              */
             computed_at: string;
-            gauge: components["schemas"]["GoldGaugeState"];
-            spot: components["schemas"]["GoldSpotTile"];
-            structural: components["schemas"]["GoldStructuralPostureModel"];
+            /**
+             * @default {
+             *       "gold_dfii10": [],
+             *       "gold_dxy": [],
+             *       "gold_gpr": []
+             *     }
+             */
+            correlation_history: components["schemas"]["GoldCorrelationHistory"];
             cyclical: components["schemas"]["GoldCyclicalPostureModel"];
-            valuation: components["schemas"]["GoldValuationPostureModel"];
-            /** Inputs Used */
-            inputs_used: {
-                [key: string]: components["schemas"]["GoldInputProvenance"];
-            };
             /**
              * Data Freshness
              * @default []
@@ -2572,69 +2567,74 @@ export interface components {
              * @default []
              */
             decomposition_rows: components["schemas"]["GoldDecompositionRow"][];
+            gauge: components["schemas"]["GoldGaugeState"];
+            /** Inputs Used */
+            inputs_used: {
+                [key: string]: components["schemas"]["GoldInputProvenance"];
+            };
             /**
-             * @default {
-             *       "gold_dfii10": [],
-             *       "gold_dxy": [],
-             *       "gold_gpr": []
-             *     }
+             * Obs Date
+             * Format: date
              */
-            correlation_history: components["schemas"]["GoldCorrelationHistory"];
+            obs_date: string;
+            spot: components["schemas"]["GoldSpotTile"];
+            structural: components["schemas"]["GoldStructuralPostureModel"];
+            valuation: components["schemas"]["GoldValuationPostureModel"];
         };
         /** GoldStructuralPostureModel */
         GoldStructuralPostureModel: {
-            /** State Label */
-            state_label?: string | null;
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
-            /** Cb Strategic 12M Sum T */
-            cb_strategic_12m_sum_t?: string | null;
-            /** Cb Tactical 12M Sum T */
-            cb_tactical_12m_sum_t?: string | null;
-            /** Cb Diversifier 12M Sum T */
-            cb_diversifier_12m_sum_t?: string | null;
             /** Cb 52W Pct */
             cb_52w_pct?: string | null;
-            /** Gld Holdings T */
-            gld_holdings_t?: string | null;
-            /** Gld 30D Net Flow T */
-            gld_30d_net_flow_t?: string | null;
-            /** Comex Registered Oz */
-            comex_registered_oz?: string | null;
-            /** Comex 20D Roc Pct */
-            comex_20d_roc_pct?: string | null;
-            /** Lbma 30D Momentum T */
-            lbma_30d_momentum_t?: string | null;
-            /** Cot Mm Net Pct */
-            cot_mm_net_pct?: string | null;
-            /** Cot Mm 4W Change Sigma */
-            cot_mm_4w_change_sigma?: string | null;
-            /** Uw 25D Skew Sigma */
-            uw_25d_skew_sigma?: string | null;
-            /** Fx Basket Dxy Z */
-            fx_basket_dxy_z?: string | null;
-            /** Xau Cny Premium Pct */
-            xau_cny_premium_pct?: string | null;
-            /**
-             * Gld History
-             * @default []
-             */
-            gld_history: components["schemas"]["GoldHistoryPoint"][];
-            /**
-             * Gold History
-             * @default []
-             */
-            gold_history: components["schemas"]["GoldHistoryPoint"][];
             /**
              * Cb Country History
              * @default []
              */
             cb_country_history: components["schemas"]["GoldCbCountryHistory"][];
+            /** Cb Diversifier 12M Sum T */
+            cb_diversifier_12m_sum_t?: string | null;
+            /** Cb Strategic 12M Sum T */
+            cb_strategic_12m_sum_t?: string | null;
+            /** Cb Tactical 12M Sum T */
+            cb_tactical_12m_sum_t?: string | null;
+            /** Comex 20D Roc Pct */
+            comex_20d_roc_pct?: string | null;
+            /** Comex Registered Oz */
+            comex_registered_oz?: string | null;
+            /** Cot Mm 4W Change Sigma */
+            cot_mm_4w_change_sigma?: string | null;
+            /** Cot Mm Net Pct */
+            cot_mm_net_pct?: string | null;
+            /** Fx Basket Dxy Z */
+            fx_basket_dxy_z?: string | null;
+            /** Gld 30D Net Flow T */
+            gld_30d_net_flow_t?: string | null;
+            /**
+             * Gld History
+             * @default []
+             */
+            gld_history: components["schemas"]["GoldHistoryPoint"][];
+            /** Gld Holdings T */
+            gld_holdings_t?: string | null;
+            /**
+             * Gold History
+             * @default []
+             */
+            gold_history: components["schemas"]["GoldHistoryPoint"][];
+            /** Lbma 30D Momentum T */
+            lbma_30d_momentum_t?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** State Label */
+            state_label?: string | null;
+            /** Uw 25D Skew Sigma */
+            uw_25d_skew_sigma?: string | null;
+            /** Xau Cny Premium Pct */
+            xau_cny_premium_pct?: string | null;
         };
         /** GoldTwoForceText */
         GoldTwoForceText: {
@@ -2650,13 +2650,6 @@ export interface components {
              * @enum {string}
              */
             flag: "Low" | "Moderate" | "High" | "Severe";
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
-            /** Real Price Percentile */
-            real_price_percentile?: string | null;
             /** Gold M2 Ratio Percentile */
             gold_m2_ratio_percentile?: string | null;
             /** Gold Oil Ratio Percentile */
@@ -2665,20 +2658,27 @@ export interface components {
             gold_spx_ratio_percentile?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** Real Price Percentile */
+            real_price_percentile?: string | null;
         };
         /** GuidanceResponse */
         GuidanceResponse: {
-            /** State */
-            state: string;
+            /** Body Md */
+            body_md: string;
+            /** Matched Condition */
+            matched_condition: string;
             /**
              * Posture
              * @enum {string}
              */
             posture: "opportunistic" | "neutral" | "cautious" | "defensive";
-            /** Body Md */
-            body_md: string;
-            /** Matched Condition */
-            matched_condition: string;
+            /** State */
+            state: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -2687,72 +2687,72 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
-            /** Ok */
-            ok: boolean;
+            /** Avg Scan Duration Seconds */
+            avg_scan_duration_seconds?: number | null;
+            /** Cache Hit Pct */
+            cache_hit_pct?: number | null;
             /** Db */
             db: string;
-            /** Scheduler Lag Seconds */
-            scheduler_lag_seconds?: number | null;
+            /** Http 2Xx */
+            http_2xx?: number | null;
+            /** Http 429 */
+            http_429?: number | null;
+            /** Http 4Xx */
+            http_4xx?: number | null;
+            /** Http 5Xx */
+            http_5xx?: number | null;
             /** Last Full Scan At */
             last_full_scan_at?: string | null;
-            /** Reason */
-            reason?: string | null;
-            /** Worker Lag Seconds */
-            worker_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Name */
-            scheduler_heartbeat_name?: string | null;
-            /** Rescan Heartbeat Lag Seconds */
-            rescan_heartbeat_lag_seconds?: number | null;
-            /** Spot Refresh Heartbeat Lag Seconds */
-            spot_refresh_heartbeat_lag_seconds?: number | null;
-            /** Spot Quote Lag Seconds */
-            spot_quote_lag_seconds?: number | null;
+            /** Latency P95 Ms */
+            latency_p95_ms?: number | null;
             /** Latest Spot Quote At */
             latest_spot_quote_at?: string | null;
             /** Latest Spot Quote Fetched At */
             latest_spot_quote_fetched_at?: string | null;
-            /** Watchlist Size */
-            watchlist_size?: number | null;
+            /** Ok */
+            ok: boolean;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
+            /** Reason */
+            reason?: string | null;
+            /** Record Health */
+            record_health?: components["schemas"]["RecordHealthCheck"][];
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
+            /** Rescan Heartbeat Lag Seconds */
+            rescan_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Name */
+            scheduler_heartbeat_name?: string | null;
+            /** Scheduler Lag Seconds */
+            scheduler_lag_seconds?: number | null;
             /**
              * Source
              * @default UnusualWhales
              */
             source: string;
-            /** Latency P95 Ms */
-            latency_p95_ms?: number | null;
-            /** Http 2Xx */
-            http_2xx?: number | null;
-            /** Http 4Xx */
-            http_4xx?: number | null;
-            /** Http 5Xx */
-            http_5xx?: number | null;
-            /** Uw Today */
-            uw_today?: number | null;
-            /** Cache Hit Pct */
-            cache_hit_pct?: number | null;
+            /** Spot Quote Lag Seconds */
+            spot_quote_lag_seconds?: number | null;
+            /** Spot Refresh Heartbeat Lag Seconds */
+            spot_refresh_heartbeat_lag_seconds?: number | null;
             /**
              * Throughput Window Minutes
              * @default 0
              */
             throughput_window_minutes: number;
-            /** Requests Per Minute */
-            requests_per_minute?: number | null;
-            /** Http 429 */
-            http_429?: number | null;
-            /** Avg Scan Duration Seconds */
-            avg_scan_duration_seconds?: number | null;
-            /** Queue Drain Rate Per Minute */
-            queue_drain_rate_per_minute?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
-            /** Record Health */
-            record_health?: components["schemas"]["RecordHealthCheck"][];
+            trade_insights_ai?: components["schemas"]["TradeInsightsAiHealth"] | null;
+            /** Uw Today */
+            uw_today?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
+            /** Worker Lag Seconds */
+            worker_lag_seconds?: number | null;
             /** Workers */
             workers?: components["schemas"]["WorkerHealth"][];
             ws_consumer?: components["schemas"]["WsConsumerHealth"] | null;
-            trade_insights_ai?: components["schemas"]["TradeInsightsAiHealth"] | null;
         };
         /** InsightBadge */
         InsightBadge: {
@@ -2768,41 +2768,48 @@ export interface components {
         };
         /** InsightLeg */
         InsightLeg: {
-            /** Side */
-            side: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Option Right */
-            option_right: string;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
             /** Mid */
             mid?: string | null;
+            /** Option Right */
+            option_right: string;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** InsightSignalRow */
         InsightSignalRow: {
-            /** Lens */
-            lens: string;
-            /** Read */
-            read: string;
-            /**
-             * Evidence
-             * @default []
-             */
-            evidence: string[];
             /**
              * Conflicts
              * @default []
              */
             conflicts: string[];
+            /**
+             * Evidence
+             * @default []
+             */
+            evidence: string[];
+            /** Lens */
+            lens: string;
+            /** Read */
+            read: string;
         };
         /** InsightsSynthesis */
         InsightsSynthesis: {
+            /**
+             * Avoid
+             * @default []
+             */
+            avoid: string[];
+            /** Best Risk Reward Idea Id */
+            best_risk_reward_idea_id?: string | null;
             /**
              * Dominant Story
              * @default
@@ -2810,13 +2817,6 @@ export interface components {
             dominant_story: string;
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
-            /** Best Risk Reward Idea Id */
-            best_risk_reward_idea_id?: string | null;
-            /**
-             * Avoid
-             * @default []
-             */
-            avoid: string[];
             /**
              * Required Before Sizing
              * @default []
@@ -2825,12 +2825,12 @@ export interface components {
         };
         /** IvHistogramBin */
         IvHistogramBin: {
-            /** Lo */
-            lo: string;
-            /** Hi */
-            hi: string;
             /** Count */
             count: number;
+            /** Hi */
+            hi: string;
+            /** Lo */
+            lo: string;
         };
         /** IvHvPoint */
         IvHvPoint: {
@@ -2870,26 +2870,26 @@ export interface components {
         };
         /** JobStatus */
         JobStatus: {
-            /** Job Id */
-            job_id: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "done" | "failed";
-            /** Run Id */
-            run_id?: number | null;
             /** Error */
             error?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Job Id */
+            job_id: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
+            /** Run Id */
+            run_id?: number | null;
             /** Started At */
             started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
         };
         /**
          * MarketAggregates
@@ -2899,51 +2899,43 @@ export interface components {
          *     sub-models. Feeds the watchlist card POSITIONING and SKEW blocks.
          */
         MarketAggregates: {
+            /** Aum */
+            aum?: string | null;
             /** Call Oi Total */
             call_oi_total?: number | null;
-            /** Put Oi Total */
-            put_oi_total?: number | null;
-            /** Call Volume Total */
-            call_volume_total?: number | null;
-            /** Put Volume Total */
-            put_volume_total?: number | null;
             /** Call Volume Ask Side */
             call_volume_ask_side?: number | null;
             /** Call Volume Bid Side */
             call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Pcr Oi */
-            pcr_oi?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
+            /** Call Volume Total */
+            call_volume_total?: number | null;
             /** Iv30D */
             iv30d?: string | null;
             /** Market Cap */
             market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
+            /** Pcr Oi */
+            pcr_oi?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Put Oi Total */
+            put_oi_total?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
+            /** Put Volume Total */
+            put_volume_total?: number | null;
         };
         /** MarketStructure */
         MarketStructure: {
-            /** Spot */
-            spot?: string | null;
-            /** Nearest Expiry */
-            nearest_expiry?: string | null;
-            /** Total Call Gex */
-            total_call_gex?: string | null;
-            /** Total Put Gex */
-            total_put_gex?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Total Call Dex Oi */
-            total_call_dex_oi?: string | null;
-            /** Total Put Dex Oi */
-            total_put_dex_oi?: string | null;
             /** Max Pain */
             max_pain?: string | null;
+            /** Nearest Expiry */
+            nearest_expiry?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Spot */
+            spot?: string | null;
             /**
              * Top Call Oi Strikes
              * @default []
@@ -2954,6 +2946,14 @@ export interface components {
              * @default []
              */
             top_put_oi_strikes: string[];
+            /** Total Call Dex Oi */
+            total_call_dex_oi?: string | null;
+            /** Total Call Gex */
+            total_call_gex?: string | null;
+            /** Total Put Dex Oi */
+            total_put_dex_oi?: string | null;
+            /** Total Put Gex */
+            total_put_gex?: string | null;
         };
         /**
          * MarketStructureLevels
@@ -2968,152 +2968,154 @@ export interface components {
          *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
          */
         MarketStructureLevels: {
-            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             max_accel?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
         };
         /** MatrixSourceFreshness */
         MatrixSourceFreshness: {
-            /** Vanna Charm */
-            vanna_charm?: string | null;
+            /** Im Vrp */
+            im_vrp?: string | null;
+            /** Oi */
+            oi?: string | null;
             /** Skew */
             skew?: string | null;
             /** Term */
             term?: string | null;
-            /** Im Vrp */
-            im_vrp?: string | null;
+            /** Vanna Charm */
+            vanna_charm?: string | null;
             /** Vrp Rv */
             vrp_rv?: string | null;
-            /** Oi */
-            oi?: string | null;
         };
         /** MatrixState */
         MatrixState: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /**
-             * Threshold Version
-             * @default 1
-             */
-            threshold_version: number;
-            /**
-             * Vanna State
-             * @enum {string}
-             */
-            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Atm Straddle Mid */
+            atm_straddle_mid?: string | null;
+            /** Back Iv */
+            back_iv?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
             /**
              * Charm State
              * @enum {string}
              */
             charm_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
+             * Charm Stress Override
+             * @default false
+             */
+            charm_stress_override: boolean;
+            /** Cluster Coverage Ok */
+            cluster_coverage_ok: boolean;
+            /**
+             * Consistency Tier
+             * @enum {string}
+             */
+            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /**
+             * Flow State
+             * @enum {string}
+             */
+            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Front Back Spread */
+            front_back_spread?: string | null;
+            /** Front Iv */
+            front_iv?: string | null;
+            /** Full Curve Slope Pct */
+            full_curve_slope_pct?: string | null;
+            /**
+             * Im State
+             * @enum {string}
+             */
+            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Implied Move Event Percentile */
+            implied_move_event_percentile?: string | null;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Pct */
+            implied_move_pct?: string | null;
+            /** Iv Atm 30D */
+            iv_atm_30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Rv 30D */
+            rv_30d?: string | null;
+            /** Single Point Bump Pct */
+            single_point_bump_pct?: string | null;
+            /** Skew 25D 5D Change */
+            skew_25d_5d_change?: string | null;
+            /** Skew 25D Zscore 180D */
+            skew_25d_zscore_180d?: string | null;
+            /** Skew Regime */
+            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
+            /**
              * Skew State
              * @enum {string}
              */
             skew_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Skew Term Structure */
+            skew_term_structure?: string | null;
+            /** Term Classification */
+            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
+            /** Term Johnson Slope Pc1 */
+            term_johnson_slope_pc1?: string | null;
             /**
              * Term State
              * @enum {string}
              */
             term_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
-             * Im State
-             * @enum {string}
+             * Threshold Version
+             * @default 1
              */
-            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            threshold_version: number;
+            /** Ticker */
+            ticker: string;
+            /** Vanna Conditional Reading */
+            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
+            /** Vanna Oi Change Bias */
+            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
             /**
-             * Flow State
+             * Vanna State
              * @enum {string}
              */
-            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Vrp State
-             * @enum {string}
-             */
-            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Consistency Tier
-             * @enum {string}
-             */
-            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
-            /** Cluster Coverage Ok */
-            cluster_coverage_ok: boolean;
-            /** Term Classification */
-            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
-            /** Skew 25D Zscore 180D */
-            skew_25d_zscore_180d?: string | null;
-            /** Iv Atm 30D */
-            iv_atm_30d?: string | null;
-            /** Rv 30D */
-            rv_30d?: string | null;
+            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp */
             vrp?: string | null;
-            /** Vrp Zscore 60D */
-            vrp_zscore_60d?: string | null;
-            /** Implied Move Pct */
-            implied_move_pct?: string | null;
-            /** Front Iv */
-            front_iv?: string | null;
-            /** Back Iv */
-            back_iv?: string | null;
-            /** Front Back Spread */
-            front_back_spread?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
+            /**
+             * Vrp Sign Flip Aligned Days
+             * @default 0
+             */
+            vrp_sign_flip_aligned_days: number;
             /**
              * Vrp Sign Flip Status
              * @default insufficient_history
              */
             vrp_sign_flip_status: boolean | "insufficient_history";
             /**
-             * Vrp Sign Flip Aligned Days
-             * @default 0
+             * Vrp State
+             * @enum {string}
              */
-            vrp_sign_flip_aligned_days: number;
-            /** Vanna Conditional Reading */
-            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
-            /** Vanna Oi Change Bias */
-            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /**
-             * Charm Stress Override
-             * @default false
-             */
-            charm_stress_override: boolean;
-            /** Skew 25D 5D Change */
-            skew_25d_5d_change?: string | null;
-            /** Skew Regime */
-            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
-            /** Skew Term Structure */
-            skew_term_structure?: string | null;
-            /** Single Point Bump Pct */
-            single_point_bump_pct?: string | null;
-            /** Full Curve Slope Pct */
-            full_curve_slope_pct?: string | null;
-            /** Term Johnson Slope Pc1 */
-            term_johnson_slope_pc1?: string | null;
-            /** Atm Straddle Mid */
-            atm_straddle_mid?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
-            /** Implied Move Event Percentile */
-            implied_move_event_percentile?: string | null;
+            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp Zscore 252D */
             vrp_zscore_252d?: string | null;
+            /** Vrp Zscore 60D */
+            vrp_zscore_60d?: string | null;
         };
         /** MaxPainRow */
         MaxPainRow: {
+            /** Close */
+            close?: string | null;
             /**
              * Expiry
              * Format: date
@@ -3121,126 +3123,124 @@ export interface components {
             expiry: string;
             /** Max Pain */
             max_pain?: string | null;
-            /** Close */
-            close?: string | null;
-            /** Open */
-            open?: string | null;
-            /** Next Upper Strike */
-            next_upper_strike?: string | null;
             /** Next Lower Strike */
             next_lower_strike?: string | null;
+            /** Next Upper Strike */
+            next_upper_strike?: string | null;
+            /** Open */
+            open?: string | null;
         };
         /** OhlcRow */
         OhlcRow: {
+            /** Close */
+            close: string;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Open */
-            open?: string | null;
             /** High */
             high?: string | null;
             /** Low */
             low?: string | null;
-            /** Close */
-            close: string;
+            /** Open */
+            open?: string | null;
             /** Volume */
             volume?: number | null;
         };
         /** OiChangeRow */
         OiChangeRow: {
-            /** Underlying Symbol */
-            underlying_symbol: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Curr Date */
-            curr_date?: string | null;
-            /** Last Date */
-            last_date?: string | null;
-            /** Curr Oi */
-            curr_oi?: number | null;
-            /** Last Oi */
-            last_oi?: number | null;
-            /** Oi Diff Plain */
-            oi_diff_plain?: number | null;
-            /** Oi Change */
-            oi_change?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Trades */
-            trades?: number | null;
+            /** Ask Volume */
+            ask_volume?: number | null;
             /** Avg Price */
             avg_price?: string | null;
-            /** Last Fill */
-            last_fill?: string | null;
+            /** Bid Volume */
+            bid_volume?: number | null;
+            /** Curr Date */
+            curr_date?: string | null;
+            /** Curr Oi */
+            curr_oi?: number | null;
             /** Days Of Oi Increases */
             days_of_oi_increases?: number | null;
             /** Days Of Vol Greater Than Oi */
             days_of_vol_greater_than_oi?: number | null;
+            /** Last Ask */
+            last_ask?: string | null;
+            /** Last Bid */
+            last_bid?: string | null;
+            /** Last Date */
+            last_date?: string | null;
+            /** Last Fill */
+            last_fill?: string | null;
+            /** Last Oi */
+            last_oi?: number | null;
+            /** Mid Volume */
+            mid_volume?: number | null;
+            /** No Side Volume */
+            no_side_volume?: number | null;
+            /** Oi Change */
+            oi_change?: string | null;
+            /** Oi Diff Plain */
+            oi_diff_plain?: number | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Percentage Of Total */
             percentage_of_total?: string | null;
-            /** Rnk */
-            rnk?: number | null;
             /** Prev Ask Volume */
             prev_ask_volume?: number | null;
             /** Prev Bid Volume */
             prev_bid_volume?: number | null;
             /** Prev Mid Volume */
             prev_mid_volume?: number | null;
-            /** Prev Neutral Volume */
-            prev_neutral_volume?: number | null;
             /** Prev Multi Leg Volume */
             prev_multi_leg_volume?: number | null;
+            /** Prev Neutral Volume */
+            prev_neutral_volume?: number | null;
             /** Prev Stock Multi Leg Volume */
             prev_stock_multi_leg_volume?: number | null;
             /** Prev Total Premium */
             prev_total_premium?: string | null;
-            /** Last Ask */
-            last_ask?: string | null;
-            /** Last Bid */
-            last_bid?: string | null;
-            /** Ask Volume */
-            ask_volume?: number | null;
-            /** Bid Volume */
-            bid_volume?: number | null;
-            /** Mid Volume */
-            mid_volume?: number | null;
-            /** No Side Volume */
-            no_side_volume?: number | null;
+            /** Rnk */
+            rnk?: number | null;
+            /** Trades */
+            trades?: number | null;
+            /** Underlying Symbol */
+            underlying_symbol: string;
+            /** Volume */
+            volume?: number | null;
         };
         /** OosLabel */
         OosLabel: {
-            /** Name */
-            name: string;
             /** Definition */
             definition: string;
+            /** Name */
+            name: string;
         };
         /** OosScore */
         OosScore: {
-            /** Model */
-            model: string;
+            /** Auc Dd10 */
+            auc_dd10?: number | null;
             /** Auc Dd5 */
             auc_dd5?: number | null;
             /** Auc Vix30 */
             auc_vix30?: number | null;
-            /** Auc Dd10 */
-            auc_dd10?: number | null;
+            /** Model */
+            model: string;
         };
         /** OosSummary */
         OosSummary: {
             /** As Of */
             as_of: string;
-            /** Notebook */
-            notebook: string;
-            /** Method */
-            method: string;
-            /** Labels */
-            labels: components["schemas"]["OosLabel"][];
-            /** Scores */
-            scores: components["schemas"]["OosScore"][];
             /** Interpretation */
             interpretation: string;
+            /** Labels */
+            labels: components["schemas"]["OosLabel"][];
+            /** Method */
+            method: string;
+            /** Notebook */
+            notebook: string;
+            /** Scores */
+            scores: components["schemas"]["OosScore"][];
         };
         /**
          * OptionChainPerStrikeRow
@@ -3249,21 +3249,21 @@ export interface components {
          *     Backs both strike-profile charts (Volume and OI variants).
          */
         OptionChainPerStrikeRow: {
+            /** Call Oi */
+            call_oi?: number | null;
+            /** Call Volume */
+            call_volume?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Oi */
-            call_oi?: number | null;
             /** Put Oi */
             put_oi?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * OptionIntradayProfile
@@ -3276,33 +3276,33 @@ export interface components {
          *     minute bars the contract actually had.
          */
         OptionIntradayProfile: {
-            /** Option Symbol */
-            option_symbol: string;
-            /**
-             * Trade Date
-             * Format: date
-             */
-            trade_date: string;
-            /**
-             * Total Volume
-             * @default 0
-             */
-            total_volume: number;
             /** First Trade Time */
             first_trade_time?: string | null;
             /** Last Trade Time */
             last_trade_time?: string | null;
-            /** Peak Window Start */
-            peak_window_start?: string | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Peak Window End */
             peak_window_end?: string | null;
             /** Peak Window Share Pct */
             peak_window_share_pct?: string | null;
+            /** Peak Window Start */
+            peak_window_start?: string | null;
             /**
              * Sparkline
              * @default []
              */
             sparkline: number[];
+            /**
+             * Total Volume
+             * @default 0
+             */
+            total_volume: number;
+            /**
+             * Trade Date
+             * Format: date
+             */
+            trade_date: string;
         };
         /**
          * OptionsDailyRow
@@ -3312,39 +3312,10 @@ export interface components {
          *     alert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot.
          */
         OptionsDailyRow: {
-            /**
-             * Date
-             * Format: date
-             */
-            date: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Volume Ask Side */
-            call_volume_ask_side?: number | null;
-            /** Call Volume Bid Side */
-            call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Call Premium */
-            call_premium?: string | null;
-            /** Put Premium */
-            put_premium?: string | null;
-            /** Net Call Premium */
-            net_call_premium?: string | null;
-            /** Net Put Premium */
-            net_put_premium?: string | null;
-            /** Bullish Premium */
-            bullish_premium?: string | null;
-            /** Bearish Premium */
-            bearish_premium?: string | null;
-            /** Call Open Interest */
-            call_open_interest?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
+            /** Avg 30 Day Call Volume */
+            avg_30_day_call_volume?: string | null;
+            /** Avg 30 Day Put Volume */
+            avg_30_day_put_volume?: string | null;
             /** Avg 3 Day Call Volume */
             avg_3_day_call_volume?: string | null;
             /** Avg 3 Day Put Volume */
@@ -3353,45 +3324,70 @@ export interface components {
             avg_7_day_call_volume?: string | null;
             /** Avg 7 Day Put Volume */
             avg_7_day_put_volume?: string | null;
-            /** Avg 30 Day Call Volume */
-            avg_30_day_call_volume?: string | null;
-            /** Avg 30 Day Put Volume */
-            avg_30_day_put_volume?: string | null;
+            /** Bearish Premium */
+            bearish_premium?: string | null;
+            /** Bullish Premium */
+            bullish_premium?: string | null;
+            /** Call Open Interest */
+            call_open_interest?: number | null;
+            /** Call Premium */
+            call_premium?: string | null;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Call Volume Ask Side */
+            call_volume_ask_side?: number | null;
+            /** Call Volume Bid Side */
+            call_volume_bid_side?: number | null;
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Net Call Premium */
+            net_call_premium?: string | null;
+            /** Net Put Premium */
+            net_put_premium?: string | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Premium */
+            put_premium?: string | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
         };
         /** PositioningBlock */
         PositioningBlock: {
             /** Call Oi */
             call_oi?: number | null;
-            /** Put Oi */
-            put_oi?: number | null;
+            /** Pcr Delta 30D */
+            pcr_delta_30d?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
             pcr_vol?: string | null;
-            /** Pcr Delta 30D */
-            pcr_delta_30d?: string | null;
+            /** Put Oi */
+            put_oi?: number | null;
         };
         /** ProviderUsageBreakdownResponse */
         ProviderUsageBreakdownResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageBreakdownRow"][];
         };
         /** ProviderUsageBreakdownRow */
         ProviderUsageBreakdownRow: {
-            /** Key */
-            key: string | null;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -3400,53 +3396,29 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
+            /** Key */
+            key: string | null;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
         };
         /** ProviderUsageRequestRow */
         ProviderUsageRequestRow: {
-            /** Request Id */
-            request_id: number;
-            /** Provider */
-            provider: string;
-            /** Endpoint Key */
-            endpoint_key: string;
-            /** Method */
-            method: string;
-            /** Path */
-            path: string;
-            /** Ticker */
-            ticker: string | null;
-            /** Params */
-            params: {
-                [key: string]: unknown;
-            };
-            /** Status Code */
-            status_code: number | null;
-            /** Status Family */
-            status_family: string;
-            /**
-             * Request Started At
-             * Format: date-time
-             */
-            request_started_at: string;
-            /**
-             * Request Finished At
-             * Format: date-time
-             */
-            request_finished_at: string;
-            /** Latency Ms */
-            latency_ms: number;
             /** Attempt */
             attempt: number;
-            /** Run Id */
-            run_id: number | null;
+            /** Endpoint Key */
+            endpoint_key: string;
+            /** Error Message */
+            error_message: string | null;
             /** Job Name */
             job_name: string | null;
-            /** Provider Request Id */
-            provider_request_id: string | null;
+            /** Latency Ms */
+            latency_ms: number;
+            /** Method */
+            method: string;
             /** Official Daily Count */
             official_daily_count: number | null;
             /** Official Daily Limit */
@@ -3455,40 +3427,56 @@ export interface components {
             official_minute_remaining: number | null;
             /** Official Minute Reset */
             official_minute_reset: string | null;
-            /** Error Message */
-            error_message: string | null;
+            /** Params */
+            params: {
+                [key: string]: unknown;
+            };
+            /** Path */
+            path: string;
+            /** Provider */
+            provider: string;
+            /** Provider Request Id */
+            provider_request_id: string | null;
+            /**
+             * Request Finished At
+             * Format: date-time
+             */
+            request_finished_at: string;
+            /** Request Id */
+            request_id: number;
+            /**
+             * Request Started At
+             * Format: date-time
+             */
+            request_started_at: string;
+            /** Run Id */
+            run_id: number | null;
+            /** Status Code */
+            status_code: number | null;
+            /** Status Family */
+            status_family: string;
+            /** Ticker */
+            ticker: string | null;
         };
         /** ProviderUsageRequestsResponse */
         ProviderUsageRequestsResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
+            /** Limit */
+            limit: number;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
-            /** Limit */
-            limit: number;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageRequestRow"][];
         };
         /** ProviderUsageSummaryResponse */
         ProviderUsageSummaryResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
-            /**
-             * Provider Day End
-             * Format: date-time
-             */
-            provider_day_end: string;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -3497,10 +3485,22 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
             /** Uw Latest Daily Count */
             uw_latest_daily_count: number | null;
             /** Uw Latest Daily Limit */
@@ -3510,11 +3510,6 @@ export interface components {
         QueueStatus: {
             /** Job Id */
             job_id: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "done" | "failed";
             /** Queue Position */
             queue_position: number;
             /**
@@ -3524,14 +3519,16 @@ export interface components {
             requested_at: string;
             /** Started At */
             started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
         };
         /** QueueSummary */
         QueueSummary: {
-            /**
-             * Total
-             * @default 0
-             */
-            total: number;
+            /** Oldest Requested At */
+            oldest_requested_at?: string | null;
             /**
              * Queued
              * @default 0
@@ -3542,8 +3539,11 @@ export interface components {
              * @default 0
              */
             running: number;
-            /** Oldest Requested At */
-            oldest_requested_at?: string | null;
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
         };
         /** RatesCrossMarketPanel */
         RatesCrossMarketPanel: {
@@ -3558,26 +3558,26 @@ export interface components {
         };
         /** RatesCurvePoint */
         RatesCurvePoint: {
-            /** Tenor */
-            tenor: string;
-            /** Series Id */
-            series_id: string;
-            /** Value */
-            value?: number | null;
             /** Delta 1D Bps */
             delta_1d_bps?: number | null;
-            /** Delta 1W Bps */
-            delta_1w_bps?: number | null;
             /** Delta 1M Bps */
             delta_1m_bps?: number | null;
+            /** Delta 1W Bps */
+            delta_1w_bps?: number | null;
             /** Obs Date */
             obs_date?: string | null;
+            /** Series Id */
+            series_id: string;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tenor */
+            tenor: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesCurveSection */
         RatesCurveSection: {
@@ -3588,93 +3588,93 @@ export interface components {
         };
         /** RatesDecomposition */
         RatesDecomposition: {
-            /** Nominal 10Y */
-            nominal_10y?: number | null;
-            /** Real 10Y */
-            real_10y?: number | null;
+            /** Attribution */
+            attribution?: components["schemas"]["RatesDecompositionAttribution"][];
             /** Breakeven 10Y */
             breakeven_10y?: number | null;
-            /** Forward Inflation 5Y5Y */
-            forward_inflation_5y5y?: number | null;
-            /** Term Forward Compensation */
-            term_forward_compensation?: number | null;
             /** Clarida Model Date */
             clarida_model_date?: string | null;
-            /** Model Real Yield 10Y */
-            model_real_yield_10y?: number | null;
-            /** Expected Short Real Rate 10Y */
-            expected_short_real_rate_10y?: number | null;
             /** Expected Short Inflation 10Y */
             expected_short_inflation_10y?: number | null;
-            /** Real Term Premium 10Y */
-            real_term_premium_10y?: number | null;
+            /** Expected Short Real Rate 10Y */
+            expected_short_real_rate_10y?: number | null;
+            /** Forward Inflation 5Y5Y */
+            forward_inflation_5y5y?: number | null;
+            /** Fred Model Residual 10Y */
+            fred_model_residual_10y?: number | null;
             /** Inflation Risk Premium 10Y */
             inflation_risk_premium_10y?: number | null;
             /** Model Nominal 10Y */
             model_nominal_10y?: number | null;
-            /** Fred Model Residual 10Y */
-            fred_model_residual_10y?: number | null;
+            /** Model Real Yield 10Y */
+            model_real_yield_10y?: number | null;
             /** Model Source */
             model_source?: string | null;
             /** Model Url */
             model_url?: string | null;
+            /** Nominal 10Y */
+            nominal_10y?: number | null;
+            /** Real 10Y */
+            real_10y?: number | null;
+            /** Real Term Premium 10Y */
+            real_term_premium_10y?: number | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Attribution */
-            attribution?: components["schemas"]["RatesDecompositionAttribution"][];
+            /** Term Forward Compensation */
+            term_forward_compensation?: number | null;
         };
         /** RatesDecompositionAttribution */
         RatesDecompositionAttribution: {
+            /** Breakeven 10Y Bps */
+            breakeven_10y_bps?: number | null;
+            /** Driver */
+            driver?: string | null;
+            /** Expected Short Inflation Bps */
+            expected_short_inflation_bps?: number | null;
+            /** Expected Short Real Bps */
+            expected_short_real_bps?: number | null;
+            /** Fred Model Residual Bps */
+            fred_model_residual_bps?: number | null;
+            /** Inflation Risk Premium Bps */
+            inflation_risk_premium_bps?: number | null;
+            /** Model Nominal 10Y Bps */
+            model_nominal_10y_bps?: number | null;
+            /** Nominal 10Y Bps */
+            nominal_10y_bps?: number | null;
+            /** Real 10Y Bps */
+            real_10y_bps?: number | null;
+            /** Real Term Premium Bps */
+            real_term_premium_bps?: number | null;
+            /** Residual Bps */
+            residual_bps?: number | null;
+            /**
+             * Status
+             * @default partial
+             * @enum {string}
+             */
+            status: "ok" | "missing" | "partial" | "stale";
             /**
              * Window
              * @enum {string}
              */
             window: "1D" | "1W" | "1M" | "YTD";
-            /** Nominal 10Y Bps */
-            nominal_10y_bps?: number | null;
-            /** Real 10Y Bps */
-            real_10y_bps?: number | null;
-            /** Breakeven 10Y Bps */
-            breakeven_10y_bps?: number | null;
-            /** Residual Bps */
-            residual_bps?: number | null;
-            /** Model Nominal 10Y Bps */
-            model_nominal_10y_bps?: number | null;
-            /** Expected Short Real Bps */
-            expected_short_real_bps?: number | null;
-            /** Expected Short Inflation Bps */
-            expected_short_inflation_bps?: number | null;
-            /** Real Term Premium Bps */
-            real_term_premium_bps?: number | null;
-            /** Inflation Risk Premium Bps */
-            inflation_risk_premium_bps?: number | null;
-            /** Fred Model Residual Bps */
-            fred_model_residual_bps?: number | null;
-            /** Driver */
-            driver?: string | null;
-            /**
-             * Status
-             * @default partial
-             * @enum {string}
-             */
-            status: "ok" | "missing" | "partial" | "stale";
         };
         /** RatesEventItem */
         RatesEventItem: {
             /** Event Date */
             event_date?: string | null;
-            /** Label */
-            label: string;
             /**
              * Importance
              * @default medium
              * @enum {string}
              */
             importance: "low" | "medium" | "high";
+            /** Label */
+            label: string;
             /** Source */
             source?: string | null;
             /**
@@ -3686,16 +3686,14 @@ export interface components {
         };
         /** RatesPolicyMeeting */
         RatesPolicyMeeting: {
+            /** Action */
+            action?: string | null;
             /** Event Date */
             event_date?: string | null;
             /** Event End Date */
             event_end_date?: string | null;
             /** Label */
             label: string;
-            /** Action */
-            action?: string | null;
-            /** Vote Split */
-            vote_split?: string | null;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -3704,76 +3702,71 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Vote Split */
+            vote_split?: string | null;
         };
         /** RatesPolicyPanel */
         RatesPolicyPanel: {
-            /** Target Range */
-            target_range?: string | null;
-            /** Target Lower */
-            target_lower?: number | null;
-            /** Target Upper */
-            target_upper?: number | null;
             /** Effr */
             effr?: number | null;
-            /** Sofr */
-            sofr?: number | null;
-            last_meeting?: components["schemas"]["RatesPolicyMeeting"] | null;
             /** Implied Path */
             implied_path?: components["schemas"]["RatesPolicyPathPoint"][];
-            /** Plumbing */
-            plumbing?: components["schemas"]["RatesPolicyPlumbingMetric"][];
-            /** Policy Read */
-            policy_read?: string | null;
+            last_meeting?: components["schemas"]["RatesPolicyMeeting"] | null;
             /** Path Read */
             path_read?: string | null;
+            /** Plumbing */
+            plumbing?: components["schemas"]["RatesPolicyPlumbingMetric"][];
             /** Plumbing Read */
             plumbing_read?: string | null;
+            /** Policy Read */
+            policy_read?: string | null;
+            /** Sofr */
+            sofr?: number | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Target Lower */
+            target_lower?: number | null;
+            /** Target Range */
+            target_range?: string | null;
+            /** Target Upper */
+            target_upper?: number | null;
         };
         /** RatesPolicyPathPoint */
         RatesPolicyPathPoint: {
+            /** Label */
+            label: string;
             /**
              * Meeting Date
              * Format: date
              */
             meeting_date: string;
-            /** Label */
-            label: string;
             /** Probability */
             probability?: number | null;
+            /** Source */
+            source?: string | null;
             /**
              * Stance
              * @default UNKNOWN
              * @enum {string}
              */
             stance: "CUT" | "HOLD" | "HIKE" | "UNKNOWN";
-            /** Target Range */
-            target_range?: string | null;
-            /** Source */
-            source?: string | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Target Range */
+            target_range?: string | null;
         };
         /** RatesPolicyPlumbingMetric */
         RatesPolicyPlumbingMetric: {
             /** Label */
             label: string;
-            /** Value */
-            value?: number | null;
-            /**
-             * Unit
-             * @default
-             */
-            unit: string;
             /** Qualifier */
             qualifier?: string | null;
             /**
@@ -3782,15 +3775,22 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /**
+             * Unit
+             * @default
+             */
+            unit: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesPositioningPanel */
         RatesPositioningPanel: {
-            /** Rows */
-            rows?: components["schemas"]["RatesSummaryTile"][];
             /** Details */
             details?: components["schemas"]["RatesPositioningRow"][];
             /** Positioning Read */
             positioning_read?: string | null;
+            /** Rows */
+            rows?: components["schemas"]["RatesSummaryTile"][];
             /**
              * Status
              * @default missing
@@ -3800,30 +3800,28 @@ export interface components {
         };
         /** RatesPositioningRow */
         RatesPositioningRow: {
-            /** Contract Code */
-            contract_code: string;
-            /** Contract Name */
-            contract_name: string;
-            /** Tenor Bucket */
-            tenor_bucket: string;
-            /** Obs Date */
-            obs_date?: string | null;
-            /** Release Date */
-            release_date?: string | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Dealer Net */
-            dealer_net?: number | null;
-            /** Dealer Net Pct Oi */
-            dealer_net_pct_oi?: number | null;
             /** Asset Mgr Net */
             asset_mgr_net?: number | null;
             /** Asset Mgr Net Pct Oi */
             asset_mgr_net_pct_oi?: number | null;
+            /** Contract Code */
+            contract_code: string;
+            /** Contract Name */
+            contract_name: string;
+            /** Dealer Net */
+            dealer_net?: number | null;
+            /** Dealer Net Pct Oi */
+            dealer_net_pct_oi?: number | null;
             /** Lev Money Net */
             lev_money_net?: number | null;
             /** Lev Money Net Pct Oi */
             lev_money_net_pct_oi?: number | null;
+            /** Obs Date */
+            obs_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Release Date */
+            release_date?: string | null;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -3832,17 +3830,13 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tenor Bucket */
+            tenor_bucket: string;
         };
         /** RatesScorecard */
         RatesScorecard: {
             /** Composite Score */
             composite_score?: number | null;
-            /**
-             * Duration Stance
-             * @default NEUTRAL
-             * @enum {string}
-             */
-            duration_stance: "BUY" | "SELL" | "NEUTRAL";
             /** Curve Score */
             curve_score?: number | null;
             /**
@@ -3851,6 +3845,12 @@ export interface components {
              * @enum {string}
              */
             curve_stance: "STEEP" | "FLAT" | "NEUTRAL";
+            /**
+             * Duration Stance
+             * @default NEUTRAL
+             * @enum {string}
+             */
+            duration_stance: "BUY" | "SELL" | "NEUTRAL";
             /** Groups */
             groups?: components["schemas"]["RatesScorecardGroup"][];
         };
@@ -3858,27 +3858,27 @@ export interface components {
         RatesScorecardFactor: {
             /** Label */
             label: string;
-            /** Value */
-            value?: string | null;
             /** Score */
             score?: number | null;
+            /** Source */
+            source?: string | null;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Source */
-            source?: string | null;
+            /** Value */
+            value?: string | null;
         };
         /** RatesScorecardGroup */
         RatesScorecardGroup: {
+            /** Factors */
+            factors?: components["schemas"]["RatesScorecardFactor"][];
             /** Id */
             id: string;
             /** Label */
             label: string;
-            /** Weight */
-            weight: number;
             /** Score */
             score?: number | null;
             /**
@@ -3887,21 +3887,21 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Factors */
-            factors?: components["schemas"]["RatesScorecardFactor"][];
+            /** Weight */
+            weight: number;
         };
         /** RatesSlopeMetric */
         RatesSlopeMetric: {
             /** Label */
             label: string;
-            /** Value Bps */
-            value_bps?: number | null;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Value Bps */
+            value_bps?: number | null;
         };
         /** RatesSnapshotResponse */
         RatesSnapshotResponse: {
@@ -3915,20 +3915,20 @@ export interface components {
              * Format: date-time
              */
             computed_at: string;
-            /** Summary */
-            summary?: components["schemas"]["RatesSummaryTile"][];
+            cross_market?: components["schemas"]["RatesCrossMarketPanel"];
             curve?: components["schemas"]["RatesCurveSection"];
             decomposition?: components["schemas"]["RatesDecomposition"];
-            scorecard?: components["schemas"]["RatesScorecard"];
-            policy?: components["schemas"]["RatesPolicyPanel"];
-            supply?: components["schemas"]["RatesSupplyPanel"];
-            positioning?: components["schemas"]["RatesPositioningPanel"];
-            cross_market?: components["schemas"]["RatesCrossMarketPanel"];
             /** Events */
             events?: components["schemas"]["RatesEventItem"][];
-            synthesis: components["schemas"]["RatesSynthesisPanel"];
+            policy?: components["schemas"]["RatesPolicyPanel"];
+            positioning?: components["schemas"]["RatesPositioningPanel"];
+            scorecard?: components["schemas"]["RatesScorecard"];
             /** Source Freshness */
             source_freshness?: components["schemas"]["RatesSourceFreshness"][];
+            /** Summary */
+            summary?: components["schemas"]["RatesSummaryTile"][];
+            supply?: components["schemas"]["RatesSupplyPanel"];
+            synthesis: components["schemas"]["RatesSynthesisPanel"];
         };
         /** RatesSourceFreshness */
         RatesSourceFreshness: {
@@ -3936,10 +3936,10 @@ export interface components {
             id: string;
             /** Label */
             label: string;
-            /** Latest Obs Date */
-            latest_obs_date?: string | null;
             /** Last Seen At */
             last_seen_at?: string | null;
+            /** Latest Obs Date */
+            latest_obs_date?: string | null;
             /**
              * Status
              * @default missing
@@ -3949,53 +3949,51 @@ export interface components {
         };
         /** RatesSummaryTile */
         RatesSummaryTile: {
-            /** Label */
-            label: string;
-            /** Value */
-            value?: number | null;
-            /**
-             * Unit
-             * @default
-             */
-            unit: string;
             /** Delta 1D */
             delta_1d?: number | null;
+            /** Label */
+            label: string;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /**
+             * Unit
+             * @default
+             */
+            unit: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesSupplyAuctionRow */
         RatesSupplyAuctionRow: {
-            /** Cusip */
-            cusip: string;
-            /** Security Type */
-            security_type: string;
-            /** Security Term */
-            security_term: string;
             /**
              * Auction Date
              * Format: date
              */
             auction_date: string;
+            /** Bid To Cover */
+            bid_to_cover?: number | null;
+            /** Cusip */
+            cusip: string;
+            /** Direct Bidder Pct */
+            direct_bidder_pct?: number | null;
+            /** High Rate */
+            high_rate?: number | null;
+            /** Indirect Bidder Pct */
+            indirect_bidder_pct?: number | null;
             /** Issue Date */
             issue_date?: string | null;
             /** Offering Amount */
             offering_amount?: number | null;
-            /** High Rate */
-            high_rate?: number | null;
-            /** Bid To Cover */
-            bid_to_cover?: number | null;
-            /** Direct Bidder Pct */
-            direct_bidder_pct?: number | null;
-            /** Indirect Bidder Pct */
-            indirect_bidder_pct?: number | null;
             /** Primary Dealer Pct */
             primary_dealer_pct?: number | null;
-            /** Tail Indicator */
-            tail_indicator?: string | null;
+            /** Security Term */
+            security_term: string;
+            /** Security Type */
+            security_type: string;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -4004,37 +4002,53 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tail Indicator */
+            tail_indicator?: string | null;
         };
         /** RatesSupplyPanel */
         RatesSupplyPanel: {
             /** Auctions */
             auctions?: components["schemas"]["RatesSummaryTile"][];
-            /** Recent Auctions */
-            recent_auctions?: components["schemas"]["RatesSupplyAuctionRow"][];
             /** Fiscal */
             fiscal?: components["schemas"]["RatesSummaryTile"][];
             /** Notes */
             notes?: string[];
-            /** Supply Read */
-            supply_read?: string | null;
+            /** Recent Auctions */
+            recent_auctions?: components["schemas"]["RatesSupplyAuctionRow"][];
             /**
              * Status
              * @default missing
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Supply Read */
+            supply_read?: string | null;
         };
         /** RatesSynthesisPanel */
         RatesSynthesisPanel: {
-            /** Duration View */
-            duration_view: string;
             /** Curve View */
             curve_view: string;
+            /** Duration View */
+            duration_view: string;
             /** Risks */
             risks?: string[];
         };
         /** RecordHealthCheck */
         RecordHealthCheck: {
+            /** Actual Rows */
+            actual_rows: number;
+            /** Actual Tickers */
+            actual_tickers: number;
+            /** Expected Min Rows */
+            expected_min_rows: number;
+            /** Expected Min Tickers */
+            expected_min_tickers: number;
+            /** Expected Tickers */
+            expected_tickers: number;
+            /** Latest At */
+            latest_at?: string | null;
+            /** Ok */
+            ok: boolean;
             /** Table */
             table: string;
             /**
@@ -4042,31 +4056,17 @@ export interface components {
              * Format: date-time
              */
             window_start: string;
-            /** Expected Tickers */
-            expected_tickers: number;
-            /** Expected Min Tickers */
-            expected_min_tickers: number;
-            /** Actual Tickers */
-            actual_tickers: number;
-            /** Expected Min Rows */
-            expected_min_rows: number;
-            /** Actual Rows */
-            actual_rows: number;
-            /** Latest At */
-            latest_at?: string | null;
-            /** Ok */
-            ok: boolean;
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
+            /** Cutoff Corr */
+            cutoff_corr?: string | null;
+            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
             /**
              * Points
              * @default []
              */
             points: components["schemas"]["RegimeQuadrantPoint"][];
-            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
-            /** Cutoff Corr */
-            cutoff_corr?: string | null;
         };
         /** RegimeQuadrantLatest */
         RegimeQuadrantLatest: {
@@ -4113,10 +4113,10 @@ export interface components {
         ReturnsBlock: {
             /** D1 */
             d1?: string | null;
-            /** W1 */
-            w1?: string | null;
             /** D30 */
             d30?: string | null;
+            /** W1 */
+            w1?: string | null;
         };
         /** RvCorrPoint */
         RvCorrPoint: {
@@ -4132,23 +4132,6 @@ export interface components {
         };
         /** ScannerCandidate */
         ScannerCandidate: {
-            /** Ticker */
-            ticker: string;
-            /** Spot */
-            spot: string | null;
-            /** Is Type F */
-            is_type_f: boolean;
-            /** Raw Score */
-            raw_score: string;
-            /** Confluence Score */
-            confluence_score: string;
-            /** Final Score */
-            final_score: string;
-            /** Hits */
-            hits: components["schemas"]["ScannerSignalHit"][];
-            /** Context Flags */
-            context_flags: components["schemas"]["ScannerContextFlag"][];
-            gates: components["schemas"]["ScannerGatesStatus"];
             /**
              * Bias
              * @enum {string}
@@ -4156,6 +4139,24 @@ export interface components {
             bias: "bullish" | "bearish" | "neutral" | "mixed";
             /** Bias Strength */
             bias_strength?: ("strong" | "moderate" | "weak") | null;
+            /** Confluence Score */
+            confluence_score: string;
+            /** Context Flags */
+            context_flags: components["schemas"]["ScannerContextFlag"][];
+            /** Final Score */
+            final_score: string;
+            gates: components["schemas"]["ScannerGatesStatus"];
+            /** Hits */
+            hits: components["schemas"]["ScannerSignalHit"][];
+            /** Is Type F */
+            is_type_f: boolean;
+            /** Raw Score */
+            raw_score: string;
+            /**
+             * Scanned At
+             * Format: date-time
+             */
+            scanned_at: string;
             /**
              * Setup
              * @enum {string}
@@ -4163,37 +4164,36 @@ export interface components {
             setup: "ready" | "caution" | "blocked";
             /** Setup Reason */
             setup_reason?: string | null;
-            /**
-             * Scanned At
-             * Format: date-time
-             */
-            scanned_at: string;
+            /** Spot */
+            spot: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** ScannerContextFlag */
         ScannerContextFlag: {
+            /** Label */
+            label: string;
             /**
              * Layer
              * @constant
              */
             layer: "pcr_sentiment";
-            /** Label */
-            label: string;
             /** Value */
             value: string | null;
         };
         /** ScannerGatedTicker */
         ScannerGatedTicker: {
-            /** Ticker */
-            ticker: string;
+            /** Blocking Chip */
+            blocking_chip?: ("SUSPENDED" | "DEGRADED") | null;
             /**
              * Reason
              * @enum {string}
              */
             reason: "regime_block" | "stale_scan";
-            /** Blocking Chip */
-            blocking_chip?: ("SUSPENDED" | "DEGRADED") | null;
             /** Scanned At */
             scanned_at: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** ScannerGatesStatus */
         ScannerGatesStatus: {
@@ -4215,12 +4215,10 @@ export interface components {
         };
         /** ScannerResponse */
         ScannerResponse: {
-            /** Scanned Universe Size */
-            scanned_universe_size: number;
-            /** Candidates With Hits */
-            candidates_with_hits: number;
             /** Candidates */
             candidates: components["schemas"]["ScannerCandidate"][];
+            /** Candidates With Hits */
+            candidates_with_hits: number;
             /** Gated */
             gated: components["schemas"]["ScannerGatedTicker"][];
             /**
@@ -4228,9 +4226,22 @@ export interface components {
              * Format: date-time
              */
             generated_at: string;
+            /** Scanned Universe Size */
+            scanned_universe_size: number;
         };
         /** ScannerSignalHit */
         ScannerSignalHit: {
+            /** Evidence */
+            evidence: {
+                [key: string]: unknown;
+            };
+            /**
+             * Freshness
+             * @enum {string}
+             */
+            freshness: "live" | "stale" | "unavailable";
+            /** Score */
+            score: string;
             /**
              * Signal Type
              * @enum {string}
@@ -4241,55 +4252,52 @@ export interface components {
              * @enum {integer}
              */
             tier: 1 | 2;
-            /** Score */
-            score: string;
-            /** Evidence */
-            evidence: {
-                [key: string]: unknown;
-            };
-            /**
-             * Freshness
-             * @enum {string}
-             */
-            freshness: "live" | "stale" | "unavailable";
         };
         /** SetupBlock */
         SetupBlock: {
-            /** Type */
-            type?: string | null;
             /** Direction */
             direction?: string | null;
             /** Score */
             score?: string | null;
+            /** Type */
+            type?: string | null;
         };
         /** SetupClassification */
         SetupClassification: {
-            /** Setup Type */
-            setup_type: string;
-            /** Label */
-            label: string;
-            /** Direction */
-            direction: string;
-            /** Score */
-            score: string;
             /**
              * Confirmations
              * @default []
              */
             confirmations: string[];
-            /**
-             * Warnings
-             * @default []
-             */
-            warnings: string[];
+            /** Direction */
+            direction: string;
+            /** Label */
+            label: string;
             /**
              * Notes
              * @default
              */
             notes: string;
+            /** Score */
+            score: string;
+            /** Setup Type */
+            setup_type: string;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: string[];
         };
         /** ShortDataRow */
         ShortDataRow: {
+            /** Fee Rate */
+            fee_rate?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Rebate Rate */
+            rebate_rate?: string | null;
+            /** Short Shares Available */
+            short_shares_available?: number | null;
             /** Symbol */
             symbol: string;
             /**
@@ -4297,41 +4305,10 @@ export interface components {
              * Format: date-time
              */
             timestamp: string;
-            /** Name */
-            name?: string | null;
-            /** Short Shares Available */
-            short_shares_available?: number | null;
-            /** Fee Rate */
-            fee_rate?: string | null;
-            /** Rebate Rate */
-            rebate_rate?: string | null;
         };
         /** SingleStockReport */
         SingleStockReport: {
-            /** Run Id */
-            run_id: number;
-            /** Ticker */
-            ticker: string;
-            /**
-             * Generated At
-             * Format: date-time
-             */
-            generated_at: string;
-            /** Spot Quoted At */
-            spot_quoted_at?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /**
-             * Short Int Note
-             * @default n/a (UW endpoint does not expose %)
-             */
-            short_int_note: string;
-            market_structure: components["schemas"]["MarketStructure"];
-            volatility: components["schemas"]["VolatilityProfile"];
-            flow: components["schemas"]["FlowSnapshot"];
-            vrp: components["schemas"]["VRPAssessment"];
-            setup?: components["schemas"]["SetupClassification"] | null;
-            trade_plan?: components["schemas"]["TradePlan"] | null;
+            aggregates?: components["schemas"]["MarketAggregates"] | null;
             /** Dark Pool Notional */
             dark_pool_notional?: string | null;
             /**
@@ -4339,52 +4316,75 @@ export interface components {
              * @default 0
              */
             dark_pool_print_count: number;
-            short_data?: components["schemas"]["ShortDataRow"] | null;
+            dealer_regime?: components["schemas"]["DealerRegime"] | null;
+            /**
+             * Exposures Summary
+             * @default []
+             */
+            exposures_summary: components["schemas"]["ExposuresSummaryRow"][];
+            flow: components["schemas"]["FlowSnapshot"];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            market_structure: components["schemas"]["MarketStructure"];
+            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
             /**
              * Max Pain Rows
              * @default []
              */
             max_pain_rows: components["schemas"]["MaxPainRow"][];
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /**
+             * Oi Change Intraday Profiles
+             * @default []
+             */
+            oi_change_intraday_profiles: components["schemas"]["OptionIntradayProfile"][];
             /**
              * Oi Change Top
              * @default []
              */
             oi_change_top: components["schemas"]["OiChangeRow"][];
             /**
-             * Oi Change Intraday Profiles
+             * Option Chain Per Strike
              * @default []
              */
-            oi_change_intraday_profiles: components["schemas"]["OptionIntradayProfile"][];
-            aggregates?: components["schemas"]["MarketAggregates"] | null;
-            /**
-             * Strike Gex Curve
-             * @default []
-             */
-            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
-            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
+            option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
             /**
              * Options Timeline
              * @default []
              */
             options_timeline: components["schemas"]["OptionsDailyRow"][];
+            /** Run Id */
+            run_id: number;
+            setup?: components["schemas"]["SetupClassification"] | null;
+            short_data?: components["schemas"]["ShortDataRow"] | null;
             /**
-             * Option Chain Per Strike
-             * @default []
+             * Short Int Note
+             * @default n/a (UW endpoint does not expose %)
              */
-            option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
+            short_int_note: string;
+            /** Spot Quoted At */
+            spot_quoted_at?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
             /**
              * Strike Exposures
              * @default []
              */
             strike_exposures: components["schemas"]["StrikeExposureRow"][];
             /**
-             * Exposures Summary
+             * Strike Gex Curve
              * @default []
              */
-            exposures_summary: components["schemas"]["ExposuresSummaryRow"][];
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            dealer_regime?: components["schemas"]["DealerRegime"] | null;
+            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
+            /** Ticker */
+            ticker: string;
+            trade_plan?: components["schemas"]["TradePlan"] | null;
+            volatility: components["schemas"]["VolatilityProfile"];
+            vrp: components["schemas"]["VRPAssessment"];
         };
         /** SkewBlock */
         SkewBlock: {
@@ -4406,18 +4406,18 @@ export interface components {
         };
         /** SmilePoint */
         SmilePoint: {
-            /** Strike */
-            strike: string;
             /** Iv */
             iv?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** SourceReconciliation */
         SourceReconciliation: {
             /**
-             * Status
-             * @default UNKNOWN
+             * Decision
+             * @default Use deterministic data only where source agreement is understood.
              */
-            status: string;
+            decision: string;
             /**
              * Headline
              * @default Source reconciliation unavailable
@@ -4433,48 +4433,48 @@ export interface components {
              */
             rows: components["schemas"]["SourceReconciliationRow"][];
             /**
-             * Decision
-             * @default Use deterministic data only where source agreement is understood.
+             * Status
+             * @default UNKNOWN
              */
-            decision: string;
+            status: string;
         };
         /** SourceReconciliationRow */
         SourceReconciliationRow: {
-            /** Source Pair */
-            source_pair: string;
             /**
-             * Price Agreement
+             * Decision
              * @default
              */
-            price_agreement: string;
+            decision: string;
             /**
              * Iv Agreement
              * @default
              */
             iv_agreement: string;
+            /** Iv Diff */
+            iv_diff?: string | null;
             /**
-             * Decision
+             * Price Agreement
              * @default
              */
-            decision: string;
-            /** Strike */
-            strike?: string | null;
+            price_agreement: string;
             /** Source A Call Iv */
             source_a_call_iv?: string | null;
             /** Source B Call Iv */
             source_b_call_iv?: string | null;
-            /** Iv Diff */
-            iv_diff?: string | null;
+            /** Source Pair */
+            source_pair: string;
+            /** Strike */
+            strike?: string | null;
         };
         /** StockHistoryResponse */
         StockHistoryResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Rows
              * @default []
              */
             rows: components["schemas"]["StockHistoryRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /**
          * StockHistoryRow
@@ -4486,27 +4486,27 @@ export interface components {
          */
         StockHistoryRow: {
             /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /** Spot */
-            spot?: string | null;
-            /** Gex Flip */
-            gex_flip?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Net Dex */
-            net_dex?: string | null;
-            /** Iv30D */
-            iv30d?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
-            /**
              * Bias
              * @default NEUTRAL
              */
             bias: string;
+            /** Gex Flip */
+            gex_flip?: string | null;
+            /** Iv30D */
+            iv30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Net Dex */
+            net_dex?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Spot */
+            spot?: string | null;
         };
         /**
          * StrikeExposureRow
@@ -4515,31 +4515,31 @@ export interface components {
          *     Net + Call/Put curves without an extra fetch.
          */
         StrikeExposureRow: {
-            /** Strike */
-            strike: string;
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Call Vanna */
-            call_vanna?: string | null;
-            /** Put Vanna */
-            put_vanna?: string | null;
-            /** Call Charm */
-            call_charm?: string | null;
             /** Put Charm */
             put_charm?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * StrikeGexBucket
          * @description One row of the per-strike, per-expiry GEX curve persisted on each scan run.
          */
         StrikeGexBucket: {
-            /** Strike */
-            strike: string;
+            /** Call Gex */
+            call_gex?: string | null;
             /**
              * Expiry
              * Format: date
@@ -4547,26 +4547,26 @@ export interface components {
             expiry: string;
             /** Net Gex */
             net_gex?: string | null;
-            /** Call Gex */
-            call_gex?: string | null;
             /** Put Gex */
             put_gex?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** TermMoveRow */
         TermMoveRow: {
+            /** Atm Straddle */
+            atm_straddle?: string | null;
+            /** Daily Implied Move Perc */
+            daily_implied_move_perc?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Atm Straddle */
-            atm_straddle?: string | null;
             /** Implied Move Perc */
             implied_move_perc?: string | null;
-            /** Daily Implied Move Perc */
-            daily_implied_move_perc?: string | null;
             /**
              * Read
              * @default
@@ -4576,19 +4576,19 @@ export interface components {
         /** TermStructureExpiryRow */
         TermStructureExpiryRow: {
             /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /**
              * By Strike
              * @default {}
              */
             by_strike: {
                 [key: string]: string;
             };
+            /** Dte */
+            dte?: number | null;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
             /**
              * Strikes
              * @default {}
@@ -4622,50 +4622,50 @@ export interface components {
              * Format: uuid
              */
             analysis_id: string;
-            /** Ticker */
-            ticker: string;
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
+            /** Error Message */
+            error_message?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Markdown */
+            markdown?: string | null;
             /** Model */
             model: string;
+            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
+            /** Produced At */
+            produced_at?: string | null;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Provider
              * @default codex
              * @enum {string}
              */
             provider: "codex" | "claude";
-            /** Prompt Version */
-            prompt_version: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "succeeded" | "failed";
-            /** Produced At */
-            produced_at?: string | null;
-            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
-            /** Markdown */
-            markdown?: string | null;
-            /** Error Message */
-            error_message?: string | null;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
-            /** Started At */
-            started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
             /**
              * Reused
              * @default false
              */
             reused: boolean;
+            /** Run Id */
+            run_id: number;
+            /** Started At */
+            started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Ticker */
+            ticker: string;
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /**
          * TradeInsightAiAnalysisStub
@@ -4673,24 +4673,24 @@ export interface components {
          */
         TradeInsightAiAnalysisStub: {
             /**
-             * Provider
-             * @enum {string}
-             */
-            provider: "codex" | "claude";
-            /**
              * Analysis Id
              * Format: uuid
              */
             analysis_id: string;
+            /** Model */
+            model: string;
+            /**
+             * Provider
+             * @enum {string}
+             */
+            provider: "codex" | "claude";
+            /** Reused */
+            reused: boolean;
             /**
              * Status
              * @enum {string}
              */
             status: "queued" | "running" | "succeeded" | "failed";
-            /** Reused */
-            reused: boolean;
-            /** Model */
-            model: string;
         };
         /**
          * TradeInsightAiAntiPin
@@ -4705,26 +4705,10 @@ export interface components {
          */
         TradeInsightAiAntiPin: {
             /**
-             * Invoked
-             * @default false
+             * Cap Reason
+             * @default
              */
-            invoked: boolean;
-            /**
-             * Direction
-             * @default none
-             * @enum {string}
-             */
-            direction: "upside" | "downside" | "none";
-            /**
-             * Score
-             * @default 0
-             */
-            score: number;
-            /**
-             * Max Score
-             * @default 4
-             */
-            max_score: number;
+            cap_reason: string;
             /** Conditions Met */
             conditions_met?: string[];
             /**
@@ -4733,86 +4717,112 @@ export interface components {
              */
             conviction_cap_applied: boolean;
             /**
-             * Cap Reason
-             * @default
+             * Direction
+             * @default none
+             * @enum {string}
              */
-            cap_reason: string;
+            direction: "upside" | "downside" | "none";
+            /**
+             * Invoked
+             * @default false
+             */
+            invoked: boolean;
+            /**
+             * Max Score
+             * @default 4
+             */
+            max_score: number;
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
         };
         /** TradeInsightAiBestExpression */
         TradeInsightAiBestExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Role */
-            role: string;
-            /** Why */
-            why: string;
             /** Caveats */
             caveats?: string[];
-            /** Status Observed */
-            status_observed: string;
+            /** Idea Id */
+            idea_id: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Role */
+            role: string;
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiConflict */
         TradeInsightAiConflict: {
+            /** Affected Idea Ids */
+            affected_idea_ids?: string[];
+            /** Description */
+            description: string;
             /** Lens */
             lens: string;
             /** Severity */
             severity: string;
-            /** Description */
-            description: string;
-            /** Affected Idea Ids */
-            affected_idea_ids?: string[];
         };
         /** TradeInsightAiDominantRead */
         TradeInsightAiDominantRead: {
-            /** Headline */
-            headline: string;
-            /** Summary */
-            summary: string;
             /** Confidence Commentary */
             confidence_commentary: string;
             /** Data Quality Commentary */
             data_quality_commentary: string;
+            /** Headline */
+            headline: string;
+            /** Summary */
+            summary: string;
         };
         /** TradeInsightAiGuardrails */
         TradeInsightAiGuardrails: {
-            /** Statuses Preserved */
-            statuses_preserved: boolean;
-            /** Risk Flags Preserved */
-            risk_flags_preserved: boolean;
             /** No Executable Recommendations */
             no_executable_recommendations: boolean;
+            /** Risk Flags Preserved */
+            risk_flags_preserved: boolean;
+            /** Statuses Preserved */
+            statuses_preserved: boolean;
         };
         /** TradeInsightAiHeadline */
         TradeInsightAiHeadline: {
-            /**
-             * Trade Intent
-             * @enum {string}
-             */
-            trade_intent: "directional_swing" | "range_income";
+            /** Conviction */
+            conviction: string;
+            /** Conviction Label */
+            conviction_label: string;
             /**
              * Directional Bias
              * @enum {string}
              */
             directional_bias: "LONG_DELTA" | "SHORT_DELTA" | "WAIT";
             /**
-             * Entry State
-             * @enum {string}
-             */
-            entry_state: "ACTIVE" | "CONDITIONAL" | "NO_ENTRY";
-            /**
-             * Underlying Path
-             * @enum {string}
-             */
-            underlying_path: "bullish_continuation" | "bearish_rejection" | "downside_break" | "pinned_no_directional_entry" | "data_insufficient";
-            /**
              * Dte Band
              * @enum {string}
              */
             dte_band: "momentum" | "standard" | "trend";
+            /**
+             * Entry State
+             * @enum {string}
+             */
+            entry_state: "ACTIVE" | "CONDITIONAL" | "NO_ENTRY";
+            /** Primary Risk */
+            primary_risk: string;
+            /** Score */
+            score: number;
+            /**
+             * Score Scale
+             * @default 100
+             */
+            score_scale: number;
+            /**
+             * Stance
+             * @enum {string}
+             */
+            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
+            /** Stance Label */
+            stance_label: string;
             /**
              * Thesis Archetype
              * @default data_insufficient
@@ -4821,28 +4831,18 @@ export interface components {
             thesis_archetype: "resistance_rejection" | "support_breakdown" | "breakout_continuation" | "pin_no_trade" | "data_insufficient";
             /** Title */
             title: string;
-            /**
-             * Stance
-             * @enum {string}
-             */
-            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
-            /** Stance Label */
-            stance_label: string;
-            /** Score */
-            score: number;
-            /**
-             * Score Scale
-             * @default 100
-             */
-            score_scale: number;
-            /** Conviction */
-            conviction: string;
-            /** Conviction Label */
-            conviction_label: string;
             /** Top Reason */
             top_reason: string;
-            /** Primary Risk */
-            primary_risk: string;
+            /**
+             * Trade Intent
+             * @enum {string}
+             */
+            trade_intent: "directional_swing" | "range_income";
+            /**
+             * Underlying Path
+             * @enum {string}
+             */
+            underlying_path: "bullish_continuation" | "bearish_rejection" | "downside_break" | "pinned_no_directional_entry" | "data_insufficient";
             /** Watch Trigger */
             watch_trigger: string;
         };
@@ -4850,15 +4850,15 @@ export interface components {
         TradeInsightAiHighlight: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /**
          * TradeInsightAiLatestPair
@@ -4870,53 +4870,53 @@ export interface components {
          *     [Codex] [Claude] tabs as a quality signal.
          */
         TradeInsightAiLatestPair: {
-            /** Current Prompt Version */
-            current_prompt_version: string;
+            claude?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
+            codex?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
             /** Current Prompt Label */
             current_prompt_label?: string | null;
-            codex?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
-            claude?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
+            /** Current Prompt Version */
+            current_prompt_version: string;
             provider_consensus?: components["schemas"]["TradeInsightAiProviderConsensus"];
         };
         /** TradeInsightAiLevel */
         TradeInsightAiLevel: {
-            /** Price */
-            price: string;
-            /** Kind */
-            kind: string;
-            /** Value */
-            value: string;
             /**
              * Importance
              * @default normal
              */
             importance: string;
-            /** Source Path */
-            source_path?: string | null;
+            /** Kind */
+            kind: string;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Price */
+            price: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiMetricCard */
         TradeInsightAiMetricCard: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /**
-             * Tone
-             * @default neutral
-             */
-            tone: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /**
+             * Tone
+             * @default neutral
+             */
+            tone: string;
+            /** Value */
+            value: string;
         };
         /**
          * TradeInsightAiOptionLeg
@@ -4937,6 +4937,11 @@ export interface components {
          */
         TradeInsightAiOptionLeg: {
             /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /**
              * Option Type
              * @enum {string}
              */
@@ -4948,100 +4953,95 @@ export interface components {
             side: "long" | "short";
             /** Strike */
             strike: string;
-            /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
         };
         /** TradeInsightAiOutcome */
         TradeInsightAiOutcome: {
-            /** Schema Version */
-            schema_version: string;
             /**
              * Analysis Produced At
              * Format: date-time
              */
             analysis_produced_at: string;
-            /** Ticker */
-            ticker: string;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
-            headline: components["schemas"]["TradeInsightAiHeadline"];
-            /** Metric Cards */
-            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
-            /** Scenario Cards */
-            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
-            /** Score Breakdown */
-            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
-            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
-            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
-            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
-            trigger_evidence?: components["schemas"]["TradeInsightAiTriggerEvidence"];
             anti_pin?: components["schemas"]["TradeInsightAiAntiPin"];
-            target_feasibility?: components["schemas"]["TradeInsightAiTargetFeasibility"];
-            thesis_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            entry_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            invalidation?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
             /** Best Expressions */
             best_expressions?: components["schemas"]["TradeInsightAiBestExpression"][];
             /** Conflicts */
             conflicts?: components["schemas"]["TradeInsightAiConflict"][];
-            /** Required Checks */
-            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
-            /** Rejected Ideas */
-            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
+            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
+            entry_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            headline: components["schemas"]["TradeInsightAiHeadline"];
+            invalidation?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            /** Metric Cards */
+            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Missing Data */
             missing_data?: string[];
+            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
+            /** Rejected Ideas */
+            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
             rendering: components["schemas"]["TradeInsightAiRendering"];
-            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            /** Required Checks */
+            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
+            /** Scenario Cards */
+            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
+            /** Schema Version */
+            schema_version: string;
+            /** Score Breakdown */
+            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
+            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
+            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
+            target_feasibility?: components["schemas"]["TradeInsightAiTargetFeasibility"];
+            thesis_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            /** Ticker */
+            ticker: string;
+            trigger_evidence?: components["schemas"]["TradeInsightAiTriggerEvidence"];
+            /** Underlying Price */
+            underlying_price?: string | null;
+            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
         };
         /** TradeInsightAiPreferredExpression */
         TradeInsightAiPreferredExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Title */
-            title: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
             /**
              * Estimated Entry
              * @default
              */
             estimated_entry: string;
-            /**
-             * Max Profit Observed
-             * @default
-             */
-            max_profit_observed: string;
+            /** Idea Id */
+            idea_id: string;
+            /** Legs */
+            legs?: components["schemas"]["TradeInsightAiOptionLeg"][];
+            /** Management Notes */
+            management_notes?: string[];
             /**
              * Max Loss Observed
              * @default
              */
             max_loss_observed: string;
             /**
+             * Max Profit Observed
+             * @default
+             */
+            max_profit_observed: string;
+            /**
              * Reward Risk
              * @default
              */
             reward_risk: string;
-            /** Why */
-            why: string;
-            /** Management Notes */
-            management_notes?: string[];
-            /** Status Observed */
-            status_observed: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Status Observed */
+            status_observed: string;
             strike_role?: components["schemas"]["TradeInsightAiStrikeRole"];
-            /** Legs */
-            legs?: components["schemas"]["TradeInsightAiOptionLeg"][];
+            /** Structure */
+            structure: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /** Title */
+            title: string;
+            /** Why */
+            why: string;
         };
         /**
          * TradeInsightAiPriorRow
@@ -5053,33 +5053,33 @@ export interface components {
          *     no outcomes have resolved yet.
          */
         TradeInsightAiPriorRow: {
+            /** Directional Bias */
+            directional_bias?: string | null;
+            /** Entry State */
+            entry_state?: string | null;
+            /** Expired No Resolution Count */
+            expired_no_resolution_count: number;
+            /** Hit Rate Pct */
+            hit_rate_pct?: string | null;
+            /** Invalidation Hit Count */
+            invalidation_hit_count: number;
+            /** Median Days To Resolution */
+            median_days_to_resolution?: string | null;
+            /** Pending Count */
+            pending_count: number;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Provider
              * @enum {string}
              */
             provider: "codex" | "claude";
-            /** Prompt Version */
-            prompt_version: string;
-            /** Thesis Archetype */
-            thesis_archetype?: string | null;
-            /** Directional Bias */
-            directional_bias?: string | null;
-            /** Entry State */
-            entry_state?: string | null;
             /** Sample Count */
             sample_count: number;
             /** Target Hit Count */
             target_hit_count: number;
-            /** Invalidation Hit Count */
-            invalidation_hit_count: number;
-            /** Pending Count */
-            pending_count: number;
-            /** Expired No Resolution Count */
-            expired_no_resolution_count: number;
-            /** Hit Rate Pct */
-            hit_rate_pct?: string | null;
-            /** Median Days To Resolution */
-            median_days_to_resolution?: string | null;
+            /** Thesis Archetype */
+            thesis_archetype?: string | null;
         };
         /**
          * TradeInsightAiPriorsResponse
@@ -5101,15 +5101,26 @@ export interface components {
          */
         TradeInsightAiProviderConsensus: {
             /**
+             * Actionable Disagreement
+             * @default
+             */
+            actionable_disagreement: string;
+            /**
              * Bias Agreement
              * @default false
              */
             bias_agreement: boolean;
             /**
-             * Structure Agreement
+             * Consensus Grade
+             * @default missing
+             * @enum {string}
+             */
+            consensus_grade: "full" | "partial" | "divergent" | "missing";
+            /**
+             * Dte Band Agreement
              * @default false
              */
-            structure_agreement: boolean;
+            dte_band_agreement: boolean;
             /**
              * Entry State Agreement
              * @default false
@@ -5121,49 +5132,38 @@ export interface components {
              */
             path_agreement: boolean;
             /**
-             * Dte Band Agreement
+             * Structure Agreement
              * @default false
              */
-            dte_band_agreement: boolean;
-            /**
-             * Consensus Grade
-             * @default missing
-             * @enum {string}
-             */
-            consensus_grade: "full" | "partial" | "divergent" | "missing";
-            /**
-             * Actionable Disagreement
-             * @default
-             */
-            actionable_disagreement: string;
+            structure_agreement: boolean;
         };
         /** TradeInsightAiRejectedIdea */
         TradeInsightAiRejectedIdea: {
             /** Idea Id */
             idea_id: string;
-            /** Structure */
-            structure: string;
             /** Reason */
             reason: string;
+            /** Structure */
+            structure: string;
         };
         /** TradeInsightAiRendering */
         TradeInsightAiRendering: {
-            /** Disclaimer */
-            disclaimer: string;
             /** Card Order */
             card_order?: string[];
+            /** Disclaimer */
+            disclaimer: string;
         };
         /** TradeInsightAiRequiredCheck */
         TradeInsightAiRequiredCheck: {
-            /** Check */
-            check: string;
-            /** Reason */
-            reason: string;
             /**
              * Blocks Sizing
              * @default true
              */
             blocks_sizing: boolean;
+            /** Check */
+            check: string;
+            /** Reason */
+            reason: string;
             /**
              * Source
              * @default
@@ -5174,59 +5174,55 @@ export interface components {
         TradeInsightAiScenarioCard: {
             /** Case */
             case: ("upside" | "base" | "downside") | string;
+            /** Description */
+            description: string;
+            /** Title */
+            title: string;
             /**
              * Tone
              * @default neutral
              */
             tone: string;
-            /** Title */
-            title: string;
-            /** Description */
-            description: string;
         };
         /** TradeInsightAiScoreBreakdown */
         TradeInsightAiScoreBreakdown: {
-            /** Section */
-            section: string;
-            /** Score */
-            score: number;
             /** Max Score */
             max_score: number;
+            /** Score */
+            score: number;
+            /** Section */
+            section: string;
             /** Summary */
             summary: string;
         };
         /** TradeInsightAiSectionCard */
         TradeInsightAiSectionCard: {
-            /** Title */
-            title: string;
-            /** Score */
-            score?: number | null;
-            /** Max Score */
-            max_score?: number | null;
-            /** Summary */
-            summary: string;
-            /** Highlights */
-            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
-            /** Levels */
-            levels?: components["schemas"]["TradeInsightAiLevel"][];
             /**
              * Data Quality
              * @default unknown
              */
             data_quality: string;
+            /** Highlights */
+            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
+            /** Levels */
+            levels?: components["schemas"]["TradeInsightAiLevel"][];
+            /** Max Score */
+            max_score?: number | null;
+            /** Score */
+            score?: number | null;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightAiSectionCards */
         TradeInsightAiSectionCards: {
+            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
             market_structure: components["schemas"]["TradeInsightAiSectionCard"];
             volatility: components["schemas"]["TradeInsightAiSectionCard"];
-            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
         };
         /** TradeInsightAiSnapshotMeta */
         TradeInsightAiSnapshotMeta: {
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
             /** Data As Of */
@@ -5236,8 +5232,12 @@ export interface components {
              * @default unknown
              */
             freshness_label: string;
+            /** Run Id */
+            run_id: number;
             /** Source Notes */
             source_notes?: string[];
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /**
          * TradeInsightAiStrikeRole
@@ -5252,6 +5252,13 @@ export interface components {
          *     level to a specific key in the deterministic payload.
          */
         TradeInsightAiStrikeRole: {
+            /** Invalid Level */
+            invalid_level?: string | null;
+            /**
+             * Invalid Source Path
+             * @default
+             */
+            invalid_source_path: string;
             /**
              * Long Leg Role
              * @default n/a
@@ -5264,27 +5271,20 @@ export interface components {
              * @enum {string}
              */
             short_leg_role: "target_level" | "next_call_wall" | "second_magnet" | "next_put_wall" | "next_downside_target" | "n/a";
-            /** Trigger Level */
-            trigger_level?: string | null;
             /** Target Level */
             target_level?: string | null;
-            /** Invalid Level */
-            invalid_level?: string | null;
-            /**
-             * Trigger Source Path
-             * @default
-             */
-            trigger_source_path: string;
             /**
              * Target Source Path
              * @default
              */
             target_source_path: string;
+            /** Trigger Level */
+            trigger_level?: string | null;
             /**
-             * Invalid Source Path
+             * Trigger Source Path
              * @default
              */
-            invalid_source_path: string;
+            trigger_source_path: string;
         };
         /**
          * TradeInsightAiTargetFeasibility
@@ -5336,6 +5336,15 @@ export interface components {
          *     against their own evidence rules.
          */
         TradeInsightAiTriggerComponent: {
+            /** Evidence Close */
+            evidence_close?: string | null;
+            /** Evidence Date */
+            evidence_date?: string | null;
+            /**
+             * Fired
+             * @default false
+             */
+            fired: boolean;
             /** Level */
             level?: string | null;
             /**
@@ -5343,15 +5352,6 @@ export interface components {
              * @default
              */
             meaning: string;
-            /**
-             * Fired
-             * @default false
-             */
-            fired: boolean;
-            /** Evidence Close */
-            evidence_close?: string | null;
-            /** Evidence Date */
-            evidence_date?: string | null;
             /**
              * Source Path
              * @default
@@ -5374,19 +5374,6 @@ export interface components {
          *     the validator rejects (or auto-downgrades) to CONDITIONAL.
          */
         TradeInsightAiTriggerEvidence: {
-            /**
-             * Trigger Fired
-             * @default false
-             */
-            trigger_fired: boolean;
-            /**
-             * Trigger Type
-             * @default unknown
-             * @enum {string}
-             */
-            trigger_type: "daily_close" | "two_session_hold" | "unknown";
-            /** Trigger Level */
-            trigger_level?: string | null;
             /** Evidence Close */
             evidence_close?: string | null;
             /** Evidence Close Date */
@@ -5396,51 +5383,59 @@ export interface components {
              * @default
              */
             source_path: string;
+            /**
+             * Trigger Fired
+             * @default false
+             */
+            trigger_fired: boolean;
+            /** Trigger Level */
+            trigger_level?: string | null;
+            /**
+             * Trigger Type
+             * @default unknown
+             * @enum {string}
+             */
+            trigger_type: "daily_close" | "two_session_hold" | "unknown";
         };
         /** TradeInsightAiVrpAssessment */
         TradeInsightAiVrpAssessment: {
-            /** Signal */
-            signal: string;
-            /** Title */
-            title: string;
-            /** Summary */
-            summary: string;
             /** Metrics */
             metrics?: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Reason */
             reason: string;
+            /** Signal */
+            signal: string;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightsAiHealth */
         TradeInsightsAiHealth: {
-            codex: components["schemas"]["TradeInsightsAiProviderHealth"];
             claude: components["schemas"]["TradeInsightsAiProviderHealth"];
+            codex: components["schemas"]["TradeInsightsAiProviderHealth"];
         };
         /**
          * TradeInsightsAiProviderHealth
          * @description Per-provider AI worker pool status.
          */
         TradeInsightsAiProviderHealth: {
+            /** Last Beat At */
+            last_beat_at?: string | null;
+            /** Queued Depth */
+            queued_depth: number;
             /** Workers Expected */
             workers_expected: number;
             /** Workers Healthy */
             workers_healthy: number;
-            /** Queued Depth */
-            queued_depth: number;
-            /** Last Beat At */
-            last_beat_at?: string | null;
         };
         /** TradeInsightsHeader */
         TradeInsightsHeader: {
             /**
-             * Dominant Bias
-             * @default NEUTRAL
+             * Badges
+             * @default []
              */
-            dominant_bias: string;
-            /**
-             * Primary Setup
-             * @default NO_CLEAR_SETUP
-             */
-            primary_setup: string;
+            badges: components["schemas"]["InsightBadge"][];
             /**
              * Confidence Label
              * @default LOW
@@ -5452,6 +5447,11 @@ export interface components {
              */
             data_quality_label: string;
             /**
+             * Dominant Bias
+             * @default NEUTRAL
+             */
+            dominant_bias: string;
+            /**
              * Idea Count
              * @default 0
              */
@@ -5459,65 +5459,63 @@ export interface components {
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
             /**
-             * Badges
-             * @default []
+             * Primary Setup
+             * @default NO_CLEAR_SETUP
              */
-            badges: components["schemas"]["InsightBadge"][];
+            primary_setup: string;
         };
         /** TradeInsightsResponse */
         TradeInsightsResponse: {
-            /** Ticker */
-            ticker: string;
             /** As Of */
             as_of?: string | null;
-            /**
-             * Mode
-             * @default research
-             */
-            mode: string;
-            header: components["schemas"]["TradeInsightsHeader"];
-            /**
-             * @default {
-             *       "status": "UNKNOWN",
-             *       "headline": "Source reconciliation unavailable",
-             *       "rows": [],
-             *       "decision": "Use deterministic data only where source agreement is understood."
-             *     }
-             */
-            source_reconciliation: components["schemas"]["SourceReconciliation"];
-            /**
-             * Signal Stack
-             * @default []
-             */
-            signal_stack: components["schemas"]["InsightSignalRow"][];
-            /**
-             * Flow Table
-             * @default []
-             */
-            flow_table: components["schemas"]["ChainFlowReadRow"][];
-            /**
-             * Term Structure Table
-             * @default []
-             */
-            term_structure_table: components["schemas"]["TermMoveRow"][];
             /**
              * Candidate Structures
              * @default []
              */
             candidate_structures: components["schemas"]["CandidateStructure"][];
             /**
+             * Flow Table
+             * @default []
+             */
+            flow_table: components["schemas"]["ChainFlowReadRow"][];
+            header: components["schemas"]["TradeInsightsHeader"];
+            /**
+             * Mode
+             * @default research
+             */
+            mode: string;
+            /**
+             * Signal Stack
+             * @default []
+             */
+            signal_stack: components["schemas"]["InsightSignalRow"][];
+            /**
              * @default {
-             *       "dominant_story": "",
+             *       "decision": "Use deterministic data only where source agreement is understood.",
+             *       "headline": "Source reconciliation unavailable",
+             *       "rows": [],
+             *       "status": "UNKNOWN"
+             *     }
+             */
+            source_reconciliation: components["schemas"]["SourceReconciliation"];
+            /**
+             * @default {
              *       "avoid": [],
+             *       "dominant_story": "",
              *       "required_before_sizing": []
              *     }
              */
             synthesis: components["schemas"]["InsightsSynthesis"];
+            /**
+             * Term Structure Table
+             * @default []
+             */
+            term_structure_table: components["schemas"]["TermMoveRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /** TradePlan */
         TradePlan: {
-            /** Structure */
-            structure: string;
             /** Direction */
             direction: string;
             /**
@@ -5525,21 +5523,17 @@ export interface components {
              * @default []
              */
             legs: components["schemas"]["TradePlanLeg"][];
-            /** Rationale */
-            rationale: string;
             /** Max Loss */
             max_loss?: string | null;
             /** Max Profit */
             max_profit?: string | null;
+            /** Rationale */
+            rationale: string;
+            /** Structure */
+            structure: string;
         };
         /** TradePlanLeg */
         TradePlanLeg: {
-            /** Option Symbol */
-            option_symbol: string;
-            /** Side */
-            side: string;
-            /** Strike */
-            strike: string;
             /**
              * Expiry
              * Format: date
@@ -5547,47 +5541,58 @@ export interface components {
             expiry: string;
             /** Mid */
             mid?: string | null;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** VRPAssessment */
         VRPAssessment: {
-            /** Vrp */
-            vrp?: string | null;
-            /** Signal */
-            signal: string;
             /** Note */
             note: string;
+            /** Signal */
+            signal: string;
+            /** Vrp */
+            vrp?: string | null;
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
         };
         /**
          * ValidationResponse
          * @description Combined warm-store backtest + OOS notebook summary.
          */
         ValidationResponse: {
-            /** Backtest Md */
-            backtest_md: string;
             /** Backtest Csv Rows */
             backtest_csv_rows: number;
+            /** Backtest Md */
+            backtest_md: string;
             oos?: components["schemas"]["OosSummary"] | null;
         };
         /** VcgAttribution */
         VcgAttribution: {
             /**
-             * Vvix Pct
+             * Model Implied
              * @default 0
              */
-            vvix_pct: number;
+            model_implied: number;
+            /**
+             * Vix Component
+             * @default 0
+             */
+            vix_component: number;
             /**
              * Vix Pct
              * @default 0
@@ -5599,30 +5604,47 @@ export interface components {
              */
             vvix_component: number;
             /**
-             * Vix Component
+             * Vvix Pct
              * @default 0
              */
-            vix_component: number;
-            /**
-             * Model Implied
-             * @default 0
-             */
-            model_implied: number;
+            vvix_pct: number;
         };
         /** VcgHistoryEntry */
         VcgHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Residual */
-            residual?: number | null;
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Beta1 */
             beta1?: number | null;
             /** Beta2 */
             beta2?: number | null;
+            /**
+             * Bounce
+             * @default 0
+             */
+            bounce: number;
+            /**
+             * Credit
+             * @default 0
+             */
+            credit: number;
+            /** Date */
+            date: string;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /** Residual */
+            residual?: number | null;
+            /**
+             * Ro
+             * @default 0
+             */
+            ro: number;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
             /**
              * Vix
              * @default 0
@@ -5633,28 +5655,6 @@ export interface components {
              * @default 0
              */
             vvix: number;
-            /**
-             * Credit
-             * @default 0
-             */
-            credit: number;
-            /**
-             * Ro
-             * @default 0
-             */
-            ro: number;
-            /**
-             * Edr
-             * @default 0
-             */
-            edr: number;
-            /** Tier */
-            tier?: number | null;
-            /**
-             * Bounce
-             * @default 0
-             */
-            bounce: number;
         };
         /** VcgInterpretationCount */
         VcgInterpretationCount: {
@@ -5679,20 +5679,20 @@ export interface components {
          * @description One row of the ±5d named-crash window for a single event.
          */
         VcgNamedCrashOffset: {
-            /** Offset Days */
-            offset_days: number;
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Beta1 */
             beta1?: number | null;
             /** Beta2 */
             beta2?: number | null;
-            /** Sign Ok */
-            sign_ok?: boolean | null;
             /** Interpretation */
             interpretation?: string | null;
+            /** Offset Days */
+            offset_days: number;
+            /** Sign Ok */
+            sign_ok?: boolean | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
         };
         /**
          * VcgResponse
@@ -5700,26 +5700,26 @@ export interface components {
          */
         VcgResponse: {
             /**
-             * Status
-             * @default empty
-             * @enum {string}
+             * Credit Proxy
+             * @default HYG
              */
-            status: "ok" | "empty";
+            credit_proxy: string;
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["VcgHistoryEntry"][];
             /**
              * Scan Time
              * @default
              */
             scan_time: string;
-            /** Date */
-            date?: string | null;
-            /**
-             * Credit Proxy
-             * @default HYG
-             */
-            credit_proxy: string;
             signal?: components["schemas"]["VcgSignal"];
-            /** History */
-            history?: components["schemas"]["VcgHistoryEntry"][];
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
         };
         /**
          * VcgScanResponse
@@ -5727,11 +5727,14 @@ export interface components {
          */
         VcgScanResponse: {
             /**
-             * Status
-             * @default ok
-             * @enum {string}
+             * Proxy
+             * @default HYG
              */
-            status: "ok" | "skipped";
+            proxy: string;
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default vcg
@@ -5739,82 +5742,47 @@ export interface components {
              */
             scanner: "vcg";
             /**
-             * Proxy
-             * @default HYG
+             * Status
+             * @default ok
+             * @enum {string}
              */
-            proxy: string;
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            status: "ok" | "skipped";
         };
         /** VcgSignal */
         VcgSignal: {
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
-            /** Residual */
-            residual?: number | null;
+            /** Alpha */
+            alpha?: number | null;
+            attribution?: components["schemas"]["VcgAttribution"];
             /** Beta1 Vvix */
             beta1_vvix?: number | null;
             /** Beta2 Vix */
             beta2_vix?: number | null;
-            /** Alpha */
-            alpha?: number | null;
-            /**
-             * Vix
-             * @default 0
-             */
-            vix: number;
-            /**
-             * Vvix
-             * @default 0
-             */
-            vvix: number;
-            /**
-             * Credit Price
-             * @default 0
-             */
-            credit_price: number;
-            /**
-             * Credit 5D Return Pct
-             * @default 0
-             */
-            credit_5d_return_pct: number;
-            /**
-             * Ro
-             * @default 0
-             */
-            ro: number;
-            /**
-             * Edr
-             * @default 0
-             */
-            edr: number;
-            /** Tier */
-            tier?: number | null;
             /**
              * Bounce
              * @default 0
              */
             bounce: number;
             /**
-             * Vvix Severity
-             * @default moderate
+             * Credit 5D Return Pct
+             * @default 0
+             */
+            credit_5d_return_pct: number;
+            /**
+             * Credit Price
+             * @default 0
+             */
+            credit_price: number;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /**
+             * Interpretation
+             * @default NORMAL
              * @enum {string}
              */
-            vvix_severity: "extreme" | "elevated" | "moderate";
-            /**
-             * Sign Ok
-             * @default true
-             */
-            sign_ok: boolean;
-            /**
-             * Sign Suppressed
-             * @default false
-             */
-            sign_suppressed: boolean;
+            interpretation: "RISK_OFF" | "EDR" | "WATCH" | "BOUNCE" | "NORMAL" | "SUPPRESSED" | "PANIC" | "INSUFFICIENT_DATA";
             /**
              * Pi Panic
              * @default 0
@@ -5826,23 +5794,55 @@ export interface components {
              * @enum {string}
              */
             regime: "PANIC" | "TRANSITION" | "DIVERGENCE";
+            /** Residual */
+            residual?: number | null;
             /**
-             * Interpretation
-             * @default NORMAL
-             * @enum {string}
+             * Ro
+             * @default 0
              */
-            interpretation: "RISK_OFF" | "EDR" | "WATCH" | "BOUNCE" | "NORMAL" | "SUPPRESSED" | "PANIC" | "INSUFFICIENT_DATA";
+            ro: number;
+            /**
+             * Sign Ok
+             * @default true
+             */
+            sign_ok: boolean;
+            /**
+             * Sign Suppressed
+             * @default false
+             */
+            sign_suppressed: boolean;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
             /**
              * Vix Percentile Rank
              * @description VIX level's 252-day rolling percentile rank (strict_lt tie rule). Used by the v2 absolute-vol-stress override gate. None during the 252-bar warmup or for v=1 payloads.
              */
             vix_percentile_rank?: number | null;
             /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
+            /**
              * Vvix Percentile Rank
              * @description VVIX level's 252-day rolling percentile rank (strict_lt tie rule). Used by the v2 absolute-vol-stress override gate.
              */
             vvix_percentile_rank?: number | null;
-            attribution?: components["schemas"]["VcgAttribution"];
+            /**
+             * Vvix Severity
+             * @default moderate
+             * @enum {string}
+             */
+            vvix_severity: "extreme" | "elevated" | "moderate";
         };
         /**
          * VcgStressHistoryEntry
@@ -5853,27 +5853,65 @@ export interface components {
         VcgStressHistoryEntry: {
             /** Date */
             date: string;
+            /** Fwd 20D Pct */
+            fwd_20d_pct?: number | null;
+            /** Fwd 5D Pct */
+            fwd_5d_pct?: number | null;
+            /** Fwd 60D Pct */
+            fwd_60d_pct?: number | null;
             /**
              * Interpretation
              * @enum {string}
              */
             interpretation: "PANIC" | "RISK_OFF" | "EDR";
-            /** Score */
-            score?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Pi Panic */
             pi_panic?: number | null;
+            /** Score */
+            score?: number | null;
             /** Sign Ok */
             sign_ok?: boolean | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
             /** Vix */
             vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
             /** Vix Percentile Rank */
             vix_percentile_rank?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix Percentile Rank */
             vvix_percentile_rank?: number | null;
+        };
+        /**
+         * VcgStressHistorySummary
+         * @description Aggregate forward-return stats for the stress_history table.
+         */
+        VcgStressHistorySummary: {
+            /** By Interpretation */
+            by_interpretation: components["schemas"]["VcgStressHistorySummaryRow"][];
+        };
+        /**
+         * VcgStressHistorySummaryRow
+         * @description Per-interpretation aggregate of realized forward SPX returns
+         *     across all stress days in the backtest run.
+         */
+        VcgStressHistorySummaryRow: {
+            /**
+             * Interpretation
+             * @enum {string}
+             */
+            interpretation: "PANIC" | "RISK_OFF" | "EDR";
+            /** Mean Fwd 20D Pct */
+            mean_fwd_20d_pct?: number | null;
+            /** Mean Fwd 5D Pct */
+            mean_fwd_5d_pct?: number | null;
+            /** Mean Fwd 60D Pct */
+            mean_fwd_60d_pct?: number | null;
+            /** N */
+            n: number;
+            /** Winrate 20D Pct */
+            winrate_20d_pct?: number | null;
+            /** Winrate 60D Pct */
+            winrate_60d_pct?: number | null;
         };
         /**
          * VcgValidationResponse
@@ -5882,14 +5920,14 @@ export interface components {
         VcgValidationResponse: {
             /** Backtest Md */
             backtest_md: string;
-            /** N Days */
-            n_days: number;
             /** Composite Version */
             composite_version: string;
             /** Credit Proxy */
             credit_proxy: string;
             /** Interpretation Distribution */
             interpretation_distribution: components["schemas"]["VcgInterpretationCount"][];
+            /** N Days */
+            n_days: number;
             /** Named Crash Window */
             named_crash_window: components["schemas"]["VcgNamedCrashEvent"][];
             /**
@@ -5897,22 +5935,25 @@ export interface components {
              * @default []
              */
             stress_history: components["schemas"]["VcgStressHistoryEntry"][];
+            stress_history_summary?: components["schemas"]["VcgStressHistorySummary"] | null;
         };
         /** VolBackdropPoint */
         VolBackdropPoint: {
+            /** Close */
+            close: number;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Close */
-            close: number;
         };
         /**
          * VolBackdropResponse
          * @description Vol-complex time series + VIX term-structure (regime page header strip).
          */
         VolBackdropResponse: {
+            /** As Of */
+            as_of?: string | null;
             /** Series */
             series?: {
                 [key: string]: components["schemas"]["VolBackdropPoint"][];
@@ -5921,68 +5962,66 @@ export interface components {
             term_structure_ratio?: number | null;
             /** Term Structure State */
             term_structure_state?: string | null;
-            /** As Of */
-            as_of?: string | null;
         };
         /** VolHeaderBlock */
         VolHeaderBlock: {
+            /** Implied Move 30D Perc */
+            implied_move_30d_perc?: string | null;
             /** Iv */
             iv?: string | null;
-            /** Rv */
-            rv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
             /** Iv Rank */
             iv_rank?: string | null;
             /** Iv Rank 1Y */
             iv_rank_1y?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
+            /** Rv */
+            rv?: string | null;
             /** Rv High 52W */
             rv_high_52w?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
-            /** Implied Move 30D Perc */
-            implied_move_30d_perc?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /** Vrp */
             vrp?: string | null;
             /**
-             * Vrp Signal
-             * @default
-             */
-            vrp_signal: string;
-            /**
              * Vrp Note
              * @default
              */
             vrp_note: string;
+            /**
+             * Vrp Signal
+             * @default
+             */
+            vrp_signal: string;
         };
         /** VolatilityProfile */
         VolatilityProfile: {
-            /** Iv */
-            iv?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv */
-            rv?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
-            /** Rv High 52W */
-            rv_high_52w?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
             /** Implied Move 30D Perc */
             implied_move_30d_perc?: string | null;
+            /** Iv */
+            iv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
+            /** Rv */
+            rv?: string | null;
+            /** Rv High 52W */
+            rv_high_52w?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /**
@@ -5996,8 +6035,6 @@ export interface components {
         };
         /** VolatilitySeriesResponse */
         VolatilitySeriesResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * As Of
              * Format: date
@@ -6005,44 +6042,6 @@ export interface components {
             as_of: string;
             /** Backfill Status */
             backfill_status: string;
-            header: components["schemas"]["VolHeaderBlock"];
-            /**
-             * Term Structure
-             * @default []
-             */
-            term_structure: components["schemas"]["TermStructureExpiryRow"][];
-            /**
-             * Smile
-             * @default []
-             */
-            smile: components["schemas"]["SmileExpiryCurve"][];
-            /**
-             * Hv Iv History
-             * @default []
-             */
-            hv_iv_history: components["schemas"]["IvHvPoint"][];
-            /**
-             * @default {
-             *       "bins": []
-             *     }
-             */
-            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
-            /**
-             * Iv Of Iv
-             * @default []
-             */
-            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
-            /**
-             * Rv Spy Corr
-             * @default []
-             */
-            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
-            /**
-             * @default {
-             *       "points": []
-             *     }
-             */
-            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
             /**
              * Divergence
              * @default []
@@ -6053,6 +6052,48 @@ export interface components {
              * @default
              */
             divergence_headline: string;
+            header: components["schemas"]["VolHeaderBlock"];
+            /**
+             * Hv Iv History
+             * @default []
+             */
+            hv_iv_history: components["schemas"]["IvHvPoint"][];
+            /**
+             * Iv Of Iv
+             * @default []
+             */
+            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
+            /**
+             * @default {
+             *       "bins": []
+             *     }
+             */
+            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
+            /**
+             * @default {
+             *       "points": []
+             *     }
+             */
+            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
+            /**
+             * Rv Spy Corr
+             * @default []
+             */
+            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
+            /**
+             * Smile
+             * @default []
+             */
+            smile: components["schemas"]["SmileExpiryCurve"][];
+            /** Spot */
+            spot?: string | null;
+            /**
+             * Term Structure
+             * @default []
+             */
+            term_structure: components["schemas"]["TermStructureExpiryRow"][];
+            /** Ticker */
+            ticker: string;
             /**
              * Vrp Spread
              * @default []
@@ -6063,8 +6104,6 @@ export interface components {
              * @default
              */
             vrp_spread_headline: string;
-            /** Spot */
-            spot?: string | null;
         };
         /** VrpDailyPoint */
         VrpDailyPoint: {
@@ -6080,12 +6119,28 @@ export interface components {
         };
         /** WatchlistCard */
         WatchlistCard: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
+            /** Aggression Pct */
+            aggression_pct?: string | null;
+            /** Aum */
+            aum?: string | null;
+            gamma: components["schemas"]["GammaBlock"];
+            /** Iv Atm */
+            iv_atm?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Market Cap */
+            market_cap?: string | null;
             /** Pinned */
             pinned: boolean;
+            positioning: components["schemas"]["PositioningBlock"];
+            queue?: components["schemas"]["QueueStatus"] | null;
+            returns: components["schemas"]["ReturnsBlock"];
+            /** Scanned At */
+            scanned_at?: string | null;
+            /** Sector */
+            sector: string;
+            setup: components["schemas"]["SetupBlock"];
+            skew: components["schemas"]["SkewBlock"];
             /** Sort Rank */
             sort_rank: number;
             /** Spot */
@@ -6094,31 +6149,11 @@ export interface components {
             spot_quoted_at?: string | null;
             /** Spot Source */
             spot_source?: string | null;
-            /** Scanned At */
-            scanned_at?: string | null;
-            /** Iv Atm */
-            iv_atm?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Market Cap */
-            market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
-            setup: components["schemas"]["SetupBlock"];
-            /** Aggression Pct */
-            aggression_pct?: string | null;
-            returns: components["schemas"]["ReturnsBlock"];
-            gamma: components["schemas"]["GammaBlock"];
-            skew: components["schemas"]["SkewBlock"];
-            positioning: components["schemas"]["PositioningBlock"];
-            queue?: components["schemas"]["QueueStatus"] | null;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistMutation */
         WatchlistMutation: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
             /** Notes */
             notes?: string | null;
             /**
@@ -6126,52 +6161,56 @@ export interface components {
              * @default false
              */
             pinned: boolean;
+            /** Sector */
+            sector: string;
             /**
              * Sort Rank
              * @default 0
              */
             sort_rank: number;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistPatch */
         WatchlistPatch: {
-            /** Sector */
-            sector?: string | null;
             /** Notes */
             notes?: string | null;
             /** Pinned */
             pinned?: boolean | null;
+            /** Sector */
+            sector?: string | null;
             /** Sort Rank */
             sort_rank?: number | null;
         };
         /** WatchlistResponse */
         WatchlistResponse: {
-            /** Scanned At Min */
-            scanned_at_min?: string | null;
+            queue?: components["schemas"]["QueueSummary"];
             /** Scanned At Max */
             scanned_at_max?: string | null;
+            /** Scanned At Min */
+            scanned_at_min?: string | null;
             /** Scheduler Lag Seconds */
             scheduler_lag_seconds?: number | null;
-            queue?: components["schemas"]["QueueSummary"];
             /** Tickers */
             tickers: components["schemas"]["WatchlistCard"][];
         };
         /** WorkerHealth */
         WorkerHealth: {
+            /** Heartbeat Name */
+            heartbeat_name: string;
+            /** Index */
+            index: number;
             /** Label */
             label: string;
+            /** Lag Seconds */
+            lag_seconds?: number | null;
+            /** Last Beat At */
+            last_beat_at?: string | null;
             /**
              * Role
              * @enum {string}
              */
             role: "uw" | "massive" | "ai";
-            /** Index */
-            index: number;
-            /** Heartbeat Name */
-            heartbeat_name: string;
-            /** Lag Seconds */
-            lag_seconds?: number | null;
-            /** Last Beat At */
-            last_beat_at?: string | null;
         };
         /**
          * WsConsumerHealth
@@ -6184,41 +6223,41 @@ export interface components {
          *     ``reason`` carries the short label the UI displays under the row.
          */
         WsConsumerHealth: {
+            /** Connection Started At */
+            connection_started_at?: string | null;
             /** Healthy */
             healthy: boolean;
-            /** Last Tick At */
-            last_tick_at?: string | null;
-            /** Last Tick Age Seconds */
-            last_tick_age_seconds?: number | null;
+            /** Last Error */
+            last_error?: string | null;
             /** Last Flush At */
             last_flush_at?: string | null;
-            /**
-             * Ticks Received
-             * @default 0
-             */
-            ticks_received: number;
+            /** Last Tick Age Seconds */
+            last_tick_age_seconds?: number | null;
+            /** Last Tick At */
+            last_tick_at?: string | null;
+            /** Reason */
+            reason?: string | null;
             /**
              * Ticks Flushed
              * @default 0
              */
             ticks_flushed: number;
-            /** Connection Started At */
-            connection_started_at?: string | null;
-            /** Last Error */
-            last_error?: string | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Ticks Received
+             * @default 0
+             */
+            ticks_received: number;
         };
         /** GexLevel */
         uw_scan__api__schemas__GexLevel: {
-            /** Strike */
-            strike?: number | null;
-            /** Gamma */
-            gamma?: number | null;
             /** Distance */
             distance?: number | null;
             /** Distance Pct */
             distance_pct?: number | null;
+            /** Gamma */
+            gamma?: number | null;
+            /** Strike */
+            strike?: number | null;
         };
         /**
          * GexLevel
@@ -6228,14 +6267,14 @@ export interface components {
          *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
          */
         uw_scan__models__GexLevel: {
-            /** Strike */
-            strike: string;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
             /** Net Gex */
             net_gex?: string | null;
             /** Pct From Spot */
             pct_from_spot?: string | null;
-            /** Gamma Per Dollar */
-            gamma_per_dollar?: string | null;
+            /** Strike */
+            strike: string;
         };
     };
     responses: never;
@@ -6246,6 +6285,308 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitDealerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitFlowImResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_state_api_cockpit__ticker__state_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_surface_api_cockpit__ticker__surface_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitVrpResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gauge_api_gold_gauge_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldGaugeResponse"];
+                };
+            };
+        };
+    };
+    get_input_series_api_gold_inputs__series_id__get: {
+        parameters: {
+            query?: {
+                from?: string | null;
+                to?: string | null;
+            };
+            header?: never;
+            path: {
+                series_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldInputSeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_lens_api_gold_lenses__lens_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                lens_id: "structural" | "cyclical" | "valuation";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldLensResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_replay_api_gold_replay_get: {
+        parameters: {
+            query: {
+                /** @description Reconstruct posture for this obs_date */
+                as_of: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_state_api_gold_state_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldStateResponse"];
+                };
+            };
+        };
+    };
     health_api_health_get: {
         parameters: {
             query?: {
@@ -6331,13 +6672,583 @@ export interface operations {
             };
         };
     };
-    get_watchlist_api_watchlist_get: {
+    get_job_api_jobs__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ohlc_api_ohlc__ticker__get: {
         parameters: {
             query?: {
+                days?: number;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OhlcRow"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_endpoints_api_provider_usage_endpoints_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_requests_api_provider_usage_requests_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+                ticker?: string | null;
+                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_summary_api_provider_usage_summary_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_tickers_api_provider_usage_tickers_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rates_snapshot_api_rates_snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RatesSnapshotResponse"];
+                };
+            };
+        };
+    };
+    get_regime_api_regime_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriResponse"];
+                };
+            };
+        };
+    };
+    get_canary_latest_api_regime_canary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryLatestResponse"];
+                };
+            };
+        };
+    };
+    get_canary_history_api_regime_canary_history_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_canary_validation_api_regime_canary_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryValidationResponse"];
+                };
+            };
+        };
+    };
+    get_dealer_regime_api_regime_dealer_get: {
+        parameters: {
+            query: {
+                ticker: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DealerRegimeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gex_api_regime_gex_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_gex_scan_api_regime_gex_scan_post: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_guidance_api_regime_guidance_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GuidanceResponse"];
+                };
+            };
+        };
+    };
+    trigger_cri_scan_api_regime_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriScanResponse"];
+                };
+            };
+        };
+    };
+    get_validation_api_regime_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationResponse"];
+                };
+            };
+        };
+    };
+    get_vcg_api_regime_vcg_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_validation_api_regime_vcg_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgValidationResponse"];
+                };
+            };
+        };
+    };
+    trigger_vcg_scan_api_regime_vcg_scan_post: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgScanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vol_backdrop_api_regime_vol_backdrop_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolBackdropResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_scanner_api_scanner_get: {
+        parameters: {
+            query?: {
+                tier_1_only?: boolean;
+                type_f_only?: boolean;
                 sector?: string | null;
-                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
-                setup?: string | null;
-                fresh_within_minutes?: number | null;
+                freshness_hours?: number | null;
             };
             header?: never;
             path?: never;
@@ -6351,7 +7262,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WatchlistResponse"];
+                    "application/json": components["schemas"]["ScannerResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6365,44 +7276,12 @@ export interface operations {
             };
         };
     };
-    post_watchlist_api_watchlist_post: {
+    get_scanner_discover_api_scanner_discover_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistMutation"];
+            query?: {
+                limit?: number;
+                alerts_limit?: number;
             };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_watchlist_queue_api_watchlist_queue_get: {
-        parameters: {
-            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -6415,64 +7294,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["QueueSummary"];
-                };
-            };
-        };
-    };
-    delete_watchlist_api_watchlist__ticker__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    patch_watchlist_api_watchlist__ticker__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistPatch"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["DiscoveryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6600,457 +7422,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SingleStockReport"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_ohlc_api_ohlc__ticker__get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OhlcRow"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_state_api_cockpit__ticker__state_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitStateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitDealerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_surface_api_cockpit__ticker__surface_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitFlowImResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitVrpResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_api_watchlist__ticker__rescan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_all_api_watchlist_rescan_all_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RescanAllRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_job_api_jobs__job_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_volatility_series_api_stock__ticker__volatility_series_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_summary_api_provider_usage_summary_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_endpoints_api_provider_usage_endpoints_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_tickers_api_provider_usage_tickers_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_requests_api_provider_usage_requests_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-                ticker?: string | null;
-                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7193,6 +7564,37 @@ export interface operations {
             };
         };
     };
+    get_volatility_series_api_stock__ticker__volatility_series_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_trade_insight_priors_api_trade_insights_priors_get: {
         parameters: {
             query?: {
@@ -7228,10 +7630,13 @@ export interface operations {
             };
         };
     };
-    get_gex_api_regime_gex_get: {
+    get_watchlist_api_watchlist_get: {
         parameters: {
             query?: {
-                ticker?: string;
+                sector?: string | null;
+                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
+                setup?: string | null;
+                fresh_within_minutes?: number | null;
             };
             header?: never;
             path?: never;
@@ -7245,7 +7650,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GexResponse"];
+                    "application/json": components["schemas"]["WatchlistResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7259,19 +7664,21 @@ export interface operations {
             };
         };
     };
-    trigger_gex_scan_api_regime_gex_scan_post: {
+    post_watchlist_api_watchlist_post: {
         parameters: {
-            query?: {
-                ticker?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistMutation"];
+            };
+        };
         responses: {
             /** @description Successful Response */
-            202: {
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7292,38 +7699,7 @@ export interface operations {
             };
         };
     };
-    get_vol_backdrop_api_regime_vol_backdrop_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolBackdropResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_regime_api_regime_get: {
+    get_watchlist_queue_api_watchlist_queue_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -7338,19 +7714,23 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriResponse"];
+                    "application/json": components["schemas"]["QueueSummary"];
                 };
             };
         };
     };
-    trigger_cri_scan_api_regime_scan_post: {
+    enqueue_rescan_all_api_watchlist_rescan_all_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RescanAllRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             202: {
@@ -7358,29 +7738,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriScanResponse"];
-                };
-            };
-        };
-    };
-    get_vcg_api_regime_vcg_get: {
-        parameters: {
-            query?: {
-                proxy?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgResponse"];
+                    "application/json": components["schemas"]["JobStatus"][];
                 };
             };
             /** @description Validation Error */
@@ -7394,56 +7752,23 @@ export interface operations {
             };
         };
     };
-    trigger_vcg_scan_api_regime_vcg_scan_post: {
+    delete_watchlist_api_watchlist__ticker__delete: {
         parameters: {
-            query?: {
-                proxy?: string;
-            };
+            query?: never;
             header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgScanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_dealer_regime_api_regime_dealer_get: {
-        parameters: {
-            query: {
+            path: {
                 ticker: string;
             };
-            header?: never;
-            path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["DealerRegimeResponse"];
-                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -7456,221 +7781,20 @@ export interface operations {
             };
         };
     };
-    get_canary_latest_api_regime_canary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryLatestResponse"];
-                };
-            };
-        };
-    };
-    get_canary_history_api_regime_canary_history_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_canary_validation_api_regime_canary_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryValidationResponse"];
-                };
-            };
-        };
-    };
-    get_guidance_api_regime_guidance_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GuidanceResponse"];
-                };
-            };
-        };
-    };
-    get_validation_api_regime_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationResponse"];
-                };
-            };
-        };
-    };
-    get_vcg_validation_api_regime_vcg_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgValidationResponse"];
-                };
-            };
-        };
-    };
-    get_gauge_api_gold_gauge_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldGaugeResponse"];
-                };
-            };
-        };
-    };
-    get_input_series_api_gold_inputs__series_id__get: {
-        parameters: {
-            query?: {
-                from?: string | null;
-                to?: string | null;
-            };
-            header?: never;
-            path: {
-                series_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldInputSeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_state_api_gold_state_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldStateResponse"];
-                };
-            };
-        };
-    };
-    get_lens_api_gold_lenses__lens_id__get: {
+    patch_watchlist_api_watchlist__ticker__patch: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                lens_id: "structural" | "cyclical" | "valuation";
+                ticker: string;
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistPatch"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -7678,7 +7802,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GoldLensResponse"];
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -7692,111 +7818,24 @@ export interface operations {
             };
         };
     };
-    get_replay_api_gold_replay_get: {
-        parameters: {
-            query: {
-                /** @description Reconstruct posture for this obs_date */
-                as_of: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldStateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    rates_snapshot_api_rates_snapshot_get: {
+    enqueue_rescan_api_watchlist__ticker__rescan_post: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RatesSnapshotResponse"];
-                };
-            };
-        };
-    };
-    get_scanner_api_scanner_get: {
-        parameters: {
-            query?: {
-                tier_1_only?: boolean;
-                type_f_only?: boolean;
-                sector?: string | null;
-                freshness_hours?: number | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScannerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_scanner_discover_api_scanner_discover_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-                alerts_limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DiscoveryResponse"];
+                    "application/json": components["schemas"]["JobStatus"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/unit/VcgStressHistorySection.test.tsx
+++ b/web/tests/unit/VcgStressHistorySection.test.tsx
@@ -1,0 +1,58 @@
+/* @vitest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import VcgStressHistorySection from "@/components/regime/vcg/VcgStressHistorySection";
+
+const FIXTURE = {
+  backtest_md: "",
+  n_days: 4710,
+  composite_version: "2",
+  credit_proxy: "HY_OAS",
+  interpretation_distribution: [],
+  named_crash_window: [],
+  stress_history: [],
+  stress_history_summary: {
+    by_interpretation: [
+      {
+        interpretation: "PANIC",
+        n: 83,
+        mean_fwd_5d_pct: 0.2,
+        mean_fwd_20d_pct: 2.88,
+        mean_fwd_60d_pct: 2.29,
+        winrate_20d_pct: 53.0,
+        winrate_60d_pct: 41.0,
+      },
+      {
+        interpretation: "RISK_OFF",
+        n: 133,
+        mean_fwd_5d_pct: 0.2,
+        mean_fwd_20d_pct: 0.15,
+        mean_fwd_60d_pct: 3.04,
+        winrate_20d_pct: 67.7,
+        winrate_60d_pct: 74.4,
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => FIXTURE,
+  } as Response);
+});
+
+describe("VcgStressHistorySection summary line", () => {
+  it("renders aggregate stats for PANIC and RISK_OFF", async () => {
+    render(<VcgStressHistorySection />);
+    await waitFor(() => {
+      expect(screen.getByTestId("vcg-stress-summary")).toBeDefined();
+    });
+    const summary = screen.getByTestId("vcg-stress-summary");
+    expect(summary.textContent).toMatch(/83 historical PANIC/);
+    expect(summary.textContent).toMatch(/\+2\.88/);
+    expect(summary.textContent).toMatch(/133 historical RISK_OFF/);
+    expect(summary.textContent).toMatch(/\+3\.04/);
+  });
+});

--- a/web/tests/unit/VcgStressHistoryTable.test.tsx
+++ b/web/tests/unit/VcgStressHistoryTable.test.tsx
@@ -165,6 +165,33 @@ describe("VcgStressHistoryTable", () => {
     expect(cells?.[11]?.textContent).toBe("—");
   });
 
+  it("interpretation pill has tooltip with historical forward-return summary", () => {
+    const rows: Row[] = [
+      {
+        date: "2020-03-16",
+        interpretation: "PANIC",
+        score: -3.2,
+        vcg_adj: -3.2,
+        pi_panic: 1.5,
+        sign_ok: true,
+        vix: 80,
+        vvix: 130,
+        vix_percentile_rank: 0.99,
+        vvix_percentile_rank: 0.99,
+        fwd_5d_pct: -8.5,
+        fwd_20d_pct: 15.3,
+        fwd_60d_pct: 22.1,
+      },
+    ];
+    const { container } = render(<VcgStressHistoryTable rows={rows} />);
+    const pill = container.querySelector(
+      '[data-testid="interpretation-pill-PANIC"]',
+    );
+    expect(pill).not.toBeNull();
+    expect(pill?.getAttribute("title")).toMatch(/capitulation/i);
+    expect(pill?.getAttribute("title")).toMatch(/\+2\.88/);
+  });
+
   it("renders '—' for null percentile ranks", () => {
     const sparse: Row[] = [
       {

--- a/web/tests/unit/VcgStressHistoryTable.test.tsx
+++ b/web/tests/unit/VcgStressHistoryTable.test.tsx
@@ -104,6 +104,67 @@ describe("VcgStressHistoryTable", () => {
     ).not.toBeNull();
   });
 
+  it("renders +5d / +20d / +60d forward-return cells with sign coloring", () => {
+    const rows: Row[] = [
+      {
+        date: "2020-03-16",
+        interpretation: "PANIC",
+        score: -3.2,
+        vcg_adj: -3.2,
+        pi_panic: 1.5,
+        sign_ok: true,
+        vix: 80,
+        vvix: 130,
+        vix_percentile_rank: 0.99,
+        vvix_percentile_rank: 0.99,
+        fwd_5d_pct: -8.5,
+        fwd_20d_pct: 15.3,
+        fwd_60d_pct: 22.1,
+      },
+    ];
+    const { container } = render(<VcgStressHistoryTable rows={rows} />);
+    const row = container.querySelector(
+      '[data-testid="vcg-stress-row-2020-03-16"]',
+    );
+    const cells = row?.querySelectorAll("td");
+    // Columns 9, 10, 11 are +5d / +20d / +60d
+    expect(cells?.[9]?.textContent).toMatch(/-8\.5/);
+    expect(cells?.[10]?.textContent).toMatch(/\+15\.3/);
+    expect(cells?.[11]?.textContent).toMatch(/\+22\.1/);
+    // Negative fwd_5d should be red; positive should be green
+    expect((cells?.[9] as HTMLElement).style.color).toContain("var(--negative");
+    expect((cells?.[10] as HTMLElement).style.color).toContain(
+      "var(--positive",
+    );
+  });
+
+  it("renders '—' for null forward-return cells (recent days)", () => {
+    const rows: Row[] = [
+      {
+        date: "2026-05-27",
+        interpretation: "RISK_OFF",
+        score: -1.9,
+        vcg_adj: -1.9,
+        pi_panic: 0,
+        sign_ok: true,
+        vix: 25,
+        vvix: 110,
+        vix_percentile_rank: 0.7,
+        vvix_percentile_rank: 0.6,
+        fwd_5d_pct: 0.5,
+        fwd_20d_pct: null,
+        fwd_60d_pct: null,
+      },
+    ];
+    const { container } = render(<VcgStressHistoryTable rows={rows} />);
+    const row = container.querySelector(
+      '[data-testid="vcg-stress-row-2026-05-27"]',
+    );
+    const cells = row?.querySelectorAll("td");
+    expect(cells?.[10]?.textContent).toBe("—");
+    expect(cells?.[11]?.textContent).toBe("—");
+  });
+
   it("renders '—' for null percentile ranks", () => {
     const sparse: Row[] = [
       {


### PR DESCRIPTION
## Summary
- Reframes the VCG stress-history UI to show what historically happened *after* each PANIC / RISK_OFF / EDR day, instead of relying on red-pill framing that implies "warning."
- Backend-additive: `VcgStressHistoryEntry` gains `fwd_5d_pct`, `fwd_20d_pct`, `fwd_60d_pct`; `VcgValidationResponse` gains optional `stress_history_summary`. No `COMPOSITE_VERSION` bump.
- Frontend-additive: 3 columns on the stress-history table (sign-colored), 1 summary line above (both 20d and 60d horizons), 1 tooltip on the interpretation pill.
- Grounded in 13 forward-return probes documented at \`docs/research/regime/vcg-forward-return-probes-2026-05-28.md\` (PANIC mean 20d = +2.88%, RISK_OFF mean 60d = +3.04%).
- Plan: \`docs/superpowers/plans/2026-05-28-vcg-ui-capitulation-framing-plan.md\` (hardened by 6-pass /review-cycle, min(confidence) >= 8).
- Task 7 (Signal Detail historical row) shipped as Option C (skip) per plan recommendation — Task 6's summary line already conveys historical context.

## Verification (numeric, against production warm-store run_id=31, 4710 days)
- PANIC n=83, mean fwd 20d = +2.878% (probe baseline: +2.88) — match
- RISK_OFF n=135, mean fwd 60d = +3.036% (probe baseline: +3.04) — match
- EDR n=8, mean fwd 5d = +1.14% — supplementary

## Test plan
- [x] \`uv run pytest tests/unit\` — 807 passed (+10 new)
- [x] \`cd web && npm run typecheck && npm run test -- --run\` — 356 passed (+4 new)
- [x] Integration: regime endpoint + openapi snapshot tests — 10 passed, 1 skipped (env-gated numeric-match test)
- [x] Manual: \`/regime\` VCG sub-tab renders summary line + 3 new columns + tooltip end-to-end (screenshots in \`output/playwright/\`)
- [x] \`curl /api/regime/vcg-validation | jq .stress_history_summary\` against worktree's API exposes correct per-interpretation aggregates

## What this does NOT change
- VCG signal math, classifier, cascade logic, \`COMPOSITE_VERSION\`
- Stress state assignment for any historical day
- Other regime indicators (CRI, Canary, GEX cockpit)