### PR TITLE
feat(research): canary WF-5 probes 2+3 — direction B LOCKED

### DIFF
--- a/docs/research/regime/canary-v2c-design-notes.md
+++ b/docs/research/regime/canary-v2c-design-notes.md
@@ -101,7 +101,29 @@ Probe scaffold lives at [`scripts/probe_canary_wf5.py`](../../../scripts/probe_c
 - VVIX percentile during WF-5 BTD-fire days — is BTD activating at *real* dip troughs or just stretched-quiet readings? Decides whether direction B's secondary-ordering signal needs an extra vol-of-vol gate.
 - Cross-asset signal correlations during WF-5 (credit, term structure) — is BTD picking up lead-lag from non-vol-complex inputs? Diagnostic for whether v1's additive formula is accidentally capturing dispersion that v2-A removed.
 
-**One caveat:** all three windows show monotonically increasing BTD lift as horizon extends (WF-5 BTD: +3.1% / 20d → +11.4% / 60d → +17.5% / 120d). This suggests the probe might be picking up *generic positive forward returns* during post-selloff windows (selection-on-dip effect) rather than BTD-specific signal. A future probe should normalize against a random-43-days-per-window control to confirm BTD beats the within-window time-of-dip baseline, not just the across-window NONE baseline.
+**Probe 3 — bootstrap random-control — completed 2026-05-28.** Script: [`scripts/probe_canary_wf5_random_control.py`](../../../scripts/probe_canary_wf5_random_control.py). K=10000 bootstrap samples of n=43 days without replacement from non-bucket pool, seed=42, per (window, bucket, horizon). Resolves the selection-on-dip caveat from probe 2.
+
+| Window | Bucket | 20td pctile / p | 60td pctile / p | 120td pctile / p |
+|---|---|---|---|---|
+| **WF-5** (quiet) | **BTD** | **100.00 / ≈0** | **100.00 / ≈0** | **100.00 / ≈0** |
+| WF-3 (crisis) | BTD | 24.83 / 0.50 | 2.73 / 0.05 | 75.84 / 0.48 |
+| WF-3 | **CCA** | **100.00 / ≈0** | **100.00 / ≈0** | **100.00 / ≈0** |
+| WF-1 (baseline) | BTD | 100.00 / ≈0 | 99.79 / 0.004 | 13.54 / 0.27 |
+
+Three findings from probe 3 that lock direction B:
+
+1. **WF-5 BTD survives the strictest within-window null at ALL horizons** (100th percentile, p ≈ 0). Null mean is +4.0% ± 0.7% / 60d; BTD's +11.4% / 60d sits ~11 standard deviations above the null mean. The +11.4%/60d alpha is real signal, not selection-on-dip. **Direction B's evidence base is empirically defensible.**
+
+2. **WF-3 BTD does NOT beat the null** (24.8 / 2.7 / 75.8 pctile). In crisis, ANY 43-day subset of the window has +1-4% / 60d forward returns driven by the COVID recovery rally; BTD's +0.9%/60d is actually *below* the null mean. **This is fine and consistent with v2-A's WF-3 win:** when vol-complex fires strongly (high tactical + structural), speed's BTD contribution adds little marginal info, so v2-A's removal of speed doesn't hurt WF-3. The regime-complementarity is exactly what direction B exploits.
+
+3. **WF-3 CCA crushes the null** at all 3 horizons (100th percentile, p ≈ 0). +14.9% / 60d and +23.3% / 120d are real GFC-style mean-reversion bounces, beyond what within-window random selection could produce. v2-A preserved this pathway (speed → 0 → vol-complex dominates → composite ranking still discriminates CCA days). This is why v2-A's WF-3 60d AUC lifted +0.087.
+
+**Regime structure (now legible):**
+- **Crisis regime (WF-3):** vol-complex + CCA carry the signal; speed's contribution is dominated by recovery-rally baseline. v2-A's "drop speed" worked here because vol-complex was already sufficient.
+- **Quiet regime (WF-5):** vol-complex is dormant (tactical=0, structural mid-range); speed-driven BTD is the alpha pathway. v2-A's "drop speed" killed this and caused the -0.134 / 60d regression.
+- **Direction B (rank inversion within BUY) preserves both** because v1's additive composite is intact for BUY-band qualification.
+
+**WF-1 BTD 120d (pctile 13.54) is an outlier worth one more probe** — at 120d horizon in 2015-2016, BTD's +2.05% sits below the null's +3.05% mean. Could be a 2015-2016 specific artifact (Brexit recovery overshoot) or a generic 120d horizon issue. Not a direction B blocker since WF-1 wasn't a regression window in v2-A, but worth understanding before the spec brainstorm locks horizon weights.
 
 ### 2. AC-F3 reformulation (gate redesign)
 
@@ -154,9 +176,10 @@ When the spec brainstorm starts (post-WF-5 probe), it should:
 | 2026-05-28 | Pre-spec docs first | WF-5 probe needed before direction-picking spec is written |
 | 2026-05-28 | Probe 2 done — direction B leading | Forward-return probe: BTD fires (driven by speed=20) predict +11.4% / 60d in WF-5. v2-A's regression cost = +11.4% / 60d alpha. Direction B (rank inversion within BUY) preserves BTD activation; A and C don't (or only conditionally). |
 | 2026-05-28 | CCA reframed as bottom signal | WF-3 CCA forward 60d = +14.9% (mean-reversion bounce, not warning). AC-F3 reformulation is now load-bearing, not optional. |
-| TBD | VVIX % during BTD-fire days probe | Needed before committing to direction B — confirms BTD activates at real troughs vs stretched readings |
-| TBD | Direction picked (B leading) | After VVIX probe |
-| TBD | v2-C spec written | After direction picked + AC reformulation locked |
+| 2026-05-28 | **Probe 3 done — direction B locked** | WF-5 BTD beats random-control at 100th pctile / p≈0 across all 3 horizons. Regime structure now legible: crisis = vol-complex + CCA; quiet = BTD. Direction B preserves both pathways. |
+| TBD | WF-1 120d outlier check | BTD 120d pctile=13.54 (below null). Diagnostic before horizon weighting in v2-C spec. Not a B blocker. |
+| TBD | VVIX % during BTD-fire days probe | Optional now — direction B is locked. Would refine VVIX-gate decision in the spec, not the direction call. |
+| TBD | v2-C spec written | Next major step — direction B, AC-F1..F7 pre-committed, AC-F3 reformulated |
 
 ---
 

--- a/docs/research/regime/canary-v2c-design-notes.md
+++ b/docs/research/regime/canary-v2c-design-notes.md
@@ -77,11 +77,31 @@ These are non-negotiable for institutional discipline.
 
 Probe scaffold lives at [`scripts/probe_canary_wf5.py`](../../../scripts/probe_canary_wf5.py). First-pass output answers: in WF-5, how often did `speed.state != NEUTRAL`? What was `speed.score`'s distribution? How does that compare to WF-3 (where v2 won big) and WF-1 (where v2 broke even)?
 
-Follow-up probes (queue):
+**Probe 2 — forward-return by `warning_state` bucket — completed 2026-05-28.** Script: [`scripts/probe_canary_wf5_fwd_return.py`](../../../scripts/probe_canary_wf5_fwd_return.py). Three windows × three horizons (20d / 60d / 120d).
 
-- Forward 60d return by `speed.state` bucket in WF-5 vs WF-3 — does speed *predict* anything in quiet, or is it noise that v1's additive formula happens to suppress?
-- Cross-asset signal correlations during WF-5: is speed picking up lead-lag from credit, vol-of-vol, or term structure that vol-complex misses?
-- Vol-of-vol (VVIX) percentile during WF-5 days when speed fires — is it actually "quiet" or just "stretched"?
+| Window | Horizon | Non-NONE mean | NONE mean | Welch's t |
+|---|---|---|---|---|
+| WF-5 (quiet) | 60d | **+11.4%** (BTD only) | +4.0% | **+17.16** |
+| WF-5 | 120d | **+17.5%** (BTD only) | +7.5% | +24.15 |
+| WF-3 (crisis) | 60d | +7.9% (CCA +14.9% / BTD +0.9%) | +2.6% | +4.77 |
+| WF-3 | 120d | +15.9% (CCA +23.3% / BTD +8.5%) | +5.5% | +9.25 |
+| WF-1 (baseline) | 60d | +3.3% (BTD only) | +1.2% | +2.59 |
+
+**Three findings that reshape the v2-C direction call:**
+
+1. **The "speed = early-instability detector in quiet regimes" framing was wrong.** In WF-5 `warning_state` never escalates beyond `BUY_THE_DIP_ACTIVE` (no CCA fires). When BTD fires (speed=20), forward 60d returns are +11.4% vs +4.0% baseline — t=17.16. Speed's load-bearing role in quiet regimes is **BTD activation**, which predicts strongly *positive* forward returns. v2-A's "drop speed from composite" killed the integer transition that drives BTD activation. The WF-5 -0.134 AUC regression is the cost of removing a +11.4%/60d alpha signal from composite ranking.
+
+2. **CCA fires at mean-reversion bottoms, not selloff tops.** WF-3 CCA bucket has +14.9% / 60d and +23.3% / 120d forward returns — wildly positive, consistent with [[project-vcg-forward-returns-descriptive]] (BOUNCE n=5 dominated by 2008 GFC; PANIC mean-reverts +2.88%/20d). CCA is a *post-selloff dip-buy signal*, NOT a warning of imminent selloff. **This re-confirms why AC-F3 was the wrong gate**: canonical event dates were event *onsets*, but CCA fires at the bottom of the resulting 2-month cluster. AC-F3 reformulation (per §2 below) is no longer optional — it's load-bearing.
+
+3. **Direction B (rank inversion within BUY) is now the leading v2-C candidate.** Direction A (regime-conditional weighting) requires a robust regime detector — itself a new failure surface. Direction C (convex blending) likely still suppresses BTD's quiet-regime contribution. Direction B (keep v1's composite intact, use speed only for *within-BUY ordering*) preserves BTD activation in both crisis AND quiet, and addresses the original BUY-band rank-inversion finding from the form-sweep. The probe's data supports B over A/C with the +11.4% / 60d signal as the load.
+
+**Follow-up probes (queue, updated):**
+
+- ~~Forward 60d return by `speed.state` bucket~~ — **DONE** (results above).
+- VVIX percentile during WF-5 BTD-fire days — is BTD activating at *real* dip troughs or just stretched-quiet readings? Decides whether direction B's secondary-ordering signal needs an extra vol-of-vol gate.
+- Cross-asset signal correlations during WF-5 (credit, term structure) — is BTD picking up lead-lag from non-vol-complex inputs? Diagnostic for whether v1's additive formula is accidentally capturing dispersion that v2-A removed.
+
+**One caveat:** all three windows show monotonically increasing BTD lift as horizon extends (WF-5 BTD: +3.1% / 20d → +11.4% / 60d → +17.5% / 120d). This suggests the probe might be picking up *generic positive forward returns* during post-selloff windows (selection-on-dip effect) rather than BTD-specific signal. A future probe should normalize against a random-43-days-per-window control to confirm BTD beats the within-window time-of-dip baseline, not just the across-window NONE baseline.
 
 ### 2. AC-F3 reformulation (gate redesign)
 
