### PR TITLE
fix(regime): self-healing recovery + populate history columns + GEX data_date fix

### DIFF
--- a/scripts/oneshot/regime_backfill_2026_05.py
+++ b/scripts/oneshot/regime_backfill_2026_05.py
@@ -22,18 +22,9 @@ Usage:
 from __future__ import annotations
 
 import logging
-import os
 from datetime import date, timedelta
 
 import psycopg
-from dotenv import load_dotenv
-
-load_dotenv()
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-)
-log = logging.getLogger("regime_backfill")
 
 from uw_scan.config import Settings
 from uw_scan.scanners import canary as canary_scanner
@@ -41,6 +32,12 @@ from uw_scan.scanners import cri as cri_scanner
 from uw_scan.scanners import vcg as vcg_scanner
 from uw_scan.storage.repository import Repository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+log = logging.getLogger("regime_backfill")
 
 
 def _patch_loaders(as_of: date):

--- a/scripts/oneshot/regime_backfill_2026_05.py
+++ b/scripts/oneshot/regime_backfill_2026_05.py
@@ -1,0 +1,127 @@
+"""One-shot backfill for CRI / VCG / 5% Canary snapshots over a date window.
+
+Why this exists: between 2026-05-21 (last `vol_index_daily` row) and 2026-06-03
+(today's latest aligned date) the macmini primary worker was offline, so the
+CRI/VCG/Canary cron jobs never fired. The lake-sync has now caught
+`vol_index_daily` up; this script loops the existing scanner.run paths once per
+trading day in the gap so the regime page history is contiguous.
+
+The scanners always compute against `common_dates[-1]`. To re-aim them at a
+historical day we monkey-patch the two data loaders they use
+(`VolIndexRepository.fetch_history` and `Repository.list_daily_ohlc`) so they
+return rows up to and including `as_of` only. No scanner code changes; no
+duplication of scoring logic.
+
+Safe to re-run: cri / vcg use INSERT (multiple rows per day OK; latest wins in
+the UI). canary uses ON CONFLICT DO NOTHING keyed on (data_date, composite_version).
+
+Usage:
+    uv run python scripts/oneshot/regime_backfill_2026_05.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date, timedelta
+
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+log = logging.getLogger("regime_backfill")
+
+from uw_scan.config import Settings
+from uw_scan.scanners import canary as canary_scanner
+from uw_scan.scanners import cri as cri_scanner
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.storage.repository import Repository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _patch_loaders(as_of: date):
+    """Cap fetch_history / list_daily_ohlc so common_dates[-1] == as_of."""
+    orig_fetch = VolIndexRepository.fetch_history
+    orig_list_ohlc = Repository.list_daily_ohlc
+
+    def fetch_history_capped(self, symbol, days):
+        rows = orig_fetch(self, symbol, days * 2)
+        rows = [r for r in rows if r["trade_date"] <= as_of]
+        return rows[-days:] if days and len(rows) > days else rows
+
+    def list_daily_ohlc_capped(self, ticker, limit=None):
+        rows = orig_list_ohlc(self, ticker, limit=(limit * 2 if limit else None))
+        rows = [r for r in rows if r.date <= as_of]
+        return rows[:limit] if limit and len(rows) > limit else rows
+
+    VolIndexRepository.fetch_history = fetch_history_capped
+    Repository.list_daily_ohlc = list_daily_ohlc_capped
+
+    def restore():
+        VolIndexRepository.fetch_history = orig_fetch
+        Repository.list_daily_ohlc = orig_list_ohlc
+
+    return restore
+
+
+def _trading_days(start: date, end: date) -> list[date]:
+    out, d = [], start
+    while d <= end:
+        if d.weekday() < 5:  # Mon-Fri
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+def main() -> int:
+    settings = Settings.from_env()
+    days = _trading_days(date(2026, 5, 20), date(2026, 6, 3))
+    log.info("backfill window: %s → %s (%d trading days)", days[0], days[-1], len(days))
+
+    conn = psycopg.connect(settings.db_dsn())
+    try:
+        for d in days:
+            log.info("=== %s ===", d.isoformat())
+            restore = _patch_loaders(d)
+            try:
+                # CRI: skip dates ≤ existing latest (2026-05-21) to avoid dup-day rows
+                if d > date(2026, 5, 21):
+                    try:
+                        rid = cri_scanner.run(conn, schema=settings.db_schema)
+                        log.info("  cri row_id=%s", rid)
+                    except Exception as exc:
+                        log.warning("  cri failed: %r", exc)
+                        conn.rollback()
+                # VCG: skip ≤ 2026-05-19
+                if d > date(2026, 5, 19):
+                    try:
+                        rid = vcg_scanner.run(
+                            conn,
+                            proxy="HYG",
+                            schema=settings.db_schema,
+                        )
+                        log.info("  vcg row_id=%s", rid)
+                    except Exception as exc:
+                        log.warning("  vcg failed: %r", exc)
+                        conn.rollback()
+                # Canary: skip ≤ 2026-05-21
+                if d > date(2026, 5, 21):
+                    try:
+                        rid = canary_scanner.run(conn, schema=settings.db_schema)
+                        log.info("  canary row_id=%s", rid)
+                    except Exception as exc:
+                        log.warning("  canary failed: %r", exc)
+                        conn.rollback()
+            finally:
+                restore()
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -66,7 +66,19 @@ def _is_market_open_now() -> bool:
 
 
 def _assemble_history(repo: Repository, ticker: str, days: int = 90) -> list[dict]:
-    """Join greek_exposure_daily × (vol_index_daily | daily_ohlc) × flip history."""
+    """Join greek_exposure_daily × (vol_index_daily | daily_ohlc) × gex_snapshots.
+
+    The per-day gex_snapshots lookup carries flip + iv_30d + vol_pc + bias
+    in one round-trip via ``fetch_metrics_history``. Days without a
+    snapshot still surface (net_gex / net_dex / spot from the upstream
+    tables); the snapshot-derived columns just come through as None so
+    the table renders ``"---"`` per cell instead of dropping the row.
+
+    Returned list is ASC by date — the SVG chart in HistoryChart.tsx
+    consumes this directly with ``xScale(i)``, so flipping the order
+    here would draw time right-to-left. The history table sorts
+    client-side and defaults to date DESC.
+    """
     g = GreekExposureDailyRepository(repo.conn, schema=repo._schema)
     gex_rows = g.fetch_history(ticker, days=days)
     if not gex_rows:
@@ -80,15 +92,18 @@ def _assemble_history(repo: Repository, ticker: str, days: int = 90) -> list[dic
         ohlc = repo.list_daily_ohlc(ticker, limit=days)
         spot_by_date = {r.date: float(r.close) for r in ohlc}
 
-    flip_by_date = repo.fetch_flip_strike_history(ticker=ticker, limit=days)
+    metrics_by_date = repo.fetch_metrics_history(ticker=ticker, limit=days)
 
     return [
         {
             "date": row["trade_date"].isoformat(),
             "net_gex": row["net_gex"],
             "net_dex": row["net_dex"],
-            "gex_flip": flip_by_date.get(row["trade_date"]),
+            "gex_flip": (metrics_by_date.get(row["trade_date"]) or {}).get("flip"),
             "spot": spot_by_date.get(row["trade_date"]),
+            "atm_iv": (metrics_by_date.get(row["trade_date"]) or {}).get("iv_30d"),
+            "vol_pc": (metrics_by_date.get(row["trade_date"]) or {}).get("vol_pc"),
+            "bias": (metrics_by_date.get(row["trade_date"]) or {}).get("bias"),
         }
         for row in gex_rows
     ]

--- a/src/uw_scan/scanners/canary.py
+++ b/src/uw_scan/scanners/canary.py
@@ -1,13 +1,17 @@
 """5% Canary scanner — reads vol_index_daily, runs cards/canary_scoring, persists.
 
 See docs/superpowers/specs/2026-05-26-5pct-canary-indicator-design.md §5, §11.
