### PR TITLE
docs(research): add regime notes, fix README index, gitignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ output/
 
 # Local-only archives of completed plans/specs/reviews
 docs/**/archive/
+.gstack/
+.artifacts/
+
+# Reference papers dropped into docs/research/ root — keep on disk, don't commit
+docs/research/*.pdf

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,26 @@
+# Research Projects
+
+This index pulls together the research work that is ready to browse from the
+`docs/` tree.
+
+VCG / regime research is intentionally not listed here while the current VCG
+composite-proxy work is in progress. See `docs/research/regime/` and
+`docs/superpowers/specs/2026-05-26-vcg-composite-research-design.md` only if
+you are working that branch directly.
+
+## Active Research Sets
+
+| Project | Status | Start Here |
+|---|---|---|
+| Gold SDF Framework | Research foundation for Gold Compass: structural flows, cyclical factors, valuation overlay, source catalog, and data-quality gaps. | [gold-sdf-framework/README.md](gold-sdf-framework/README.md) |
+| Goyal-Saretto IPCA Options | Replication and codebase impact analysis for the option-return IPCA paper, centered on RV-IV as the dominant cross-sectional factor. | [goyal-saretto-ipca-options/README.md](goyal-saretto-ipca-options/README.md) |
+| Six-Dimension Options Matrix | Cockpit research set for index market structure: vanna, charm, skew, term, implied move plus flow, and VRP. | [six-dimension-matrix/README.md](six-dimension-matrix/README.md) |
+
+## Focused Research Notes
+
+| Note | Why It Exists |
+|---|---|
+| [Spec % and Skew DTE](options-signals/2026-05-12-spec-pct-and-skew-dte-research.md) | Defines the watchlist card's flow-aggression metric and records why the UI avoids copying an undefined proprietary "Spec %" number. |
+| [Skew DTE Verification](options-signals/2026-05-12-skew-dte-verification.md) | Confirms that the existing `volatility.skew_25d` is nearest-expiry skew, not 30-DTE skew. |
+| [Vol-Neutral Mean Reversion](options-signals/2026-05-13-vol-neutral-mean-reversion-strategy-research.md) | Maps Volatility Tab v2 features to future defined-risk volatility and mean-reversion research. |
+| [Setup Classifier Evidence](options-signals/2026-05-15-setup-classifier-evidence.md) | Documents why signed option flow drives setup direction while IV rank is retained as context instead of a hard directional gate. |

--- a/docs/research/regime/2026-06-02-regime-data-source-local-vs-r2.md
+++ b/docs/research/regime/2026-06-02-regime-data-source-local-vs-r2.md
@@ -1,0 +1,118 @@
+# Regime page data source — local FS vs R2
+
+Date: 2026-06-02
+Status: decision report (no code change yet)
+
+## TL;DR
+
+Keep the layered architecture; pick the source per call site, not globally.
+
+- **Scan-time / request-time reads → Postgres (unchanged).** Neither local FS nor R2 belongs on the page-render path.
+- **Nightly hydrator → local FS, with R2 as the reconciliation target.** The mac mini is the warehouse host; local reads are 10–100× faster than R2 reads, and DR comes from a separate `warehouse → R2 push`, not from making the read remote.
+- **Backfills / multi-year replay → R2 directly** (already the 2026-05-25 standing rule).
+- **MacBook detached from the mini → R2** via the existing `lake_resolver` fallback.
+
+The mac-mini-as-warehouse-host doesn't change which layer should sit on the critical path. It just makes the local layer cheap enough to be worth wiring as the hot path for the offline jobs that already exist.
+
+---
+
+## 1. Context
+
+The mac mini (`100.66.147.98`) now hosts both:
+
+- The shared Postgres instance (`option_wizard` DB, schema `uw_scan`).
+- The local mirror of the market-warehouse parquet lake at `~/market-warehouse/data-lake/bronze/asset_class={volatility,equity,...}/symbol=<sym>/1d.parquet`.
+
+The regime page (`web/app/regime/page.tsx`) renders CRI, VCG, GEX, and vol-backdrop. Its underlying inputs come from a small set of "local-retrieved" series:
+
+| Indicator | Inputs | Storage today | Lookback | Heaviness |
+|-----------|--------|---------------|----------|-----------|
+| CRI | VIX, VVIX, COR1M, SPY closes | `vol_index_daily` + `daily_ohlc` (Postgres) | 200d | ~280 rows aligned |
+| VCG | VIX, VVIX, HYG (credit proxy) | `vol_index_daily` (Postgres) | 200d | ~280 rows aligned |
+| GEX | per-strike Γ + spot | UW REST API (live) | snapshot | 1 HTTP call |
+| Vol backdrop | VIX/VIX3M/VVIX/COR1M | `vol_index_daily` (Postgres) | 90d | ~250 rows |
+
+Postgres rows are upserted by a nightly `vol_index_lake_sync` job that today reads from the **local** parquet lake (`src/uw_scan/worker/jobs/vol_index_lake_sync.py`). A `lake_resolver` already exists (`src/uw_scan/sources/lake_resolver.py:69-95`) that picks R2 when `R2_*` env vars are configured, else falls back to local. So the choice is not "wire new code" — it's "which side do we default to."
+
+The warehouse side has a `scripts/sync_to_r2.py` that can push local → R2, but I haven't confirmed it's on a schedule. Flagged below.
+
+## 2. What "the data" actually is
+
+This is small data, not big data:
+
+- Volatility lake (`asset_class=volatility`): ~49 MB total, 16 symbols, ~9k rows per symbol.
+- Credit/equity slice the regime touches (HYG/JNK/LQD/SPX): a few MB.
+- Per-scan working set (200 trading days × 4 symbols): single-digit kilobytes once parsed.
+
+Both approaches comfortably fit in RAM; neither has a streaming-vs-batch tradeoff. The differences are entirely in **latency**, **failure modes**, and **operational coupling**.
+
+## 3. Approach A — Local file directory
+
+Read from `~/market-warehouse/data-lake/bronze/asset_class=volatility/symbol=VIX/1d.parquet` via `pyarrow.dataset` / `duckdb` / `pd.read_parquet`.
+
+**Pros**
+
+- **Latency is essentially free.** Cold load of the full 49 MB volatility tree is ~5–20ms on the mac mini's SSD; warm load (page cache) is sub-millisecond. The OS page cache will retain it indefinitely as long as it's accessed regularly.
+- **No external dependency.** Survives Cloudflare incidents, expired R2 tokens, account-level throttling, or a misconfigured endpoint URL.
+- **No credential surface.** Nothing to leak, rotate, or scope.
+- **Trivial to debug.** `ls`, `duckdb -c "SELECT * FROM read_parquet('…')"`, `pyarrow.dataset.dataset(…).to_table()` all just work. Errors are filesystem errors, not partial-S3-listing-with-truncation errors.
+
+**Cons**
+
+- **Single point of failure.** If the mini's disk dies between the last `sync_to_r2.py` run and now, anything ingested in that window is gone. The cost of this is bounded by how regularly the push runs (open question §6).
+- **No cross-machine consistency by default.** A laptop that wants to render the regime page locally either has to Tailscale-mount the mini's filesystem (couples to the mini's uptime and the VPN), maintain a parallel local mirror (drift risk), or read from R2 anyway (which defeats the local-only choice).
+- **Couples the regime app to filesystem layout.** Moving the warehouse path (external SSD, NAS, different home dir) requires touching every consumer's config.
+
+## 4. Approach B — R2
+
+Read via `s3://market-data/market-warehouse/data-lake/bronze/…` using `pyarrow.fs.S3FileSystem` with the account-scoped endpoint, or `duckdb` with `httpfs`.
+
+**Pros**
+
+- **Single source of truth across machines.** Mac mini, MacBook, any future host see byte-identical data. The cross-machine consistency story becomes "they both read R2," which is unambiguous.
+- **Disaster recovery is automatic.** Lose the mini's disk and the data is intact — provided the push loop is closed (§6).
+- **Decouples the app from filesystem layout.** The config surface shrinks to `R2_BUCKET` + prefix.
+- **Egress is free (Cloudflare R2)**, so the marginal cost of reads is genuinely zero rather than "cheap."
+
+**Cons**
+
+- **Network is on the critical path.** Even mac mini → Cloudflare's nearest PoP → mac mini is ~30–80 ms RTT before HTTPS handshake and parquet partition fetching. Cold reads for the volatility tree land in the 200–500 ms range. This isn't a problem for a nightly job, but it would be catastrophic on a per-page-load path.
+- **Cloudflare-side availability is on the critical path** for any job that reads from R2. R2 has had multi-region outages.
+- **Credential surface.** `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` have to be present (and current) wherever the regime API or worker runs.
+- **Harder to debug.** Listings can be truncated, prefix-vs-key bugs are silent, region/endpoint misconfig produces opaque errors.
+
+## 5. The decisive axis — read pattern × latency budget
+
+Latency only matters where the read is on the critical path.
+
+| Read | Cadence | Latency budget | Right source |
+|------|---------|----------------|--------------|
+| `vol_index_lake_sync` nightly hydrator | 1×/day | minutes | **Local** — fastest; R2 reconciliation is a separate concern |
+| CRI / VCG scan (snapshot recompute) | ~1/min (worker) | < 500 ms | **Postgres** — neither parquet source is appropriate here |
+| `/regime`, `/regime/vcg`, `/regime/vol-backdrop` API | per page load | < 100 ms | **Postgres** — already the case |
+| Multi-year backfill / replay | occasional | minutes | **R2** — per 2026-05-25 directive |
+| Cross-machine read (laptop reading mini's data) | occasional | seconds | **R2** — only consistent option when detached |
+
+Two observations follow from this table:
+
+1. **No regime page-render path tolerates a 200 ms parquet round-trip.** Whichever side you wire as the lake reader, the request-time path must continue to be Postgres. The local-vs-R2 question is only live for the hydrator and for backfills — not for the page itself.
+2. **The mac-mini-as-warehouse-host doesn't shift any of the latency budgets.** It just makes Approach A's "essentially free" cell genuinely free for the nightly job that runs on the same box.
+
+## 6. Recommendation
+
+The two approaches are not mutually exclusive; the codebase already supports both. The right policy is to assign each call site to the source that matches its latency budget.
+
+1. **Keep Postgres on the request-time path** for `/regime`, `/regime/vcg`, `/regime/vol-backdrop`, CRI snapshots, and VCG snapshots. No change.
+2. **Default the nightly `vol_index_lake_sync` job to local FS** when the warehouse mirror is present on the same host. The `lake_resolver` already produces a `Local` root when R2 env vars are absent; configure the mini's worker env to omit `R2_*` for this job's scope (or add an explicit `UW_LAKE_PREFER=local` switch). Trade-off accepted: this job will not detect data that exists in R2 but not in the local mirror — which is fine, because the local mirror IS the canonical write target.
+3. **Default backfills / replays to R2** (already specified by the 2026-05-25 rule).
+4. **MacBook should read from R2** via the existing fallback — no change needed there beyond ensuring `R2_*` env vars are set on the laptop.
+5. **Close the local → R2 push loop on a schedule.** This is the load-bearing assumption behind picking local-as-primary; without it, Approach A's DR cost is unbounded. Recommend: launchd or cron job on the mini that runs `market-data-warehouse/scripts/sync_to_r2.py` after `vol_index_lake_sync` completes.
+
+The decision framing isn't "which one wins" — it's "what is each one for." Local FS is the hot path for jobs that share a disk with the warehouse. R2 is the durability layer and the cross-machine layer. Postgres is the request-time layer. Each does the thing it's best at.
+
+## 7. Open questions / things I didn't verify
+
+- **Is `sync_to_r2.py` actually scheduled on the mini today?** I confirmed the script exists at `market-data-warehouse/scripts/sync_to_r2.py`; I did not confirm a launchd / cron entry. If it's manual-only, the DR value of Approach A is theoretical until that loop is closed.
+- **Measured RTT mac mini → R2.** I quoted 30–80 ms from typical Cloudflare-PoP latency; this should be measured directly before committing to the recommendation. A `time aws s3 ls s3://market-data/market-warehouse/data-lake/bronze/asset_class=volatility/ --endpoint-url …` on the mini would settle it.
+- **Does any other "local-retrieved" regime input bypass the parquet lake?** GEX reads UW REST live (not lake), and FRED/COMEX/LBMA series in the gold pipeline have their own fetchers. This report covers the vol-index and OHLC inputs; the gold-side dataflow needs its own pass if a parallel decision is needed there.
+- **Postgres availability dependency.** The recommendation keeps Postgres on the request path. If Postgres is down, the regime page is down — that's not a new risk, but worth noting that "local FS on the hot path" is NOT one of our options today (the regime API doesn't read parquet directly), and adding it would be a separate architectural change.

--- a/docs/research/regime/canary-next-steps-2026-05-27.md
+++ b/docs/research/regime/canary-next-steps-2026-05-27.md
@@ -1,0 +1,267 @@
+# 5% Canary — Next Steps After v1 Merge (PR #83)
+
+**Date**: 2026-05-27
+**Status**: roadmap / decision memo. Follow-up to `canary-5yr-executive-summary.md` (PR #83, merged via `9657dea`).
+**Composite version (in production)**: `1` (`score_form=linear`, frozen calibration in `canary-calibration-v1.json`)
+**Data on hand**: `uw_scan.canary_snapshots` — 3,843 rows, 2011-02-08 → 2026-05-21 (verified)
+**Run ids in `regime_backtest_runs`**: `18` (final OOS), `19–24` (walk-forward WF-1..WF-6), `25` (extra robustness — candidate for archival), `26` (canonical robustness)
+
+---
+
+## TL;DR
+
+- v1 shipped honest about what it is: a **vol-resolution predictor with speed-as-context**. The 15-year backfill + walk-forward validated that framing (5/6 windows pass 60d AUC ≥ 0.58, vol-only ≥ composite at every horizon × every subset). PR #83 is in production at `composite_version=1`.
+- Four v2 candidates surfaced in v1 §10 (v2-A through v2-D). They split cleanly into **two cheap measurement steps** that should run before any score-machinery change, and **two design-stage candidates** that require a real spec.
+- **The user's standing intuition** — *"WATCH overfires, BUY isn't strong enough when fear is max'd"* — maps to **v2-C** (WATCH band overfire) and **v2-D** (capitulation scorer). The first is measurable today; the second needs a literature pass.
+- **Recommended phase-A action**: re-run `--form-sweep` against the full 2011-2026 dataset (cheap; can falsify or re-confirm the `linear` pick that was originally chosen against only 2015-2019). This is the single highest-information action for the dollar.
+- **Recommended phase-B action**: file v2-A / v2-B / v2-C / v2-D as GitHub issues so the design conversations have a home, then decide whether to invest in v2-D's literature pass or v2-A's architecture change first.
+- **Calibration discipline**: do **not** retune calibration thresholds against the same 15-year dataset the walk-forward was validated against. That would invalidate the validation. Any v2 calibration must reserve a holdout window.
+
+---
+
+## 1. Where we are post-merge
+
+| Artifact | State | Notes |
+|---|---|---|
+| `canary_snapshots` (full dataset) | 3,843 rows, 2011-02-08 → 2026-05-21 | `MIN_ALIGNED_BARS=350` warm-up gate against VIX3M (2009-09-18 first bar) is binding |
+| `canary-calibration-v1.json` | `composite_version=1`, `score_form=linear`, v0.1 priors | Train window 2007-2014 per methodology §3; **never re-calibrated against the 2011 backfill** |
+| Walk-forward verdict | 5/6 windows pass 60d ≥ 0.58 | WF-2 (2017-18 Volmageddon) the lone failure at 0.569 |
+| Robustness verdict | Composite 0.620 / 0.627 / 0.619; vol-only beats by 0.01-0.04 | Excluding 2020-Q4 lifts 60d to 0.665 |
+| Within-band rank | NONE / WATCH carry signal (AUC 0.58-0.63); BUY band internally anti-predictive (0.35-0.45) | Regression-to-mean within BUY |
+| API contract | `composite_version=1` baked into snapshot rows + validation panel | Any breaking change requires a `COMPOSITE_VERSION` bump and re-backfill |
+| OOS gate (`tests/integration/regime/test_canary_oos_gate.py`) | Locked to v1 `LAST_KNOWN_AUC_*` constants | Recalibration changes >0.02 AUC require updating these per `docs/research/regime/CLAUDE.md:25` |
+
+The "we just merged a 15-year validation" position is the strongest the indicator has ever been in. The right thing to protect is the validation, not the calibration constants.
+
+---
+
+## 2. The honest read of the v2 questions
+
+Three of the four v2 candidates (A, B, C) are about **band / score arithmetic**, which is cheap to test. v2-D is about **adding a new scorer**, which is design work. The cheap items should not be gated on the expensive one.
+
+The vol-only-beats-composite finding (v2-A) is the most counter-intuitive — it says the speed layer is *mildly net negative* for rank prediction across 15 years, despite being central to the design hypothesis. Either:
+- The speed layer truly adds nothing to rank, and v2-A is right (drop it from the composite, keep it as state/veto only), OR
+- The speed layer adds rank in regimes the AUC averaging hides (e.g. it's predictive during CCA-active days but those days are too few to move the mean across 3,843 rows)
+
+Item v2-A is in the **"test before you change"** bucket. Items v2-B and v2-C are in the **"measure on the full dataset, then decide"** bucket. Item v2-D is the only one in the **"new design needed"** bucket.
+
+---
+
+## 3. Ranked next-step map
+
+### #1 — Re-run `--form-sweep` against the full 2011-2026 dataset (highest leverage)
+
+**Why first.** The current `score_form=linear` was picked by `cmd_form_sweep` at `scripts/backtest_canary.py:408` running against `VALID_START=2015-01-01..VALID_END=2019-12-31` (`scripts/backtest_canary.py:43-44`) — five years of relatively benign vol regime. We now have ~3× more data including Euro crisis 2011, China 2015, Volmageddon, COVID, 2022 Fed pivot, 2026 dip. A re-sweep on the full dataset tests whether `linear` is still the winner, or whether `convex` / `concave` / `sigmoid` would compress middle scores into NONE (which is what v2-C's "WATCH overfires" hypothesis needs).
+
+**Cost.** ~1 hour. The mechanism already exists. The change is a one-line widening of the sweep window (or a `--full-history` flag) in `cmd_form_sweep` to use the snapshot table's full range instead of `VALID_*`. Persists 4 rows to `regime_backtest_runs` (one per form) with `params.phase='form_sweep_full'`.
+
+**Acceptance.**
+- Each of the 4 forms returns 5d/20d/60d AUC against the full 3,843-row dataset.
+- A row is committed to `regime_backtest_runs` per form (4 rows total) with `params.phase='form_sweep_full'`.
+- Band distribution drift is reported (% NONE / WATCH / BUY / STRONG_BUY per form).
+
+**Expected outcomes.**
+- *(a)* `linear` still wins — v2-C "WATCH overfires" requires a separate fix, not a form change.
+- *(b)* A different form wins by ≥0.02 AUC on 2+ horizons — v2-C has its solution and we have a candidate for v2 with empirical backing.
+- *(c)* Forms tie — the score-form choice is regime-insensitive and the WATCH overfire must be addressed via threshold change, not arithmetic.
+
+This action is the smallest possible step that materially changes what we know about the system. Do this before any of #2-#6 below.
+
+### #2 — File v2-A / v2-B / v2-C / v2-D as GitHub issues
+
+**Why.** Right now the v2 candidates exist only in §10 of `canary-5yr-executive-summary.md`. Without issues, there is no place to attach further evidence (e.g. the output of #1), comment threads, or links to related PRs. Issues become the persistent home for these design conversations.
+
+**Cost.** 30 minutes. Each issue includes:
+- Hypothesis (from §10)
+- Current evidence (AUC numbers, run ids)
+- Falsification criteria (what would make us drop the candidate)
+- Effort estimate (S / M / L)
+- Whether it requires a `COMPOSITE_VERSION` bump
+
+**Unlocks.** Allows the v2 conversation to happen async / with collaborators / over weeks without losing context. Also makes it easy to link any future PR to the originating hypothesis.
+
+### #3 — Decide on v2-A (drop speed from composite) using the full-dataset re-sweep result
+
+**Why.** v2-A is the architecture change with the strongest empirical case — vol-only beats composite at every horizon × every subset by 0.01-0.04 AUC. But "drop speed from score, surface state separately" is a breaking API change (the `score` field changes semantics), so the cost is real.
+
+**Cost.** Medium. Steps:
+- New API field `vol_resolution_score` alongside `score`, dual-publishing during the transition
+- `COMPOSITE_VERSION` bump to 2 (per methodology §1, the spec says a non-backward-compatible composite must bump)
+- Full backfill rerun with `--overwrite` (~10 min)
+- Methodology doc update
+- OOS gate `LAST_KNOWN_AUC_*` constants updated to the v2 values
+- Validation panel UI updates to show the two scores side-by-side
+
+**Gate before doing this.** The full-dataset form-sweep (#1) must complete first. If a non-`linear` form closes most of the vol-vs-composite gap, v2-A loses urgency.
+
+**Falsification.** If `vol_only_auc - composite_auc < 0.01` across all horizons in the new form-sweep, v2-A is not worth the API break. Keep speed in the composite and just promote `vol_resolution_score` to a sibling field.
+
+### #4 — Decide on v2-B (STRONG_BUY threshold too high)
+
+**Why.** Zero STRONG_BUY hits across 15 years including GFC-era stress (Euro crisis 2011 → max score not observed there because the warm-up gate excludes pre-2011-02-08; but Volmageddon, COVID 2020, 2022, 2026 all available — max in dataset is 66.36 on 2020-11-12). Either the threshold (75) is correct for once-in-a-generation events and 15 years is not long enough, or it's miscalibrated.
+
+**Cost.** Small. Band thresholds are post-score classifications (per `canary_scoring.derive_band`) — changing them does **not** require a `COMPOSITE_VERSION` bump under the spec's invariant. Three candidate thresholds:
+- Lower STRONG_BUY to 60 — would fire ~12 days in 15 years (the 2020-11-12 cluster plus any score>60 days)
+- Lower STRONG_BUY to 55 — would fire ~50 days, overlapping the BUY band's high end
+- Eliminate STRONG_BUY entirely — collapse to NONE/WATCH/BUY three-band model
+
+**Falsification.** The within-band AUC table (v1 §9) showed BUY band is internally anti-predictive (0.35-0.45). If we extend the same analysis to a hypothetical "STRONG_BUY ≥ 60" band, internal AUC is likely also anti-predictive — in which case the threshold change is cosmetic, not informative.
+
+**Recommendation.** Defer until v2-C is resolved. STRONG_BUY's existence as a band is part of the user-facing contract; changing it shouldn't be done before the score arithmetic itself is settled.
+
+### #5 — Decide on v2-C (WATCH band overfiring; within-BUY anti-predictive)
+
+**Why.** WATCH is 31-39% of all days vs. design intent of ~25%. Within-BUY anti-predictivity is a regression-to-mean signature. The user's stated intuition — *"WATCH state is a bit too many"* — aligns with this.
+
+**Cost depends on root cause** (which #1 will help diagnose):
+- *If the form-sweep picks `convex` / `sigmoid`*: change the form, refit thresholds. Score-machinery-level change. Requires `COMPOSITE_VERSION` bump.
+- *If the form-sweep stays `linear`*: tighten WATCH threshold from 25 upward (e.g. to 30). Band-only change, no version bump. But this just moves days from WATCH to NONE — doesn't fix the within-BUY anti-predictivity.
+- *If the within-BUY problem is structural*: the score may need an entirely different post-BUY-entry treatment (e.g. cap the score at 50 once it enters BUY and use a separate "BUY intensity" signal for further rank).
+
+**Falsification.** Run #1 first. The output determines which sub-path is live.
+
+### #6 — Brainstorm v2-D (capitulation scorer)
+
+**Why.** The user's intuition that the score should peak during max fear (capitulation), not during recovery (current design), is real. v1's 2025-03 CCA peaked at score 33.4 while SPX drew down ~10% — that does feel wrong intuitively, but it's actually consistent with the indicator's *named purpose* (the canary scores "favorability for buying the dip *after stress resolves*", per methodology §1). Thrasher's original design fires *at the dip*, not during the bleeding.
+
+So v2-D is not a bug-fix — it's a **scope-expansion** question: should the indicator publish both a "dip-buy favorability" score (current) and a "capitulation intensity" score (new), or should they be a single composite?
+
+**Cost.** Large. This is a literature pass + design spec, not a code change. Needs:
+- Literature review on capitulation indicators (Whaley's "fear gauge" framing, Bekaert/Hoerova "uncertainty vs risk" decomposition, Cboe SKEW)
+- Decision on whether capitulation is a 6th scorer in the existing composite or its own indicator
+- If it's its own indicator: where does it live in the API contract? Side-by-side with canary in `/regime/canary/`? Or a new `/regime/capitulation/` endpoint?
+
+Per `docs/research/regime/CLAUDE.md` and the v1 design spec, calibration changes require their own spec under `docs/superpowers/specs/`. v2-D is past calibration — it's a new indicator. **This is a multi-week effort. Don't start until the cheap items (#1, #2) are done.**
+
+### #7 — UI window picker on the Validation panel
+
+**Why.** The current `/regime/canary/validation` endpoint returns the most recent winning-form run for the current `composite_version`. Walk-forward windows WF-1..WF-6 are not accessible to the user. A user looking at the panel during a 2026-style dip cannot see how the indicator performed in WF-2 (Volmageddon) for comparison.
+
+**Cost.** Medium. Backend change (extend `/regime/canary/validation` with a `?run_id=...` or `?window=WF-N` query param) + frontend window selector + types regeneration. ~2-3 hours.
+
+**Priority.** Low. The walk-forward results are in the DB and accessible via the SQL cookbook in `closure-2026-05-24.md`. A UI is convenience; the methodology is sound without it.
+
+### #8 — Archive run id 25 (smoke duplicate of run 26)
+
+**Why.** Run 25 and run 26 are both `phase=robustness` against the same 2011-02-08..2026-05-21 window. Run 26 is the canonical one cited in v1 §9. Run 25 is a duplicate that survived. Currently the table has no soft-delete mechanism.
+
+**Cost.** This is the same migration the VCG roadmap already calls for as item #7 (`regime_backtest_runs.archived_at` column + repository helper). Build the migration once, both indicators benefit.
+
+**Status.** Coordinate with VCG roadmap's item #7. Don't build two parallel migrations.
+
+---
+
+## 4. Cross-cutting decisions to make explicit
+
+### When does `COMPOSITE_VERSION` bump?
+
+Per the v1 design spec, the rule is: **any change to score arithmetic that produces different score values for the same input bumps the version**. Band-threshold changes do **not** bump (they're post-score classifications).
+
+| Candidate | Bumps version? | Why |
+|---|---|---|
+| v2-A (drop speed from score) | YES (1 → 2) | Score values change for every day with non-NEUTRAL speed |
+| v2-B (STRONG_BUY threshold) | NO | Band classification only; raw scores unchanged |
+| v2-C (form change `linear` → `convex` etc.) | YES (1 → 2) | Score arithmetic changes |
+| v2-C (threshold-only WATCH tighten) | NO | Band classification only |
+| v2-D (capitulation scorer added) | YES (1 → 2) — or 2 → 3 if v2-A already shipped | New scoring component |
+
+Each `COMPOSITE_VERSION` bump triggers a full backfill rerun with `--overwrite` (per `scripts/canary_backfill.py:97`). Plan accordingly.
+
+### Calibration recalibration discipline
+
+**Do not** rerun `--calibrate` against the train window using the freshly-backfilled 2011-2014 data and then run walk-forward against 2015-2026.
+
+Why: the 2011 data is the same data the walk-forward judged the v1 calibration on. Recalibrating against it and then re-evaluating against the rest of the same period would be circular — the v1 walk-forward result is the empirical anchor we just bought with the backfill. Throwing it away by recalibrating defeats the purpose.
+
+If recalibration is genuinely needed (e.g. v2-A or v2-C ships), the discipline is:
+- Reserve a holdout (e.g. 2024-onward) that is not used for any threshold setting.
+- Calibrate on 2011-2023.
+- Evaluate the final v2 calibration on 2024-onward as a pure OOS check.
+
+This is the same discipline applied in v1 but with a different holdout window.
+
+### OOS gate update protocol
+
+Per `docs/research/regime/CLAUDE.md:25`, any recalibration that moves AUCs >0.02 must update `LAST_KNOWN_AUC_*` in `tests/integration/regime/test_canary_oos_gate.py`. This is a CI-blocking gate — the update must be in the same PR as the calibration change, not a follow-up.
+
+---
+
+## 5. Recommended sequencing
+
+```
+Phase A — measurement (do this week):
+  #1 Re-run --form-sweep against full 2011-2026 dataset
+  #2 File v2-A / v2-B / v2-C / v2-D as GitHub issues
+  → Both can run in parallel; #1 produces data, #2 produces a home for the conversation
+
+Phase B — decision (after #1 reports):
+  #3 Decide on v2-A using #1 output
+  #5 Decide on v2-C sub-path using #1 output
+  #4 Decide on v2-B (lower priority, defer if v2-C is moving)
+
+Phase C — convenience / hygiene (parallel to Phase B):
+  #7 UI window picker (when there's a slow day)
+  #8 archived_at migration (coordinate with VCG roadmap item #7)
+
+Phase D — design (no earlier than Phase B resolves):
+  #6 v2-D capitulation scorer brainstorm + spec
+```
+
+**If only one item ships from this list in the next two weeks, make it #1.** It is the smallest measurement that meaningfully changes what we know about the system.
+
+If two ship, make them #1 and #2.
+
+If three ship, make them #1, #2, and #3 (the decision on v2-A — the architecture call most affected by #1's output).
+
+---
+
+## 6. Acceptance criteria for each phase
+
+### Phase A acceptance
+- 4 new rows in `regime_backtest_runs` (one per `score_form`) with `params.phase='form_sweep_full'`, `start_date=2011-02-08`, `end_date=2026-05-21`, `composite_version='1'`.
+- An updated section in this memo (or a new artifact) capturing winning form, AUC delta vs the original 2015-2019 sweep, and band-distribution drift.
+- 4 GitHub issues filed (or local issues — wherever follow-ups live), each with hypothesis / evidence / falsification / effort / version-bump-required fields.
+
+### Phase B acceptance
+- A go/no-go decision for v2-A, v2-B, v2-C captured as a single commit on `main` updating §10 of `canary-5yr-executive-summary.md` with current state ("DEFERRED" / "PROMOTED to PR planning" / "REJECTED with reason").
+- If any candidate is promoted: a draft spec under `docs/superpowers/specs/` referencing the v1 spec's invariants section.
+
+### Phase C acceptance
+- UI window picker: user can select WF-1..WF-6 from the validation panel and see per-window AUC + episode count.
+- `archived_at` migration: `SELECT id FROM uw_scan.regime_backtest_runs WHERE archived_at IS NOT NULL` returns ≥ 1 row (run 25 archived).
+
+### Phase D acceptance
+- A capitulation-scorer design spec exists and has been reviewed via `/codex-review --plan`.
+- The spec answers explicitly: 6th scorer in the composite vs separate indicator; API contract; train/OOS partition; how it interacts with v2-A if v2-A shipped.
+
+---
+
+## 7. Risks and what could go wrong
+
+| Risk | Mitigation |
+|---|---|
+| #1 returns a non-`linear` winner — we get pressured to ship v2-C quickly | Don't. Re-pin to the train/holdout discipline in §4. A new form requires a calibration redo with a reserved holdout, which takes 1-2 days minimum, not 1 hour. |
+| v2-A ships and breaks the v1 OOS gate, blocking CI | Update `LAST_KNOWN_AUC_*` constants in the same PR (per the standing rule). Don't ship v2-A as a separate PR from the gate update. |
+| `COMPOSITE_VERSION` bumps and snapshot rows for `version=1` are orphaned | The backfill script's `--overwrite` flag handles this cleanly. Plan for ~10 min of downtime on the live snapshot during the rerun. |
+| v2-D scope-creeps into "rewrite the whole indicator" | Hard-cap the spec to one literature review week + one design spec. If the spec doesn't converge, the answer is "capitulation is its own indicator, not part of canary." |
+| Running #1 against the full dataset masks the original 2015-2019 form result | Don't overwrite the run 18 row. Add a new `phase=form_sweep_full` set of rows; keep the original sweep visible for comparison. |
+
+---
+
+## 8. Out of scope
+
+These came up in the v1 conversation but are deliberately not on this roadmap:
+
+- **Per-window recalibration in walk-forward** (true expanding-train walk-forward where each window has its own thresholds): correct in principle, but requires `--calibrate` per window and a per-window `composite_version` in the DB schema. ~1 week of work, low expected lift over the frozen-calibration approach we just validated.
+- **Intraday canary updates**: out of scope by design — the indicator is EOD-only because all five inputs (VIX, VVIX, VIX3M, COR1M, SPX) are EOD-anchored.
+- **Joint signal with CRI or VCG**: explicitly the VCG roadmap's territory (`vcg-next-steps-2026-05-26.md` item #3). When joint-signal work happens, canary will be a co-occurrence input; it does not lead.
+
+---
+
+## 9. The discipline this enforces
+
+After a validated v1, the temptation is to start "improving" the calibration immediately. But v1 earned its right to ship by being honest about its limitations (vol-only beats composite, WATCH overfires, STRONG_BUY never fires) and by passing 5/6 walk-forward windows with the *frozen* calibration. Rushing to change the calibration before measuring what would actually move it would burn that signal.
+
+The cheap measurement (#1) is the work that protects the v1 result while still moving forward. The issue-filing step (#2) creates the venue where v2 designs can be debated without ad-hoc Slack threads. Both are unsexy compared to "let's redesign the scorer", but both are the prerequisite to redesigning the scorer well.
+
+If this memo prompts the urge to skip to #6 (capitulation scorer) — pause. #1 first.


### PR DESCRIPTION
## Summary

- Add regime data-source decision report (local FS vs R2, 2026-06-02)
- Add 5% canary v1→v2 roadmap notes (next steps after PR #83)
- Replace orphan `README.local-backup.md` with corrected `docs/research/README.md`
  - paths fixed: `docs/superpowers/research/` (never existed) → actual `docs/research/options-signals/` and `docs/research/six-dimension-matrix/`
- Gitignore `.artifacts/` (vcg-weights output dir + local launchd log dumps) and `docs/research/*.pdf` (reference papers stay on disk, never committed)

## Test plan

- [x] `git check-ignore -v docs/research/ssrn-4619084.pdf` confirms the new rule fires on the right file only
- [x] No code touched — docs + `.gitignore` only
- [ ] CI lint + unit passes (no source changes expected to affect this)
- [ ] Web build passes (no web changes)