### PR TITLE
fix(trade-blast): wire framework payload sections + fix short-interest list normalizer

### DIFF
--- a/scripts/refresh_blast_analysis_inputs.py
+++ b/scripts/refresh_blast_analysis_inputs.py
@@ -89,10 +89,28 @@ def main() -> int:
     ticker_filter: Callable[[str], bool] | None = None
     if args.ticker:
         ticker_upper = args.ticker.upper()
-        ticker_filter = lambda t: t == ticker_upper  # noqa: E731
+        # Watchlist tickers are uppercase by convention, but compare
+        # case-insensitively so an --ticker tsla never silently no-ops.
+        ticker_filter = lambda t: t.upper() == ticker_upper  # noqa: E731
 
     with psycopg.connect(settings.db_dsn()) as conn:
         repo = Repository(conn, schema=settings.db_schema)
+
+        if not args.ticker:
+            # No per-ticker scope; default refreshes the whole active watchlist.
+            # Positioning hits 5 UW endpoints per ticker; fundamentals hits 3
+            # Massive endpoints per ticker. Surface the rough call count up
+            # front so an operator doesn't burn their daily budget unaware.
+            tickers = repo.list_active_watchlist()
+            est_positioning = 0 if args.skip_positioning else len(tickers) * 5
+            est_fundamentals = 0 if args.skip_fundamentals else len(tickers) * 3
+            logger.warning(
+                "default-all refresh: %d active watchlist tickers — "
+                "est %d UW calls + %d Massive calls; pass --ticker T to scope down",
+                len(tickers),
+                est_positioning,
+                est_fundamentals,
+            )
 
         if not args.skip_positioning:
             with _build_uw_client(settings) as uw:

