### PR TITLE
chore(watchlist): reclassify into 20-tag taxonomy

### DIFF
--- a/src/uw_scan/storage/migrations/069_reclass_watchlist_20tags.sql
+++ b/src/uw_scan/storage/migrations/069_reclass_watchlist_20tags.sql
@@ -1,0 +1,60 @@
+-- 069_reclass_watchlist_20tags.sql
+--
+-- Reclassifies uw_scan.watchlist into the 20-tag taxonomy:
+--   Index:     Beta, Sector-ETF, Credit, Macro
+--   AI/Tech:   M7, Foundry, Semi-Logic, Semi-Cap, Memory, DC-Connect,
+--              NeoCloud, Power, SaaS
+--   Thematic:  Crypto, Fintech, Space
+--   Defensive: Healthcare, Energy, Banks, Consumer
+--
+-- Idempotent — every UPDATE narrows by ticker/sector, every INSERT uses
+-- ON CONFLICT DO UPDATE. Safe to re-run.
+
+SET search_path TO uw_scan, public;
+
+-- 1. Soft-delete removed tickers (Defense/Telecom-Media/Airlines tabs +
+--    individual removes: ARKK, ES, SMCI, ZS, DDOG, ABBV, MRK).
+UPDATE uw_scan.watchlist SET removed_at = NOW()
+ WHERE ticker IN ('ES','ARKK','SMCI','ZS','DDOG','ABBV','MRK',
+                  'LMT','RTX','BA','CRS','T','VZ','DIS','DAL')
+   AND removed_at IS NULL;
+
+-- 2. Split the legacy "ETF" tag into four cohorts by driver:
+--    Beta (broad equity), Sector-ETF (sector betas),
+--    Credit (HY bonds), Macro (rates + real assets).
+UPDATE uw_scan.watchlist SET sector = 'Beta',       sort_rank = 0
+ WHERE ticker IN ('SPY','QQQ','IWM','DIA');
+UPDATE uw_scan.watchlist SET sector = 'Sector-ETF', sort_rank = 0
+ WHERE ticker IN ('SMH','SOXX','XLE','XLF','IGV');
+UPDATE uw_scan.watchlist SET sector = 'Macro',      sort_rank = 0
+ WHERE ticker IN ('TLT','GLD');
+
+-- 3. Split "Semiconductor" into Foundry / Semi-Logic / Semi-Cap.
+UPDATE uw_scan.watchlist SET sector = 'Foundry',    sort_rank = 0
+ WHERE ticker IN ('TSM','TSEM','INTC');
+UPDATE uw_scan.watchlist SET sector = 'Semi-Logic', sort_rank = 0
+ WHERE ticker IN ('AMD','AVGO','QCOM','ARM','TXN');
+UPDATE uw_scan.watchlist SET sector = 'Semi-Cap',   sort_rank = 0
+ WHERE ticker = 'ASML';
+
+-- 4. Optical → DC-Connect rename, absorb Networking (ANET, NOK) and
+--    MRVL (datacenter-interconnect silicon / PAM4 DSPs).
+UPDATE uw_scan.watchlist SET sector = 'DC-Connect', sort_rank = 0
+ WHERE sector = 'Optical' OR ticker IN ('ANET','NOK','MRVL');
+
+-- 5. Insert / restore 10 adds.
+INSERT INTO uw_scan.watchlist (ticker, sector, sort_rank, pinned) VALUES
+  ('ISRG', 'Healthcare', 0, FALSE),
+  ('HYG',  'Credit',     0, FALSE),
+  ('JNK',  'Credit',     0, FALSE),
+  ('SLV',  'Macro',      0, FALSE),
+  ('AMAT', 'Semi-Cap',   0, FALSE),
+  ('LRCX', 'Semi-Cap',   0, FALSE),
+  ('KLAC', 'Semi-Cap',   0, FALSE),
+  ('SNPS', 'Semi-Cap',   0, FALSE),
+  ('CDNS', 'Semi-Cap',   0, FALSE),
+  ('TER',  'Semi-Cap',   0, FALSE)
+ON CONFLICT (ticker) DO UPDATE
+  SET sector     = EXCLUDED.sector,
+      sort_rank  = EXCLUDED.sort_rank,
+      removed_at = NULL;

--- a/tests/integration/storage/test_migrations.py
+++ b/tests/integration/storage/test_migrations.py
@@ -53,9 +53,11 @@ def test_watchlist_seeded(fresh_schema):
         row = cur.fetchone()
         assert row is not None
         count = row[0]
