### PR TITLE
chore: three-tier DB isolation with (host, db_name) tripwire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,17 @@
 UW_SCAN_API_KEY=
-# UW_SCAN_DB_HOST: 127.0.0.1 for fully local; 100.66.147.98 (Tailscale) for the
-# Mac mini shared instance. Per-machine override via .env.local (gitignored) —
-# Settings.from_env loads .env.local first, then this file.
+# DB isolation rules (enforced by Settings.from_env → _enforce_db_isolation):
+#   UW_SCAN_DB_HOST=127.0.0.1      → UW_SCAN_DB_NAME must be option_wizard_local
+#                                    (local dev) or option_wizard_test (pytest)
+#   UW_SCAN_DB_HOST=100.66.147.98  → UW_SCAN_DB_NAME must be option_wizard
+#                                    (the Mac mini's prodlike instance)
+# Per-machine override via .env.local (gitignored) — Settings.from_env loads
+# .env.local first, then this file. On the MacBook, .env.local should set
+# BOTH UW_SCAN_DB_HOST=100.66.147.98 AND UW_SCAN_DB_NAME=option_wizard when
+# you want a browse-mini session. Override the tripwire for one-off scripts
+# with UW_SCAN_ALLOW_DB_MISMATCH=1.
 UW_SCAN_DB_HOST=127.0.0.1
 UW_SCAN_DB_PORT=5432
-UW_SCAN_DB_NAME=option_wizard
+UW_SCAN_DB_NAME=option_wizard_local
 UW_SCAN_DB_SCHEMA=uw_scan
 UW_SCAN_DB_USER=argon_app
 # UW_SCAN_DB_PASSWORD: leave blank on MacBook for fully-local development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,10 @@ jobs:
     env:
       UW_SCAN_DB_HOST: 127.0.0.1
       UW_SCAN_DB_PORT: 5432
-      UW_SCAN_DB_NAME: option_wizard
+      # CI uses option_wizard_local as the "working" DB to satisfy the host/db
+      # isolation tripwire in uw_scan.config._enforce_db_isolation (the bare
+      # name option_wizard is reserved for the Mac mini Tailscale host).
+      UW_SCAN_DB_NAME: option_wizard_local
       UW_SCAN_DB_SCHEMA: uw_scan
       UW_SCAN_DB_USER: postgres
       UW_SCAN_DB_PASSWORD: postgres
@@ -100,9 +103,9 @@ jobs:
       - name: Sync deps
         run: uv sync --extra postgres
 
-      - name: Create option_wizard + option_wizard_test DBs
+      - name: Create option_wizard_local + option_wizard_test DBs
         run: |
-          PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d postgres -c "CREATE DATABASE option_wizard"
+          PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d postgres -c "CREATE DATABASE option_wizard_local"
           PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres -d postgres -c "CREATE DATABASE option_wizard_test"
 
       - name: Verify integration shard candidates match pytest collection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,17 @@ Per-ticker options analytics, watchlist-driven. Three processes share a single P
 - **FastAPI** (`src/uw_scan/api/`, port 8400) — read-only over the warm store, mutations only via `/jobs`
 - **APScheduler worker** (`src/uw_scan/worker/`) — full-scan / OHLC / spot-refresh / rescan-poll / nightly vol rollup
 
-Postgres `option_wizard` DB, schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual Whales) is the primary data source; massive.com supplies OHLC. **Never fall back to Yahoo.**
+Postgres schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual Whales) is the primary data source; massive.com supplies OHLC. **Never fall back to Yahoo.**
 
-Mac mini (`100.66.147.98`) hosts the shared production-ish Postgres instance. MacBook can run fully local (`UW_SCAN_DB_HOST=127.0.0.1`) or point at the mini via a per-machine `.env.local` override (`UW_SCAN_DB_HOST=100.66.147.98`). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
+**Three-tier DB isolation** — `uw_scan.config._enforce_db_isolation` refuses to start on a `(host, db_name)` mismatch (override with `UW_SCAN_ALLOW_DB_MISMATCH=1` for one-off scripts):
+
+| Host | DB name | Writer | Reset |
+|------|---------|--------|-------|
+| `100.66.147.98` (Mac mini, Tailscale) | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
+| `127.0.0.1` (MacBook / CI) | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned) |
+| either host | `option_wizard_test` | `uv run pytest` | wiped per-fixture (DROP SCHEMA CASCADE) |
+
+MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
 
 ## Tech stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,17 @@ Per-ticker options analytics, watchlist-driven. Three processes share a single P
 - **FastAPI** (`src/uw_scan/api/`, port 8400) — read-only over the warm store, mutations only via `/jobs`
 - **APScheduler worker** (`src/uw_scan/worker/`) — full-scan / OHLC / spot-refresh / rescan-poll / nightly vol rollup
 
