### PR TITLE
fix(ws): bypass system proxy on Massive connect, flush-based health, clear stale errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 - **Persist analytical results to Postgres** — vol/scan/regime outputs land in tables, never in-memory-only
 - **No naked shorts** in any strategy/trade-plan code — defined-risk only
 - **Data source priority**: IB → UW → FMP → massive (OHLC). Yahoo is banned
+- **Massive WS bypasses system proxies** — `MassiveWsClient` passes `proxy=None` to `websockets.connect`; the market-data stream must never inherit macOS SOCKS/HTTP proxy settings (`python-socks` is not installed, so an inherited proxy kills every connect). The configured feed is ~15-min delayed, so WS-consumer health keys on `last_flush_at` (is the consumer alive?), not tick event time
 - **No secrets to local Codex subprocesses** — do not pass UW/FMP/Massive keys, DB credentials, or unrelated app secrets to `codex exec`
 - **Never commit without an explicit user request.** Draft first, wait
 - **Big projects use milestone commits** — when the user has explicitly requested commits for a large project/task, commit each closed milestone after its relevant verification before continuing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 - **Persist analytical results to Postgres** — vol/scan/regime outputs land in tables, never in-memory-only
 - **No naked shorts** in any strategy/trade-plan code — defined-risk only
 - **Data source priority**: IB → UW → FMP → massive (OHLC). Yahoo is banned
+- **Massive WS bypasses system proxies** — `MassiveWsClient` passes `proxy=None` to `websockets.connect`; the market-data stream must never inherit macOS SOCKS/HTTP proxy settings (`python-socks` is not installed, so an inherited proxy kills every connect). The configured feed is ~15-min delayed, so WS-consumer health keys on `last_flush_at` (is the consumer alive?), not tick event time
 - **No secrets to local Codex subprocesses** — do not pass UW/FMP/Massive keys, DB credentials, or unrelated app secrets to `codex exec`
 - **Never commit without an explicit user request.** Draft first, wait
 - **Big projects use milestone commits** — when the user has explicitly requested commits for a large project/task, commit each closed milestone after its relevant verification before continuing

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -80,7 +80,7 @@ class WsConsumerHealth(BaseModel):
 
     ``healthy`` is true when:
       * the market is closed (no ticks are expected), OR
-      * ``last_tick_at`` is within ``massive_ws_heartbeat_stale_after_seconds``.
+      * ``last_flush_at`` is within ``massive_ws_heartbeat_stale_after_seconds``.
 
     ``reason`` carries the short label the UI displays under the row.
     """
@@ -345,7 +345,9 @@ def health(
         )
     else:
         age_s = (now_utc - ws_state.last_tick_at).total_seconds()
-        stale = age_s >= settings.massive_ws_heartbeat_stale_after_seconds
+        heartbeat_at = ws_state.last_flush_at or ws_state.last_tick_at
+        heartbeat_age_s = (now_utc - heartbeat_at).total_seconds()
+        stale = heartbeat_age_s >= settings.massive_ws_heartbeat_stale_after_seconds
         ws_consumer = WsConsumerHealth(
             healthy=(not stale) or (not in_session),
             last_tick_at=ws_state.last_tick_at,

--- a/src/uw_scan/sources/massive_ws.py
+++ b/src/uw_scan/sources/massive_ws.py
@@ -122,6 +122,7 @@ class MassiveWsClient:
             self._url,
             open_timeout=self._open_timeout,
             ping_interval=self._ping_interval,
+            proxy=None,
         )
         await self._authenticate()
         return self

--- a/src/uw_scan/storage/ws_consumer_state.py
+++ b/src/uw_scan/storage/ws_consumer_state.py
@@ -62,7 +62,10 @@ class _WsConsumerStateMixin:
             cur.execute(
                 f"""
                 UPDATE {self._schema}.ws_consumer_state