+
+Recovery: ``recover_recent_gaps`` walks the last N trading days and runs the
+scanner for any day that has aligned vol_index_daily data but no
+canary_snapshots row at the current composite_version.
 """
 
 from __future__ import annotations
 
 import logging
 import math
-from datetime import date as _date
+from datetime import date as _date, timedelta
 from decimal import Decimal
 from typing import Iterable
 
@@ -29,9 +33,23 @@ CALENDAR_DAYS_REQUESTED = 500
 RV_WINDOW = 20
 
 
-def _load(vol_repo: VolIndexRepository, symbol: str, days: int) -> dict[_date, float]:
-    """Load {date: close}. v0.5 patch: raise on NaN / non-finite values."""
-    rows = vol_repo.fetch_history(symbol, days=days)
+def _load(
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    days: int,
+    *,
+    as_of: _date | None = None,
+) -> dict[_date, float]:
+    """Load {date: close}. v0.5 patch: raise on NaN / non-finite values.
+
+    When ``as_of`` is set the lookback caps at ``trade_date <= as_of`` so
+    ``recover_recent_gaps`` can re-aim the scanner at a previous day.
+    """
+    fetch_days = days * 2 if as_of is not None else days
+    rows = vol_repo.fetch_history(symbol, days=fetch_days)
+    if as_of is not None:
+        rows = [r for r in rows if r["trade_date"] <= as_of]
+        rows = rows[-days:]
     out: dict[_date, float] = {}
     for r in rows:
         c = r.get("close")
@@ -166,16 +184,25 @@ def _events_in_window(
 
 
 def run(
-    conn: Connection, *, schema: str = "uw_scan", force_recompute: bool = False
+    conn: Connection,
+    *,
+    schema: str = "uw_scan",
+    force_recompute: bool = False,
+    as_of: _date | None = None,
 ) -> int | None:
-    """Run a 5% Canary scan; persist a new snapshot row. Returns row id or None."""
+    """Run a 5% Canary scan; persist a new snapshot row. Returns row id or None.
+
+    When ``as_of`` is set, the scanner computes for that historical date by
+    capping every loaded series to ``trade_date <= as_of`` so
+    ``common_dates[-1]`` equals ``as_of``. Used by ``recover_recent_gaps``.
+    """
     vol_repo = VolIndexRepository(conn, schema=schema)
     raw = {
-        "VIX": _load(vol_repo, "VIX", CALENDAR_DAYS_REQUESTED),
-        "VVIX": _load(vol_repo, "VVIX", CALENDAR_DAYS_REQUESTED),
-        "VIX3M": _load(vol_repo, "VIX3M", CALENDAR_DAYS_REQUESTED),
-        "COR1M": _load(vol_repo, "COR1M", CALENDAR_DAYS_REQUESTED),
-        "SPX": _load(vol_repo, "SPX", CALENDAR_DAYS_REQUESTED),
+        "VIX": _load(vol_repo, "VIX", CALENDAR_DAYS_REQUESTED, as_of=as_of),
+        "VVIX": _load(vol_repo, "VVIX", CALENDAR_DAYS_REQUESTED, as_of=as_of),
+        "VIX3M": _load(vol_repo, "VIX3M", CALENDAR_DAYS_REQUESTED, as_of=as_of),
+        "COR1M": _load(vol_repo, "COR1M", CALENDAR_DAYS_REQUESTED, as_of=as_of),
+        "SPX": _load(vol_repo, "SPX", CALENDAR_DAYS_REQUESTED, as_of=as_of),
     }
     aligned, common_dates = _align(raw)
     if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
@@ -242,10 +269,83 @@ def run(
         on_conflict="overwrite" if force_recompute else "noop",
     )
     log.info(
-        "canary_scan_persisted row=%s score=%.1f band=%s state=%s",
+        "canary_scan_persisted row=%s data_date=%s score=%.1f band=%s state=%s",
         row_id,
+        today,
         payload["canary"]["score"],
         payload["canary"]["band"],
         payload["canary"]["warning_state"],
     )
     return row_id
+
+
+def _existing_canary_dates(
+    conn: Connection, schema: str, *, since: _date, composite_version: int
+) -> set[_date]:
+    """Distinct ``data_date`` already in ``canary_snapshots`` at this composite_version."""
+    sql = f"""
+        SELECT DISTINCT data_date
+          FROM {schema}.canary_snapshots
+         WHERE data_date IS NOT NULL
+           AND data_date >= %s
+           AND composite_version = %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (since, composite_version))
+        return {r[0] for r in cur.fetchall()}
+
+
+def recover_recent_gaps(
+    conn: Connection,
+    schema: str = "uw_scan",
+    *,
+    lookback_days: int = 7,
+) -> dict:
+    """Fill any missing 5% Canary snapshot in the last ``lookback_days`` days.
+
+    Mirrors the CRI/VCG recovery shape. composite_version is part of the
+    canary uniqueness key — older snapshots from a previous calibration
+    don't count as "filled" for the current version.
+    """
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    needed = ("VIX", "VVIX", "VIX3M", "COR1M", "SPX")
+    dates_by_sym = {sym: vol_repo.fetch_dates_for(sym) for sym in needed}
+    if not all(dates_by_sym.values()):
+        log.info("canary_recover_skipped: mandatory series missing in lake")
+        return {"checked": 0, "filled": 0, "skipped": 0}
+
+    aligned_days = sorted(set.intersection(*dates_by_sym.values()))
+    if not aligned_days:
+        return {"checked": 0, "filled": 0, "skipped": 0}
+
+    latest = aligned_days[-1]
+    cutoff = latest - timedelta(days=lookback_days)
+    window = [d for d in aligned_days if d >= cutoff]
+
+    existing = _existing_canary_dates(
+        conn, schema, since=cutoff, composite_version=COMPOSITE_VERSION
+    )
+    missing = [d for d in window if d not in existing]
+
+    filled = 0
+    skipped = 0
+    for d in missing:
+        try:
+            rid = run(conn, schema=schema, as_of=d)
+            if rid is None:
+                skipped += 1
+            else:
+                filled += 1
+        except Exception as exc:  # noqa: BLE001
+            log.warning("canary_recover_failed as_of=%s err=%s", d, repr(exc))
+            conn.rollback()
+            skipped += 1
+
+    log.info(
+        "canary_recover_done checked=%d filled=%d skipped=%d lookback=%dd",
+        len(window),
+        filled,
+        skipped,
+        lookback_days,
+    )
+    return {"checked": len(window), "filled": filled, "skipped": skipped}