--- a/scripts/refresh_blast_analysis_inputs.py
+++ b/scripts/refresh_blast_analysis_inputs.py
@@ -1,0 +1,123 @@
+"""One-shot refresh of the two source tables the trade-blast lane reads
+from (`uw_positioning` and `massive_fundamentals`).
+
+The APScheduler worker normally keeps these tables fresh via the
+`positioning_refresh` (06:00 ET, Sun-Thu) and `fundamentals_refresh`
+(19:00 ET, Sun-Thu) cron jobs (see src/uw_scan/worker/scheduler.py). When
+running without a long-lived worker process (e.g. local dev outside
+`bash scripts/dev.sh`), those tables can sit empty and the blast lane's
+framework conviction ledger collapses — short-interest, earnings reactions
+and fundamentals all degrade to `na`.
+
+This script invokes `positioning_refresh_once` and `fundamentals_refresh_once`
+directly against the active watchlist, with the same construction shape the
+scheduler uses (per src/uw_scan/worker/scheduler.py::_uw_client,
+_fundamentals_provider, _repo). It is idempotent; running it twice produces
+the same DB state as the cron jobs running twice.
+
+Usage:
+    uv run python scripts/refresh_blast_analysis_inputs.py            # all watchlist tickers
+    uv run python scripts/refresh_blast_analysis_inputs.py --ticker TSLA
+    uv run python scripts/refresh_blast_analysis_inputs.py --skip-fundamentals
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Callable
+
+import psycopg
+
+from uw_scan.api.client import UwClient
+from uw_scan.config import Settings
+from uw_scan.storage.repository import Repository
+from uw_scan.worker.jobs.fundamentals_jobs import fundamentals_refresh_once
+from uw_scan.worker.jobs.positioning_jobs import positioning_refresh_once
+
+logger = logging.getLogger("refresh_blast_analysis_inputs")
+
+
+def _build_uw_client(settings: Settings) -> UwClient:
+    return UwClient(
+        api_key=settings.api_key.get_secret_value(),
+        base_url=settings.base_url,
+        timeout=settings.request_timeout_seconds,
+        job_name="refresh_blast_analysis_inputs",
+    )
+
+
+def _build_fundamentals_provider(settings: Settings):
+    from uw_scan.sources.massive_fundamentals import MassiveFundamentalsProvider
+
+    if settings.massive_api_key is None:
+        return None
+    return MassiveFundamentalsProvider(
+        api_key=settings.massive_api_key.get_secret_value(),
+        base_url=settings.massive_base_url,
+        timeout=settings.request_timeout_seconds,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Refresh blast lane source tables (uw_positioning + massive_fundamentals)."
+    )
+    parser.add_argument(
+        "--ticker",
+        help="Refresh just one ticker (case-insensitive). Default: all watchlist.",
+    )
+    parser.add_argument(
+        "--skip-positioning",
+        action="store_true",
+        help="Skip the UW positioning refresh leg.",
+    )
+    parser.add_argument(
+        "--skip-fundamentals",
+        action="store_true",
+        help="Skip the massive fundamentals refresh leg.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    settings = Settings.from_env()
+    ticker_filter: Callable[[str], bool] | None = None
+    if args.ticker:
+        ticker_upper = args.ticker.upper()
+        ticker_filter = lambda t: t == ticker_upper  # noqa: E731
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        repo = Repository(conn, schema=settings.db_schema)
+
+        if not args.skip_positioning:
+            with _build_uw_client(settings) as uw:
+                n = positioning_refresh_once(repo, uw, ticker_filter=ticker_filter)
+                logger.info("positioning_refresh: refreshed %d tickers", n)
+        else:
+            logger.info("positioning_refresh: skipped (--skip-positioning)")
+
+        if not args.skip_fundamentals:
+            provider = _build_fundamentals_provider(settings)
+            if provider is None:
+                logger.warning("MASSIVE_API_KEY not set; skipping fundamentals refresh")
+            else:
+                try:
+                    n = fundamentals_refresh_once(
+                        repo, provider, ticker_filter=ticker_filter
+                    )
+                    logger.info("fundamentals_refresh: refreshed %d tickers", n)
+                finally:
+                    provider.close()
+        else:
+            logger.info("fundamentals_refresh: skipped (--skip-fundamentals)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/uw_scan/api/routers/trade_insights.py
+++ b/src/uw_scan/api/routers/trade_insights.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date as _date
+from datetime import datetime
 from decimal import Decimal
 from typing import Any, Literal
 from uuid import UUID
@@ -106,8 +107,12 @@ _BLAST_MACRO_SERIES: tuple[str, ...] = (
 
 
 def _build_blast_macro_payload(repo: Repository) -> dict[str, Any] | None:
+    """Latest-vintage value per curated macro series. The top-level ``as_of``
+    is intentionally the same key the blast assembler reads via
+    ``payload.get('as_of')`` to compute ``age_days`` / ``stale`` for the
+    macro section — do not rename without updating the assembler."""
     out: dict[str, Any] = {}
-    latest_as_of: object | None = None
+    latest_as_of: datetime | None = None
     for series_id in _BLAST_MACRO_SERIES:
         rows = repo.fetch_macro_series_daily(series_id)
         if not rows:
@@ -119,7 +124,10 @@ def _build_blast_macro_payload(repo: Repository) -> dict[str, Any] | None:
             "as_of": latest["as_of"],
         }
         as_of = latest["as_of"]
-        if latest_as_of is None or as_of > latest_as_of:
+        # macro_series_daily.as_of is TIMESTAMPTZ NOT NULL in migration 037,
+        # but guard for defensive depth — a future ingestion bug shouldn't
+        # 500 the blast endpoint.
+        if as_of is not None and (latest_as_of is None or as_of > latest_as_of):
             latest_as_of = as_of
     if not out:
         return None

--- a/src/uw_scan/api/routers/trade_insights.py
+++ b/src/uw_scan/api/routers/trade_insights.py
@@ -95,6 +95,38 @@ def _build_stock_history_response(
     return StockHistoryResponse(ticker=ticker, rows=rows)
 
 
+_BLAST_MACRO_SERIES: tuple[str, ...] = (
+    "VIXCLS",  # SPX implied vol
+    "ANFCI",  # adjusted financial conditions
+    "NFCI",  # raw financial conditions
+    "DGS10",  # 10-yr Treasury
+    "BAMLH0A0HYM2",  # HY OAS spread
+    "GVZCLS",  # gold vol
+)
+
+
+def _build_blast_macro_payload(repo: Repository) -> dict[str, Any] | None:
+    out: dict[str, Any] = {}
+    latest_as_of: object | None = None
+    for series_id in _BLAST_MACRO_SERIES:
+        rows = repo.fetch_macro_series_daily(series_id)
+        if not rows:
+            continue
+        latest = rows[-1]
+        out[series_id] = {
+            "value": latest["value"],
+            "obs_date": latest["obs_date"],
+            "as_of": latest["as_of"],
+        }
+        as_of = latest["as_of"]
+        if latest_as_of is None or as_of > latest_as_of:
+            latest_as_of = as_of
+    if not out:
+        return None
+    out["as_of"] = latest_as_of
+    return out
+
+
 def _build_and_persist_trade_insights(
     ticker: str,
     repo: Repository,
@@ -304,6 +336,14 @@ def post_trade_insights_ai_analysis(
         backfill_status=backfill_status,
         persist_derived=False,
     )
+    extra_kwargs: dict[str, Any] = {}
+    if is_blast:
+        extra_kwargs = {
+            "ohlcv_rows": repo.list_daily_ohlc(t, limit=260),
+            "positioning_payload": repo.get_uw_positioning(t),
+            "fundamentals_payload": repo.get_massive_fundamentals(t),
+            "macro_payload": _build_blast_macro_payload(repo),
+        }
     analysis_input = _build_analysis_input(
         ticker=t,
         run_id=run_id,
@@ -312,6 +352,7 @@ def post_trade_insights_ai_analysis(
         stock_report_payload=stock_report.model_dump(mode="json"),
         stock_history_payload=stock_history.model_dump(mode="json"),
         volatility_series_payload=volatility.model_dump(mode="json"),
+        **extra_kwargs,
     )
     analysis_hash = _hash_analysis_input(analysis_input)
 

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -92,8 +92,14 @@ def _data_obj(payload: dict) -> dict:
 
 
 def normalize_short_interest_float(payload: dict) -> dict:
-    """V2 short-interest+float `data` object → uw_positioning si_* columns."""
-    raw = _data_obj(payload)
+    """V2 short-interest+float endpoint → uw_positioning si_* columns.
+
+    UW returns `data` as a list of historical snapshots ordered most-recent-first
+    (one entry per market-date). We take the first (latest) entry. An empty
+    list returns the standard "data unavailable" tuple of Nones via _dec(None).
+    """
+    rows = _data_list(payload)
+    raw = rows[0] if rows else {}
     return {
         "si_pct_float": _dec(raw.get("si_float")),
         "si_short_interest": _dec(raw.get("short_interest")),

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -99,7 +99,14 @@ def normalize_short_interest_float(payload: dict) -> dict:
     list returns the standard "data unavailable" tuple of Nones via _dec(None).
     """
     rows = _data_list(payload)
