### PR TITLE
fix(scan-runs): exclude side-channel notes from latest_run_id

### DIFF
--- a/src/uw_scan/storage/external_api.py
+++ b/src/uw_scan/storage/external_api.py
@@ -173,6 +173,10 @@ class _ExternalApiMixin:
                       AND finished_at IS NOT NULL
                       AND started_at IS NOT NULL
                       AND (notes IS DISTINCT FROM 'flow_data_refresh')
+                      AND (notes IS DISTINCT FROM 'positioning_refresh')
+                      AND (notes IS DISTINCT FROM 'intraday_refresh')
+                      AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot')
+                      AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%')
                     """,
                     (start, end),
                 )

--- a/src/uw_scan/storage/pipeline_benchmark.py
+++ b/src/uw_scan/storage/pipeline_benchmark.py
@@ -174,6 +174,9 @@ class _PipelineBenchmarkMixin:
                           AND status = 'ok'
                           AND finished_at IS NOT NULL
                           AND (notes IS DISTINCT FROM 'flow_data_refresh')
+                          AND (notes IS DISTINCT FROM 'positioning_refresh')
+                          AND (notes IS DISTINCT FROM 'intraday_refresh')
+                          AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot')
                           AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%')
                           AND EXISTS (
                               SELECT 1

--- a/src/uw_scan/storage/scan_runs.py
+++ b/src/uw_scan/storage/scan_runs.py
@@ -25,6 +25,9 @@ class _ScanRunsMixin:
         GEX, volatility — all keyed by run_id). Excluded:
 
         - ``flow_data_refresh`` (writes options_volume_daily + option_chain only)
+        - ``positioning_refresh`` (M4 trade-framework: uw_positioning only)
+        - ``intraday_refresh`` (OI movers intraday: option_chain_oi only)
+        - ``cockpit_daily_snapshot`` (SPX/SPY/QQQ/IWM greeks/skew only)
         - ``gex_scan_*`` (SPX/SPY index-only GEX scanner running every 5 min)
         """
         with self._conn.cursor() as cur:
@@ -32,6 +35,9 @@ class _ScanRunsMixin:
                 f"SELECT run_id FROM {self._schema}.scan_runs "
                 "WHERE ticker = %s "
                 "  AND (notes IS DISTINCT FROM 'flow_data_refresh') "
+                "  AND (notes IS DISTINCT FROM 'positioning_refresh') "
+                "  AND (notes IS DISTINCT FROM 'intraday_refresh') "
+                "  AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot') "
                 "  AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%') "
                 "ORDER BY run_id DESC LIMIT 1",
                 (ticker.upper(),),
@@ -76,6 +82,9 @@ class _ScanRunsMixin:
                   AND started_at IS NOT NULL
                   AND status = 'ok'
                   AND (notes IS DISTINCT FROM 'flow_data_refresh')