--- a/src/uw_scan/scanners/cri.py
+++ b/src/uw_scan/scanners/cri.py
@@ -5,12 +5,17 @@ closes from daily_ohlc (massive-backed). Aligns to a common date set,
 runs ``cards/cri_scoring.run_analysis``, persists the snapshot.
 
 No external API calls — purely local DB reads + math + write.
+
+Recovery: ``recover_recent_gaps`` walks the last N trading days and runs
+the scanner for any day that has aligned vol_index_daily data but no
+cri_snapshots row. Designed to be called once per scheduler tick so the
+job self-heals if the worker was offline for a stretch.
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import date as _date
+from datetime import date as _date, timedelta
 
 import numpy as np
 from psycopg import Connection
@@ -32,22 +37,44 @@ MIN_ALIGNED_BARS = cri_scoring.MA_WINDOW + cri_scoring.VOL_WINDOW
 
 
 def _load_vol_series(
-    vol_repo: VolIndexRepository, symbol: str, days: int
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    days: int,
+    *,
+    as_of: _date | None = None,
 ) -> dict[_date, float]:
-    rows = vol_repo.fetch_history(symbol, days=days)
+    """Load up to ``days`` most-recent rows for ``symbol``.
+
+    When ``as_of`` is set, the lookback is capped at ``trade_date <= as_of``
+    so the historical-recovery path can re-aim the scanner at a previous
+    day without changing the rest of the orchestration.
+    """
+    fetch_days = days * 2 if as_of is not None else days
+    rows = vol_repo.fetch_history(symbol, days=fetch_days)
+    if as_of is not None:
+        rows = [r for r in rows if r["trade_date"] <= as_of]
+        rows = rows[-days:]
     return {
         r["trade_date"]: float(r["close"]) for r in rows if r.get("close") is not None
     }
 
 
-def _load_spy_series(repo: Repository, days: int) -> dict[_date, float]:
-    rows = repo.list_daily_ohlc("SPY", limit=days)
+def _load_spy_series(
+    repo: Repository, days: int, *, as_of: _date | None = None
+) -> dict[_date, float]:
+    fetch_days = days * 2 if as_of is not None else days
+    rows = repo.list_daily_ohlc("SPY", limit=fetch_days)
+    if as_of is not None:
+        rows = [r for r in rows if r.date <= as_of]
+        rows = rows[:days]
     return {r.date: float(r.close) for r in rows}
 
 
-def _load_spx_series(vol_repo: VolIndexRepository, days: int) -> dict[_date, float]:
+def _load_spx_series(
+    vol_repo: VolIndexRepository, days: int, *, as_of: _date | None = None
+) -> dict[_date, float]:
     """SPX closing levels from vol_index_daily (parquet-lake-backed)."""
