### PR TITLE
chore(tests): session-scoped migrate + per-test TRUNCATE/COPY restore

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
-# scripts/migrate.sh — apply all SQL migrations under src/uw_scan/storage/migrations/
-# in lexical order against the configured Postgres. Idempotent: every migration uses
-# IF NOT EXISTS / ON CONFLICT, so re-running is a no-op.
+# scripts/migrate.sh — apply all SQL migrations under
+# src/uw_scan/storage/migrations/ in lexical order against the configured
+# Postgres. Idempotent: every migration uses IF NOT EXISTS / ON CONFLICT,
+# so re-running is a no-op.
 #
-# Honors UW_SCAN_DB_NAME / UW_SCAN_DB_HOST / UW_SCAN_DB_PORT etc. through Settings.
+# Honors UW_SCAN_DB_NAME / UW_SCAN_DB_HOST / UW_SCAN_DB_PORT etc. through
+# Settings. Runs in-process via psycopg (no per-file psql subprocess).
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-
-DSN=$(uv run python -c 'from uw_scan.config import Settings; print(Settings.from_env().db_dsn())')
-
-for f in src/uw_scan/storage/migrations/*.sql; do
-  echo "Applying $f..."
-  psql "$DSN" -v ON_ERROR_STOP=1 -f "$f"
-done
-
-echo "All migrations applied."
+exec uv run python -m uw_scan.storage.migrate_runner

--- a/src/uw_scan/storage/migrate_runner.py
+++ b/src/uw_scan/storage/migrate_runner.py
@@ -1,0 +1,189 @@
+"""In-process SQL migration runner.
+
+Reads every ``*.sql`` under ``src/uw_scan/storage/migrations/`` in lexical
+order and applies it via a single psycopg connection. Replaces the
+per-file ``psql`` subprocess loop that ``scripts/migrate.sh`` used to run,
+which paid ~30ms × 82 files of fork+connect cost per invocation. The
+integration-test conftest now imports ``apply_migrations`` directly so
+fixtures pay zero subprocess overhead.
+
+Requires ``conn.autocommit = True`` because at least three migrations
+(``026``, ``027``, ``035``) use ``CREATE INDEX CONCURRENTLY`` /
+``DROP INDEX CONCURRENTLY``, which PostgreSQL forbids inside an explicit
+transaction block. Each statement in a file is sent as its own simple
+query so the server doesn't wrap multi-statement batches in an implicit
+transaction.
+
+CLI entry point::
+
+    uv run python -m uw_scan.storage.migrate_runner
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import psycopg
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+
+
+def discover_migrations(migrations_dir: Path = MIGRATIONS_DIR) -> list[Path]:
+    """Return every ``*.sql`` file in ``migrations_dir`` sorted lexically."""
+    return sorted(p for p in migrations_dir.glob("*.sql"))
+
+
+def split_sql_statements(sql: str) -> list[str]:
+    """Split a SQL script on top-level ``;`` boundaries.
+
+    Aware of single-quoted strings, double-quoted identifiers,
+    ``$tag$``-style dollar quotes (used for ``DO $$ ... $$`` blocks),
+    ``-- line`` comments and ``/* block */`` comments. Statements with
+    only whitespace/comments are dropped.
+
+    We send each statement separately because psycopg's multi-statement
+    ``execute`` wraps the batch in an implicit transaction on the server,
+    which ``CREATE INDEX CONCURRENTLY`` rejects.
+    """
+    statements: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(sql)
+    state: str | None = None
+    dollar_tag = ""
+
+    while i < n:
+        c = sql[i]
+
+        if state is None:
+            if c == ";":
+                stmt = "".join(current).strip()
+                if stmt:
+                    statements.append(stmt)
+                current = []
+                i += 1
+                continue
+            if c == "'":
+                state = "sq"
+                current.append(c)
+                i += 1
+                continue
+            if c == '"':
+                state = "id"
+                current.append(c)
+                i += 1
+                continue
+            if c == "-" and i + 1 < n and sql[i + 1] == "-":
+                state = "lc"
+                current.append(c)
+                i += 1
+                continue
+            if c == "/" and i + 1 < n and sql[i + 1] == "*":
+                state = "bc"
+                current.append(c)
+                current.append(sql[i + 1])
+                i += 2
+                continue
+            if c == "$":
+                # Try to consume a dollar-quote tag: $tag$ or $$.
+                j = i + 1
+                while j < n and (sql[j].isalnum() or sql[j] == "_"):
+                    j += 1
+                if j < n and sql[j] == "$":
+                    dollar_tag = sql[i : j + 1]
+                    state = "dq"
+                    current.append(dollar_tag)
+                    i = j + 1
+                    continue
+            current.append(c)
+            i += 1
+            continue
+
+        if state == "sq":
+            current.append(c)
+            if c == "'":
+                # Escaped quote ('') stays inside the string literal.
+                if i + 1 < n and sql[i + 1] == "'":
+                    current.append(sql[i + 1])
+                    i += 2
+                    continue
+                state = None
+            i += 1
+            continue
+
+        if state == "id":
+            current.append(c)
+            if c == '"':
+                if i + 1 < n and sql[i + 1] == '"':
+                    current.append(sql[i + 1])
+                    i += 2
+                    continue
+                state = None
+            i += 1
+            continue
+
+        if state == "lc":
+            current.append(c)
+            if c == "\n":
+                state = None
+            i += 1
+            continue
+
+        if state == "bc":
+            current.append(c)
+            if c == "*" and i + 1 < n and sql[i + 1] == "/":
+                current.append(sql[i + 1])
+                i += 2
+                state = None
+                continue
+            i += 1
+            continue
+
+        if state == "dq":
+            if c == "$" and sql.startswith(dollar_tag, i):
+                current.append(dollar_tag)
+                i += len(dollar_tag)
+                state = None
+                dollar_tag = ""
+                continue
+            current.append(c)
+            i += 1
+            continue
+
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def apply_migrations(
+    conn: psycopg.Connection,
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+    log: Callable[[str], None] = print,
+) -> None:
+    if not conn.autocommit:
+        raise RuntimeError(
+            "apply_migrations requires conn.autocommit=True "
+            "(CONCURRENTLY index ops cannot run inside a transaction)"
+        )
+    for f in discover_migrations(migrations_dir):
+        log(f"Applying {f.name}...")
+        for stmt in split_sql_statements(f.read_text()):
+            conn.execute(stmt)
+
+
+def main() -> int:
+    from uw_scan.config import Settings
+
+    settings = Settings.from_env()
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        apply_migrations(conn)
+    print("All migrations applied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,7 +23,7 @@ Standalone module-level tests (`test_smile_trim.py`, `test_fill_rv_from_price.py
 - **Run with `uv run pytest`.** Never bare `pytest`.
 - **`live` tests are excluded by default.** Add the `@pytest.mark.live` marker; they only run when `UW_SCAN_API_KEY` is set and the marker is selected.
 - **No mocked DB / fake cursors.** Integration tests use `pytest-postgresql` to spin up a real Postgres; the project policy explicitly bans `unittest.mock` of cursors.
-- **Migrations run on every fixture.** `conftest.py` applies `scripts/migrate.sh` against the test DB; migrations must stay idempotent (covered in `src/uw_scan/storage/CLAUDE.md`).
+- **Migrations run once per pytest session.** `tests/integration/conftest.py` applies every migration in-process via `uw_scan.storage.migrate_runner.apply_migrations` exactly once per session; the `seeded_db_empty_cards` fixture then restores the post-migration baseline per test by `TRUNCATE ... CASCADE` + `COPY`. Migrations must stay idempotent (covered in `src/uw_scan/storage/CLAUDE.md`).
 - **`asyncio_mode = "auto"`** is enabled via `pytest-asyncio` — bare `async def test_…` works.
 - **Fixture data** lives next to the test that uses it. Don't add a global fixtures dump.
 - **CI Guardrail 2** scans every `except` block for `.exception(...)`, `repr(exc)`, `traceback`, or `raise`. If a test introduces a try/except handler in production code, satisfy the guardrail (usually `log.debug(..., repr(exc))`).

--- a/tests/integration/api/test_gold_router_gauge.py
+++ b/tests/integration/api/test_gold_router_gauge.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -16,8 +14,6 @@ from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.server import create_app
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -32,33 +28,24 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def app_with_seed() -> TestClient:
+def app_with_seed(seeded_db_empty_cards) -> TestClient:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. Seed the macro series for the gauge endpoint into the same DB.
     settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        repo = Repository(conn, schema=settings.db_schema)
-        base = date(2025, 1, 1)
-        for i in range(400):
-            d = base + timedelta(days=i)
-            repo.insert_macro_series_daily(
-                "DFII10",
-                d,
-                Decimal(str(2.0 - i * 0.003)),
-                datetime.combine(d, datetime.min.time(), tzinfo=UTC),
-                None,
-                "FRED",
-                None,
-            )
+    repo = seeded_db_empty_cards
+    base = date(2025, 1, 1)
+    for i in range(400):
+        d = base + timedelta(days=i)
+        repo.insert_macro_series_daily(
+            "DFII10",
+            d,
+            Decimal(str(2.0 - i * 0.003)),
+            datetime.combine(d, datetime.min.time(), tzinfo=UTC),
+            None,
+            "FRED",
+            None,
+        )
+    repo.conn.commit()
 
     app = create_app()
 

--- a/tests/integration/api/test_gold_router_replay.py
+++ b/tests/integration/api/test_gold_router_replay.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -15,8 +13,6 @@ from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.server import create_app
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -64,24 +60,13 @@ def _insert(repo: Repository, computed_at: datetime, state: str) -> None:
 
 
 @pytest.fixture
-def app_with_multi_vintage() -> TestClient:
+def app_with_multi_vintage(seeded_db_empty_cards) -> TestClient:
     """Two posture rows for the same obs_date — replay must return the FIRST."""
     settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        repo = Repository(conn, schema=settings.db_schema)
-        _insert(repo, datetime(2026, 5, 11, 21, tzinfo=UTC), "suspended")
-        _insert(repo, datetime(2026, 5, 20, 21, tzinfo=UTC), "partial")
+    repo = seeded_db_empty_cards
+    _insert(repo, datetime(2026, 5, 11, 21, tzinfo=UTC), "suspended")
+    _insert(repo, datetime(2026, 5, 20, 21, tzinfo=UTC), "partial")
+    repo.conn.commit()
 
     app = create_app()
 

--- a/tests/integration/api/test_gold_router_state.py
+++ b/tests/integration/api/test_gold_router_state.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -16,8 +14,6 @@ from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.server import create_app
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -29,103 +25,92 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def app_with_posture() -> TestClient:
+def app_with_posture(seeded_db_empty_cards) -> TestClient:
     settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        repo = Repository(conn, schema=settings.db_schema)
-        for obs_month, reserves_t in (
-            (date(2025, 3, 31), Decimal("2264.3")),
-            (date(2026, 3, 31), Decimal("2313.5")),
-        ):
-            repo.insert_cb_gold_reserves_monthly(
-                country_iso3="CHN",
-                obs_month=obs_month,
-                reserves_t=reserves_t,
-                bucket="strategic_accumulator",
-                is_reported=True,
-                is_estimated=False,
-                as_of=datetime(2026, 5, 16, tzinfo=UTC),
-                release_date=date(2026, 5, 1),
-                source="test",
-            )
-        repo.insert_gold_posture_daily(
-            obs_date=date(2026, 5, 16),
-            computed_at=datetime(2026, 5, 17, tzinfo=UTC),
-            gauge_corr_60d=Decimal("-0.04"),
-            gauge_corr_126d=Decimal("-0.05"),
-            gauge_corr_252d=Decimal("-0.07"),
-            gauge_corr_504d=Decimal("-0.31"),
-            gauge_corr_252d_returns=Decimal("-0.06"),
-            gauge_state="suspended",
-            structural_state_label="structural-bid-intact",
-            cb_strategic_12m_sum_t=Decimal("210"),
-            cb_tactical_12m_sum_t=Decimal("12"),
-            cb_diversifier_12m_sum_t=Decimal("34"),
-            gld_holdings_t=Decimal("872.5"),
-            gld_30d_net_flow_t=Decimal("-12.4"),
-            comex_registered_oz=Decimal("17500100"),
-            comex_20d_roc_pct=Decimal("0.14"),
-            cot_mm_net_pct=Decimal("0.72"),
-            cyclical_zone_label="moderate-trap",
-            cpi_yoy=Decimal("2.8"),
-            t5yifr=Decimal("2.31"),
-            dfii10=Decimal("1.97"),
-            dfii10_60d_change_bps=Decimal("12"),
-            factors_jsonb={"F5": 1.8},
-            valuation_flag="Severe",
-            real_price_percentile=Decimal("0.92"),
-            gold_m2_ratio_percentile=Decimal("0.78"),
-            gold_spx_ratio_percentile=Decimal("0.64"),
-            structural_posture_text="Structural bid intact.",
-            cyclical_posture_text="Cyclical posture suspended.",
-            valuation_posture_text="Mean-reversion risk: SEVERE.",
-            inputs_jsonb={
-                "DFII10": {
-                    "obs_date": "2026-05-16",
-                    "as_of": "2026-05-17T00:00:00Z",
-                }
-            },
-            structural_posture_chip="FAVORABLE",
-            cyclical_posture_chip="SUSPENDED",
-            valuation_posture_chip="STRETCHED",
-            spot_jsonb={
-                "last": "4561.50",
-                "delta_abs": "-157.20",
-                "delta_pct": "-0.0332",
-                "high": "4615.20",
-                "low": "4524.30",
-                "open": "4615.20",
-            },
-            data_freshness_jsonb=[
-                {
-                    "id": "FRED",
-                    "last_as_of": "2026-05-17T00:00:00+00:00",
-                    "stale_seconds": 60,
-                }
-            ],
-            decomposition_jsonb=[
-                {"lens": "L1", "factor": "CB", "contribution": "1.4"},
-            ],
-            correlation_history_jsonb={
-                "gold_dfii10": [],
-                "gold_dxy": [],
-                "gold_gpr": [],
-                "pre_2022_band": {"mean": "-0.84", "std": "0.04"},
-            },
-            gld_history_jsonb=[],
-            gold_history_jsonb=[],
+    repo = seeded_db_empty_cards
+    for obs_month, reserves_t in (
+        (date(2025, 3, 31), Decimal("2264.3")),
+        (date(2026, 3, 31), Decimal("2313.5")),
+    ):
+        repo.insert_cb_gold_reserves_monthly(
+            country_iso3="CHN",
+            obs_month=obs_month,
+            reserves_t=reserves_t,
+            bucket="strategic_accumulator",
+            is_reported=True,
+            is_estimated=False,
+            as_of=datetime(2026, 5, 16, tzinfo=UTC),
+            release_date=date(2026, 5, 1),
+            source="test",
         )
+    repo.insert_gold_posture_daily(
+        obs_date=date(2026, 5, 16),
+        computed_at=datetime(2026, 5, 17, tzinfo=UTC),
+        gauge_corr_60d=Decimal("-0.04"),
+        gauge_corr_126d=Decimal("-0.05"),
+        gauge_corr_252d=Decimal("-0.07"),
+        gauge_corr_504d=Decimal("-0.31"),
+        gauge_corr_252d_returns=Decimal("-0.06"),
+        gauge_state="suspended",
+        structural_state_label="structural-bid-intact",
+        cb_strategic_12m_sum_t=Decimal("210"),
+        cb_tactical_12m_sum_t=Decimal("12"),
+        cb_diversifier_12m_sum_t=Decimal("34"),
+        gld_holdings_t=Decimal("872.5"),
+        gld_30d_net_flow_t=Decimal("-12.4"),
+        comex_registered_oz=Decimal("17500100"),
+        comex_20d_roc_pct=Decimal("0.14"),
+        cot_mm_net_pct=Decimal("0.72"),
+        cyclical_zone_label="moderate-trap",
+        cpi_yoy=Decimal("2.8"),
+        t5yifr=Decimal("2.31"),
+        dfii10=Decimal("1.97"),
+        dfii10_60d_change_bps=Decimal("12"),
+        factors_jsonb={"F5": 1.8},
+        valuation_flag="Severe",
+        real_price_percentile=Decimal("0.92"),
+        gold_m2_ratio_percentile=Decimal("0.78"),
+        gold_spx_ratio_percentile=Decimal("0.64"),
+        structural_posture_text="Structural bid intact.",
+        cyclical_posture_text="Cyclical posture suspended.",
+        valuation_posture_text="Mean-reversion risk: SEVERE.",
+        inputs_jsonb={
+            "DFII10": {
+                "obs_date": "2026-05-16",
+                "as_of": "2026-05-17T00:00:00Z",
+            }
+        },
+        structural_posture_chip="FAVORABLE",
+        cyclical_posture_chip="SUSPENDED",
+        valuation_posture_chip="STRETCHED",
+        spot_jsonb={
+            "last": "4561.50",
+            "delta_abs": "-157.20",
+            "delta_pct": "-0.0332",
+            "high": "4615.20",
+            "low": "4524.30",
+            "open": "4615.20",
+        },
+        data_freshness_jsonb=[
+            {
+                "id": "FRED",
+                "last_as_of": "2026-05-17T00:00:00+00:00",
+                "stale_seconds": 60,
+            }
+        ],
+        decomposition_jsonb=[
+            {"lens": "L1", "factor": "CB", "contribution": "1.4"},
+        ],
+        correlation_history_jsonb={
+            "gold_dfii10": [],
+            "gold_dxy": [],
+            "gold_gpr": [],
+            "pre_2022_band": {"mean": "-0.84", "std": "0.04"},
+        },
+        gld_history_jsonb=[],
+        gold_history_jsonb=[],
+    )
+    repo.conn.commit()
 
     app = create_app()
 

--- a/tests/integration/api/test_rates_router.py
+++ b/tests/integration/api/test_rates_router.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -26,8 +24,6 @@ from uw_scan.models import (
 )
 from uw_scan.storage.repository import Repository
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
 
 def _test_settings() -> Settings:
     test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
@@ -38,19 +34,11 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def rates_client() -> TestClient:
+def rates_client(seeded_db_empty_cards) -> TestClient:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. We still need settings to wire the FastAPI dependency overrides.
+    _ = seeded_db_empty_cards
     settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
 
     app = create_app()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,20 +2,36 @@
 
 Requires UW_SCAN_TEST_DB_NAME to point at a dedicated test DB. Fixtures
 refuse to run otherwise — never touches the developer's working DB.
+
+Performance design
+------------------
+Previously every test fixture re-ran ``bash scripts/migrate.sh``, which
+paid ~150ms of ``uv run python`` startup + ~30ms × 82 of ``psql`` fork-
+and-connect per fixture invocation. Across the integration suite this
+was ~2-5s per test → many minutes of pure setup overhead per CI shard.
+
+Now we migrate once per pytest session, snapshot the post-migration
+baseline via ``COPY`` (which natively handles JSONB, TEXT[], custom
+enums, etc.), and per test ``TRUNCATE ... CASCADE`` + ``COPY`` the
+baseline back. Sequence positions are restored via ``setval`` so
+test-issued IDs remain deterministic across resets.
 """
 
 from __future__ import annotations
 