+                  AND (notes IS DISTINCT FROM 'positioning_refresh')
+                  AND (notes IS DISTINCT FROM 'intraday_refresh')
+                  AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot')
                   AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%')
                 """,
                 (start, end),

--- a/tests/integration/storage/test_flow_tab.py
+++ b/tests/integration/storage/test_flow_tab.py
@@ -94,10 +94,11 @@ def test_latest_run_id_skips_side_channel_refresh_runs(seeded_db_empty_cards) ->
     for note in ("positioning_refresh", "intraday_refresh", "cockpit_daily_snapshot"):
         shadow = repo.insert_scan_run("GOOGL", notes=note)
         repo.finish_scan_run(shadow, status="ok")
+        repo.conn.commit()
         assert shadow > full_run, f"{note} sanity: shadow would otherwise win"
-    repo.conn.commit()
-
-    assert repo.latest_run_id("GOOGL") == full_run
+        assert repo.latest_run_id("GOOGL") == full_run, (
+            f"{note} shadow was not excluded"
+        )
 
 
 def test_option_chain_per_strike_returns_only_latest_snapshot(

--- a/tests/integration/storage/test_flow_tab.py
+++ b/tests/integration/storage/test_flow_tab.py
@@ -82,6 +82,24 @@ def test_latest_run_id_skips_flow_data_refresh_runs(seeded_db_empty_cards) -> No
     assert repo.latest_run_id("GOOGL") == full_run
 
 
+def test_latest_run_id_skips_side_channel_refresh_runs(seeded_db_empty_cards) -> None:
+    """positioning_refresh / intraday_refresh / cockpit_daily_snapshot each
+    insert a scan_runs row that populates only a narrow slice of tables
+    (uw_positioning, option_chain_oi, cockpit greeks respectively) and must
+    NOT shadow the real full-scan run the report assembler reads from.
+    """
+    repo = seeded_db_empty_cards
+    full_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.finish_scan_run(full_run, status="ok")
+    for note in ("positioning_refresh", "intraday_refresh", "cockpit_daily_snapshot"):
+        shadow = repo.insert_scan_run("GOOGL", notes=note)
+        repo.finish_scan_run(shadow, status="ok")
+        assert shadow > full_run, f"{note} sanity: shadow would otherwise win"
+    repo.conn.commit()
+
+    assert repo.latest_run_id("GOOGL") == full_run
+
+
 def test_option_chain_per_strike_returns_only_latest_snapshot(
     seeded_db_empty_cards,
 ) -> None:


### PR DESCRIPTION
## Summary

- `latest_run_id` only excluded `flow_data_refresh` and `gex_scan_*` from the "real full-scan" lookup. Three newer side-channel jobs — `positioning_refresh` (M4), `intraday_refresh`, `cockpit_daily_snapshot` — were never added, so any one of them firing for a ticker would shadow that ticker's last full_scan and the stock detail page rendered `None` for every GEX/DEX/magnet/wall/IV field.
- Repro from this morning: `positioning_refresh` had run for the entire 102-ticker watchlist; with no weekend full_scan to overwrite it, `GET /api/stock/TSLA` returned `run_id=24413` (positioning_refresh, empty `strike_gex_curve`) instead of `24304` (Friday's full_scan, 87 strikes). After the fix the same request returns 24304 and the UI shows GEX flip 430, max magnet 450, bias BULL, etc.
- Added the three notes to the exclusion list in `latest_run_id` and to the three sibling queries that share the same "real full-scan only" filter (`get_scan_duration_summary`, `external_api.py` provider stats, `pipeline_benchmark.py` freshness gate) so they don't drift apart again.
- New regression test mirrors `test_latest_run_id_skips_flow_data_refresh_runs` — each of the three new notes inserts a row with `run_id > full_run` and is asserted unshadowed per-iteration.

## Behavioral side effects (called out from Pass-2 review)

- **`intraday_refresh` was self-shadowing.** Its job at `option_intraday_jobs.py:69` calls `latest_run_id(ticker)` BEFORE inserting its own row. Pre-fix, that call could return a *previous* `intraday_refresh` row (empty `fetch_oi_change_top` data), so the job would log "no OI movers in latest run" and silently no-op. Post-fix it reads from the latest full_scan and does the real bucket-collection work it was designed for. Expect a small UW request-rate increase from that job after merge.
- **`external_api.py` provider-stats query also gains the `gex_scan_*` LIKE exclusion** (it was previously only filtering `flow_data_refresh`). ~6,300 `gex_scan_*` runs over the last 30 days are now excluded from the avg-scan-duration telemetry — a correction toward the query's intent ("real full_scan duration"), but the reported avg will shift after merge.

## Test plan

- [x] `uv run pytest tests/integration/storage/test_flow_tab.py` — 6 passed (existing + new + Pass-1 tightening)
- [x] Local API: `GET /api/stock/TSLA` returns `run_id=24304`, `strike_gex_curve` length 87, `aggregates` populated, `market_structure_levels.gex_flip.strike=430`
- [x] Local API SPY/QQQ/IWM (cockpit tickers): all return populated runs (gex_n=175/175/85, net_gex computed, aggregates present)
- [x] Local UI: TSLA market-structure page renders all panels (GEX flip 430, net GEX +$24.7K, IV 41.7%, magnets 450/445, walls 440); bias flipped NEUTRAL → BULL with reasoning
- [ ] CI: full `uv run pytest`
- [ ] CI: `cd web && npm run test`

## Pass-2 review trail

Tribunal review run via `/review-cycle`:
- Codex: unavailable (hit usage limit; resets 13:35 local). Bilateral mode (Gemini + Claude).
- **Gemini ISSUE-1 (REFUTED)** — proposed removing `signal_gates EXISTS` clause from `count_pipeline_scanner_freshness`. Commit `4404be4` ("align benchmark history with scanner semantics") added it deliberately — it makes the metric "fresh tickers with signals," intentionally different from `latest_run_id`'s "most recent valid run." Keeping the clause.
- **Gemini ISSUE-2 / Claude J1 (DEFERRED)** — recommend a `run_type` column / shared constant to replace the stringly-typed exclusion list. Explicitly out of scope per the original scope decision; held as a follow-up.

## Notes

The exclusion list is now duplicated across four queries. Worth a follow-up to centralize (e.g. a `SIDE_CHANNEL_SCAN_NOTES` tuple or a `scan_runs_excluding_side_channels()` SQL fragment helper, or — per Gemini — a `run_type` schema column) so the next side-channel job — M5 etc. — can't reintroduce this class of bug by editing one place and forgetting the other three.