### PR TITLE
fix(deploy): correct API health URL + add curl retry

### DIFF
--- a/scripts/deploy/macmini-deploy-branch.sh
+++ b/scripts/deploy/macmini-deploy-branch.sh
@@ -84,8 +84,10 @@ ssh "$SSH_HOST" "$REMOTE_CMD"
 
 # 4. Health check from MacBook side over Tailscale
 say "Health probe"
-for endpoint in "http://100.66.147.98:8400/health" "http://100.66.147.98:3001"; do
-  if curl -fsS --max-time 5 "$endpoint" >/dev/null 2>&1; then
+for endpoint in "http://100.66.147.98:8400/api/health?source=uw" "http://100.66.147.98:3001"; do
+  # API takes ~3-5s to bind after launchctl kickstart; brief retry loop avoids
+  # racing the warm-up window.
+  if curl -fsS --max-time 5 --retry 4 --retry-delay 2 --retry-connrefused "$endpoint" >/dev/null 2>&1; then
     say "  ✓ $endpoint"
   else
     die "  ✗ $endpoint (check ssh $SSH_HOST 'tail logs/api.err.log logs/web.err.log')"


### PR DESCRIPTION
## Summary

The post-deploy probe in `macmini-deploy-branch.sh` was hitting `:8400/health`, but FastAPI mounts every route under `/api/*` — so the probe always 404'd and the script reported deploy failure even on a fully healthy deploy. The previous deploy of #131 surfaced this: API was serving 200s on `/api/health` from the moment uvicorn finished startup, but the script died at the probe step.

Two small changes:

1. **URL fix**: `:8400/health` → `:8400/api/health?source=uw` (the canonical liveness path the web client polls).
2. **Retry**: add `--retry 4 --retry-delay 2 --retry-connrefused` to ride the 3–5 s window between `launchctl kickstart` and uvicorn binding the port. Without it, the probe races the warm-up even on the correct URL.

## Test plan

- [ ] Next `bash scripts/deploy/macmini-deploy-branch.sh main` succeeds end-to-end including the probe step
- [ ] Failure mode (API actually dead) still trips `die` and prints the same log-tail hint