### PR TITLE
fix(regime): pyarrow-native lake reader, GEX flip above spot, nice axis ticks

### DIFF
--- a/scripts/backfill_gex_flip.py
+++ b/scripts/backfill_gex_flip.py
@@ -1,0 +1,116 @@
+"""Backfill gex_snapshots.level_gex_flip_strike from stored payloads.
+
+Issue #123: compute_gex_flip dropped negative→positive crossings above spot,
+so short-gamma-regime rows persisted levels.gex_flip = null even though the
+full per-strike profile (and spot) sit in the payload. This script recomputes
+the flip with the fixed function and writes it back into payload.levels.
+level_gex_flip_strike is GENERATED ALWAYS from the payload, so it updates
+automatically.
+
+Idempotent: only touches rows whose levels.gex_flip is currently null, and a
+recomputation that still finds no crossing leaves the row untouched.
+
+Usage:
+    uv run python scripts/backfill_gex_flip.py [--dry-run] [--ticker SPX]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.scanners.gex import compute_gex_flip
+
+logger = logging.getLogger("backfill_gex_flip")
+
+_SELECT = """
+SELECT id, ticker, payload->'spot' AS spot, payload->'profile' AS profile
+FROM {schema}.gex_snapshots
+WHERE (payload->'levels'->'gex_flip' IS NULL
+       OR jsonb_typeof(payload->'levels'->'gex_flip') = 'null')
+  AND payload->'profile' IS NOT NULL
+  AND payload->'spot' IS NOT NULL
+  {ticker_clause}
+ORDER BY id
+"""
+
+_UPDATE = """
+UPDATE {schema}.gex_snapshots
+SET payload = jsonb_set(payload, '{{levels,gex_flip}}', %s::jsonb)
+WHERE id = %s
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report only, no writes")
+    parser.add_argument("--ticker", default=None, help="restrict to one ticker")
+    parser.add_argument("--batch", type=int, default=500, help="commit every N updates")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    settings = Settings.from_env()
+    conn = psycopg.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        user=settings.db_user,
+        password=settings.db_password.get_secret_value(),
+        dbname=settings.db_name,
+    )
+    schema = settings.db_schema
+
+    ticker_clause = "AND ticker = %(ticker)s" if args.ticker else ""
+    select_sql = _SELECT.format(schema=schema, ticker_clause=ticker_clause)
+    update_sql = _UPDATE.format(schema=schema)
+
+    read_cur = conn.cursor()
+    read_cur.execute(select_sql, {"ticker": args.ticker} if args.ticker else {})
+    rows = read_cur.fetchall()  # ~6K rows incl. profiles — fits in memory
+
+    write_cur = conn.cursor()
+    scanned = filled = still_none = skipped_thin = 0
+    pending = 0
+    for row_id, ticker, spot, profile in rows:
+        scanned += 1
+        if not profile or spot is None:
+            skipped_thin += 1
+            continue
+        flip = compute_gex_flip(profile, float(spot))
+        if flip is None:
+            still_none += 1
+            continue
+        flip_obj = {
+            "strike": flip,
+            "gamma": 0.0,
+            "distance": round(flip - float(spot), 2),
+            "distance_pct": round((flip - float(spot)) / float(spot) * 100, 2),
+        }
+        filled += 1
+        if args.dry_run:
+            continue
+        write_cur.execute(update_sql, (json.dumps(flip_obj), row_id))
+        pending += 1
+        if pending >= args.batch:
+            conn.commit()
+            pending = 0
+            logger.info("progress: scanned=%d filled=%d (%s)", scanned, filled, ticker)
+    if not args.dry_run and pending:
+        conn.commit()
+    conn.close()
+    logger.info(
+        "done%s: scanned=%d filled=%d no_crossing=%d thin=%d",
+        " (dry-run)" if args.dry_run else "",
+        scanned,
+        filled,
+        still_none,
+        skipped_thin,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uw_scan/scanners/gex.py
+++ b/src/uw_scan/scanners/gex.py
@@ -87,15 +87,22 @@ def bucket_profile(
 
 
 def compute_gex_flip(profile: list[dict[str, Any]], spot: float) -> float | None:
-    """Find the GEX flip: last strike below spot where net GEX crosses from negative to positive."""
-    flip = None
+    """Find the strike where net dealer gamma flips from short to long.
+
+    Returns the negative→positive crossing nearest to spot — above or below.
+    In a short-gamma regime the crossing sits above spot (net GEX is negative
+    through and below spot); restricting to strikes <= spot made the flip
+    null on 96-100% of intraday ticks there (issue #123).
+    """
+    crossings = []
     for i in range(1, len(profile)):
         prev_net = profile[i - 1]["net_gex"]
         curr_net = profile[i]["net_gex"]
-        strike = profile[i]["strike"]
-        if prev_net < 0 and curr_net > 0 and strike <= spot:
-            flip = strike
-    return flip
+        if prev_net < 0 and curr_net > 0:
+            crossings.append(profile[i]["strike"])
+    if not crossings:
+        return None
+    return min(crossings, key=lambda s: abs(s - spot))
 
 
 def find_key_levels(

--- a/src/uw_scan/sources/lake.py
+++ b/src/uw_scan/sources/lake.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import io
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -171,19 +171,26 @@ def _read_s3(lr: LakeRoot, symbol: str, *, since: date | None) -> list[dict]:
 
 
 def _rows_from_table(table, symbol: str, *, since: date | None) -> list[dict]:
-    df = table.to_pandas()
-    if "trade_date" not in df.columns:
+    # pyarrow-native conversion — keep pandas out of this path. The nightly
+    # vol_index_lake_sync died for days with ModuleNotFoundError
+    # ('pyarrow.pandas_compat') when pandas drifted out of the worker venv;
+    # to_pylist() needs nothing beyond pyarrow (issue #122).
+    if "trade_date" not in table.column_names:
         return []
-    if since is not None:
-        df = df[df["trade_date"] >= since]
-    df = df.sort_values("trade_date")
     rows: list[dict] = []
-    for r in df.itertuples(index=False):
-        rd = r._asdict()
+    for rd in table.to_pylist():
+        td = rd.get("trade_date")
+        if td is None:
+            continue
+        if isinstance(td, datetime):
+            # tolerate timestamp-typed lake columns; DB + dedup expect dates
+            td = td.date()
+        if since is not None and td < since:
+            continue
         rows.append(
             {
                 "symbol": symbol,
-                "trade_date": rd["trade_date"],
+                "trade_date": td,
                 "open": _maybe_float(rd.get("open")),
                 "high": _maybe_float(rd.get("high")),
                 "low": _maybe_float(rd.get("low")),
@@ -192,6 +199,7 @@ def _rows_from_table(table, symbol: str, *, since: date | None) -> list[dict]:
                 "volume": int(rd["volume"]) if rd.get("volume") is not None else None,
             }
         )
+    rows.sort(key=lambda r: r["trade_date"])
     return rows
 
 

--- a/tests/unit/test_gex_flip.py
+++ b/tests/unit/test_gex_flip.py
@@ -1,0 +1,50 @@
+"""compute_gex_flip: negative→positive net-GEX crossing nearest to spot.
+
+Regression tests for issue #123 — the old implementation kept only crossings
+at strikes <= spot, silently returning None for the entire short-gamma regime
+shape (net GEX negative through/below spot, crossing only above).
+"""
+
+from uw_scan.scanners.gex import compute_gex_flip
+
+
+def _profile(net_by_strike: dict[float, float]) -> list[dict]:
+    return [
+        {"strike": s, "net_gex": g, "call_gex": 0.0, "put_gex": 0.0}
+        for s, g in sorted(net_by_strike.items())
+    ]
+
+
+def test_flip_below_spot_preserved() -> None:
+    # Long-gamma shape: negative tail below, positive through spot.
+    profile = _profile({7000: -5.0, 7100: -2.0, 7200: 3.0, 7300: 6.0})
+    assert compute_gex_flip(profile, spot=7250.0) == 7200
+
+
+def test_flip_above_spot_now_returned() -> None:
+    # Short-gamma regime: net GEX negative through and below spot, the
+    # negative→positive crossing only appears at an upper strike. The old
+    # `strike <= spot` filter returned None here.
+    profile = _profile({7000: -8.0, 7200: -4.0, 7400: -1.0, 7600: 2.0})
+    assert compute_gex_flip(profile, spot=7266.0) == 7600
+
+
+def test_multiple_crossings_returns_nearest_to_spot() -> None:
+    # Crossings at 7100 (below) and 7350 (above); spot 7300 is nearer 7350.
+    profile = _profile(
+        {7000: -3.0, 7100: 1.0, 7200: -2.0, 7350: 4.0, 7500: 5.0}
+    )
+    assert compute_gex_flip(profile, spot=7300.0) == 7350
+    # Same profile, spot near the lower crossing.
+    assert compute_gex_flip(profile, spot=7120.0) == 7100
+
+
+def test_no_crossing_returns_none() -> None:
+    all_negative = _profile({7000: -3.0, 7100: -2.0, 7200: -1.0})
+    assert compute_gex_flip(all_negative, spot=7100.0) is None
+    all_positive = _profile({7000: 1.0, 7100: 2.0, 7200: 3.0})
+    assert compute_gex_flip(all_positive, spot=7100.0) is None
+
+
+def test_empty_profile_returns_none() -> None:
+    assert compute_gex_flip([], spot=7100.0) is None

--- a/tests/unit/test_lake_reader.py
+++ b/tests/unit/test_lake_reader.py
@@ -88,3 +88,48 @@ def test_list_vol_index_symbols(tmp_path: Path) -> None:
 
 def test_read_missing_symbol_returns_empty(tmp_path: Path) -> None:
     assert read_vol_index_parquet(tmp_path, "NONEXISTENT") == []
+
+
+def test_read_does_not_require_pandas(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for issue #122: the nightly vol_index_lake_sync crashed with
+    ModuleNotFoundError('pyarrow.pandas_compat') when pandas drifted out of
+    the worker venv. The reader must stay pyarrow-native so a pandas-less
+    environment can still sync the lake."""
+    import builtins
+    import sys
+
+    _write_fixture(
+        tmp_path,
+        "VIX",
+        [
+            {
+                "trade_date": date(2026, 6, 9),
+                "open": 20.0,
+                "high": 21.0,
+                "low": 19.5,
+                "close": 20.5,
+                "adj_close": 20.5,
+                "volume": 0,
+            },
+        ],
+    )
+
+    for mod in [m for m in sys.modules if m == "pandas" or m.startswith("pandas.")]:
+        monkeypatch.delitem(sys.modules, mod)
+    monkeypatch.delitem(sys.modules, "pyarrow.pandas_compat", raising=False)
+
+    real_import = builtins.__import__
+
+    def _no_pandas(name, *args, **kwargs):
+        if name == "pandas" or name.startswith("pandas."):
+            raise ModuleNotFoundError("No module named 'pandas'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_pandas)
+
+    rows = read_vol_index_parquet(tmp_path, "VIX")
+    assert len(rows) == 1
+    assert rows[0]["trade_date"] == date(2026, 6, 9)
+    assert rows[0]["close"] == pytest.approx(20.5)

--- a/web/lib/svgChart.ts
+++ b/web/lib/svgChart.ts
@@ -68,21 +68,20 @@ export function pathFromNullablePoints(
 
 export function niceTicks(min: number, max: number, count = 5): number[] {
   if (!isFinite(min) || !isFinite(max) || min === max) return [min];
-  const span = max - min;
-  const step = Math.pow(10, Math.floor(Math.log10(span / count)));
-  const err = (count * step) / span;
-  const adjusted =
-    err >= 0.15
-      ? step * 10
-      : err >= 0.35
-        ? step * 5
-        : err >= 0.75
-          ? step * 2
-          : step;
-  const start = Math.floor(min / adjusted) * adjusted;
-  const end = Math.ceil(max / adjusted) * adjusted;
+  // Heckbert nice-number rounding: snap the raw step to 1/2/5/10 × 10^k.
+  // (The previous err-ladder compared in the wrong direction, so spans like
+  // 7260–7600 fell through to a step of 10 → ~35 overlapping axis labels.)
+  const raw = (max - min) / Math.max(1, count - 1);
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const frac = raw / mag;
+  const nice = frac < 1.5 ? 1 : frac < 3 ? 2 : frac < 7 ? 5 : 10;
+  const step = nice * mag;
+  const start = Math.floor(min / step) * step;
+  const end = Math.ceil(max / step) * step;
   const out: number[] = [];
-  for (let v = start; v <= end + 1e-9; v += adjusted) out.push(v);
+  for (let i = 0; start + i * step <= end + step * 1e-6; i++) {
+    out.push(start + i * step);
+  }
   return out;
 }
 

--- a/web/tests/unit/svgChart.test.ts
+++ b/web/tests/unit/svgChart.test.ts
@@ -35,6 +35,24 @@ describe("svgChart helpers", () => {
     expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(100);
   });
 
+  it("niceTicks stays near the requested count (regression: 35-label price axis)", () => {
+    // SPX intraday price band — the old err-ladder inverted its comparisons,
+    // fell through to a step of 10 and produced ~35 overlapping labels.
+    const price = niceTicks(7260, 7600, 4);
+    expect(price.length).toBeGreaterThanOrEqual(3);
+    expect(price.length).toBeLessThanOrEqual(8);
+
+    // Net-GEX-shaped domain should not collapse to 2 ticks either.
+    const netGex = niceTicks(-120_000, 110_000, 4);
+    expect(netGex.length).toBeGreaterThanOrEqual(3);
+    expect(netGex.length).toBeLessThanOrEqual(8);
+
+    // Small decimal domains keep working.
+    const small = niceTicks(0.1, 0.9, 4);
+    expect(small.length).toBeGreaterThanOrEqual(3);
+    expect(small.length).toBeLessThanOrEqual(8);
+  });
+
   describe("finiteDomain — NaN-safety helper", () => {
     it("returns min/max of finite values only", () => {
       const d = finiteDomain([1, NaN, 2, null, 3, undefined, 5] as number[]);


### PR DESCRIPTION
## Summary

Fixes the three root causes behind the 2026-06-11 regime-page staleness report (GEX flip `---`, dense price axis, flat SPX spot line, CRI/VCG/Canary 2-3 days stale).

- **`sources/lake.py` — pyarrow-native row conversion (#122 P0).** `_rows_from_table` used `table.to_pandas()`; when pandas drifted out of the worker venv, the nightly `vol_index_lake_sync` crashed with `ModuleNotFoundError: pyarrow.pandas_compat` for 3 consecutive nights, cascading staleness into `vol_index_daily` → CRI/VCG/Canary/SPX-spot. Now uses `to_pylist()` — no pandas on this path, ever. A unit test monkeypatches the pandas import away to lock this in. Also tolerates timestamp-typed `trade_date` columns.
- **`scanners/gex.py` — flip crossing above spot (#123).** `compute_gex_flip` filtered to strikes ≤ spot, so the entire short-gamma regime (crossing above spot) persisted `gex_flip = null` — 96-100% of intraday ticks this week. Now returns the negative→positive crossing **nearest** spot on either side. Unit tests cover below-spot, above-spot, multiple crossings, no crossing, and empty profile.
- **`scripts/backfill_gex_flip.py` (new).** Idempotent backfill that recomputes flips from the stored payload `profile` + `spot` for rows where `levels.gex_flip` is null (`level_gex_flip_strike` is GENERATED from the payload, so it regenerates automatically). Supports `--dry-run` / `--ticker` / `--batch`. Already run in prod: 5,783 rows filled, 100% flip coverage on 11,011 snapshots.
- **`web/lib/svgChart.ts` — Heckbert nice ticks.** The err-ladder in `niceTicks` compared in the wrong direction (the ×2/×5 branches were unreachable), so a 7260–7600 span fell through to step=10 → ~35 overlapping price labels on the intraday GEX chart. Rewritten as standard nice-number rounding; regression test pins tick counts for price-, net-GEX-, and decimal-shaped domains.

Closes #122, closes #123.

## Verification

- 955 Python unit tests green (`uv run pytest tests/unit`), incl. 5 new flip tests + pandas-blocked lake reader test
- 385 web vitest green incl. new `niceTicks` regression
- Deployed on the mini stack: live GEX flip tile shows 7,425 (+1.91%), intraday axis renders 5 ticks (7200…7600), CRI/Canary recovered to 06-10, VCG to 06-09 (upstream HYG lake lags one day — not an argon bug)
- Browser screenshots under `output/playwright/regime-*-after-fixes.png`

## Notes

- R2 lake is stale at 2026-05-21 (external producer→R2 push dead again); the PR #117 resolver correctly falls back to the local mirror. Out of scope here — tracked in #118.
- Integration tests not run locally (`psql` not on PATH on this machine, pre-existing); CI covers them.