### PR TITLE
fix(regime,gold): VCG 252d %ile populated + CB picker no-default

### DIFF
--- a/scripts/oneshot/vcg_percentile_backfill.py
+++ b/scripts/oneshot/vcg_percentile_backfill.py
@@ -123,11 +123,14 @@ def main() -> int:
             log.info("=== %s ===", d.isoformat())
             restore = _patch_loader(d)
             try:
+                # The monkey-patch above caps fetch_history at as_of; vcg.run()
+                # then aligns to common_dates[-1] = as_of with no as_of kwarg
+                # needed. This keeps the script independent of the as_of-aware
+                # scanner signature (added in a sibling branch / PR #115).
                 row_id = vcg_scanner.run(
                     conn,
                     proxy=args.proxy,
                     schema=settings.db_schema,
-                    as_of=d,
                 )
                 if row_id is None:
                     log.warning("  skipped (thin data)")

--- a/scripts/oneshot/vcg_percentile_backfill.py
+++ b/scripts/oneshot/vcg_percentile_backfill.py
@@ -37,18 +37,16 @@ import logging
 from datetime import date
 
 import psycopg
-from dotenv import load_dotenv
 
-load_dotenv()
+from uw_scan.config import Settings
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 log = logging.getLogger("vcg_percentile_backfill")
-
-from uw_scan.config import Settings
-from uw_scan.scanners import vcg as vcg_scanner
-from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 
 def _patch_loader(as_of: date):

--- a/scripts/oneshot/vcg_percentile_backfill.py
+++ b/scripts/oneshot/vcg_percentile_backfill.py
@@ -1,0 +1,149 @@
+"""One-shot backfill for VCG snapshots missing vix/vvix percentile_rank fields.
+
+Why this exists: between 2026-05-15 and 2026-06-03, every persisted
+``vcg_snapshots`` row has ``payload->signal->vix_percentile_rank = null``
+because ``scanners/vcg.py`` loaded ``LOOKBACK_DAYS=200`` while
+``vcg_scoring.VOL_PERCENTILE_WINDOW=252``. The rolling window never had
+enough bars and ``compute_rolling_percentile_rank`` silently returned NaN,
+which ``_round_or_none`` then turned into ``None``. The constant was bumped
+to ``LOOKBACK_DAYS=300`` so new scans populate the field — this script
+re-runs the scanner once per distinct ``data_date`` so the historical rows
+stop showing "—" on the regime page's Signal Detail tile.
+
+The scanner always computes against ``common_dates[-1]``. To re-aim it at a
+historical day we monkey-patch ``VolIndexRepository.fetch_history`` so it
+returns rows up to and including ``as_of`` only. Same pattern as
+``regime_backfill_2026_05.py``.
+
+Safe to re-run: vcg uses INSERT (multiple rows per day OK; ``fetch_latest``
+returns ORDER BY scanned_at DESC LIMIT 1, so the freshest backfill wins).
+
+**Where to run:** the macmini launchd worker host (the canonical writer for
+``option_wizard``). Running from the MacBook against the mini DB is allowed
+by the tripwire if ``.env.local`` overrides both host and db name, but the
+hourly cron on the mini will produce the same fix on its own — this script
+just shortcuts that for the existing historical rows.
+
+Usage:
+    uv run python scripts/oneshot/vcg_percentile_backfill.py
+    uv run python scripts/oneshot/vcg_percentile_backfill.py --dry-run
+    uv run python scripts/oneshot/vcg_percentile_backfill.py --proxy HYG
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import date
+
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+log = logging.getLogger("vcg_percentile_backfill")
+
+from uw_scan.config import Settings
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _patch_loader(as_of: date):
+    """Cap ``VolIndexRepository.fetch_history`` so ``common_dates[-1] == as_of``."""
+    orig_fetch = VolIndexRepository.fetch_history
+
+    def fetch_history_capped(self, symbol, days):
+        rows = orig_fetch(self, symbol, days * 2)
+        rows = [r for r in rows if r["trade_date"] <= as_of]
+        return rows[-days:] if days and len(rows) > days else rows
+
+    VolIndexRepository.fetch_history = fetch_history_capped
+
+    def restore():
+        VolIndexRepository.fetch_history = orig_fetch
+
+    return restore
+
+
+def _stale_data_dates(conn: psycopg.Connection, schema: str, proxy: str) -> list[date]:
+    """Distinct ``data_date`` values whose latest row for ``proxy`` lacks vix_pr."""
+    sql = f"""
+        SELECT data_date
+          FROM {schema}.vcg_snapshots
+         WHERE data_date IS NOT NULL
+           AND credit_proxy = %s
+         GROUP BY data_date
+        HAVING bool_and(
+                 payload->'signal'->>'vix_percentile_rank' IS NULL
+              OR payload->'signal'->>'vix_percentile_rank' = 'null'
+               )
+         ORDER BY data_date
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (proxy,))
+        return [r[0] for r in cur.fetchall()]
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--proxy", default=vcg_scanner.DEFAULT_PROXY)
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List dates that would be backfilled without inserting.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    settings = Settings.from_env()
+    log.info(
+        "target: %s/%s schema=%s proxy=%s",
+        settings.db_host,
+        settings.db_name,
+        settings.db_schema,
+        args.proxy,
+    )
+
+    conn = psycopg.connect(settings.db_dsn())
+    try:
+        dates = _stale_data_dates(conn, settings.db_schema, args.proxy)
+        log.info("found %d data_date(s) with all-null vix_percentile_rank", len(dates))
+        for d in dates:
+            log.info("  stale: %s", d.isoformat())
+        if args.dry_run or not dates:
+            return 0
+
+        inserted = 0
+        for d in dates:
+            log.info("=== %s ===", d.isoformat())
+            restore = _patch_loader(d)
+            try:
+                row_id = vcg_scanner.run(
+                    conn,
+                    proxy=args.proxy,
+                    schema=settings.db_schema,
+                    as_of=d,
+                )
+                if row_id is None:
+                    log.warning("  skipped (thin data)")
+                else:
+                    log.info("  vcg row_id=%s inserted", row_id)
+                    inserted += 1
+            except Exception as exc:
+                log.warning("  vcg failed: %r", exc)
+                conn.rollback()
+            finally:
+                restore()
+        log.info("backfill complete: %d/%d days re-scanned", inserted, len(dates))
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uw_scan/scanners/vcg.py
+++ b/src/uw_scan/scanners/vcg.py
@@ -22,9 +22,11 @@ from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 log = logging.getLogger(__name__)
 
