### PR TITLE
perf(watchlist): replace seq-scan CTEs with LATERAL per-ticker lookups

### DIFF
--- a/src/uw_scan/storage/watchlist.py
+++ b/src/uw_scan/storage/watchlist.py
@@ -271,31 +271,12 @@ class _WatchlistMixin:
                   FROM {self._schema}.scan_results
                   WHERE marketcap IS NOT NULL
                   ORDER BY ticker, run_id DESC
-                ),
-                latest_screener_sizes AS (
-                  SELECT DISTINCT ON (r.ticker)
-                    r.ticker,
-                    p.payload_jsonb->'data'->0->>'marketcap' AS market_cap
-                  FROM {self._schema}.scan_runs r
-                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
-                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
-                  WHERE a.endpoint_slug = 'bulk_screener_stocks'
-                    AND jsonb_typeof(p.payload_jsonb->'data') = 'array'
-                    AND p.payload_jsonb->'data'->0->>'marketcap' IS NOT NULL
-                  ORDER BY r.ticker, r.run_id DESC
-                ),
-                latest_etf_aum AS (
-                  SELECT DISTINCT ON (r.ticker)
-                    r.ticker,
-                    p.payload_jsonb->'data'->>'aum' AS aum
-                  FROM {self._schema}.scan_runs r
-                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
-                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
-                  WHERE a.endpoint_slug = 'etf_info'
-                    AND jsonb_typeof(p.payload_jsonb->'data') = 'object'
-                    AND p.payload_jsonb->'data'->>'aum' IS NOT NULL
-                  ORDER BY r.ticker, r.run_id DESC
                 )
+                -- The screener / etf-AUM fallbacks are LEFT JOIN LATERAL
+                -- below so they only scan payloads for the ~100 watchlist
+                -- tickers, not the full audit history. The pre-LATERAL CTE
+                -- form tripped the planner into a parallel seq scan over
+                -- 2.6 GB of raw_payloads (9.4 s on the watchlist endpoint).
                 SELECT
                   w.ticker, w.sector, w.pinned, w.sort_rank,
                   c.run_id, c.scanned_at,
@@ -341,8 +322,30 @@ class _WatchlistMixin:
                 LEFT JOIN {self._schema}.watchlist_card c ON w.ticker = c.ticker
                 LEFT JOIN {self._schema}.scan_runs sr ON c.run_id = sr.run_id
                 LEFT JOIN latest_market_caps lmc ON w.ticker = lmc.ticker
-                LEFT JOIN latest_screener_sizes lss ON w.ticker = lss.ticker
-                LEFT JOIN latest_etf_aum lea ON w.ticker = lea.ticker
+                LEFT JOIN LATERAL (
+                  SELECT p.payload_jsonb->'data'->0->>'marketcap' AS market_cap
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE r.ticker = w.ticker
+                    AND a.endpoint_slug = 'bulk_screener_stocks'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'array'
+                    AND p.payload_jsonb->'data'->0->>'marketcap' IS NOT NULL
+                  ORDER BY r.run_id DESC
+                  LIMIT 1
+                ) lss ON TRUE
+                LEFT JOIN LATERAL (
+                  SELECT p.payload_jsonb->'data'->>'aum' AS aum
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE r.ticker = w.ticker
+                    AND a.endpoint_slug = 'etf_info'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'object'
+                    AND p.payload_jsonb->'data'->>'aum' IS NOT NULL
+                  ORDER BY r.run_id DESC
+                  LIMIT 1
+                ) lea ON TRUE
                 LEFT JOIN {self._schema}.intraday_quote q ON w.ticker = q.ticker
                 LEFT JOIN active_jobs j ON w.ticker = j.ticker
                 WHERE w.removed_at IS NULL
@@ -393,31 +396,9 @@ class _WatchlistMixin:
                   FROM {self._schema}.scan_results
                   WHERE marketcap IS NOT NULL
                   ORDER BY ticker, run_id DESC
-                ),
-                latest_screener_sizes AS (
-                  SELECT DISTINCT ON (r.ticker)
-                    r.ticker,
-                    p.payload_jsonb->'data'->0->>'marketcap' AS market_cap
-                  FROM {self._schema}.scan_runs r
-                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
-                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
-                  WHERE a.endpoint_slug = 'bulk_screener_stocks'
-                    AND jsonb_typeof(p.payload_jsonb->'data') = 'array'
-                    AND p.payload_jsonb->'data'->0->>'marketcap' IS NOT NULL
-                  ORDER BY r.ticker, r.run_id DESC
-                ),
-                latest_etf_aum AS (
-                  SELECT DISTINCT ON (r.ticker)
-                    r.ticker,
-                    p.payload_jsonb->'data'->>'aum' AS aum
-                  FROM {self._schema}.scan_runs r
-                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
-                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
-                  WHERE a.endpoint_slug = 'etf_info'
-                    AND jsonb_typeof(p.payload_jsonb->'data') = 'object'
-                    AND p.payload_jsonb->'data'->>'aum' IS NOT NULL
-                  ORDER BY r.ticker, r.run_id DESC
                 )