-Postgres `option_wizard` DB, schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual Whales) is the primary data source; massive.com supplies OHLC. **Never fall back to Yahoo.**
+Postgres schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual Whales) is the primary data source; massive.com supplies OHLC. **Never fall back to Yahoo.**
 
-Mac mini (`100.66.147.98`) hosts the shared production-ish Postgres instance. MacBook can run fully local (`UW_SCAN_DB_HOST=127.0.0.1`) or point at the mini via a per-machine `.env.local` override (`UW_SCAN_DB_HOST=100.66.147.98`). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
+**Three-tier DB isolation** — `uw_scan.config._enforce_db_isolation` refuses to start on a `(host, db_name)` mismatch (override with `UW_SCAN_ALLOW_DB_MISMATCH=1` for one-off scripts):
+
+| Host | DB name | Writer | Reset |
+|------|---------|--------|-------|
+| `100.66.147.98` (Mac mini, Tailscale) | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
+| `127.0.0.1` (MacBook / CI) | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned) |
+| either host | `option_wizard_test` | `uv run pytest` | wiped per-fixture (DROP SCHEMA CASCADE) |
+
+MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
 
 ## Tech stack
 

--- a/scripts/deploy/macmini-data-promote.sh
+++ b/scripts/deploy/macmini-data-promote.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 # macmini-data-promote.sh — MacBook → Mac mini full Postgres mirror.
 #
-# RUN FROM THE MACBOOK. Dumps the source DB (default: option_wizard), ships
-# over SSH, restores onto the Mac mini's option_wizard. Destructive on the
-# target (--clean --if-exists).
+# RUN FROM THE MACBOOK. Dumps the source DB (default: option_wizard_local),
+# ships over SSH, restores onto the Mac mini's option_wizard. Destructive on
+# the target (--clean --if-exists).
 #
 # Usage:
 #   ./scripts/deploy/macmini-data-promote.sh <ssh-host> --confirm \
-#       [--src-db option_wizard] [--src-user chenxi]
+#       [--src-db option_wizard_local] [--src-user chenxi]
 #
-# Phase 3 cutover: --src-db option_wizard (pre-migration MacBook DB) →
-# mini's option_wizard.  Same name on both sides — no rename during transfer.
-# Ad-hoc re-mirror later: --src-db option_wizard_macbook (or whatever your
-# local rollback-insurance DB is named); only sensible if you maintain a
-# local Postgres post-migration.
+# Post-rename default (chore/db-tripwire and later): --src-db option_wizard_local
+# (MacBook dev DB) → mini's option_wizard. Different names on each side so the
+# host/db isolation tripwire (uw_scan.config._enforce_db_isolation) refuses
+# anything else.
 #
 # Example:
 #   ./scripts/deploy/macmini-data-promote.sh moremeds@100.66.147.98 --confirm
@@ -39,11 +38,11 @@ die()  { printf '\033[1;31m[promote] FAIL: %s\033[0m\n' "$*" >&2; exit 1; }
 step() { printf '\n\033[1;36m=== %s ===\033[0m\n' "$*"; }
 
 # ---------- Source DB explicit (not inferred from .env) ----------