+import io
 import os
-import subprocess
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import psycopg
 import pytest
 
 from uw_scan.config import Settings
+from uw_scan.storage.migrate_runner import apply_migrations
 from uw_scan.storage.repository import Repository
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -33,27 +49,99 @@ def _test_settings() -> Settings:
     return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
-def _reset_and_migrate(settings: Settings) -> None:
+@pytest.fixture(scope="session")
+def _migrated_settings() -> Settings:
+    """Drop+migrate the test schema once per pytest session.
+
+    This is the big perf lever: the 82-file migration runs once per
+    session instead of once per test. ``seeded_db_empty_cards`` below
+    delivers per-test isolation via TRUNCATE+COPY against the snapshot
+    captured in ``_baseline_snapshot``.
+    """
+    settings = _test_settings()
     with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
         with conn.cursor() as cur:
             cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
             cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
+        apply_migrations(conn, log=lambda _msg: None)
+    return settings
+
+
+@pytest.fixture(scope="session")
+def _baseline_snapshot(_migrated_settings: Settings) -> dict[str, Any]:
+    """Capture the post-migration state once.
+
+    ``COPY ... TO STDOUT`` is used because it round-trips every column
+    type Postgres supports (JSONB, TEXT[], enums, tstzrange, ...) without
+    needing per-column psycopg adapter registration. Sequence positions
+    are captured separately so we can restore them with ``setval`` after
+    TRUNCATE wipes them back to 1.
+    """
+    settings = _migrated_settings
+    tables: list[str] = []
+    table_dumps: dict[str, bytes] = {}
+    sequences: dict[str, tuple[int, bool]] = {}
+    with psycopg.connect(settings.db_dsn()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT tablename FROM pg_tables "
+                "WHERE schemaname = 'uw_scan' ORDER BY tablename"
+            )
+            tables = [r[0] for r in cur.fetchall()]
+            for t in tables:
+                buf = io.BytesIO()
+                with cur.copy(f'COPY uw_scan."{t}" TO STDOUT') as copy:
+                    for chunk in copy:
+                        buf.write(bytes(chunk))
+                table_dumps[t] = buf.getvalue()
+            cur.execute(
+                "SELECT sequence_name FROM information_schema.sequences "
+                "WHERE sequence_schema = 'uw_scan' ORDER BY sequence_name"
+            )
+            seq_names = [r[0] for r in cur.fetchall()]
+            for s in seq_names:
+                cur.execute(f'SELECT last_value, is_called FROM uw_scan."{s}"')
+                row = cur.fetchone()
+                sequences[s] = (int(row[0]), bool(row[1]))
+    return {"tables": tables, "dumps": table_dumps, "sequences": sequences}
+
+
+def _reset_to_baseline(
+    conn: psycopg.Connection,
+    snapshot: dict[str, Any],
+) -> None:
+    """Restore the post-migration baseline on ``conn``."""
+    tables: list[str] = snapshot["tables"]
+    dumps: dict[str, bytes] = snapshot["dumps"]
+    sequences: dict[str, tuple[int, bool]] = snapshot["sequences"]
+    with conn.cursor() as cur:
+        if tables:
+            quoted = ", ".join(f'uw_scan."{t}"' for t in tables)
+            cur.execute(f"TRUNCATE {quoted} CASCADE")
+        for t in tables:
+            data = dumps[t]
+            if not data:
+                continue
+            with cur.copy(f'COPY uw_scan."{t}" FROM STDIN') as copy:
+                copy.write(data)
+        for s, (last_value, is_called) in sequences.items():
+            cur.execute(
+                f'SELECT setval(\'uw_scan."{s}"\', %s, %s)',
+                (last_value, is_called),
+            )
 
 
 @pytest.fixture
