### PR TITLE
fix(storage): exclude failed scan_runs from latest_run_id

### DIFF
--- a/src/uw_scan/storage/scan_runs.py
+++ b/src/uw_scan/storage/scan_runs.py
@@ -17,7 +17,7 @@ class _ScanRunsMixin:
     _schema: str
 
     def latest_run_id(self, ticker: str) -> int:
-        """Return the highest full-scan run_id for `ticker`, or 0 if none.
+        """Return the highest *successful* full-scan run_id for `ticker`, or 0 if none.
 
         Excludes runs created by side-channel jobs that populate only a
         narrow slice of tables and would otherwise shadow the actual
@@ -29,11 +29,19 @@ class _ScanRunsMixin:
         - ``intraday_refresh`` (OI movers intraday: option_chain_oi only)
         - ``cockpit_daily_snapshot`` (SPX/SPY/QQQ/IWM greeks/skew only)
         - ``gex_scan_*`` (SPX/SPY index-only GEX scanner running every 5 min)
+
+        Also requires ``status = 'ok'`` — a failed full-scan (e.g. UW HTTP
+        429 daily-quota hit) commits the scan_runs row with status set to
+        a ``failed: …`` string but leaves exposures/aggregates/gex_curve
+        unwritten. Without this filter the report assembler resolves to
+        the failed run and joins on a run_id that has no detail rows,
+        producing an empty stock detail page.
         """
         with self._conn.cursor() as cur:
             cur.execute(
                 f"SELECT run_id FROM {self._schema}.scan_runs "
                 "WHERE ticker = %s "
+                "  AND status = 'ok' "
                 "  AND (notes IS DISTINCT FROM 'flow_data_refresh') "
                 "  AND (notes IS DISTINCT FROM 'positioning_refresh') "
                 "  AND (notes IS DISTINCT FROM 'intraday_refresh') "

--- a/tests/integration/storage/test_flow_tab.py
+++ b/tests/integration/storage/test_flow_tab.py
@@ -82,6 +82,25 @@ def test_latest_run_id_skips_flow_data_refresh_runs(seeded_db_empty_cards) -> No
     assert repo.latest_run_id("GOOGL") == full_run
 
 
+def test_latest_run_id_skips_failed_runs(seeded_db_empty_cards) -> None:
+    """A failed full-scan (e.g. UW HTTP 429 daily-quota hit) commits a
+    scan_runs row with ``status`` set to ``failed: …`` but leaves the
+    per-run exposures / aggregates / gex_curve unwritten. Without the
+    status filter, ``latest_run_id`` would return the failed run and the
+    report assembler would join on a run_id with no detail rows, producing
+    an empty stock detail page.
+    """
+    repo = seeded_db_empty_cards
+    full_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.finish_scan_run(full_run, status="ok")
+    failed_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.finish_scan_run(failed_run, status="failed: UwHTTPError('UW HTTP 429')")
+    repo.conn.commit()
+
+    assert failed_run > full_run  # sanity: failed run would otherwise win
+    assert repo.latest_run_id("GOOGL") == full_run
+
+
 def test_latest_run_id_skips_side_channel_refresh_runs(seeded_db_empty_cards) -> None:
     """positioning_refresh / intraday_refresh / cockpit_daily_snapshot each
     insert a scan_runs row that populates only a narrow slice of tables


### PR DESCRIPTION
## Summary

- `Repository.latest_run_id` already filters out side-channel notes (`flow_data_refresh`, `gex_scan_*`, …) but never checked `status`. A failed full-scan (UW HTTP 429 today) commits the parent `scan_runs` row but never writes the per-run detail tables — so when it shadows the previous good run, the stock detail page renders with `net_gex`, `market_structure_levels`, `aggregates`, `strike_gex_curve`, `oi_change_top` all null/empty.
- Visible today on every watchlist ticker after UW's 20k/day quota was hit at ~04:00. Every major ticker's `latest_run_id` currently resolves to a `failed: UwHTTPError('UW HTTP 429 …')` run.
- Fix: add `AND status = 'ok'` to the lookup (mirrors the existing filter on `get_scan_duration_summary`).

## Not a #128 regression

The xenon-WS scheduler change only touched `upsert_watchlist_card`'s `preserve_spot` guard; the report run_id resolution path was untouched. This is a latent bug surfaced by the UW quota hit. The quota cadence itself is a separate operational issue (worth a follow-up).

## Test plan

- [x] New integration test `test_latest_run_id_skips_failed_runs` verifies a more-recent failed run does not shadow the prior ok run.
- [x] All existing `latest_run_id` tests pass (flow_data_refresh + side-channel-refresh exclusions).
- [x] `tests/integration/storage`, `tests/integration/reports`, `tests/integration/api/test_scanner_endpoint.py`, `tests/integration/api/test_regime_dealer.py`, `tests/unit/test_report_assembly.py` — 180 passed.
- [x] Full unit suite — 973 passed.
- [x] `ruff check` clean.

## Deploy

API + worker + AI workers all call `latest_run_id`, so deploy via `scripts/deploy/macmini-bootstrap.sh` (or `launchctl kickstart` each agent).