-# Phase 4 changes MacBook's .env.local to point UW_SCAN_DB_HOST at the mini.
-# Both sides use the DB name `option_wizard`, so sourcing .env after that
-# would silently dump the WRONG thing (the mini's option_wizard via MacBook's
-# connection). Make the source explicit and document it.
-SRC_DB="option_wizard"   # default for the initial Phase 3 cutover
+# .env.local on the MacBook points UW_SCAN_DB_HOST at the mini, so sourcing
+# .env here would silently dump the WRONG thing (the mini's option_wizard via
+# the MacBook's Tailscale connection). Make the source explicit and document
+# it. Default reflects the post-rename world: macbook = option_wizard_local.
+SRC_DB="option_wizard_local"
 SRC_USER="chenxi"        # default MacBook DB owner
 # Parse extra args (after ssh host + --confirm)
 while [[ $# -gt 2 ]]; do

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,24 +5,33 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# ---- Mac mini cutover tripwire ----
+# ---- Mac mini cutover tripwire (shell layer) ----
 # Refuse to spawn local workers if .env / .env.local point UW_SCAN_DB_HOST at
 # the mini (100.66.147.98). Two writers (MacBook + mini) on the same queue
 # would race via FOR UPDATE SKIP LOCKED and double-charge AI providers.
+# The stronger (host, db_name) check lives in uw_scan.config._enforce_db_isolation;
+# this shell-level check exits earlier (before npm/uv start) and complements it.
 # Override with UW_SCAN_ALLOW_DEV_AGAINST_MINI=1 if you really want to debug
 # against mini state (read-only browser session, no workers expected).
-_env_db_host() {
-  local f="$1"
+_env_var() {
+  local key="$1" f="$2"
   [[ -f "$f" ]] || { echo ""; return; }
-  grep -E '^[[:space:]]*UW_SCAN_DB_HOST=' "$f" \
+  grep -E "^[[:space:]]*${key}=" "$f" \
     | tail -1 | cut -d= -f2 | tr -d '"' | tr -d "'" | xargs
 }
-# Precedence matches Settings.from_env: shell env > .env.local > .env.
-db_host="${UW_SCAN_DB_HOST:-}"
-if [[ -z "$db_host" ]]; then
-  db_host="$(_env_db_host .env.local)"
-  [[ -n "$db_host" ]] || db_host="$(_env_db_host .env)"
-fi
+_resolve_env_var() {
+  local key="$1" current="${!1:-}"
+  if [[ -n "$current" ]]; then echo "$current"; return; fi
+  local v
+  v="$(_env_var "$key" .env.local)"
+  [[ -n "$v" ]] || v="$(_env_var "$key" .env)"
+  echo "$v"
+}
+db_host="$(_resolve_env_var UW_SCAN_DB_HOST)"
+db_name="$(_resolve_env_var UW_SCAN_DB_NAME)"
+: "${db_host:=127.0.0.1}"
+: "${db_name:=option_wizard_local}"
+printf '[dev.sh] Resolved DB: host=%s db_name=%s\n' "$db_host" "$db_name" >&2
 
 if [[ "$db_host" == "100.66.147.98" ]] && [[ "${UW_SCAN_ALLOW_DEV_AGAINST_MINI:-0}" != "1" ]]; then
   cat >&2 <<EOF
@@ -34,7 +43,8 @@ if [[ "$db_host" == "100.66.147.98" ]] && [[ "${UW_SCAN_ALLOW_DEV_AGAINST_MINI:-
 [dev.sh]   UW_SCAN_ALLOW_DEV_AGAINST_MINI=1 bash scripts/dev.sh
 [dev.sh]
 [dev.sh] Normal MacBook dev: revert .env.local to a local Postgres
-[dev.sh] (UW_SCAN_DB_HOST=127.0.0.1) or delete it entirely.
+[dev.sh] (UW_SCAN_DB_HOST=127.0.0.1 + UW_SCAN_DB_NAME=option_wizard_local)
+[dev.sh] or delete .env.local entirely.
 EOF
   exit 1
 fi

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -56,13 +56,51 @@ def _load_dotenv(env_path: Path) -> None:
         logger.exception("failed to read .env file %s: %s", env_path, repr(exc))
 
 
+# Host → set of legal db names. Refuses to start on (host, db_name) mismatch
+# so a stray .env on the wrong machine cannot write into the wrong tier.
+#   100.66.147.98 = Mac mini Tailscale (prodlike): option_wizard for the live
+#                   data feed; option_wizard_test allowed too because
+#                   integration tests on the macbook (with .env.local active)
+#                   reach the mini's test DB via migrate.sh.
+#   127.0.0.1     = local Postgres on macbook / CI: option_wizard_local for
+#                   dev work, option_wizard_test for pytest (wiped by
+#                   integration fixtures via DROP SCHEMA CASCADE).
+# Override with UW_SCAN_ALLOW_DB_MISMATCH=1 for one-off ad-hoc scripts
+# (e.g. backfilling from R2 into a scratch DB on the macbook).
+_HOST_DB_RULES: dict[str, frozenset[str]] = {
+    "100.66.147.98": frozenset({"option_wizard", "option_wizard_test"}),
+    "127.0.0.1": frozenset({"option_wizard_local", "option_wizard_test"}),
+    "localhost": frozenset({"option_wizard_local", "option_wizard_test"}),
+}
+
+
+def _enforce_db_isolation(db_host: str, db_name: str) -> None:
+    allowed = _HOST_DB_RULES.get(db_host)
+    if allowed is None or db_name in allowed:
+        return
+    if _env_bool("UW_SCAN_ALLOW_DB_MISMATCH"):
+        logger.warning(
+            "DB isolation override active: host=%s db_name=%s "
+            "(UW_SCAN_ALLOW_DB_MISMATCH=1)",
+            db_host,
+            db_name,
+        )
+        return
+    raise RuntimeError(
+        f"Refusing to start: UW_SCAN_DB_HOST={db_host!r} is not allowed to "
+        f"target UW_SCAN_DB_NAME={db_name!r}. Allowed on this host: "
+        f"{sorted(allowed)}. Set UW_SCAN_ALLOW_DB_MISMATCH=1 to override "
+        "(one-off scripts only)."
+    )
+
+
 class Settings(BaseModel):
     """Strongly-typed configuration. Raises on missing required fields."""
 
     api_key: SecretStr = Field(...)
     db_host: str = "127.0.0.1"
     db_port: int = 5432
-    db_name: str = "option_wizard"
+    db_name: str = "option_wizard_local"
     db_schema: str = "uw_scan"
     db_user: str = "argon_app"
     db_password: SecretStr = SecretStr("")
@@ -238,11 +276,15 @@ class Settings(BaseModel):
                 "UW_SCAN_API_KEY is not set. Add it to .env or export it before running."
             )
 
+        db_host = os.environ.get("UW_SCAN_DB_HOST", "127.0.0.1")
+        db_name = os.environ.get("UW_SCAN_DB_NAME", "option_wizard_local")
+        _enforce_db_isolation(db_host, db_name)
+
         return cls(
             api_key=SecretStr(api_key),
-            db_host=os.environ.get("UW_SCAN_DB_HOST", "127.0.0.1"),
+            db_host=db_host,
             db_port=int(os.environ.get("UW_SCAN_DB_PORT", "5432")),
-            db_name=os.environ.get("UW_SCAN_DB_NAME", "option_wizard"),
+            db_name=db_name,
             db_schema=os.environ.get("UW_SCAN_DB_SCHEMA", "uw_scan"),
             db_user=os.environ.get("UW_SCAN_DB_USER", "") or "argon_app",
             db_password=SecretStr(os.environ.get("UW_SCAN_DB_PASSWORD", "")),

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -62,8 +62,8 @@ pytestmark = pytest.mark.skipif(
 def test_pipeline_e2e_tsla_exit_gate(tmp_path_factory):
     """Run the S1 pipeline against TSLA and assert the exit-gate row counts.
 
-    Uses the local `option_wizard` DB but a fresh schema (`uw_scan_e2e`) so this
-    test does not collide with developer state.
+    Uses the local `option_wizard_local` DB but a fresh schema (`uw_scan_e2e`)
+    so this test does not collide with developer state.
     """
     settings = _test_settings()
     _reset_and_migrate(settings)

--- a/tests/integration/test_pipeline_strike_gex.py
+++ b/tests/integration/test_pipeline_strike_gex.py
@@ -2,7 +2,7 @@
 assemble_single_stock_report should round-trip the curve into the report.
 
 Runs against the isolated test DB (UW_SCAN_TEST_DB_NAME required) so this never
-touches the developer's `option_wizard` data.
+touches the developer's `option_wizard_local` data.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_config_env_local.py
+++ b/tests/unit/test_config_env_local.py
@@ -37,16 +37,18 @@ def _write_env(path: Path, **kwargs: str) -> None:
 def test_env_local_overrides_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, env_isolated: None
 ) -> None:
-    """When .env.local sets UW_SCAN_DB_HOST, it wins over .env."""
+    """When .env.local sets UW_SCAN_DB_HOST and UW_SCAN_DB_NAME, both win
+    over .env, and non-overridden keys (api_key) still flow through."""
     _write_env(
         tmp_path / ".env",
         UW_SCAN_API_KEY="from-env",
         UW_SCAN_DB_HOST="127.0.0.1",
-        UW_SCAN_DB_NAME="local_db",
+        UW_SCAN_DB_NAME="option_wizard_local",
     )
     _write_env(
         tmp_path / ".env.local",
         UW_SCAN_DB_HOST="100.66.147.98",
+        UW_SCAN_DB_NAME="option_wizard",
     )
 
     # Re-root from_env at the temp dir by patching the file's resolution.
@@ -59,8 +61,8 @@ def test_env_local_overrides_env(
     s = Settings.from_env()
 
     assert s.db_host == "100.66.147.98"  # .env.local wins
-    assert s.db_name == "local_db"  # .env still supplies non-overridden keys
-    assert s.api_key.get_secret_value() == "from-env"
+    assert s.db_name == "option_wizard"  # .env.local wins
+    assert s.api_key.get_secret_value() == "from-env"  # only in .env
 
 
 def test_env_only_when_no_local(


### PR DESCRIPTION
## Summary

- Adds `_enforce_db_isolation` in `src/uw_scan/config.py` that refuses to start `Settings.from_env()` on a `(host, db_name)` mismatch. Prevents a stray `.env` from writing dev rows into the macmini's prodlike DB or vice-versa.
- Renames the MacBook's local DB `option_wizard` → `option_wizard_local` (already executed via `ALTER DATABASE`; this PR aligns the code). Macmini's `option_wizard` stays as-is.
- CI working DB switched to `option_wizard_local` so the new tripwire passes in GitHub Actions.

## Policy

| Host | DB name | Writer | Reset |
|------|---------|--------|-------|
| `100.66.147.98` (Mac mini, Tailscale) | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
| `127.0.0.1` (MacBook / CI) | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned) |
| either host | `option_wizard_test` | `uv run pytest` | wiped per-fixture (DROP SCHEMA CASCADE) |

Override with `UW_SCAN_ALLOW_DB_MISMATCH=1` for one-off scripts (e.g. backfill into a scratch DB).

`option_wizard_test` is allowed on both hosts because integration tests on the macbook with `.env.local` active reach the mini's test DB via `migrate.sh`.

## Why

Pre-PR, the resolution logic let any process on either host point at `option_wizard` — there was no guard against e.g. a macbook backfill script writing dev rows into the mini's prodlike DB. The only defense was a host-only shell tripwire in `scripts/dev.sh`, which was bypassed by `uv run uvicorn …` or any direct Python invocation.

The new `_enforce_db_isolation` runs at config-load time in `Settings.from_env()`, so it intercepts every entry point (API, worker, scripts, pytest) before psycopg opens a connection.

## What changed

| File | Purpose |
|------|---------|
| `src/uw_scan/config.py` | tripwire + `_HOST_DB_RULES` + default `db_name=option_wizard_local` |
| `.env.example` | default + policy comment |
| `.github/workflows/ci.yml` | CI working DB → `option_wizard_local` |
| `scripts/dev.sh` | resolved-`(host, db_name)` print; existing host-only tripwire kept as defense-in-depth |
| `scripts/deploy/macmini-data-promote.sh` | `SRC_DB` default → `option_wizard_local` |
| `CLAUDE.md` + `AGENTS.md` | replaced single-DB line with policy table |
| `tests/unit/test_config_env_local.py` | rewritten to exercise the realistic post-policy scenario (`.env.local` overrides BOTH host and db_name) |
| `tests/integration/test_pipeline_{e2e,strike_gex}.py` | docstring updates |

## Test plan

- [x] 943 unit tests pass locally (`uv run pytest tests/unit/`)
- [x] Tripwire manually verified — blocks mini+local-name, blocks local+prodlike-name, allows override env, allows test-DB on either host
- [x] Macbook DB rename executed; row counts confirmed intact (`raw_payloads=249,371`, `wgc_etf_monthly=1,338,260`, `trade_insight_ai_analyses=220`)
- [x] `Settings.from_env()` resolves correctly in both modes (local: `(127.0.0.1, option_wizard_local)`; browse-mini via `.env.local`: `(100.66.147.98, option_wizard)`)
- [ ] CI green
- [ ] After merge: restart `dev.sh` on the macbook and confirm the resolved-DB print line; verify the macmini launchd stack remains unaffected (it never resolved through the changed default)

## Post-merge

No action required on the macmini — its `option_wizard` name is unchanged, its `.env` already has `UW_SCAN_DB_NAME=option_wizard`, its launchd plists keep working.