-def seeded_db_empty_cards() -> Repository:
+def seeded_db_empty_cards(
+    _migrated_settings: Settings,
+    _baseline_snapshot: dict[str, Any],
+) -> Iterator[Repository]:
     """Freshly-migrated test DB + 54-ticker watchlist seed; zero card rows."""
-    settings = _test_settings()
-    _reset_and_migrate(settings)
+    settings = _migrated_settings
     conn = psycopg.connect(settings.db_dsn())
     try:
+        _reset_to_baseline(conn, _baseline_snapshot)
+        conn.commit()
         yield Repository(conn, schema=settings.db_schema)
     finally:
         conn.close()

--- a/tests/integration/e2e/test_gold_replay_acceptance.py
+++ b/tests/integration/e2e/test_gold_replay_acceptance.py
@@ -12,18 +12,12 @@ For 5 evenly-spaced historical obs_dates within a 90-day seeded window:
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 from uw_scan.config import Settings
 from uw_scan.reports.gold_posture import compute_and_persist_gold_posture
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -35,23 +29,8 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def _seed_three_months(repo: Repository, start: date) -> None:
     """Seed 90 days of inputs (gold, real rate, breakeven)."""
     for i in range(90):

--- a/tests/integration/reports/test_gold_posture_orchestrator.py
+++ b/tests/integration/reports/test_gold_posture_orchestrator.py
@@ -2,51 +2,17 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.reports.gold_posture import compute_and_persist_gold_posture
 from uw_scan.storage.repository import Repository
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
-
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def _seed_minimum(repo: Repository, today: date) -> None:
     """Seed enough data for the orchestrator to produce a non-empty posture."""
     base = today - timedelta(days=300)