@@ -132,7 +152,10 @@ When the spec brainstorm starts (post-WF-5 probe), it should:
 | 2026-05-28 | v2-A rejected, terminal | AC-F4 + AC-F3 failed; WF-5 regression of −0.134 + 3 of 4 canonical CCA dates missed |
 | 2026-05-28 | v2-C promoted to top of queue | Speed contribution in quiet regimes confirmed empirically |
 | 2026-05-28 | Pre-spec docs first | WF-5 probe needed before direction-picking spec is written |
-| TBD | Direction picked (A / B / C) | After WF-5 probe results |
+| 2026-05-28 | Probe 2 done — direction B leading | Forward-return probe: BTD fires (driven by speed=20) predict +11.4% / 60d in WF-5. v2-A's regression cost = +11.4% / 60d alpha. Direction B (rank inversion within BUY) preserves BTD activation; A and C don't (or only conditionally). |
+| 2026-05-28 | CCA reframed as bottom signal | WF-3 CCA forward 60d = +14.9% (mean-reversion bounce, not warning). AC-F3 reformulation is now load-bearing, not optional. |
+| TBD | VVIX % during BTD-fire days probe | Needed before committing to direction B — confirms BTD activates at real troughs vs stretched readings |
+| TBD | Direction picked (B leading) | After VVIX probe |
 | TBD | v2-C spec written | After direction picked + AC reformulation locked |
 
 ---