-                SET connection_started_at = %s, updated_at = NOW()
+                SET connection_started_at = %s,
+                    last_error = NULL,
+                    last_error_at = NULL,
+                    updated_at = NOW()
                 WHERE id = 1
                 """,
                 (started_at,),

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -16530,7 +16530,7 @@
         "type": "object"
       },
       "WsConsumerHealth": {
-        "description": "Massive.com WS consumer status, surfaced for the HealthPanel.\n\n``healthy`` is true when:\n  * the market is closed (no ticks are expected), OR\n  * ``last_tick_at`` is within ``massive_ws_heartbeat_stale_after_seconds``.\n\n``reason`` carries the short label the UI displays under the row.",
+        "description": "Massive.com WS consumer status, surfaced for the HealthPanel.\n\n``healthy`` is true when:\n  * the market is closed (no ticks are expected), OR\n  * ``last_flush_at`` is within ``massive_ws_heartbeat_stale_after_seconds``.\n\n``reason`` carries the short label the UI displays under the row.",
         "properties": {
           "connection_started_at": {
             "anyOf": [

--- a/tests/integration/api/test_health_ws.py
+++ b/tests/integration/api/test_health_ws.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
@@ -33,6 +33,32 @@ def test_health_includes_ws_consumer_when_healthy(
     # be near zero immediately after the heartbeat write.
     assert body["ws_consumer"]["last_tick_age_seconds"] is not None
     assert body["ws_consumer"]["last_tick_age_seconds"] < 5
+
+
+def test_health_ws_consumer_uses_fresh_flush_for_delayed_feed(
+    client: TestClient, seeded_db_empty_cards, monkeypatch
+):
+    """Delayed event time is healthy when the consumer is actively flushing."""
+    from uw_scan.worker import market_session
+
+    monkeypatch.setattr(
+        market_session, "current_market_date", lambda *_a, **_k: datetime.now().date()
+    )
+    repo = seeded_db_empty_cards
+    now = datetime.now(timezone.utc)
+    repo.record_ws_heartbeat(
+        last_tick_at=now - timedelta(minutes=15),
+        last_flush_at=now,
+        ticks_received_delta=10,
+        ticks_flushed_delta=10,
+    )
+    repo._conn.commit()
+
+    body = client.get("/api/health").json()
+
+    assert body["ws_consumer"]["healthy"] is True
+    assert body["ws_consumer"]["reason"] is None
+    assert body["ws_consumer"]["last_tick_age_seconds"] > 14 * 60
 
 
 def test_health_ws_consumer_null_state_outside_session(

--- a/tests/integration/storage/test_ws_consumer_state.py
+++ b/tests/integration/storage/test_ws_consumer_state.py
@@ -57,6 +57,20 @@ def test_record_ws_connection_started(seeded_db_empty_cards):
     assert row.connection_started_at == ts
 
 
+def test_record_ws_connection_started_clears_previous_error(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    ts = _utcnow()
+    repo.record_ws_error("old connection failure", ts)
+    repo._conn.commit()
+
+    repo.record_ws_connection_started(_utcnow())
+    repo._conn.commit()
+
+    row = repo.get_ws_consumer_state()
+    assert row.last_error is None
+    assert row.last_error_at is None
+
+
 def test_record_ws_error(seeded_db_empty_cards):
     repo = seeded_db_empty_cards
     ts = _utcnow()

--- a/tests/unit/sources/test_massive_ws.py
+++ b/tests/unit/sources/test_massive_ws.py
@@ -131,6 +131,33 @@ def test_parse_ws_message_non_utf8_bytes_raises():
 
 
 @pytest.mark.asyncio
+async def test_client_bypasses_system_proxy(monkeypatch):
+    """The dedicated market-data stream must not inherit macOS proxy settings."""
+    connect_kwargs: dict[str, object] = {}
+
+    class FakeWebSocket:
+        async def send(self, _message: str) -> None:
+            return None
+
+        async def recv(self) -> str:
+            return '[{"ev":"status","status":"auth_success"}]'
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_connect(_url: str, **kwargs):
+        connect_kwargs.update(kwargs)
+        return FakeWebSocket()
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+
+    async with MassiveWsClient("wss://delayed.massive.com/stocks", "TEST_KEY"):
+        pass
+
+    assert connect_kwargs["proxy"] is None
+
+
+@pytest.mark.asyncio
 async def test_client_authenticates_and_subscribes():
     """Spin up a fake WS server, verify auth + subscribe messages are sent."""
     received: list[str] = []


### PR DESCRIPTION
## Summary

The Massive websocket consumer was down: `websockets.connect` inherited macOS's system SOCKS proxy, and every connection attempt failed because `python-socks` is not installed. Three fixes plus the documented operating rule:

- **`sources/massive_ws.py`** — pass `proxy=None` to `websockets.connect` so the dedicated market-data stream never inherits macOS SOCKS/HTTP proxy settings. New unit test asserts the kwarg reaches `connect`.
- **`api/routers/health.py`** — WS-consumer staleness now keys on `last_flush_at` (falling back to `last_tick_at`) instead of tick event time. The configured Massive feed is intentionally ~15-min delayed, so a perfectly healthy consumer carries 15-min-old event timestamps; the signal that matters is whether ingestion/flush is alive. New integration test: delayed event time + fresh flush ⇒ healthy.
- **`storage/ws_consumer_state.py`** — a successful connection start clears `last_error`/`last_error_at`, so the health row stops reporting an error a reconnect already resolved. New integration test covers the clear.
- **AGENTS.md + CLAUDE.md** — operating rule documented (no-proxy on the Massive stream; flush-based health semantics for the delayed feed), kept in sync per the standing rule.

## Verification

- 18 unit tests pass (`uv run pytest tests/unit/sources/test_massive_ws.py`)
- Verified live on the mini stack after restarting `com.argon.api` + `com.argon.massive-ws`: direct TCP connection to Massive established, 391 ticks received in 8 seconds, `ws_consumer.healthy=true`, `last_error=null`
- Integration tests (`test_health_ws.py`, `test_ws_consumer_state.py`) run in CI (`psql` not on PATH on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)