--- a/tests/integration/storage/test_exposures_summary_migration.py
+++ b/tests/integration/storage/test_exposures_summary_migration.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 import os
-import subprocess
-from pathlib import Path
 
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.storage.migrate_runner import apply_migrations
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_exposures_summary_table_created(seeded_db_empty_cards: Repository):
-    """conftest's _reset_and_migrate already ran migrate.sh; assert the table + columns exist."""
+    """conftest's session migration already applied every migration; assert the table + columns exist."""
     repo = seeded_db_empty_cards
     with repo.conn.cursor() as cur:
         cur.execute("SELECT to_regclass('uw_scan.exposures_summary')")
@@ -55,16 +55,13 @@ def test_exposures_summary_table_created(seeded_db_empty_cards: Repository):
 
 
 def test_migration_is_idempotent(seeded_db_empty_cards: Repository):
-    """Re-running scripts/migrate.sh on the already-migrated DB must be a no-op."""
+    """Re-applying every migration on the already-migrated DB must be a no-op."""
     repo = seeded_db_empty_cards
-    test_db = os.environ["UW_SCAN_TEST_DB_NAME"]
-    env = {**os.environ, "UW_SCAN_DB_NAME": test_db}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
+    settings = Settings.from_env().model_copy(
+        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
     )
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        apply_migrations(conn, log=lambda _msg: None)
     with repo.conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM uw_scan.exposures_summary")
         assert cur.fetchone()[0] == 0

--- a/tests/integration/storage/test_flow_alerts_daily_rollup.py
+++ b/tests/integration/storage/test_flow_alerts_daily_rollup.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
-from uw_scan.config import Settings
 from uw_scan.models import FlowAlert
+from uw_scan.storage.migrate_runner import split_sql_statements
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKFILL_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "src/uw_scan/storage/migrations/023_backfill_flow_alerts_daily_rollup.sql"
+)
 
 
 def _alert(
@@ -104,24 +105,13 @@ def test_backfill_migration_rolls_up_existing_flow_events(seeded_db_empty_cards)
     )
     repo.conn.commit()
 