-# Lookback — enough for the 21d OLS, the 63d z-window, the 20-day history,
-# plus slack for weekends/holidays so we still have ≥ MIN_BARS aligned days.
-LOOKBACK_DAYS = 200
+# Lookback — must cover the 252-day rolling percentile window (VIX/VVIX
+# %ile) which is the largest budget. 21d OLS, 63d z-window, and 20-day
+# history all fit inside that. Slack for proxy alignment gaps (HYG/JNK
+# don't always overlap VIX days 1:1).
+LOOKBACK_DAYS = 300
 MIN_ALIGNED_BARS = vcg_scoring.MIN_BARS
 
 DEFAULT_PROXY = "HYG"

--- a/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
+++ b/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
@@ -71,8 +71,10 @@ const CB_COLORS = [
 
 const CHART_PADDING = { top: 12, right: 56, bottom: 24, left: 48 } as const;
 
-function defaultSelected(_countries: Country[]): string[] {
-  return [];
+function strategicCountries(countries: Country[]): string[] {
+  return countries
+    .filter((c) => c.bucket === "strategic_accumulator")
+    .map((c) => c.country_iso3);
 }
 
 function fmtCountryTonnes(v: string | number | null | undefined): string {
@@ -89,9 +91,7 @@ export function GoldHoldingsVsPriceChart({
   width = 1040,
   height = 200,
 }: Props) {
-  const [selectedCountries, setSelectedCountries] = useState<string[]>(() =>
-    defaultSelected(cbCountryHistory),
-  );
+  const [selectedCountries, setSelectedCountries] = useState<string[]>([]);
   const selectedSet = useMemo(
     () => new Set(selectedCountries),
     [selectedCountries],
@@ -421,7 +421,7 @@ export function GoldHoldingsVsPriceChart({
             <button
               type="button"
               onClick={() =>
-                setSelectedCountries(defaultSelected(cbCountryHistory))
+                setSelectedCountries(strategicCountries(cbCountryHistory))
               }
               style={toggleButtonStyle}
               title="Strategic accumulators: China, Russia, India, and Turkey when present."

--- a/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
+++ b/web/components/gold/lens1/GoldHoldingsVsPriceChart.tsx
@@ -71,12 +71,8 @@ const CB_COLORS = [
 
 const CHART_PADDING = { top: 12, right: 56, bottom: 24, left: 48 } as const;
 
-function defaultSelected(countries: Country[]): string[] {
-  const strategic = countries
-    .filter((c) => c.bucket === "strategic_accumulator")
-    .map((c) => c.country_iso3);
-  if (strategic.length > 0) return strategic;
-  return countries.slice(0, 4).map((c) => c.country_iso3);
+function defaultSelected(_countries: Country[]): string[] {
+  return [];
 }
 
 function fmtCountryTonnes(v: string | number | null | undefined): string {
@@ -212,10 +208,12 @@ export function GoldHoldingsVsPriceChart({
       visibleCountries.map((country) => ({
         country,
         points: tonnesYScale
-          ? (country.history ?? []).map((p): Point => [
-              xScale?.(new Date(p.obs_date).getTime()) ?? 0,
-              tonnesYScale(toNumber(p.value)),
-            ])
+          ? (country.history ?? []).map(
+              (p): Point => [
+                xScale?.(new Date(p.obs_date).getTime()) ?? 0,
+                tonnesYScale(toNumber(p.value)),
+              ],
+            )
           : [],
       })),
     [visibleCountries, tonnesYScale, xScale],
@@ -384,7 +382,11 @@ export function GoldHoldingsVsPriceChart({
                 GLD price ($)
               </text>
               {tonnesYScale && (
-                <text x={padding.left + 70} y={9} fill="var(--warning, #f5a623)">
+                <text
+                  x={padding.left + 70}
+                  y={9}
+                  fill="var(--warning, #f5a623)"
+                >
                   GLD holdings + CB reserves (tonnes)
                 </text>
               )}
@@ -474,7 +476,8 @@ export function GoldHoldingsVsPriceChart({
                     width: 8,
                     height: 8,
                     background:
-                      countryColorByIso3.get(country.country_iso3) ?? CB_COLORS[0],
+                      countryColorByIso3.get(country.country_iso3) ??
+                      CB_COLORS[0],
                     display: "inline-block",
                   }}
                 />
@@ -485,7 +488,8 @@ export function GoldHoldingsVsPriceChart({
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {country.country_iso3} · {fmtCountryTonnes(country.latest_reserves_t)}
+                  {country.country_iso3} ·{" "}
+                  {fmtCountryTonnes(country.latest_reserves_t)}
                 </span>
               </label>
             );

--- a/web/tests/unit/goldCompassLayout.test.tsx
+++ b/web/tests/unit/goldCompassLayout.test.tsx
@@ -178,8 +178,10 @@ describe("GoldCompassLayout", () => {
     expect(screen.getByText(/Central bank reserves by country/)).toBeTruthy();
     const chinaToggle = screen.getByLabelText("Toggle China");
     expect(chinaToggle).toBeTruthy();
-    fireEvent.click(chinaToggle);
+    // Page starts with no CBs pre-selected — toggle should be unchecked.
     expect((chinaToggle as HTMLInputElement).checked).toBe(false);
+    fireEvent.click(chinaToggle);
+    expect((chinaToggle as HTMLInputElement).checked).toBe(true);
   });
 
   it("uses posture language only (no buy/sell/long/short)", () => {


### PR DESCRIPTION
## Summary

Two independent bug fixes that surfaced during a regime/rates page audit:

1. **VCG VIX/VVIX 252d %ile always rendered "—"** — `scanners/vcg.py` loaded `LOOKBACK_DAYS=200` from `vol_index_daily`, but `vcg_scoring.VOL_PERCENTILE_WINDOW=252`. The 252-day rolling window never had enough bars, `compute_rolling_percentile_rank` returned NaN, and `_round_or_none` turned it into `None`. All 2392 persisted `vcg_snapshots` had `payload->signal->vix_percentile_rank = null`. The regime page's Signal Detail tile rendered "—" for both VIX 252d %ile and VVIX 252d %ile on every load.

   **Fix:** bump `LOOKBACK_DAYS` to 300 (252 + ~48 slack for proxy alignment gaps when HYG/JNK don't perfectly overlap VIX days). Comment updated to make the percentile window the binding budget.

   **Backfill:** `scripts/oneshot/vcg_percentile_backfill.py` finds `data_dates` whose every payload has `vix_pr=null` and re-runs `vcg.run()` once per date with the loader monkey-patched to cap at `as_of`. Same shape as `oneshot/regime_backfill_2026_05.py`. Idempotent (append-only INSERT + latest-wins `fetch_latest`).

2. **Gold page CB picker pre-checked CHN/RUS/IND/TUR** — `GoldHoldingsVsPriceChart.tsx`'s `defaultSelected` pre-selected every `strategic_accumulator` bucket country on first paint. Replaced with empty-array default — users start clean. The existing "Strategic" quick-button at L421 still gives one-click access to the accumulator bucket.

## Verification

**DB (live mini):**
```
backfill complete: 12/12 days re-scanned
2026-06-03 vix_pr=0.251  vvix_pr=0.0916
2026-06-02 vix_pr=0.2072 vvix_pr=0.1116
2026-06-01 vix_pr=0.243  vvix_pr=0.1594
...
```

**Web (localhost:3001/regime VCG tab) after API restart:**
- VIX 252d %ile: 25.1% (was "—")
- VVIX 252d %ile: 9.2% (was "—")

## Test plan

- [ ] `uv run pytest` (no VCG unit tests exist — see follow-up below)
- [ ] `cd web && npm run typecheck` — passes ✓
- [ ] After merge: macmini pulls main → workers restart → hourly VCG tick (`:25`) auto-fixes the LATEST panel
- [ ] After merge: run `uv run python scripts/oneshot/vcg_percentile_backfill.py` on the mini to also populate the 11 historical `data_dates` (optional — they're not surfaced in the current UI)
- [ ] Web redeploy picks up the gold CB default

## Follow-up (not in this PR)

- No VCG unit tests exist; worth adding a regression that asserts `vix_percentile_rank is not None` for a >252-bar fixture.

## Related

- Branch `fix/regime-page-backfill-and-iv30d-tile` / #115 is the separate (already-open) regime ingest self-heal PR — the LOOKBACK_DAYS issue is independent of that recovery work.