### PR TITLE
feat(regime): intraday 5-session GEX chart + daily HistoryChart upgrade

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,208 @@
+# Handover — `feat/regime-gex-intraday-chart`
+
+PR: <https://github.com/moremeds/argon/pull/121>
+Branch: `feat/regime-gex-intraday-chart` (2 commits ahead of `main`)
+Worktree: `/Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart/`
+
+## What this branch does
+
+1. **New backend endpoint** `GET /api/regime/gex/intraday?ticker=SPX&sessions=5&rth_only=true`.
+   Returns the last N **ET trading sessions** of intraday `gex_snapshots` rows. Each
+   point carries `ts` (UTC ISO), `spot`, `net_gex`, `gex_flip`, `iv30d`. Grouped by
+   ET date so UTC `data_date` straddling doesn't bleed sessions into each other.
+
+2. **New chart component** `GexIntradayChart` rendered above the existing daily
+   `HistoryChart` on the GEX tab. Card frame, legend (SPOT / GEX FLIP / NET GEX /
+   IV 30D), per-session date dividers (MM/DD), intraday tick marks at 09:30 /
+   12:00 / 16:00 ET, dual y-axis.
+
+3. **Daily HistoryChart upgraded** with the same visual frame: title, legend,
+   x-axis date anchors, dual y-axis tick labels. SVG paths unchanged.
+
+Files touched:
+
+```
+src/uw_scan/api/routers/regime.py              | +30 lines  (new route)
+src/uw_scan/api/schemas.py                     | +30 lines  (GexIntradayResponse/Session/Point)
+src/uw_scan/storage/gex.py                     | +67 lines  (fetch_intraday_sessions)
+tests/integration/test_gex_repository.py       | +65 lines  (new integration test)
+web/components/regime/GexSubTab.tsx            |   ±8 lines (mount intraday chart)
+web/components/regime/HistoryChart.tsx         | rewritten  (card + legend + axes)
+web/components/regime/gex/GexIntradayChart.tsx | NEW
+web/lib/regime/api.ts                          |  +2 lines  (gex_intraday URL)
+web/lib/regime/useGexIntraday.ts               | NEW
+web/tests/unit/gexIntradayChart.test.tsx       | NEW (5 tests)
+```
+
+## Quick setup in a fresh session
+
+The worktree is already provisioned. From any new shell:
+
+```bash
+cd /Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart
+
+# Verify you're on the right branch
+git branch --show-current        # → feat/regime-gex-intraday-chart
+git log --oneline main..HEAD     # → 2 commits
+
+# .env lives in the canonical worktree; the dev API + DB come from there.
+ls -la ../../.env                # links via parent
+```
+
+## How to run locally (mirrors what the verification session did)
+
+### 1. Start a worktree-coded FastAPI on port 8401
+
+The main repo's API on port 8400 is the live production process — it doesn't
+know about the new endpoint. Spin up a separate one against this branch's
+code using the main repo's `.venv` (the worktree `.venv` lacks `psycopg-binary`).
+
+```bash
+cd /Users/moremeds/projects/argon
+env $(grep -v '^#' .env | xargs) \
+  PYTHONPATH=/Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart/src \
+  /Users/moremeds/projects/argon/.venv/bin/python -c "
+import uvicorn
+from uw_scan.api.server import app
+uvicorn.run(app, host='127.0.0.1', port=8401, log_level='info')
+"
+```
+
+Smoke-test:
+
+```bash
+curl -s 'http://127.0.0.1:8401/api/regime/gex/intraday?ticker=SPX&sessions=5' \
+  | python3 -m json.tool | head -40
+# Expect 5 sessions (06/04, 06/05, 06/08, 06/09, 06/10 as of 2026-06-11),
+# ~74-78 points each.
+```
+
+### 2. Start Next.js dev on port 3100, pointed at the worktree API
+
+The worktree shares `web/node_modules` with the main repo via a symlink so no
+`pnpm install` is needed.
+
+```bash
+cd /Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart/web
+NEXT_INTERNAL_API_BASE=http://127.0.0.1:8401 \
+  ./node_modules/.bin/next dev -p 3100
+```
+
+Open <http://localhost:3100/regime>, click the **GEX** tab.
+
+### 3. What you should see on the GEX tab
+
+Scroll past the live tiles and the GEX profile. The order is now:
+
+```
+… (existing live metrics + profile chart) …
+┌──────────────────────────────────────────────────┐
+│ SPX — INTRADAY GEX, LAST 5 SESSIONS (RTH)        │ ← NEW (card + legend top-right)
+│ Legend: SPOT, GEX FLIP, NET GEX, IV 30D          │
+│ … chart … 06/04 09:30 12:00 16:00 06/05 09:30 …  │
+└──────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│ SPX — 90-DAY GEX HISTORY                         │ ← UPGRADED (was bare SVG)
+│ Legend: NET GEX, GEX FLIP, SPOT                  │
+│ … chart … 02/02 03/05 04/08 05/08 06/10 …        │
+└──────────────────────────────────────────────────┘
+(existing history table)
+```
+
+The orange GEX FLIP line on the intraday chart will look sparse / blocky —
+this is **real data**: the scanner has been writing `gex_flip = null` on many
+recent ticks. Not a chart bug.
+
+The white SPX line on the **daily** chart visibly flat-lines at the right
+edge. That's the `vol_index_lake_sync` regression — see "Known issues".
+
+## How to run the test suites
+
+```bash
+# Frontend — full suite (~7s)
+cd /Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart/web
+./node_modules/.bin/tsc --noEmit          # strict typecheck
+./node_modules/.bin/vitest run             # 372 tests, 0 failures
+./node_modules/.bin/vitest run tests/unit/gexIntradayChart.test.tsx  # the new ones
+./node_modules/.bin/next build             # production build green
+
+# Backend — integration test (requires psql installed locally; runs in CI)
+cd /Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart
+pytest tests/integration/test_gex_repository.py -v
+```
+
+## Evidence already captured in this branch's `docs/`
+
+Gitignored, so they live only on disk:
+
+- `docs/intraday-card.png` — element screenshot of the new chart
+- `docs/daily-card.png` — element screenshot of the upgraded daily chart
+- `docs/regime-gex-fullpage.png` — full `/regime` page
+
+If you want to regenerate them, see "How to run locally" then re-screenshot.
+
+## Known issues outside this branch's scope
+
+### `vol_index_lake_sync` is broken (P0)
+
+Symptom: SPX / VIX / VIX3M / VVIX / COR1M last `trade_date` in
+`vol_index_daily` is **2026-06-08** (3 days stale as of 2026-06-11).
+Cascade: CRI / VCG / Canary snapshots also stuck at 06-08; the SPX line on
+this branch's daily HistoryChart flat-lines.
+
+Root cause:
+```
+ModuleNotFoundError: No module named 'pyarrow.pandas_compat'
+  at src/uw_scan/sources/lake.py:174  df = table.to_pandas()
+```
+`pyarrow >= 15` removed that internal. Two fixes:
+1. `cd /Users/moremeds/projects/argon && uv pip install pandas` then restart
+   the worker (`launchctl kickstart -k gui/$(id -u)/com.argon.worker.uw-0`).
+2. Or change `_rows_from_table` to use `table.to_pylist()` and skip the
+   pandas detour entirely.
+
+After either fix, backfill:
+```python
+# Inside the worktree venv with .env exported:
+from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+from uw_scan.worker.jobs.credit_etf_lake_sync import run_credit_etf_lake_sync
+# … then trigger the regime scanners' recover_recent_gaps for CRI/VCG/Canary.
+```
+
+Full audit lives at:
+`~/.claude/projects/-Users-moremeds-projects-argon/memory/regime-data-staleness-2026-06.md`
+
+### Worker SSL bundle missing (P1)
+
+`logs/worker-uw-0.err.log` shows recurring
+`FileNotFoundError: [Errno 2] No such file or directory` in
+`ssl.create_default_context`. The `regime_gex_scan` path still succeeds; the
+ad-hoc rescan poll fails. Likely a stale `SSL_CERT_FILE` env or a removed
+certifi bundle. Not blocking this PR.
+
+## Verification I already performed in the previous session
+
+- `next build` ✓ green, `/regime` listed as static.
+- `tsc --noEmit` ✓ clean.
+- `vitest run` ✓ 372 / 372 pass (including 5 new tests).
+- Live-DB end-to-end via `TestClient`: 5 sessions × ~78 RTH ticks, `as_of` =
+  last `ts`, unknown ticker returns `sessions: []` not 500.
+- Real browser load on Next dev port 3100 via Playwright: both chart cards
+  mounted, correct path counts (4 intraday, 3 daily), full legend text.
+- Element screenshots captured (above).
+- The CTE/RTH-filter alignment bug found and fixed mid-stream (ET 06-11
+  ETH-only date was squeezing 06-04 out of the top-N window before the fix).
+
+## When you're done testing
+
+```bash
+# Stop dev servers
+kill $(lsof -ti :3100 :8401) 2>/dev/null
+
+# Merge after approval
+gh pr merge 121 --squash --delete-branch
+# or interactive: gh pr view 121 --web
+
+# Clean up the worktree once merged
+git worktree remove /Users/moremeds/projects/argon/.worktrees/regime-gex-intraday-chart
+```

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -28,6 +28,8 @@ from uw_scan.api.schemas import (
     DealerRegimeSignal,
     GammaDecayBucket,
     GexHistoryEntry,
+    GexIntradayResponse,
+    GexIntradaySession,
     GexResponse,
     VcgResponse,
     VcgScanResponse,
@@ -129,6 +131,34 @@ def get_gex(
     raw["market_open"] = _is_market_open_now()
     raw["history"] = history
     return GexResponse.model_validate(raw)
+
+
+@router.get("/gex/intraday", response_model=GexIntradayResponse)
+def get_gex_intraday(
+    repo: Annotated[Repository, Depends(get_repo)],
+    ticker: str = Query("SPX"),
+    sessions: int = Query(5, ge=1, le=20),
+    rth_only: bool = Query(True),
+) -> GexIntradayResponse:
+    """Last N RTH sessions of intraday gex_snapshots for ``ticker``.
+
+    Drives the intraday line chart on the GEX tab. Sessions are ET-anchored
+    (UTC `data_date` straddles sessions). Empty `sessions` array is a valid
+    response when no rows exist for the ticker.
+    """
+    t = ticker.upper()
+    raw = repo.fetch_intraday_sessions(
+        ticker=t, sessions=sessions, rth_only=rth_only
+    )
+    payload_sessions = [GexIntradaySession.model_validate(s) for s in raw]
+    last_ts = None
+    if payload_sessions and payload_sessions[-1].points:
+        last_ts = payload_sessions[-1].points[-1].ts
+    return GexIntradayResponse(
+        ticker=t,
+        sessions=payload_sessions,
+        as_of=last_ts,
+    )
 
 
 @router.post("/gex/scan", status_code=202)

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -5,7 +5,7 @@ Keep stable; update `openapi-typescript` regen when fields change.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -218,6 +218,36 @@ EMPTY_GEX_RESPONSE = GexResponse()
 class VolBackdropPoint(BaseModel):
     date: date
     close: float
+
+
+# ─── GEX intraday (5-session RTH tape from gex_snapshots) ────────
+
+
+class GexIntradayPoint(BaseModel):
+    """One row from gex_snapshots inside a single ET trading session."""
+
+    ts: datetime  # scanned_at, ISO timestamp (UTC on the wire)
+    spot: float | None = None
+    net_gex: float | None = None
+    gex_flip: float | None = None
+    iv30d: float | None = None
+
+
+class GexIntradaySession(BaseModel):
+    et_date: date
+    points: list[GexIntradayPoint] = Field(default_factory=list)
+
+
+class GexIntradayResponse(BaseModel):
+    """Last N RTH sessions of intraday GEX snapshots for a ticker.
+
+    Sessions are ordered oldest→newest so the chart can scan left-to-right.
+    Points within each session are also ASC by ``ts``.
+    """
+
+    ticker: str
+    sessions: list[GexIntradaySession] = Field(default_factory=list)
+    as_of: datetime | None = None
 
 
 class VolBackdropResponse(BaseModel):

--- a/src/uw_scan/storage/gex.py
+++ b/src/uw_scan/storage/gex.py
@@ -87,6 +87,68 @@ class _GexMixin:
                 for row in cur.fetchall()
             }
 
+    def fetch_intraday_sessions(
+        self,
+        *,
+        ticker: str,
+        sessions: int = 5,
+        rth_only: bool = True,
+    ) -> list[dict]:
+        """Return the last ``sessions`` ET trading sessions of gex_snapshots.
+
+        Each row is keyed by ET date (``scanned_at AT TIME ZONE
+        'America/New_York'``) so weekends/holidays are handled by DISTINCT,
+        not by data_date (which is UTC and straddles ET sessions).
+
+        Result is grouped server-side: ``[{"et_date": d, "points": [...]}]``
+        oldest→newest. Each point is the generated scalar columns from
+        ``gex_snapshots`` — no JSONB parse needed.
+        """
+        rth_filter = (
+            "AND (scanned_at AT TIME ZONE 'America/New_York')::time "
+            "BETWEEN '09:30' AND '16:00'"
+            if rth_only
+            else ""
+        )
+        sql = f"""
+            WITH recent_sessions AS (
+                SELECT DISTINCT
+                       (scanned_at AT TIME ZONE 'America/New_York')::date AS et_date
+                  FROM {self._schema}.gex_snapshots
+                 WHERE ticker = %s
+                 ORDER BY et_date DESC
+                 LIMIT %s
+            )
+            SELECT (g.scanned_at AT TIME ZONE 'America/New_York')::date AS et_date,
+                   g.scanned_at,
+                   g.spot::float8                     AS spot,
+                   g.net_gex::float8                  AS net_gex,
+                   g.level_gex_flip_strike::float8    AS gex_flip,
+                   g.iv_30d::float8                   AS iv30d
+              FROM {self._schema}.gex_snapshots g
+              JOIN recent_sessions rs
+                ON (g.scanned_at AT TIME ZONE 'America/New_York')::date = rs.et_date
+             WHERE g.ticker = %s
+               {rth_filter}
+             ORDER BY g.scanned_at ASC
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (ticker.upper(), sessions, ticker.upper()))
+            rows = cur.fetchall()
+
+        out: dict[object, list[dict]] = {}
+        for et_date, scanned_at, spot, net_gex, gex_flip, iv30d in rows:
+            out.setdefault(et_date, []).append(
+                {
+                    "ts": scanned_at,
+                    "spot": spot,
+                    "net_gex": net_gex,
+                    "gex_flip": gex_flip,
+                    "iv30d": iv30d,
+                }
+            )
+        return [{"et_date": d, "points": pts} for d, pts in sorted(out.items())]
+
     def upsert_gex_snapshot(
         self,
         *,

--- a/src/uw_scan/storage/gex.py
+++ b/src/uw_scan/storage/gex.py
@@ -104,6 +104,10 @@ class _GexMixin:
         oldest→newest. Each point is the generated scalar columns from
         ``gex_snapshots`` — no JSONB parse needed.
         """
+        # When rth_only=True the same predicate is applied inside the CTE
+        # so a date with only overnight/pre-market rows isn't picked as one
+        # of the top-N sessions (would otherwise produce an empty session
+        # in the result).
         rth_filter = (
             "AND (scanned_at AT TIME ZONE 'America/New_York')::time "
             "BETWEEN '09:30' AND '16:00'"
@@ -116,6 +120,7 @@ class _GexMixin:
                        (scanned_at AT TIME ZONE 'America/New_York')::date AS et_date
                   FROM {self._schema}.gex_snapshots
                  WHERE ticker = %s
+                   {rth_filter}
                  ORDER BY et_date DESC
                  LIMIT %s
             )

--- a/tests/integration/test_gex_repository.py
+++ b/tests/integration/test_gex_repository.py
@@ -42,3 +42,68 @@ def test_fetch_latest_gex_populates_scan_time_and_ticker_when_missing(
     assert result is not None
     assert result["ticker"] == "SPX"
     assert result["scan_time"]  # populated from scanned_at
+
+
+def test_fetch_intraday_sessions_returns_grouped_rth_points(
+    seeded_db_empty_cards: Repository,
+) -> None:
+    """fetch_intraday_sessions groups by ET trading date, ASC sorted,
+    filtered to RTH 09:30-16:00 ET."""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    repo = seeded_db_empty_cards
+    et = ZoneInfo("America/New_York")
+    schema = repo._schema
+
+    # Seed three sessions with mixed RTH + pre-market ticks. Override the
+    # default-now scanned_at so we control ET grouping.
+    seeds = [
+        # 06-09 ET: one pre-market (filtered out) + two RTH
+        (datetime(2026, 6, 9, 8, 0, tzinfo=et), 7400.0, -50000.0, 7395.0, 0.18),
+        (datetime(2026, 6, 9, 10, 0, tzinfo=et), 7402.0, -49000.0, 7396.0, 0.18),
+        (datetime(2026, 6, 9, 15, 30, tzinfo=et), 7405.0, -48000.0, 7398.0, 0.19),
+        # 06-10 ET: two RTH
+        (datetime(2026, 6, 10, 9, 30, tzinfo=et), 7406.0, -47000.0, 7400.0, 0.19),
+        (datetime(2026, 6, 10, 14, 0, tzinfo=et), 7410.0, -46000.0, 7402.0, 0.20),
+    ]
+    for ts, spot, net_gex, flip, iv in seeds:
+        payload = {
+            "spot": spot,
+            "net_gex": net_gex,
+            "levels": {"gex_flip": {"strike": flip, "gamma": 1.0}},
+            "iv": {"iv30d": iv},
+        }
+        with repo._conn.cursor() as cur:
+            cur.execute(
+                f"INSERT INTO {schema}.gex_snapshots "
+                "(ticker, data_date, scanned_at, payload) "
+                "VALUES (%s, %s, %s, %s::jsonb)",
+                ("SPX", ts.date(), ts, _json_dump(payload)),
+            )
+        repo._conn.commit()
+
+    out = repo.fetch_intraday_sessions(ticker="SPX", sessions=5, rth_only=True)
+    assert len(out) == 2
+    assert out[0]["et_date"].isoformat() == "2026-06-09"
+    assert out[1]["et_date"].isoformat() == "2026-06-10"
+    # Pre-market 08:00 row filtered out → 2 RTH points on 06-09.
+    assert len(out[0]["points"]) == 2
+    assert len(out[1]["points"]) == 2
+    # Ascending order within each session.
+    assert out[0]["points"][0]["spot"] == 7402.0
+    assert out[0]["points"][1]["spot"] == 7405.0
+    assert out[1]["points"][0]["gex_flip"] == 7400.0
+    assert out[1]["points"][1]["iv30d"] == 0.20
+
+    # rth_only=False keeps the pre-market row.
+    out_all = repo.fetch_intraday_sessions(
+        ticker="SPX", sessions=5, rth_only=False
+    )
+    assert len(out_all[0]["points"]) == 3
+
+
+def _json_dump(payload: dict) -> str:
+    import json
+
+    return json.dumps(payload)

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -7,12 +7,14 @@ import {
   type MqLevels,
   type SourceDelta,
 } from "@/lib/regime/useGex";
+import { useGexIntraday } from "@/lib/regime/useGexIntraday";
 import { MarketState } from "@/lib/regime/useMarketHours";
 import InfoTooltip from "./InfoTooltip";
 import GexProfileChart from "./GexProfileChart";
 import { HistoryChart } from "./HistoryChart";
 import { ExpectedRangeBar } from "./gex/ExpectedRangeBar";
 import { GexHistoryTable } from "./gex/GexHistoryTable";
+import { GexIntradayChart } from "./gex/GexIntradayChart";
 import { MqLevelsPanel } from "./gex/MqLevelsPanel";
 import { biasColor, biasLabel, fmtGex, fmtPrice } from "./gex/format";
 import { formatPercent } from "./primitives/format";
@@ -127,6 +129,7 @@ function LevelCard({
 
 export default function GexSubTab({ marketState }: GexSubTabProps) {
   const { data, loading, error, lastSync } = useGex(marketState ?? null);
+  const { data: intraday } = useGexIntraday(marketState ?? null, "SPX", 5);
 
   if (loading && !data) {
     return (
@@ -440,7 +443,10 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
           </div>
         </div>
 
-        {/* ── 90-day History Chart (net_gex / flip / spot) ── */}
+        {/* ── 5-Session Intraday Chart (spot / flip / net_gex / iv30d) ── */}
+        <GexIntradayChart data={intraday} ticker={data.ticker} />
+
+        {/* ── 90-day Daily History Chart (net_gex / flip / spot) ── */}
         <HistoryChart history={data.history} ticker={data.ticker} />
 
         {/* ── History Table ── */}

--- a/web/components/regime/HistoryChart.tsx
+++ b/web/components/regime/HistoryChart.tsx
@@ -1,11 +1,74 @@
 "use client";
 
-import { finiteDomain, linearScale, pathFromPoints } from "@/lib/svgChart";
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+} from "@/lib/svgChart";
 import type { GexHistoryEntry } from "@/lib/regime/useGex";
 
-const WIDTH = 760;
-const HEIGHT = 220;
-const PAD = { top: 12, right: 56, bottom: 28, left: 56 };
+const WIDTH = 880;
+const HEIGHT = 260;
+const PAD = { top: 16, right: 64, bottom: 36, left: 64 };
+
+const COLORS = {
+  netGex: "var(--accent-bg, #05AD98)",
+  flip: "var(--accent-warm, #F5A623)",
+  spot: "var(--text-primary)",
+  zero: "var(--border-dim)",
+  grid: "rgba(148,163,184,0.08)",
+};
+
+function LegendSwatch({
+  color,
+  label,
+  dashed,
+}: {
+  color: string;
+  label: string;
+  dashed?: boolean;
+}) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.06em",
+        color: "var(--text-secondary)",
+      }}
+    >
+      <svg width="20" height="6" aria-hidden="true">
+        <line
+          x1={0}
+          x2={20}
+          y1={3}
+          y2={3}
+          stroke={color}
+          strokeWidth={2}
+          strokeDasharray={dashed ? "3 2" : undefined}
+        />
+      </svg>
+      {label}
+    </span>
+  );
+}
+
+/** Pick ~5 evenly-spaced indices to label on the x-axis. */
+function dateTickIndices(n: number, count: number = 5): number[] {
+  if (n <= count) return Array.from({ length: n }, (_, i) => i);
+  const step = (n - 1) / (count - 1);
+  return Array.from({ length: count }, (_, i) => Math.round(i * step));
+}
+
+/** "YYYY-MM-DD" → "MM/DD". */
+function shortDate(iso: string): string {
+  const [, m, d] = iso.split("-");
+  return `${m}/${d}`;
+}
 
 export function HistoryChart({
   history,
@@ -16,17 +79,26 @@ export function HistoryChart({
 }) {
   if (!history.length) {
     return (
-      <div
-        style={{
-          padding: "24px",
-          color: "var(--text-muted)",
-          fontFamily: "var(--font-mono)",
-          fontSize: 11,
-          letterSpacing: "0.06em",
-          textTransform: "uppercase",
-        }}
-      >
-        No history available
+      <div className="section" data-testid="gex-history-empty">
+        <div className="section-header">
+          <div className="section-title">
+            {ticker} — 90-Day GEX History
+          </div>
+        </div>
+        <div
+          className="section-body"
+          style={{
+            padding: 24,
+            textAlign: "center",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+          }}
+        >
+          No history available
+        </div>
       </div>
     );
   }
@@ -36,7 +108,6 @@ export function HistoryChart({
     [PAD.left, WIDTH - PAD.right],
   );
 
-  // finiteDomain returns {lo, hi, count} | null — null on <2 finite values
   const netGexD = finiteDomain(history.map((h) => h.net_gex));
   const priceD = finiteDomain(history.flatMap((h) => [h.spot, h.gex_flip]));
 
@@ -80,54 +151,150 @@ export function HistoryChart({
             .filter((p): p is [number, number] => p != null),
         );
 
+  const xTickIdx = dateTickIndices(history.length, 5);
+  const leftTicks = netGexD ? niceTicks(netGexD.lo, netGexD.hi, 4) : [];
+  const rightTicks = priceD ? niceTicks(priceD.lo, priceD.hi, 4) : [];
+
   return (
-    <svg
-      role="img"
-      aria-label={`${ticker} 90-day GEX history`}
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      style={{ width: "100%", height: HEIGHT, display: "block" }}
-    >
-      <title>{`${ticker} — net GEX, flip migration, spot`}</title>
+    <div className="section" data-testid="gex-history-chart">
+      <div className="section-header">
+        <div className="section-title">
+          {ticker} — 90-Day GEX History
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 14,
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <LegendSwatch color={COLORS.netGex} label="NET GEX" />
+          <LegendSwatch color={COLORS.flip} label="GEX FLIP" dashed />
+          <LegendSwatch color={COLORS.spot} label="SPOT" />
+        </div>
+      </div>
+      <div className="section-body" style={{ padding: "8px 12px 12px" }}>
+        <svg
+          role="img"
+          aria-label={`${ticker} 90-day GEX history`}
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          style={{ width: "100%", height: HEIGHT, display: "block" }}
+        >
+          <title>{`${ticker} — net GEX, flip migration, spot`}</title>
 
-      {/* zero line for net GEX (only when scale exists and crosses zero) */}
-      {yGex != null &&
-        netGexD != null &&
-        netGexD.lo <= 0 &&
-        netGexD.hi >= 0 && (
-          <line
-            x1={PAD.left}
-            x2={WIDTH - PAD.right}
-            y1={yGex(0)}
-            y2={yGex(0)}
-            stroke="var(--border-dim)"
-            strokeDasharray="2 3"
+          {/* Zero line for net GEX. */}
+          {yGex != null &&
+            netGexD != null &&
+            netGexD.lo <= 0 &&
+            netGexD.hi >= 0 && (
+              <line
+                x1={PAD.left}
+                x2={WIDTH - PAD.right}
+                y1={yGex(0)}
+                y2={yGex(0)}
+                stroke={COLORS.zero}
+                strokeDasharray="2 3"
+              />
+            )}
+
+          {/* Left y-axis (net GEX) ticks. */}
+          {yGex &&
+            leftTicks.map((v) => {
+              const y = yGex(v);
+              return (
+                <g key={`L${v}`}>
+                  <line
+                    x1={PAD.left - 4}
+                    x2={WIDTH - PAD.right}
+                    y1={y}
+                    y2={y}
+                    stroke={COLORS.grid}
+                  />
+                  <text
+                    x={PAD.left - 6}
+                    y={y + 3}
+                    textAnchor="end"
+                    fontSize={9}
+                    fontFamily="var(--font-mono)"
+                    fill={COLORS.netGex}
+                  >
+                    {Math.abs(v) >= 1000
+                      ? `${(v / 1000).toFixed(1)}K`
+                      : v.toFixed(0)}
+                  </text>
+                </g>
+              );
+            })}
+
+          {/* Right y-axis (price band). */}
+          {yPrice &&
+            rightTicks.map((v) => {
+              const y = yPrice(v);
+              return (
+                <text
+                  key={`R${v}`}
+                  x={WIDTH - PAD.right + 6}
+                  y={y + 3}
+                  textAnchor="start"
+                  fontSize={9}
+                  fontFamily="var(--font-mono)"
+                  fill="var(--text-secondary)"
+                >
+                  {v.toFixed(0)}
+                </text>
+              );
+            })}
+
+          {/* X-axis date labels. */}
+          {xTickIdx.map((i) => {
+            const x = xScale(i);
+            const entry = history[i];
+            if (!entry?.date) return null;
+            return (
+              <g key={`X${i}`}>
+                <line
+                  x1={x}
+                  x2={x}
+                  y1={HEIGHT - PAD.bottom}
+                  y2={HEIGHT - PAD.bottom + 4}
+                  stroke="var(--text-muted)"
+                />
+                <text
+                  x={x}
+                  y={HEIGHT - PAD.bottom + 16}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fontFamily="var(--font-mono)"
+                  fill="var(--text-secondary)"
+                >
+                  {shortDate(entry.date)}
+                </text>
+              </g>
+            );
+          })}
+
+          <path
+            d={netGexPath}
+            fill="none"
+            stroke={COLORS.netGex}
+            strokeWidth={1.5}
           />
-        )}
-
-      {/* net_gex (left axis) */}
-      <path
-        d={netGexPath}
-        fill="none"
-        stroke="var(--accent-bg)"
-        strokeWidth={1.5}
-      />
-
-      {/* gex_flip (right axis) — sparse / forward-only */}
-      <path
-        d={flipPath}
-        fill="none"
-        stroke="var(--accent-warm)"
-        strokeWidth={1.2}
-        strokeDasharray="3 2"
-      />
-
-      {/* spot (right axis) */}
-      <path
-        d={spotPath}
-        fill="none"
-        stroke="var(--text-primary)"
-        strokeWidth={1.2}
-      />
-    </svg>
+          <path
+            d={flipPath}
+            fill="none"
+            stroke={COLORS.flip}
+            strokeWidth={1.2}
+            strokeDasharray="3 2"
+          />
+          <path
+            d={spotPath}
+            fill="none"
+            stroke={COLORS.spot}
+            strokeWidth={1.2}
+          />
+        </svg>
+      </div>
+    </div>
   );
 }

--- a/web/components/regime/HistoryChart.tsx
+++ b/web/components/regime/HistoryChart.tsx
@@ -4,7 +4,7 @@ import {
   finiteDomain,
   linearScale,
   niceTicks,
-  pathFromPoints,
+  pathFromNullablePoints,
 } from "@/lib/svgChart";
 import type { GexHistoryEntry } from "@/lib/regime/useGex";
 
@@ -81,9 +81,7 @@ export function HistoryChart({
     return (
       <div className="section" data-testid="gex-history-empty">
         <div className="section-header">
-          <div className="section-title">
-            {ticker} — 90-Day GEX History
-          </div>
+          <div className="section-title">{ticker} — 90-Day GEX History</div>
         </div>
         <div
           className="section-body"
@@ -118,37 +116,35 @@ export function HistoryChart({
     ? linearScale([priceD.lo, priceD.hi], [HEIGHT - PAD.bottom, PAD.top])
     : null;
 
+  // Keep nulls in each per-series array so pathFromNullablePoints breaks the
+  // SVG path at gaps. Filtering nulls out (the old behavior) caused the
+  // sparse gex_flip line to draw a straight segment across multi-bar gaps,
+  // which lies about the data.
   const netGexPath =
     yGex == null
       ? ""
-      : pathFromPoints(
-          history
-            .map((h, i): [number, number] | null =>
-              h.net_gex == null ? null : [xScale(i), yGex(h.net_gex)],
-            )
-            .filter((p): p is [number, number] => p != null),
+      : pathFromNullablePoints(
+          history.map((h, i): [number, number] | null =>
+            h.net_gex == null ? null : [xScale(i), yGex(h.net_gex)],
+          ),
         );
 
   const flipPath =
     yPrice == null
       ? ""
-      : pathFromPoints(
-          history
-            .map((h, i): [number, number] | null =>
-              h.gex_flip == null ? null : [xScale(i), yPrice(h.gex_flip)],
-            )
-            .filter((p): p is [number, number] => p != null),
+      : pathFromNullablePoints(
+          history.map((h, i): [number, number] | null =>
+            h.gex_flip == null ? null : [xScale(i), yPrice(h.gex_flip)],
+          ),
         );
 
   const spotPath =
     yPrice == null
       ? ""
-      : pathFromPoints(
-          history
-            .map((h, i): [number, number] | null =>
-              h.spot == null ? null : [xScale(i), yPrice(h.spot)],
-            )
-            .filter((p): p is [number, number] => p != null),
+      : pathFromNullablePoints(
+          history.map((h, i): [number, number] | null =>
+            h.spot == null ? null : [xScale(i), yPrice(h.spot)],
+          ),
         );
 
   const xTickIdx = dateTickIndices(history.length, 5);
@@ -158,9 +154,7 @@ export function HistoryChart({
   return (
     <div className="section" data-testid="gex-history-chart">
       <div className="section-header">
-        <div className="section-title">
-          {ticker} — 90-Day GEX History
-        </div>
+        <div className="section-title">{ticker} — 90-Day GEX History</div>
         <div
           style={{
             display: "flex",

--- a/web/components/regime/HistoryChart.tsx
+++ b/web/components/regime/HistoryChart.tsx
@@ -10,12 +10,16 @@ import type { GexHistoryEntry } from "@/lib/regime/useGex";
 
 const WIDTH = 880;
 const HEIGHT = 260;
-const PAD = { top: 16, right: 64, bottom: 36, left: 64 };
+// Y-axis tick labels render INSIDE the chart canvas (just above each
+// gridline), so PAD.left no longer reserves a gutter for "100.0K" text —
+// only enough room for the leftmost data point to breathe.
+const PAD = { top: 16, right: 64, bottom: 36, left: 16 };
 
 const COLORS = {
   netGex: "var(--accent-bg, #05AD98)",
   flip: "var(--accent-warm, #F5A623)",
   spot: "var(--text-primary)",
+  iv: "var(--extreme, #D946A8)",
   zero: "var(--border-dim)",
   grid: "rgba(148,163,184,0.08)",
 };
@@ -108,12 +112,18 @@ export function HistoryChart({
 
   const netGexD = finiteDomain(history.map((h) => h.net_gex));
   const priceD = finiteDomain(history.flatMap((h) => [h.spot, h.gex_flip]));
+  const ivD = finiteDomain(history.map((h) => h.atm_iv));
 
   const yGex = netGexD
     ? linearScale([netGexD.lo, netGexD.hi], [HEIGHT - PAD.bottom, PAD.top])
     : null;
   const yPrice = priceD
     ? linearScale([priceD.lo, priceD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+  // IV 30D rescaled into the same vertical band as the price scale so the
+  // four series share one viewport. Matches the intraday chart's approach.
+  const yIv = ivD
+    ? linearScale([ivD.lo, ivD.hi], [HEIGHT - PAD.bottom, PAD.top])
     : null;
 
   // Keep nulls in each per-series array so pathFromNullablePoints breaks the
@@ -147,6 +157,15 @@ export function HistoryChart({
           ),
         );
 
+  const ivPath =
+    yIv == null
+      ? ""
+      : pathFromNullablePoints(
+          history.map((h, i): [number, number] | null =>
+            h.atm_iv == null ? null : [xScale(i), yIv(h.atm_iv)],
+          ),
+        );
+
   const xTickIdx = dateTickIndices(history.length, 5);
   const leftTicks = netGexD ? niceTicks(netGexD.lo, netGexD.hi, 4) : [];
   const rightTicks = priceD ? niceTicks(priceD.lo, priceD.hi, 4) : [];
@@ -166,6 +185,7 @@ export function HistoryChart({
           <LegendSwatch color={COLORS.netGex} label="NET GEX" />
           <LegendSwatch color={COLORS.flip} label="GEX FLIP" dashed />
           <LegendSwatch color={COLORS.spot} label="SPOT" />
+          <LegendSwatch color={COLORS.iv} label="IV 30D" />
         </div>
       </div>
       <div className="section-body" style={{ padding: "8px 12px 12px" }}>
@@ -192,23 +212,35 @@ export function HistoryChart({
               />
             )}
 
-          {/* Left y-axis (net GEX) ticks. */}
+          {/* Left y-axis (net GEX) ticks — label sits INSIDE the canvas,
+              just above the gridline (or clamped to the canvas top/bottom
+              when niceTicks extends beyond the data domain — e.g. an upper
+              tick of +100K when data peaks at +95K would otherwise render
+              above the SVG viewBox). The gridline is only drawn when it
+              falls inside the canvas. */}
           {yGex &&
             leftTicks.map((v) => {
               const y = yGex(v);
+              const labelY = Math.max(
+                PAD.top + 10,
+                Math.min(HEIGHT - PAD.bottom - 4, y - 4),
+              );
+              const lineInside = y >= PAD.top && y <= HEIGHT - PAD.bottom;
               return (
                 <g key={`L${v}`}>
-                  <line
-                    x1={PAD.left - 4}
-                    x2={WIDTH - PAD.right}
-                    y1={y}
-                    y2={y}
-                    stroke={COLORS.grid}
-                  />
+                  {lineInside && (
+                    <line
+                      x1={PAD.left}
+                      x2={WIDTH - PAD.right}
+                      y1={y}
+                      y2={y}
+                      stroke={COLORS.grid}
+                    />
+                  )}
                   <text
-                    x={PAD.left - 6}
-                    y={y + 3}
-                    textAnchor="end"
+                    x={PAD.left + 4}
+                    y={labelY}
+                    textAnchor="start"
                     fontSize={9}
                     fontFamily="var(--font-mono)"
                     fill={COLORS.netGex}
@@ -221,15 +253,21 @@ export function HistoryChart({
               );
             })}
 
-          {/* Right y-axis (price band). */}
+          {/* Right y-axis (price band). niceTicks may extend beyond the
+              data domain; clamp labels to the canvas y-range so they don't
+              render off-viewBox (the same bug the left axis had). */}
           {yPrice &&
             rightTicks.map((v) => {
               const y = yPrice(v);
+              const labelY = Math.max(
+                PAD.top + 10,
+                Math.min(HEIGHT - PAD.bottom - 4, y + 3),
+              );
               return (
                 <text
                   key={`R${v}`}
                   x={WIDTH - PAD.right + 6}
-                  y={y + 3}
+                  y={labelY}
                   textAnchor="start"
                   fontSize={9}
                   fontFamily="var(--font-mono)"
@@ -268,24 +306,39 @@ export function HistoryChart({
             );
           })}
 
+          {/* `strokeLinecap="round"` makes the zero-length L emitted by
+              pathFromNullablePoints for isolated points render as a visible
+              dot — critical for daily gex_flip, which the EOD job emits as
+              very sparse single observations. */}
           <path
             d={netGexPath}
             fill="none"
             stroke={COLORS.netGex}
             strokeWidth={1.5}
+            strokeLinecap="round"
           />
           <path
             d={flipPath}
             fill="none"
             stroke={COLORS.flip}
-            strokeWidth={1.2}
+            strokeWidth={1.6}
             strokeDasharray="3 2"
+            strokeLinecap="round"
           />
           <path
             d={spotPath}
             fill="none"
             stroke={COLORS.spot}
             strokeWidth={1.2}
+            strokeLinecap="round"
+          />
+          <path
+            d={ivPath}
+            fill="none"
+            stroke={COLORS.iv}
+            strokeWidth={1.1}
+            opacity={0.7}
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/web/components/regime/gex/GexIntradayChart.tsx
+++ b/web/components/regime/gex/GexIntradayChart.tsx
@@ -4,7 +4,7 @@ import {
   finiteDomain,
   linearScale,
   niceTicks,
-  pathFromPoints,
+  pathFromNullablePoints,
 } from "@/lib/svgChart";
 import type {
   GexIntradayData,
@@ -174,7 +174,9 @@ export function GexIntradayChart({
     return (
       <div className="section" data-testid="gex-intraday-empty">
         <div className="section-header">
-          <div className="section-title">{ticker} — Intraday GEX, 5 Sessions</div>
+          <div className="section-title">
+            {ticker} — Intraday GEX, 5 Sessions
+          </div>
         </div>
         <div
           className="section-body"
@@ -197,7 +199,9 @@ export function GexIntradayChart({
     return (
       <div className="section" data-testid="gex-intraday-thin">
         <div className="section-header">
-          <div className="section-title">{ticker} — Intraday GEX, 5 Sessions</div>
+          <div className="section-title">
+            {ticker} — Intraday GEX, 5 Sessions
+          </div>
         </div>
         <div
           className="section-body"
@@ -244,13 +248,14 @@ export function GexIntradayChart({
     scale: ((v: number) => number) | null,
   ): string {
     if (scale == null) return "";
-    return pathFromPoints(
-      flat
-        .map((p): [number, number] | null => {
-          const v = accessor(p);
-          return v == null ? null : [xScale(p.x), scale(v)];
-        })
-        .filter((p): p is [number, number] => p != null),
+    // Keep nulls in the array so pathFromNullablePoints breaks the path at
+    // gaps instead of straight-line interpolating across them. Critical for
+    // gex_flip, which the scanner emits sparsely.
+    return pathFromNullablePoints(
+      flat.map((p): [number, number] | null => {
+        const v = accessor(p);
+        return v == null ? null : [xScale(p.x), scale(v)];
+      }),
     );
   }
 

--- a/web/components/regime/gex/GexIntradayChart.tsx
+++ b/web/components/regime/gex/GexIntradayChart.tsx
@@ -24,6 +24,9 @@ const COLORS = {
   divider: "var(--border-dim)",
   grid: "rgba(148,163,184,0.08)",
   zero: "var(--border-dim)",
+  // Subtle alternating fill behind every other session column. The shade
+  // separates adjacent ET dates without competing with the four series.
+  sessionBand: "rgba(148,163,184,0.05)",
 };
 
 const ET_TZ = "America/New_York";
@@ -174,9 +177,7 @@ export function GexIntradayChart({
     return (
       <div className="section" data-testid="gex-intraday-empty">
         <div className="section-header">
-          <div className="section-title">
-            {ticker} — Intraday GEX, 5 Sessions
-          </div>
+          <div className="section-title">{ticker} — Intraday GEX (RTH)</div>
         </div>
         <div
           className="section-body"
@@ -199,9 +200,7 @@ export function GexIntradayChart({
     return (
       <div className="section" data-testid="gex-intraday-thin">
         <div className="section-header">
-          <div className="section-title">
-            {ticker} — Intraday GEX, 5 Sessions
-          </div>
+          <div className="section-title">{ticker} — Intraday GEX (RTH)</div>
         </div>
         <div
           className="section-body"
@@ -248,15 +247,23 @@ export function GexIntradayChart({
     scale: ((v: number) => number) | null,
   ): string {
     if (scale == null) return "";
-    // Keep nulls in the array so pathFromNullablePoints breaks the path at
-    // gaps instead of straight-line interpolating across them. Critical for
-    // gex_flip, which the scanner emits sparsely.
-    return pathFromNullablePoints(
-      flat.map((p): [number, number] | null => {
-        const v = accessor(p);
-        return v == null ? null : [xScale(p.x), scale(v)];
-      }),
-    );
+    // Build a separate sub-path PER SESSION and concatenate. This breaks
+    // every series at the session boundary so a line from session N's
+    // 16:00 ET close never crosses to session N+1's 09:30 ET open
+    // (overnight RTH motion that did not happen). pathFromNullablePoints
+    // also handles intra-session gaps + isolated singletons within each
+    // session — see svgChart.ts.
+    return sessionRanges
+      .map((s) =>
+        pathFromNullablePoints(
+          flat.slice(s.start, s.end + 1).map((p): [number, number] | null => {
+            const v = accessor(p);
+            return v == null ? null : [xScale(p.x), scale(v)];
+          }),
+        ),
+      )
+      .filter((sub) => sub.length > 0)
+      .join(" ");
   }
 
   const netGexPath = pathFor((p) => p.netGex, yLeft);
@@ -297,6 +304,23 @@ export function GexIntradayChart({
           style={{ width: "100%", height: HEIGHT, display: "block" }}
         >
           <title>{`${ticker} intraday — spot, flip, net GEX, IV30d`}</title>
+
+          {/* Alternating session bands. Rendered first so every other ET
+              date column reads as a subtly-different background — replaces
+              what the colliding 09:30/16:00 boundary labels were trying to
+              communicate. */}
+          {sessionRanges.map((s, i) =>
+            i % 2 === 1 ? (
+              <rect
+                key={`band-${s.et_date}`}
+                x={xScale(s.start)}
+                y={PAD.top}
+                width={xScale(s.end) - xScale(s.start)}
+                height={HEIGHT - PAD.top - PAD.bottom}
+                fill={COLORS.sessionBand}
+              />
+            ) : null,
+          )}
 
           {/* Zero line for net GEX (only when the scale crosses zero). */}
           {yLeft && netGexD && netGexD.lo <= 0 && netGexD.hi >= 0 && (
@@ -340,28 +364,35 @@ export function GexIntradayChart({
                 >
                   {etDateLabel(s.et_date)}
                 </text>
-                {/* RTH intraday ticks (09:30, 12:00, 16:00 ET). */}
+                {/* RTH intraday ticks. Only the 12:00 anchor carries a
+                    label — 09:30 and 16:00 sit at the session band edges
+                    where adjacent-session labels used to collide; the band
+                    edges themselves now communicate open/close. */}
                 {rthTicksForSession(s.points).map((t) => {
                   const tx = xScale(s.start + t.idx);
+                  const labeled = t.label === "12:00";
                   return (
                     <g key={`${s.et_date}-${t.label}`}>
                       <line
                         x1={tx}
                         x2={tx}
                         y1={HEIGHT - PAD.bottom}
-                        y2={HEIGHT - PAD.bottom + 4}
+                        y2={HEIGHT - PAD.bottom + (labeled ? 4 : 2)}
                         stroke="var(--text-muted)"
+                        opacity={labeled ? 1 : 0.5}
                       />
-                      <text
-                        x={tx}
-                        y={HEIGHT - PAD.bottom + 14}
-                        textAnchor="middle"
-                        fontSize={8}
-                        fontFamily="var(--font-mono)"
-                        fill="var(--text-muted)"
-                      >
-                        {t.label}
-                      </text>
+                      {labeled && (
+                        <text
+                          x={tx}
+                          y={HEIGHT - PAD.bottom + 14}
+                          textAnchor="middle"
+                          fontSize={8}
+                          fontFamily="var(--font-mono)"
+                          fill="var(--text-muted)"
+                        >
+                          {t.label}
+                        </text>
+                      )}
                     </g>
                   );
                 })}
@@ -369,22 +400,33 @@ export function GexIntradayChart({
             );
           })}
 
-          {/* Left y-axis (net GEX). */}
+          {/* Y-axis tick labels. niceTicks may extend beyond the data
+              domain (e.g. an upper tick of +100K when data peaks at +95K);
+              clamp the label y so it always renders inside the SVG viewBox
+              and only draw the gridline when its y falls inside the chart
+              canvas. Same fix the daily HistoryChart got. */}
           {yLeft &&
             leftTicks.map((v) => {
               const y = yLeft(v);
+              const labelY = Math.max(
+                PAD.top + 10,
+                Math.min(HEIGHT - PAD.bottom - 4, y + 3),
+              );
+              const lineInside = y >= PAD.top && y <= HEIGHT - PAD.bottom;
               return (
                 <g key={`L${v}`}>
-                  <line
-                    x1={PAD.left - 4}
-                    x2={WIDTH - PAD.right}
-                    y1={y}
-                    y2={y}
-                    stroke={COLORS.grid}
-                  />
+                  {lineInside && (
+                    <line
+                      x1={PAD.left - 4}
+                      x2={WIDTH - PAD.right}
+                      y1={y}
+                      y2={y}
+                      stroke={COLORS.grid}
+                    />
+                  )}
                   <text
                     x={PAD.left - 6}
-                    y={y + 3}
+                    y={labelY}
                     textAnchor="end"
                     fontSize={9}
                     fontFamily="var(--font-mono)"
@@ -402,11 +444,15 @@ export function GexIntradayChart({
           {yRight &&
             rightTicks.map((v) => {
               const y = yRight(v);
+              const labelY = Math.max(
+                PAD.top + 10,
+                Math.min(HEIGHT - PAD.bottom - 4, y + 3),
+              );
               return (
                 <g key={`R${v}`}>
                   <text
                     x={WIDTH - PAD.right + 6}
-                    y={y + 3}
+                    y={labelY}
                     textAnchor="start"
                     fontSize={9}
                     fontFamily="var(--font-mono)"
@@ -418,25 +464,32 @@ export function GexIntradayChart({
               );
             })}
 
-          {/* Series (draw net_gex first so price lines sit on top visually). */}
+          {/* Series (draw net_gex first so price lines sit on top visually).
+              `strokeLinecap="round"` is REQUIRED so the zero-length L emitted
+              by pathFromNullablePoints for isolated points renders as a
+              visible dot (diameter = strokeWidth). Critical for gex_flip,
+              which the scanner emits as sparse single observations. */}
           <path
             d={netGexPath}
             fill="none"
             stroke={COLORS.netGex}
             strokeWidth={1.4}
+            strokeLinecap="round"
           />
           <path
             d={flipPath}
             fill="none"
             stroke={COLORS.flip}
-            strokeWidth={1.2}
+            strokeWidth={1.6}
             strokeDasharray="3 2"
+            strokeLinecap="round"
           />
           <path
             d={spotPath}
             fill="none"
             stroke={COLORS.spot}
             strokeWidth={1.4}
+            strokeLinecap="round"
           />
           <path
             d={ivPath}
@@ -444,6 +497,7 @@ export function GexIntradayChart({
             stroke={COLORS.iv}
             strokeWidth={1.1}
             opacity={0.7}
+            strokeLinecap="round"
           />
         </svg>
       </div>

--- a/web/components/regime/gex/GexIntradayChart.tsx
+++ b/web/components/regime/gex/GexIntradayChart.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import {
+  finiteDomain,
+  linearScale,
+  niceTicks,
+  pathFromPoints,
+} from "@/lib/svgChart";
+import type {
+  GexIntradayData,
+  GexIntradayPoint,
+  GexIntradaySession,
+} from "@/lib/regime/useGexIntraday";
+
+const WIDTH = 880;
+const HEIGHT = 280;
+const PAD = { top: 16, right: 72, bottom: 38, left: 64 };
+
+const COLORS = {
+  spot: "var(--text-primary)",
+  flip: "var(--accent-warm, #F5A623)",
+  netGex: "var(--accent-bg, #05AD98)",
+  iv: "var(--extreme, #D946A8)",
+  divider: "var(--border-dim)",
+  grid: "rgba(148,163,184,0.08)",
+  zero: "var(--border-dim)",
+};
+
+const ET_TZ = "America/New_York";
+
+/** "YYYY-MM-DD" ET → ET noon ISO so callers don't need to parse twice. */
+function etDateLabel(d: string): string {
+  // d is already a YYYY-MM-DD string from the API; show month+day only.
+  const [, m, day] = d.split("-");
+  return `${m}/${day}`;
+}
+
+/** ET time-of-day in minutes from midnight, derived from an ISO timestamp. */
+function etMinutes(ts: string): number {
+  const date = new Date(ts);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: ET_TZ,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const h = Number(parts.find((p) => p.type === "hour")?.value ?? 0);
+  const min = Number(parts.find((p) => p.type === "minute")?.value ?? 0);
+  return h * 60 + min;
+}
+
+type Flat = {
+  x: number; // index across the concatenated session timeline
+  spot: number | null;
+  flip: number | null;
+  netGex: number | null;
+  iv: number | null;
+};
+
+/** Concatenate sessions into a single index space, also remembering the
+ * index range covered by each session for date dividers + tick labels. */
+function flatten(sessions: GexIntradaySession[]): {
+  flat: Flat[];
+  sessionRanges: {
+    et_date: string;
+    start: number;
+    end: number;
+    points: GexIntradayPoint[];
+  }[];
+} {
+  const flat: Flat[] = [];
+  const ranges: {
+    et_date: string;
+    start: number;
+    end: number;
+    points: GexIntradayPoint[];
+  }[] = [];
+  for (const s of sessions) {
+    if (!s.points.length) continue;
+    const start = flat.length;
+    for (const p of s.points) {
+      flat.push({
+        x: flat.length,
+        spot: p.spot,
+        flip: p.gex_flip,
+        netGex: p.net_gex,
+        iv: p.iv30d,
+      });
+    }
+    ranges.push({
+      et_date: s.et_date,
+      start,
+      end: flat.length - 1,
+      points: s.points,
+    });
+  }
+  return { flat, sessionRanges: ranges };
+}
+
+/** Tick-mark indices inside a session at 9:30, 12:00, 16:00 ET (when
+ * those minutes are present in the session's point list). */
+function rthTicksForSession(points: GexIntradayPoint[]): {
+  idx: number;
+  label: string;
+}[] {
+  const targets: [number, string][] = [
+    [9 * 60 + 30, "09:30"],
+    [12 * 60, "12:00"],
+    [16 * 60, "16:00"],
+  ];
+  const out: { idx: number; label: string }[] = [];
+  for (const [target, label] of targets) {
+    let bestIdx = -1;
+    let bestDelta = Infinity;
+    for (let i = 0; i < points.length; i++) {
+      const d = Math.abs(etMinutes(points[i].ts) - target);
+      if (d < bestDelta) {
+        bestDelta = d;
+        bestIdx = i;
+      }
+    }
+    // Skip the tick when the closest point is > 15 min away (e.g. partial
+    // session, or session that doesn't reach the close).
+    if (bestIdx >= 0 && bestDelta <= 15) out.push({ idx: bestIdx, label });
+  }
+  return out;
+}
+
+function LegendSwatch({
+  color,
+  label,
+  dashed,
+}: {
+  color: string;
+  label: string;
+  dashed?: boolean;
+}) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.06em",
+        color: "var(--text-secondary)",
+      }}
+    >
+      <svg width="20" height="6" aria-hidden="true">
+        <line
+          x1={0}
+          x2={20}
+          y1={3}
+          y2={3}
+          stroke={color}
+          strokeWidth={2}
+          strokeDasharray={dashed ? "3 2" : undefined}
+        />
+      </svg>
+      {label}
+    </span>
+  );
+}
+
+export function GexIntradayChart({
+  data,
+  ticker,
+}: {
+  data: GexIntradayData | null;
+  ticker: string;
+}) {
+  if (!data || !data.sessions.length) {
+    return (
+      <div className="section" data-testid="gex-intraday-empty">
+        <div className="section-header">
+          <div className="section-title">{ticker} — Intraday GEX, 5 Sessions</div>
+        </div>
+        <div
+          className="section-body"
+          style={{
+            padding: 24,
+            textAlign: "center",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+          }}
+        >
+          No intraday GEX snapshots available.
+        </div>
+      </div>
+    );
+  }
+
+  const { flat, sessionRanges } = flatten(data.sessions);
+  if (flat.length < 2) {
+    return (
+      <div className="section" data-testid="gex-intraday-thin">
+        <div className="section-header">
+          <div className="section-title">{ticker} — Intraday GEX, 5 Sessions</div>
+        </div>
+        <div
+          className="section-body"
+          style={{
+            padding: 24,
+            textAlign: "center",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+          }}
+        >
+          Only {flat.length} intraday tick available — chart needs at least 2.
+        </div>
+      </div>
+    );
+  }
+
+  const xScale = linearScale(
+    [0, flat.length - 1],
+    [PAD.left, WIDTH - PAD.right],
+  );
+
+  // Two y-axes:
+  //   left  = net GEX ($), often crosses zero
+  //   right = price band (SPX spot + flip strike share the same scale) and
+  //           IV30D as a percent (rescaled into the same band).
+  const netGexD = finiteDomain(flat.map((p) => p.netGex));
+  const priceD = finiteDomain(flat.flatMap((p) => [p.spot, p.flip]));
+  const ivD = finiteDomain(flat.map((p) => p.iv));
+
+  const yLeft = netGexD
+    ? linearScale([netGexD.lo, netGexD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+  const yRight = priceD
+    ? linearScale([priceD.lo, priceD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+  // IV30D rescaled into the right-axis band so all four series share one viewport.
+  const yIv = ivD
+    ? linearScale([ivD.lo, ivD.hi], [HEIGHT - PAD.bottom, PAD.top])
+    : null;
+
+  function pathFor(
+    accessor: (p: Flat) => number | null,
+    scale: ((v: number) => number) | null,
+  ): string {
+    if (scale == null) return "";
+    return pathFromPoints(
+      flat
+        .map((p): [number, number] | null => {
+          const v = accessor(p);
+          return v == null ? null : [xScale(p.x), scale(v)];
+        })
+        .filter((p): p is [number, number] => p != null),
+    );
+  }
+
+  const netGexPath = pathFor((p) => p.netGex, yLeft);
+  const flipPath = pathFor((p) => p.flip, yRight);
+  const spotPath = pathFor((p) => p.spot, yRight);
+  const ivPath = pathFor((p) => p.iv, yIv);
+
+  // Y-axis ticks for the left scale (net GEX).
+  const leftTicks = netGexD ? niceTicks(netGexD.lo, netGexD.hi, 4) : [];
+  // Y-axis ticks for the right scale (price band).
+  const rightTicks = priceD ? niceTicks(priceD.lo, priceD.hi, 4) : [];
+
+  return (
+    <div className="section" data-testid="gex-intraday-chart">
+      <div className="section-header">
+        <div className="section-title">
+          {ticker} — Intraday GEX, last {sessionRanges.length} sessions (RTH)
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 14,
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <LegendSwatch color={COLORS.spot} label="SPOT" />
+          <LegendSwatch color={COLORS.flip} label="GEX FLIP" dashed />
+          <LegendSwatch color={COLORS.netGex} label="NET GEX" />
+          <LegendSwatch color={COLORS.iv} label="IV 30D" />
+        </div>
+      </div>
+      <div className="section-body" style={{ padding: "8px 12px 12px" }}>
+        <svg
+          role="img"
+          aria-label={`${ticker} intraday GEX, last ${sessionRanges.length} RTH sessions`}
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          style={{ width: "100%", height: HEIGHT, display: "block" }}
+        >
+          <title>{`${ticker} intraday — spot, flip, net GEX, IV30d`}</title>
+
+          {/* Zero line for net GEX (only when the scale crosses zero). */}
+          {yLeft && netGexD && netGexD.lo <= 0 && netGexD.hi >= 0 && (
+            <line
+              x1={PAD.left}
+              x2={WIDTH - PAD.right}
+              y1={yLeft(0)}
+              y2={yLeft(0)}
+              stroke={COLORS.zero}
+              strokeDasharray="2 3"
+            />
+          )}
+
+          {/* Session dividers + date labels along the bottom. */}
+          {sessionRanges.map((s, i) => {
+            const xStart = xScale(s.start);
+            const xEnd = xScale(s.end);
+            const midX = (xStart + xEnd) / 2;
+            const showDivider = i > 0;
+            return (
+              <g key={s.et_date}>
+                {showDivider && (
+                  <line
+                    x1={xStart}
+                    x2={xStart}
+                    y1={PAD.top}
+                    y2={HEIGHT - PAD.bottom}
+                    stroke={COLORS.divider}
+                    strokeWidth={1}
+                  />
+                )}
+                {/* Date label */}
+                <text
+                  x={midX}
+                  y={HEIGHT - 6}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fontFamily="var(--font-mono)"
+                  fill="var(--text-secondary)"
+                  letterSpacing="0.06em"
+                >
+                  {etDateLabel(s.et_date)}
+                </text>
+                {/* RTH intraday ticks (09:30, 12:00, 16:00 ET). */}
+                {rthTicksForSession(s.points).map((t) => {
+                  const tx = xScale(s.start + t.idx);
+                  return (
+                    <g key={`${s.et_date}-${t.label}`}>
+                      <line
+                        x1={tx}
+                        x2={tx}
+                        y1={HEIGHT - PAD.bottom}
+                        y2={HEIGHT - PAD.bottom + 4}
+                        stroke="var(--text-muted)"
+                      />
+                      <text
+                        x={tx}
+                        y={HEIGHT - PAD.bottom + 14}
+                        textAnchor="middle"
+                        fontSize={8}
+                        fontFamily="var(--font-mono)"
+                        fill="var(--text-muted)"
+                      >
+                        {t.label}
+                      </text>
+                    </g>
+                  );
+                })}
+              </g>
+            );
+          })}
+
+          {/* Left y-axis (net GEX). */}
+          {yLeft &&
+            leftTicks.map((v) => {
+              const y = yLeft(v);
+              return (
+                <g key={`L${v}`}>
+                  <line
+                    x1={PAD.left - 4}
+                    x2={WIDTH - PAD.right}
+                    y1={y}
+                    y2={y}
+                    stroke={COLORS.grid}
+                  />
+                  <text
+                    x={PAD.left - 6}
+                    y={y + 3}
+                    textAnchor="end"
+                    fontSize={9}
+                    fontFamily="var(--font-mono)"
+                    fill={COLORS.netGex}
+                  >
+                    {Math.abs(v) >= 1000
+                      ? `${(v / 1000).toFixed(1)}K`
+                      : v.toFixed(0)}
+                  </text>
+                </g>
+              );
+            })}
+
+          {/* Right y-axis (price band: SPX + flip strike). */}
+          {yRight &&
+            rightTicks.map((v) => {
+              const y = yRight(v);
+              return (
+                <g key={`R${v}`}>
+                  <text
+                    x={WIDTH - PAD.right + 6}
+                    y={y + 3}
+                    textAnchor="start"
+                    fontSize={9}
+                    fontFamily="var(--font-mono)"
+                    fill="var(--text-secondary)"
+                  >
+                    {v.toFixed(0)}
+                  </text>
+                </g>
+              );
+            })}
+
+          {/* Series (draw net_gex first so price lines sit on top visually). */}
+          <path
+            d={netGexPath}
+            fill="none"
+            stroke={COLORS.netGex}
+            strokeWidth={1.4}
+          />
+          <path
+            d={flipPath}
+            fill="none"
+            stroke={COLORS.flip}
+            strokeWidth={1.2}
+            strokeDasharray="3 2"
+          />
+          <path
+            d={spotPath}
+            fill="none"
+            stroke={COLORS.spot}
+            strokeWidth={1.4}
+          />
+          <path
+            d={ivPath}
+            fill="none"
+            stroke={COLORS.iv}
+            strokeWidth={1.1}
+            opacity={0.7}
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/regime/api.ts
+++ b/web/lib/regime/api.ts
@@ -15,6 +15,8 @@ export const regimeApi = {
   vcg_scan: () => `${API}/api/regime/vcg/scan`,
   gex: (ticker: string) =>
     `${API}/api/regime/gex?ticker=${encodeURIComponent(ticker)}`,
+  gex_intraday: (ticker: string, sessions: number = 5) =>
+    `${API}/api/regime/gex/intraday?ticker=${encodeURIComponent(ticker)}&sessions=${sessions}`,
   gex_scan: (ticker: string) =>
     `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
   vol_backdrop: () => `${API}/api/regime/vol-backdrop`,

--- a/web/lib/regime/useGex.ts
+++ b/web/lib/regime/useGex.ts
@@ -34,7 +34,11 @@ export type GexHistoryEntry = {
   net_gex: number;
   net_dex: number;
   gex_flip: number | null;
-  spot: number;
+  // Server returns null when greek_exposure_daily has the row but the
+  // spot-source table (vol_index_daily for indices, daily_ohlc for stocks)
+  // does not have a close for that trade_date. HistoryChart breaks the
+  // path at nulls, so the runtime contract is `number | null`.
+  spot: number | null;
   atm_iv: number | null;
   vol_pc: number | null;
   bias: string | null;

--- a/web/lib/regime/useGexIntraday.ts
+++ b/web/lib/regime/useGexIntraday.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { regimeApi } from "./api";
+import { MarketState } from "./useMarketHours";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type GexIntradayPoint = {
+  ts: string;
+  spot: number | null;
+  net_gex: number | null;
+  gex_flip: number | null;
+  iv30d: number | null;
+};
+
+export type GexIntradaySession = {
+  et_date: string;
+  points: GexIntradayPoint[];
+};
+
+export type GexIntradayData = {
+  ticker: string;
+  sessions: GexIntradaySession[];
+  as_of: string | null;
+};
+
+export function useGexIntraday(
+  marketState: MarketState | null = null,
+  ticker: string = "SPX",
+  sessions: number = 5,
+): UseSyncReturn<GexIntradayData> {
+  // Same activity rules as useGex — the dataset moves only when the GEX
+  // scanner ticks, and that's gated on market state in the worker.
+  const active =
+    marketState === MarketState.CLOSED ? false : true;
+
+  const config = {
+    endpoint: regimeApi.gex_intraday(ticker, sessions),
+    interval: marketState === MarketState.EXTENDED ? 300_000 : 60_000,
+    hasPost: false,
+    extractTimestamp: (d: GexIntradayData) => d.as_of,
+    shouldRetry: () => false,
+    retryIntervalMs: 5000,
+    retryMethod: "GET" as const,
+  };
+
+  return useSyncHook<GexIntradayData>(config, active);
+}

--- a/web/lib/svgChart.ts
+++ b/web/lib/svgChart.ts
@@ -26,19 +26,41 @@ export function pathFromPoints(points: Point[]): string {
  * starts a fresh `M`. Use this for sparse series (e.g. `gex_flip`) where the
  * filtered-out version of `pathFromPoints` produces a misleading line that
  * connects across multi-bar gaps.
+ *
+ * **Isolated points:** when a finite point is surrounded by nulls on both
+ * sides (or sits at start/end with a null neighbour), the sub-path would be
+ * a lone `M{x},{y}` which SVG renders as nothing — sparse single-observation
+ * series go invisible. To preserve those dots, an isolated point is emitted
+ * as `M{x},{y} L{x},{y}` (a zero-length line). Consumers MUST set
+ * `stroke-linecap="round"` (or "square") on the rendered `<path>` so the
+ * zero-length segment becomes a visible dot of diameter = strokeWidth.
  */
 export function pathFromNullablePoints(
   points: ReadonlyArray<Point | null>,
 ): string {
+  function isFinitePoint(p: Point | null | undefined): p is Point {
+    return p != null && Number.isFinite(p[0]) && Number.isFinite(p[1]);
+  }
   let out = "";
   let pendingMove = true;
-  for (const p of points) {
-    if (p == null || !Number.isFinite(p[0]) || !Number.isFinite(p[1])) {
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    if (!isFinitePoint(p)) {
       pendingMove = true;
       continue;
     }
     const [x, y] = p;
-    out += `${pendingMove ? "M" : "L"}${x},${y} `;
+    if (pendingMove) {
+      out += `M${x},${y} `;
+      // If the next index isn't a finite continuation, this point is
+      // isolated — emit a zero-length line so a round-cap stroke draws a
+      // dot rather than nothing.
+      if (!isFinitePoint(points[i + 1])) {
+        out += `L${x},${y} `;
+      }
+    } else {
+      out += `L${x},${y} `;
+    }
     pendingMove = false;
   }
   return out.trimEnd();

--- a/web/lib/svgChart.ts
+++ b/web/lib/svgChart.ts
@@ -18,6 +18,32 @@ export function pathFromPoints(points: Point[]): string {
   return points.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x},${y}`).join(" ");
 }
 
+/**
+ * Build an SVG path that BREAKS at null/undefined/non-finite values instead
+ * of straight-line interpolating across them.
+ *
+ * Each `null` in the input ends the current sub-path; the next finite point
+ * starts a fresh `M`. Use this for sparse series (e.g. `gex_flip`) where the
+ * filtered-out version of `pathFromPoints` produces a misleading line that
+ * connects across multi-bar gaps.
+ */
+export function pathFromNullablePoints(
+  points: ReadonlyArray<Point | null>,
+): string {
+  let out = "";
+  let pendingMove = true;
+  for (const p of points) {
+    if (p == null || !Number.isFinite(p[0]) || !Number.isFinite(p[1])) {
+      pendingMove = true;
+      continue;
+    }
+    const [x, y] = p;
+    out += `${pendingMove ? "M" : "L"}${x},${y} `;
+    pendingMove = false;
+  }
+  return out.trimEnd();
+}
+
 export function niceTicks(min: number, max: number, count = 5): number[] {
   if (!isFinite(min) || !isFinite(max) || min === max) return [min];
   const span = max - min;

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -570,6 +570,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/regime/gex/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Gex Intraday
+         * @description Last N RTH sessions of intraday gex_snapshots for ``ticker``.
+         *
+         *     Drives the intraday line chart on the GEX tab. Sessions are ET-anchored
+         *     (UTC `data_date` straddles sessions). Empty `sessions` array is a valid
+         *     response when no rows exist for the ticker.
+         */
+        get: operations["get_gex_intraday_api_regime_gex_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/regime/gex/scan": {
         parameters: {
             query?: never;
@@ -2174,6 +2198,50 @@ export interface components {
             vol_pc?: number | null;
             /** Bias */
             bias?: string | null;
+        };
+        /**
+         * GexIntradayPoint
+         * @description One row from gex_snapshots inside a single ET trading session.
+         */
+        GexIntradayPoint: {
+            /**
+             * Ts
+             * Format: date-time
+             */
+            ts: string;
+            /** Spot */
+            spot?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Iv30D */
+            iv30d?: number | null;
+        };
+        /**
+         * GexIntradayResponse
+         * @description Last N RTH sessions of intraday GEX snapshots for a ticker.
+         *
+         *     Sessions are ordered oldest→newest so the chart can scan left-to-right.
+         *     Points within each session are also ASC by ``ts``.
+         */
+        GexIntradayResponse: {
+            /** Ticker */
+            ticker: string;
+            /** Sessions */
+            sessions?: components["schemas"]["GexIntradaySession"][];
+            /** As Of */
+            as_of?: string | null;
+        };
+        /** GexIntradaySession */
+        GexIntradaySession: {
+            /**
+             * Et Date
+             * Format: date
+             */
+            et_date: string;
+            /** Points */
+            points?: components["schemas"]["GexIntradayPoint"][];
         };
         /** GexIvData */
         GexIvData: {
@@ -7481,6 +7549,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gex_intraday_api_regime_gex_intraday_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexIntradayResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/unit/gexIntradayChart.test.tsx
+++ b/web/tests/unit/gexIntradayChart.test.tsx
@@ -73,11 +73,61 @@ describe("GexIntradayChart", () => {
     expect(screen.getAllByText("06/10").length).toBeGreaterThan(0);
   });
 
-  it("renders RTH tick labels (09:30, 12:00, 16:00)", () => {
-    render(<GexIntradayChart data={makeSessions()} ticker="SPX" />);
-    expect(screen.getAllByText("09:30").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("12:00").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("16:00").length).toBeGreaterThan(0);
+  it("labels the 12:00 midday anchor per session and renders 09:30/16:00 as tick marks only", () => {
+    const { container } = render(
+      <GexIntradayChart data={makeSessions()} ticker="SPX" />,
+    );
+    // Midday is the labelled anchor — one label per session.
+    expect(screen.getAllByText("12:00").length).toBe(3);
+    // 09:30 and 16:00 no longer carry text labels (they used to collide at
+    // adjacent-session boundaries). Their tick marks still render — see the
+    // <line> count check below.
+    expect(screen.queryAllByText("09:30").length).toBe(0);
+    expect(screen.queryAllByText("16:00").length).toBe(0);
+    // Three tick marks per session × 3 sessions = 9 short axis lines at the
+    // bottom edge of the chart canvas (y1 = HEIGHT - PAD.bottom = 242).
+    const tickMarks = container.querySelectorAll(
+      'svg line[y1="242"][y2="244"], svg line[y1="242"][y2="246"]',
+    );
+    expect(tickMarks.length).toBe(9);
+  });
+
+  it("renders an alternating session band for every other session", () => {
+    const { container } = render(
+      <GexIntradayChart data={makeSessions()} ticker="SPX" />,
+    );
+    // 3 sessions → exactly 1 banded session (index 1, the middle one).
+    const bands = container.querySelectorAll(
+      'svg rect[fill="rgba(148,163,184,0.05)"]',
+    );
+    expect(bands.length).toBe(1);
+  });
+
+  it("breaks every series path at session boundaries (no overnight RTH line)", () => {
+    const { container } = render(
+      <GexIntradayChart data={makeSessions()} ticker="SPX" />,
+    );
+    // Each of 4 series paths should have 3 `M` commands — one per session —
+    // so the path visually starts fresh at each 09:30 ET and never connects
+    // from one session's 16:00 close to the next session's 09:30 open.
+    const paths = Array.from(container.querySelectorAll("svg path"));
+    expect(paths.length).toBe(4);
+    for (const p of paths) {
+      const d = p.getAttribute("d") ?? "";
+      const moveCount = (d.match(/M/g) ?? []).length;
+      expect(moveCount).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("uses stroke-linecap=round on series paths so isolated singletons render as dots", () => {
+    const { container } = render(
+      <GexIntradayChart data={makeSessions()} ticker="SPX" />,
+    );
+    const paths = Array.from(container.querySelectorAll("svg path"));
+    expect(paths.length).toBe(4);
+    for (const p of paths) {
+      expect(p.getAttribute("stroke-linecap")).toBe("round");
+    }
   });
 
   it("renders the thin-data fallback when only one tick is present", () => {

--- a/web/tests/unit/gexIntradayChart.test.tsx
+++ b/web/tests/unit/gexIntradayChart.test.tsx
@@ -1,0 +1,105 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GexIntradayChart } from "@/components/regime/gex/GexIntradayChart";
+import type { GexIntradayData } from "@/lib/regime/useGexIntraday";
+
+/** 6.5h RTH at 5-min cadence per session, 3 sessions back-to-back. */
+function makeSessions(): GexIntradayData {
+  const sessions = ["2026-06-08", "2026-06-09", "2026-06-10"].map((d) => ({
+    et_date: d,
+    points: Array.from({ length: 78 }, (_, i) => {
+      const minutesFromOpen = i * 5;
+      const hour = 9 + Math.floor((30 + minutesFromOpen) / 60);
+      const minute = (30 + minutesFromOpen) % 60;
+      const hh = String(hour).padStart(2, "0");
+      const mm = String(minute).padStart(2, "0");
+      // ISO timestamp in ET (-04:00) — chart converts to ET internally.
+      return {
+        ts: `${d}T${hh}:${mm}:00-04:00`,
+        spot: 7400 + Math.sin(i / 8) * 12 + (d === "2026-06-10" ? 5 : 0),
+        net_gex: -50000 + Math.cos(i / 6) * 15000,
+        gex_flip: i % 6 === 0 ? 7395 + i / 6 : null,
+        iv30d: 0.18 + (i / 78) * 0.01,
+      };
+    }),
+  }));
+  return {
+    ticker: "SPX",
+    sessions,
+    as_of: sessions[sessions.length - 1].points.at(-1)!.ts,
+  };
+}
+
+describe("GexIntradayChart", () => {
+  it("renders empty state when sessions is empty", () => {
+    render(
+      <GexIntradayChart
+        data={{ ticker: "SPX", sessions: [], as_of: null }}
+        ticker="SPX"
+      />,
+    );
+    expect(screen.getByText(/no intraday gex/i)).toBeTruthy();
+  });
+
+  it("renders empty state when data is null", () => {
+    render(<GexIntradayChart data={null} ticker="SPX" />);
+    expect(screen.getByText(/no intraday gex/i)).toBeTruthy();
+  });
+
+  it("renders 4 series paths + session dividers for multi-session data", () => {
+    const { container } = render(
+      <GexIntradayChart data={makeSessions()} ticker="SPX" />,
+    );
+    // 4 series (spot, flip, net_gex, iv) + the swatch <line> elements per
+    // legend item are siblings — only the four <path> elements should be
+    // present in the SVG.
+    const paths = container.querySelectorAll("svg path");
+    expect(paths.length).toBe(4);
+
+    // Header shows the session count.
+    expect(screen.getByText(/last 3 sessions/i)).toBeTruthy();
+
+    // Legend swatches present.
+    expect(screen.getAllByText(/SPOT/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/GEX FLIP/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/NET GEX/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/IV 30D/i).length).toBeGreaterThan(0);
+
+    // Date labels render (MM/DD format) for each session.
+    expect(screen.getAllByText("06/08").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("06/09").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("06/10").length).toBeGreaterThan(0);
+  });
+
+  it("renders RTH tick labels (09:30, 12:00, 16:00)", () => {
+    render(<GexIntradayChart data={makeSessions()} ticker="SPX" />);
+    expect(screen.getAllByText("09:30").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("12:00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("16:00").length).toBeGreaterThan(0);
+  });
+
+  it("renders the thin-data fallback when only one tick is present", () => {
+    const data: GexIntradayData = {
+      ticker: "SPX",
+      sessions: [
+        {
+          et_date: "2026-06-10",
+          points: [
+            {
+              ts: "2026-06-10T09:30:00-04:00",
+              spot: 7400,
+              net_gex: -50000,
+              gex_flip: 7395,
+              iv30d: 0.18,
+            },
+          ],
+        },
+      ],
+      as_of: "2026-06-10T09:30:00-04:00",
+    };
+    render(<GexIntradayChart data={data} ticker="SPX" />);
+    expect(screen.getByText(/needs at least 2/i)).toBeTruthy();
+  });
+});

--- a/web/tests/unit/historyChart.test.tsx
+++ b/web/tests/unit/historyChart.test.tsx
@@ -56,4 +56,18 @@ describe("HistoryChart", () => {
     const paths = container.querySelectorAll("path");
     expect(paths.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("renders four series + the IV30D legend swatch when atm_iv is present", () => {
+    const withIv = sample.map((h, i) => ({ ...h, atm_iv: 0.18 + i * 0.005 }));
+    const { container } = render(
+      <HistoryChart history={withIv} ticker="SPX" />,
+    );
+    // 4 series paths inside the chart SVG (net_gex, gex_flip, spot, iv30d).
+    const chartSvg = container.querySelector(
+      '[data-testid="gex-history-chart"] svg[role="img"]',
+    );
+    expect(chartSvg).toBeTruthy();
+    expect(chartSvg!.querySelectorAll("path").length).toBe(4);
+    expect(screen.getAllByText("IV 30D").length).toBeGreaterThan(0);
+  });
 });

--- a/web/tests/unit/svgChart.test.ts
+++ b/web/tests/unit/svgChart.test.ts
@@ -103,5 +103,32 @@ describe("svgChart helpers", () => {
       expect((out.match(/M/g) ?? []).length).toBe(1);
       expect(out.startsWith("M1,1")).toBe(true);
     });
+
+    it("emits a zero-length L for an isolated point so a round-cap stroke draws a dot", () => {
+      // Singleton at the end of the array.
+      const trailing = pathFromNullablePoints([[0, 0], [1, 1], null, [3, 3]]);
+      expect(trailing).toContain("M3,3");
+      expect(trailing).toContain("L3,3");
+
+      // Singleton surrounded by nulls.
+      const middle = pathFromNullablePoints([null, [1, 1], null, [3, 3], null]);
+      expect((middle.match(/M/g) ?? []).length).toBe(2);
+      // Each isolated point gets the M+L pair (M then L at same coord).
+      expect(middle).toContain("M1,1");
+      expect(middle).toContain("L1,1");
+      expect(middle).toContain("M3,3");
+      expect(middle).toContain("L3,3");
+    });
+
+    it("does not emit a stray L when the isolated point sits between two finite points (no isolation)", () => {
+      // [0,0]-[1,1]-[2,2] — no isolation; should be M0,0 L1,1 L2,2 (one M, two Ls).
+      const out = pathFromNullablePoints([
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ]);
+      expect((out.match(/M/g) ?? []).length).toBe(1);
+      expect((out.match(/L/g) ?? []).length).toBe(2);
+    });
   });
 });

--- a/web/tests/unit/svgChart.test.ts
+++ b/web/tests/unit/svgChart.test.ts
@@ -3,6 +3,7 @@ import {
   finiteDomain,
   linearScale,
   niceTicks,
+  pathFromNullablePoints,
   pathFromPoints,
 } from "@/lib/svgChart";
 
@@ -52,6 +53,55 @@ describe("svgChart helpers", () => {
         hi: 2,
         count: 2,
       });
+    });
+  });
+
+  describe("pathFromNullablePoints — gap-aware path builder", () => {
+    it("returns empty string for empty input", () => {
+      expect(pathFromNullablePoints([])).toBe("");
+    });
+
+    it("matches pathFromPoints when there are no gaps", () => {
+      const pts: [number, number][] = [
+        [0, 0],
+        [1, 2],
+        [2, 4],
+      ];
+      expect(pathFromNullablePoints(pts)).toBe(pathFromPoints(pts));
+    });
+
+    it("emits a fresh M after a null gap", () => {
+      const out = pathFromNullablePoints([
+        [0, 0],
+        [1, 1],
+        null,
+        [3, 3],
+        [4, 4],
+      ]);
+      expect((out.match(/M/g) ?? []).length).toBe(2);
+      expect(out).toContain("M0,0");
+      expect(out).toContain("M3,3");
+    });
+
+    it("treats consecutive nulls as a single break", () => {
+      const out = pathFromNullablePoints([[0, 0], null, null, null, [4, 4]]);
+      expect((out.match(/M/g) ?? []).length).toBe(2);
+    });
+
+    it("breaks on non-finite coordinates too", () => {
+      const out = pathFromNullablePoints([
+        [0, 0],
+        [1, Number.NaN],
+        [2, 2],
+      ]);
+      expect((out.match(/M/g) ?? []).length).toBe(2);
+      expect(out).not.toContain("NaN");
+    });
+
+    it("skips a leading null without emitting an empty M", () => {
+      const out = pathFromNullablePoints([null, [1, 1], [2, 2]]);
+      expect((out.match(/M/g) ?? []).length).toBe(1);
+      expect(out.startsWith("M1,1")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- New `GET /api/regime/gex/intraday?ticker=SPX&sessions=5&rth_only=true` endpoint returns the last N ET trading sessions of intraday `gex_snapshots` rows. Reads the generated scalar columns (`spot`, `net_gex`, `level_gex_flip_strike`, `iv_30d`) — no JSONB parse. Groups server-side by ET trading date (`scanned_at AT TIME ZONE 'America/New_York'`) so UTC `data_date` straddling doesn't bleed sessions into each other. RTH predicate is applied inside the recent-sessions CTE so a date with only ETH ticks can't squeeze a real RTH session out of the top-N window.
- New `GexIntradayChart` component on the GEX tab, above the existing daily chart. Card-wrapped, with a visible legend (SPOT / GEX FLIP / NET GEX / IV 30D), per-session date dividers (MM/DD), and intraday 09:30 / 12:00 / 16:00 ET tick labels. Dual y-axis: left = net GEX (K-scaled), right = price band (SPX + flip strike + IV).
- Existing daily `HistoryChart` reskinned with the same card frame: title, legend, 5 x-axis date anchors, dual y-axis tick labels. SVG paths unchanged — purely a visual upgrade.
- Backed by `useGexIntraday` hook mirroring `useGex`'s poll cadence (60 s during RTH, 5 min during extended-hours, paused when closed).

## Why
The GEX scanner already persists every 5-minute tick to `gex_snapshots`, but the only thing the UI exposed was the 90-day end-of-day rollup. Intraday flip migration and spot drift were invisible. This adds the intraday view without changing the scanner or schema.

Separately surfaced (not addressed in this PR): the SPX / VIX / VIX3M / VVIX / COR1M lake sync (`vol_index_lake_sync`) has been crashing since 2026-06-08 with `ModuleNotFoundError: pyarrow.pandas_compat` — `pyarrow >= 15` removed that internal. Cascade: CRI / VCG / Canary snapshots and the SPX line on the daily chart are stuck at 06-08. Worker venv likely needs `uv pip install pandas`, or `_rows_from_table` in `src/uw_scan/sources/lake.py` needs to switch to `table.to_pylist()`. See `~/.claude/projects/-Users-moremeds-projects-argon/memory/regime-data-staleness-2026-06.md` for the full audit.

## Test plan
- [ ] `cd web && pnpm vitest run` — 372 / 372 pass locally (includes 5 new tests in `gexIntradayChart.test.tsx` covering empty/null state, 4-series rendering, RTH tick labels, session-divider count, thin-data fallback)
- [ ] `cd web && pnpm tsc --noEmit` — clean
- [ ] `cd web && pnpm next build` — `/regime` still static
- [ ] CI: `pytest tests/integration/test_gex_repository.py::test_fetch_intraday_sessions_returns_grouped_rth_points` (requires psql + Postgres fixture)
- [ ] Manual: open `/regime`, GEX tab, scroll to the new "Intraday GEX, last N sessions (RTH)" card — confirm 4–5 session dividers, intraday tick labels at 09:30 / 12:00 / 16:00 ET, all 4 series visible in the legend
- [ ] Manual: same tab, "90-Day GEX History" card now has a visible legend and dated x-axis
- [ ] Live-DB smoke: `curl '/api/regime/gex/intraday?ticker=SPX&sessions=5'` returns `sessions[].et_date` in ASC order, ~75-80 RTH ticks each