### PR TITLE
chore(macmini): align deploy + bootstrap with the new DB tripwire

### DIFF
--- a/scripts/deploy/macmini-bootstrap.sh
+++ b/scripts/deploy/macmini-bootstrap.sh
@@ -253,15 +253,17 @@ step ".env files"
 if [[ ! -f "${ARGON_HOME}/.env" ]]; then
   say "Creating .env from .env.example (you must fill secrets before services start)"
   cp "${ARGON_HOME}/.env.example" "${ARGON_HOME}/.env"
-  # The .env.example default points UW_SCAN_DB_HOST at 127.0.0.1 already; for
-  # the mini, this is correct (loopback to local Postgres). Inject the
-  # generated password.
+  # The .env.example defaults are tuned for MacBook dev (HOST=127.0.0.1,
+  # NAME=option_wizard_local). On the mini, we point HOST at the Tailscale
+  # address so the (host, db_name) tripwire in uw_scan.config recognises
+  # (100.66.147.98, option_wizard) as the prodlike combo, and override
+  # NAME / USER / PASSWORD to the mini-specific values.
   python3 - <<PY
 from pathlib import Path
 p = Path("${ARGON_HOME}/.env")
 text = p.read_text()
-text = text.replace("UW_SCAN_DB_HOST=100.66.147.98", "UW_SCAN_DB_HOST=127.0.0.1")
-text = text.replace("UW_SCAN_DB_NAME=option_wizard", "UW_SCAN_DB_NAME=${ARGON_DB_NAME}")
+text = text.replace("UW_SCAN_DB_HOST=127.0.0.1", "UW_SCAN_DB_HOST=100.66.147.98")
+text = text.replace("UW_SCAN_DB_NAME=option_wizard_local", "UW_SCAN_DB_NAME=${ARGON_DB_NAME}")
 text = text.replace("UW_SCAN_DB_USER=argon_app", "UW_SCAN_DB_USER=${ARGON_DB_ROLE}")
 text = text.replace("UW_SCAN_DB_PASSWORD=", "UW_SCAN_DB_PASSWORD=${ARGON_DB_PASSWORD}", 1)
 p.write_text(text)

--- a/scripts/deploy/macmini-deploy-branch.sh
+++ b/scripts/deploy/macmini-deploy-branch.sh
@@ -45,7 +45,12 @@ say "Push $BRANCH to origin"
 git push origin "$BRANCH"
 
 # 2. Build the remote command
-REMOTE_CMD="set -euo pipefail
+# PATH prefix: non-interactive SSH doesn't source ~/.zprofile, so Homebrew-
+# installed CLIs (uv) and the keg-only postgresql@17 psql aren't on PATH.
+# Mirror the PATH that com.argon.worker plists already use, plus the
+# postgresql@17 bindir for migrate.sh.
+REMOTE_CMD='export PATH="/opt/homebrew/bin:/opt/homebrew/opt/postgresql@17/bin:/usr/local/bin:/usr/bin:/bin"
+'"set -euo pipefail
 cd ~/projects/unusual-whales
 git fetch origin
 # Non-destructive checkout: refuse if working tree dirty (mini should be clean).


### PR DESCRIPTION
## Summary

Two follow-ups from PR #113 caught during the live deploy earlier today.

1. **`scripts/deploy/macmini-bootstrap.sh`** — the `.env`-generation block targeted `.env.example` values that PR #113 changed. The old `text.replace(...)` calls silently no-op'd against the new template, leaving the mini's `.env` with `HOST=127.0.0.1` / `NAME=option_wizard_local` — which the new `(host, db_name)` tripwire blocks. Fix: switch the source patterns to the post-#113 defaults and set `HOST=100.66.147.98` (mini's own Tailscale address) so the resolved combo is `(100.66.147.98, option_wizard)`, which the tripwire allows. Postgres already listens on that interface for cross-machine browse sessions, so no network change required.
2. **`scripts/deploy/macmini-deploy-branch.sh`** — prepend Homebrew's bindir + the keg-only `postgresql@17` bindir to `PATH` inside `REMOTE_CMD`. Non-interactive SSH doesn't source `~/.zprofile`, so `uv sync` and `bash scripts/migrate.sh` failed with "command not found" on this afternoon's release. The new PATH mirrors what `com.argon.worker` plists already use.

## Why now

I caught both during today's PR #113 release. Hand-patched the mini's running `.env` to `UW_SCAN_DB_HOST=100.66.147.98` (backup at `.env.bak.20260602-*`) so services would start. This PR makes the same state come out of the next bootstrap re-run automatically, so we don't lose it the next time bootstrap runs.

## Test plan

- [x] `git diff` reviewed — `text.replace()` lines now target the actual `.env.example` defaults (verified by grep)
- [x] `REMOTE_CMD` quoting verified via dry-run — `BRANCH=main` correctly expands, `PATH=` line lands first
- [ ] CI green
- [ ] Re-run bootstrap on the mini (next time it's needed) and confirm `.env` resolves correctly
- [ ] Future `bash scripts/deploy/macmini-deploy-branch.sh` runs end-to-end without manual `bash -lc` wrapping

## Risk

Bootstrap edits are gated by `if [[ ! -f "${ARGON_HOME}/.env" ]]` — they only fire on a fresh install, never overwriting an existing `.env`. So this PR can't break the mini's current state. Deploy script change is additive (just `export PATH=…` prefix), no behavior change beyond making `uv` / `psql` resolvable.

Builds on #113.