### PR TITLE
feat(trade-ai): per-provider run buttons + blast framework coercer hardening

### DIFF
--- a/src/uw_scan/reports/trade_blast/leniency/framework.py
+++ b/src/uw_scan/reports/trade_blast/leniency/framework.py
@@ -117,6 +117,23 @@ def _resolve_enum(
     return default
 
 
+_FALSE_STRINGS = frozenset({"false", "no", "0", "off", "none", ""})
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a value to bool, handling string "false"/"true" correctly.
+
+    Python's bool("false") is True — this handles that case.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSE_STRINGS
+    if value is None:
+        return default
+    return bool(value)
+
+
 def _pick(raw: dict[str, Any], allowed: set[str]) -> dict[str, Any]:
     """Return only the keys in `allowed`, stripping extras for extra='forbid'."""
     return {k: v for k, v in raw.items() if k in allowed}
@@ -327,7 +344,7 @@ def _coerce_vega(raw: Any) -> dict[str, Any]:
 def _coerce_asymmetry(raw: Any) -> dict[str, Any]:
     d = _dict_or_empty(raw)
     return {
-        "rule_on": bool(d.get("rule_on", True)),
+        "rule_on": _coerce_bool(d.get("rule_on"), True),
         "structure_family": _resolve_enum(
             d.get("structure_family") or d.get("read"),
             ("directional_defined_risk", "pin_vega"),
@@ -399,7 +416,7 @@ def _coerce_confluence(raw: Any) -> dict[str, Any]:
             }
         )
     return {
-        "aligned": bool(d.get("aligned", False)),
+        "aligned": _coerce_bool(d.get("aligned"), False),
         "signals": signals,
         "prose": _str_or(d.get("prose"), ""),
     }
@@ -410,7 +427,7 @@ def _coerce_pitfall(raw: Any) -> dict[str, Any]:
     return {
         "id": _str_or(d.get("id"), ""),
         "title": _str_or(d.get("title"), ""),
-        "triggered": bool(d.get("triggered", False)),
+        "triggered": _coerce_bool(d.get("triggered"), False),
         "note": _str_or(d.get("note"), ""),
     }
 

--- a/src/uw_scan/reports/trade_blast/leniency/framework.py
+++ b/src/uw_scan/reports/trade_blast/leniency/framework.py
@@ -45,6 +45,101 @@ CANONICAL_CONVICTION_FACTORS: tuple[str, ...] = (
 
 _VALID_FACTOR_STATUS = {"yes", "no", "na"}
 
+# --- Alias maps for framework enum coercion ---
+# Claude (and occasionally DeepSeek) emits free-form strings where the contract
+# expects a narrow Literal.  These maps collapse cosmetic drift BEFORE
+# model_validate so the Pydantic Literal check passes.
+
+_POSITION_TYPE_ALIASES: dict[str, str] = {
+    "directional_swing": "swing",
+    "swing_trade": "swing",
+    "swing trade": "swing",
+    "leaps_position": "leaps",
+    "stand-aside": "stand_aside",
+    "no_trade": "stand_aside",
+}
+
+_DIRECTION_VERDICT_ALIASES: dict[str, str] = {
+    "bullish": "bull",
+    "bearish": "bear",
+    "long": "bull",
+    "short": "bear",
+    "flat": "neutral",
+}
+
+_VEGA_REGIME_ALIASES: dict[str, str] = {
+    "event": "event_iv",
+    "demand": "demand_iv",
+    "low": "low_iv",
+    "high_iv": "event_iv",
+    "elevated": "event_iv",
+    "depressed": "low_iv",
+}
+
+_GAMMA_REGIME_ALIASES: dict[str, str] = {
+    "short_gamma": "short",
+    "long_gamma": "long",
+    "negative": "short",
+    "positive": "long",
+}
+
+_STRUCTURE_FAMILY_ALIASES: dict[str, str] = {
+    "directional": "directional_defined_risk",
+    "defined_risk": "directional_defined_risk",
+    "pin": "pin_vega",
+    "vega": "pin_vega",
+}
+
+_CATALYST_HANDLING_ALIASES: dict[str, str] = {
+    "exit_before": "exit_before_print",
+    "exit": "exit_before_print",
+    "stand-aside": "stand_aside",
+    "hold_through": "hold_through_leaps",
+    "hold": "hold_through_leaps",
+    "no_er": "stand_aside",
+}
+
+
+def _resolve_enum(
+    value: Any,
+    valid: tuple[str, ...] | frozenset[str],
+    aliases: dict[str, str],
+    default: str,
+) -> str:
+    """Resolve a raw model value to a valid enum member via alias map."""
+    if not isinstance(value, str):
+        return default
+    v = value.strip().lower().replace(" ", "_").replace("-", "_")
+    if v in valid:
+        return v
+    if v in aliases:
+        return aliases[v]
+    return default
+
+
+def _pick(raw: dict[str, Any], allowed: set[str]) -> dict[str, Any]:
+    """Return only the keys in `allowed`, stripping extras for extra='forbid'."""
+    return {k: v for k, v in raw.items() if k in allowed}
+
+
+def _str_list_or_empty(raw: Any) -> list[str]:
+    """Coerce a legs-like field to list[str].
+
+    Claude emits leg dicts ({type, strike, ...}) where the contract expects
+    plain strings. Stringify non-str elements so Pydantic's list[str] passes.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            out.append(" ".join(str(v) for v in item.values() if v))
+        else:
+            out.append(str(item))
+    return out
+
 
 def _norm(name: str) -> str:
     """Case/space/hyphen-fold a strategy or factor name (no alias fuzzing)."""
@@ -120,22 +215,232 @@ def _pad_conviction_factors(raw_factors: Any) -> list[dict[str, Any]]:
     return out
 
 
+_DEFINED_RISK_TOKENS = frozenset(
+    {
+        "spread",
+        "butterfly",
+        "condor",
+        "collar",
+        "diagonal",
+        "calendar",
+        "vertical",
+        "debit",
+        "iron",
+        "long",
+        "protective",
+        "covered",
+    }
+)
+
+
+def _is_defined_risk_name(normed_name: str) -> bool:
+    """Infer defined_risk from the structure name when the model omits the flag.
+
+    Spreads, butterflies, condors, and other capped-loss structures are
+    defined-risk by construction. Only naked shorts (short_call, short_put,
+    short_strangle, short_straddle without protection) are undefined-risk.
+    When uncertain, default False so the validator catches it.
+    """
+    parts = set(normed_name.split("_"))
+    return bool(parts & _DEFINED_RISK_TOKENS)
+
+
 def _coerce_candidate(raw: Any) -> dict[str, Any]:
     cd = _dict_or_empty(raw)
+    _CANDIDATE_FIELDS = {
+        "name",
+        "legs",
+        "debit_credit",
+        "net_delta",
+        "net_vega",
+        "pnl_bull",
+        "pnl_base",
+        "pnl_bear",
+        "defined_risk",
+    }
+    out = _pick(cd, _CANDIDATE_FIELDS)
     name = _str_or(cd.get("name"), "")
-    out = dict(cd)
     out["name"] = _norm(name) if name else name
-    # net_delta / net_vega are Decimal | None greeks. Models frequently emit a
-    # direction word ("long"/"short") here; coerce non-numeric to None so the
-    # candidate still validates (the safety property is defined_risk, not the
-    # exact greek). Only touch keys the model actually supplied.
+    out["legs"] = _str_list_or_empty(cd.get("legs"))
     if "net_delta" in cd:
         out["net_delta"] = _decimal_or_none(cd.get("net_delta"))
     if "net_vega" in cd:
         out["net_vega"] = _decimal_or_none(cd.get("net_vega"))
-    # Fail-safe: absent defined_risk => False so the validator rejects a naked
-    # candidate rather than silently accepting it.
-    out["defined_risk"] = bool(cd.get("defined_risk", False))
+    raw_dr = cd.get("defined_risk")
+    if isinstance(raw_dr, bool):
+        out["defined_risk"] = raw_dr
+    else:
+        out["defined_risk"] = _is_defined_risk_name(out["name"])
+    return out
+
+
+def _coerce_header(raw: dict[str, Any]) -> dict[str, Any]:
+    """Coerce framework header — normalize enums, fill required, strip extras."""
+    _HEADER_FIELDS = {"thesis_one_liner", "position_type", "spot", "conviction_n"}
+    out = _pick(raw, _HEADER_FIELDS)
+    out["thesis_one_liner"] = _str_or(
+        raw.get("thesis_one_liner") or raw.get("headline"), "partial output"
+    )
+    out["position_type"] = _resolve_enum(
+        raw.get("position_type"),
+        ("swing", "leaps", "stand_aside"),
+        _POSITION_TYPE_ALIASES,
+        "swing",
+    )
+    if "spot" in raw:
+        out["spot"] = _decimal_or_none(raw.get("spot"))
+    out["conviction_n"] = _int_or(raw.get("conviction_n"), 0)
+    return out
+
+
+def _coerce_direction(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    return {
+        "verdict": _resolve_enum(
+            d.get("verdict") or d.get("read"),
+            ("bull", "bear", "neutral"),
+            _DIRECTION_VERDICT_ALIASES,
+            "neutral",
+        ),
+        "prose": _str_or(d.get("prose") or d.get("evidence"), "data insufficient"),
+    }
+
+
+def _coerce_vega(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    out: dict[str, Any] = {
+        "regime": _resolve_enum(
+            d.get("regime") or d.get("read"),
+            ("event_iv", "demand_iv", "low_iv"),
+            _VEGA_REGIME_ALIASES,
+            "low_iv",
+        ),
+        "prose": _str_or(d.get("prose") or d.get("evidence"), "data insufficient"),
+    }
+    if "ivr" in d:
+        out["ivr"] = _decimal_or_none(d.get("ivr"))
+    if "term_slope" in d:
+        out["term_slope"] = _str_or(d.get("term_slope"), None)
+    return out
+
+
+def _coerce_asymmetry(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    return {
+        "rule_on": bool(d.get("rule_on", True)),
+        "structure_family": _resolve_enum(
+            d.get("structure_family") or d.get("read"),
+            ("directional_defined_risk", "pin_vega"),
+            _STRUCTURE_FAMILY_ALIASES,
+            "directional_defined_risk",
+        ),
+        "prose": _str_or(d.get("prose") or d.get("evidence"), "data insufficient"),
+    }
+
+
+def _coerce_three_axis(raw: Any) -> dict[str, Any]:
+    ta = _dict_or_empty(raw)
+    return {
+        "direction": _coerce_direction(ta.get("direction")),
+        "vega": _coerce_vega(ta.get("vega")),
+        "asymmetry": _coerce_asymmetry(ta.get("asymmetry")),
+    }
+
+
+def _coerce_gamma(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    out: dict[str, Any] = {
+        "regime": _resolve_enum(
+            d.get("regime"),
+            ("short", "long"),
+            _GAMMA_REGIME_ALIASES,
+            "short",
+        ),
+        "prose": _str_or(d.get("prose"), "data insufficient"),
+    }
+    if "flip_strike" in d:
+        out["flip_strike"] = _decimal_or_none(d.get("flip_strike"))
+    if "call_wall" in d:
+        out["call_wall"] = _decimal_or_none(d.get("call_wall"))
+    if "put_wall" in d:
+        out["put_wall"] = _decimal_or_none(d.get("put_wall"))
+    return out
+
+
+def _coerce_catalyst(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    out: dict[str, Any] = {
+        "handling": _resolve_enum(
+            d.get("handling"),
+            ("exit_before_print", "stand_aside", "hold_through_leaps"),
+            _CATALYST_HANDLING_ALIASES,
+            "stand_aside",
+        ),
+        "prose": _str_or(d.get("prose"), "data insufficient"),
+    }
+    if "next_er_date" in d:
+        out["next_er_date"] = _str_or(d.get("next_er_date"), None)
+    if "dte_to_er" in d:
+        out["dte_to_er"] = _int_or(d.get("dte_to_er"), None)
+    if "implied_move" in d:
+        out["implied_move"] = _decimal_or_none(d.get("implied_move"))
+    return out
+
+
+def _coerce_confluence(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    signals = []
+    for s in _list_or_empty(d.get("signals")):
+        sd = _dict_or_empty(s)
+        signals.append(
+            {
+                "name": _str_or(sd.get("name"), ""),
+                "direction": _str_or(sd.get("direction"), ""),
+            }
+        )
+    return {
+        "aligned": bool(d.get("aligned", False)),
+        "signals": signals,
+        "prose": _str_or(d.get("prose"), ""),
+    }
+
+
+def _coerce_pitfall(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    return {
+        "id": _str_or(d.get("id"), ""),
+        "title": _str_or(d.get("title"), ""),
+        "triggered": bool(d.get("triggered", False)),
+        "note": _str_or(d.get("note"), ""),
+    }
+
+
+def _coerce_what_changes(raw: Any) -> dict[str, Any]:
+    d = _dict_or_empty(raw)
+    return {
+        "signal": _str_or(d.get("signal"), ""),
+        "effect": _str_or(d.get("effect"), ""),
+    }
+
+
+def _coerce_best_setup(raw: dict[str, Any]) -> dict[str, Any]:
+    _BEST_SETUP_FIELDS = {
+        "structure",
+        "legs",
+        "cost",
+        "max_risk",
+        "rationale",
+        "why_not_alternatives",
+        "invalidation",
+    }
+    out = _pick(raw, _BEST_SETUP_FIELDS)
+    structure = _str_or(raw.get("structure"), "")
+    if structure:
+        out["structure"] = _norm(structure)
+    out["legs"] = _str_list_or_empty(raw.get("legs"))
+    out["rationale"] = _str_or(raw.get("rationale"), "data insufficient")
+    out["invalidation"] = _str_or(raw.get("invalidation"), "data insufficient")
+    out.setdefault("why_not_alternatives", "")
     return out
 
 
@@ -144,43 +449,62 @@ def _coerce_framework(
 ) -> dict[str, Any]:
     """Coerce a Claude-shaped framework dict toward the strict contract.
 
-    `candidates` is the deterministic candidate map (id -> candidate dict); it
-    is accepted for signature symmetry with the other leniency coercers and
-    future cross-checks, but the framework's own candidates[] are self-contained
-    so it is currently unused for lookups.
+    Handles enum normalization, extra-field stripping (models use
+    ``extra="forbid"``), missing required field defaults, and conviction
+    factor padding — everything needed for a model's free-form framework
+    output to round-trip through ``TradeFramework.model_validate``.
     """
     fw = _dict_or_empty(raw)
-    out: dict[str, Any] = dict(fw)
 
-    # 1. conviction: normalize score str->int, pad factors to canonical 8.
+    # 1. header — normalize position_type, strip extras, fill thesis_one_liner.
+    out: dict[str, Any] = {}
+    out["header"] = _coerce_header(_dict_or_empty(fw.get("header")))
+
+    # 2. three_axis — normalize verdict/regime enums, fill required prose.
+    out["three_axis"] = _coerce_three_axis(fw.get("three_axis"))
+
+    # 3. gamma — normalize regime enum.
+    out["gamma"] = _coerce_gamma(fw.get("gamma"))
+
+    # 4. catalyst — normalize handling enum.
+    out["catalyst"] = _coerce_catalyst(fw.get("catalyst"))
+
+    # 5. conviction — normalize score str->int, pad factors to canonical 8.
     conviction = _dict_or_empty(fw.get("conviction"))
-    conviction_out = dict(conviction)
+    conviction_out: dict[str, Any] = {}
     conviction_out["score"] = _int_or(conviction.get("score"), 0)
     conviction_out["factors"] = _pad_conviction_factors(conviction.get("factors"))
+    conviction_out["prose"] = _str_or(conviction.get("prose"), "")
     out["conviction"] = conviction_out
 
-    # 2. header.conviction_n: normalize str->int (validator enforces == score).
-    header = _dict_or_empty(fw.get("header"))
-    if header:
-        header_out = dict(header)
-        if "conviction_n" in header:
-            header_out["conviction_n"] = _int_or(header.get("conviction_n"), 0)
-        out["header"] = header_out
+    # 6. confluence — normalize signals list.
+    out["confluence"] = _coerce_confluence(fw.get("confluence"))
 
-    # 3. candidates: default defined_risk False, _norm names.
-    if "candidates" in fw:
-        out["candidates"] = [
-            _coerce_candidate(c) for c in _list_or_empty(fw.get("candidates"))
-        ]
+    # 7. pitfalls — coerce each item.
+    out["pitfalls"] = [_coerce_pitfall(p) for p in _list_or_empty(fw.get("pitfalls"))]
 
-    # 4. best_setup.structure: _norm so the validator's verbatim match is
-    #    drift-tolerant (matches the _norm applied to candidates[].name).
+    # 8. candidates — default defined_risk False, _norm names.
+    out["candidates"] = [
+        _coerce_candidate(c) for c in _list_or_empty(fw.get("candidates"))
+    ]
+
+    # 9. best_setup — _norm structure, fill required fields.
     best_setup = _dict_or_empty(fw.get("best_setup"))
-    if best_setup:
-        best_out = dict(best_setup)
-        structure = _str_or(best_setup.get("structure"), "")
-        if structure:
-            best_out["structure"] = _norm(structure)
-        out["best_setup"] = best_out
+    out["best_setup"] = (
+        _coerce_best_setup(best_setup)
+        if best_setup
+        else {
+            "structure": "stand_aside",
+            "legs": [],
+            "rationale": "data insufficient",
+            "invalidation": "data insufficient",
+        }
+    )
+
+    # 10. what_changes + bottom_line.
+    out["what_changes"] = [
+        _coerce_what_changes(w) for w in _list_or_empty(fw.get("what_changes"))
+    ]
+    out["bottom_line"] = _str_or(fw.get("bottom_line"), "data insufficient")
 
     return out

--- a/tests/unit/reports/leniency/test_framework_coerce.py
+++ b/tests/unit/reports/leniency/test_framework_coerce.py
@@ -95,8 +95,15 @@ def test_coerce_matches_paraphrased_factor_by_norm():
     assert len(out["conviction"]["factors"]) == 8
 
 
-def test_coerce_defined_risk_defaults_false_failsafe():
+def test_coerce_defined_risk_inferred_from_name():
     raw = {"candidates": [{"name": "bull put spread"}]}  # defined_risk omitted
+    out = _coerce_framework(raw, candidates={})
+    # "spread" token → inferred as defined-risk
+    assert out["candidates"][0]["defined_risk"] is True
+
+
+def test_coerce_defined_risk_defaults_false_for_naked_structure():
+    raw = {"candidates": [{"name": "short call"}]}  # genuinely naked
     out = _coerce_framework(raw, candidates={})
     assert out["candidates"][0]["defined_risk"] is False
 

--- a/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
+++ b/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import type { ReactNode } from "react";
 
 import { InsightPanel, InsightStatusBanner } from "./InsightPanel";
 import {
@@ -15,69 +14,18 @@ import { ProviderTabBar } from "./tradeInsightsAi/ProviderTabBar";
 
 export { AI_ANALYSIS_POLL_MAX_MS } from "./tradeInsightsAi/useAiAnalysisPolling";
 
-function ActionButton({
-  children,
-  disabled,
-  compact = false,
-  onClick,
-}: {
-  children: ReactNode;
-  disabled?: boolean;
-  compact?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      style={{
-        justifySelf: "start",
-        border: "1px solid var(--border-dim)",
-        borderRadius: 4,
-        background: disabled ? "var(--bg-panel)" : "var(--bg-base)",
-        color: disabled ? "var(--text-muted)" : "var(--text-primary)",
-        cursor: disabled ? "not-allowed" : "pointer",
-        fontFamily: "var(--font-mono)",
-        fontSize: compact ? 10 : 11,
-        padding: compact ? "5px 8px" : "7px 10px",
-      }}
-    >
-      {children}
-    </button>
-  );
-}
-
 export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
   const [active, setActive] = useState<Provider>("codex");
   const {
-    actionLabel,
-    allPending,
-    canRun,
     consensusForTicker,
-    forceRun,
     latestForTicker,
-    loadingForTicker,
     pendingIdsForTicker,
     promptMetadataForTicker,
-    run,
+    runOne,
     unavailableForTicker,
   } = useAiAnalysisPolling(ticker);
   return (
-    <InsightPanel
-      heading="AI ANALYSIS"
-      action={
-        canRun ? (
-          <ActionButton
-            compact
-            onClick={() => run(forceRun)}
-            disabled={loadingForTicker || allPending}
-          >
-            {actionLabel}
-          </ActionButton>
-        ) : undefined
-      }
-    >
+    <InsightPanel heading="AI ANALYSIS">
       <div style={{ display: "grid", gap: 12 }}>
         {unavailableForTicker && (
           <InsightStatusBanner
@@ -136,6 +84,7 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
           pendingIds={pendingIdsForTicker}
           providers={PROVIDERS}
           setActive={setActive}
+          onRun={(p) => runOne(p, true)}
         />
         <ProviderTabBody
           provider={active}

--- a/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
+++ b/web/components/stock/panels/TradeInsightsAiAnalysisPanel.tsx
@@ -19,6 +19,7 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
   const {
     consensusForTicker,
     latestForTicker,
+    loadingForTicker,
     pendingIdsForTicker,
     promptMetadataForTicker,
     runOne,
@@ -81,6 +82,7 @@ export function TradeInsightsAiAnalysisPanel({ ticker }: { ticker: string }) {
         <ProviderTabBar
           active={active}
           latest={latestForTicker}
+          loading={loadingForTicker}
           pendingIds={pendingIdsForTicker}
           providers={PROVIDERS}
           setActive={setActive}

--- a/web/components/stock/panels/tradeInsightsAi/ProviderTabBar.tsx
+++ b/web/components/stock/panels/tradeInsightsAi/ProviderTabBar.tsx
@@ -22,6 +22,7 @@ function stateBadge(
 export function ProviderTabBar({
   active,
   latest,
+  loading,
   pendingIds,
   providers,
   setActive,
@@ -29,6 +30,7 @@ export function ProviderTabBar({
 }: {
   active: Provider;
   latest: ProviderAnalysisPair;
+  loading?: boolean;
   pendingIds: ProviderPendingPair;
   providers: readonly Provider[];
   setActive: (provider: Provider) => void;
@@ -38,6 +40,7 @@ export function ProviderTabBar({
     <div style={{ display: "flex", gap: 6 }}>
       {providers.map((p) => {
         const pending = Boolean(pendingIds[p]);
+        const disabled = pending || Boolean(loading);
         return (
           <div key={p} style={{ display: "flex", gap: 2 }}>
             <button
@@ -62,7 +65,7 @@ export function ProviderTabBar({
               <button
                 type="button"
                 onClick={() => onRun(p)}
-                disabled={pending}
+                disabled={disabled}
                 data-testid={`ai-run-${p}`}
                 title={`Run ${providerLabel(p)}`}
                 style={{
@@ -71,11 +74,11 @@ export function ProviderTabBar({
                   borderBottom: "1px solid var(--border-dim)",
                   borderLeft: "none",
                   borderRadius: "0 4px 4px 0",
-                  background: pending ? "var(--bg-panel)" : "var(--bg-base)",
-                  color: pending
+                  background: disabled ? "var(--bg-panel)" : "var(--bg-base)",
+                  color: disabled
                     ? "var(--text-muted)"
                     : "var(--text-secondary)",
-                  cursor: pending ? "not-allowed" : "pointer",
+                  cursor: disabled ? "not-allowed" : "pointer",
                   fontFamily: "var(--font-mono)",
                   fontSize: 10,
                   padding: "5px 6px",

--- a/web/components/stock/panels/tradeInsightsAi/ProviderTabBar.tsx
+++ b/web/components/stock/panels/tradeInsightsAi/ProviderTabBar.tsx
@@ -1,4 +1,8 @@
-import type { Provider, ProviderAnalysisPair, ProviderPendingPair } from "./useAiAnalysisPolling";
+import type {
+  Provider,
+  ProviderAnalysisPair,
+  ProviderPendingPair,
+} from "./useAiAnalysisPolling";
 
 function providerLabel(p: Provider): string {
   return p.charAt(0).toUpperCase() + p.slice(1);
@@ -21,38 +25,69 @@ export function ProviderTabBar({
   pendingIds,
   providers,
   setActive,
+  onRun,
 }: {
   active: Provider;
   latest: ProviderAnalysisPair;
   pendingIds: ProviderPendingPair;
   providers: readonly Provider[];
   setActive: (provider: Provider) => void;
+  onRun?: (provider: Provider) => void;
 }) {
   return (
     <div style={{ display: "flex", gap: 6 }}>
-      {providers.map((p) => (
-        <button
-          key={p}
-          type="button"
-          onClick={() => setActive(p)}
-          data-testid={`ai-tab-${p}`}
-          style={{
-            border: "1px solid var(--border-dim)",
-            borderRadius: 4,
-            background: active === p ? "var(--bg-panel)" : "var(--bg-base)",
-            color: "var(--text-primary)",
-            cursor: "pointer",
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            padding: "5px 10px",
-          }}
-        >
-          {providerLabel(p)}{" "}
-          <span aria-hidden="true">
-            {stateBadge(latest[p], Boolean(pendingIds[p]))}
-          </span>
-        </button>
-      ))}
+      {providers.map((p) => {
+        const pending = Boolean(pendingIds[p]);
+        return (
+          <div key={p} style={{ display: "flex", gap: 2 }}>
+            <button
+              type="button"
+              onClick={() => setActive(p)}
+              data-testid={`ai-tab-${p}`}
+              style={{
+                border: "1px solid var(--border-dim)",
+                borderRadius: onRun ? "4px 0 0 4px" : 4,
+                background: active === p ? "var(--bg-panel)" : "var(--bg-base)",
+                color: "var(--text-primary)",
+                cursor: "pointer",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                padding: "5px 10px",
+              }}
+            >
+              {providerLabel(p)}{" "}
+              <span aria-hidden="true">{stateBadge(latest[p], pending)}</span>
+            </button>
+            {onRun && (
+              <button
+                type="button"
+                onClick={() => onRun(p)}
+                disabled={pending}
+                data-testid={`ai-run-${p}`}
+                title={`Run ${providerLabel(p)}`}
+                style={{
+                  borderTop: "1px solid var(--border-dim)",
+                  borderRight: "1px solid var(--border-dim)",
+                  borderBottom: "1px solid var(--border-dim)",
+                  borderLeft: "none",
+                  borderRadius: "0 4px 4px 0",
+                  background: pending ? "var(--bg-panel)" : "var(--bg-base)",
+                  color: pending
+                    ? "var(--text-muted)"
+                    : "var(--text-secondary)",
+                  cursor: pending ? "not-allowed" : "pointer",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  padding: "5px 6px",
+                  lineHeight: 1,
+                }}
+              >
+                ▶
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/web/components/stock/panels/tradeInsightsAi/useAiAnalysisPolling.ts
+++ b/web/components/stock/panels/tradeInsightsAi/useAiAnalysisPolling.ts
@@ -196,15 +196,13 @@ export function useAiAnalysisPolling(
   const loadingForTicker = isLoadedTicker ? loading : false;
   const unavailableForTicker = isLoadedTicker ? unavailable : false;
 
-  async function run(force_rerun = false) {
+  async function runProviders(providers: Provider[], force_rerun = false) {
     const token = ++requestTokenRef.current;
     const isCurrentRequest = () => requestTokenRef.current === token;
     setLoadedTicker(ticker);
     setLoading(true);
     setUnavailable(false);
-    const providersToRun: Provider[] = PROVIDERS.filter(
-      (p) => !pendingIdsForTicker[p],
-    );
+    const providersToRun = providers.filter((p) => !pendingIdsForTicker[p]);
     if (providersToRun.length === 0) {
       setLoading(false);
       return;
@@ -256,6 +254,15 @@ export function useAiAnalysisPolling(
     }
   }
 
+  async function run(force_rerun = false) {
+    const all = PROVIDERS.filter((p) => !pendingIdsForTicker[p]);
+    return runProviders(all, force_rerun);
+  }
+
+  async function runOne(provider: Provider, force_rerun = false) {
+    return runProviders([provider], force_rerun);
+  }
+
   const allPending = PROVIDERS.every((p) => Boolean(pendingIdsForTicker[p]));
   const anyFailed = PROVIDERS.some(
     (p) => latestForTicker[p]?.status === "failed",
@@ -279,6 +286,7 @@ export function useAiAnalysisPolling(
     pendingIdsForTicker,
     promptMetadataForTicker,
     run,
+    runOne,
     unavailableForTicker,
   };
 }

--- a/web/components/stock/tabs/FrameworkTab.tsx
+++ b/web/components/stock/tabs/FrameworkTab.tsx
@@ -67,14 +67,8 @@ function stateLabel(state: ProviderState): string {
 }
 
 export function FrameworkTab({ ticker }: { ticker: string }) {
-  const {
-    latestForTicker,
-    pendingIdsForTicker,
-    run,
-    canRun,
-    actionLabel,
-    unavailableForTicker,
-  } = useAiAnalysisPolling(ticker, "blast");
+  const { latestForTicker, pendingIdsForTicker, runOne, unavailableForTicker } =
+    useAiAnalysisPolling(ticker, "blast");
   const [active, setActive] = useState<Provider>("codex");
 
   const stateFor = (provider: Provider): ProviderState => {
@@ -133,22 +127,6 @@ export function FrameworkTab({ ticker }: { ticker: string }) {
         <h2 style={{ margin: 0, color: "var(--text-primary)" }}>
           {ticker} · Trade Plan
         </h2>
-        <button
-          type="button"
-          onClick={() => run(true)}
-          disabled={!canRun}
-          style={{
-            marginLeft: "auto",
-            padding: "6px 14px",
-            borderRadius: 4,
-            border: "1px solid var(--border-dim)",
-            background: canRun ? "var(--accent-bg, #1a2a3a)" : "transparent",
-            color: canRun ? "var(--text-primary)" : "var(--text-muted)",
-            cursor: canRun ? "pointer" : "not-allowed",
-          }}
-        >
-          {actionLabel}
-        </button>
       </div>
 
       {unavailableForTicker ? (
@@ -171,33 +149,64 @@ export function FrameworkTab({ ticker }: { ticker: string }) {
         {consensusBanner}
       </div>
 
-      {/* Provider toggle with per-provider state badges */}
+      {/* Provider toggle with per-provider run buttons + state badges */}
       <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
         {PROVIDERS.map((p) => {
           const s = stateFor(p);
           const isActive = p === active;
+          const pending = Boolean(pendingIdsForTicker[p]);
           return (
-            <button
-              key={p}
-              type="button"
-              onClick={() => setActive(p)}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                padding: "6px 12px",
-                borderRadius: 4,
-                border: `1px solid ${
-                  isActive ? "var(--text-secondary)" : "var(--border-dim)"
-                }`,
-                background: isActive ? "var(--bg-panel)" : "transparent",
-                color: "var(--text-primary)",
-                cursor: "pointer",
-              }}
-            >
-              <span>{PROVIDER_LABEL[p]}</span>
-              <Pill text={stateLabel(s)} color={stateColor(s.kind)} />
-            </button>
+            <div key={p} style={{ display: "flex", gap: 0 }}>
+              <button
+                type="button"
+                onClick={() => setActive(p)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "6px 12px",
+                  borderRadius: "4px 0 0 4px",
+                  border: `1px solid ${
+                    isActive ? "var(--text-secondary)" : "var(--border-dim)"
+                  }`,
+                  background: isActive ? "var(--bg-panel)" : "transparent",
+                  color: "var(--text-primary)",
+                  cursor: "pointer",
+                }}
+              >
+                <span>{PROVIDER_LABEL[p]}</span>
+                <Pill text={stateLabel(s)} color={stateColor(s.kind)} />
+              </button>
+              <button
+                type="button"
+                onClick={() => runOne(p, true)}
+                disabled={pending}
+                title={`Run ${PROVIDER_LABEL[p]}`}
+                style={{
+                  borderTop: `1px solid ${
+                    isActive ? "var(--text-secondary)" : "var(--border-dim)"
+                  }`,
+                  borderRight: `1px solid ${
+                    isActive ? "var(--text-secondary)" : "var(--border-dim)"
+                  }`,
+                  borderBottom: `1px solid ${
+                    isActive ? "var(--text-secondary)" : "var(--border-dim)"
+                  }`,
+                  borderLeft: "none",
+                  borderRadius: "0 4px 4px 0",
+                  background: pending ? "var(--bg-panel)" : "transparent",
+                  color: pending
+                    ? "var(--text-muted)"
+                    : "var(--text-secondary)",
+                  cursor: pending ? "not-allowed" : "pointer",
+                  padding: "6px 8px",
+                  fontSize: 11,
+                  lineHeight: 1,
+                }}
+              >
+                ▶
+              </button>
+            </div>
           );
         })}
       </div>

--- a/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
+++ b/web/tests/unit/tradeInsightsAiAnalysisPanel.test.tsx
@@ -185,12 +185,13 @@ describe("TradeInsightsAiAnalysisPanel", () => {
     vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(EMPTY_PAIR);
   });
 
-  it("renders Codex and Claude tabs with empty state by default", async () => {
+  it("renders Codex and Claude tabs with per-provider run buttons", async () => {
     render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
     expect(await screen.findByTestId("ai-tab-codex")).toBeDefined();
     expect(screen.getByTestId("ai-tab-claude")).toBeDefined();
     expect(screen.getByText("AI ANALYSIS")).toBeDefined();
-    expect(screen.getByText("Run Analysis")).toBeDefined();
+    expect(screen.getByTestId("ai-run-codex")).toBeDefined();
+    expect(screen.getByTestId("ai-run-claude")).toBeDefined();
   });
 
   it("keeps polling long enough for the deeper local Codex prompt", () => {
@@ -239,11 +240,11 @@ describe("TradeInsightsAiAnalysisPanel", () => {
       succeededResponse(),
     );
     render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
-    fireEvent.click(await screen.findByText("Run Analysis"));
+    fireEvent.click(await screen.findByTestId("ai-run-codex"));
     await waitFor(() =>
       expect(api.tradeInsightsAiAnalysis).toHaveBeenCalledWith(
         "TSLA",
-        {},
+        { force_rerun: true, providers: ["codex"] },
         "insights",
       ),
     );
@@ -263,30 +264,25 @@ describe("TradeInsightsAiAnalysisPanel", () => {
       new Error("API 503 for /ai-analysis: disabled"),
     );
     render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
-    fireEvent.click(await screen.findByText("Run Analysis"));
+    fireEvent.click(await screen.findByTestId("ai-run-codex"));
     expect(await screen.findByText(/not enabled/i)).toBeDefined();
   });
 
-  it("skips polling when both providers cache-hit on Run", async () => {
+  it("skips polling when provider cache-hits on Run", async () => {
     vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(EMPTY_PAIR);
     vi.mocked(api.tradeInsightsAiAnalysis).mockResolvedValueOnce(
-      enqueueResp("succeeded", "succeeded"),
+      enqueueResp("succeeded", null),
     );
     // /latest is also refreshed after the run resolves with the cached pair.
     vi.mocked(api.tradeInsightsAiAnalysisLatest).mockResolvedValue(
       latestPair({
         codex: succeededResponse(),
-        claude: succeededResponse({
-          analysis_id: "33333333-3333-3333-3333-333333333333",
-          provider: "claude",
-          model: "claude-opus-4-7",
-        }),
       }),
     );
     render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
-    fireEvent.click(await screen.findByText("Run Analysis"));
+    fireEvent.click(await screen.findByTestId("ai-run-codex"));
     await waitFor(() => expect(api.tradeInsightsAiAnalysis).toHaveBeenCalled());
-    // No polling expected when both stubs are succeeded+reused.
+    // No polling expected when the stub is succeeded+reused.
     await waitFor(() =>
       expect(api.tradeInsightsAiAnalysisStatus).not.toHaveBeenCalled(),
     );
@@ -337,23 +333,21 @@ describe("TradeInsightsAiAnalysisPanel", () => {
 
     render(<TradeInsightsAiAnalysisPanel ticker="TSLA" />);
 
-    // First click: triggers the initial Run that sets the hung-codex state.
-    fireEvent.click(await screen.findByText("Run Analysis"));
+    // First click: run codex — sets the hung-codex state.
+    fireEvent.click(await screen.findByTestId("ai-run-codex"));
     await waitFor(() =>
       expect(api.tradeInsightsAiAnalysis).toHaveBeenCalledTimes(1),
     );
 
-    // Second click: button must be re-enabled because allPending=false
-    // (claude was cleared on cache hit, codex still pending but that alone
-    // does not block Run). POST scope is the non-pending providers
-    // (claude + deepseek).
-    fireEvent.click(await screen.findByText("Run Analysis"));
+    // Second click: run claude while codex is still pending — claude run button
+    // is still enabled, codex is pending/disabled.
+    fireEvent.click(await screen.findByTestId("ai-run-claude"));
     await waitFor(() =>
       expect(api.tradeInsightsAiAnalysis).toHaveBeenCalledTimes(2),
     );
     const lastCall = vi.mocked(api.tradeInsightsAiAnalysis).mock.calls.at(-1);
     expect(lastCall?.[0]).toBe("TSLA");
-    expect(lastCall?.[1]?.providers).toEqual(["claude", "deepseek"]);
+    expect(lastCall?.[1]?.providers).toEqual(["claude"]);
   });
 
   it("switching to Claude tab renders the Claude analysis body", async () => {


### PR DESCRIPTION
## Summary

- Replace single "Run Analysis" button with per-provider ▶ buttons on both AI Analysis (insights) and Trade Plan (blast) tabs — each provider runs independently
- Harden blast framework coercer (`_coerce_framework`) to handle Claude's free-form JSON: enum alias maps, extra-field stripping for `extra="forbid"`, field name remapping (`read`→`verdict`, `evidence`→`prose`, `headline`→`thesis_one_liner`), legs stringification, defined-risk inference from structure name, conviction factor padding
- Add `runOne(provider, force_rerun)` to `useAiAnalysisPolling` hook, keeping `run()` as backward-compatible wrapper
- Fix CSS `border`/`borderLeft` shorthand conflict in both `ProviderTabBar` and `FrameworkTab`

## Test plan

- [x] All 362 vitest tests pass
- [x] DeepSeek blast succeeded on NVDA (framework renders)
- [x] Claude blast validated on NVDA (67 → 0 validation errors)
- [x] Per-provider ▶ buttons render and disable correctly while pending
- [x] `_is_defined_risk_name` correctly identifies spreads/condors/butterflies as defined-risk
- [ ] Claude blast on GOOGL (blocked by 429 rate limit during testing)
- [ ] Codex blast (blocked by OpenAI usage limit during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)