-    return _load_vol_series(vol_repo, "SPX", days)
+    return _load_vol_series(vol_repo, "SPX", days, as_of=as_of)
 
 
 def _align(
@@ -70,8 +97,18 @@ def _align(
     return aligned, [d.isoformat() for d in sorted_dates]
 
 
-def run(conn: Connection, schema: str = "uw_scan") -> int | None:
+def run(
+    conn: Connection,
+    schema: str = "uw_scan",
+    *,
+    as_of: _date | None = None,
+) -> int | None:
     """Run a CRI scan against the warm store; persist a new snapshot row.
+
+    When ``as_of`` is set, the scanner computes for that historical date
+    by capping every loaded series to ``trade_date <= as_of``. The
+    resulting ``common_dates[-1]`` then equals ``as_of`` and the snapshot
+    is persisted with ``data_date=as_of``. Used by ``recover_recent_gaps``.
 
     Returns the inserted row id, or None if there isn't enough aligned data.
     """
@@ -79,15 +116,15 @@ def run(conn: Connection, schema: str = "uw_scan") -> int | None:
     repo = Repository(conn, schema=schema)
 
     mandatory_vol = {
-        "VIX": _load_vol_series(vol_repo, "VIX", LOOKBACK_DAYS),
-        "VVIX": _load_vol_series(vol_repo, "VVIX", LOOKBACK_DAYS),
-        "COR1M": _load_vol_series(vol_repo, "COR1M", LOOKBACK_DAYS),
+        "VIX": _load_vol_series(vol_repo, "VIX", LOOKBACK_DAYS, as_of=as_of),
+        "VVIX": _load_vol_series(vol_repo, "VVIX", LOOKBACK_DAYS, as_of=as_of),
+        "COR1M": _load_vol_series(vol_repo, "COR1M", LOOKBACK_DAYS, as_of=as_of),
     }
 
     # Attempt 1: SPX from vol_index_daily.
     aligned: dict[str, np.ndarray] = {}
     common_dates: list[str] = []
-    spx = _load_spx_series(vol_repo, LOOKBACK_DAYS)
+    spx = _load_spx_series(vol_repo, LOOKBACK_DAYS, as_of=as_of)
     if spx:
         aligned, common_dates = _align({**mandatory_vol, "SPX": spx})
 
@@ -101,14 +138,15 @@ def run(conn: Connection, schema: str = "uw_scan") -> int | None:
             len(common_dates),
             MIN_ALIGNED_BARS,
         )
-        spy = _load_spy_series(repo, LOOKBACK_DAYS)
+        spy = _load_spy_series(repo, LOOKBACK_DAYS, as_of=as_of)
         aligned, common_dates = _align({**mandatory_vol, "SPY": spy})
 
     if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
         log.warning(
-            "cri_scan_skipped_thin_data aligned_bars=%d need=%d",
+            "cri_scan_skipped_thin_data aligned_bars=%d need=%d as_of=%s",
             len(common_dates),
             MIN_ALIGNED_BARS,
+            as_of,
         )
         return None
 
@@ -116,7 +154,7 @@ def run(conn: Connection, schema: str = "uw_scan") -> int | None:
     # want today's value (or the latest available close on the same date
     # as the CRI snapshot) for the term-structure tile; we do NOT want a
     # stale VIX3M sync to suppress the whole snapshot.
-    vix3m_series = _load_vol_series(vol_repo, "VIX3M", LOOKBACK_DAYS)
+    vix3m_series = _load_vol_series(vol_repo, "VIX3M", LOOKBACK_DAYS, as_of=as_of)
     if vix3m_series:
         vix3m_aligned = np.array(
             [
@@ -133,10 +171,97 @@ def run(conn: Connection, schema: str = "uw_scan") -> int | None:
     data_date = _date.fromisoformat(payload["date"])
     row_id = snap_repo.insert_snapshot(payload=payload, data_date=data_date)
     log.info(
-        "cri_scan_persisted row_id=%d score=%.1f level=%s fired=%s",
+        "cri_scan_persisted row_id=%d data_date=%s score=%.1f level=%s fired=%s",
         row_id,
+        data_date,
         payload["cri"]["score"],
         payload["cri"]["level"],
         payload["crash_trigger"]["fired"],
     )
     return row_id
+
+
+def _existing_cri_dates(
+    conn: Connection, schema: str, *, since: _date
+) -> set[_date]:
+    """Distinct ``data_date`` already in ``cri_snapshots`` since ``since``."""
+    sql = f"""
+        SELECT DISTINCT data_date
+          FROM {schema}.cri_snapshots
+         WHERE data_date IS NOT NULL
+           AND data_date >= %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (since,))
+        return {r[0] for r in cur.fetchall()}
+
+
+def recover_recent_gaps(
+    conn: Connection, schema: str = "uw_scan", *, lookback_days: int = 7
+) -> dict:
+    """Fill any missing CRI snapshot in the last ``lookback_days`` trading days.
+
+    Walks the dates that exist in ``vol_index_daily`` across the three
+    mandatory series (VIX/VVIX/COR1M) plus an SPX or SPY anchor, finds the
+    subset within ``[latest - lookback_days, latest]`` that has no
+    snapshot, and runs the scanner once per missing day. Silent on dates
+    where data isn't yet present in the lake — that's the "skip if not
+    available" half of the contract.
+
+    Returns ``{"checked": N, "filled": K, "skipped": S}``. Idempotent: a
+    second call right after the first sees no missing dates and is a no-op.
+    """
+    vol_repo = VolIndexRepository(conn, schema=schema)
+
+    # Intersect mandatory series so we only consider days the scanner can
+    # actually score. SPX is preferred; SPY is the fallback (mirrors run()).
+    vix = vol_repo.fetch_dates_for("VIX")
+    vvix = vol_repo.fetch_dates_for("VVIX")
+    cor1m = vol_repo.fetch_dates_for("COR1M")
+    spx = vol_repo.fetch_dates_for("SPX")
+    if not (vix and vvix and cor1m):
+        log.info("cri_recover_skipped: mandatory series missing in lake")
+        return {"checked": 0, "filled": 0, "skipped": 0}
+
+    anchor = spx if spx else _spy_dates(conn, schema)
+    aligned_days = sorted(vix & vvix & cor1m & anchor)
+    if not aligned_days:
+        return {"checked": 0, "filled": 0, "skipped": 0}
+
+    latest = aligned_days[-1]
+    cutoff = latest - timedelta(days=lookback_days)
+    window = [d for d in aligned_days if d >= cutoff]
+
+    existing = _existing_cri_dates(conn, schema, since=cutoff)
+    missing = [d for d in window if d not in existing]
+
+    filled = 0
+    skipped = 0
+    for d in missing:
+        try:
+            rid = run(conn, schema=schema, as_of=d)
+            if rid is None:
+                skipped += 1
+            else:
+                filled += 1
+        except Exception as exc:  # noqa: BLE001
+            log.warning("cri_recover_failed as_of=%s err=%s", d, repr(exc))
+            conn.rollback()
+            skipped += 1
+
+    log.info(
+        "cri_recover_done checked=%d filled=%d skipped=%d lookback=%dd",
+        len(window),
+        filled,
+        skipped,
+        lookback_days,
+    )
+    return {"checked": len(window), "filled": filled, "skipped": skipped}
+
+
+def _spy_dates(conn: Connection, schema: str) -> set[_date]:
+    """Trade dates present in ``daily_ohlc`` for SPY — the CRI fallback anchor."""
+    sql = f"SELECT date FROM {schema}.daily_ohlc WHERE ticker = 'SPY'"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        return {r[0] for r in cur.fetchall()}

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -552,7 +552,11 @@ def run(client: UwClient, repo: Repository, ticker: str = "SPX") -> int:
             "source_delta": None,
         }
 
-        row_id = repo.upsert_gex_snapshot(ticker=ticker, payload=payload)
+        row_id = repo.upsert_gex_snapshot(
+            ticker=ticker,
+            payload=payload,
+            data_date=datetime.now(timezone.utc).date(),
+        )
         repo.finish_scan_run(run_id, status="ok")
         log.info(
             "gex_scan_done ticker=%s row_id=%d net_gex=%.2e",

--- a/src/uw_scan/scanners/vcg.py
+++ b/src/uw_scan/scanners/vcg.py
@@ -6,12 +6,16 @@ set, runs ``cards/vcg_scoring.run_analysis``, persists the snapshot via
 
 No external API calls — all inputs come from the parquet-lake-backed
 vol_index_daily table.
+
+Recovery: ``recover_recent_gaps`` walks the last N trading days and runs
+the scanner for any day that has aligned vol_index_daily data but no
+vcg_snapshots row.
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import date as _date
+from datetime import date as _date, timedelta
 
 import numpy as np
 from psycopg import Connection
@@ -38,6 +42,7 @@ def _load_series(
     days: int,
     *,
     prefer_adj_close: bool = False,
+    as_of: _date | None = None,
 ) -> dict[_date, float]:
     """Build {date: price} from vol_index_daily.
 
@@ -46,8 +51,15 @@ def _load_series(
     as credit stress. Set ``prefer_adj_close=True`` for the credit proxy so
     distributions are absorbed at source; VIX/VVIX have no such adjustment
     and keep raw ``close``.
+
+    When ``as_of`` is set the lookback caps at ``trade_date <= as_of`` so
+    the historical-recovery path can re-aim the scanner at a previous day.
     """
-    rows = vol_repo.fetch_history(symbol, days=days)
+    fetch_days = days * 2 if as_of is not None else days
+    rows = vol_repo.fetch_history(symbol, days=fetch_days)
+    if as_of is not None:
+        rows = [r for r in rows if r["trade_date"] <= as_of]
+        rows = rows[-days:]
     out: dict[_date, float] = {}
     for r in rows:
         price = r.get("adj_close") if prefer_adj_close else None
@@ -84,25 +96,37 @@ def run(
     *,
     proxy: str = DEFAULT_PROXY,
     schema: str = "uw_scan",
+    as_of: _date | None = None,
 ) -> int | None:
     """Run a VCG scan; persist a new snapshot row.
+
+    When ``as_of`` is set, the scanner computes for that historical date by
+    capping every loaded series; the snapshot persists with
+    ``data_date=as_of``. Used by ``recover_recent_gaps``.
 
     Returns the inserted row id, or None if there isn't enough aligned data.
     """
     vol_repo = VolIndexRepository(conn, schema=schema)
     raw = {
-        "VIX": _load_series(vol_repo, "VIX", LOOKBACK_DAYS),
-        "VVIX": _load_series(vol_repo, "VVIX", LOOKBACK_DAYS),
-        proxy: _load_series(vol_repo, proxy, LOOKBACK_DAYS, prefer_adj_close=True),
+        "VIX": _load_series(vol_repo, "VIX", LOOKBACK_DAYS, as_of=as_of),
+        "VVIX": _load_series(vol_repo, "VVIX", LOOKBACK_DAYS, as_of=as_of),
+        proxy: _load_series(
+            vol_repo,
+            proxy,
+            LOOKBACK_DAYS,
+            prefer_adj_close=True,
+            as_of=as_of,
+        ),
     }
     aligned, common_dates = _align(raw)
 
     if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
         log.warning(
-            "vcg_scan_skipped_thin_data proxy=%s aligned_bars=%d need=%d",
+            "vcg_scan_skipped_thin_data proxy=%s aligned_bars=%d need=%d as_of=%s",
             proxy,
             len(common_dates),
             MIN_ALIGNED_BARS,
+            as_of,
         )
         return None
 
@@ -112,8 +136,9 @@ def run(
     row_id = snap_repo.insert_snapshot(payload=payload, data_date=data_date)
     sig = payload["signal"]
     log.info(
-        "vcg_scan_persisted row_id=%d proxy=%s vcg=%s interp=%s ro=%d edr=%d",
+        "vcg_scan_persisted row_id=%d data_date=%s proxy=%s vcg=%s interp=%s ro=%d edr=%d",
         row_id,
+        data_date,
         proxy,
         sig.get("vcg"),
         sig.get("interpretation"),
@@ -121,3 +146,77 @@ def run(
         sig.get("edr", 0),
     )
     return row_id
+
+
+def _existing_vcg_dates(
+    conn: Connection, schema: str, *, since: _date, proxy: str
+) -> set[_date]:
+    """Distinct ``data_date`` in ``vcg_snapshots`` for ``proxy`` since ``since``.
+
+    Filters by ``payload->>'credit_proxy'`` (the field name vcg_scoring
+    writes) so swapping HYG → JNK in config doesn't cause us to skip the
+    JNK day because an HYG row happened to land on it.
+    """
+    sql = f"""
+        SELECT DISTINCT data_date
+          FROM {schema}.vcg_snapshots
+         WHERE data_date IS NOT NULL
+           AND data_date >= %s
+           AND payload->>'credit_proxy' = %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (since, proxy))
+        return {r[0] for r in cur.fetchall()}
+
+
+def recover_recent_gaps(
+    conn: Connection,
+    schema: str = "uw_scan",
+    *,
+    proxy: str = DEFAULT_PROXY,
+    lookback_days: int = 7,
+) -> dict:
+    """Fill any missing VCG snapshot in the last ``lookback_days`` trading days.
+
+    Mirrors the CRI recovery shape — see ``scanners/cri.recover_recent_gaps``
+    for the doc and contract.
+    """
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    vix = vol_repo.fetch_dates_for("VIX")
+    vvix = vol_repo.fetch_dates_for("VVIX")
+    proxy_dates = vol_repo.fetch_dates_for(proxy)
+    if not (vix and vvix and proxy_dates):
+        log.info("vcg_recover_skipped: mandatory series missing in lake")
+        return {"checked": 0, "filled": 0, "skipped": 0}
+
+    aligned_days = sorted(vix & vvix & proxy_dates)
+    latest = aligned_days[-1]
+    cutoff = latest - timedelta(days=lookback_days)
+    window = [d for d in aligned_days if d >= cutoff]
+
+    existing = _existing_vcg_dates(conn, schema, since=cutoff, proxy=proxy)
+    missing = [d for d in window if d not in existing]
+
+    filled = 0
+    skipped = 0
+    for d in missing:
+        try:
+            rid = run(conn, proxy=proxy, schema=schema, as_of=d)
+            if rid is None:
+                skipped += 1
+            else:
+                filled += 1
+        except Exception as exc:  # noqa: BLE001
+            log.warning("vcg_recover_failed as_of=%s err=%s", d, repr(exc))
+            conn.rollback()
+            skipped += 1
+
+    log.info(
+        "vcg_recover_done proxy=%s checked=%d filled=%d skipped=%d lookback=%dd",
+        proxy,
+        len(window),
+        filled,
+        skipped,
+        lookback_days,
+    )
+    return {"checked": len(window), "filled": filled, "skipped": skipped}

--- a/src/uw_scan/storage/gex.py
+++ b/src/uw_scan/storage/gex.py
@@ -38,24 +38,54 @@ class _GexMixin:
     def fetch_flip_strike_history(self, *, ticker: str, limit: int = 90) -> dict:
         """Return ``{trade_date: gex_flip_strike}`` for the most recent N days.
 
+        Thin shim over ``fetch_metrics_history`` — kept for the (still-shipped)
+        callers that only need the flip strike. New call sites should reach
+        for ``fetch_metrics_history`` to get flip + iv30d + vol_pc + bias in
+        a single query.
+        """
+        metrics = self.fetch_metrics_history(ticker=ticker, limit=limit)
+        return {d: m["flip"] for d, m in metrics.items() if m.get("flip") is not None}
+
+    def fetch_metrics_history(
+        self, *, ticker: str, limit: int = 90
+    ) -> dict[object, dict]:
+        """Return ``{trade_date: {flip, iv_30d, vol_pc, bias}}`` for the most
+        recent N days.
+
         Multiple snapshots per day may exist; the latest scan wins (max
-        ``scanned_at`` per ``data_date``). Days without a flip strike are
-        omitted — UI renders sparse.
+        ``scanned_at`` per ``data_date``). Days where the column is NULL come
+        through as ``None`` so the GEX history table can render ``"---"``
+        per cell instead of dropping the whole row.
+
+        ``bias`` is read from ``payload->'bias'->>'direction'`` rather than
+        a dedicated column because the snapshot schema kept the bias
+        derivation inside the JSON payload (see ``scanners/gex.py``
+        ``compute_directional_bias``).
         """
         sql = f"""
             SELECT DISTINCT ON (data_date)
                    data_date,
-                   level_gex_flip_strike::float8 AS flip
+                   level_gex_flip_strike::float8 AS flip,
+                   iv_30d::float8                AS iv_30d,
+                   vol_pc::float8                AS vol_pc,
+                   payload->'bias'->>'direction' AS bias
               FROM {self._schema}.gex_snapshots
              WHERE ticker = %s
                AND data_date IS NOT NULL
-               AND level_gex_flip_strike IS NOT NULL
              ORDER BY data_date DESC, scanned_at DESC
              LIMIT %s
         """
         with self._conn.cursor() as cur:
             cur.execute(sql, (ticker.upper(), limit))
-            return {row[0]: row[1] for row in cur.fetchall()}
+            return {
+                row[0]: {
+                    "flip": row[1],
+                    "iv_30d": row[2],
+                    "vol_pc": row[3],
+                    "bias": row[4],
+                }
+                for row in cur.fetchall()
+            }
 
     def upsert_gex_snapshot(
         self,

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -65,6 +65,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger("uw_scan.worker")
 RESCAN_WORKER_CONCURRENCY = 2
+# Each regime scan tick checks the last N trading days for missing snapshots
+# and fills them. 7 days is enough to ride out a long-weekend outage on the
+# primary worker without growing the per-tick work unboundedly. Match this
+# value if you change the cron interval — too-short means missed gaps
+# linger; too-long is wasted set-membership checks per tick (cheap, but
+# pointless).
+REGIME_RECOVERY_LOOKBACK_DAYS = 7
 WorkerGroup = Literal["uw", "massive", "ai", "ai-codex", "ai-claude", "ai-deepseek"]
 WORKER_ROLES: set[str] = {
     "all",
@@ -479,42 +486,65 @@ def main() -> int:
 
     def _regime_vcg_scan() -> None:
         # Reads vol_index_daily (VIX/VVIX + the credit proxies); writes
-        # vcg_snapshots. No external API spend. Append-only.
+        # vcg_snapshots. No external API spend. Self-healing via
+        # ``recover_recent_gaps`` — fills any missing day in the last
+        # ``REGIME_RECOVERY_LOOKBACK_DAYS``, including today. Idempotent;
+        # repeated ticks with no new lake data are a no-op.
         from uw_scan.scanners import vcg as vcg_scanner
 
         proxy = settings.credit_etf_symbols[0] if settings.credit_etf_symbols else "HYG"
         with _repo(settings) as repo:
-            row_id = vcg_scanner.run(repo.conn, proxy=proxy, schema=settings.db_schema)
-            if row_id is None:
-                logger.info("regime_vcg_scan_skipped_thin_data proxy=%s", proxy)
-            else:
-                logger.info(
-                    "regime_vcg_scan_persisted proxy=%s row_id=%d", proxy, row_id
-                )
+            summary = vcg_scanner.recover_recent_gaps(
+                repo.conn,
+                schema=settings.db_schema,
+                proxy=proxy,
+                lookback_days=REGIME_RECOVERY_LOOKBACK_DAYS,
+            )
+        logger.info(
+            "regime_vcg_scan_tick proxy=%s checked=%d filled=%d skipped=%d",
+            proxy,
+            summary["checked"],
+            summary["filled"],
+            summary["skipped"],
+        )
 
     def _regime_cri_scan() -> None:
         # Reads vol_index_daily + daily_ohlc; writes cri_snapshots. No external
-        # API spend. Append-only — running twice in an hour is harmless.
+        # API spend. Self-healing — see _regime_vcg_scan comment.
         from uw_scan.scanners import cri as cri_scanner
 
         with _repo(settings) as repo:
-            row_id = cri_scanner.run(repo.conn, schema=settings.db_schema)
-            if row_id is None:
-                logger.info("regime_cri_scan_skipped_thin_data")
-            else:
-                logger.info("regime_cri_scan_persisted row_id=%d", row_id)
+            summary = cri_scanner.recover_recent_gaps(
+                repo.conn,
+                schema=settings.db_schema,
+                lookback_days=REGIME_RECOVERY_LOOKBACK_DAYS,
+            )
+        logger.info(
+            "regime_cri_scan_tick checked=%d filled=%d skipped=%d",
+            summary["checked"],
+            summary["filled"],
+            summary["skipped"],
+        )
 
     def _regime_canary_scan() -> None:
         # Reads vol_index_daily (VIX/VVIX/VIX3M/COR1M/SPX); writes
-        # canary_snapshots. No external API spend. Append-only / idempotent.
+        # canary_snapshots. composite_version is part of the dedup key, so
+        # bumping the calibration version automatically triggers fresh
+        # snapshots on the next tick. Self-healing — see _regime_vcg_scan.
         from uw_scan.scanners import canary as canary_scanner
 
         with _repo(settings) as repo:
-            row_id = canary_scanner.run(repo.conn, schema=settings.db_schema)
-            if row_id is None:
-                logger.info("regime_canary_scan_skipped_thin_data")
-            else:
-                logger.info("regime_canary_scan_persisted row_id=%d", row_id)
+            summary = canary_scanner.recover_recent_gaps(
+                repo.conn,
+                schema=settings.db_schema,
+                lookback_days=REGIME_RECOVERY_LOOKBACK_DAYS,
+            )
+        logger.info(
+            "regime_canary_scan_tick checked=%d filled=%d skipped=%d",
+            summary["checked"],
+            summary["filled"],
+            summary["skipped"],
+        )
 
     def _regime_gex_scan() -> None:
         # Weekday gate — UW data only meaningful during regular sessions.

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -284,7 +284,8 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
                   }}
                 >
                   {data.day_change >= 0 ? "+" : ""}
-                  {fmtPrice(data.day_change)} ({formatPercent(data.day_change_pct)})
+                  {fmtPrice(data.day_change)} (
+                  {formatPercent(data.day_change_pct)})
                 </span>
               ) : undefined
             }
@@ -333,17 +334,18 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
             label="IV 30D"
             tooltip="30-day implied volatility from UW iv_rank endpoint (not 0DTE greeks). Source-tagged: UW = Unusual Whales, MQ = MenthorQ, UW+MQ = both sources agree."
             value={
+              // UW iv_rank.volatility is a 0–1 fraction; tile shows percent.
               data.iv?.iv30d != null
-                ? `${data.iv.iv30d.toFixed(1)}%`
+                ? `${(data.iv.iv30d * 100).toFixed(1)}%`
                 : data.iv?.mq_iv30d != null
-                  ? `${data.iv.mq_iv30d.toFixed(1)}%`
+                  ? `${(data.iv.mq_iv30d * 100).toFixed(1)}%`
                   : data.atm_iv != null
-                    ? `${data.atm_iv.toFixed(1)}%`
+                    ? `${(data.atm_iv * 100).toFixed(1)}%`
                     : "---"
             }
             sub={
               data.iv?.iv_rank != null
-                ? `rank ${data.iv.iv_rank.toFixed(0)}%${data.iv.hv30 != null ? `  HV ${data.iv.hv30.toFixed(1)}%` : ""}`
+                ? `rank ${data.iv.iv_rank.toFixed(0)}%${data.iv.hv30 != null ? `  HV ${(data.iv.hv30 * 100).toFixed(1)}%` : ""}`
                 : data.expected_range.iv_1d != null
                   ? `±${data.expected_range.iv_1d.toFixed(2)}% 1d`
                   : undefined

--- a/web/components/regime/gex/GexHistoryTable.tsx
+++ b/web/components/regime/gex/GexHistoryTable.tsx
@@ -25,7 +25,9 @@ function sortIndicator(
 }
 
 export function GexHistoryTable({ history }: { history: GexHistoryEntry[] }) {
-  const [sortCol, setSortCol] = useState<GexSortCol | null>(null);
+  // Default newest-first; the sibling chart consumes the same `history`
+  // array ASC, so we sort here instead of flipping the API response.
+  const [sortCol, setSortCol] = useState<GexSortCol | null>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [expanded, setExpanded] = useState(false);
 
@@ -111,7 +113,9 @@ export function GexHistoryTable({ history }: { history: GexHistoryEntry[] }) {
                   </td>
                   <td className="text-right">{fmtGex(row.net_dex)}</td>
                   <td className="text-right">
-                    {row.atm_iv != null ? `${row.atm_iv.toFixed(1)}%` : "---"}
+                    {row.atm_iv != null
+                      ? `${(row.atm_iv * 100).toFixed(1)}%`
+                      : "---"}
                   </td>
                   <td className="text-right">
                     {row.vol_pc != null ? row.vol_pc.toFixed(2) : "---"}


### PR DESCRIPTION
## Summary

Fixes the regime page after the macmini scheduler stalled for ~13 days in May, and prevents the next freeze from compounding the same way.

### What broke (root causes)

1. **GEX history flip line empty everywhere** — scanner stored `data_date` in payload JSON but never as the dedicated column. `fetch_flip_strike_history` filters `WHERE data_date IS NOT NULL` so it returned empty for all 8621 rows.
2. **CRI / VCG / Canary stale for 2 weeks** — primary worker stopped firing the hourly regime crons around 2026-05-25 ~11:20 ET. Even after the worker came back, the scanners only computed "today" so the gap stayed unfilled.
3. **IV 30D tile showed "0.1%"** — UW `iv_rank.volatility` is a 0–1 fraction; tile hand-rolled `iv30d.toFixed(1) + "%"` without ×100. Same bug in the history table cell.
4. **IV 30D / VOL P/C / Bias columns rendered "---"** in the history table — Pydantic + TS schemas already had the fields, but `_assemble_history` never populated them.
5. **History table sorted oldest-first** — table had no default sort; rendered in API order which is ASC (the chart needs ASC, the table wants DESC).

### What's in this PR

**Commit 1 — `fix(regime): populate gex_snapshots.data_date + scale iv30d tile`**
- `scanners/gex.py:555` — pass `data_date=` to `upsert_gex_snapshot`.
- `web/components/regime/GexSubTab.tsx` — multiply `iv30d` / `mq_iv30d` / `atm_iv` / `hv30` by 100 in the tile (matches the canonical `fmtPct` helper used elsewhere).
- `scripts/oneshot/regime_backfill_2026_05.py` — one-shot already used to recompute CRI/VCG/Canary for 2026-05-22 → 06-03 against macmini.

**Commit 2 — `fix(regime): self-healing recovery + populate history columns + sort DESC`**
- `scanners/cri.py`, `scanners/vcg.py`, `scanners/canary.py` — added `as_of: date | None = None` kwarg (caps every loaded series to `<= as_of`; existing callers backwards-compatible) and a new `recover_recent_gaps(conn, schema, lookback_days=7)` that walks recent trading days and fills any day with aligned lake data but no snapshot.
- `worker/scheduler.py` — each `_regime_cri_scan / vcg_scan / canary_scan` tick now calls `recover_recent_gaps` instead of single-shot `run()`. Idempotent — a clean DB sees zero missing days and the tick is a no-op.
- `storage/gex.py` — new `fetch_metrics_history(ticker, limit)` pulls `flip + iv_30d + vol_pc + payload->bias->>direction` per day. `fetch_flip_strike_history` kept as a thin shim.
- `api/routers/regime.py` `_assemble_history` — populates `atm_iv`, `vol_pc`, `bias` per row via the new fetch.
- `web/components/regime/gex/GexHistoryTable.tsx` — defaults `sortCol="date" sortDir="desc"` so the table reads newest-first (chart still consumes ASC for `xScale(i)`); IV 30D cell uses ×100.

### DB writes already applied to macmini (no rollback needed)

- `vol_index_daily`: +113 vol rows + 30 credit-ETF rows; fresh through 2026-06-03
- `gex_snapshots`: 8621 rows had `data_date` backfilled from payload JSON
- `cri_snapshots`: +9 rows · `vcg_snapshots`: +11 rows · `canary_snapshots`: +9 rows

### Tests

- Python: 94 affected integration + e2e tests pass (`test_cri_scanner`, `test_vcg_scanner`, `test_canary_scanner`, `test_gex_repository`, `test_gex_scanner`, `test_regime_classification_e2e`, full `tests/integration/regime/`, etc.)
- Vitest: 367/367
- TypeScript: clean
- `recover_recent_gaps` smoke-tested against macmini DB: cri/vcg/canary all returned `checked=6 filled=0 skipped=0` (already healed)

## Test plan

- [ ] Deploy via `scripts/deploy/macmini-deploy-branch.sh`
- [ ] Hit `/api/regime/gex?ticker=SPX` — verify history rows now include populated `atm_iv` / `vol_pc` / `bias` for the days where gex_snapshots exists
- [ ] Open `/regime` GEX sub-tab — verify IV 30D tile shows ~12.7% not 0.1%; history table newest-first; IV 30D / VOL P/C / Bias columns populate on the recent ~12 rows
- [ ] Watch `tail -F logs/worker-uw-0.err.log` for `regime_cri_scan_tick checked=N filled=0 skipped=0` lines confirming the self-healing runs
- [ ] Separately investigate the upstream R2 publisher (R2 lake stuck at 2026-05-21 while MacBook mirror is fresh through 06-03) and the dead `com.argon.massive-ws` — these are unrelated to this PR