-    # 006 seeds 54 base tickers; 008 adds 36 more; 009 adds 4 optical
-    # (AAOI, ALAB, COHR, FN); 010 adds OKLO; 011 adds BE = 96 active rows.
-    assert count == 96
+    # 006 seeds 54 base; 008 +36; 009 +4 (Optical); 010 +1 (OKLO); 011 +1 (BE);
+    # 012 +1 (IREN) = 97 active pre-069. 069 soft-deletes 15 (Defense, Telecom-
+    # Media, Airlines + ARKK/ES/SMCI/ZS/DDOG/ABBV/MRK) and inserts 10 (ISRG,
+    # HYG, JNK, SLV, AMAT, LRCX, KLAC, SNPS, CDNS, TER) → 92 active.
+    assert count == 92
 
 
 def test_watchlist_card_fk_to_scan_runs(fresh_schema):

--- a/web/components/watchlist/CardGrid.tsx
+++ b/web/components/watchlist/CardGrid.tsx
@@ -37,11 +37,12 @@ function sectorRank(sector: string, tickers: WatchlistCard[]) {
   return PRIORITY_SECTORS.length + (Number.MAX_SAFE_INTEGER / 2 - maxSize);
 }
 
+const ETF_LIKE_SECTORS = new Set(["Beta", "Sector-ETF", "Credit", "Macro"]);
+
 function sizeValue(card: WatchlistCard) {
-  const raw =
-    card.sector === "ETF"
-      ? (card.aum ?? card.market_cap)
-      : (card.market_cap ?? card.aum);
+  const raw = ETF_LIKE_SECTORS.has(card.sector)
+    ? (card.aum ?? card.market_cap)
+    : (card.market_cap ?? card.aum);
   return toNum(raw);
 }
 

--- a/web/components/watchlist/sectorGroups.ts
+++ b/web/components/watchlist/sectorGroups.ts
@@ -1,29 +1,23 @@
 export const SECTOR_ROWS: { label: string; items: string[] }[] = [
-  { label: "Index", items: ["All", "ETF"] },
+  { label: "Index", items: ["All", "Beta", "Sector-ETF", "Credit", "Macro"] },
   {
     label: "AI/Tech",
     items: [
       "M7",
-      "Semiconductor",
+      "Foundry",
+      "Semi-Logic",
+      "Semi-Cap",
       "Memory",
-      "Optical",
+      "DC-Connect",
       "NeoCloud",
       "Power",
       "SaaS",
-      "Networking",
     ],
   },
-  { label: "Thematic", items: ["Crypto", "Fintech", "Space", "Defense"] },
+  { label: "Thematic", items: ["Crypto", "Fintech", "Space"] },
   {
     label: "Defensive",
-    items: [
-      "Healthcare",
-      "Energy",
-      "Banks",
-      "Consumer",
-      "Telecom-Media",
-      "Airlines",
-    ],
+    items: ["Healthcare", "Energy", "Banks", "Consumer"],
   },
 ];
 
@@ -31,4 +25,4 @@ export const WATCHLIST_SECTORS = SECTOR_ROWS.flatMap((row) =>
   row.items.filter((item) => item !== "All"),
 );
 
-export const PRIORITY_SECTORS = ["ETF", "M7", "Semiconductor"] as const;
+export const PRIORITY_SECTORS = ["Beta", "M7", "Semi-Logic"] as const;

--- a/web/tests/unit/cardGrid.test.tsx
+++ b/web/tests/unit/cardGrid.test.tsx
@@ -69,21 +69,21 @@ describe("CardGrid", () => {
           tickers: [
             card("UNH", "Healthcare", 0, "500"),
             card("HUT", "NeoCloud", 0, "4"),
-            card("AMD", "Semiconductor", 301, "300"),
+            card("AMD", "Semi-Logic", 301, "300"),
             card("TSLA", "M7", 206, "900"),
-            card("QQQ", "ETF", 102, "250", "600"),
+            card("QQQ", "Beta", 102, "250", "600"),
             card("AAPL", "M7", 201, "3000"),
-            card("SPY", "ETF", 101, "500", "400"),
-            card("AVGO", "Semiconductor", 302, "1200"),
+            card("SPY", "Beta", 101, "500", "400"),
+            card("AVGO", "Semi-Logic", 302, "1200"),
           ],
         }}
       />,
     );
 
     expect(screen.getAllByRole("heading").map((h) => h.textContent)).toEqual([
-      "ETF · 2",
+      "Beta · 2",
       "M7 · 2",
-      "Semiconductor · 2",
+      "Semi-Logic · 2",
       "Healthcare · 1",
       "NeoCloud · 1",
     ]);
