### PR TITLE
chore(macmini): align deploy + bootstrap with the new DB tripwire

### DIFF
--- a/scripts/deploy/macmini-bootstrap.sh
+++ b/scripts/deploy/macmini-bootstrap.sh
@@ -253,15 +253,17 @@ step ".env files"
 if [[ ! -f "${ARGON_HOME}/.env" ]]; then
   say "Creating .env from .env.example (you must fill secrets before services start)"
   cp "${ARGON_HOME}/.env.example" "${ARGON_HOME}/.env"
-  # The .env.example default points UW_SCAN_DB_HOST at 127.0.0.1 already; for
-  # the mini, this is correct (loopback to local Postgres). Inject the
-  # generated password.
+  # The .env.example defaults are tuned for MacBook dev (HOST=127.0.0.1,
+  # NAME=option_wizard_local). On the mini, we point HOST at the Tailscale
+  # address so the (host, db_name) tripwire in uw_scan.config recognises
+  # (100.66.147.98, option_wizard) as the prodlike combo, and override
+  # NAME / USER / PASSWORD to the mini-specific values.
   python3 - <<PY
 from pathlib import Path
 p = Path("${ARGON_HOME}/.env")
 text = p.read_text()
-text = text.replace("UW_SCAN_DB_HOST=100.66.147.98", "UW_SCAN_DB_HOST=127.0.0.1")
-text = text.replace("UW_SCAN_DB_NAME=option_wizard", "UW_SCAN_DB_NAME=${ARGON_DB_NAME}")
+text = text.replace("UW_SCAN_DB_HOST=127.0.0.1", "UW_SCAN_DB_HOST=100.66.147.98")
+text = text.replace("UW_SCAN_DB_NAME=option_wizard_local", "UW_SCAN_DB_NAME=${ARGON_DB_NAME}")
 text = text.replace("UW_SCAN_DB_USER=argon_app", "UW_SCAN_DB_USER=${ARGON_DB_ROLE}")
 text = text.replace("UW_SCAN_DB_PASSWORD=", "UW_SCAN_DB_PASSWORD=${ARGON_DB_PASSWORD}", 1)
 p.write_text(text)

--- a/scripts/deploy/macmini-deploy-branch.sh
+++ b/scripts/deploy/macmini-deploy-branch.sh
@@ -45,7 +45,12 @@ say "Push $BRANCH to origin"
 git push origin "$BRANCH"
 
 # 2. Build the remote command
-REMOTE_CMD="set -euo pipefail
+# PATH prefix: non-interactive SSH doesn't source ~/.zprofile, so Homebrew-
+# installed CLIs (uv) and the keg-only postgresql@17 psql aren't on PATH.
+# Mirror the PATH that com.argon.worker plists already use, plus the
+# postgresql@17 bindir for migrate.sh.
+REMOTE_CMD='export PATH="/opt/homebrew/bin:/opt/homebrew/opt/postgresql@17/bin:/usr/local/bin:/usr/bin:/bin"
+'"set -euo pipefail
 cd ~/projects/unusual-whales
 git fetch origin
 # Non-destructive checkout: refuse if working tree dirty (mini should be clean).


### PR DESCRIPTION
## Summary

Two deploy-script follow-ups from PR #113 (three-tier DB isolation tripwire), both caught during the live mini deploy.

1. **`scripts/deploy/macmini-bootstrap.sh`** — the `.env`-generation block patched `.env.example` values that #113 changed. The old `text.replace(...)` calls silently no-op'd against the new defaults, leaving the mini's `.env` with `HOST=127.0.0.1 / NAME=option_wizard_local` — which the `(host, db_name)` tripwire blocks.
   - was: `HOST=100.66.147.98 → 127.0.0.1`, `NAME=option_wizard → ${ARGON_DB_NAME}`
   - now: `HOST=127.0.0.1 → 100.66.147.98`, `NAME=option_wizard_local → ${ARGON_DB_NAME}`
   - Result: `(100.66.147.98, option_wizard)` — the prodlike combo the tripwire allows.
   - No network-layer change: Postgres already listens on `100.66.147.98` for MacBook→mini connections.

2. **`scripts/deploy/macmini-deploy-branch.sh`** — prepend Homebrew's bindir and the keg-only `postgresql@17` bindir to `PATH` inside `REMOTE_CMD`. Non-interactive SSH doesn't source `~/.zprofile`, so `uv sync` and `bash scripts/migrate.sh` failed with `command not found` on the 2026-06-02 release. Mirrors the `PATH` already set by `com.argon.worker` plists.

The mini's running `.env` was hand-patched to `UW_SCAN_DB_HOST=100.66.147.98` during the live release (backup at `.env.bak.20260602-*`); this PR makes the same state come out of the next bootstrap re-run automatically — so this is a **no-op against the currently-running services**.

## Scope

- `scripts/deploy/macmini-bootstrap.sh` (+8 / −5)
- `scripts/deploy/macmini-deploy-branch.sh` (+5 / −1)
- No Python, SQL, web, or worker code touched.

## Test plan

- [ ] CI: lint + tests pass on the diff.
- [ ] On next mini re-bootstrap (or a fresh provision run), verify the generated `.env` contains `UW_SCAN_DB_HOST=100.66.147.98` and `UW_SCAN_DB_NAME=option_wizard` and that `uw_scan.config._enforce_db_isolation` accepts it.
- [ ] On next `bash scripts/deploy/macmini-deploy-branch.sh <branch>` run, confirm `uv sync` and `bash scripts/migrate.sh` no longer fail with `command not found`.

Follow-up to #113.