-    raw = rows[0] if rows else {}
+    raw: dict[str, Any] = {}
+    if rows:
+        first = rows[0]
+        if not isinstance(first, dict):
+            raise NormalizationError(
+                f"payload['data'][0] expected dict, got {type(first).__name__}"
+            )
+        raw = first
     return {
         "si_pct_float": _dec(raw.get("si_float")),
         "si_short_interest": _dec(raw.get("short_interest")),

--- a/tests/integration/api/test_trade_insights_router_blast_wiring.py
+++ b/tests/integration/api/test_trade_insights_router_blast_wiring.py
@@ -23,16 +23,8 @@ from tests.integration.api.test_trade_insights_ai_endpoint import (
     _seed_run,
     _settings_for_repo,
 )
+from uw_scan.api.routers.trade_insights import _BLAST_MACRO_SERIES
 from uw_scan.storage.repository import Repository
-
-_BLAST_MACRO_SERIES = (
-    "VIXCLS",
-    "ANFCI",
-    "NFCI",
-    "DGS10",
-    "BAMLH0A0HYM2",
-    "GVZCLS",
-)
 
 
 def _seed_ohlc_rows(repo: Repository, *, ticker: str, n: int) -> None:
@@ -160,7 +152,10 @@ def test_blast_lane_picks_up_seeded_source_data(
     =True with si_pct_float, etc."""
     repo = seeded_db_empty_cards
     _seed_run(repo)
-    _seed_ohlc_rows(repo, ticker="TSLA", n=60)
+    # 220 bars exercises BOTH dma_50 and dma_200 paths — locks the router's
+    # `limit=260` against a regression where someone trims it below 200 and
+    # silently drops the 200-DMA signal.
+    _seed_ohlc_rows(repo, ticker="TSLA", n=220)
     _seed_positioning(repo, ticker="TSLA")
     _seed_fundamentals(repo, ticker="TSLA")
     _seed_macro(repo, as_of=datetime.now(timezone.utc))
@@ -177,8 +172,9 @@ def test_blast_lane_picks_up_seeded_source_data(
 
     tape = analysis_input["tape"]
     assert tape["available"] is True
-    assert tape["bars"] == 60
-    assert tape["dma_50"] is not None  # 60 bars > 50, dma_50 computable
+    assert tape["bars"] == 220
+    assert tape["dma_50"] is not None
+    assert tape["dma_200"] is not None  # locks the 200-bar coverage
     assert tape["return_5d"] is not None
     assert tape["return_20d"] is not None
     assert tape["drawdown_from_6m_high"] is not None
@@ -194,7 +190,7 @@ def test_blast_lane_picks_up_seeded_source_data(
     assert fundamentals["fiscal_period"] == "Q1"
 
     macro = analysis_input["macro"]
-    assert macro["available"] is not False
+    assert macro["available"] is True
     # All 6 curated series surface as nested objects
     for series_id in _BLAST_MACRO_SERIES:
         assert series_id in macro, (

--- a/tests/integration/api/test_trade_insights_router_blast_wiring.py
+++ b/tests/integration/api/test_trade_insights_router_blast_wiring.py
@@ -1,0 +1,236 @@
+"""Wiring contract: confirm the blast lane router passes ohlcv_rows /
+positioning_payload / fundamentals_payload / macro_payload through to the
+blast assembler, AND that the insights lane never receives those kwargs.
+
+Regression target: before this PR, the router omitted the 5 optional kwargs
+the blast assembler accepts, so every succeeded blast row degraded to
+`{available: False}` across tape/positioning/fundamentals/macro and the
+8-factor conviction ledger collapsed to ~1-2/8.
+
+These tests only assert the wiring contract — that the keys are present
+with the right shape. End-to-end conviction-ledger improvements are
+verified via the live smoke-test in the PR description.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+from tests.integration.api.test_trade_insights_ai_endpoint import (
+    _client_for_settings,
+    _patch_api_sources,
+    _seed_run,
+    _settings_for_repo,
+)
+from uw_scan.storage.repository import Repository
+
+_BLAST_MACRO_SERIES = (
+    "VIXCLS",
+    "ANFCI",
+    "NFCI",
+    "DGS10",
+    "BAMLH0A0HYM2",
+    "GVZCLS",
+)
+
+
+def _seed_ohlc_rows(repo: Repository, *, ticker: str, n: int) -> None:
+    """Seed `n` consecutive daily_ohlc rows ending today. Synthetic monotonic
+    rise from 100 → 100 + n; enough bars to exercise tape derivations
+    without requiring a full 260-bar fixture."""
+    base_date = date.today() - timedelta(days=n - 1)
+    for i in range(n):
+        close = Decimal(100 + i)
+        repo.upsert_daily_ohlc(
+            ticker=ticker,
+            date=base_date + timedelta(days=i),
+            open=close,
+            high=close + Decimal("1"),
+            low=close - Decimal("1"),
+            close=close,
+            volume=1_000_000,
+            source="test",
+        )
+
+
+def _seed_positioning(repo: Repository, *, ticker: str) -> None:
+    repo.upsert_uw_positioning(
+        ticker=ticker,
+        snapshot_date=date.today(),
+        si_pct_float=Decimal("15.0"),
+        si_days_to_cover=Decimal("3.2"),
+        earn_reactions_positive=3,
+        earn_reactions_total=4,
+        next_er_date=date.today() + timedelta(days=60),
+    )
+    repo.conn.commit()
+
+
+def _seed_fundamentals(repo: Repository, *, ticker: str) -> None:
+    repo.upsert_massive_fundamentals(
+        ticker=ticker,
+        period_end=date(2026, 3, 31),
+        fiscal_period="Q1",
+        revenue=Decimal("21_000_000_000"),
+        gross_margin=Decimal("0.45"),
+        op_margin=Decimal("0.12"),
+        net_margin=Decimal("0.09"),
+        fcf=Decimal("2_500_000_000"),
+        total_debt=Decimal("8_000_000_000"),
+        shareholders_equity=Decimal("60_000_000_000"),
+        diluted_shares=Decimal("3_500_000_000"),
+    )
+    repo.conn.commit()
+
+
+def _seed_macro(repo: Repository, *, as_of: datetime) -> None:
+    for i, series_id in enumerate(_BLAST_MACRO_SERIES):
+        repo.insert_macro_series_daily(
+            series_id=series_id,
+            obs_date=date.today() - timedelta(days=1),
+            value=Decimal(10 + i),
+            as_of=as_of,
+            release_date=None,
+            source="test",
+            source_url=None,
+        )
+    repo.conn.commit()
+
+
+def _fetch_analysis_input_jsonb(repo: Repository) -> dict:
+    """Return analysis_input_jsonb from the most recently inserted row."""
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT analysis_input_jsonb
+              FROM {repo._schema}.trade_insight_ai_analyses
+              ORDER BY requested_at DESC
+              LIMIT 1
+            """,
+        )
+        row = cur.fetchone()
+    assert row is not None, "no trade_insight_ai_analyses row was persisted"
+    return row[0]
+
+
+def test_blast_lane_emits_all_four_payload_sections_even_with_empty_sources(
+    seeded_db_empty_cards,
+    monkeypatch,
+) -> None:
+    """Wiring contract: blast lane must always emit tape/positioning/
+    fundamentals/macro keys in analysis_input_jsonb, even when the
+    underlying source tables are empty (sections degrade to available=False
+    but the keys themselves are present)."""
+    repo = seeded_db_empty_cards
+    _seed_run(repo)
+    _patch_api_sources(monkeypatch)
+    client = _client_for_settings(_settings_for_repo(repo))
+
+    response = client.post(
+        "/api/stock/TSLA/trade-insights/ai-analysis?kind=blast", json={}
+    )
+    assert response.status_code == 202, response.text
+
+    analysis_input = _fetch_analysis_input_jsonb(repo)
+
+    # All four blast-only sections must be present
+    assert "tape" in analysis_input, (
+        "tape missing — blast lane wiring regressed; "
+        f"keys present: {sorted(analysis_input.keys())}"
+    )
+    assert "positioning" in analysis_input
+    assert "fundamentals" in analysis_input
+    assert "macro" in analysis_input
+
+    # With empty source tables, each section's available flag is False
+    assert analysis_input["tape"]["available"] is False
+    assert analysis_input["positioning"]["available"] is False
+    assert analysis_input["fundamentals"]["available"] is False
+    # macro is None when no series exist — assembler emits {available: False}
+    assert analysis_input["macro"]["available"] is False
+
+
+def test_blast_lane_picks_up_seeded_source_data(
+    seeded_db_empty_cards,
+    monkeypatch,
+) -> None:
+    """When the four source tables are populated, the blast payload picks
+    up the data — tape.available=True with bars>0, positioning.available
+    =True with si_pct_float, etc."""
+    repo = seeded_db_empty_cards
+    _seed_run(repo)
+    _seed_ohlc_rows(repo, ticker="TSLA", n=60)
+    _seed_positioning(repo, ticker="TSLA")
+    _seed_fundamentals(repo, ticker="TSLA")
+    _seed_macro(repo, as_of=datetime.now(timezone.utc))
+    repo.conn.commit()
+    _patch_api_sources(monkeypatch)
+    client = _client_for_settings(_settings_for_repo(repo))
+
+    response = client.post(
+        "/api/stock/TSLA/trade-insights/ai-analysis?kind=blast", json={}
+    )
+    assert response.status_code == 202, response.text
+
+    analysis_input = _fetch_analysis_input_jsonb(repo)
+
+    tape = analysis_input["tape"]
+    assert tape["available"] is True
+    assert tape["bars"] == 60
+    assert tape["dma_50"] is not None  # 60 bars > 50, dma_50 computable
+    assert tape["return_5d"] is not None
+    assert tape["return_20d"] is not None
+    assert tape["drawdown_from_6m_high"] is not None
+
+    positioning = analysis_input["positioning"]
+    assert positioning["available"] is True
+    assert positioning["si_pct_float"] == "15.0"
+    assert positioning["earn_reactions_positive"] == 3
+    assert positioning["earn_reactions_total"] == 4
+
+    fundamentals = analysis_input["fundamentals"]
+    assert fundamentals["available"] is True
+    assert fundamentals["fiscal_period"] == "Q1"
+
+    macro = analysis_input["macro"]
+    assert macro["available"] is not False
+    # All 6 curated series surface as nested objects
+    for series_id in _BLAST_MACRO_SERIES:
+        assert series_id in macro, (
+            f"{series_id} missing from blast macro payload; "
+            f"keys: {sorted(macro.keys())}"
+        )
+        assert macro[series_id]["value"] is not None
+
+
+def test_insights_lane_does_not_receive_blast_only_payload_sections(
+    seeded_db_empty_cards,
+    monkeypatch,
+) -> None:
+    """Regression assertion: the v5.3 insights lane must continue to omit
+    tape/positioning/fundamentals/macro from its analysis_input. The
+    insights assembler doesn't take those kwargs at all, so passing them
+    would raise TypeError. The conditional-extra-kwargs wiring guarantees
+    the insights lane stays byte-identical."""
+    repo = seeded_db_empty_cards
+    _seed_run(repo)
+    # Even seed the source tables — insights lane must IGNORE them.
+    _seed_ohlc_rows(repo, ticker="TSLA", n=60)
+    _seed_positioning(repo, ticker="TSLA")
+    _patch_api_sources(monkeypatch)
+    client = _client_for_settings(_settings_for_repo(repo))
+
+    response = client.post(
+        "/api/stock/TSLA/trade-insights/ai-analysis?kind=insights", json={}
+    )
+    assert response.status_code == 202, response.text
+
+    analysis_input = _fetch_analysis_input_jsonb(repo)
+
+    blast_only_keys = {"tape", "fundamentals", "positioning", "macro"}
+    leaked = blast_only_keys & set(analysis_input.keys())
+    assert not leaked, (
+        f"insights lane leaked blast-only keys: {sorted(leaked)}; "
+        "the extra_kwargs gate must be is_blast-conditional"
+    )

--- a/tests/integration/worker/test_positioning_job.py
+++ b/tests/integration/worker/test_positioning_job.py
@@ -19,13 +19,17 @@ from uw_scan.worker.jobs.positioning_jobs import positioning_refresh_once
 
 _PAYLOADS: dict[EndpointSlug, dict[str, Any]] = {
     EndpointSlug.SHORT_INTEREST_FLOAT: {
-        "data": {
-            "si_float": "0.0734",
-            "short_interest": 175611155,
-            "total_float": 2392000000,
-            "days_to_cover": "1.205",
-            "market_date": "2026-05-15",
-        }
+        # UW v2 returns `data` as a list of historical snapshots
+        # (most-recent first); the normalizer takes `rows[0]`.
+        "data": [
+            {
+                "si_float": "0.0734",
+                "short_interest": 175611155,
+                "total_float": 2392000000,
+                "days_to_cover": "1.205",
+                "market_date": "2026-05-15",
+            }
+        ]
     },
     EndpointSlug.ANALYST_RATINGS: {
         "data": [

--- a/tests/unit/sources/test_uw_positioning_fetchers.py
+++ b/tests/unit/sources/test_uw_positioning_fetchers.py
@@ -35,17 +35,31 @@ from uw_scan.sources.uw import (
 # Spec-derived synthetic payloads
 # --------------------------------------------------------------------------- #
 SHORT_INTEREST = {
-    "data": {
-        "si_float": "0.0734",
-        "short_interest": 175611155,
-        "total_float": 2392000000,
-        "days_to_cover": "1.205",
-        "short_shares_available": 12000000,
-        "fee_rate": "0.51",
-        "rebate_rate": "4.25",
-        "market_date": "2026-05-15",
-        "symbol": "NVDA",
-    }
+    "data": [
+        {
+            "si_float": "0.0734",
+            "short_interest": 175611155,
+            "total_float": 2392000000,
+            "days_to_cover": "1.205",
+            "short_shares_available": 12000000,
+            "fee_rate": "0.51",
+            "rebate_rate": "4.25",
+            "market_date": "2026-05-15",
+            "symbol": "NVDA",
+        },
+        {
+            # older snapshot — must be ignored; latest-first ordering
+            "si_float": "0.0500",
+            "short_interest": 100000000,
+            "total_float": 2392000000,
+            "days_to_cover": "0.800",
+            "short_shares_available": 12000000,
+            "fee_rate": "0.30",
+            "rebate_rate": "4.00",
+            "market_date": "2026-04-30",
+            "symbol": "NVDA",
+        },
+    ]
 }
 
 ANALYST = {
@@ -150,9 +164,19 @@ def test_normalize_raises_on_missing_data_key():
         normalize_short_interest_float({"oops": {}})
 
 
-def test_normalize_short_interest_requires_object_not_list():
-    with pytest.raises(NormalizationError):
-        normalize_short_interest_float({"data": [1, 2, 3]})
+def test_normalize_short_interest_takes_latest_from_list():
+    """UW returns a list of historical snapshots ordered most-recent-first;
+    the normalizer must take the first entry, not raise."""
+    out = normalize_short_interest_float(SHORT_INTEREST)
+    # market_date from the FIRST list entry; second entry's 2026-04-30 is ignored
+    assert out["si_market_date"] == date(2026, 5, 15)
+    assert out["si_pct_float"] == Decimal("0.0734")
+
+
+def test_normalize_short_interest_empty_list_yields_nones():
+    out = normalize_short_interest_float({"data": []})
+    assert out["si_pct_float"] is None
+    assert out["si_market_date"] is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/sources/test_uw_positioning_fetchers.py
+++ b/tests/unit/sources/test_uw_positioning_fetchers.py
@@ -179,6 +179,34 @@ def test_normalize_short_interest_empty_list_yields_nones():
     assert out["si_market_date"] is None
 
 
+def test_normalize_short_interest_rejects_non_dict_first_element():
+    """A malformed payload like `{data: [1, 2, 3]}` must raise rather than
+    AttributeError out on `int.get(...)`."""
+    with pytest.raises(NormalizationError):
+        normalize_short_interest_float({"data": [1, 2, 3]})
+
+
+def test_insights_assembler_rejects_blast_only_kwargs():
+    """Locks the PR's TypeError claim: passing blast-only kwargs to the
+    insights-lane assembler MUST raise — the conditional `extra_kwargs`
+    gate in trade_insights.py:339 is load-bearing, not aesthetic."""
+    from uw_scan.reports.trade_insights_ai import (
+        build_trade_insights_ai_analysis_input as insights_build,
+    )
+
+    minimal_kwargs = dict(
+        ticker="TSLA",
+        run_id=1,
+        trade_insights_input_hash="x",
+        trade_insights_payload={},
+        stock_report_payload={},
+        stock_history_payload={},
+        volatility_series_payload={},
+    )
+    with pytest.raises(TypeError):
+        insights_build(**minimal_kwargs, ohlcv_rows=[])  # type: ignore[call-arg]
+
+
 # --------------------------------------------------------------------------- #
 # Fetchers — audit-first contract (mirror test_market_flow_alerts.py)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

The blast lane's 8-factor conviction ledger was collapsing to ~1-2/8 because every framework data section degraded to `{available: False}`. Two coupled defects:

1. **Router wiring bug** — `api/routers/trade_insights.py:307` invoked `build_blast_analysis_input(...)` without the five optional payload kwargs (`ohlcv_rows`, `positioning_payload`, `fundamentals_payload`, `macro_payload`, `flow_series_payload`). The blast assembler defaults each to `None` and emits empty sections. The insights-lane assembler does NOT accept those kwargs (would raise `TypeError`), so the fix uses a conditional `extra_kwargs` dict gated on `is_blast`.

2. **`normalize_short_interest_float` rejected the real API shape** — UW's `/api/shorts/{ticker}/interest-float/v2` returns `data` as a list of historical snapshots (most-recent-first), but the normalizer used `_data_obj` and raised `NormalizationError: payload['data'] expected dict, got list`. Every `positioning_refresh` job has been silently failing here, which is why `uw_scan.uw_positioning` was empty in production. Switched to `_data_list` + `rows[0]`.

Adds a curated 6-series macro payload helper (VIXCLS, ANFCI, NFCI, DGS10, BAMLH0A0HYM2, GVZCLS) — full 17-series surface bloats the prompt without adding ledger signal.

Adds `scripts/refresh_blast_analysis_inputs.py` so local dev can populate `uw_positioning` + `massive_fundamentals` without waiting for the APScheduler worker's daily cron.

## Evidence

| Source table | Pre-PR rows | Post-PR rows (after running script) |
|---|---:|---:|
| `uw_positioning` | 0 | 102 (102 tickers) |
| `massive_fundamentals` | 0 | 669 (86 tickers) |

Direct-build smoke test against the real DB on TSLA after running the refresh script:

```
=== TAPE ===
available=True  bars=68
latest_close=435.79  dma_50=391.80
drawdown_from_6m_high=-3.88%  return_5d=+4.3%  return_20d=+14.2%
=== POSITIONING ===
available=True  si_pct_float=2.04%  si_days_to_cover=1.21
earn_reactions_positive=1/3
=== FUNDAMENTALS ===
available=True  period_end=2026-03-31  fiscal_period=Q1  revenue=$22.4B
=== MACRO ===
VIXCLS=15.74  ANFCI=-0.478  NFCI=-0.523  DGS10=4.45  BAMLH0A0HYM2=2.72  GVZCLS=24.83
```

The conviction ledger now gets deterministic verdicts on Factors 3 (drawdown), 4 (ER reactions), 7 (SI) instead of `na`. Factors 1 and 5 remain permanent `na` by design — structural ceiling stays ~6/8 per `project_trade_framework_conviction_factors`.

## Verification (post-merge runbook)

```bash
# 1. Populate the source tables (local dev only — production scheduler handles this on cron)
uv run python scripts/refresh_blast_analysis_inputs.py

# 2. Confirm tables non-empty
psql -d option_wizard -c "SELECT count(*) FROM uw_scan.uw_positioning; "      # > 0
psql -d option_wizard -c "SELECT count(*) FROM uw_scan.massive_fundamentals; "  # > 0

# 3. Enqueue a TSLA blast (worker must be running for actual model run)
curl -X POST 'http://127.0.0.1:8400/api/stock/TSLA/trade-insights/ai-analysis?kind=blast' \
  -H 'Content-Type: application/json' -d '{"force_rerun": true}'

# 4. Verify the persisted payload now contains the four sections with real data
psql -d option_wizard -c "
  SELECT
    analysis_input_jsonb->'tape'->>'available' AS tape_avail,
    analysis_input_jsonb->'tape'->>'bars' AS bars,
    analysis_input_jsonb->'positioning'->>'available' AS pos_avail,
    analysis_input_jsonb->'positioning'->>'si_pct_float' AS si_pct,
    analysis_input_jsonb->'fundamentals'->>'available' AS fund_avail
  FROM uw_scan.trade_insight_ai_analyses
  WHERE ticker='TSLA' AND analysis_kind='blast'
  ORDER BY requested_at DESC LIMIT 1; "
```

## Test plan

- [x] `tests/unit/sources/test_uw_positioning_fetchers.py` — 11/11 pass (updated SHORT_INTEREST fixture to list shape; new `test_normalize_short_interest_takes_latest_from_list` + `test_normalize_short_interest_empty_list_yields_nones`)
- [x] `tests/integration/api/test_trade_insights_router_blast_wiring.py` — 3 new tests, all green:
  - blast lane emits all four sections even with empty sources (wiring contract)
  - blast lane picks up seeded source data (data flows end-to-end)
  - insights lane does NOT receive blast-only sections (regression assertion)
- [x] Existing `tests/integration/api/test_trade_insights_ai_endpoint.py` — 14/14 pass (no regression)
- [x] Full unit/source + trade-insights integration sweep — 113 pass
- [x] Live smoke test on TSLA after running `scripts/refresh_blast_analysis_inputs.py` — all four sections populated with real values, conviction-ledger inputs available

## Out of scope (deferred to separate spec)

The drafted prompt-hardening spec at `docs/superpowers/specs/2026-05-31-trade-blast-prompt-hardening-design.md` covers:

- `flow_series` aggregator (Factor 6 sharpening — Factor 6 currently scores 8/18 via the legacy `tabs.flow` proxy, so the gap is quality not unlock)
- ENTRY_STATE auto-correct in the soft validator
- `no_conflict` catalyst enum extension
- Likelihood buckets for scenarios
- na-vs-no prompt discipline (Factors 1/5 currently show 3 erroneous `no` votes each)

That spec is a separate PR. This PR is strictly the data-pipeline wiring + the upstream normalizer fix that gates it.