--- a/scripts/probe_canary_wf5_fwd_return.py
+++ b/scripts/probe_canary_wf5_fwd_return.py
@@ -1,0 +1,342 @@
+"""WF-5 forward-return probe: does warning_state predict in quiet regimes?
+
+Follow-on to scripts/probe_canary_wf5.py. The first probe established that
+WF-5's speed fires (score >= 8) on 100% of days while WF-3 quiets 10%.
+Open question: when warning_state fires in WF-5, is it predicting anything
+about forward SPX returns, or is it noise that v1's additive formula
+happens to absorb?
+
+Payload shape (verified against WF-5 row 2023-01-03):
+  - payload.speed         → integer score (0 / 8 / 20)
+  - payload.warning_state → semantic bucket: NONE / CONFIRMED_CANARY_ACTIVE
+                            / BUY_THE_DIP_ACTIVE
+  (Note: probe_canary_wf5.py had a defensive `speed.state` reader that
+  never fired — older nested shape doesn't exist in current payloads.)
+
+What it does:
+  1. For each window in {WF-1, WF-3, WF-5}, pulls v1 walk-forward daily
+     rows from regime_backtest_daily.
+  2. Pulls SPX close series from vol_index_daily (single shared series).
+  3. For each row, looks up forward 20 / 60 / 120 trading-day SPX log-return.
+  4. Buckets by warning_state, reports per-bucket count, mean, median,
+     std, IQR, plus Welch's t for non-NONE vs NONE (no p-value).
+  5. Side-by-sides the three windows.
+
+Inventory (from production canary v1 walk-forward, verified 2026-05-28):
+  WF-1  NONE=461  BTD=43                                (no CCA — quiet)
+  WF-3  NONE=355  CCA=43  BTD=43                        (full crucible)
+  WF-5  NONE=459  BTD=43                                (no CCA — quiet)
+
+Interpretation guide (per canary-v2c-design-notes.md §1):
+  - WF-5 has only NONE vs BTD — there is NO warning-firing bucket to test.
+    What this DOES reveal: in a quiet regime, does BTD predict forward
+    returns differently than baseline? (BTD is a dip-buy signal, so
+    positive forward returns would just confirm v1's BTD logic.)
+  - The deeper hypothesis ("speed is an early-instability detector in
+    quiet regimes") CANNOT be tested directly here because WF-5's
+    warning_state never escalates beyond BTD. This is itself a finding:
+    if v2-A's WF-5 regression was caused by removing speed, the mechanism
+    is NOT speed-as-warning — it's the integer score's drift contribution
+    to the composite, independent of warning_state.
+  - WF-3 is the discriminating crucible: 3-bucket breakout including CCA.
+    If CCA non-NONE has a strongly negative forward-return signal in
+    WF-3 but BTD has a positive one, the warning_state bucket carries
+    real directional content during crisis.
+  - WF-1 is a sanity baseline.
+
+Usage:
+  PGUSER=chenxi UW_SCAN_API_KEY=local-smoke uv run python \\
+      scripts/probe_canary_wf5_fwd_return.py
+
+Output: stdout (human-readable + TSV). Not persisted to DB.
+
+Spec context: docs/research/regime/canary-v2c-design-notes.md §1
+Prior probe:  scripts/probe_canary_wf5.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import statistics
+import sys
+from datetime import date
+
+import psycopg
+
+from uw_scan.config import Settings
+
+WINDOWS: dict[str, tuple[str, str, str]] = {
+    "WF-1": ("2015-01-01", "2016-12-31", "China deval, Brexit"),
+    "WF-3": ("2019-01-01", "2020-09-30", "Repo crisis, COVID crash"),
+    "WF-5": ("2023-01-01", "2024-12-31", "Bond-yield selloff, 2024 quiet"),
+}
+
+HORIZONS_TD = (20, 60, 120)
+
+
+def _fetch_v1_window_daily(conn, *, schema: str, window_id: str) -> list[dict]:
+    """Pull v1 walk-forward daily rows for one window_id.
+
+    Reads payload.warning_state (top-level string field). The integer
+    payload.speed is also extracted for cross-checking; see the inventory
+    in this file's module docstring.
+    """
+    sql = f"""
+        SELECT d.trade_date, d.payload
+        FROM {schema}.regime_backtest_daily d
+        JOIN {schema}.regime_backtest_runs r ON d.run_id = r.id
+        WHERE r.indicator = 'canary'
+          AND r.run_scope = 'production'
+          AND r.composite_version = '1'
+          AND r.params->>'phase' = 'walk_forward'
+          AND r.params->>'window_id' = %s
+          AND r.completed_at IS NOT NULL
+        ORDER BY d.trade_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (window_id,))
+        rows = []
+        for trade_date, payload in cur.fetchall():
+            warning_state = payload.get("warning_state") or "UNKNOWN"
+            speed_raw = payload.get("speed")
+            speed = int(speed_raw) if isinstance(speed_raw, (int, float)) else None
+            rows.append(
+                {"date": trade_date, "warning_state": warning_state, "speed": speed}
+            )
+        return rows
+
+
+def _fetch_spx_close_series(
+    conn, *, schema: str, start: date, end: date
+) -> tuple[list[date], dict[date, int], list[float]]:
+    """Pull SPX close series from vol_index_daily for [start, end].
+
+    Returns (dates_asc, date_to_idx, closes_asc) — the trading-day index
+    lets us advance by trading days (not calendar days) for forward returns.
+    Schema verified: vol_index_daily(symbol, trade_date, ..., close, ...).
+    """
+    sql = f"""
+        SELECT trade_date, close
+        FROM {schema}.vol_index_daily
+        WHERE symbol = 'SPX'
+          AND trade_date BETWEEN %s AND %s
+        ORDER BY trade_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (start, end))
+        rows = cur.fetchall()
+    dates_asc = [r[0] for r in rows]
+    closes_asc = [float(r[1]) for r in rows]
+    date_to_idx = {d: i for i, d in enumerate(dates_asc)}
+    return dates_asc, date_to_idx, closes_asc
+
+
+def _forward_log_return(
+    *,
+    date_to_idx: dict[date, int],
+    closes: list[float],
+    spot_date: date,
+    horizon_td: int,
+) -> float | None:
+    """Look up the trading-day-indexed forward log-return, or None at the
+    series tail."""
+    i = date_to_idx.get(spot_date)
+    if i is None:
+        return None
+    j = i + horizon_td
+    if j >= len(closes):
+        return None
+    spot = closes[i]
+    fwd = closes[j]
+    if spot <= 0 or fwd <= 0:
+        return None
+    return math.log(fwd / spot)
+
+
+def _welch_t_stat(a: list[float], b: list[float]) -> float | None:
+    """Welch's t-statistic for mean(a) - mean(b). No p-value; user reads
+    magnitude (|t| > 2 ≈ noteworthy, > 3 ≈ strong, given n's reported)."""
+    if len(a) < 2 or len(b) < 2:
+        return None
+    var_a = statistics.variance(a)
+    var_b = statistics.variance(b)
+    se = math.sqrt(var_a / len(a) + var_b / len(b))
+    if se == 0:
+        return None
+    return (statistics.mean(a) - statistics.mean(b)) / se
+
+
+def _bucket_stats(returns: list[float]) -> dict:
+    """count / mean / median / std / IQR (Q3-Q1) for one bucket."""
+    n = len(returns)
+    if n == 0:
+        return {"n": 0, "mean": None, "median": None, "std": None, "iqr": None}
+    if n == 1:
+        return {
+            "n": 1,
+            "mean": returns[0],
+            "median": returns[0],
+            "std": None,
+            "iqr": None,
+        }
+    qs = statistics.quantiles(returns, n=4)
+    return {
+        "n": n,
+        "mean": statistics.mean(returns),
+        "median": statistics.median(returns),
+        "std": statistics.stdev(returns),
+        "iqr": qs[2] - qs[0],
+    }
+
+
+def _print_window_section(
+    *,
+    window_id: str,
+    label: str,
+    buckets: dict[str, dict[int, list[float]]],
+) -> None:
+    """One section per window: per-state-bucket × per-horizon stats table."""
+    print(f"\n=== {window_id} — {label} ===")
+    states_sorted = sorted(buckets.keys())
+    if not states_sorted:
+        print("  (no rows)")
+        return
+    for h in HORIZONS_TD:
+        print(f"\n  horizon {h}td:")
+        print(
+            "    {:<18}  {:>6}  {:>9}  {:>9}  {:>9}  {:>9}".format(
+                "state", "n", "mean", "median", "std", "iqr"
+            )
+        )
+        for state in states_sorted:
+            rs = buckets[state].get(h, [])
+            s = _bucket_stats(rs)
+            mean = f"{s['mean']:+.4f}" if s["mean"] is not None else "—"
+            med = f"{s['median']:+.4f}" if s["median"] is not None else "—"
+            std = f"{s['std']:.4f}" if s["std"] is not None else "—"
+            iqr = f"{s['iqr']:.4f}" if s["iqr"] is not None else "—"
+            print(
+                "    {:<18}  {:>6}  {:>9}  {:>9}  {:>9}  {:>9}".format(
+                    state, s["n"], mean, med, std, iqr
+                )
+            )
+        non_none = []
+        for state, by_h in buckets.items():
+            if state and state != "NONE":
+                non_none.extend(by_h.get(h, []))
+        none_bucket = buckets.get("NONE", {}).get(h, [])
+        t = _welch_t_stat(non_none, none_bucket)
+        if t is not None:
+            print(
+                f"    Welch's t (non-NONE vs NONE): "
+                f"{t:+.2f}  n_nn={len(non_none)}  n_n={len(none_bucket)}"
+            )
+        else:
+            print(
+                "    Welch's t (non-NONE vs NONE): — "
+                f"(n_nn={len(non_none)}, n_n={len(none_bucket)})"
+            )
+
+
+def _print_tsv_summary(
+    summaries: dict[str, dict[str, dict[int, list[float]]]],
+) -> None:
+    """TSV one row per (window, horizon): non-NEUTRAL mean - NEUTRAL mean, t."""
+    print("\n=== TSV (window\thorizon\tn_nn\tn_n\tmean_nn\tmean_n\tdiff\twelch_t) ===")
+    for wid, buckets in summaries.items():
+        for h in HORIZONS_TD:
+            nn = []
+            for state, by_h in buckets.items():
+                if state and state != "NONE":
+                    nn.extend(by_h.get(h, []))
+            n = buckets.get("NONE", {}).get(h, [])
+            mean_nn = statistics.mean(nn) if nn else 0.0
+            mean_n = statistics.mean(n) if n else 0.0
+            t = _welch_t_stat(nn, n)
+            t_str = f"{t:+.3f}" if t is not None else "—"
+            print(
+                f"{wid}\t{h}td\t{len(nn)}\t{len(n)}\t"
+                f"{mean_nn:+.4f}\t{mean_n:+.4f}\t"
+                f"{(mean_nn - mean_n):+.4f}\t{t_str}"
+            )
+
+
+def main() -> int:
+    argparse.ArgumentParser(description=__doc__).parse_args()
+
+    settings = Settings.from_env()
+
+    win_start = min(date.fromisoformat(s) for s, _, _ in WINDOWS.values())
+    win_end = max(date.fromisoformat(e) for _, e, _ in WINDOWS.values())
+    spx_start = date(win_start.year - 1, 1, 1)
+    spx_end = date(win_end.year + 1, 12, 31)
+
+    summaries: dict[str, dict[str, dict[int, list[float]]]] = {}
+    with psycopg.connect(settings.db_dsn()) as conn:
+        _, date_to_idx, closes = _fetch_spx_close_series(
+            conn, schema=settings.db_schema, start=spx_start, end=spx_end
+        )
+        if not closes:
+            print(
+                f"ERROR: no SPX rows in vol_index_daily for {spx_start}..{spx_end}",
+                file=sys.stderr,
+            )
+            return 1
+
+        for wid, (start, end, label) in WINDOWS.items():
+            rows = _fetch_v1_window_daily(
+                conn, schema=settings.db_schema, window_id=wid
+            )
+            if not rows:
+                print(
+                    f"WARN: {wid} has zero v1 walk-forward daily rows.",
+                    file=sys.stderr,
+                )
+                continue
+
+            buckets: dict[str, dict[int, list[float]]] = {}
+            for r in rows:
+                state = r["warning_state"] or "UNKNOWN"
+                state_buckets = buckets.setdefault(state, {h: [] for h in HORIZONS_TD})
+                for h in HORIZONS_TD:
+                    fr = _forward_log_return(
+                        date_to_idx=date_to_idx,
+                        closes=closes,
+                        spot_date=r["date"],
+                        horizon_td=h,
+                    )
+                    if fr is not None:
+                        state_buckets[h].append(fr)
+
+            summaries[wid] = buckets
+            _print_window_section(
+                window_id=wid, label=f"{label} ({start} → {end})", buckets=buckets
+            )
+
+    if not summaries:
+        print("ERROR: no v1 walk-forward rows for any window.", file=sys.stderr)
+        return 1
+
+    _print_tsv_summary(summaries)
+
+    print("\n=== How to read this ===")
+    print("- WF-3 is the crucible: 3-bucket breakout (NONE / CCA / BTD).")
+    print("  Strongly negative t in CCA bucket = warning catches selloff;")
+    print("  strongly positive t in BTD bucket = dip-buy works in crisis.")
+    print("- WF-1 + WF-5 only have NONE vs BTD (no CCA fires in quiet).")
+    print("  Positive t = BTD predicts above-baseline forward returns,")
+    print("  confirming v1's dip-buy logic even in non-crisis regimes.")
+    print("- The 'speed-as-quiet-instability' hypothesis (v2-A regression")
+    print("  source) is NOT directly testable here — WF-5 warning_state")
+    print("  never escalates beyond BTD. The integer speed=8→20 transition")
+    print("  IS what BTD captures, so this probe DOES indirectly probe it.")
+    print("- If BTD shows large positive forward returns in WF-5, v2-A's")
+    print("  removal of speed cost those days' contribution to ranking →")
+    print("  supports v2-C direction A or B (preserve quiet-regime BTD lift).")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_canary_wf5_random_control.py
+++ b/scripts/probe_canary_wf5_random_control.py
@@ -1,0 +1,357 @@
+"""WF-5 random-control probe: does BTD beat 43 random within-window days?
+
+Follow-on to scripts/probe_canary_wf5_fwd_return.py. The prior probe
+established that in WF-5 the BTD bucket's forward 60d return is +11.4%
+vs +4.0% NONE baseline (Welch's t=+17.16). Open caveat: monotonic
+positive lift across horizons suggests possible selection-on-dip
+effect — maybe ANY 43 days within WF-5 would show ~similar lift if
+they happened to fall in the post-March-2023 SPX rally.
+
+This probe resolves the caveat via bootstrap percentile test:
+  - For each (window, bucket-of-interest, horizon), build a null
+    distribution by drawing K=10000 random samples of n=43 days
+    WITHOUT replacement from the pool of non-{bucket} days within
+    that window, computing each sample's mean forward log-return.
+  - Compare the OBSERVED bucket mean against the null distribution.
+  - Report observed, null mean ± std, percentile of observed in
+    null, two-tailed p-value approximation.
+
+Decision rule (locks direction B if BTD survives):
+  - BTD observed >= 99th percentile of null (p <= 0.02) in WF-5
+    → BTD signal beats random within-window selection → direction
+    B's evidence base survives, can lock.
+  - 50th <= pctile < 99th → ambiguous; need stricter control
+    (matched on prior 20d return, or alternative bucketing).
+  - < 50th → BTD signal collapses; reconsider direction call.
+
+Statistical details:
+  - K=10000 bootstrap samples, fixed seed (42) for reproducibility.
+  - Sampling WITHOUT replacement (BTD picked 43 distinct days; with-
+    replacement would inflate null variance and make BTD look more
+    significant than warranted).
+  - Pool = window-wide non-{bucket} days. So BTD's null excludes
+    BTD days; CCA's null excludes CCA days.
+  - Per-horizon independent filtering for forward-return availability
+    (drops rows where forward close is past the SPX series tail).
+
+Usage:
+  PGUSER=chenxi UW_SCAN_API_KEY=local-smoke uv run python \\
+      scripts/probe_canary_wf5_random_control.py
+
+Output: stdout (human-readable + TSV). Not persisted to DB.
+
+Spec context:  docs/research/regime/canary-v2c-design-notes.md §1
+Prior probes:  scripts/probe_canary_wf5.py (warning_state inventory)
+               scripts/probe_canary_wf5_fwd_return.py (BTD vs NONE Welch's t)
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import statistics
+import sys
+from datetime import date
+
+import psycopg
+
+from uw_scan.config import Settings
+
+WINDOWS: dict[str, tuple[str, str, str]] = {
+    "WF-1": ("2015-01-01", "2016-12-31", "China deval, Brexit"),
+    "WF-3": ("2019-01-01", "2020-09-30", "Repo crisis, COVID crash"),
+    "WF-5": ("2023-01-01", "2024-12-31", "Bond-yield selloff, 2024 quiet"),
+}
+
+HORIZONS_TD = (20, 60, 120)
+
+# Buckets to test against random-control null. WF-1 and WF-5 only have BTD
+# as a non-NONE bucket; WF-3 has both CCA and BTD. The probe runs every
+# bucket present in each window.
+BUCKETS_OF_INTEREST = ("BUY_THE_DIP_ACTIVE", "CONFIRMED_CANARY_ACTIVE")
+
+K_BOOTSTRAP = 10_000
+SEED = 42
+
+
+def _fetch_v1_window_daily(conn, *, schema: str, window_id: str) -> list[dict]:
+    """Pull v1 walk-forward daily rows for one window_id.
+
+    Reads payload.warning_state (top-level string). Same query shape as
+    probe_canary_wf5_fwd_return.py.
+    """
+    sql = f"""
+        SELECT d.trade_date, d.payload
+        FROM {schema}.regime_backtest_daily d
+        JOIN {schema}.regime_backtest_runs r ON d.run_id = r.id
+        WHERE r.indicator = 'canary'
+          AND r.run_scope = 'production'
+          AND r.composite_version = '1'
+          AND r.params->>'phase' = 'walk_forward'
+          AND r.params->>'window_id' = %s
+          AND r.completed_at IS NOT NULL
+        ORDER BY d.trade_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (window_id,))
+        rows = []
+        for trade_date, payload in cur.fetchall():
+            warning_state = payload.get("warning_state") or "UNKNOWN"
+            rows.append({"date": trade_date, "warning_state": warning_state})
+        return rows
+
+
+def _fetch_spx_close_series(
+    conn, *, schema: str, start: date, end: date
+) -> tuple[dict[date, int], list[float]]:
+    """Pull SPX close series from vol_index_daily for [start, end].
+
+    Returns (date_to_idx, closes_asc).
+    """
+    sql = f"""
+        SELECT trade_date, close
+        FROM {schema}.vol_index_daily
+        WHERE symbol = 'SPX'
+          AND trade_date BETWEEN %s AND %s
+        ORDER BY trade_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (start, end))
+        rows = cur.fetchall()
+    dates_asc = [r[0] for r in rows]
+    closes_asc = [float(r[1]) for r in rows]
+    date_to_idx = {d: i for i, d in enumerate(dates_asc)}
+    return date_to_idx, closes_asc
+
+
+def _forward_log_return(
+    *,
+    date_to_idx: dict[date, int],
+    closes: list[float],
+    spot_date: date,
+    horizon_td: int,
+) -> float | None:
+    i = date_to_idx.get(spot_date)
+    if i is None:
+        return None
+    j = i + horizon_td
+    if j >= len(closes):
+        return None
+    spot, fwd = closes[i], closes[j]
+    if spot <= 0 or fwd <= 0:
+        return None
+    return math.log(fwd / spot)
+
+
+def _compute_returns_by_state(
+    *,
+    rows: list[dict],
+    date_to_idx: dict[date, int],
+    closes: list[float],
+) -> dict[str, dict[int, list[float]]]:
+    """Build {warning_state: {horizon: [returns]}} for one window."""
+    buckets: dict[str, dict[int, list[float]]] = {}
+    for r in rows:
+        state = r["warning_state"]
+        state_buckets = buckets.setdefault(state, {h: [] for h in HORIZONS_TD})
+        for h in HORIZONS_TD:
+            fr = _forward_log_return(
+                date_to_idx=date_to_idx,
+                closes=closes,
+                spot_date=r["date"],
+                horizon_td=h,
+            )
+            if fr is not None:
+                state_buckets[h].append(fr)
+    return buckets
+
+
+def _bootstrap_null(
+    *,
+    pool_returns: list[float],
+    n: int,
+    k: int,
+    rng: random.Random,
+) -> list[float]:
+    """Draw k samples of size n WITHOUT replacement from pool_returns;
+    return each sample's mean."""
+    if len(pool_returns) < n:
+        return []
+    means: list[float] = []
+    for _ in range(k):
+        sample = rng.sample(pool_returns, n)
+        means.append(statistics.mean(sample))
+    return means
+
+
+def _percentile_of(obs: float, null_dist: list[float]) -> float:
+    """Fraction (0-100) of null distribution at or below obs."""
+    if not null_dist:
+        return float("nan")
+    below_or_eq = sum(1 for x in null_dist if x <= obs)
+    return 100.0 * below_or_eq / len(null_dist)
+
+
+def _two_tailed_p(pctile: float) -> float:
+    """Approximate two-tailed p-value from percentile.
+
+    pctile=99.5 → p=0.01;  pctile=50 → p=1.0;  pctile=0.5 → p=0.01.
+    """
+    return min(pctile, 100.0 - pctile) * 2.0 / 100.0
+
+
+def _print_window_section(
+    *,
+    window_id: str,
+    label: str,
+    buckets: dict[str, dict[int, list[float]]],
+    rng: random.Random,
+) -> list[dict]:
+    """Per-window section + TSV-summary rows. Returns rows for global TSV."""
+    print(f"\n=== {window_id} — {label} ===")
+    summary_rows: list[dict] = []
+    for bucket_name in BUCKETS_OF_INTEREST:
+        bucket = buckets.get(bucket_name)
+        if not bucket:
+            continue
+        print(f"\n  Bucket: {bucket_name}")
+        for h in HORIZONS_TD:
+            obs_returns = bucket.get(h, [])
+            if len(obs_returns) < 2:
+                print(f"    {h}td: n={len(obs_returns)} — skipped")
+                continue
+            obs_mean = statistics.mean(obs_returns)
+            n_obs = len(obs_returns)
+
+            pool: list[float] = []
+            for other_name, other in buckets.items():
+                if other_name == bucket_name:
+                    continue
+                pool.extend(other.get(h, []))
+
+            if len(pool) < n_obs:
+                print(f"    {h}td: pool ({len(pool)}) < n_obs ({n_obs}) — skipped")
+                continue
+
+            null = _bootstrap_null(pool_returns=pool, n=n_obs, k=K_BOOTSTRAP, rng=rng)
+            null_mean = statistics.mean(null)
+            null_std = statistics.stdev(null) if len(null) > 1 else 0.0
+            pct = _percentile_of(obs_mean, null)
+            p = _two_tailed_p(pct)
+
+            verdict = (
+                "BEATS NULL"
+                if pct >= 99.0
+                else "INSIDE NULL"
+                if pct >= 50.0
+                else "WORSE THAN NULL"
+            )
+
+            print(
+                f"    {h:>3}td:  obs={obs_mean:+.4f} (n={n_obs})  "
+                f"null={null_mean:+.4f} ± {null_std:.4f}  "
+                f"pctile={pct:.2f}  p≈{p:.4f}  {verdict}"
+            )
+            summary_rows.append(
+                {
+                    "window": window_id,
+                    "bucket": bucket_name,
+                    "horizon": h,
+                    "n_obs": n_obs,
+                    "obs_mean": obs_mean,
+                    "null_mean": null_mean,
+                    "null_std": null_std,
+                    "pctile": pct,
+                    "p": p,
+                    "verdict": verdict,
+                }
+            )
+    return summary_rows
+
+
+def _print_tsv(summary_rows: list[dict]) -> None:
+    print(
+        "\n=== TSV (window\tbucket\thorizon\tn_obs\tobs\tnull_mean\tnull_std\tpctile\tp\tverdict) ==="
+    )
+    for r in summary_rows:
+        print(
+            f"{r['window']}\t{r['bucket']}\t{r['horizon']}td\t{r['n_obs']}\t"
+            f"{r['obs_mean']:+.4f}\t{r['null_mean']:+.4f}\t{r['null_std']:.4f}\t"
+            f"{r['pctile']:.2f}\t{r['p']:.4f}\t{r['verdict']}"
+        )
+
+
+def main() -> int:
+    argparse.ArgumentParser(description=__doc__).parse_args()
+
+    rng = random.Random(SEED)
+    print(f"[seed={SEED}  K_bootstrap={K_BOOTSTRAP}]")
+
+    settings = Settings.from_env()
+    win_start = min(date.fromisoformat(s) for s, _, _ in WINDOWS.values())
+    win_end = max(date.fromisoformat(e) for _, e, _ in WINDOWS.values())
+    spx_start = date(win_start.year - 1, 1, 1)
+    spx_end = date(win_end.year + 1, 12, 31)
+
+    all_rows: list[dict] = []
+    with psycopg.connect(settings.db_dsn()) as conn:
+        date_to_idx, closes = _fetch_spx_close_series(
+            conn, schema=settings.db_schema, start=spx_start, end=spx_end
+        )
+        if not closes:
+            print(
+                f"ERROR: no SPX rows in vol_index_daily for {spx_start}..{spx_end}",
+                file=sys.stderr,
+            )
+            return 1
+
+        for wid, (start, end, label) in WINDOWS.items():
+            rows = _fetch_v1_window_daily(
+                conn, schema=settings.db_schema, window_id=wid
+            )
+            if not rows:
+                print(f"WARN: {wid} no v1 walk-forward rows.", file=sys.stderr)
+                continue
+            buckets = _compute_returns_by_state(
+                rows=rows, date_to_idx=date_to_idx, closes=closes
+            )
+            section_rows = _print_window_section(
+                window_id=wid,
+                label=f"{label} ({start} → {end})",
+                buckets=buckets,
+                rng=rng,
+            )
+            all_rows.extend(section_rows)
+
+    if not all_rows:
+        print("ERROR: no buckets tested.", file=sys.stderr)
+        return 1
+
+    _print_tsv(all_rows)
+
+    print("\n=== Decision summary ===")
+    btd_wf5_results = [
+        r
+        for r in all_rows
+        if r["window"] == "WF-5" and r["bucket"] == "BUY_THE_DIP_ACTIVE"
+    ]
+    if btd_wf5_results:
+        beats = [r for r in btd_wf5_results if r["pctile"] >= 99.0]
+        if len(beats) == len(btd_wf5_results):
+            print("- WF-5 BTD survives random-control at ALL horizons (p<=0.02).")
+            print("  → Direction B's evidence base SURVIVES. Can lock direction B.")
+        elif beats:
+            print(
+                f"- WF-5 BTD beats random-control at {len(beats)}/{len(btd_wf5_results)} horizons."
+            )
+            print("  → Mixed evidence; eyeball the failing horizons before locking.")
+        else:
+            print("- WF-5 BTD does NOT beat random-control at any horizon.")
+            print("  → Direction B's evidence base COLLAPSES. Reconsider direction.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two exploratory probes (probe 2 + probe 3) that resolve v2-C direction selection after v2-A's STOP verdict. **Direction B (rank inversion within BUY) is now empirically locked.**

- **Probe 2** (`scripts/probe_canary_wf5_fwd_return.py`): BTD vs NONE Welch's t on forward returns
- **Probe 3** (`scripts/probe_canary_wf5_random_control.py`): bootstrap random-control against strictest within-window null (K=10000, seed=42)
- **Docs** (`docs/research/regime/canary-v2c-design-notes.md`): §1 updated, decision log locked

Both scripts stdout-only, not persisted to DB — same precedent as `probe_canary_wf5.py` (merged in #95). No production code touched.

## Headline finding — Direction B is empirically locked

**WF-5 BTD beats the strictest within-window random-control null at 100th percentile / p≈0 across ALL three horizons.** The +11.4% / 60d alpha is real signal, not selection-on-dip. Null mean +4.0% ± 0.7% std; observed +11.4% sits ~11 SDs above null.

| Window | Bucket | 20td pctile/p | 60td pctile/p | 120td pctile/p |
|---|---|---|---|---|
| **WF-5** (quiet) | **BTD** | **100.00 / ≈0** | **100.00 / ≈0** | **100.00 / ≈0** |
| WF-3 (crisis) | BTD | 24.83 / 0.50 | 2.73 / 0.05 | 75.84 / 0.48 |
| WF-3 | **CCA** | **100.00 / ≈0** | **100.00 / ≈0** | **100.00 / ≈0** |
| WF-1 (baseline) | BTD | 100.00 / ≈0 | 99.79 / 0.004 | 13.54 / 0.27 |

## Three findings that sharpen the regime story

1. **WF-5 BTD signal is real, not artifact.** ~11 SDs above null — direction B's evidence base survives the strictest within-window test.

2. **WF-3 BTD does NOT beat null** (pctile 24.8 / 2.7 / 75.8). In crisis, vol-complex carries the signal; recovery-rally baseline dominates any 43-day subset. Consistent with v2-A's WF-3 win — speed contributes little when vol-complex fires strongly, so v2-A's removal of speed didn't hurt WF-3. This is the regime-complementarity direction B exploits.

3. **WF-3 CCA crushes null** at 100th pctile / p≈0 at all 3 horizons. +14.9% / 60d and +23.3% / 120d are real GFC-style mean-reversion bounces. v2-A correctly preserved this pathway (speed → 0 → vol-complex dominates → composite still discriminates CCA days). This is why v2-A's WF-3 60d AUC lifted +0.087.

## Regime structure (now legible)

- **Crisis (WF-3):** vol-complex + CCA carry the signal; speed's contribution is dominated. v2-A's "drop speed" worked here.
- **Quiet (WF-5):** vol-complex is dormant; speed-driven BTD is the alpha pathway. v2-A's "drop speed" killed this → -0.134 / 60d regression.
- **Direction B preserves both** because v1's additive composite is intact for BUY-band qualification, and speed is used only for within-BUY ordering.

Directions A (regime-conditional weighting) and C (convex blending) are now dropped from consideration — direction B has the cleanest empirical mandate.

## Outstanding diagnostic (not a B blocker)

WF-1 120d BTD at pctile 13.54 (below null). Could be 2015-2016 specific artifact (Brexit recovery overshoot) or a generic 120d horizon issue. Worth a future probe before horizon weighting in v2-C spec, but does NOT block direction B locking.

## Test plan

- [ ] CI green (no production code touched — pure research artifacts)
- [ ] Reviewers: confirm probe 3 bootstrap math (K=10000, seed=42, without-replacement sampling, percentile vs two-tailed p approximation)
- [ ] Reviewers: confirm regime-structure interpretation (crisis = vol-complex + CCA, quiet = BTD) is consistent with `src/uw_scan/cards/canary_scoring.py` semantics
- [ ] Manual rerun: `PGUSER=chenxi UW_SCAN_API_KEY=local-smoke uv run python scripts/probe_canary_wf5_random_control.py`

Same research-only PR pattern as #94 / #95: no production flip, no AC gating, no flip-gate evidence renderer changes.

## Next step

v2-C spec brainstorm with direction B, AC-F1..F7 pre-committed (F7 = WF-5 must not regress > -0.02), AC-F3 reformulated to stress-cluster onset window match.