@@ -145,14 +145,14 @@ describe("CardGrid", () => {
             // ahead. Priority prefix (ETF) stays first either way.
             card("XLF", "Banks", 400, "1000000000"),
             card("JNJ", "Healthcare", 420, "500000000000"),
-            card("SPY", "ETF", 101, "300000000000"),
+            card("SPY", "Beta", 101, "300000000000"),
           ],
         }}
       />,
     );
 
     expect(screen.getAllByRole("heading").map((h) => h.textContent)).toEqual([
-      "ETF · 1",
+      "Beta · 1",
       "Healthcare · 1",
       "Banks · 1",
     ]);
@@ -167,8 +167,8 @@ describe("CardGrid", () => {
           scheduler_lag_seconds: null,
           queue: { total: 0, queued: 0, running: 0, oldest_requested_at: null },
           tickers: [
-            card("ZZZ", "ETF", 100, null),
-            card("AAA", "ETF", 100, null),
+            card("ZZZ", "Beta", 100, null),
+            card("AAA", "Beta", 100, null),
           ],
         }}
       />,

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -256,19 +256,19 @@ describe("AddTickerDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /\+ ticker/i }));
 
     expect(screen.queryByRole("combobox")).toBeNull();
-    expect(screen.getByRole("button", { name: /sector etf/i })).not.toBeNull();
+    expect(screen.getByRole("button", { name: /sector beta/i })).not.toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /sector etf/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sector beta/i }));
 
     expect(screen.getByText("Index")).not.toBeNull();
     expect(screen.getByText("AI/Tech")).not.toBeNull();
     expect(screen.getByText("Thematic")).not.toBeNull();
     expect(screen.getByText("Defensive")).not.toBeNull();
-    expect(screen.getByRole("option", { name: "ETF" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "Beta" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "M7" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "NeoCloud" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "Power" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "Airlines" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "Healthcare" })).not.toBeNull();
     expect(screen.queryByRole("option", { name: "Technology" })).toBeNull();
     expect(screen.queryByRole("option", { name: "All" })).toBeNull();
 


### PR DESCRIPTION
## Summary

Split the lumped `ETF` and `Semiconductor` tags into cohorts that share earnings drivers, rename `Optical` → `DC-Connect` (absorbing networking + MRVL), drop three empty tags, and add 10 tickers.

**Driver-based splits**
- `ETF` → **Beta** (broad equity) · **Sector-ETF** (sector betas) · **Credit** (HY bonds) · **Macro** (rates + real assets)
- `Semiconductor` → **Foundry** (wafer demand) · **Semi-Logic** (fabless/IP, end-demand) · **Semi-Cap** (WFE capex + EDA — defensive)
- `Optical` → **DC-Connect**, absorbing `Networking` (ANET, NOK) and `MRVL` (PAM4 DSPs / datacenter-interconnect silicon)

**Drops** (singletons / empty tabs): `Defense`, `Telecom-Media`, `Airlines`

**Adds** (10): ISRG (Healthcare); HYG, JNK (Credit); SLV (Macro); AMAT, LRCX, KLAC, SNPS, CDNS, TER (Semi-Cap)
**Removes** (15): ES, ARKK, SMCI, ZS, DDOG, ABBV, MRK, LMT, RTX, BA, CRS, T, VZ, DIS, DAL

**Final state:** 20 tags / 99 active tickers (was 17 / 104).

## Code changes

- `web/components/watchlist/sectorGroups.ts` — new 20-tag taxonomy; `PRIORITY_SECTORS` → `["Beta", "M7", "Semi-Logic"]`.
- `web/components/watchlist/CardGrid.tsx` — the AUM-priority sizing (`card.sector === "ETF"`) now applies to all four ETF-class tags via an `ETF_LIKE_SECTORS` set predicate.
- `web/tests/unit/cardGrid.test.tsx` + `watchlistUi.test.tsx` — fixtures and assertions updated to the new tag names (`ETF` → `Beta`, `Semiconductor` → `Semi-Logic`, `Airlines` → `Healthcare`).
- `src/uw_scan/storage/migrations/069_reclass_watchlist_20tags.sql` — idempotent migration mirroring the SQL already applied on the mini, so fresh dev / CI test DBs reach the same state via `scripts/migrate.sh`.

## DB state

Already applied on the mini's `option_wizard` (single transaction, 15 deletes / 10 inserts / 30 reclassifications). Migration 069 re-runs as a no-op there.

## Test plan

- [x] `cd web && npm run typecheck` — clean
- [x] `cd web && npx vitest run tests/unit/cardGrid.test.tsx tests/unit/watchlistUi.test.tsx` — 17 / 17 green
- [ ] After merge: confirm landing-page sidebar chips render the 4 new groups (Index/AI-Tech/Thematic/Defensive) and that new tickers appear as empty cards until the next scan/spot cycle fills `watchlist_card`
- [ ] On a fresh local DB (`option_wizard_local`), run `bash scripts/migrate.sh` and verify membership matches the mini's 20-tag / 99-ticker layout