-    settings = Settings.from_env().model_copy(
-        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
-    )
-    subprocess.run(
-        [
-            "psql",
-            settings.db_dsn(),
-            "-v",
-            "ON_ERROR_STOP=1",
-            "-f",
-            str(
-                REPO_ROOT
-                / "src/uw_scan/storage/migrations/023_backfill_flow_alerts_daily_rollup.sql"
-            ),
-        ],
-        check=True,
-        cwd=REPO_ROOT,
-    )
+    # Re-apply the backfill migration in-process. Statements are split so
+    # multi-statement files don't get wrapped in an implicit transaction.
+    sql = BACKFILL_MIGRATION.read_text()
+    with repo.conn.cursor() as cur:
+        for stmt in split_sql_statements(sql):
+            cur.execute(stmt)
+    repo.conn.commit()
 
     with repo.conn.cursor() as cur:
         cur.execute(

--- a/tests/integration/storage/test_gold_migrations.py
+++ b/tests/integration/storage/test_gold_migrations.py
@@ -1,59 +1,35 @@
 """Smoke test: Phase A1 gold tables exist with PIT-disciplined columns after migrate.
 
-Uses the project's `fresh_schema` pattern (DROP SCHEMA CASCADE + re-run migrate.sh
-against the isolated test DB pointed to by UW_SCAN_TEST_DB_NAME). Matches the
-pattern in tests/integration/storage/test_migrations.py rather than the
-pytest-postgresql fixture variant.
+Uses the shared `seeded_db_empty_cards` fixture (session-scoped migrate +
+per-test TRUNCATE+COPY baseline restore). The post-migration state is what
+these tests assert against — a fresh DROP+migrate would produce the same
+schema, and the idempotency test re-applies migrations in-process.
 """
 
 from __future__ import annotations
 
 import os
-import subprocess
-from pathlib import Path
 
 import psycopg
 import pytest
 
 from uw_scan.config import Settings
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
+from uw_scan.storage.migrate_runner import apply_migrations
 
 
 def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set. Create a dedicated test DB "
-            "(e.g. `createdb option_wizard_test`) and export "
-            "`UW_SCAN_TEST_DB_NAME=option_wizard_test` before running pytest.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    base = Settings.from_env()
-    return base.model_copy(update={"db_name": test_db})
+    test_db = os.environ["UW_SCAN_TEST_DB_NAME"]
+    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 def _run_migrations(settings: Settings) -> None:
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        apply_migrations(conn, log=lambda _msg: None)
 
 
 @pytest.fixture
-def fresh_schema():
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    _run_migrations(settings)
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield conn
+def fresh_schema(seeded_db_empty_cards):
+    yield seeded_db_empty_cards.conn
 
 
 def _table_columns(conn: psycopg.Connection, table: str) -> set[str]:

--- a/tests/integration/storage/test_gold_repo_etf_inventory.py
+++ b/tests/integration/storage/test_gold_repo_etf_inventory.py
@@ -2,50 +2,16 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_insert_and_fetch_etf_holdings_daily(repo: Repository) -> None:
     repo.insert_etf_holdings_daily(
         ticker="GLD",

--- a/tests/integration/storage/test_gold_repo_flows.py
+++ b/tests/integration/storage/test_gold_repo_flows.py
@@ -2,50 +2,16 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_cb_reserves_round_trip(repo: Repository) -> None:
     as_of = datetime.now(UTC)
     for obs_month, reserves_t in (

--- a/tests/integration/storage/test_gold_repo_macro_series.py
+++ b/tests/integration/storage/test_gold_repo_macro_series.py
@@ -2,50 +2,16 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_insert_and_fetch_macro_series_daily(repo: Repository) -> None:
     now = datetime.now(UTC)
     repo.insert_macro_series_daily(

--- a/tests/integration/storage/test_gold_repo_posture.py
+++ b/tests/integration/storage/test_gold_repo_posture.py
@@ -2,50 +2,16 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def _kwargs_for_posture(**overrides):
     base = dict(
         obs_date=date(2026, 5, 16),

--- a/tests/integration/storage/test_migrations.py
+++ b/tests/integration/storage/test_migrations.py
@@ -1,69 +1,21 @@
 """Verify migrations 003-006 produce the expected schema and seed against an
 ISOLATED test database — never against the developer's real `option_wizard` DB.
 
-Requires `UW_SCAN_TEST_DB_NAME` env var to point at a dedicated test database
-(e.g. `option_wizard_test`). The fixture refuses to run if it isn't set, so
-running `pytest` cannot destroy local scan data by accident."""
+Uses the shared `seeded_db_empty_cards` fixture (session-scoped migrate +
+per-test TRUNCATE+COPY restore from baseline). The post-migration state is
+identical to what a fresh `DROP SCHEMA CASCADE` + full migration would
+produce, which is what these tests assert against."""
 
 from __future__ import annotations
 
-import os
-import subprocess
-from pathlib import Path
-
-import psycopg
+import psycopg  # noqa: F401 — tests below reference psycopg.errors
 import pytest
-
-from uw_scan.config import Settings
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    """Return a Settings instance pointing at the isolated test DB.
-
-    HARD REQUIREMENT: the developer must set UW_SCAN_TEST_DB_NAME to a database
-    name that is NOT their working `option_wizard` DB. The fixture refuses to
-    run otherwise — protects against `DROP SCHEMA` against the wrong target.
-
-    DB-only tests (migrations, repository) don't need a UW API key. We inject
-    a dummy `UW_SCAN_API_KEY` before calling `Settings.from_env()` so the
-    `RuntimeError("UW_SCAN_API_KEY is not set")` from config.py doesn't fail
-    fresh dev/CI environments.
-    """
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set. Create a dedicated test DB "
-            "(e.g. `createdb option_wizard_test`) and export "
-            "`UW_SCAN_TEST_DB_NAME=option_wizard_test` before running pytest. "
-            "This fixture refuses to operate on the working DB because it "
-            "performs `DROP SCHEMA uw_scan CASCADE`.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    base = Settings.from_env()
-    return base.model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def fresh_schema():
-    """DROP + CREATE uw_scan schema on the TEST database, then re-apply all
-    migrations. Yields a connection."""
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield conn
+def fresh_schema(seeded_db_empty_cards):
+    """Yields a Repository connection backed by the freshly-migrated schema."""
+    yield seeded_db_empty_cards.conn
 
 
 def test_all_new_tables_exist(fresh_schema):

--- a/tests/integration/storage/test_pipeline_benchmark_repository.py
+++ b/tests/integration/storage/test_pipeline_benchmark_repository.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.storage.migrate_runner import apply_migrations
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_pipeline_benchmark_snapshot_roundtrip(
@@ -102,13 +102,14 @@ def test_pipeline_benchmark_migration_repairs_existing_snapshot_table(
         )
     repo.conn.commit()
 
-    env = {**os.environ, "UW_SCAN_DB_NAME": os.environ["UW_SCAN_TEST_DB_NAME"]}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
+    # Re-apply migrations in-process to verify idempotent repair of the
+    # snapshot table. autocommit=True is required by apply_migrations
+    # (CONCURRENTLY index ops cannot run inside a transaction block).
+    settings = Settings.from_env().model_copy(
+        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
     )
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        apply_migrations(conn, log=lambda _msg: None)
 
     with repo.conn.cursor() as cur:
         cur.execute(

--- a/tests/integration/storage/test_provider_usage_recorder.py
+++ b/tests/integration/storage/test_provider_usage_recorder.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import logging
 import os
-import subprocess
 from dataclasses import replace
 from datetime import UTC, datetime
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -17,8 +15,6 @@ from uw_scan.storage.provider_usage import (
 )
 from uw_scan.storage.repository import Repository
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
 
 def _test_settings() -> Settings:
     os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
@@ -28,20 +24,11 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def settings() -> Settings:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    return settings
+def settings(seeded_db_empty_cards) -> Settings:
+    # seeded_db_empty_cards triggers the session migration + per-test baseline
+    # restore. This fixture only needs the resolved Settings — the recorder
+    # opens its own connection from the DSN, distinct from the fixture's repo.
+    return _test_settings()
 
 
 def _event() -> ExternalApiRequestEvent:

--- a/tests/integration/storage/test_provider_usage_repository.py
+++ b/tests/integration/storage/test_provider_usage_repository.py
@@ -1,48 +1,14 @@
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_external_api_request_roundtrip(repo: Repository):
     now = datetime(2026, 5, 14, 14, 0, tzinfo=UTC)
 

--- a/tests/integration/storage/test_rates_repository.py
+++ b/tests/integration/storage/test_rates_repository.py
@@ -1,53 +1,19 @@
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.models import (
     RatesSnapshotResponse,
     RatesSynthesisPanel,
 )
 from uw_scan.storage.repository import Repository
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
-
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_rates_observations_are_idempotent_across_ingest_runs(repo: Repository):
     rows = [
         {

--- a/tests/integration/storage/test_repository_etf_aum.py
+++ b/tests/integration/storage/test_repository_etf_aum.py
@@ -7,50 +7,16 @@ near-100% cache hit rate in steady state.
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import timedelta
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_get_recent_etf_aum_returns_none_when_no_row(repo: Repository) -> None:
     assert repo.get_recent_etf_aum("SPY", max_age=timedelta(days=7)) is None
 

--- a/tests/integration/storage/test_repository_jobs.py
+++ b/tests/integration/storage/test_repository_jobs.py
@@ -8,49 +8,15 @@ repo root; UW_SCAN_TEST_DB_NAME must be set; migrations applied per test).
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import timedelta
-from pathlib import Path
-
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_mark_job_done_no_op_when_job_was_reclaimed(repo: Repository):
     """B1 race: worker A claims, requeue_stale flips it back, worker B reclaims
     under a fresh claim_token, then worker A finally finishes and tries to mark

--- a/tests/integration/storage/test_repository_watchlist.py
+++ b/tests/integration/storage/test_repository_watchlist.py
@@ -8,18 +8,12 @@ sequential runs don't leak state through the watchlist or jobs tables.
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -37,29 +31,8 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def repo():
-    """Repository against a FRESHLY migrated test DB.
-
-    Repository methods commit internally, so writes from one test would persist
-    across tests if we didn't reset. We DROP+CREATE the schema and re-apply
-    migrations every test — slow but correct.
-    """
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_list_active_watchlist_excludes_soft_deleted(repo):
     repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
     repo.soft_delete_watchlist_ticker("ZZTEST")

--- a/tests/integration/test_migration_059.py
+++ b/tests/integration/test_migration_059.py
@@ -8,11 +8,15 @@ by running the migration script twice.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import psycopg
 import pytest
 from psycopg.types.json import Jsonb
+
+from uw_scan.config import Settings
+from uw_scan.storage.migrate_runner import apply_migrations
 
 MIGRATION = Path(
     "src/uw_scan/storage/migrations/059_regime_backtest_research_scope.sql"
@@ -23,6 +27,21 @@ def _apply(conn: psycopg.Connection, sql_path: Path) -> None:
     with conn.cursor() as cur:
         cur.execute(sql_path.read_text())
     conn.commit()
+
+
+@pytest.fixture(autouse=True)
+def _restore_full_migration_state():
+    """Re-apply every migration after each test in this file so subsequent
+    tests don't inherit constraint state that was rewound to the v059 era
+    (the tests below intentionally drop and re-add 059's constraint, which
+    would otherwise leave subsequent tests without the v061 widening of
+    composite_method to include 'classification_accuracy')."""
+    yield
+    settings = Settings.from_env().model_copy(
+        update={"db_name": os.environ["UW_SCAN_TEST_DB_NAME"]}
+    )
+    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
+        apply_migrations(conn, log=lambda _msg: None)
 
 
 def test_migration_promotes_columns_and_backfills_research_rows(

--- a/tests/integration/test_pcr_history_append.py
+++ b/tests/integration/test_pcr_history_append.py
@@ -7,18 +7,12 @@ relies on.
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import date
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _test_settings() -> Settings:
@@ -31,23 +25,8 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def repo():
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_pcr_history_appended_and_idempotent(repo):
     today = date.today()
     repo.append_pcr_history(

--- a/tests/integration/test_pipeline_aggregates.py
+++ b/tests/integration/test_pipeline_aggregates.py
@@ -9,18 +9,12 @@ the persistence layer so the round-trip is verified without live API costs.
 from __future__ import annotations
 
 import os
-import subprocess
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
 from uw_scan.config import Settings
 from uw_scan.models import MarketAggregates
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _test_settings() -> Settings:
@@ -36,23 +30,8 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def repo():
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_aggregates_round_trip(repo):
     repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
     run_id = repo.insert_scan_run("ZZTEST", notes="t")

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -8,24 +8,27 @@ one TSLA run.
 from __future__ import annotations
 
 import os
-import subprocess
-from pathlib import Path
+import re
 
-import psycopg
 import pytest
 
 from uw_scan.api.client import UwClient
 from uw_scan.config import Settings
 from uw_scan.pipeline import run_single_stock
-from uw_scan.storage.repository import Repository
 
 LIVE_MARK = pytest.mark.live
-REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# UW issues bearer tokens in canonical UUID form. We require that shape so a
+# placeholder like `dummy` or `test-dummy-not-used-by-db-tests` doesn't trip
+# the test into a guaranteed 401 from the live API.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 
 def _has_live_key() -> bool:
-    settings_env = os.environ.get("UW_SCAN_API_KEY", "")
-    return bool(settings_env.strip())
+    return bool(_UUID_RE.match(os.environ.get("UW_SCAN_API_KEY", "").strip()))
 
 
 def _test_settings() -> Settings:
@@ -39,38 +42,24 @@ def _test_settings() -> Settings:
     return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
-def _reset_and_migrate(settings: Settings) -> None:
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-
-
 pytestmark = pytest.mark.skipif(
-    not _has_live_key(), reason="UW_SCAN_API_KEY not set; live pipeline test is skipped"
+    not _has_live_key(),
+    reason="UW_SCAN_API_KEY not set or not a UUID; live pipeline test is skipped",
 )
 
 
 @LIVE_MARK
-def test_pipeline_e2e_tsla_exit_gate(tmp_path_factory):
+def test_pipeline_e2e_tsla_exit_gate(seeded_db_empty_cards, tmp_path_factory):
     """Run the S1 pipeline against TSLA and assert the exit-gate row counts.
 
-    Uses the local `option_wizard_local` DB but a fresh schema (`uw_scan_e2e`)
-    so this test does not collide with developer state.
+    Uses `seeded_db_empty_cards` for the schema migration (in-process, no
+    psql subprocess) and runs against the shared option_wizard_test DB.
     """
     settings = _test_settings()
-    _reset_and_migrate(settings)
-    schema = "uw_scan"
-    conn = psycopg.connect(settings.db_dsn())
+    repo = seeded_db_empty_cards
+    schema = repo._schema
+    conn = repo.conn
     try:
-        repo = Repository(conn, schema=schema)
         with UwClient(
             api_key=settings.api_key.get_secret_value(),
             base_url=settings.base_url,
@@ -116,7 +105,6 @@ def test_pipeline_e2e_tsla_exit_gate(tmp_path_factory):
                     failures.append(f"{table}: got {n}, expected ≤ {max_count}")
         assert not failures, "exit gate row counts failed:\n  " + "\n  ".join(failures)
     finally:
-        with conn.cursor() as cur:
-            cur.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
-        conn.commit()
-        conn.close()
+        # `seeded_db_empty_cards` owns the connection and restores baseline
+        # for the next test — no per-test schema drop is needed here.
+        pass

--- a/tests/integration/test_pipeline_etf_caching.py
+++ b/tests/integration/test_pipeline_etf_caching.py
@@ -9,52 +9,19 @@ failures degrade gracefully, and we don't write spurious None aum values.
 
 from __future__ import annotations
 
-import os
-import subprocess
 from datetime import timedelta
 from decimal import Decimal
-from pathlib import Path
 from typing import Any
 
-import psycopg
 import pytest
 
-from uw_scan.config import Settings
 from uw_scan.pipeline import _get_or_fetch_etf_aum
 from uw_scan.storage.repository import Repository
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-
-
-def _test_settings() -> Settings:
-    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
-    if not test_db:
-        pytest.fail(
-            "UW_SCAN_TEST_DB_NAME is not set; refusing to write into the working DB.",
-            pytrace=False,
-        )
-    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
-    return Settings.from_env().model_copy(update={"db_name": test_db})
-
 
 @pytest.fixture
-def repo() -> Repository:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 class _StubClient:
     """Stand-in for UwClient. _get_or_fetch_etf_aum only passes it through to
     uw_sources.fetch_etf_info, which is monkeypatched in each test."""

--- a/tests/integration/test_pipeline_strike_gex.py
+++ b/tests/integration/test_pipeline_strike_gex.py
@@ -8,17 +8,11 @@ touches the developer's `option_wizard_local` data.
 from __future__ import annotations
 
 import os
-import subprocess
 from decimal import Decimal
-from pathlib import Path
-
-import psycopg
 import pytest
 
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _test_settings() -> Settings:
@@ -34,23 +28,8 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def repo():
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    with psycopg.connect(settings.db_dsn()) as conn:
-        yield Repository(conn, schema=settings.db_schema)
-
-
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 def test_strike_gex_curve_persisted_and_round_trips(repo):
     repo.add_watchlist_ticker(ticker="ZZTEST", sector="ETF", notes="t")
     run_id = repo.insert_scan_run("ZZTEST", notes="t")

--- a/tests/integration/test_repository_real_pg.py
+++ b/tests/integration/test_repository_real_pg.py
@@ -1,59 +1,27 @@
 """Integration tests for `storage.repository` against a real Postgres instance.
 
-Uses `pytest-postgresql` to spin up an isolated DB per test. Migration is applied
-fresh in each fixture. Fake-cursor tests are explicitly banned by the
-Implementation Guardrails — every assertion below hits a real DB.
+Fake-cursor tests are explicitly banned by the Implementation Guardrails —
+every assertion below hits a real DB. The `seeded_db_empty_cards` fixture
+(see tests/integration/conftest.py) provides a freshly-migrated schema with
+the baseline seed; the snapshot/restore path is shared with every other
+integration test, so the schema under test is the current production
+schema rather than a frozen subset.
 """
 
 from __future__ import annotations
 
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
 
-import psycopg
 import pytest
-from pytest_postgresql import factories
 
 from uw_scan import models
 from uw_scan.storage.repository import Repository
 
-MIGRATIONS_DIR = (
-    Path(__file__).resolve().parents[2] / "src" / "uw_scan" / "storage" / "migrations"
-)
-
-postgresql_my_proc = factories.postgresql_proc(load=[])
-postgresql_my = factories.postgresql("postgresql_my_proc")
-
 
 @pytest.fixture
-def repo(postgresql_my):
-    """Open a psycopg connection to the isolated test DB and apply every migration
-    in lexical order — same order `scripts/migrate.sh` uses in prod/dev. Tests on
-    this fixture see the current schema, not a frozen S1+S2 snapshot.
-    """
-    dsn = (
-        f"host={postgresql_my.info.host} port={postgresql_my.info.port} "
-        f"dbname={postgresql_my.info.dbname} user={postgresql_my.info.user}"
-    )
-    if postgresql_my.info.password:
-        dsn += f" password={postgresql_my.info.password}"
-    # Apply migrations via psql, the same way scripts/migrate.sh does in
-    # prod/dev. psycopg wraps multi-statement execute() calls in implicit
-    # transactions, which breaks statements like DROP INDEX CONCURRENTLY.
-    for sql_path in sorted(MIGRATIONS_DIR.glob("*.sql")):
-        subprocess.run(
-            ["psql", dsn, "-v", "ON_ERROR_STOP=1", "-f", str(sql_path)],
-            check=True,
-            capture_output=True,
-        )
-    conn = psycopg.connect(dsn)
-    r = Repository(conn, schema="uw_scan")
-    try:
-        yield r
-    finally:
-        conn.close()
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
 
 
 def test_migration_creates_expected_tables(repo: Repository):

--- a/tests/integration/test_scan_e2e.py
+++ b/tests/integration/test_scan_e2e.py
@@ -7,6 +7,7 @@ with developer-driven state. A small fixed universe limits cost.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import psycopg
@@ -24,14 +25,21 @@ MIGRATIONS_DIR = (
 MIGRATION_S1 = MIGRATIONS_DIR / "001_s1_core_tables.sql"
 MIGRATION_S2 = MIGRATIONS_DIR / "002_s2_scan_tables.sql"
 
+# UW issues bearer tokens in canonical UUID form. A non-empty but non-UUID
+# value (e.g. `dummy`) would otherwise pass the gate and 401 on the live call.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
 
 def _has_live_key() -> bool:
-    return bool(os.environ.get("UW_SCAN_API_KEY", "").strip())
+    return bool(_UUID_RE.match(os.environ.get("UW_SCAN_API_KEY", "").strip()))
 
 
 pytestmark = pytest.mark.skipif(
     not _has_live_key(),
-    reason="UW_SCAN_API_KEY not set; live full-scan test is skipped",
+    reason="UW_SCAN_API_KEY not set or not a UUID; live full-scan test is skipped",
 )
 
 

--- a/tests/integration/worker/test_gold_daily_jobs.py
+++ b/tests/integration/worker/test_gold_daily_jobs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from io import BytesIO
@@ -27,9 +26,6 @@ from uw_scan.worker.jobs.gold_jobs import (
     gold_fred_ingest_job,
     gold_gpr_ingest_job,
 )
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
 
 class _FixedDatetime(datetime):
     @classmethod
@@ -124,20 +120,11 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def fresh_db() -> Settings:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    return settings
+def fresh_db(seeded_db_empty_cards) -> Settings:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. The job under test opens its own connection from settings.db_dsn().
+    _ = seeded_db_empty_cards
+    return _test_settings()
 
 
 def test_gold_fred_ingest_writes_macro_series_daily(fresh_db: Settings) -> None:

--- a/tests/integration/worker/test_gold_periodic_jobs.py
+++ b/tests/integration/worker/test_gold_periodic_jobs.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
 from unittest.mock import patch
 
 import psycopg
@@ -22,8 +20,6 @@ from uw_scan.worker.jobs.gold_jobs import (
     gold_lbma_vault_ingest_job,
     gold_wgc_cb_ingest_job,
 )
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class _FixedDatetime(datetime):
@@ -41,20 +37,11 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def fresh_db() -> Settings:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    return settings
+def fresh_db(seeded_db_empty_cards) -> Settings:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. The job under test opens its own connection from settings.db_dsn().
+    _ = seeded_db_empty_cards
+    return _test_settings()
 
 
 def test_gold_cftc_cot_ingest_writes_rows(fresh_db: Settings) -> None:

--- a/tests/integration/worker/test_gold_posture_compute_job.py
+++ b/tests/integration/worker/test_gold_posture_compute_job.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -14,8 +12,6 @@ import pytest
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.gold_jobs import gold_posture_compute_job
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _test_settings() -> Settings:
@@ -27,20 +23,11 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def fresh_db() -> Settings:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    return settings
+def fresh_db(seeded_db_empty_cards) -> Settings:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. The job under test opens its own connection from settings.db_dsn().
+    _ = seeded_db_empty_cards
+    return _test_settings()
 
 
 def test_gold_posture_compute_writes_row(fresh_db: Settings) -> None:

--- a/tests/integration/worker/test_rates_jobs.py
+++ b/tests/integration/worker/test_rates_jobs.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from pathlib import Path
 
 import psycopg
 import pytest
@@ -20,8 +18,6 @@ from uw_scan.worker.jobs.rates_jobs import (
     rates_fred_ingest_job,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-
 
 def _test_settings() -> Settings:
     test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
@@ -35,20 +31,10 @@ def _test_settings() -> Settings:
 
 
 @pytest.fixture
-def migrated_settings() -> Settings:
-    settings = _test_settings()
-    with psycopg.connect(settings.db_dsn(), autocommit=True) as conn:
-        with conn.cursor() as cur:
-            cur.execute("DROP SCHEMA IF EXISTS uw_scan CASCADE")
-            cur.execute("CREATE SCHEMA uw_scan")
-    env = {**os.environ, "UW_SCAN_DB_NAME": settings.db_name}
-    subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts/migrate.sh")],
-        check=True,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    return settings
+def migrated_settings(seeded_db_empty_cards) -> Settings:
+    # seeded_db_empty_cards drives the session migrate + per-test baseline
+    # restore. The job under test opens its own connection from settings.db_dsn().
+    return _test_settings()
 
 
 class _Provider:

--- a/tests/integration/worker/test_xenon_failover.py
+++ b/tests/integration/worker/test_xenon_failover.py
@@ -177,20 +177,30 @@ async def test_massive_session_switches_back_when_xenon_recovers(
                 x_port = xenon_srv.sockets[0].getsockname()[1]
                 port_file.write_text(json.dumps({"port": x_port, "pid": 1}))
                 await asyncio.wait_for(xenon_tick.wait(), timeout=10.0)
-                await asyncio.sleep(0.4)  # let a xenon flush land
+                # Poll until the xenon switch has both flushed a tick AND
+                # written active_source='xenon_ws' to ws_consumer_state.
+                # A fixed sleep was previously used and flaked under heavy
+                # suite load (5+ second gap to commit observed).
+                deadline = asyncio.get_event_loop().time() + 10.0
+                q = None
+                state = None
+                while asyncio.get_event_loop().time() < deadline:
+                    q = repo.get_intraday_quote("TSLA")
+                    state = repo.get_ws_consumer_state()
+                    if (
+                        q is not None
+                        and q.price == Decimal("444.0")
+                        and state is not None
+                        and state.active_source == "xenon_ws"
+                    ):
+                        break
+                    await asyncio.sleep(0.1)
         finally:
             consumer_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await consumer_task
 
-    q = None
-    for _ in range(20):
-        q = repo.get_intraday_quote("TSLA")
-        if q is not None and q.price == Decimal("444.0"):
-            break
-        await asyncio.sleep(0.1)
     assert q is not None and q.price == Decimal("444.0")
-    state = repo.get_ws_consumer_state()
     assert state is not None and state.active_source == "xenon_ws"
 
 


### PR DESCRIPTION
## Summary

- Replaces the per-test `bash scripts/migrate.sh` fixture (≈3s/test of `uv run python` + 82 `psql` forks) with a session-scoped in-process migration and a per-test `TRUNCATE … CASCADE` + `COPY` restore against a captured baseline. Public fixture surface (`seeded_db_empty_cards`, `seeded_db_with_cards`, …) unchanged.
- New `src/uw_scan/storage/migrate_runner.py` exposes `apply_migrations(conn)` + `python -m uw_scan.storage.migrate_runner` CLI. Includes a dollar-quote / quoted-string / comment-aware SQL splitter so `DO $$ … $$` blocks and `CREATE INDEX CONCURRENTLY` survive psycopg's implicit multi-statement transaction wrapping. `scripts/migrate.sh` becomes a single `exec uv run python -m …` line.
- 35 test files converted to consume the shared fixture instead of their own per-file `repo` / `fresh_db` / `settings` / `app_with_seed` patterns. `test_repository_real_pg.py` no longer uses `pytest-postgresql`'s ephemeral pg spawn (which fails `pg_ctl initdb` on macOS 15 / pg 18).

## Adjacent fixes (only surface at-scale)

- **Live e2e tests** (`test_pipeline_e2e.py`, `test_scan_e2e.py`) gate on a UUID-shaped `UW_SCAN_API_KEY` — `dummy` no longer trips them into a guaranteed 401.
- **Xenon failover flake** — `test_massive_session_switches_back_when_xenon_recovers` replaces a fixed `asyncio.sleep(0.4)` with a 10s poll until both the intraday quote and `ws_consumer_state.active_source` reflect the switch.
- **`test_migration_059.py`** — adds an `autouse` teardown that re-applies every migration. The test intentionally rewinds the `composite_method` CHECK constraint to its v059 shape; without cleanup, the session-scoped baseline carried that into every subsequent test and broke `test_regime_classification_e2e.py`.

## Local results

- 534 passed, 10 skipped, 0 failures in 5:05 (single MacBook core, full integration suite)
- 973 unit tests pass in 11.3s
- ruff + Guardrail 2 (lint_except) clean

`tests/CLAUDE.md` updated to reflect the new "migrate once per session, TRUNCATE+COPY per test" model.

## Test plan

- [ ] CI `lint + unit` passes
- [ ] CI `integration (1/4)` through `(4/4)` all pass with reduced wall-clock per shard (target: well under 10 min per shard, ideally ~1.5–2 min)
- [ ] `web` typecheck + test + build pass (no changes here)