+                -- The screener / etf-AUM fallbacks are LEFT JOIN LATERAL
+                -- below (see list_watchlist_cards for the same rewrite).
                 SELECT
                   w.ticker, w.sector, w.pinned, w.sort_rank,
                   c.run_id, c.scanned_at,
@@ -464,8 +445,30 @@ class _WatchlistMixin:
                 LEFT JOIN {self._schema}.watchlist_card c ON w.ticker = c.ticker
                 LEFT JOIN {self._schema}.scan_runs sr ON c.run_id = sr.run_id
                 LEFT JOIN latest_market_caps lmc ON w.ticker = lmc.ticker
-                LEFT JOIN latest_screener_sizes lss ON w.ticker = lss.ticker
-                LEFT JOIN latest_etf_aum lea ON w.ticker = lea.ticker
+                LEFT JOIN LATERAL (
+                  SELECT p.payload_jsonb->'data'->0->>'marketcap' AS market_cap
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE r.ticker = w.ticker
+                    AND a.endpoint_slug = 'bulk_screener_stocks'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'array'
+                    AND p.payload_jsonb->'data'->0->>'marketcap' IS NOT NULL
+                  ORDER BY r.run_id DESC
+                  LIMIT 1
+                ) lss ON TRUE
+                LEFT JOIN LATERAL (
+                  SELECT p.payload_jsonb->'data'->>'aum' AS aum
+                  FROM {self._schema}.scan_runs r
+                  JOIN {self._schema}.api_request_audit a ON r.run_id = a.run_id
+                  JOIN {self._schema}.raw_payloads p ON a.audit_id = p.audit_id
+                  WHERE r.ticker = w.ticker
+                    AND a.endpoint_slug = 'etf_info'
+                    AND jsonb_typeof(p.payload_jsonb->'data') = 'object'
+                    AND p.payload_jsonb->'data'->>'aum' IS NOT NULL
+                  ORDER BY r.run_id DESC
+                  LIMIT 1
+                ) lea ON TRUE
                 LEFT JOIN {self._schema}.intraday_quote q ON w.ticker = q.ticker
                 LEFT JOIN active_jobs j ON w.ticker = j.ticker
                 CROSS JOIN summary sm

--- a/web/app/loading.tsx
+++ b/web/app/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <main
+      style={{
+        padding: 24,
+        color: "var(--text-muted)",
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      Loading dashboard…
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

The dashboard was taking ~9.4 s to load. Root cause: the `/api/watchlist` endpoint's underlying query materialized two CTEs (`latest_screener_sizes`, `latest_etf_aum`) that joined `scan_runs ⋈ api_request_audit ⋈ raw_payloads` with a JSONB filter. The planner couldn't estimate the JSONB filter selectivity and picked a parallel seq scan over `raw_payloads` (**2.6 GB**, 254k rows scanned per query).

Rewriting both CTEs as `LEFT JOIN LATERAL (... ORDER BY r.run_id DESC LIMIT 1)` ties the lookup to each watchlist ticker, so Postgres reaches the result via `idx_scan_runs_ticker_run_desc` → `idx_raw_payloads_audit_id`. Same semantics, ~30× faster.

Applied to both `list_watchlist_cards` and `list_watchlist_cards_with_queue_summary` since 4 worker jobs (`full_scan`, `volatility`, `option_intraday`, `flow_data_refresh`) hit the un-queue variant on every tick.

Also adds `web/app/loading.tsx` so navigating to `/` shows immediate feedback instead of freezing the previous page during SSR (mirrors existing `app/watchlist/loading.tsx`).

## Measured impact (mac mini production stack)

| Metric | Before | After |
|---|---|---|
| `/api/watchlist` (warm) | 9.4 s | **240–620 ms** |
| Dashboard SSR end-to-end | 9.4 s | **0.85 s** |
| `raw_payloads` buffers/query | 930k pages (~7.3 GB I/O) | <100 hits |

EXPLAIN ANALYZE before:
```
->  Parallel Seq Scan on raw_payloads p_1
    (actual time=1.245..9609.470 rows=13479 loops=2)
    Filter: ((payload_jsonb -> 'data' -> 0 ->> 'marketcap') IS NOT NULL ...)
    Rows Removed by Filter: 114,330
    Buffers: shared hit=592,447 read=337,865
```

After (LATERAL form): 608 ms total execution.

## Test plan

- [x] `uv run pytest tests/integration/api/test_watchlist_endpoint.py tests/integration/storage/test_repository_watchlist.py` — 18 passed
- [x] Payload shape unchanged: 102 tickers, same keys, same `market_cap`/`aum` values
- [x] Mini smoke test: `/api/watchlist` warm samples 240–620 ms, dashboard SSR 0.85 s
- [ ] CI green
- [ ] Post-merge: redeploy mini cleanly (currently running the patched file out-of-tree from local timing verification)