### PR TITLE
feat(regime): live CRI/VCG — WS-quote compute, 5-min snapshots, intraday/daily grids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ The spot WS consumer (`uw_scan.worker.massive_ws_consumer` — module name retai
 - `XENON_WS_PORT_FILE` — default `/tmp/xenon-ib-realtime.json`; xenon writes its actual port there if 8765 is taken. Only consulted when the URL host is localhost; empty string disables
 - `XENON_WS_RETRY_PRIMARY_SECONDS` — stay on massive this long after a xenon failure before re-probing; default 300
 - `XENON_WS_QUIET_FAILOVER_SECONDS` — in-session silence threshold before failover; default 120; 0 disables
+- `REGIME_WS_SYMBOLS` — always-subscribed regime symbols beyond the watchlist; default `VIX,VVIX,VIX3M,COR1M,SPX,HYG`. Feeds the live CRI/VCG compute (`/api/regime/{cri,vcg}/live`) and the 5-min `regime_live_scan` job (basis='live' rows in cri/vcg_snapshots; hourly :20/:25 scans stay the canonical basis='eod' dailies). Quotes older than `REGIME_LIVE_QUOTE_MAX_AGE_SECONDS` (default 900) are ignored — live endpoints then fall back to the EOD snapshot. `REGIME_LIVE_SCAN_INTERVAL_MINUTES` (default 5) sets the snapshot cadence. Nightly 03:40 ET `regime_live_validation` diffs the live-captured close vs the lake close (>0.5% → WARN). Massive fallback is stocks-only: indices stall during failover, HYG keeps ticking.
 
 The worker process freezes env at fork — rotating any `XENON_*` value requires restarting the spot-WS consumer process. Subscription mapping: stocks/ETFs → xenon `symbols` (IB SMART); index symbols (SPX/VIX/VVIX/COR1M/…) → `indexes` with exchange CBOE — extend `XENON_INDEX_SYMBOLS` in `sources/xenon_ws.py` when the watchlist grows a new index.
 
@@ -125,6 +126,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
 | Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
 | Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
+| Regime live CRI/VCG (WS quotes) | `src/uw_scan/scanners/live_quotes.py` + `scanners/{cri,vcg}.py` `run_live` + `worker/jobs/regime_live.py` + `api/routers/regime.py` (`/cri/live` etc.) + `web/components/regime/MultiPanelGrid.tsx` |
 | Gold Compass — code | `api/routers/gold.py` + `storage/gold_etf.py` + `worker/jobs/gold_jobs.py` + `sources/{fred,gpr,lbma,comex,etf_holdings,uw_gold_options,cftc_cot,wgc_etf,wgc_cb}.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
 | Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ The spot WS consumer (`uw_scan.worker.massive_ws_consumer` — module name retai
 - `XENON_WS_PORT_FILE` — default `/tmp/xenon-ib-realtime.json`; xenon writes its actual port there if 8765 is taken. Only consulted when the URL host is localhost; empty string disables
 - `XENON_WS_RETRY_PRIMARY_SECONDS` — stay on massive this long after a xenon failure before re-probing; default 300
 - `XENON_WS_QUIET_FAILOVER_SECONDS` — in-session silence threshold before failover; default 120; 0 disables
+- `REGIME_WS_SYMBOLS` — always-subscribed regime symbols beyond the watchlist; default `VIX,VVIX,VIX3M,COR1M,SPX,HYG`. Feeds the live CRI/VCG compute (`/api/regime/{cri,vcg}/live`) and the 5-min `regime_live_scan` job (basis='live' rows in cri/vcg_snapshots; hourly :20/:25 scans stay the canonical basis='eod' dailies). Quotes older than `REGIME_LIVE_QUOTE_MAX_AGE_SECONDS` (default 900) are ignored — live endpoints then fall back to the EOD snapshot. `REGIME_LIVE_SCAN_INTERVAL_MINUTES` (default 5) sets the snapshot cadence. Nightly 03:40 ET `regime_live_validation` diffs the live-captured close vs the lake close (>0.5% → WARN). Massive fallback is stocks-only: indices stall during failover, HYG keeps ticking.
 
 The worker process freezes env at fork — rotating any `XENON_*` value requires restarting the spot-WS consumer process. Subscription mapping: stocks/ETFs → xenon `symbols` (IB SMART); index symbols (SPX/VIX/VVIX/COR1M/…) → `indexes` with exchange CBOE — extend `XENON_INDEX_SYMBOLS` in `sources/xenon_ws.py` when the watchlist grows a new index.
 
@@ -124,6 +125,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 | Volatility derivers | `src/uw_scan/cards/vol_series.py`, `reports/volatility_series.py` |
 | Scanner (detectors + ranking + discovery) | `src/uw_scan/scanner/` (pipeline, signals, ranking, discovery, gates, context) + `api/routers/scanner.py` + `web/app/scanner/page.tsx` |
 | Regime indicators (CRI / GEX / VCG) | `src/uw_scan/scanners/{cri,gex,vcg}.py` + `api/routers/regime.py` + `web/app/regime/page.tsx` + `web/components/regime/*` |
+| Regime live CRI/VCG (WS quotes) | `src/uw_scan/scanners/live_quotes.py` + `scanners/{cri,vcg}.py` `run_live` + `worker/jobs/regime_live.py` + `api/routers/regime.py` (`/cri/live` etc.) + `web/components/regime/MultiPanelGrid.tsx` |
 | Gold Compass — code | `api/routers/gold.py` + `storage/gold_etf.py` + `worker/jobs/gold_jobs.py` + `sources/{fred,gpr,lbma,comex,etf_holdings,uw_gold_options,cftc_cot,wgc_etf,wgc_cb}.py` + `web/app/gold/page.tsx` (+ `gold/replay/[date]/`) + `web/components/gold/*` |
 | Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated
 from zoneinfo import ZoneInfo
 
@@ -22,6 +22,11 @@ from uw_scan.api.schemas import (
     EMPTY_GEX_RESPONSE,
     EMPTY_VCG_RESPONSE,
     ClosestLevel,
+    CriDailyEntry,
+    CriDailyHistoryResponse,
+    CriIntradayResponse,
+    CriIntradaySession,
+    CriLiveResponse,
     CriResponse,
     CriScanResponse,
     DealerRegimeResponse,
@@ -31,6 +36,13 @@ from uw_scan.api.schemas import (
     GexIntradayResponse,
     GexIntradaySession,
     GexResponse,
+    RegimeLiveQuote,
+    RegimeQuotesResponse,
+    VcgDailyEntry,
+    VcgDailyHistoryResponse,
+    VcgIntradayResponse,
+    VcgIntradaySession,
+    VcgLiveResponse,
     VcgResponse,
     VcgScanResponse,
     VolBackdropResponse,
@@ -43,6 +55,7 @@ from uw_scan.config import Settings
 from uw_scan.scanners import cri as cri_scanner
 from uw_scan.scanners import gex as gex_scanner
 from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.scanners.live_quotes import load_live_quotes
 from uw_scan.storage.canary_snapshot_repository import CanarySnapshotRepository
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.greek_exposure_repository import GreekExposureDailyRepository
@@ -147,9 +160,7 @@ def get_gex_intraday(
     response when no rows exist for the ticker.
     """
     t = ticker.upper()
-    raw = repo.fetch_intraday_sessions(
-        ticker=t, sessions=sessions, rth_only=rth_only
-    )
+    raw = repo.fetch_intraday_sessions(ticker=t, sessions=sessions, rth_only=rth_only)
     payload_sessions = [GexIntradaySession.model_validate(s) for s in raw]
     last_ts = None
     if payload_sessions and payload_sessions[-1].points:
@@ -274,6 +285,162 @@ def trigger_vcg_scan(
     if row_id is None:
         return VcgScanResponse(status="skipped", proxy=proxy_upper, reason="thin_data")
     return VcgScanResponse(status="ok", proxy=proxy_upper, row_id=row_id)
+
+
+# ─── CRI / VCG live (WS-quote-driven) ────────────────────────────
+
+
+def _active_ws_source(repo: Repository) -> str | None:
+    state = repo.get_ws_consumer_state()
+    return state.active_source if state is not None else None
+
+
+@router.get("/cri/live", response_model=CriLiveResponse)
+def get_cri_live(
+    repo: Annotated[Repository, Depends(get_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> CriLiveResponse:
+    """Request-time CRI with live quotes spliced as today's provisional
+    close. Does NOT persist (the 5-min regime_live_scan job owns writes).
+    Falls back to the latest basis='eod' snapshot when quotes are stale."""
+    quotes = load_live_quotes(
+        repo,
+        settings.regime_ws_symbols,
+        max_age_seconds=settings.regime_live_quote_max_age_seconds,
+    )
+    payload = None
+    if quotes:
+        payload = cri_scanner.run_live(repo.conn, schema=repo._schema, quotes=quotes)
+    if payload is None:
+        snap_repo = CriSnapshotRepository(repo.conn, schema=repo._schema)
+        latest = snap_repo.fetch_latest()
+        if latest is None:
+            return CriLiveResponse(basis="eod")
+        return CriLiveResponse.model_validate(
+            {"status": "ok", "basis": "eod", **latest}
+        )
+    return CriLiveResponse.model_validate(
+        {
+            "status": "ok",
+            "scan_time": datetime.now(timezone.utc).isoformat(),
+            "active_source": _active_ws_source(repo),
+            **payload,
+        }
+    )
+
+
+@router.get("/cri/intraday", response_model=CriIntradayResponse)
+def get_cri_intraday(
+    repo: Annotated[Repository, Depends(get_repo)],
+    sessions: int = Query(5, ge=1, le=20),
+    rth_only: bool = Query(True),
+) -> CriIntradayResponse:
+    snap_repo = CriSnapshotRepository(repo.conn, schema=repo._schema)
+    raw = snap_repo.fetch_intraday_sessions(sessions=sessions, rth_only=rth_only)
+    payload_sessions = [CriIntradaySession.model_validate(s) for s in raw]
+    last_ts = None
+    if payload_sessions and payload_sessions[-1].points:
+        last_ts = payload_sessions[-1].points[-1].ts
+    return CriIntradayResponse(sessions=payload_sessions, as_of=last_ts)
+
+
+@router.get("/cri/history", response_model=CriDailyHistoryResponse)
+def get_cri_history(
+    repo: Annotated[Repository, Depends(get_repo)],
+    days: int = Query(90, ge=5, le=365),
+) -> CriDailyHistoryResponse:
+    snap_repo = CriSnapshotRepository(repo.conn, schema=repo._schema)
+    rows = snap_repo.fetch_daily_history(days=days)
+    return CriDailyHistoryResponse(rows=[CriDailyEntry.model_validate(r) for r in rows])
+
+
+@router.get("/vcg/live", response_model=VcgLiveResponse)
+def get_vcg_live(
+    repo: Annotated[Repository, Depends(get_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    proxy: str = Query("HYG"),
+) -> VcgLiveResponse:
+    proxy_upper = proxy.upper()
+    quotes = load_live_quotes(
+        repo,
+        settings.regime_ws_symbols,
+        max_age_seconds=settings.regime_live_quote_max_age_seconds,
+    )
+    payload = None
+    if quotes:
+        payload = vcg_scanner.run_live(
+            repo.conn, schema=repo._schema, quotes=quotes, proxy=proxy_upper
+        )
+    if payload is None:
+        snap_repo = VcgSnapshotRepository(repo.conn, schema=repo._schema)
+        latest = snap_repo.fetch_latest(proxy=proxy_upper)
+        if latest is None:
+            empty = VcgLiveResponse(basis="eod")
+            empty.credit_proxy = proxy_upper
+            return empty
+        return VcgLiveResponse.model_validate(
+            {"status": "ok", "basis": "eod", **latest}
+        )
+    return VcgLiveResponse.model_validate(
+        {
+            "status": "ok",
+            "scan_time": datetime.now(timezone.utc).isoformat(),
+            "active_source": _active_ws_source(repo),
+            **payload,
+        }
+    )
+
+
+@router.get("/vcg/intraday", response_model=VcgIntradayResponse)
+def get_vcg_intraday(
+    repo: Annotated[Repository, Depends(get_repo)],
+    proxy: str = Query("HYG"),
+    sessions: int = Query(5, ge=1, le=20),
+    rth_only: bool = Query(True),
+) -> VcgIntradayResponse:
+    snap_repo = VcgSnapshotRepository(repo.conn, schema=repo._schema)
+    raw = snap_repo.fetch_intraday_sessions(
+        proxy=proxy.upper(), sessions=sessions, rth_only=rth_only
+    )
+    payload_sessions = [VcgIntradaySession.model_validate(s) for s in raw]
+    last_ts = None
+    if payload_sessions and payload_sessions[-1].points:
+        last_ts = payload_sessions[-1].points[-1].ts
+    return VcgIntradayResponse(
+        credit_proxy=proxy.upper(), sessions=payload_sessions, as_of=last_ts
+    )
+
+
+@router.get("/vcg/history", response_model=VcgDailyHistoryResponse)
+def get_vcg_history(
+    repo: Annotated[Repository, Depends(get_repo)],
+    proxy: str = Query("HYG"),
+    days: int = Query(90, ge=5, le=365),
+) -> VcgDailyHistoryResponse:
+    snap_repo = VcgSnapshotRepository(repo.conn, schema=repo._schema)
+    rows = snap_repo.fetch_daily_history(proxy=proxy.upper(), days=days)
+    return VcgDailyHistoryResponse(
+        credit_proxy=proxy.upper(),
+        rows=[VcgDailyEntry.model_validate(r) for r in rows],
+    )
+
+
+@router.get("/quotes", response_model=RegimeQuotesResponse)
+def get_regime_quotes(
+    repo: Annotated[Repository, Depends(get_repo)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> RegimeQuotesResponse:
+    rows = repo.get_intraday_quotes([s.upper() for s in settings.regime_ws_symbols])
+    quotes = {
+        r.ticker: RegimeLiveQuote(
+            price=float(r.price), quoted_at=r.quoted_at, source=r.source
+        )
+        for r in rows
+    }
+    as_of = max((r.quoted_at for r in rows), default=None)
+    return RegimeQuotesResponse(
+        quotes=quotes, active_source=_active_ws_source(repo), as_of=as_of
+    )
 
 
 # ─── Dealer regime (per-ticker, live) ─────────────────────────────

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -439,7 +439,10 @@ def get_regime_quotes(
     }
     as_of = max((r.quoted_at for r in rows), default=None)
     return RegimeQuotesResponse(
-        quotes=quotes, active_source=_active_ws_source(repo), as_of=as_of
+        quotes=quotes,
+        active_source=_active_ws_source(repo),
+        as_of=as_of,
+        fresh_within_seconds=settings.regime_live_quote_max_age_seconds,
     )
 
 

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -633,6 +633,10 @@ class RegimeQuotesResponse(BaseModel):
     quotes: dict[str, RegimeLiveQuote] = Field(default_factory=dict)
     active_source: str | None = None
     as_of: datetime | None = None
+    # The server's staleness window (REGIME_LIVE_QUOTE_MAX_AGE_SECONDS) so
+    # the client's "is this quote live?" check can't drift from the value
+    # the live endpoints actually use.
+    fresh_within_seconds: int = 900
 
 
 # ----------------------------------------------------------------------

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -511,6 +511,130 @@ class VcgScanResponse(BaseModel):
     reason: str | None = None
 
 
+# ─── Regime live (WS-quote-driven CRI/VCG) ───────────────────────
+
+
+class RegimeLiveQuote(BaseModel):
+    """One live WS quote echoed by the live endpoints / quotes strip."""
+
+    price: float
+    quoted_at: datetime
+    source: str | None = None
+
+
+class CriLiveResponse(CriResponse):
+    """CRI computed at request time with live quotes spliced as today's
+    provisional close. ``basis='eod'`` means the live compute wasn't
+    possible (stale/no quotes) and the latest persisted EOD snapshot is
+    being served instead."""
+
+    basis: Literal["live", "eod"] = "eod"
+    live_quotes: dict[str, RegimeLiveQuote] = Field(default_factory=dict)
+    carried_forward: list[str] = Field(default_factory=list)
+    active_source: str | None = None
+
+
+class VcgLiveResponse(VcgResponse):
+    basis: Literal["live", "eod"] = "eod"
+    live_quotes: dict[str, RegimeLiveQuote] = Field(default_factory=dict)
+    carried_forward: list[str] = Field(default_factory=list)
+    active_source: str | None = None
+
+
+class CriIntradayPoint(BaseModel):
+    ts: datetime
+    cri_score: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    spx: float | None = None
+    cor1m: float | None = None
+    vix3m: float | None = None
+    realized_vol: float | None = None
+    vrp: float | None = None
+    vix_zscore_30d: float | None = None
+    vix_vix3m_ratio: float | None = None
+    spx_distance_pct: float | None = None
+
+
+class CriIntradaySession(BaseModel):
+    et_date: date
+    points: list[CriIntradayPoint] = Field(default_factory=list)
+
+
+class CriIntradayResponse(BaseModel):
+    sessions: list[CriIntradaySession] = Field(default_factory=list)
+    as_of: datetime | None = None
+
+
+class CriDailyEntry(BaseModel):
+    date: date
+    cri_score: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    spx: float | None = None
+    cor1m: float | None = None
+    vix3m: float | None = None
+    realized_vol: float | None = None
+    vrp: float | None = None
+    vix_zscore_30d: float | None = None
+    vix_vix3m_ratio: float | None = None
+    spx_distance_pct: float | None = None
+
+
+class CriDailyHistoryResponse(BaseModel):
+    rows: list[CriDailyEntry] = Field(default_factory=list)
+
+
+class VcgIntradayPoint(BaseModel):
+    ts: datetime
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    residual: float | None = None
+    credit_price: float | None = None
+    credit_5d_return_pct: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    beta1: float | None = None
+    beta2: float | None = None
+
+
+class VcgIntradaySession(BaseModel):
+    et_date: date
+    points: list[VcgIntradayPoint] = Field(default_factory=list)
+
+
+class VcgIntradayResponse(BaseModel):
+    credit_proxy: str = "HYG"
+    sessions: list[VcgIntradaySession] = Field(default_factory=list)
+    as_of: datetime | None = None
+
+
+class VcgDailyEntry(BaseModel):
+    date: date
+    vcg: float | None = None
+    vcg_adj: float | None = None
+    residual: float | None = None
+    credit_price: float | None = None
+    credit_5d_return_pct: float | None = None
+    vix: float | None = None
+    vvix: float | None = None
+    beta1: float | None = None
+    beta2: float | None = None
+
+
+class VcgDailyHistoryResponse(BaseModel):
+    credit_proxy: str = "HYG"
+    rows: list[VcgDailyEntry] = Field(default_factory=list)
+
+
+class RegimeQuotesResponse(BaseModel):
+    """Lightweight live-quote projection for the regime header strip."""
+
+    quotes: dict[str, RegimeLiveQuote] = Field(default_factory=dict)
+    active_source: str | None = None
+    as_of: datetime | None = None
+
+
 # ----------------------------------------------------------------------
 # Dealer-regime (per-ticker) — feeds Magnet/Gamma bar + Volatility regime
 # panel. See docs/superpowers/archive/plans/2026-05-21-gex-volatility-enrichment.md

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -229,6 +229,15 @@ class Settings(BaseModel):
     # Regime / GEX scanner (port from xenon — ships GEX live; CRI/VCG pending)
     gex_scan_tickers: list[str] = ["SPX", "SPY"]
     gex_scan_interval_minutes: int = 5
+    # Regime live feed — symbols the WS consumer always subscribes IN ADDITION
+    # to the watchlist (indexes route via XENON_INDEX_SYMBOLS → CBOE; HYG is a
+    # plain ETF symbol). Drives the live CRI/VCG compute + 5-min snapshots.
+    regime_ws_symbols: list[str] = ["VIX", "VVIX", "VIX3M", "COR1M", "SPX", "HYG"]
+    # Cadence of the regime_live_scan job (basis='live' snapshot writes).
+    regime_live_scan_interval_minutes: int = 5
+    # Quotes older than this are ignored by the live compute (stale feed →
+    # the live endpoints fall back to the latest basis='eod' snapshot).
+    regime_live_quote_max_age_seconds: int = 900
     # Parquet lake root for CBOE vol indices and SPX daily OHLC.
     # Maintained by the peer ``market-data-warehouse`` project. Symbol subdirs
     # are named ``symbol=<TICKER>`` with a ``1d.parquet`` payload inside.
@@ -511,6 +520,16 @@ class Settings(BaseModel):
             gex_scan_tickers=_parse_csv_env("GEX_SCAN_TICKERS", default=["SPX", "SPY"]),
             gex_scan_interval_minutes=int(
                 os.environ.get("GEX_SCAN_INTERVAL_MINUTES", "5")
+            ),
+            regime_ws_symbols=_parse_csv_env(
+                "REGIME_WS_SYMBOLS",
+                default=["VIX", "VVIX", "VIX3M", "COR1M", "SPX", "HYG"],
+            ),
+            regime_live_scan_interval_minutes=int(
+                os.environ.get("REGIME_LIVE_SCAN_INTERVAL_MINUTES", "5")
+            ),
+            regime_live_quote_max_age_seconds=int(
+                os.environ.get("REGIME_LIVE_QUOTE_MAX_AGE_SECONDS", "900")
             ),
             # Parquet-lake roots are env-overridable so deployments without
             # the user's home-dir layout (containers, CI) can point at their

--- a/src/uw_scan/scanners/cri.py
+++ b/src/uw_scan/scanners/cri.py
@@ -15,12 +15,21 @@ job self-heals if the worker was offline for a stretch.
 from __future__ import annotations
 
 import logging
-from datetime import date as _date, timedelta
+from collections.abc import Mapping
+from datetime import date as _date
+from datetime import timedelta
 
 import numpy as np
 from psycopg import Connection
 
 from uw_scan.cards import cri_scoring
+from uw_scan.scanners.live_quotes import (
+    LiveQuote,
+    carry_forward,
+    live_session_date,
+    quotes_payload,
+    splice_session_value,
+)
 from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
 from uw_scan.storage.repository import Repository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
@@ -181,15 +190,104 @@ def run(
     return row_id
 
 
-def _existing_cri_dates(
-    conn: Connection, schema: str, *, since: _date
-) -> set[_date]:
-    """Distinct ``data_date`` already in ``cri_snapshots`` since ``since``."""
+def run_live(
+    conn: Connection,
+    schema: str = "uw_scan",
+    *,
+    quotes: Mapping[str, LiveQuote],
+    persist: bool = False,
+) -> dict | None:
+    """CRI computed with live WS quotes spliced as today's provisional close.
+
+    Mandatory series (VIX/VVIX/COR1M/SPX) without a fresh quote are carried
+    forward from their last daily close so the inner-join alignment keeps
+    today's bar — a dead COR1M feed degrades that input to "yesterday's
+    value", it does not kill the live read. Returns the full payload (with
+    history arrays — the API serves it directly); when ``persist`` is set,
+    a SLIM copy (no history / spy_closes) lands in cri_snapshots with
+    basis='live'. Returns None when no usable quote exists.
+    """
+    session_date = live_session_date(quotes)
+    if session_date is None:
+        return None
+
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    series: dict[str, dict[_date, float]] = {
+        "VIX": _load_vol_series(vol_repo, "VIX", LOOKBACK_DAYS),
+        "VVIX": _load_vol_series(vol_repo, "VVIX", LOOKBACK_DAYS),
+        "COR1M": _load_vol_series(vol_repo, "COR1M", LOOKBACK_DAYS),
+        "SPX": _load_spx_series(vol_repo, LOOKBACK_DAYS),
+    }
+    live_syms: list[str] = []
+    carried: list[str] = []
+    for sym in list(series):
+        q = quotes.get(sym)
+        if q is not None:
+            series[sym] = splice_session_value(series[sym], q.price, session_date)
+            live_syms.append(sym)
+        else:
+            series[sym], was_carried = carry_forward(series[sym], session_date)
+            if was_carried:
+                carried.append(sym)
+    if not live_syms:
+        return None
+
+    aligned, common_dates = _align(series)
+    if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
+        log.warning(
+            "cri_live_skipped_thin_data aligned_bars=%d need=%d",
+            len(common_dates),
+            MIN_ALIGNED_BARS,
+        )
+        return None
+
+    vix3m_series = _load_vol_series(vol_repo, "VIX3M", LOOKBACK_DAYS)
+    q3m = quotes.get("VIX3M")
+    if q3m is not None:
+        vix3m_series = splice_session_value(vix3m_series, q3m.price, session_date)
+    if vix3m_series:
+        aligned["VIX3M"] = np.array(
+            [
+                vix3m_series.get(_date.fromisoformat(d), float("nan"))
+                for d in common_dates
+            ],
+            dtype=float,
+        )
+
+    payload = cri_scoring.run_analysis(aligned, common_dates)
+    payload["basis"] = "live"
+    payload["live_quotes"] = quotes_payload(quotes)
+    payload["carried_forward"] = carried
+
+    if persist:
+        slim = {k: v for k, v in payload.items() if k not in ("history", "spy_closes")}
+        snap_repo = CriSnapshotRepository(conn, schema=schema)
+        row_id = snap_repo.insert_snapshot(
+            payload=slim, data_date=session_date, basis="live"
+        )
+        log.info(
+            "cri_live_persisted row_id=%d session=%s live=%s carried=%s score=%.1f",
+            row_id,
+            session_date,
+            sorted(live_syms),
+            carried,
+            payload["cri"]["score"],
+        )
+    return payload
+
+
+def _existing_cri_dates(conn: Connection, schema: str, *, since: _date) -> set[_date]:
+    """Distinct EOD ``data_date`` already in ``cri_snapshots`` since ``since``.
+
+    basis='eod' only — a 5-min live row landing on today's date must not
+    suppress the EOD gap recovery for that same date.
+    """
     sql = f"""
         SELECT DISTINCT data_date
           FROM {schema}.cri_snapshots
          WHERE data_date IS NOT NULL
            AND data_date >= %s
+           AND basis = 'eod'
     """
     with conn.cursor() as cur:
         cur.execute(sql, (since,))

--- a/src/uw_scan/scanners/cri.py
+++ b/src/uw_scan/scanners/cri.py
@@ -245,6 +245,14 @@ def run_live(
     q3m = quotes.get("VIX3M")
     if q3m is not None:
         vix3m_series = splice_session_value(vix3m_series, q3m.price, session_date)
+    else:
+        # Without carry-forward today's bar is NaN and the term-structure
+        # tiles (vix3m / vix_vix3m_ratio) blank out on a LIVE read even
+        # though the EOD view had values — same degradation rule as the
+        # mandatory series.
+        vix3m_series, was_carried = carry_forward(vix3m_series, session_date)
+        if was_carried:
+            carried.append("VIX3M")
     if vix3m_series:
         aligned["VIX3M"] = np.array(
             [

--- a/src/uw_scan/scanners/live_quotes.py
+++ b/src/uw_scan/scanners/live_quotes.py
@@ -1,0 +1,93 @@
+"""Live-quote primitives for the regime scanners (CRI / VCG live compute).
+
+The live compute splices the latest WS quote onto the vol_index_daily
+history as TODAY's provisional close, then re-runs the existing pure
+run_analysis orchestrators. Symbols without a fresh quote (e.g. COR1M if
+IB never ticks it, or any index while on the massive stocks-only fallback)
+are carried forward from their last daily close so the inner-join
+alignment doesn't drop the session entirely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+from uw_scan.storage.repository import Repository
+
+_ET = ZoneInfo("America/New_York")
+
+
+@dataclass(frozen=True)
+class LiveQuote:
+    symbol: str
+    price: float
+    quoted_at: datetime
+    source: str | None
+
+
+def load_live_quotes(
+    repo: Repository,
+    symbols: Sequence[str],
+    *,
+    max_age_seconds: int,
+    now: datetime | None = None,
+) -> dict[str, LiveQuote]:
+    """Latest intraday_quote per symbol, dropping anything older than
+    ``max_age_seconds``. Deterministic: pass ``now`` in tests."""
+    now = now or datetime.now(timezone.utc)
+    out: dict[str, LiveQuote] = {}
+    for row in repo.get_intraday_quotes([s.upper() for s in symbols]):
+        if (now - row.quoted_at).total_seconds() > max_age_seconds:
+            continue
+        out[row.ticker] = LiveQuote(
+            symbol=row.ticker,
+            price=float(row.price),
+            quoted_at=row.quoted_at,
+            source=row.source,
+        )
+    return out
+
+
+def live_session_date(quotes: Mapping[str, LiveQuote]) -> date | None:
+    """ET trading date implied by the freshest quote, or None when empty."""
+    if not quotes:
+        return None
+    freshest = max(q.quoted_at for q in quotes.values())
+    return freshest.astimezone(_ET).date()
+
+
+def splice_session_value(
+    series: dict[date, float], price: float, session_date: date
+) -> dict[date, float]:
+    """Copy ``series`` with ``session_date`` set to the live price (replaces
+    an already-synced lake close for the same date — live wins intraday)."""
+    out = dict(series)
+    out[session_date] = price
+    return out
+
+
+def carry_forward(
+    series: dict[date, float], session_date: date
+) -> tuple[dict[date, float], bool]:
+    """If ``series`` has no value for ``session_date``, repeat its latest
+    close. Returns (series, was_carried)."""
+    if not series or session_date in series:
+        return series, False
+    out = dict(series)
+    out[session_date] = series[max(series)]
+    return out, True
+
+
+def quotes_payload(quotes: Mapping[str, LiveQuote]) -> dict[str, dict]:
+    """JSON-serializable live_quotes block persisted into snapshot payloads."""
+    return {
+        sym: {
+            "price": q.price,
+            "quoted_at": q.quoted_at.isoformat(),
+            "source": q.source,
+        }
+        for sym, q in quotes.items()
+    }

--- a/src/uw_scan/scanners/vcg.py
+++ b/src/uw_scan/scanners/vcg.py
@@ -15,12 +15,21 @@ vcg_snapshots row.
 from __future__ import annotations
 
 import logging
-from datetime import date as _date, timedelta
+from collections.abc import Mapping
+from datetime import date as _date
+from datetime import timedelta
 
 import numpy as np
 from psycopg import Connection
 
 from uw_scan.cards import vcg_scoring
+from uw_scan.scanners.live_quotes import (
+    LiveQuote,
+    carry_forward,
+    live_session_date,
+    quotes_payload,
+    splice_session_value,
+)
 from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
 
@@ -148,14 +157,86 @@ def run(
     return row_id
 
 
+def run_live(
+    conn: Connection,
+    schema: str = "uw_scan",
+    *,
+    quotes: Mapping[str, LiveQuote],
+    proxy: str = DEFAULT_PROXY,
+    persist: bool = False,
+) -> dict | None:
+    """VCG computed with live quotes spliced as today's provisional close.
+
+    The live credit price splices onto the adj_close series — adj_close
+    equals close between distributions, so an intraday HYG last-price is a
+    consistent provisional bar until the next ex-div date re-syncs from
+    the lake overnight. Slim persist (no history) with basis='live'.
+    """
+    session_date = live_session_date(quotes)
+    if session_date is None:
+        return None
+
+    vol_repo = VolIndexRepository(conn, schema=schema)
+    raw = {
+        "VIX": _load_series(vol_repo, "VIX", LOOKBACK_DAYS),
+        "VVIX": _load_series(vol_repo, "VVIX", LOOKBACK_DAYS),
+        proxy: _load_series(vol_repo, proxy, LOOKBACK_DAYS, prefer_adj_close=True),
+    }
+    live_syms: list[str] = []
+    carried: list[str] = []
+    for sym in list(raw):
+        q = quotes.get(sym)
+        if q is not None:
+            raw[sym] = splice_session_value(raw[sym], q.price, session_date)
+            live_syms.append(sym)
+        else:
+            raw[sym], was_carried = carry_forward(raw[sym], session_date)
+            if was_carried:
+                carried.append(sym)
+    if not live_syms:
+        return None
+
+    aligned, common_dates = _align(raw)
+    if not common_dates or len(common_dates) < MIN_ALIGNED_BARS:
+        log.warning(
+            "vcg_live_skipped_thin_data proxy=%s aligned_bars=%d need=%d",
+            proxy,
+            len(common_dates),
+            MIN_ALIGNED_BARS,
+        )
+        return None
+
+    payload = vcg_scoring.run_analysis(aligned, common_dates, proxy=proxy)
+    payload["basis"] = "live"
+    payload["live_quotes"] = quotes_payload(quotes)
+    payload["carried_forward"] = carried
+
+    if persist:
+        slim = {k: v for k, v in payload.items() if k != "history"}
+        snap_repo = VcgSnapshotRepository(conn, schema=schema)
+        row_id = snap_repo.insert_snapshot(
+            payload=slim, data_date=session_date, basis="live"
+        )
+        log.info(
+            "vcg_live_persisted row_id=%d session=%s proxy=%s vcg=%s",
+            row_id,
+            session_date,
+            proxy,
+            payload["signal"].get("vcg"),
+        )
+    return payload
+
+
 def _existing_vcg_dates(
     conn: Connection, schema: str, *, since: _date, proxy: str
 ) -> set[_date]:
-    """Distinct ``data_date`` in ``vcg_snapshots`` for ``proxy`` since ``since``.
+    """Distinct EOD ``data_date`` in ``vcg_snapshots`` for ``proxy`` since ``since``.
 
     Filters by ``payload->>'credit_proxy'`` (the field name vcg_scoring
     writes) so swapping HYG → JNK in config doesn't cause us to skip the
-    JNK day because an HYG row happened to land on it.
+    JNK day because an HYG row happened to land on it. basis='eod' only —
+    a 5-min live row landing on today's date must not suppress the EOD
+    gap recovery for that same date.
     """
     sql = f"""
         SELECT DISTINCT data_date
@@ -163,6 +244,7 @@ def _existing_vcg_dates(
          WHERE data_date IS NOT NULL
            AND data_date >= %s
            AND payload->>'credit_proxy' = %s
+           AND basis = 'eod'
     """
     with conn.cursor() as cur:
         cur.execute(sql, (since, proxy))

--- a/src/uw_scan/storage/cri_snapshot_repository.py
+++ b/src/uw_scan/storage/cri_snapshot_repository.py
@@ -19,29 +19,33 @@ class CriSnapshotRepository:
         with conn.cursor() as cur:
             cur.execute(f"SET search_path TO {schema}, public")
 
-    def insert_snapshot(self, *, payload: dict, data_date: date | None = None) -> int:
+    def insert_snapshot(
+        self, *, payload: dict, data_date: date | None = None, basis: str = "eod"
+    ) -> int:
         sql = """
-            INSERT INTO cri_snapshots (data_date, payload)
-            VALUES (%s, %s)
+            INSERT INTO cri_snapshots (data_date, payload, basis)
+            VALUES (%s, %s, %s)
             RETURNING id
         """
         with self._conn.cursor() as cur:
-            cur.execute(sql, (data_date, Jsonb(payload)))
+            cur.execute(sql, (data_date, Jsonb(payload), basis))
             row = cur.fetchone()
         assert row is not None
         self._conn.commit()
         return int(row[0])
 
-    def fetch_latest(self) -> dict | None:
-        """Return most-recent payload, or None."""
+    def fetch_latest(self, *, basis: str = "eod") -> dict | None:
+        """Most-recent payload for ``basis`` ('eod' default keeps the
+        pre-live /api/regime contract: full payload with history arrays)."""
         sql = """
             SELECT payload, scanned_at
               FROM cri_snapshots
+             WHERE basis = %s
              ORDER BY scanned_at DESC
              LIMIT 1
         """
         with self._conn.cursor() as cur:
-            cur.execute(sql)
+            cur.execute(sql, (basis,))
             row = cur.fetchone()
         if row is None:
             return None
@@ -69,6 +73,7 @@ class CriSnapshotRepository:
                    spx_distance_pct::float8,
                    realized_vol::float8
               FROM cri_snapshots
+             WHERE basis = 'eod'
              ORDER BY scanned_at DESC
              LIMIT %s
         """
@@ -80,4 +85,80 @@ class CriSnapshotRepository:
         for r in rows:
             if r.get("scanned_at") is not None:
                 r["scan_time"] = r["scanned_at"].isoformat()
+        return rows
+
+    # ---- live charting reads (regime tab) ----
+
+    _POINT_COLS = """
+                   cri_score::float8        AS cri_score,
+                   vix::float8              AS vix,
+                   vvix::float8             AS vvix,
+                   spx::float8              AS spx,
+                   cor1m::float8            AS cor1m,
+                   vix3m::float8            AS vix3m,
+                   realized_vol::float8     AS realized_vol,
+                   vrp::float8              AS vrp,
+                   vix_zscore_30d::float8   AS vix_zscore_30d,
+                   vix_vix3m_ratio::float8  AS vix_vix3m_ratio,
+                   spx_distance_pct::float8 AS spx_distance_pct
+    """
+
+    def fetch_intraday_sessions(
+        self, *, sessions: int = 5, rth_only: bool = True
+    ) -> list[dict]:
+        """Last N ET sessions of basis='live' rows, grouped server-side.
+        Mirrors _GexMixin.fetch_intraday_sessions (storage/gex.py)."""
+        rth_filter = (
+            "AND (scanned_at AT TIME ZONE 'America/New_York')::time "
+            "BETWEEN '09:30' AND '16:00'"
+            if rth_only
+            else ""
+        )
+        sql = f"""
+            WITH recent_sessions AS (
+                SELECT DISTINCT
+                       (scanned_at AT TIME ZONE 'America/New_York')::date AS et_date
+                  FROM cri_snapshots
+                 WHERE basis = 'live'
+                   {rth_filter}
+                 ORDER BY et_date DESC
+                 LIMIT %s
+            )
+            SELECT (c.scanned_at AT TIME ZONE 'America/New_York')::date AS et_date,
+                   c.scanned_at,
+                   {self._POINT_COLS}
+              FROM cri_snapshots c
+              JOIN recent_sessions rs
+                ON (c.scanned_at AT TIME ZONE 'America/New_York')::date = rs.et_date
+             WHERE c.basis = 'live'
+               {rth_filter}
+             ORDER BY c.scanned_at ASC
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (sessions,))
+            cols = [d.name for d in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        out: dict[object, list[dict]] = {}
+        for r in rows:
+            et_date = r.pop("et_date")
+            r["ts"] = r.pop("scanned_at")
+            out.setdefault(et_date, []).append(r)
+        return [{"et_date": d, "points": pts} for d, pts in sorted(out.items())]
+
+    def fetch_daily_history(self, *, days: int = 90) -> list[dict]:
+        """Latest basis='eod' row per data_date, ASC, for the daily grid."""
+        sql = f"""
+            SELECT DISTINCT ON (data_date)
+                   data_date AS date,
+                   {self._POINT_COLS}
+              FROM cri_snapshots
+             WHERE basis = 'eod' AND data_date IS NOT NULL
+             ORDER BY data_date DESC, scanned_at DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (days,))
+            cols = [d.name for d in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
         return rows

--- a/src/uw_scan/storage/market_data.py
+++ b/src/uw_scan/storage/market_data.py
@@ -119,6 +119,20 @@ class _MarketDataMixin:
             row = cur.fetchone()
             return IntradayQuoteRow(*row) if row else None
 
+    def get_intraday_quotes(self, tickers: list[str]) -> list[IntradayQuoteRow]:
+        """Batch read of the latest WS quote per ticker (regime live compute)."""
+        if not tickers:
+            return []
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT ticker, price, quoted_at, fetched_at, source
+                FROM {self._schema}.intraday_quote WHERE ticker = ANY(%s)
+                """,
+                (tickers,),
+            )
+            return [IntradayQuoteRow(*row) for row in cur.fetchall()]
+
     def get_latest_intraday_quote_times(self) -> tuple[datetime, datetime] | None:
         with self._conn.cursor() as cur:
             cur.execute(

--- a/src/uw_scan/storage/migrations/070_regime_snapshot_basis.sql
+++ b/src/uw_scan/storage/migrations/070_regime_snapshot_basis.sql
@@ -1,0 +1,55 @@
+-- 070_regime_snapshot_basis.sql
+--
+-- Live CRI/VCG snapshots share cri_snapshots / vcg_snapshots with the EOD
+-- scans (mirrors how gex_snapshots serves both the daily HistoryChart and
+-- the intraday 5-session chart). `basis` distinguishes the two write paths:
+--   'eod'  — hourly :20/:25 scans off vol_index_daily daily closes (canonical)
+--   'live' — 5-min regime_live_scan rows with WS quotes spliced as today's
+--            provisional close (slim payload: no history / spy_closes arrays)
+-- New generated columns expose every series the intraday/daily multi-panel
+-- charts need without a JSONB parse (gex_snapshots pattern).
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS basis TEXT NOT NULL DEFAULT 'eod';
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS spx NUMERIC(12,2)
+        GENERATED ALWAYS AS ((payload->>'spy')::numeric) STORED;
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS vix3m NUMERIC(8,2)
+        GENERATED ALWAYS AS ((payload->>'vix3m')::numeric) STORED;
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS vrp NUMERIC(8,2)
+        GENERATED ALWAYS AS ((payload->>'vrp')::numeric) STORED;
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS vix_zscore_30d NUMERIC(8,2)
+        GENERATED ALWAYS AS ((payload->>'vix_zscore_30d')::numeric) STORED;
+ALTER TABLE uw_scan.cri_snapshots
+    ADD COLUMN IF NOT EXISTS vix_vix3m_ratio NUMERIC(8,3)
+        GENERATED ALWAYS AS ((payload->>'vix_vix3m_ratio')::numeric) STORED;
+
+ALTER TABLE uw_scan.vcg_snapshots
+    ADD COLUMN IF NOT EXISTS basis TEXT NOT NULL DEFAULT 'eod';
+ALTER TABLE uw_scan.vcg_snapshots
+    ADD COLUMN IF NOT EXISTS residual NUMERIC(14,6)
+        GENERATED ALWAYS AS (((payload->'signal')->>'residual')::numeric) STORED;
+ALTER TABLE uw_scan.vcg_snapshots
+    ADD COLUMN IF NOT EXISTS credit_5d_return NUMERIC(10,3)
+        GENERATED ALWAYS AS (((payload->'signal')->>'credit_5d_return_pct')::numeric) STORED;
+ALTER TABLE uw_scan.vcg_snapshots
+    ADD COLUMN IF NOT EXISTS beta1 NUMERIC(14,6)
+        GENERATED ALWAYS AS (((payload->'signal')->>'beta1_vvix')::numeric) STORED;
+ALTER TABLE uw_scan.vcg_snapshots
+    ADD COLUMN IF NOT EXISTS beta2 NUMERIC(14,6)
+        GENERATED ALWAYS AS (((payload->'signal')->>'beta2_vix')::numeric) STORED;
+
+CREATE INDEX IF NOT EXISTS ix_cri_basis_scanned_at
+    ON uw_scan.cri_snapshots (basis, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS ix_vcg_basis_scanned_at
+    ON uw_scan.vcg_snapshots (basis, scanned_at DESC);
+
+COMMIT;

--- a/src/uw_scan/storage/vcg_snapshot_repository.py
+++ b/src/uw_scan/storage/vcg_snapshot_repository.py
@@ -19,21 +19,26 @@ class VcgSnapshotRepository:
         with conn.cursor() as cur:
             cur.execute(f"SET search_path TO {schema}, public")
 
-    def insert_snapshot(self, *, payload: dict, data_date: date | None = None) -> int:
+    def insert_snapshot(
+        self, *, payload: dict, data_date: date | None = None, basis: str = "eod"
+    ) -> int:
         sql = """
-            INSERT INTO vcg_snapshots (data_date, payload)
-            VALUES (%s, %s)
+            INSERT INTO vcg_snapshots (data_date, payload, basis)
+            VALUES (%s, %s, %s)
             RETURNING id
         """
         with self._conn.cursor() as cur:
-            cur.execute(sql, (data_date, Jsonb(payload)))
+            cur.execute(sql, (data_date, Jsonb(payload), basis))
             row = cur.fetchone()
         assert row is not None
         self._conn.commit()
         return int(row[0])
 
-    def fetch_latest(self, *, proxy: str | None = None) -> dict | None:
-        """Return the most recent payload (optionally filtered by proxy).
+    def fetch_latest(
+        self, *, proxy: str | None = None, basis: str = "eod"
+    ) -> dict | None:
+        """Return the most recent payload for ``basis`` (optionally filtered
+        by proxy). 'eod' default keeps the pre-live /api/regime/vcg contract.
 
         ``id DESC`` is the tie-breaker for the rare case where two snapshots
         share a ``scanned_at`` microsecond (manual scan racing the cron tick).
@@ -42,19 +47,20 @@ class VcgSnapshotRepository:
             sql = """
                 SELECT payload, scanned_at
                   FROM vcg_snapshots
+                 WHERE basis = %s
                  ORDER BY scanned_at DESC, id DESC
                  LIMIT 1
             """
-            params: tuple = ()
+            params: tuple = (basis,)
         else:
             sql = """
                 SELECT payload, scanned_at
                   FROM vcg_snapshots
-                 WHERE credit_proxy = %s
+                 WHERE credit_proxy = %s AND basis = %s
                  ORDER BY scanned_at DESC, id DESC
                  LIMIT 1
             """
-            params = (proxy,)
+            params = (proxy, basis)
         with self._conn.cursor() as cur:
             cur.execute(sql, params)
             row = cur.fetchone()
@@ -88,6 +94,7 @@ class VcgSnapshotRepository:
                        credit_price::float8,
                        vvix_severity
                   FROM vcg_snapshots
+                 WHERE basis = 'eod'
                  ORDER BY scanned_at DESC, id DESC
                  LIMIT %s
             """
@@ -109,7 +116,7 @@ class VcgSnapshotRepository:
                        credit_price::float8,
                        vvix_severity
                   FROM vcg_snapshots
-                 WHERE credit_proxy = %s
+                 WHERE credit_proxy = %s AND basis = 'eod'
                  ORDER BY scanned_at DESC, id DESC
                  LIMIT %s
             """
@@ -122,4 +129,78 @@ class VcgSnapshotRepository:
         for r in rows:
             if r.get("scanned_at") is not None:
                 r["scan_time"] = r["scanned_at"].isoformat()
+        return rows
+
+    # ---- live charting reads (regime tab) ----
+
+    _POINT_COLS = """
+                   vcg_score::float8        AS vcg,
+                   vcg_adj::float8          AS vcg_adj,
+                   residual::float8         AS residual,
+                   credit_price::float8     AS credit_price,
+                   credit_5d_return::float8 AS credit_5d_return_pct,
+                   vix::float8              AS vix,
+                   vvix::float8             AS vvix,
+                   beta1::float8            AS beta1,
+                   beta2::float8            AS beta2
+    """
+
+    def fetch_intraday_sessions(
+        self, *, proxy: str = "HYG", sessions: int = 5, rth_only: bool = True
+    ) -> list[dict]:
+        """Last N ET sessions of basis='live' rows, grouped server-side.
+        Mirrors CriSnapshotRepository.fetch_intraday_sessions."""
+        rth_filter = (
+            "AND (scanned_at AT TIME ZONE 'America/New_York')::time "
+            "BETWEEN '09:30' AND '16:00'"
+            if rth_only
+            else ""
+        )
+        sql = f"""
+            WITH recent_sessions AS (
+                SELECT DISTINCT
+                       (scanned_at AT TIME ZONE 'America/New_York')::date AS et_date
+                  FROM vcg_snapshots
+                 WHERE basis = 'live' AND credit_proxy = %s
+                   {rth_filter}
+                 ORDER BY et_date DESC
+                 LIMIT %s
+            )
+            SELECT (v.scanned_at AT TIME ZONE 'America/New_York')::date AS et_date,
+                   v.scanned_at,
+                   {self._POINT_COLS}
+              FROM vcg_snapshots v
+              JOIN recent_sessions rs
+                ON (v.scanned_at AT TIME ZONE 'America/New_York')::date = rs.et_date
+             WHERE v.basis = 'live' AND v.credit_proxy = %s
+               {rth_filter}
+             ORDER BY v.scanned_at ASC
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (proxy, sessions, proxy))
+            cols = [d.name for d in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        out: dict[object, list[dict]] = {}
+        for r in rows:
+            et_date = r.pop("et_date")
+            r["ts"] = r.pop("scanned_at")
+            out.setdefault(et_date, []).append(r)
+        return [{"et_date": d, "points": pts} for d, pts in sorted(out.items())]
+
+    def fetch_daily_history(self, *, proxy: str = "HYG", days: int = 90) -> list[dict]:
+        """Latest basis='eod' row per data_date, ASC, for the daily grid."""
+        sql = f"""
+            SELECT DISTINCT ON (data_date)
+                   data_date AS date,
+                   {self._POINT_COLS}
+              FROM vcg_snapshots
+             WHERE basis = 'eod' AND credit_proxy = %s AND data_date IS NOT NULL
+             ORDER BY data_date DESC, scanned_at DESC
+             LIMIT %s
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (proxy, days))
+            cols = [d.name for d in cur.description]
+            rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+        rows.reverse()
         return rows

--- a/src/uw_scan/worker/jobs/regime_live.py
+++ b/src/uw_scan/worker/jobs/regime_live.py
@@ -45,9 +45,12 @@ def regime_live_scan_once(
     except Exception as exc:  # noqa: BLE001
         logger.warning("regime_live_cri_failed err=%s", repr(exc))
         repo.conn.rollback()
+    # Same proxy choice as the EOD _regime_vcg_scan — live and EOD VCG
+    # histories must describe the same credit instrument (Codex P2).
+    proxy = settings.credit_etf_symbols[0] if settings.credit_etf_symbols else "HYG"
     try:
         vcg_payload = vcg_scanner.run_live(
-            repo.conn, schema=repo._schema, quotes=quotes, persist=True
+            repo.conn, schema=repo._schema, quotes=quotes, proxy=proxy, persist=True
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("regime_live_vcg_failed err=%s", repr(exc))
@@ -67,9 +70,14 @@ def validate_live_close_vs_lake(
     *,
     threshold_pct: float = DIVERGENCE_THRESHOLD_PCT,
 ) -> list[dict]:
-    """Per symbol: lake close vs the price the last live CRI snapshot of
-    that trade date captured. Returns the rows it compared; logs WARN on
-    divergence above ``threshold_pct`` percent."""
+    """Per symbol: lake close vs the price the last live snapshot of that
+    trade date captured. Returns the rows it compared; logs WARN on
+    divergence above ``threshold_pct`` percent.
+
+    Reads BOTH snapshot tables: during a massive failover only HYG ticks,
+    so a VCG live row can exist for a day with no CRI live row — reading
+    cri_snapshots alone would silently skip HYG on exactly those days.
+    """
     sql = f"""
         SELECT DISTINCT ON (v.symbol)
                v.symbol,
@@ -77,9 +85,14 @@ def validate_live_close_vs_lake(
                v.close::float8 AS lake_close,
                (c.payload->'live_quotes'->v.symbol->>'price')::float8 AS live_close
           FROM {repo._schema}.vol_index_daily v
-          JOIN {repo._schema}.cri_snapshots c
-            ON c.basis = 'live'
-           AND c.data_date = v.trade_date
+          JOIN (
+                SELECT data_date, scanned_at, payload
+                  FROM {repo._schema}.cri_snapshots WHERE basis = 'live'
+                UNION ALL
+                SELECT data_date, scanned_at, payload
+                  FROM {repo._schema}.vcg_snapshots WHERE basis = 'live'
+               ) c
+            ON c.data_date = v.trade_date
            AND c.payload->'live_quotes' ? v.symbol
          WHERE v.symbol = ANY(%s)
            AND v.trade_date >= CURRENT_DATE - 7

--- a/src/uw_scan/worker/jobs/regime_live.py
+++ b/src/uw_scan/worker/jobs/regime_live.py
@@ -1,0 +1,114 @@
+"""Regime live scan — 5-min basis='live' CRI/VCG snapshots off WS quotes.
+
+Also home of the nightly live-vs-lake validation: after the parquet lake
+syncs (03:15/03:20 ET), compare the close each symbol's last live snapshot
+captured against the lake's official close. Divergence > threshold is
+logged loudly — the lake stays the canonical EOD source; live rows are the
+intraday record.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from uw_scan.config import Settings
+from uw_scan.scanners import cri as cri_scanner
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.scanners.live_quotes import load_live_quotes
+from uw_scan.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+DIVERGENCE_THRESHOLD_PCT = 0.5
+
+
+def regime_live_scan_once(
+    repo: Repository, settings: Settings, *, now: datetime | None = None
+) -> dict:
+    """One live tick: load fresh quotes → run CRI + VCG live → persist."""
+    quotes = load_live_quotes(
+        repo,
+        settings.regime_ws_symbols,
+        max_age_seconds=settings.regime_live_quote_max_age_seconds,
+        now=now,
+    )
+    if not quotes:
+        return {"status": "skipped_no_fresh_quotes"}
+
+    cri_payload = None
+    vcg_payload = None
+    try:
+        cri_payload = cri_scanner.run_live(
+            repo.conn, schema=repo._schema, quotes=quotes, persist=True
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("regime_live_cri_failed err=%s", repr(exc))
+        repo.conn.rollback()
+    try:
+        vcg_payload = vcg_scanner.run_live(
+            repo.conn, schema=repo._schema, quotes=quotes, persist=True
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("regime_live_vcg_failed err=%s", repr(exc))
+        repo.conn.rollback()
+
+    return {
+        "status": "ok",
+        "live_symbols": sorted(quotes),
+        "cri": cri_payload is not None,
+        "vcg": vcg_payload is not None,
+    }
+
+
+def validate_live_close_vs_lake(
+    repo: Repository,
+    settings: Settings,
+    *,
+    threshold_pct: float = DIVERGENCE_THRESHOLD_PCT,
+) -> list[dict]:
+    """Per symbol: lake close vs the price the last live CRI snapshot of
+    that trade date captured. Returns the rows it compared; logs WARN on
+    divergence above ``threshold_pct`` percent."""
+    sql = f"""
+        SELECT DISTINCT ON (v.symbol)
+               v.symbol,
+               v.trade_date,
+               v.close::float8 AS lake_close,
+               (c.payload->'live_quotes'->v.symbol->>'price')::float8 AS live_close
+          FROM {repo._schema}.vol_index_daily v
+          JOIN {repo._schema}.cri_snapshots c
+            ON c.basis = 'live'
+           AND c.data_date = v.trade_date
+           AND c.payload->'live_quotes' ? v.symbol
+         WHERE v.symbol = ANY(%s)
+           AND v.trade_date >= CURRENT_DATE - 7
+         ORDER BY v.symbol, v.trade_date DESC, c.scanned_at DESC
+    """
+    with repo.conn.cursor() as cur:
+        cur.execute(sql, ([s.upper() for s in settings.regime_ws_symbols],))
+        rows = [
+            {
+                "symbol": r[0],
+                "trade_date": r[1],
+                "lake_close": r[2],
+                "live_close": r[3],
+            }
+            for r in cur.fetchall()
+        ]
+    for row in rows:
+        if not row["lake_close"] or row["live_close"] is None:
+            continue
+        div = abs(row["live_close"] - row["lake_close"]) / row["lake_close"] * 100.0
+        row["divergence_pct"] = round(div, 3)
+        if div > threshold_pct:
+            logger.warning(
+                "regime_live_lake_divergence symbol=%s date=%s live=%.4f "
+                "lake=%.4f pct=%.2f",
+                row["symbol"],
+                row["trade_date"],
+                row["live_close"],
+                row["lake_close"],
+                div,
+            )
+    return rows

--- a/src/uw_scan/worker/massive_ws_consumer.py
+++ b/src/uw_scan/worker/massive_ws_consumer.py
@@ -42,6 +42,7 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import Iterable
 from datetime import datetime, timezone
 
 import psycopg
@@ -76,6 +77,17 @@ def compute_subscription_diff(
     """
     desired_channels = {f"{channel}.{t}" for t in desired}
     return (desired_channels - current, current - desired_channels)
+
+
+def desired_subscription_tickers(watchlist: set[str], extra: Iterable[str]) -> set[str]:
+    """Watchlist tickers ∪ the always-on regime set, upper-cased.
+
+    The regime symbols (VIX/VVIX/VIX3M/COR1M/SPX/HYG by default) feed the
+    live CRI/VCG compute and are subscribed regardless of watchlist state.
+    intraday_quote accepts them since migration 052 dropped the watchlist
+    FK; watchlist_card writes are UPDATE-only and skip them silently.
+    """
+    return {t.upper() for t in watchlist} | {t.upper() for t in extra}
 
 
 class _ReaderDone(Exception):
@@ -159,11 +171,14 @@ async def _subscription_loop(
     channel: str,
     current_subs: set[str],
     poll_interval_seconds: float,
+    extra_tickers: frozenset[str] = frozenset(),
 ) -> None:
     while True:
         try:
             desired = await asyncio.to_thread(
-                lambda: {w.ticker for w in repo.list_active_watchlist()}
+                lambda: desired_subscription_tickers(
+                    {w.ticker for w in repo.list_active_watchlist()}, extra_tickers
+                )
             )
             to_add, to_drop = compute_subscription_diff(
                 current=current_subs, desired=desired, channel=channel
@@ -203,6 +218,7 @@ async def run_consumer_once(
     source_tag: str = "massive.com_ws",
     quiet_failover_seconds: float = 0.0,
     rth_tz: str = "America/New_York",
+    extra_tickers: frozenset[str] = frozenset(),
 ) -> bool:
     """One full WS session: connect → subscribe → reader/flusher/subscriber
     → final flush on exit.
@@ -296,6 +312,7 @@ async def run_consumer_once(
                             channel=channel,
                             current_subs=current_subs,
                             poll_interval_seconds=subscription_poll_interval_seconds,
+                            extra_tickers=extra_tickers,
                         ),
                         name="ws_subscriber",
                     )
@@ -439,6 +456,7 @@ async def run_consumer_forever(settings: Settings, repo_factory) -> None:
         settings.massive_ws_enabled and settings.massive_api_key is not None
     )
     xenon_blocked_until = 0.0  # time.monotonic() deadline; 0 = try now
+    extra_tickers = frozenset(t.upper() for t in settings.regime_ws_symbols)
     while True:
         use_xenon = settings.xenon_ws_enabled and (
             time.monotonic() >= xenon_blocked_until
@@ -461,7 +479,10 @@ async def run_consumer_forever(settings: Settings, repo_factory) -> None:
                 repo_factory("reader") as reader_repo,
             ):
                 desired = await asyncio.to_thread(
-                    lambda: {w.ticker for w in reader_repo.list_active_watchlist()}
+                    lambda: desired_subscription_tickers(
+                        {w.ticker for w in reader_repo.list_active_watchlist()},
+                        extra_tickers,
+                    )
                 )
                 if use_xenon:
                     url = discover_xenon_ws_url(
@@ -481,6 +502,7 @@ async def run_consumer_forever(settings: Settings, repo_factory) -> None:
                         source_tag="xenon_ws",
                         quiet_failover_seconds=settings.xenon_ws_quiet_failover_seconds,
                         rth_tz=settings.rth_tz,
+                        extra_tickers=extra_tickers,
                     )
                 else:
                     session = asyncio.create_task(
@@ -494,6 +516,7 @@ async def run_consumer_forever(settings: Settings, repo_factory) -> None:
                             flush_interval_seconds=settings.massive_ws_flush_interval_seconds,
                             subscription_poll_interval_seconds=settings.massive_ws_watchlist_poll_interval_seconds,
                             buffer=buffer,
+                            extra_tickers=extra_tickers,
                         ),
                         name="massive_fallback_session",
                     )

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -167,6 +167,19 @@ def _should_schedule_pipeline_benchmark(settings: Settings) -> bool:
     return role == "all" or (role == "uw" and settings.worker_index == 0)
 
 
+def _should_schedule_regime_live(settings: Settings) -> bool:
+    """Exactly one process owns the 5-min live snapshot writes.
+
+    _is_primary_worker is true for index-0 of EVERY role (uw-0, massive-0,
+    ai-*-0 all match) — fine for the idempotent gap-recovery scans that
+    share its block, but regime_live_scan appends a row per tick, so a
+    multi-role stack would write N duplicates. Pin to massive-0 (market-
+    data role) following the rates-FRED precedent.
+    """
+    role = settings.worker_role.lower()
+    return role == "all" or (role == "massive" and settings.worker_index == 0)
+
+
 def _worker_label(settings: Settings) -> str:
     role = settings.worker_role.lower()
     if role == "all":
@@ -784,6 +797,28 @@ def main() -> int:
             coalesce=True,
         )
 
+    if _should_schedule_regime_live(settings):
+        # Live regime snapshot — basis='live' CRI/VCG rows every N minutes.
+        # Pure DB-read math off intraday_quote + vol_index_daily; no provider
+        # spend. Append-only writes, so exactly ONE process may own this.
+        sched.add_job(
+            _regime_live_scan,
+            IntervalTrigger(minutes=settings.regime_live_scan_interval_minutes),
+            id="regime_live_scan",
+            name="Regime live CRI/VCG snapshot",
+            max_instances=1,
+            coalesce=True,
+        )
+        # Live-vs-lake close validation — after both lake syncs (03:15/03:20).
+        sched.add_job(
+            _regime_live_validation,
+            CronTrigger(hour=3, minute=40, timezone=settings.rth_tz),
+            id="regime_live_validation",
+            name="Regime live close vs lake validation",
+            max_instances=1,
+            coalesce=True,
+        )
+
     # Legacy single-pool role (claims any provider's row).
     if "ai" in groups and (
         settings.trade_insights_ai_enabled
@@ -851,26 +886,6 @@ def main() -> int:
             CronTrigger(minute=20, timezone=settings.rth_tz),
             id="regime_cri_scan",
             name="Regime CRI scan",
-            max_instances=1,
-            coalesce=True,
-        )
-        # Live regime snapshot — basis='live' CRI/VCG rows every N minutes.
-        # Pure DB-read math off intraday_quote + vol_index_daily; no provider
-        # spend, so primary-worker-only is about avoiding duplicate rows.
-        sched.add_job(
-            _regime_live_scan,
-            IntervalTrigger(minutes=settings.regime_live_scan_interval_minutes),
-            id="regime_live_scan",
-            name="Regime live CRI/VCG snapshot",
-            max_instances=1,
-            coalesce=True,
-        )
-        # Live-vs-lake close validation — after both lake syncs (03:15/03:20).
-        sched.add_job(
-            _regime_live_validation,
-            CronTrigger(hour=3, minute=40, timezone=settings.rth_tz),
-            id="regime_live_validation",
-            name="Regime live close vs lake validation",
             max_instances=1,
             coalesce=True,
         )

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -527,6 +527,24 @@ def main() -> int:
             summary["skipped"],
         )
 
+    def _regime_live_scan() -> None:
+        # Weekday gate — quotes only flow Mon-Fri (xenon streams 24h but the
+        # market session is what makes a provisional close meaningful).
+        if datetime.now(ZoneInfo(settings.rth_tz)).weekday() >= 5:
+            return
+        from uw_scan.worker.jobs.regime_live import regime_live_scan_once
+
+        with _repo(settings) as repo:
+            summary = regime_live_scan_once(repo, settings)
+        logger.info("regime_live_scan_tick %s", summary)
+
+    def _regime_live_validation() -> None:
+        from uw_scan.worker.jobs.regime_live import validate_live_close_vs_lake
+
+        with _repo(settings) as repo:
+            rows = validate_live_close_vs_lake(repo, settings)
+        logger.info("regime_live_validation_done symbols=%d", len(rows))
+
     def _regime_canary_scan() -> None:
         # Reads vol_index_daily (VIX/VVIX/VIX3M/COR1M/SPX); writes
         # canary_snapshots. composite_version is part of the dedup key, so
@@ -833,6 +851,26 @@ def main() -> int:
             CronTrigger(minute=20, timezone=settings.rth_tz),
             id="regime_cri_scan",
             name="Regime CRI scan",
+            max_instances=1,
+            coalesce=True,
+        )
+        # Live regime snapshot — basis='live' CRI/VCG rows every N minutes.
+        # Pure DB-read math off intraday_quote + vol_index_daily; no provider
+        # spend, so primary-worker-only is about avoiding duplicate rows.
+        sched.add_job(
+            _regime_live_scan,
+            IntervalTrigger(minutes=settings.regime_live_scan_interval_minutes),
+            id="regime_live_scan",
+            name="Regime live CRI/VCG snapshot",
+            max_instances=1,
+            coalesce=True,
+        )
+        # Live-vs-lake close validation — after both lake syncs (03:15/03:20).
+        sched.add_job(
+            _regime_live_validation,
+            CronTrigger(hour=3, minute=40, timezone=settings.rth_tz),
+            id="regime_live_validation",
+            name="Regime live close vs lake validation",
             max_instances=1,
             coalesce=True,
         )

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -2035,6 +2035,154 @@
         "title": "CriComponents",
         "type": "object"
       },
+      "CriDailyEntry": {
+        "properties": {
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "cri_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cri Score"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "spx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx"
+          },
+          "spx_distance_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Distance Pct"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vix3m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix3M"
+          },
+          "vix_vix3m_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Vix3M Ratio"
+          },
+          "vix_zscore_30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Zscore 30D"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "CriDailyEntry",
+        "type": "object"
+      },
+      "CriDailyHistoryResponse": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/CriDailyEntry"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "title": "CriDailyHistoryResponse",
+        "type": "object"
+      },
       "CriHistoryEntry": {
         "properties": {
           "cor1m": {
@@ -2156,6 +2304,489 @@
           "date"
         ],
         "title": "CriHistoryEntry",
+        "type": "object"
+      },
+      "CriIntradayPoint": {
+        "properties": {
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "cri_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cri Score"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "spx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx"
+          },
+          "spx_distance_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Distance Pct"
+          },
+          "ts": {
+            "format": "date-time",
+            "title": "Ts",
+            "type": "string"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vix3m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix3M"
+          },
+          "vix_vix3m_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Vix3M Ratio"
+          },
+          "vix_zscore_30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Zscore 30D"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          }
+        },
+        "required": [
+          "ts"
+        ],
+        "title": "CriIntradayPoint",
+        "type": "object"
+      },
+      "CriIntradayResponse": {
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/CriIntradaySession"
+            },
+            "title": "Sessions",
+            "type": "array"
+          }
+        },
+        "title": "CriIntradayResponse",
+        "type": "object"
+      },
+      "CriIntradaySession": {
+        "properties": {
+          "et_date": {
+            "format": "date",
+            "title": "Et Date",
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/CriIntradayPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "et_date"
+        ],
+        "title": "CriIntradaySession",
+        "type": "object"
+      },
+      "CriLiveResponse": {
+        "description": "CRI computed at request time with live quotes spliced as today's\nprovisional close. ``basis='eod'`` means the live compute wasn't\npossible (stale/no quotes) and the latest persisted EOD snapshot is\nbeing served instead.",
+        "properties": {
+          "active_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Source"
+          },
+          "basis": {
+            "default": "eod",
+            "enum": [
+              "live",
+              "eod"
+            ],
+            "title": "Basis",
+            "type": "string"
+          },
+          "carried_forward": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Carried Forward",
+            "type": "array"
+          },
+          "cor1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M"
+          },
+          "cor1m_5d_change": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M 5D Change"
+          },
+          "cor1m_previous_close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cor1M Previous Close"
+          },
+          "crash_trigger": {
+            "$ref": "#/components/schemas/CrashTriggerBlock"
+          },
+          "cri": {
+            "$ref": "#/components/schemas/CriBlock"
+          },
+          "cta": {
+            "$ref": "#/components/schemas/CtaBlock"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/CriHistoryEntry"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "live_quotes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RegimeLiveQuote"
+            },
+            "title": "Live Quotes",
+            "type": "object"
+          },
+          "pullback_20d_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pullback 20D Pct"
+          },
+          "realized_vol": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realized Vol"
+          },
+          "scan_time": {
+            "default": "",
+            "title": "Scan Time",
+            "type": "string"
+          },
+          "spx_100d_ma": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx 100D Ma"
+          },
+          "spx_distance_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Distance Pct"
+          },
+          "spx_source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "SPX",
+                  "SPY"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spx Source"
+          },
+          "spy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spy"
+          },
+          "spy_closes": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Spy Closes",
+            "type": "array"
+          },
+          "status": {
+            "default": "empty",
+            "enum": [
+              "ok",
+              "empty"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vix3m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix3M"
+          },
+          "vix_5d_roc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix 5D Roc"
+          },
+          "vix_delta_3d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Delta 3D"
+          },
+          "vix_vix3m_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Vix3M Ratio"
+          },
+          "vix_zscore_30d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix Zscore 30D"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          },
+          "vvix_5d_roc": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix 5D Roc"
+          },
+          "vvix_vix_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix Vix Ratio"
+          }
+        },
+        "title": "CriLiveResponse",
         "type": "object"
       },
       "CriResponse": {
@@ -10617,6 +11248,37 @@
         "title": "RecordHealthCheck",
         "type": "object"
       },
+      "RegimeLiveQuote": {
+        "description": "One live WS quote echoed by the live endpoints / quotes strip.",
+        "properties": {
+          "price": {
+            "title": "Price",
+            "type": "number"
+          },
+          "quoted_at": {
+            "format": "date-time",
+            "title": "Quoted At",
+            "type": "string"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "required": [
+          "price",
+          "quoted_at"
+        ],
+        "title": "RegimeLiveQuote",
+        "type": "object"
+      },
       "RegimeQuadrantBlock": {
         "properties": {
           "cutoff_corr": {
@@ -10732,6 +11394,43 @@
           "date"
         ],
         "title": "RegimeQuadrantPoint",
+        "type": "object"
+      },
+      "RegimeQuotesResponse": {
+        "description": "Lightweight live-quote projection for the regime header strip.",
+        "properties": {
+          "active_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Source"
+          },
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "quotes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RegimeLiveQuote"
+            },
+            "title": "Quotes",
+            "type": "object"
+          }
+        },
+        "title": "RegimeQuotesResponse",
         "type": "object"
       },
       "RescanAllRequest": {
@@ -14789,6 +15488,137 @@
         "title": "VcgAttribution",
         "type": "object"
       },
+      "VcgDailyEntry": {
+        "properties": {
+          "beta1": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta1"
+          },
+          "beta2": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta2"
+          },
+          "credit_5d_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit 5D Return Pct"
+          },
+          "credit_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit Price"
+          },
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "residual": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Residual"
+          },
+          "vcg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg"
+          },
+          "vcg_adj": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg Adj"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "title": "VcgDailyEntry",
+        "type": "object"
+      },
+      "VcgDailyHistoryResponse": {
+        "properties": {
+          "credit_proxy": {
+            "default": "HYG",
+            "title": "Credit Proxy",
+            "type": "string"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/VcgDailyEntry"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "title": "VcgDailyHistoryResponse",
+        "type": "object"
+      },
       "VcgHistoryEntry": {
         "properties": {
           "beta1": {
@@ -14919,6 +15749,250 @@
           "pct"
         ],
         "title": "VcgInterpretationCount",
+        "type": "object"
+      },
+      "VcgIntradayPoint": {
+        "properties": {
+          "beta1": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta1"
+          },
+          "beta2": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Beta2"
+          },
+          "credit_5d_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit 5D Return Pct"
+          },
+          "credit_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit Price"
+          },
+          "residual": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Residual"
+          },
+          "ts": {
+            "format": "date-time",
+            "title": "Ts",
+            "type": "string"
+          },
+          "vcg": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg"
+          },
+          "vcg_adj": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcg Adj"
+          },
+          "vix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vix"
+          },
+          "vvix": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vvix"
+          }
+        },
+        "required": [
+          "ts"
+        ],
+        "title": "VcgIntradayPoint",
+        "type": "object"
+      },
+      "VcgIntradayResponse": {
+        "properties": {
+          "as_of": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "credit_proxy": {
+            "default": "HYG",
+            "title": "Credit Proxy",
+            "type": "string"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/VcgIntradaySession"
+            },
+            "title": "Sessions",
+            "type": "array"
+          }
+        },
+        "title": "VcgIntradayResponse",
+        "type": "object"
+      },
+      "VcgIntradaySession": {
+        "properties": {
+          "et_date": {
+            "format": "date",
+            "title": "Et Date",
+            "type": "string"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/VcgIntradayPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "et_date"
+        ],
+        "title": "VcgIntradaySession",
+        "type": "object"
+      },
+      "VcgLiveResponse": {
+        "properties": {
+          "active_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Source"
+          },
+          "basis": {
+            "default": "eod",
+            "enum": [
+              "live",
+              "eod"
+            ],
+            "title": "Basis",
+            "type": "string"
+          },
+          "carried_forward": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Carried Forward",
+            "type": "array"
+          },
+          "credit_proxy": {
+            "default": "HYG",
+            "title": "Credit Proxy",
+            "type": "string"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "history": {
+            "items": {
+              "$ref": "#/components/schemas/VcgHistoryEntry"
+            },
+            "title": "History",
+            "type": "array"
+          },
+          "live_quotes": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RegimeLiveQuote"
+            },
+            "title": "Live Quotes",
+            "type": "object"
+          },
+          "scan_time": {
+            "default": "",
+            "title": "Scan Time",
+            "type": "string"
+          },
+          "signal": {
+            "$ref": "#/components/schemas/VcgSignal"
+          },
+          "status": {
+            "default": "empty",
+            "enum": [
+              "ok",
+              "empty"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "VcgLiveResponse",
         "type": "object"
       },
       "VcgNamedCrashEvent": {
@@ -17946,6 +19020,128 @@
         ]
       }
     },
+    "/api/regime/cri/history": {
+      "get": {
+        "operationId": "get_cri_history_api_regime_cri_history_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 90,
+              "maximum": 365,
+              "minimum": 5,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CriDailyHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Cri History",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/cri/intraday": {
+      "get": {
+        "operationId": "get_cri_intraday_api_regime_cri_intraday_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sessions",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Sessions",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rth_only",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Rth Only",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CriIntradayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Cri Intraday",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/cri/live": {
+      "get": {
+        "description": "Request-time CRI with live quotes spliced as today's provisional\nclose. Does NOT persist (the 5-min regime_live_scan job owns writes).\nFalls back to the latest basis='eod' snapshot when quotes are stale.",
+        "operationId": "get_cri_live_api_regime_cri_live_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CriLiveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Cri Live",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
     "/api/regime/dealer": {
       "get": {
         "description": "Per-ticker dealer Greek regime \u2014 feeds the Magnet/Gamma summary bar\nand the Volatility tab regime panel. Uses the same `gather_inputs`\nhelper the report assembler uses so both paths see the same upstream.",
@@ -18168,6 +19364,27 @@
         ]
       }
     },
+    "/api/regime/quotes": {
+      "get": {
+        "operationId": "get_regime_quotes_api_regime_quotes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegimeQuotesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Regime Quotes",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
     "/api/regime/scan": {
       "post": {
         "description": "Run a CRI scan synchronously off the warm store; persist a snapshot.",
@@ -18275,6 +19492,169 @@
         "summary": "Get Vcg Validation",
         "tags": [
           "regime",
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vcg/history": {
+      "get": {
+        "operationId": "get_vcg_history_api_regime_vcg_history_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "proxy",
+            "required": false,
+            "schema": {
+              "default": "HYG",
+              "title": "Proxy",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 90,
+              "maximum": 365,
+              "minimum": 5,
+              "title": "Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcgDailyHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vcg History",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vcg/intraday": {
+      "get": {
+        "operationId": "get_vcg_intraday_api_regime_vcg_intraday_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "proxy",
+            "required": false,
+            "schema": {
+              "default": "HYG",
+              "title": "Proxy",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sessions",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "maximum": 20,
+              "minimum": 1,
+              "title": "Sessions",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rth_only",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Rth Only",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcgIntradayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vcg Intraday",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vcg/live": {
+      "get": {
+        "operationId": "get_vcg_live_api_regime_vcg_live_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "proxy",
+            "required": false,
+            "schema": {
+              "default": "HYG",
+              "title": "Proxy",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcgLiveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vcg Live",
+        "tags": [
           "regime"
         ]
       }

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -11422,6 +11422,11 @@
             ],
             "title": "As Of"
           },
+          "fresh_within_seconds": {
+            "default": 900,
+            "title": "Fresh Within Seconds",
+            "type": "integer"
+          },
           "quotes": {
             "additionalProperties": {
               "$ref": "#/components/schemas/RegimeLiveQuote"

--- a/tests/integration/api/test_regime_live_endpoints.py
+++ b/tests/integration/api/test_regime_live_endpoints.py
@@ -1,0 +1,76 @@
+"""Live/intraday/history regime endpoints.
+
+The live endpoints check quote staleness against real wall-clock
+(`load_live_quotes` defaults `now=datetime.now`), so quotes are seeded
+RELATIVE to now — fresh quotes a few seconds old, stale quotes days old.
+The fixed-date history seed still works: `run_live` splices today's ET
+date onto the 130 seeded bars, and COR1M (no quote) carries forward.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from tests.integration.test_regime_live_compute import _seed
+
+
+def _seed_quotes(repo, quoted_at: datetime) -> None:
+    repo.bulk_upsert_intraday_quotes(
+        [
+            ("VIX", Decimal("25.5"), quoted_at, "xenon_ws"),
+            ("VVIX", Decimal("112.0"), quoted_at, "xenon_ws"),
+            ("SPX", Decimal("7300.0"), quoted_at, "xenon_ws"),
+            ("HYG", Decimal("78.90"), quoted_at, "xenon_ws"),
+        ]
+    )
+    repo.conn.commit()
+
+
+def test_cri_live_returns_live_basis(client, seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    _seed_quotes(repo, datetime.now(timezone.utc))  # fresh: well inside 900s
+    r = client.get("/api/regime/cri/live")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["basis"] == "live"
+    assert body["vix"] == 25.5
+    assert "VIX" in body["live_quotes"]
+    assert "COR1M" in body["carried_forward"]
+
+
+def test_cri_live_falls_back_to_eod_when_stale(client, seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    _seed_quotes(repo, datetime.now(timezone.utc) - timedelta(days=2))  # stale
+    r = client.get("/api/regime/cri/live")
+    assert r.status_code == 200
+    assert r.json()["basis"] == "eod"  # graceful degradation, status may be empty
+
+
+def test_cri_intraday_and_history_shapes(client, seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    _seed_quotes(repo, datetime.now(timezone.utc))
+    client.get("/api/regime/cri/live")  # request-time compute does NOT persist
+    r = client.get("/api/regime/cri/intraday?sessions=5")
+    assert r.status_code == 200
+    assert r.json()["sessions"] == []  # only the 5-min job persists live rows
+    r2 = client.get("/api/regime/cri/history?days=90")
+    assert r2.status_code == 200
+    assert "rows" in r2.json()
+
+
+def test_vcg_live_and_quotes(client, seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    _seed_quotes(repo, datetime.now(timezone.utc))
+    r = client.get("/api/regime/vcg/live")
+    assert r.status_code == 200
+    assert r.json()["basis"] == "live"
+    assert r.json()["signal"]["credit_price"] == 78.9
+    rq = client.get("/api/regime/quotes")
+    assert rq.status_code == 200
+    body = rq.json()
+    assert body["quotes"]["VIX"]["price"] == 25.5

--- a/tests/integration/storage/test_intraday_quotes_batch.py
+++ b/tests/integration/storage/test_intraday_quotes_batch.py
@@ -1,0 +1,28 @@
+"""get_intraday_quotes — batch read for the regime live compute."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+
+def test_get_intraday_quotes_returns_only_requested(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    now = datetime.now(timezone.utc)
+    repo.bulk_upsert_intraday_quotes(
+        [
+            ("VIX", Decimal("22.22"), now, "xenon_ws"),
+            ("HYG", Decimal("79.75"), now, "xenon_ws"),
+            ("AAPL", Decimal("212.10"), now, "xenon_ws"),
+        ]
+    )
+    repo.conn.commit()
+    rows = repo.get_intraday_quotes(["VIX", "HYG", "COR1M"])
+    by_ticker = {r.ticker: r for r in rows}
+    assert set(by_ticker) == {"VIX", "HYG"}  # COR1M has no quote; AAPL not asked
+    assert by_ticker["VIX"].price == Decimal("22.22")
+    assert by_ticker["VIX"].source == "xenon_ws"
+
+
+def test_get_intraday_quotes_empty_input(seeded_db_empty_cards):
+    assert seeded_db_empty_cards.get_intraday_quotes([]) == []

--- a/tests/integration/storage/test_migration_070.py
+++ b/tests/integration/storage/test_migration_070.py
@@ -1,0 +1,86 @@
+"""Migration 070 — basis column + chart generated columns on cri/vcg snapshots."""
+
+from __future__ import annotations
+
+import json
+
+
+def _cols(conn, table: str) -> set[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name FROM information_schema.columns
+             WHERE table_schema = 'uw_scan' AND table_name = %s
+            """,
+            (table,),
+        )
+        return {r[0] for r in cur.fetchall()}
+
+
+def test_070_adds_basis_and_chart_columns(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    cri = _cols(conn, "cri_snapshots")
+    assert {"basis", "spx", "vix3m", "vrp", "vix_zscore_30d", "vix_vix3m_ratio"} <= cri
+    vcg = _cols(conn, "vcg_snapshots")
+    assert {"basis", "residual", "credit_5d_return", "beta1", "beta2"} <= vcg
+
+
+def test_070_basis_defaults_to_eod_and_generated_cols_extract(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    payload = {
+        "date": "2026-06-11",
+        "vix": 22.22,
+        "vvix": 108.16,
+        "spy": 7266.99,
+        "cor1m": 17.8,
+        "vix3m": 22.89,
+        "vrp": 7.82,
+        "vix_zscore_30d": 3.6,
+        "vix_vix3m_ratio": 0.971,
+        "realized_vol": 14.4,
+        "spx_distance_pct": 3.7,
+        "cri": {"score": 41.0, "level": "ELEVATED"},
+        "crash_trigger": {"fired": False},
+    }
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.cri_snapshots (data_date, payload) "
+            "VALUES ('2026-06-11', %s::jsonb) RETURNING basis, spx::float8, "
+            "vix3m::float8, vrp::float8, vix_zscore_30d::float8, "
+            "vix_vix3m_ratio::float8",
+            (json.dumps(payload),),
+        )
+        basis, spx, vix3m, vrp, vix_z, ratio = cur.fetchone()
+    conn.commit()
+    assert basis == "eod"
+    assert (spx, vix3m, vrp, vix_z, ratio) == (7266.99, 22.89, 7.82, 3.6, 0.971)
+
+
+def test_070_vcg_generated_cols_extract(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    payload = {
+        "date": "2026-06-11",
+        "credit_proxy": "HYG",
+        "signal": {
+            "vcg": 1.44,
+            "vcg_adj": 1.44,
+            "residual": 0.003446,
+            "credit_5d_return_pct": -0.19,
+            "beta1_vvix": 0.013704,
+            "beta2_vix": -0.025669,
+            "vix": 19.87,
+            "vvix": 95.81,
+            "credit_price": 79.75,
+        },
+    }
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.vcg_snapshots (data_date, payload) "
+            "VALUES ('2026-06-11', %s::jsonb) RETURNING basis, residual::float8, "
+            "credit_5d_return::float8, beta1::float8, beta2::float8",
+            (json.dumps(payload),),
+        )
+        basis, residual, c5d, b1, b2 = cur.fetchone()
+    conn.commit()
+    assert basis == "eod"
+    assert (residual, c5d, b1, b2) == (0.003446, -0.19, 0.013704, -0.025669)

--- a/tests/integration/storage/test_regime_snapshot_basis_repos.py
+++ b/tests/integration/storage/test_regime_snapshot_basis_repos.py
@@ -1,0 +1,162 @@
+"""basis-aware snapshot repo surface: insert, fetch_latest filter,
+intraday session grouping, daily history."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
+
+ET_NOON_UTC = 16  # 12:00 ET == 16:00 UTC in June (EDT)
+
+
+def _cri_payload(d: str, score: float) -> dict:
+    return {
+        "date": d,
+        "vix": 22.0,
+        "vvix": 108.0,
+        "spy": 7266.0,
+        "cor1m": 17.8,
+        "vix3m": 22.9,
+        "vrp": 7.8,
+        "vix_zscore_30d": 3.6,
+        "vix_vix3m_ratio": 0.971,
+        "realized_vol": 14.4,
+        "spx_distance_pct": 3.7,
+        "cri": {"score": score, "level": "ELEVATED"},
+        "crash_trigger": {"fired": False},
+    }
+
+
+def _set_scanned_at(conn, table: str, row_id: int, ts: datetime) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"UPDATE uw_scan.{table} SET scanned_at = %s WHERE id = %s", (ts, row_id)
+        )
+    conn.commit()
+
+
+def test_cri_fetch_latest_defaults_to_eod(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    repo = CriSnapshotRepository(conn)
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-11", 41.0), data_date=date(2026, 6, 11)
+    )
+    repo.insert_snapshot(
+        payload={**_cri_payload("2026-06-12", 44.0), "basis": "live"},
+        data_date=date(2026, 6, 12),
+        basis="live",
+    )
+    latest = repo.fetch_latest()
+    assert latest["cri"]["score"] == 41.0  # live row must NOT shadow eod default
+    latest_live = repo.fetch_latest(basis="live")
+    assert latest_live["cri"]["score"] == 44.0
+    # the pre-live history surface must keep excluding live rows
+    hist = repo.fetch_history(limit=30)
+    assert [r["cri_score"] for r in hist] == [41.0]
+
+
+def test_cri_intraday_sessions_group_by_et_date(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    repo = CriSnapshotRepository(conn)
+    # two live points on 06-11, one on 06-12, one eod row that must be excluded
+    rid1 = repo.insert_snapshot(
+        payload=_cri_payload("2026-06-11", 40.0),
+        data_date=date(2026, 6, 11),
+        basis="live",
+    )
+    rid2 = repo.insert_snapshot(
+        payload=_cri_payload("2026-06-11", 41.0),
+        data_date=date(2026, 6, 11),
+        basis="live",
+    )
+    rid3 = repo.insert_snapshot(
+        payload=_cri_payload("2026-06-12", 43.0),
+        data_date=date(2026, 6, 12),
+        basis="live",
+    )
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-12", 99.0),
+        data_date=date(2026, 6, 12),
+        basis="eod",
+    )
+    base = datetime(2026, 6, 11, ET_NOON_UTC, 0, tzinfo=timezone.utc)
+    _set_scanned_at(conn, "cri_snapshots", rid1, base)
+    _set_scanned_at(conn, "cri_snapshots", rid2, base + timedelta(minutes=5))
+    _set_scanned_at(conn, "cri_snapshots", rid3, base + timedelta(days=1))
+    sessions = repo.fetch_intraday_sessions(sessions=5, rth_only=True)
+    assert [s["et_date"].isoformat() for s in sessions] == ["2026-06-11", "2026-06-12"]
+    assert [p["cri_score"] for p in sessions[0]["points"]] == [40.0, 41.0]
+    assert sessions[1]["points"][0]["spx"] == 7266.0
+
+
+def test_cri_daily_history_latest_eod_per_day(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    repo = CriSnapshotRepository(conn)
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-10", 30.0), data_date=date(2026, 6, 10)
+    )
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-10", 31.0), data_date=date(2026, 6, 10)
+    )
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-11", 41.0), data_date=date(2026, 6, 11)
+    )
+    repo.insert_snapshot(
+        payload=_cri_payload("2026-06-11", 88.0),
+        data_date=date(2026, 6, 11),
+        basis="live",
+    )
+    rows = repo.fetch_daily_history(days=90)
+    assert [(r["date"].isoformat(), r["cri_score"]) for r in rows] == [
+        ("2026-06-10", 31.0),
+        ("2026-06-11", 41.0),
+    ]
+
+
+def _vcg_payload(d: str, vcg: float) -> dict:
+    return {
+        "date": d,
+        "credit_proxy": "HYG",
+        "signal": {
+            "vcg": vcg,
+            "vcg_adj": vcg,
+            "residual": 0.003,
+            "credit_5d_return_pct": -0.19,
+            "beta1_vvix": 0.0137,
+            "beta2_vix": -0.0257,
+            "vix": 19.9,
+            "vvix": 95.8,
+            "credit_price": 79.75,
+        },
+    }
+
+
+def test_vcg_intraday_and_daily(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    repo = VcgSnapshotRepository(conn)
+    rid = repo.insert_snapshot(
+        payload=_vcg_payload("2026-06-11", 1.44),
+        data_date=date(2026, 6, 11),
+        basis="live",
+    )
+    repo.insert_snapshot(
+        payload=_vcg_payload("2026-06-11", 1.40), data_date=date(2026, 6, 11)
+    )
+    _set_scanned_at(
+        conn,
+        "vcg_snapshots",
+        rid,
+        datetime(2026, 6, 11, ET_NOON_UTC, 0, tzinfo=timezone.utc),
+    )
+    sessions = repo.fetch_intraday_sessions(proxy="HYG", sessions=5, rth_only=True)
+    assert len(sessions) == 1
+    assert sessions[0]["points"][0]["vcg"] == 1.44
+    assert sessions[0]["points"][0]["credit_price"] == 79.75
+    daily = repo.fetch_daily_history(proxy="HYG", days=90)
+    assert [(r["date"].isoformat(), r["vcg"]) for r in daily] == [("2026-06-11", 1.40)]
+    assert repo.fetch_latest(proxy="HYG")["signal"]["vcg"] == 1.40  # eod default
+    # the pre-live history surface must keep excluding live rows
+    hist = repo.fetch_history(proxy="HYG", limit=30)
+    assert [r["vcg_score"] for r in hist] == [1.40]

--- a/tests/integration/test_regime_live_compute.py
+++ b/tests/integration/test_regime_live_compute.py
@@ -1,0 +1,118 @@
+"""cri.run_live / vcg.run_live — quote splice, carry-forward, slim persist."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from uw_scan.scanners import cri as cri_scanner
+from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.scanners.live_quotes import LiveQuote
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+LAST_BAR = date(2026, 6, 11)
+SESSION = date(2026, 6, 12)  # a Friday — the live session being computed
+N_BARS = 130
+
+
+def _weekdays_back(end: date, n: int) -> list[date]:
+    out: list[date] = []
+    d = end
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d -= timedelta(days=1)
+    return list(reversed(out))
+
+
+def _row(symbol: str, d: date, close: float, adj_close: float | None = None) -> dict:
+    return {
+        "symbol": symbol,
+        "trade_date": d,
+        "open": None,
+        "high": None,
+        "low": None,
+        "close": close,
+        "adj_close": adj_close,
+        "volume": None,
+    }
+
+
+def _seed(conn) -> None:
+    vol_repo = VolIndexRepository(conn)
+    days = _weekdays_back(LAST_BAR, N_BARS)
+    rows = []
+    for i, d in enumerate(days):
+        rows.append(_row("VIX", d, 18.0 + 0.01 * i))
+        rows.append(_row("VVIX", d, 95.0 + 0.05 * i))
+        rows.append(_row("COR1M", d, 15.0 + 0.01 * i))
+        rows.append(_row("SPX", d, 7000.0 + 2.0 * i))
+        rows.append(_row("VIX3M", d, 19.0 + 0.01 * i))
+        rows.append(_row("HYG", d, 79.0 + 0.005 * i, adj_close=79.0 + 0.005 * i))
+    vol_repo.upsert_rows(rows)
+    conn.commit()
+
+
+def _quote(sym: str, price: float) -> LiveQuote:
+    quoted = datetime.combine(SESSION, time(15, 30), tzinfo=timezone.utc)
+    return LiveQuote(symbol=sym, price=price, quoted_at=quoted, source="xenon_ws")
+
+
+def test_cri_run_live_splices_quotes_and_carries_missing(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    _seed(conn)
+    quotes = {
+        "VIX": _quote("VIX", 25.5),
+        "VVIX": _quote("VVIX", 112.0),
+        "SPX": _quote("SPX", 7300.0),
+        # COR1M and VIX3M intentionally absent → carry-forward
+    }
+    payload = cri_scanner.run_live(conn, quotes=quotes)
+    assert payload is not None
+    assert payload["basis"] == "live"
+    assert payload["date"] == SESSION.isoformat()
+    assert payload["vix"] == 25.5
+    assert payload["spy"] == 7300.0
+    assert payload["cor1m"] is not None  # carried forward from LAST_BAR
+    assert "COR1M" in payload["carried_forward"]
+    assert set(payload["live_quotes"]) == {"VIX", "VVIX", "SPX"}
+
+
+def test_cri_run_live_persist_writes_slim_live_row(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    _seed(conn)
+    quotes = {
+        "VIX": _quote("VIX", 25.5),
+        "VVIX": _quote("VVIX", 112.0),
+        "SPX": _quote("SPX", 7300.0),
+    }
+    payload = cri_scanner.run_live(conn, quotes=quotes, persist=True)
+    assert payload is not None
+    snap = CriSnapshotRepository(conn).fetch_latest(basis="live")
+    assert snap is not None
+    assert "history" not in snap and "spy_closes" not in snap  # slim
+    assert snap["vix"] == 25.5
+    assert CriSnapshotRepository(conn).fetch_latest(basis="eod") is None
+
+
+def test_cri_run_live_no_quotes_returns_none(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    _seed(conn)
+    assert cri_scanner.run_live(conn, quotes={}) is None
+
+
+def test_vcg_run_live_splices_credit_quote(seeded_db_empty_cards):
+    conn = seeded_db_empty_cards.conn
+    _seed(conn)
+    quotes = {
+        "VIX": _quote("VIX", 25.5),
+        "VVIX": _quote("VVIX", 112.0),
+        "HYG": _quote("HYG", 78.9),
+    }
+    payload = vcg_scanner.run_live(conn, quotes=quotes, persist=True)
+    assert payload is not None
+    assert payload["basis"] == "live"
+    assert payload["signal"]["credit_price"] == 78.9
+    snap = VcgSnapshotRepository(conn).fetch_latest(proxy="HYG", basis="live")
+    assert snap is not None and "history" not in snap

--- a/tests/integration/worker/test_regime_live_job.py
+++ b/tests/integration/worker/test_regime_live_job.py
@@ -1,0 +1,51 @@
+"""regime_live_scan_once — quote-gated live snapshot of CRI + VCG."""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from decimal import Decimal
+
+from uw_scan.worker.jobs.regime_live import regime_live_scan_once
+
+# reuse the seeding helpers from the live-compute test
+from tests.integration.test_regime_live_compute import SESSION, _seed
+from uw_scan.config import Settings
+from uw_scan.storage.cri_snapshot_repository import CriSnapshotRepository
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
+
+
+def _settings() -> Settings:
+    return Settings.from_env()
+
+
+def test_skips_when_no_fresh_quotes(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    summary = regime_live_scan_once(repo, _settings())
+    assert summary["status"] == "skipped_no_fresh_quotes"
+    assert CriSnapshotRepository(repo.conn).fetch_latest(basis="live") is None
+
+
+def test_persists_live_cri_and_vcg_rows(seeded_db_empty_cards):
+    repo = seeded_db_empty_cards
+    _seed(repo.conn)
+    quoted = datetime.combine(SESSION, time(15, 30), tzinfo=timezone.utc)
+    repo.bulk_upsert_intraday_quotes(
+        [
+            ("VIX", Decimal("25.5"), quoted, "xenon_ws"),
+            ("VVIX", Decimal("112.0"), quoted, "xenon_ws"),
+            ("SPX", Decimal("7300.0"), quoted, "xenon_ws"),
+            ("HYG", Decimal("78.90"), quoted, "xenon_ws"),
+        ]
+    )
+    repo.conn.commit()
+    summary = regime_live_scan_once(
+        repo, _settings(), now=quoted + timedelta(minutes=1)
+    )
+    assert summary["status"] == "ok"
+    assert summary["cri"] is True and summary["vcg"] is True
+    assert CriSnapshotRepository(repo.conn).fetch_latest(basis="live")["vix"] == 25.5
+    assert (
+        VcgSnapshotRepository(repo.conn).fetch_latest(proxy="HYG", basis="live")
+        is not None
+    )

--- a/tests/unit/test_config_regime_live.py
+++ b/tests/unit/test_config_regime_live.py
@@ -1,0 +1,30 @@
+"""Regime live-scan settings — defaults + env parsing."""
+
+from __future__ import annotations
+
+from uw_scan.config import Settings
+
+
+def test_regime_live_defaults(monkeypatch):
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-dummy")
+    for var in (
+        "REGIME_WS_SYMBOLS",
+        "REGIME_LIVE_SCAN_INTERVAL_MINUTES",
+        "REGIME_LIVE_QUOTE_MAX_AGE_SECONDS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings.from_env()
+    assert s.regime_ws_symbols == ["VIX", "VVIX", "VIX3M", "COR1M", "SPX", "HYG"]
+    assert s.regime_live_scan_interval_minutes == 5
+    assert s.regime_live_quote_max_age_seconds == 900
+
+
+def test_regime_live_env_overrides(monkeypatch):
+    monkeypatch.setenv("UW_SCAN_API_KEY", "test-dummy")
+    monkeypatch.setenv("REGIME_WS_SYMBOLS", "VIX,HYG")
+    monkeypatch.setenv("REGIME_LIVE_SCAN_INTERVAL_MINUTES", "2")
+    monkeypatch.setenv("REGIME_LIVE_QUOTE_MAX_AGE_SECONDS", "300")
+    s = Settings.from_env()
+    assert s.regime_ws_symbols == ["VIX", "HYG"]
+    assert s.regime_live_scan_interval_minutes == 2
+    assert s.regime_live_quote_max_age_seconds == 300

--- a/tests/unit/test_live_quotes.py
+++ b/tests/unit/test_live_quotes.py
@@ -1,0 +1,62 @@
+"""Pure splice/carry-forward primitives for the regime live compute."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from uw_scan.scanners.live_quotes import (
+    LiveQuote,
+    carry_forward,
+    live_session_date,
+    splice_session_value,
+)
+
+
+def _q(symbol: str, price: float, iso: str) -> LiveQuote:
+    return LiveQuote(
+        symbol=symbol,
+        price=price,
+        quoted_at=datetime.fromisoformat(iso).astimezone(timezone.utc),
+        source="xenon_ws",
+    )
+
+
+def test_live_session_date_is_et_date_of_freshest_quote():
+    quotes = {
+        # 2026-06-12 01:30 UTC == 2026-06-11 21:30 ET → ET date is the 11th
+        "VIX": _q("VIX", 22.2, "2026-06-12T01:30:00+00:00"),
+        "HYG": _q("HYG", 79.7, "2026-06-11T19:55:00+00:00"),
+    }
+    assert live_session_date(quotes) == date(2026, 6, 11)
+
+
+def test_live_session_date_empty():
+    assert live_session_date({}) is None
+
+
+def test_splice_appends_today():
+    series = {date(2026, 6, 10): 20.0, date(2026, 6, 11): 21.0}
+    out = splice_session_value(series, 22.2, date(2026, 6, 12))
+    assert out[date(2026, 6, 12)] == 22.2
+    assert series == {date(2026, 6, 10): 20.0, date(2026, 6, 11): 21.0}  # no mutation
+
+
+def test_splice_replaces_existing_close():
+    series = {date(2026, 6, 11): 21.0}
+    out = splice_session_value(series, 22.2, date(2026, 6, 11))
+    assert out[date(2026, 6, 11)] == 22.2
+
+
+def test_carry_forward_fills_missing_session():
+    series = {date(2026, 6, 10): 17.5, date(2026, 6, 11): 17.8}
+    out, carried = carry_forward(series, date(2026, 6, 12))
+    assert carried is True
+    assert out[date(2026, 6, 12)] == 17.8
+
+
+def test_carry_forward_noop_when_present_or_empty():
+    series = {date(2026, 6, 12): 17.8}
+    out, carried = carry_forward(series, date(2026, 6, 12))
+    assert carried is False and out == series
+    out2, carried2 = carry_forward({}, date(2026, 6, 12))
+    assert carried2 is False and out2 == {}

--- a/tests/unit/test_ws_consumer_regime_symbols.py
+++ b/tests/unit/test_ws_consumer_regime_symbols.py
@@ -1,0 +1,22 @@
+"""Regime symbols merge into the WS subscription diff."""
+
+from __future__ import annotations
+
+from uw_scan.worker.massive_ws_consumer import (
+    compute_subscription_diff,
+    desired_subscription_tickers,
+)
+
+
+def test_desired_merges_watchlist_and_regime_set():
+    out = desired_subscription_tickers({"AAPL", "spy"}, ["VIX", "hyg"])
+    assert out == {"AAPL", "SPY", "VIX", "HYG"}
+
+
+def test_diff_subscribes_regime_symbols():
+    desired = desired_subscription_tickers({"AAPL"}, ["VIX", "VVIX"])
+    to_add, to_drop = compute_subscription_diff(
+        current={"A.AAPL"}, desired=desired, channel="A"
+    )
+    assert to_add == {"A.VIX", "A.VVIX"}
+    assert to_drop == set()

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4952,6 +4952,12 @@ tr {
     gap: 5px;
   }
 
+  /* The cell becomes a two-column grid here; without this the sparkline
+     auto-places into the narrow label column. */
+  .regime-strip-cell .regime-strip-spark {
+    grid-column: 1 / -1;
+  }
+
   .regime-strip-meta-row {
     justify-content: flex-start;
     flex-direction: row;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4687,6 +4687,38 @@ tr {
   padding: 24px;
 }
 
+.regime-hero-top {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.regime-hero-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.regime-hero-spark {
+  flex: 0 1 420px;
+  min-width: 200px;
+}
+
+.regime-hero-spark-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  text-align: right;
+}
+
+@media (max-width: 900px) {
+  .regime-hero-spark {
+    display: none;
+  }
+}
+
 .regime-hero-score {
   font-family: var(--font-mono);
   font-size: 64px;

--- a/web/components/regime/CanarySubTab.tsx
+++ b/web/components/regime/CanarySubTab.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Bird } from "lucide-react";
+
 import { useCanary, useCanaryHistory } from "@/lib/regime/useCanary";
 
 import { CanaryHistoryTable } from "./canary/CanaryHistoryTable";
@@ -11,19 +13,39 @@ import { RegimePill, type RegimePillState } from "./primitives/RegimePill";
 // give the sortable history table meaningful depth.
 const HISTORY_DAYS = 252;
 
+function CanaryShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="section gex-panel">
+      <div className="section-header">
+        <div className="section-title">
+          <Bird size={14} />
+          5% Canary — Dip-Buy Composite
+        </div>
+      </div>
+      <div className="section-body">{children}</div>
+    </div>
+  );
+}
+
 export default function CanarySubTab() {
   const { data: latest, error: latestErr } = useCanary();
   const { data: history } = useCanaryHistory(HISTORY_DAYS);
 
   if (latestErr) {
     return (
-      <div className="regime-empty" data-testid="canary-empty-state">
-        No 5% Canary snapshot at the current composite_version yet.
-      </div>
+      <CanaryShell>
+        <div className="regime-empty" data-testid="canary-empty-state">
+          No 5% Canary snapshot at the current composite_version yet.
+        </div>
+      </CanaryShell>
     );
   }
   if (!latest) {
-    return <div data-testid="canary-loading">Loading…</div>;
+    return (
+      <CanaryShell>
+        <div data-testid="canary-loading">Loading…</div>
+      </CanaryShell>
+    );
   }
 
   // The full structured payload sits under `latest.payload` per the API.
@@ -47,129 +69,131 @@ export default function CanarySubTab() {
   const speedState = p.speed.state as RegimePillState;
 
   return (
-    <div className="regime-panel-inner" data-testid="canary-subtab">
-      <header
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          marginBottom: 24,
-        }}
-      >
-        <div>
-          <div
-            style={{
-              fontSize: 40,
-              fontWeight: 600,
-              fontVariantNumeric: "tabular-nums",
-            }}
-          >
-            {latest.score.toFixed(1)}
+    <CanaryShell>
+      <div className="regime-panel-inner" data-testid="canary-subtab">
+        <header
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            marginBottom: 24,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 40,
+                fontWeight: 600,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {latest.score.toFixed(1)}
+            </div>
+            <div
+              style={{
+                fontSize: 12,
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+                color: "var(--text-muted)",
+              }}
+            >
+              {latest.band.replace("_", " ")} · score_form: {latest.score_form}
+            </div>
           </div>
-          <div
+          <RegimePill state={warning} />
+        </header>
+
+        <section style={{ marginBottom: 24 }}>
+          <h3
             style={{
-              fontSize: 12,
-              letterSpacing: "0.08em",
+              fontSize: 10,
+              letterSpacing: "0.15em",
               textTransform: "uppercase",
               color: "var(--text-muted)",
+              marginBottom: 8,
             }}
           >
-            {latest.band.replace("_", " ")} · score_form: {latest.score_form}
-          </div>
-        </div>
-        <RegimePill state={warning} />
-      </header>
-
-      <section style={{ marginBottom: 24 }}>
-        <h3
-          style={{
-            fontSize: 10,
-            letterSpacing: "0.15em",
-            textTransform: "uppercase",
-            color: "var(--text-muted)",
-            marginBottom: 8,
-          }}
-        >
-          Tactical Vol (0–30)
-        </h3>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <ComponentBar
-            label="VIX Spike Reversion"
-            score={p.tactical_vol.vix_spike_revert.score}
-            max={15}
-          />
-          <ComponentBar
-            label="VIX/VIX3M Backwardation Normalize"
-            score={p.tactical_vol.vix_vix3m_back.score}
-            max={15}
-          />
-        </div>
-      </section>
-
-      <section style={{ marginBottom: 24 }}>
-        <h3
-          style={{
-            fontSize: 10,
-            letterSpacing: "0.15em",
-            textTransform: "uppercase",
-            color: "var(--text-muted)",
-            marginBottom: 8,
-          }}
-        >
-          Structural Vol (0–50)
-        </h3>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <ComponentBar
-            label="Variance Risk Premium"
-            score={p.structural_vol.vrp.score}
-            max={21}
-          />
-          <ComponentBar
-            label="COR1M Peak-and-Decay"
-            score={p.structural_vol.cor1m_decay.score}
-            max={17}
-          />
-          <ComponentBar
-            label="VVIX/VIX Recovery"
-            score={p.structural_vol.vvix_vix_recovery.score}
-            max={12}
-          />
-        </div>
-      </section>
-
-      <section style={{ marginBottom: 24 }}>
-        <h3
-          style={{
-            fontSize: 10,
-            letterSpacing: "0.15em",
-            textTransform: "uppercase",
-            color: "var(--text-muted)",
-            marginBottom: 8,
-          }}
-        >
-          Price Speed (Thrasher)
-        </h3>
-        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <RegimePill state={speedState} />
-          <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
-            {p.speed.score} of 20 pts
-          </span>
-        </div>
-      </section>
-
-      {history && history.rows.length > 0 && (
-        <>
-          <section style={{ marginBottom: 24 }}>
-            <CanaryScoreChart
-              history={history.rows}
-              title={`Composite score — last ${history.rows.length} sessions`}
+            Tactical Vol (0–30)
+          </h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <ComponentBar
+              label="VIX Spike Reversion"
+              score={p.tactical_vol.vix_spike_revert.score}
+              max={15}
             />
-          </section>
-          <section>
-            <CanaryHistoryTable history={history.rows} />
-          </section>
-        </>
-      )}
-    </div>
+            <ComponentBar
+              label="VIX/VIX3M Backwardation Normalize"
+              score={p.tactical_vol.vix_vix3m_back.score}
+              max={15}
+            />
+          </div>
+        </section>
+
+        <section style={{ marginBottom: 24 }}>
+          <h3
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            Structural Vol (0–50)
+          </h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <ComponentBar
+              label="Variance Risk Premium"
+              score={p.structural_vol.vrp.score}
+              max={21}
+            />
+            <ComponentBar
+              label="COR1M Peak-and-Decay"
+              score={p.structural_vol.cor1m_decay.score}
+              max={17}
+            />
+            <ComponentBar
+              label="VVIX/VIX Recovery"
+              score={p.structural_vol.vvix_vix_recovery.score}
+              max={12}
+            />
+          </div>
+        </section>
+
+        <section style={{ marginBottom: 24 }}>
+          <h3
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--text-muted)",
+              marginBottom: 8,
+            }}
+          >
+            Price Speed (Thrasher)
+          </h3>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <RegimePill state={speedState} />
+            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              {p.speed.score} of 20 pts
+            </span>
+          </div>
+        </section>
+
+        {history && history.rows.length > 0 && (
+          <>
+            <section style={{ marginBottom: 24 }}>
+              <CanaryScoreChart
+                history={history.rows}
+                title={`Composite score — last ${history.rows.length} sessions`}
+              />
+            </section>
+            <section>
+              <CanaryHistoryTable history={history.rows} />
+            </section>
+          </>
+        )}
+      </div>
+    </CanaryShell>
   );
 }

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -23,7 +23,9 @@ import {
   formatPercent,
   formatSignedNumber,
 } from "./primitives/format";
-import { type CriBlock, type CriResponse, useCri } from "@/lib/regime/useCri";
+import CriSeriesGrids from "./cri/CriSeriesGrids";
+import { type CriBlock } from "@/lib/regime/useCri";
+import { useCriLive, type CriLiveResponse } from "@/lib/regime/useCriLive";
 
 type CriLevel = "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
 
@@ -179,7 +181,7 @@ export function CriSubTabView({
   onSyncNow,
   syncing = false,
 }: {
-  data: CriResponse | null;
+  data: CriLiveResponse | null;
   onSyncNow?: () => void;
   syncing?: boolean;
 }) {
@@ -257,8 +259,13 @@ export function CriSubTabView({
   const spxBelowMa = trigger?.conditions?.spx_below_100d_ma ?? false;
   const rvolTriggerMet = trigger?.conditions?.realized_vol_gt_25 ?? false;
 
-  // Page is end-of-day in this project — never "live".
-  const live = false;
+  // Live when the request-time compute ran off fresh WS quotes; falls back
+  // to "eod"/CACHED when quotes are stale or the feed is down.
+  const live = data.basis === "live";
+  // Per-symbol chip: live only if that symbol's quote actually spliced
+  // (a carried-forward symbol is yesterday's close, not a live tick).
+  const liveFor = (sym: string): boolean =>
+    live && !!data.live_quotes?.[sym] && !data.carried_forward?.includes(sym);
   const lastSync = data.scan_time || null;
 
   // History payload is the 20-session window (oldest → newest).
@@ -288,9 +295,15 @@ export function CriSubTabView({
           </span>
           <span
             className="regime-live-dot"
-            style={{ background: "var(--text-muted)" }}
+            style={{
+              background: live ? "var(--positive)" : "var(--text-muted)",
+            }}
           />
-          <span className="regime-hero-label">CACHED</span>
+          <span className="regime-hero-label">
+            {live
+              ? `LIVE${data.active_source ? ` · ${data.active_source === "xenon_ws" ? "XENON" : "MASSIVE"}` : ""}`
+              : "CACHED"}
+          </span>
           {lastSync && (
             <span className="regime-hero-timestamp">
               Last scan: {new Date(lastSync).toLocaleTimeString()}
@@ -317,7 +330,7 @@ export function CriSubTabView({
           testId="strip-vix"
           label={
             <>
-              VIX <LiveBadge live={live} />
+              VIX <LiveBadge live={liveFor("VIX")} />
             </>
           }
           value={formatNumber(vix)}
@@ -328,7 +341,7 @@ export function CriSubTabView({
           testId="strip-vvix"
           label={
             <>
-              VVIX <LiveBadge live={live} />
+              VVIX <LiveBadge live={liveFor("VVIX")} />
             </>
           }
           value={formatNumber(vvix)}
@@ -340,7 +353,7 @@ export function CriSubTabView({
           label={
             <>
               {data.spx_source === "SPY" ? "SPY" : "SPX"}{" "}
-              <LiveBadge live={live} />
+              <LiveBadge live={liveFor("SPX")} />
             </>
           }
           value={`$${formatNumber(spy)}`}
@@ -364,7 +377,7 @@ export function CriSubTabView({
           testId="strip-cor1m"
           label={
             <>
-              COR1M <LiveBadge live={live} />
+              COR1M <LiveBadge live={liveFor("COR1M")} />
             </>
           }
           value={formatNumber(cor1m, 2)}
@@ -499,11 +512,14 @@ export function CriSubTabView({
           <CriHistoryTable history={history} />
         </>
       )}
+
+      {/* ── Row 6: Intraday / daily small-multiples grids (basis='live' rows) ── */}
+      <CriSeriesGrids />
     </div>
   );
 }
 
 export default function CriSubTab() {
-  const { data, syncing, syncNow } = useCri();
+  const { data, syncing, syncNow } = useCriLive();
   return <CriSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
 }

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -24,8 +24,10 @@ import {
   formatSignedNumber,
 } from "./primitives/format";
 import CriSeriesGrids from "./cri/CriSeriesGrids";
+import CardSparkline from "./primitives/CardSparkline";
 import { type CriBlock } from "@/lib/regime/useCri";
 import { useCriLive, type CriLiveResponse } from "@/lib/regime/useCriLive";
+import { useCriDaily, type CriDailyEntry } from "@/lib/regime/useCriSeries";
 
 type CriLevel = "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
 
@@ -178,42 +180,55 @@ const COR_RIGHT: ChartSeries = {
 
 export function CriSubTabView({
   data,
+  daily,
   onSyncNow,
   syncing = false,
 }: {
   data: CriLiveResponse | null;
+  /** 90d daily history rows — drives the in-card sparklines. */
+  daily?: CriDailyEntry[] | null;
   onSyncNow?: () => void;
   syncing?: boolean;
 }) {
   // Empty/loading state — mirrors xenon's "no CRI data" shield empty.
   if (!data || data.status === "empty") {
     return (
-      <div className="regime-empty" data-testid="cri-empty-state">
-        <Shield size={32} strokeWidth={1} />
-        <p>No CRI data available. Click Sync Now to run a scan.</p>
-        {onSyncNow && (
-          <button
-            type="button"
-            onClick={onSyncNow}
-            disabled={syncing}
-            data-testid="cri-sync-now"
-            style={{
-              marginTop: "12px",
-              padding: "6px 14px",
-              fontFamily: "var(--font-mono)",
-              fontSize: "11px",
-              letterSpacing: "0.08em",
-              textTransform: "uppercase",
-              background: "var(--bg-panel-raised, var(--bg-panel))",
-              border: "1px solid var(--border-dim, var(--line-grid))",
-              color: "var(--text-primary)",
-              cursor: syncing ? "default" : "pointer",
-              opacity: syncing ? 0.6 : 1,
-            }}
-          >
-            {syncing ? "Syncing…" : "Sync Now"}
-          </button>
-        )}
+      <div className="section gex-panel">
+        <div className="section-header">
+          <div className="section-title">
+            <Shield size={14} />
+            SPX Crash Risk Index (CRI)
+          </div>
+        </div>
+        <div className="section-body">
+          <div className="regime-empty" data-testid="cri-empty-state">
+            <Shield size={32} strokeWidth={1} />
+            <p>No CRI data available. Click Sync Now to run a scan.</p>
+            {onSyncNow && (
+              <button
+                type="button"
+                onClick={onSyncNow}
+                disabled={syncing}
+                data-testid="cri-sync-now"
+                style={{
+                  marginTop: "12px",
+                  padding: "6px 14px",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  background: "var(--bg-panel-raised, var(--bg-panel))",
+                  border: "1px solid var(--border-dim, var(--line-grid))",
+                  color: "var(--text-primary)",
+                  cursor: syncing ? "default" : "pointer",
+                  opacity: syncing ? 0.6 : 1,
+                }}
+              >
+                {syncing ? "Syncing…" : "Sync Now"}
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     );
   }
@@ -274,252 +289,343 @@ export function CriSubTabView({
   const priorHistory =
     history.length >= 2 ? history[history.length - 2] : undefined;
 
+  // 90d daily series for in-card sparklines (oldest → newest).
+  const dailyRows = daily ?? [];
+  const dseries = (k: keyof CriDailyEntry): (number | null)[] =>
+    dailyRows.map((r) => {
+      const v = r[k];
+      return typeof v === "number" && Number.isFinite(v) ? v : null;
+    });
+  const vixDaily = dseries("vix");
+  // VIX Δ (3d) has no daily column — derive it from the VIX series, matching
+  // the tile's definition (absolute change over the last 3 sessions).
+  const vixDelta3dDaily = vixDaily.map((v, i) => {
+    const base = i >= 3 ? vixDaily[i - 3] : null;
+    return v != null && base != null ? v - base : null;
+  });
+
   return (
-    <div className="regime-panel" data-testid="cri-subtab">
-      {/* ── Row 1: Hero ───────────────────── */}
-      <div className="regime-hero">
-        <div className="regime-hero-score" style={{ color }}>
-          <span data-testid="cri-score">{cri.score.toFixed(0)}</span>
-          <span className="regime-hero-max">/100</span>
-        </div>
-        <div className="regime-hero-meta">
-          <span
-            className="regime-level-badge"
-            style={{
-              background: color,
-              color: level === "LOW" ? "#000" : "#fff",
-            }}
-            data-testid="cri-level"
-          >
-            {level}
-          </span>
-          <span
-            className="regime-live-dot"
-            style={{
-              background: live ? "var(--positive)" : "var(--text-muted)",
-            }}
-          />
-          <span className="regime-hero-label">
-            {live
-              ? `LIVE${data.active_source ? ` · ${data.active_source === "xenon_ws" ? "XENON" : "MASSIVE"}` : ""}`
-              : "CACHED"}
-          </span>
-          {lastSync && (
-            <span className="regime-hero-timestamp">
-              Last scan: {new Date(lastSync).toLocaleTimeString()}
-            </span>
-          )}
-        </div>
-        <div className="regime-hero-bar">
-          <div
-            className="regime-hero-bar-fill"
-            style={{ width: `${cri.score}%`, background: color }}
-          />
-        </div>
-        <div className="regime-hero-scale">
-          <span>LOW</span>
-          <span>ELEVATED</span>
-          <span>HIGH</span>
-          <span>CRITICAL</span>
+    <div className="section gex-panel" data-testid="cri-subtab">
+      <div className="section-header">
+        <div className="section-title">
+          <Shield size={14} />
+          SPX Crash Risk Index (CRI)
         </div>
       </div>
-
-      {/* ── Row 2: Live ticker strip (DAILY badges in our project) ── */}
-      <RegimeStrip>
-        <RegimeStripCell
-          testId="strip-vix"
-          label={
-            <>
-              VIX <LiveBadge live={liveFor("VIX")} />
-            </>
-          }
-          value={formatNumber(vix)}
-          change={<DayChange last={vix} close={vixClose} />}
-          sub={<>5d RoC: {formatPercent(data.vix_5d_roc, 1)}</>}
-        />
-        <RegimeStripCell
-          testId="strip-vvix"
-          label={
-            <>
-              VVIX <LiveBadge live={liveFor("VVIX")} />
-            </>
-          }
-          value={formatNumber(vvix)}
-          change={<DayChange last={vvix} close={vvixClose} />}
-          sub={<>VVIX/VIX: {formatNumber(vvixVixRatio)}</>}
-        />
-        <RegimeStripCell
-          testId="strip-spy"
-          label={
-            <>
-              {data.spx_source === "SPY" ? "SPY" : "SPX"}{" "}
-              <LiveBadge live={liveFor("SPX")} />
-            </>
-          }
-          value={`$${formatNumber(spy)}`}
-          change={<DayChange last={spy} close={spyClose} prefix="$" />}
-          sub={<>vs 100d MA: {formatPercent(spxDistPct)}</>}
-        />
-        <RegimeStripCell
-          testId="strip-rvol"
-          label={
-            <>
-              <span className="regime-strip-label-text-full">REALIZED VOL</span>
-              <span className="regime-strip-label-text-short">RVOL</span>
-              <LiveBadge live={live} />
-            </>
-          }
-          value={realizedVol != null ? `${formatNumber(realizedVol)}%` : "---"}
-          change={<PointChange change={null} suffix="%" label="intraday" />}
-          sub={<>20d annualized</>}
-        />
-        <RegimeStripCell
-          testId="strip-cor1m"
-          label={
-            <>
-              COR1M <LiveBadge live={liveFor("COR1M")} />
-            </>
-          }
-          value={formatNumber(cor1m, 2)}
-          change={<DayChange last={cor1m} close={cor1mPrevClose} />}
-          sub={
-            <>{`5d chg: ${corr5dChange != null ? `${formatSignedNumber(corr5dChange)} pts` : "---"}`}</>
-          }
-        />
-      </RegimeStrip>
-
-      {/* ── Mean-reversion tiles (VRP / VIX z-score / VIX-VIX3M ratio / VIX Δ 3d) ── */}
-      <MeanReversionTiles
-        vrp={data.vrp ?? null}
-        vixZscore={data.vix_zscore_30d ?? null}
-        vixVix3mRatio={data.vix_vix3m_ratio ?? null}
-        vixDelta3d={data.vix_delta_3d ?? null}
-      />
-
-      {/* ── Row 3+4: Components + Crash trigger ── */}
-      <div className="regime-detail-grid">
-        <div className="regime-components">
-          <div className="regime-panel-title">
-            <Zap size={12} />
-            CRI COMPONENTS
-            <InfoTooltip text={SECTION_TOOLTIPS["CRI COMPONENTS"]} />
-          </div>
-          <ComponentBar
-            label="VIX"
-            slot="vix"
-            score={components.vix}
-            priorScore={priorComponentScore(priorHistory, "vix")}
-            live={live}
-          />
-          <ComponentBar
-            label="VVIX"
-            slot="vvix"
-            score={components.vvix}
-            priorScore={priorComponentScore(priorHistory, "vvix")}
-            live={live}
-          />
-          <ComponentBar
-            label="CORRELATION"
-            slot="correlation"
-            score={components.correlation}
-            priorScore={priorComponentScore(priorHistory, "correlation")}
-            live={live}
-          />
-          <ComponentBar
-            label="TREND BREAK"
-            slot="momentum"
-            score={components.momentum}
-            priorScore={priorComponentScore(priorHistory, "momentum")}
-            live={live}
-          />
-          {data.pullback_20d_pct != null && data.pullback_20d_pct < 0 && (
-            <div
-              className="regime-component-subtext"
-              data-testid="trend-break-pullback-line"
-            >
-              Pullback: {data.pullback_20d_pct.toFixed(2)}% from 20d high
+      <div className="section-body regime-panel">
+        {/* ── Row 1: Hero ───────────────────── */}
+        <div className="regime-hero">
+          <div className="regime-hero-top">
+            <div className="regime-hero-main">
+              <div className="regime-hero-score" style={{ color }}>
+                <span data-testid="cri-score">{cri.score.toFixed(0)}</span>
+                <span className="regime-hero-max">/100</span>
+              </div>
+              <div className="regime-hero-meta">
+                <span
+                  className="regime-level-badge"
+                  style={{
+                    background: color,
+                    color: level === "LOW" ? "#000" : "#fff",
+                  }}
+                  data-testid="cri-level"
+                >
+                  {level}
+                </span>
+                <span
+                  className="regime-live-dot"
+                  style={{
+                    background: live ? "var(--positive)" : "var(--text-muted)",
+                  }}
+                />
+                <span className="regime-hero-label">
+                  {live
+                    ? `LIVE${data.active_source ? ` · ${data.active_source === "xenon_ws" ? "XENON" : "MASSIVE"}` : ""}`
+                    : "CACHED"}
+                </span>
+                {lastSync && (
+                  <span className="regime-hero-timestamp">
+                    Last scan: {new Date(lastSync).toLocaleTimeString()}
+                  </span>
+                )}
+              </div>
             </div>
-          )}
+            {dailyRows.length > 0 && (
+              <div className="regime-hero-spark" data-testid="cri-hero-spark">
+                <div className="regime-hero-spark-label">CRI — DAILY 90D</div>
+                <CardSparkline
+                  values={dseries("cri_score")}
+                  label="CRI daily score, 90 days"
+                  color="var(--accent-warm, #F5A623)"
+                  height={48}
+                />
+              </div>
+            )}
+          </div>
+          <div className="regime-hero-bar">
+            <div
+              className="regime-hero-bar-fill"
+              style={{ width: `${cri.score}%`, background: color }}
+            />
+          </div>
+          <div className="regime-hero-scale">
+            <span>LOW</span>
+            <span>ELEVATED</span>
+            <span>HIGH</span>
+            <span>CRITICAL</span>
+          </div>
         </div>
-        <div className="regime-triggers">
-          <div className="regime-panel-title">
-            <AlertTriangle size={12} />
-            CRASH TRIGGER CONDITIONS
-            <InfoTooltip text={SECTION_TOOLTIPS["CRASH TRIGGER CONDITIONS"]} />
-          </div>
-          <div
-            className={`regime-trigger-status ${triggered ? "regime-triggered" : ""}`}
-            data-testid="crash-trigger-state"
-          >
-            {triggered ? "TRIGGERED" : "INACTIVE"}
-          </div>
-          <TriggerRow
-            label="SPX < 100d MA"
-            met={spxBelowMa}
-            value={`${formatPercent(spxDistPct)} (MA: $${formatNumber(ma)})`}
-            live={live}
+
+        {/* ── Row 2: Live ticker strip (DAILY badges in our project) ── */}
+        <RegimeStrip>
+          <RegimeStripCell
+            testId="strip-vix"
+            label={
+              <>
+                VIX <LiveBadge live={liveFor("VIX")} />
+              </>
+            }
+            value={formatNumber(vix)}
+            change={<DayChange last={vix} close={vixClose} />}
+            sub={<>5d RoC: {formatPercent(data.vix_5d_roc, 1)}</>}
+            spark={<CardSparkline values={vixDaily} label="VIX daily, 90d" />}
           />
-          <TriggerRow
-            label="Realized Vol > 25%"
-            met={rvolTriggerMet}
+          <RegimeStripCell
+            testId="strip-vvix"
+            label={
+              <>
+                VVIX <LiveBadge live={liveFor("VVIX")} />
+              </>
+            }
+            value={formatNumber(vvix)}
+            change={<DayChange last={vvix} close={vvixClose} />}
+            sub={<>VVIX/VIX: {formatNumber(vvixVixRatio)}</>}
+            spark={
+              <CardSparkline
+                values={dseries("vvix")}
+                label="VVIX daily, 90d"
+                color="var(--accent-vol, #8B5CF6)"
+              />
+            }
+          />
+          <RegimeStripCell
+            testId="strip-spy"
+            label={
+              <>
+                {data.spx_source === "SPY" ? "SPY" : "SPX"}{" "}
+                <LiveBadge live={liveFor("SPX")} />
+              </>
+            }
+            value={`$${formatNumber(spy)}`}
+            change={<DayChange last={spy} close={spyClose} prefix="$" />}
+            sub={<>vs 100d MA: {formatPercent(spxDistPct)}</>}
+            spark={
+              <CardSparkline
+                values={dseries("spx")}
+                label="SPX daily, 90d"
+                color="var(--text-primary)"
+              />
+            }
+          />
+          <RegimeStripCell
+            testId="strip-rvol"
+            label={
+              <>
+                <span className="regime-strip-label-text-full">
+                  REALIZED VOL
+                </span>
+                <span className="regime-strip-label-text-short">RVOL</span>
+                <LiveBadge live={live} />
+              </>
+            }
             value={
               realizedVol != null ? `${formatNumber(realizedVol)}%` : "---"
             }
-            live={live}
+            change={<PointChange change={null} suffix="%" label="intraday" />}
+            sub={<>20d annualized</>}
+            spark={
+              <CardSparkline
+                values={dseries("realized_vol")}
+                label="Realized vol daily, 90d"
+              />
+            }
           />
-          <TriggerRow
-            label="COR1M > 60"
-            met={correlationTriggerMet}
+          <RegimeStripCell
+            testId="strip-cor1m"
+            label={
+              <>
+                COR1M <LiveBadge live={liveFor("COR1M")} />
+              </>
+            }
             value={formatNumber(cor1m, 2)}
-            live={live}
+            change={<DayChange last={cor1m} close={cor1mPrevClose} />}
+            sub={
+              <>{`5d chg: ${corr5dChange != null ? `${formatSignedNumber(corr5dChange)} pts` : "---"}`}</>
+            }
+            spark={
+              <CardSparkline
+                values={dseries("cor1m")}
+                label="COR1M daily, 90d"
+              />
+            }
           />
+        </RegimeStrip>
+
+        {/* ── Mean-reversion tiles (VRP / VIX z-score / VIX-VIX3M ratio / VIX Δ 3d) ── */}
+        <MeanReversionTiles
+          vrp={data.vrp ?? null}
+          vixZscore={data.vix_zscore_30d ?? null}
+          vixVix3mRatio={data.vix_vix3m_ratio ?? null}
+          vixDelta3d={data.vix_delta_3d ?? null}
+          series={
+            dailyRows.length > 0
+              ? {
+                  vrp: dseries("vrp"),
+                  vixZscore: dseries("vix_zscore_30d"),
+                  vixVix3mRatio: dseries("vix_vix3m_ratio"),
+                  vixDelta3d: vixDelta3dDaily,
+                }
+              : undefined
+          }
+        />
+
+        {/* ── Row 3+4: Components + Crash trigger ── */}
+        <div className="regime-detail-grid">
+          <div className="regime-components">
+            <div className="regime-panel-title">
+              <Zap size={12} />
+              CRI COMPONENTS
+              <InfoTooltip text={SECTION_TOOLTIPS["CRI COMPONENTS"]} />
+            </div>
+            <ComponentBar
+              label="VIX"
+              slot="vix"
+              score={components.vix}
+              priorScore={priorComponentScore(priorHistory, "vix")}
+              live={live}
+            />
+            <ComponentBar
+              label="VVIX"
+              slot="vvix"
+              score={components.vvix}
+              priorScore={priorComponentScore(priorHistory, "vvix")}
+              live={live}
+            />
+            <ComponentBar
+              label="CORRELATION"
+              slot="correlation"
+              score={components.correlation}
+              priorScore={priorComponentScore(priorHistory, "correlation")}
+              live={live}
+            />
+            <ComponentBar
+              label="TREND BREAK"
+              slot="momentum"
+              score={components.momentum}
+              priorScore={priorComponentScore(priorHistory, "momentum")}
+              live={live}
+            />
+            {data.pullback_20d_pct != null && data.pullback_20d_pct < 0 && (
+              <div
+                className="regime-component-subtext"
+                data-testid="trend-break-pullback-line"
+              >
+                Pullback: {data.pullback_20d_pct.toFixed(2)}% from 20d high
+              </div>
+            )}
+          </div>
+          <div className="regime-triggers">
+            <div className="regime-panel-title">
+              <AlertTriangle size={12} />
+              CRASH TRIGGER CONDITIONS
+              <InfoTooltip
+                text={SECTION_TOOLTIPS["CRASH TRIGGER CONDITIONS"]}
+              />
+            </div>
+            <div
+              className={`regime-trigger-status ${triggered ? "regime-triggered" : ""}`}
+              data-testid="crash-trigger-state"
+            >
+              {triggered ? "TRIGGERED" : "INACTIVE"}
+            </div>
+            <TriggerRow
+              label="SPX < 100d MA"
+              met={spxBelowMa}
+              value={`${formatPercent(spxDistPct)} (MA: $${formatNumber(ma)})`}
+              live={live}
+            />
+            <TriggerRow
+              label="Realized Vol > 25%"
+              met={rvolTriggerMet}
+              value={
+                realizedVol != null ? `${formatNumber(realizedVol)}%` : "---"
+              }
+              live={live}
+            />
+            <TriggerRow
+              label="COR1M > 60"
+              met={correlationTriggerMet}
+              value={formatNumber(cor1m, 2)}
+              live={live}
+            />
+          </div>
         </div>
+
+        {/* ── Regime guidance (markdown-driven via /api/regime/guidance) ── */}
+        <GuidancePanel />
+
+        {/* ── Row 5: 20-Session History (two charts side-by-side) ── */}
+        {history.length > 0 && (
+          <>
+            <div className="section-header" data-testid="regime-history-header">
+              <div className="section-title" data-testid="regime-history-title">
+                <span>20-SESSION HISTORY</span>
+                <InfoTooltip text={SECTION_TOOLTIPS["20-SESSION HISTORY"]} />
+              </div>
+            </div>
+            <div
+              className="regime-history-grid"
+              data-testid="regime-history-grid"
+            >
+              <div data-testid="regime-history-chart-vix-vvix">
+                <CriHistoryChart
+                  history={history}
+                  series={[VIX_VVIX_LEFT, VIX_VVIX_RIGHT]}
+                  title="VIX / VVIX"
+                  liveValues={liveValues}
+                />
+              </div>
+              <div data-testid="regime-history-chart-rvol-cor1m">
+                <CriHistoryChart
+                  history={history}
+                  series={[RVOL_LEFT, COR_RIGHT]}
+                  title="REALIZED VOL / COR1M"
+                  liveValues={liveValues}
+                />
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Row 6: Intraday small-multiples grid (basis='live' rows) ── */}
+        <CriSeriesGrids />
+
+        {/* ── Row 7: Historical table (folded by default) ── */}
+        {history.length > 0 && <CriHistoryTable history={history} />}
       </div>
-
-      {/* ── Regime guidance (markdown-driven via /api/regime/guidance) ── */}
-      <GuidancePanel />
-
-      {/* ── Row 5: 20-Session History (two charts side-by-side) ── */}
-      {history.length > 0 && (
-        <>
-          <div className="section-header" data-testid="regime-history-header">
-            <div className="section-title" data-testid="regime-history-title">
-              <span>20-SESSION HISTORY</span>
-              <InfoTooltip text={SECTION_TOOLTIPS["20-SESSION HISTORY"]} />
-            </div>
-          </div>
-          <div
-            className="regime-history-grid"
-            data-testid="regime-history-grid"
-          >
-            <div data-testid="regime-history-chart-vix-vvix">
-              <CriHistoryChart
-                history={history}
-                series={[VIX_VVIX_LEFT, VIX_VVIX_RIGHT]}
-                title="VIX / VVIX"
-                liveValues={liveValues}
-              />
-            </div>
-            <div data-testid="regime-history-chart-rvol-cor1m">
-              <CriHistoryChart
-                history={history}
-                series={[RVOL_LEFT, COR_RIGHT]}
-                title="REALIZED VOL / COR1M"
-                liveValues={liveValues}
-              />
-            </div>
-          </div>
-          <CriHistoryTable history={history} />
-        </>
-      )}
-
-      {/* ── Row 6: Intraday / daily small-multiples grids (basis='live' rows) ── */}
-      <CriSeriesGrids />
     </div>
   );
 }
 
 export default function CriSubTab() {
   const { data, syncing, syncNow } = useCriLive();
-  return <CriSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
+  const { data: daily } = useCriDaily(90);
+  return (
+    <CriSubTabView
+      data={data}
+      daily={daily?.rows ?? null}
+      syncing={syncing}
+      onSyncNow={syncNow}
+    />
+  );
 }

--- a/web/components/regime/CriSubTab.tsx
+++ b/web/components/regime/CriSubTab.tsx
@@ -303,6 +303,23 @@ export function CriSubTabView({
     const base = i >= 3 ? vixDaily[i - 3] : null;
     return v != null && base != null ? v - base : null;
   });
+  // Historical rows can mix SPX- and SPY-scale values when a snapshot
+  // captured the SPY fallback (observed in dev: 739.17 amid ~7400). Drop
+  // points outside a 2× band around the median — the index can't halve or
+  // double inside the 90d window, so only cross-scale points are removed.
+  const spxDailyRaw = dseries("spx");
+  const spxSorted = spxDailyRaw
+    .filter((v): v is number => v != null)
+    .sort((a, b) => a - b);
+  const spxMedian = spxSorted.length
+    ? spxSorted[Math.floor(spxSorted.length / 2)]
+    : null;
+  const spxDaily =
+    spxMedian == null
+      ? spxDailyRaw
+      : spxDailyRaw.map((v) =>
+          v != null && (v < spxMedian / 2 || v > spxMedian * 2) ? null : v,
+        );
 
   return (
     <div className="section gex-panel" data-testid="cri-subtab">
@@ -421,7 +438,7 @@ export function CriSubTabView({
             sub={<>vs 100d MA: {formatPercent(spxDistPct)}</>}
             spark={
               <CardSparkline
-                values={dseries("spx")}
+                values={spxDaily}
                 label="SPX daily, 90d"
                 color="var(--text-primary)"
               />

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { Activity, TrendingUp, TrendingDown } from "lucide-react";
+import { useMemo } from "react";
 import {
   useGex,
+  type GexBucket,
   type GexLevel,
   type MqLevels,
   type SourceDelta,
 } from "@/lib/regime/useGex";
 import { useGexIntraday } from "@/lib/regime/useGexIntraday";
 import { MarketState } from "@/lib/regime/useMarketHours";
+import { quoteIsFresh, useRegimeQuotes } from "@/lib/regime/useRegimeQuotes";
 import InfoTooltip from "./InfoTooltip";
 import GexProfileChart from "./GexProfileChart";
 import { HistoryChart } from "./HistoryChart";
@@ -130,6 +133,52 @@ function LevelCard({
 export default function GexSubTab({ marketState }: GexSubTabProps) {
   const { data, loading, error, lastSync } = useGex(marketState ?? null);
   const { data: intraday } = useGexIntraday(marketState ?? null, "SPX", 5);
+  const { data: quotes } = useRegimeQuotes();
+
+  // Live SPX splice: when the WS quote is fresh, the SPOT card and the
+  // profile chart tick with it; everything else stays on the scan snapshot.
+  const spxQuote = data?.ticker === "SPX" ? quotes?.quotes?.SPX : undefined;
+  const liveSpot =
+    spxQuote && quoteIsFresh(spxQuote.quoted_at, quotes?.fresh_within_seconds)
+      ? spxQuote.price
+      : null;
+
+  // Re-anchor the profile on the live spot: recompute each bucket's distance
+  // and re-place the SPOT tag on the nearest strike, mirroring the backend's
+  // tag_profile precedence (SPOT first, GEX FLIP overrides, levels fill the
+  // remaining strikes) so a spot move can't strand a stale SPOT row.
+  const liveProfile: GexBucket[] = useMemo(() => {
+    const profile = data?.profile ?? [];
+    if (liveSpot == null || !profile.length) return profile;
+    let nearest: number | null = null;
+    let minDist = Infinity;
+    for (const b of profile) {
+      const d = Math.abs(b.strike - liveSpot);
+      if (d < minDist) {
+        minDist = d;
+        nearest = b.strike;
+      }
+    }
+    const tagMap = new Map<number, string>();
+    if (nearest != null) tagMap.set(nearest, "SPOT");
+    const lv = data?.levels;
+    if (lv?.gex_flip) tagMap.set(lv.gex_flip.strike, "GEX FLIP");
+    const labelled: [GexLevel, string][] = [
+      [lv?.max_magnet ?? null, "MAX MAGNET"],
+      [lv?.second_magnet ?? null, "SECOND MAGNET"],
+      [lv?.max_accelerator ?? null, "MAX ACCELERATOR"],
+      [lv?.put_wall ?? null, "PUT WALL"],
+      [lv?.call_wall ?? null, "CALL WALL"],
+    ];
+    for (const [level, label] of labelled) {
+      if (level && !tagMap.has(level.strike)) tagMap.set(level.strike, label);
+    }
+    return profile.map((b) => ({
+      ...b,
+      pct_from_spot: ((b.strike - liveSpot) / liveSpot) * 100,
+      tag: tagMap.get(b.strike) ?? null,
+    }));
+  }, [data, liveSpot]);
 
   if (loading && !data) {
     return (
@@ -207,6 +256,18 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
   const daysCount = Math.abs(daysAbove);
   const spotFreshnessAnchorMs = Date.parse(lastSync ?? data.scan_time);
 
+  const displaySpot = liveSpot ?? data.spot;
+  const prevClose = data.prev_close;
+  const dayChange =
+    liveSpot != null && prevClose != null
+      ? liveSpot - prevClose
+      : data.day_change;
+  const dayChangePct =
+    liveSpot != null && prevClose
+      ? ((liveSpot - prevClose) / prevClose) * 100
+      : data.day_change_pct;
+  const spotTapeTime = liveSpot != null ? spxQuote?.quoted_at : data.tape_time;
+
   const netGexColor = data.net_gex >= 0 ? "var(--signal-core)" : "var(--fault)";
   const netDexColor = data.net_dex >= 0 ? "var(--signal-core)" : "var(--fault)";
 
@@ -267,7 +328,7 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
             label="SPOT"
             badge={
               <SpotFreshnessPill
-                tapeTime={data.tape_time}
+                tapeTime={spotTapeTime}
                 nowMs={
                   Number.isFinite(spotFreshnessAnchorMs)
                     ? spotFreshnessAnchorMs
@@ -275,20 +336,17 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
                 }
               />
             }
-            value={fmtPrice(data.spot)}
+            value={fmtPrice(displaySpot)}
             sub={
-              data.day_change != null ? (
+              dayChange != null ? (
                 <span
                   style={{
                     color:
-                      data.day_change >= 0
-                        ? "var(--positive)"
-                        : "var(--negative)",
+                      dayChange >= 0 ? "var(--positive)" : "var(--negative)",
                   }}
                 >
-                  {data.day_change >= 0 ? "+" : ""}
-                  {fmtPrice(data.day_change)} (
-                  {formatPercent(data.day_change_pct)})
+                  {dayChange >= 0 ? "+" : ""}
+                  {fmtPrice(dayChange)} ({formatPercent(dayChangePct)})
                 </span>
               ) : undefined
             }
@@ -409,7 +467,7 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
         )}
 
         {/* ── GEX Profile Chart ── */}
-        <GexProfileChart profile={data.profile} spot={data.spot} />
+        <GexProfileChart profile={liveProfile} spot={displaySpot} />
 
         {/* ── Bottom Row: Expected Range + Bias ── */}
         <div className="gex-bottom-row">

--- a/web/components/regime/GexSubTab.tsx
+++ b/web/components/regime/GexSubTab.tsx
@@ -94,6 +94,59 @@ export function SpotFreshnessPill({
   );
 }
 
+/* ─── Live-spot profile re-anchor ─────────────────────── */
+
+/**
+ * Recompute each bucket's distance from a live spot and re-place the SPOT
+ * tag on the nearest strike, mirroring the backend's tag_profile precedence
+ * (SPOT first, GEX FLIP overrides, levels fill the remaining strikes) so a
+ * spot move can't strand a stale SPOT row. Exported for unit testing.
+ */
+export function retagProfileForSpot(
+  profile: GexBucket[],
+  liveSpot: number,
+  levels:
+    | {
+        gex_flip?: GexLevel;
+        max_magnet?: GexLevel;
+        second_magnet?: GexLevel;
+        max_accelerator?: GexLevel;
+        put_wall?: GexLevel;
+        call_wall?: GexLevel;
+      }
+    | null
+    | undefined,
+): GexBucket[] {
+  if (!profile.length) return profile;
+  let nearest: number | null = null;
+  let minDist = Infinity;
+  for (const b of profile) {
+    const d = Math.abs(b.strike - liveSpot);
+    if (d < minDist) {
+      minDist = d;
+      nearest = b.strike;
+    }
+  }
+  const tagMap = new Map<number, string>();
+  if (nearest != null) tagMap.set(nearest, "SPOT");
+  if (levels?.gex_flip) tagMap.set(levels.gex_flip.strike, "GEX FLIP");
+  const labelled: [GexLevel, string][] = [
+    [levels?.max_magnet ?? null, "MAX MAGNET"],
+    [levels?.second_magnet ?? null, "SECOND MAGNET"],
+    [levels?.max_accelerator ?? null, "MAX ACCELERATOR"],
+    [levels?.put_wall ?? null, "PUT WALL"],
+    [levels?.call_wall ?? null, "CALL WALL"],
+  ];
+  for (const [level, label] of labelled) {
+    if (level && !tagMap.has(level.strike)) tagMap.set(level.strike, label);
+  }
+  return profile.map((b) => ({
+    ...b,
+    pct_from_spot: ((b.strike - liveSpot) / liveSpot) * 100,
+    tag: tagMap.get(b.strike) ?? null,
+  }));
+}
+
 /* ─── Level Card ──────────────────────────────────────── */
 
 function LevelCard({
@@ -137,47 +190,27 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
 
   // Live SPX splice: when the WS quote is fresh, the SPOT card and the
   // profile chart tick with it; everything else stays on the scan snapshot.
+  // The quote must also not predate the snapshot's own tick (tape_time) —
+  // a stalled WS feed inside the freshness window must not move spot
+  // backwards past a newer scan.
   const spxQuote = data?.ticker === "SPX" ? quotes?.quotes?.SPX : undefined;
+  const quoteAtMs = spxQuote?.quoted_at ? Date.parse(spxQuote.quoted_at) : NaN;
+  const tapeMs = data?.tape_time ? Date.parse(data.tape_time) : NaN;
+  const quoteNotBehindTape =
+    !Number.isFinite(quoteAtMs) || !Number.isFinite(tapeMs)
+      ? true
+      : quoteAtMs >= tapeMs;
   const liveSpot =
-    spxQuote && quoteIsFresh(spxQuote.quoted_at, quotes?.fresh_within_seconds)
+    spxQuote &&
+    quoteNotBehindTape &&
+    quoteIsFresh(spxQuote.quoted_at, quotes?.fresh_within_seconds)
       ? spxQuote.price
       : null;
 
-  // Re-anchor the profile on the live spot: recompute each bucket's distance
-  // and re-place the SPOT tag on the nearest strike, mirroring the backend's
-  // tag_profile precedence (SPOT first, GEX FLIP overrides, levels fill the
-  // remaining strikes) so a spot move can't strand a stale SPOT row.
   const liveProfile: GexBucket[] = useMemo(() => {
     const profile = data?.profile ?? [];
     if (liveSpot == null || !profile.length) return profile;
-    let nearest: number | null = null;
-    let minDist = Infinity;
-    for (const b of profile) {
-      const d = Math.abs(b.strike - liveSpot);
-      if (d < minDist) {
-        minDist = d;
-        nearest = b.strike;
-      }
-    }
-    const tagMap = new Map<number, string>();
-    if (nearest != null) tagMap.set(nearest, "SPOT");
-    const lv = data?.levels;
-    if (lv?.gex_flip) tagMap.set(lv.gex_flip.strike, "GEX FLIP");
-    const labelled: [GexLevel, string][] = [
-      [lv?.max_magnet ?? null, "MAX MAGNET"],
-      [lv?.second_magnet ?? null, "SECOND MAGNET"],
-      [lv?.max_accelerator ?? null, "MAX ACCELERATOR"],
-      [lv?.put_wall ?? null, "PUT WALL"],
-      [lv?.call_wall ?? null, "CALL WALL"],
-    ];
-    for (const [level, label] of labelled) {
-      if (level && !tagMap.has(level.strike)) tagMap.set(level.strike, label);
-    }
-    return profile.map((b) => ({
-      ...b,
-      pct_from_spot: ((b.strike - liveSpot) / liveSpot) * 100,
-      tag: tagMap.get(b.strike) ?? null,
-    }));
+    return retagProfileForSpot(profile, liveSpot, data?.levels);
   }, [data, liveSpot]);
 
   if (loading && !data) {
@@ -254,16 +287,26 @@ export default function GexSubTab({ marketState }: GexSubTabProps) {
   const daysAbove = bias.days_above_flip;
   const daysSide = daysAbove > 0 ? "ABOVE" : daysAbove < 0 ? "BELOW" : "AT";
   const daysCount = Math.abs(daysAbove);
-  const spotFreshnessAnchorMs = Date.parse(lastSync ?? data.scan_time);
+  // Freshness pill anchor: when the live splice is active, anchor on the
+  // quotes response's as_of (refreshes every quote poll) — the GEX scan
+  // timestamp goes stale between scans and would mislabel an aging quote
+  // as LIVE. Snapshot mode keeps the scan-derived anchor.
+  const quotesAsOfMs = quotes?.as_of ? Date.parse(quotes.as_of) : NaN;
+  const spotFreshnessAnchorMs =
+    liveSpot != null && Number.isFinite(quotesAsOfMs)
+      ? quotesAsOfMs
+      : Date.parse(lastSync ?? data.scan_time);
 
   const displaySpot = liveSpot ?? data.spot;
-  const prevClose = data.prev_close;
+  // prev_close of 0 means "missing", not a real reference price.
+  const prevClose =
+    data.prev_close != null && data.prev_close > 0 ? data.prev_close : null;
   const dayChange =
     liveSpot != null && prevClose != null
       ? liveSpot - prevClose
       : data.day_change;
   const dayChangePct =
-    liveSpot != null && prevClose
+    liveSpot != null && prevClose != null
       ? ((liveSpot - prevClose) / prevClose) * 100
       : data.day_change_pct;
   const spotTapeTime = liveSpot != null ? spxQuote?.quoted_at : data.tape_time;

--- a/web/components/regime/MeanReversionTiles.tsx
+++ b/web/components/regime/MeanReversionTiles.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import InfoTooltip from "./InfoTooltip";
+import CardSparkline from "./primitives/CardSparkline";
+
+type Series = ReadonlyArray<number | null | undefined>;
 
 interface Props {
   vrp: number | null | undefined;
   vixZscore: number | null | undefined;
   vixVix3mRatio: number | null | undefined;
   vixDelta3d: number | null | undefined;
+  /** Daily history per tile (90d) — when present, drawn as a sparkline. */
+  series?: {
+    vrp?: Series;
+    vixZscore?: Series;
+    vixVix3mRatio?: Series;
+    vixDelta3d?: Series;
+  };
 }
 
 const TOOLTIPS = {
@@ -44,11 +54,13 @@ function Tile({
   value,
   dec = 2,
   signed = false,
+  series,
 }: {
   label: string;
   value: number | null | undefined;
   dec?: number;
   signed?: boolean;
+  series?: Series;
 }) {
   let display = "—";
   if (value != null && Number.isFinite(value)) {
@@ -67,6 +79,7 @@ function Tile({
       >
         {display}
       </div>
+      {series && <CardSparkline values={series} label={`${label} daily`} />}
     </div>
   );
 }
@@ -76,13 +89,24 @@ export function MeanReversionTiles({
   vixZscore,
   vixVix3mRatio,
   vixDelta3d,
+  series,
 }: Props) {
   return (
     <div className="regime-meanrev-row" data-testid="meanrev-row">
-      <Tile label="VRP" value={vrp} />
-      <Tile label="VIX Z (30d)" value={vixZscore} />
-      <Tile label="VIX / VIX3M" value={vixVix3mRatio} dec={3} />
-      <Tile label="VIX Δ (3d)" value={vixDelta3d} signed />
+      <Tile label="VRP" value={vrp} series={series?.vrp} />
+      <Tile label="VIX Z (30d)" value={vixZscore} series={series?.vixZscore} />
+      <Tile
+        label="VIX / VIX3M"
+        value={vixVix3mRatio}
+        dec={3}
+        series={series?.vixVix3mRatio}
+      />
+      <Tile
+        label="VIX Δ (3d)"
+        value={vixDelta3d}
+        signed
+        series={series?.vixDelta3d}
+      />
     </div>
   );
 }

--- a/web/components/regime/MultiPanelGrid.tsx
+++ b/web/components/regime/MultiPanelGrid.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import {
+  finiteDomain,
+  linearScale,
+  pathFromNullablePoints,
+} from "@/lib/svgChart";
+
+const PANEL_W = 210;
+const PANEL_H = 96;
+const PAD = { top: 6, right: 8, bottom: 8, left: 8 };
+
+export type PanelSpec<Row> = {
+  key: string;
+  label: string;
+  color?: string;
+  fmt?: (v: number) => string;
+  get: (row: Row) => number | null | undefined;
+};
+
+function defaultFmt(v: number): string {
+  return Math.abs(v) >= 1000 ? v.toFixed(0) : v.toFixed(2);
+}
+
+function MiniSeries({
+  label,
+  color,
+  fmt,
+  values,
+  dividers,
+}: {
+  label: string;
+  color: string;
+  fmt: (v: number) => string;
+  values: (number | null)[];
+  dividers: number[];
+}) {
+  const x = linearScale(
+    [0, Math.max(values.length - 1, 1)],
+    [PAD.left, PANEL_W - PAD.right],
+  );
+  const domain = finiteDomain(values);
+  const y = domain
+    ? linearScale([domain.lo, domain.hi], [PANEL_H - PAD.bottom, PAD.top + 14])
+    : null;
+
+  // Break the path at each session divider so overnight motion isn't drawn —
+  // same rule as GexIntradayChart.pathFor.
+  const bounds = [0, ...dividers, values.length];
+  const path = y
+    ? bounds
+        .slice(0, -1)
+        .map((start, i) =>
+          pathFromNullablePoints(
+            values
+              .slice(start, bounds[i + 1])
+              .map((v, j): [number, number] | null =>
+                v == null ? null : [x(start + j), y(v)],
+              ),
+          ),
+        )
+        .filter((s) => s.length > 0)
+        .join(" ")
+    : "";
+
+  const latest = [...values].reverse().find((v) => v != null) ?? null;
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-dim)",
+        background: "var(--bg-panel)",
+        padding: 4,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          padding: "0 4px",
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {latest != null ? fmt(latest) : "—"}
+        </span>
+      </div>
+      <svg
+        role="img"
+        aria-label={label}
+        viewBox={`0 0 ${PANEL_W} ${PANEL_H}`}
+        style={{ width: "100%", height: "auto", display: "block" }}
+      >
+        {dividers.map((d) => (
+          <line
+            key={d}
+            x1={x(d)}
+            x2={x(d)}
+            y1={PAD.top + 14}
+            y2={PANEL_H - PAD.bottom}
+            stroke="var(--border-dim)"
+            strokeWidth={1}
+          />
+        ))}
+        <path
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth={1.3}
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  );
+}
+
+export function MultiPanelGrid<Row>({
+  title,
+  panels,
+  rows,
+  dividers,
+  testId,
+}: {
+  title: string;
+  panels: PanelSpec<Row>[];
+  rows: Row[];
+  /** Row indices where a new session starts (empty for daily grids). */
+  dividers: number[];
+  testId: string;
+}) {
+  if (!rows.length) {
+    return (
+      <div className="section" data-testid={`${testId}-empty`}>
+        <div className="section-header">
+          <div className="section-title">{title}</div>
+        </div>
+        <div
+          className="section-body"
+          style={{
+            padding: 24,
+            textAlign: "center",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+          }}
+        >
+          No snapshots yet.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="section" data-testid={testId}>
+      <div className="section-header">
+        <div className="section-title">{title}</div>
+      </div>
+      <div
+        className="section-body"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 8,
+          padding: 12,
+        }}
+      >
+        {panels.map((p) => (
+          <MiniSeries
+            key={p.key}
+            label={p.label}
+            color={p.color ?? "var(--accent-bg, #05AD98)"}
+            fmt={p.fmt ?? defaultFmt}
+            values={rows.map((r) => p.get(r) ?? null)}
+            dividers={dividers}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/components/regime/RegimeStrip.tsx
+++ b/web/components/regime/RegimeStrip.tsx
@@ -91,6 +91,7 @@ type RegimeStripCellProps = {
   change?: ReactNode;
   sub?: ReactNode;
   timestamp?: ReactNode;
+  spark?: ReactNode;
 };
 
 export function RegimeStripCell({
@@ -100,6 +101,7 @@ export function RegimeStripCell({
   change,
   sub,
   timestamp,
+  spark,
 }: RegimeStripCellProps) {
   return (
     <div className="regime-strip-cell" data-testid={testId}>
@@ -112,6 +114,7 @@ export function RegimeStripCell({
         {sub ? <div className="regime-strip-sub">{sub}</div> : null}
         {timestamp ? <div className="regime-strip-ts">{timestamp}</div> : null}
       </div>
+      {spark}
     </div>
   );
 }

--- a/web/components/regime/RegimeStrip.tsx
+++ b/web/components/regime/RegimeStrip.tsx
@@ -114,7 +114,7 @@ export function RegimeStripCell({
         {sub ? <div className="regime-strip-sub">{sub}</div> : null}
         {timestamp ? <div className="regime-strip-ts">{timestamp}</div> : null}
       </div>
-      {spark}
+      {spark ? <div className="regime-strip-spark">{spark}</div> : null}
     </div>
   );
 }

--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -450,9 +450,8 @@ export function VcgSubTabView({
                 {data.credit_proxy} @ ${formatNumber(sig.credit_price)}
               </div>
               <CardSparkline
-                values={dseries("credit_price")}
-                label={`${data.credit_proxy} daily, 90d`}
-                color="var(--text-primary)"
+                values={dseries("credit_5d_return_pct")}
+                label="Credit 5d return daily, 90d"
               />
             </div>
             <div className="metric-card">

--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -5,7 +5,9 @@ import { AlertTriangle, Shield, TrendingUp, Zap } from "lucide-react";
 import InfoTooltip from "./InfoTooltip";
 import { VcgHistoryTable } from "./vcg/VcgHistoryTable";
 import VcgStressHistorySection from "./vcg/VcgStressHistorySection";
-import { type VcgResponse, type VcgSignal, useVcg } from "@/lib/regime/useVcg";
+import { type VcgSignal } from "@/lib/regime/useVcg";
+import { useVcgLive, type VcgLiveResponse } from "@/lib/regime/useVcgLive";
+import VcgSeriesGrids from "./vcg/VcgSeriesGrids";
 import {
   formatNumber,
   formatPercent,
@@ -146,7 +148,7 @@ export function VcgSubTabView({
   onSyncNow,
   syncing = false,
 }: {
-  data: VcgResponse | null;
+  data: VcgLiveResponse | null;
   onSyncNow?: () => void;
   syncing?: boolean;
 }) {
@@ -306,9 +308,14 @@ export function VcgSubTabView({
                 style={{
                   fontFamily: "var(--font-mono)",
                   fontSize: "9px",
-                  color: "var(--text-muted)",
+                  color:
+                    data.basis === "live"
+                      ? "var(--positive)"
+                      : "var(--text-muted)",
                 }}
+                data-testid="vcg-live-time"
               >
+                {data.basis === "live" ? "LIVE · " : ""}
                 {new Date(lastSync).toLocaleTimeString("en-US", {
                   hour: "numeric",
                   minute: "2-digit",
@@ -745,11 +752,14 @@ export function VcgSubTabView({
 
       {/* ── All-time stress history (v2 backtest) ───────────── */}
       <VcgStressHistorySection />
+
+      {/* ── Intraday / daily small-multiples grids (basis='live' rows) ── */}
+      <VcgSeriesGrids />
     </div>
   );
 }
 
 export default function VcgSubTab() {
-  const { data, syncing, syncNow } = useVcg();
+  const { data, syncing, syncNow } = useVcgLive();
   return <VcgSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
 }

--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -1,13 +1,23 @@
 "use client";
 
-import { AlertTriangle, Shield, TrendingUp, Zap } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Shield,
+  TrendingUp,
+  Zap,
+} from "lucide-react";
+import { useState, type ComponentProps } from "react";
 
 import InfoTooltip from "./InfoTooltip";
 import { VcgHistoryTable } from "./vcg/VcgHistoryTable";
 import VcgStressHistorySection from "./vcg/VcgStressHistorySection";
 import { type VcgSignal } from "@/lib/regime/useVcg";
 import { useVcgLive, type VcgLiveResponse } from "@/lib/regime/useVcgLive";
+import { useVcgDaily, type VcgDailyEntry } from "@/lib/regime/useVcgSeries";
 import VcgSeriesGrids from "./vcg/VcgSeriesGrids";
+import CardSparkline from "./primitives/CardSparkline";
 import {
   formatNumber,
   formatPercent,
@@ -141,14 +151,57 @@ function pctRankColor(v: number | null | undefined): string {
   return "var(--text-primary)";
 }
 
+/* ─── 20d history table, folded by default (same toggle pattern as
+ * VcgStressHistorySection). ─────────────────────────────────── */
+
+function VcgHistorySection(props: ComponentProps<typeof VcgHistoryTable>) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="section" data-testid="vcg-history-section">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        data-testid="vcg-history-toggle"
+        className="section-header"
+        style={{
+          width: "100%",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+          textAlign: "left",
+          color: "inherit",
+        }}
+      >
+        <div
+          className="section-title"
+          style={{ display: "flex", alignItems: "center", gap: "6px" }}
+        >
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          VCG History (20d)
+        </div>
+      </button>
+      {open && (
+        <div className="section-body table-wrap">
+          <VcgHistoryTable {...props} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ─── Main view (1:1 mirror of xenon VcgPanel) ───────────────── */
 
 export function VcgSubTabView({
   data,
+  daily,
   onSyncNow,
   syncing = false,
 }: {
   data: VcgLiveResponse | null;
+  /** 90d daily history rows — drives the in-card sparklines. */
+  daily?: VcgDailyEntry[] | null;
   onSyncNow?: () => void;
   syncing?: boolean;
 }) {
@@ -158,35 +211,45 @@ export function VcgSubTabView({
     (!data.signal?.vcg && data.signal?.vcg !== 0)
   ) {
     return (
-      <div className="regime-empty" data-testid="vcg-empty-state">
-        <Shield size={32} strokeWidth={1} />
-        <p>
-          No VCG data available. Click Sync Now to run a scan for{" "}
-          {data?.credit_proxy ?? "HYG"}.
-        </p>
-        {onSyncNow && (
-          <button
-            type="button"
-            onClick={onSyncNow}
-            disabled={syncing}
-            data-testid="vcg-sync-now"
-            style={{
-              marginTop: "12px",
-              padding: "6px 14px",
-              fontFamily: "var(--font-mono)",
-              fontSize: "11px",
-              letterSpacing: "0.08em",
-              textTransform: "uppercase",
-              background: "var(--bg-panel-raised, var(--bg-panel))",
-              border: "1px solid var(--border-dim, var(--line-grid))",
-              color: "var(--text-primary)",
-              cursor: syncing ? "default" : "pointer",
-              opacity: syncing ? 0.6 : 1,
-            }}
-          >
-            {syncing ? "Syncing…" : "Sync Now"}
-          </button>
-        )}
+      <div className="section gex-panel">
+        <div className="section-header">
+          <div className="section-title">
+            <Zap size={14} />
+            Volatility-Credit Gap (VCG)
+          </div>
+        </div>
+        <div className="section-body">
+          <div className="regime-empty" data-testid="vcg-empty-state">
+            <Shield size={32} strokeWidth={1} />
+            <p>
+              No VCG data available. Click Sync Now to run a scan for{" "}
+              {data?.credit_proxy ?? "HYG"}.
+            </p>
+            {onSyncNow && (
+              <button
+                type="button"
+                onClick={onSyncNow}
+                disabled={syncing}
+                data-testid="vcg-sync-now"
+                style={{
+                  marginTop: "12px",
+                  padding: "6px 14px",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "11px",
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  background: "var(--bg-panel-raised, var(--bg-panel))",
+                  border: "1px solid var(--border-dim, var(--line-grid))",
+                  color: "var(--text-primary)",
+                  cursor: syncing ? "default" : "pointer",
+                  opacity: syncing ? 0.6 : 1,
+                }}
+              >
+                {syncing ? "Syncing…" : "Sync Now"}
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     );
   }
@@ -203,260 +266,250 @@ export function VcgSubTabView({
   const lastSync = data.scan_time;
   const history = data.history ?? [];
 
+  // 90d daily series for in-card sparklines (oldest → newest).
+  const dailyRows = daily ?? [];
+  const dseries = (k: keyof VcgDailyEntry): (number | null)[] =>
+    dailyRows.map((r) => {
+      const v = r[k];
+      return typeof v === "number" && Number.isFinite(v) ? v : null;
+    });
+
   return (
-    <div className="regime-panel" data-testid="vcg-subtab">
-      {/* ── Signal strip ───────────────────────────────────── */}
-      <div className="section">
-        <div className="section-header">
-          <div className="section-title">
-            <Zap size={14} />
-            VCG Signal
-            <InfoTooltip text="Volatility-Credit Gap: detects divergence between the vol complex (VIX/VVIX) and credit markets (HYG/JNK/LQD). Signals: RISK_OFF (tier 1–2), EDR (early divergence), BOUNCE (counter-signal), NORMAL." />
+    <div className="section gex-panel" data-testid="vcg-subtab">
+      <div className="section-header">
+        <div className="section-title">
+          <Zap size={14} />
+          Volatility-Credit Gap (VCG)
+        </div>
+      </div>
+      <div className="section-body regime-panel">
+        {/* ── Signal strip ───────────────────────────────────── */}
+        <div className="section">
+          <div className="section-header">
+            <div className="section-title">
+              <Zap size={14} />
+              VCG Signal
+              <InfoTooltip text="Volatility-Credit Gap: detects divergence between the vol complex (VIX/VVIX) and credit markets (HYG/JNK/LQD). Signals: RISK_OFF (tier 1–2), EDR (early divergence), BOUNCE (counter-signal), NORMAL." />
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "6px",
+                flexWrap: "wrap",
+              }}
+            >
+              {/* Regime badge */}
+              <span
+                className="pill"
+                style={{
+                  background: regimeBadgeColor(sig.regime),
+                  color: "#fff",
+                  fontSize: "9px",
+                }}
+                data-testid="vcg-regime-badge"
+              >
+                {sig.regime}
+              </span>
+              {/* RISK-OFF */}
+              {sig.ro === 1 && (
+                <span
+                  className="pill"
+                  style={{
+                    background: "var(--fault, var(--negative))",
+                    color: "#fff",
+                    fontSize: "9px",
+                  }}
+                  data-testid="vcg-ro-badge"
+                >
+                  <AlertTriangle size={10} style={{ marginRight: "3px" }} />
+                  RISK-OFF
+                </span>
+              )}
+              {/* EDR (only when not already RISK-OFF) */}
+              {sig.edr === 1 && sig.ro !== 1 && (
+                <span
+                  className="pill"
+                  style={{
+                    background: "var(--warning)",
+                    color: "#000",
+                    fontSize: "9px",
+                    fontWeight: 700,
+                  }}
+                  data-testid="vcg-edr-badge"
+                >
+                  EDR
+                </span>
+              )}
+              {/* Tier badge */}
+              {sig.tier != null && (
+                <span
+                  className="pill"
+                  style={{
+                    background: tierColor(sig.tier),
+                    color: "#fff",
+                    fontSize: "9px",
+                  }}
+                  data-testid="vcg-tier-badge"
+                >
+                  T{sig.tier}
+                </span>
+              )}
+              {/* Bounce */}
+              {sig.bounce === 1 && (
+                <span
+                  className="pill"
+                  style={{
+                    background: "var(--signal-core, var(--positive))",
+                    color: "#000",
+                    fontSize: "9px",
+                    fontWeight: 700,
+                  }}
+                  data-testid="vcg-bounce-badge"
+                >
+                  <TrendingUp size={10} style={{ marginRight: "3px" }} />
+                  BOUNCE
+                </span>
+              )}
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "9px",
+                  color: "var(--text-muted)",
+                }}
+                data-testid="vcg-proxy"
+              >
+                {data.credit_proxy}
+              </span>
+              {lastSync && (
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "9px",
+                    color:
+                      data.basis === "live"
+                        ? "var(--positive)"
+                        : "var(--text-muted)",
+                  }}
+                  data-testid="vcg-live-time"
+                >
+                  {data.basis === "live" ? "LIVE · " : ""}
+                  {new Date(lastSync).toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </span>
+              )}
+            </div>
           </div>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "6px",
-              flexWrap: "wrap",
-            }}
-          >
-            {/* Regime badge */}
+
+          <div className="metrics-grid">
+            <div className="metric-card">
+              <div className="metric-label">VCG Z-Score</div>
+              <div
+                className="metric-value"
+                style={{ color: interpColor }}
+                data-testid="vcg-z-score"
+              >
+                {formatSignedNumber(sig.vcg)}
+              </div>
+              <div className="metric-change" style={{ color: interpColor }}>
+                {interpretationLabel(sig.interpretation)}
+              </div>
+              <CardSparkline
+                values={dseries("vcg")}
+                label="VCG z-score daily, 90d"
+                color="var(--accent-warm, #F5A623)"
+              />
+            </div>
+            <div className="metric-card">
+              <div className="metric-label">VCG Adj (Panic-Adj)</div>
+              <div className="metric-value">
+                {formatSignedNumber(sig.vcg_adj)}
+              </div>
+              <div className="metric-change neutral">
+                {sig.pi_panic > 0
+                  ? `π = ${sig.pi_panic.toFixed(2)} (panic-adjustment active)`
+                  : "π = 0 (no panic adjustment)"}
+              </div>
+              <CardSparkline
+                values={dseries("vcg_adj")}
+                label="VCG adjusted daily, 90d"
+              />
+            </div>
+            <div className="metric-card">
+              <div className="metric-label">Credit 5d Return</div>
+              <div
+                className={`metric-value ${
+                  sig.credit_5d_return_pct >= 0 ? "positive" : "negative"
+                }`}
+              >
+                {formatPercent(sig.credit_5d_return_pct)}
+              </div>
+              <div className="metric-change neutral">
+                {data.credit_proxy} @ ${formatNumber(sig.credit_price)}
+              </div>
+              <CardSparkline
+                values={dseries("credit_price")}
+                label={`${data.credit_proxy} daily, 90d`}
+                color="var(--text-primary)"
+              />
+            </div>
+            <div className="metric-card">
+              <div className="metric-label">Residual</div>
+              <div className="metric-value">
+                {sig.residual != null ? sig.residual.toFixed(6) : "---"}
+              </div>
+              <div className="metric-change neutral">MODEL ε</div>
+              <CardSparkline
+                values={dseries("residual")}
+                label="Model residual daily, 90d"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* ── Signal Detail + Attribution ─────────────────────── */}
+        <div className="section">
+          <div className="section-header">
+            <div className="section-title">
+              <Zap size={14} />
+              Signal Detail
+              <InfoTooltip text="Severity tier (1=critical, 2=high, 3=elevated), VVIX amplifier, and bounce conditions. Tier activates when ro=1 (Tier 1/2) or edr=1 (Tier 3)." />
+            </div>
             <span
               className="pill"
               style={{
-                background: regimeBadgeColor(sig.regime),
-                color: "#fff",
+                background: interpColor,
+                color:
+                  sig.interpretation === "NORMAL" ||
+                  sig.interpretation === "BOUNCE"
+                    ? "#000"
+                    : "#fff",
                 fontSize: "9px",
               }}
-              data-testid="vcg-regime-badge"
+              data-testid="vcg-interpretation-pill"
             >
-              {sig.regime}
-            </span>
-            {/* RISK-OFF */}
-            {sig.ro === 1 && (
-              <span
-                className="pill"
-                style={{
-                  background: "var(--fault, var(--negative))",
-                  color: "#fff",
-                  fontSize: "9px",
-                }}
-                data-testid="vcg-ro-badge"
-              >
-                <AlertTriangle size={10} style={{ marginRight: "3px" }} />
-                RISK-OFF
-              </span>
-            )}
-            {/* EDR (only when not already RISK-OFF) */}
-            {sig.edr === 1 && sig.ro !== 1 && (
-              <span
-                className="pill"
-                style={{
-                  background: "var(--warning)",
-                  color: "#000",
-                  fontSize: "9px",
-                  fontWeight: 700,
-                }}
-                data-testid="vcg-edr-badge"
-              >
-                EDR
-              </span>
-            )}
-            {/* Tier badge */}
-            {sig.tier != null && (
-              <span
-                className="pill"
-                style={{
-                  background: tierColor(sig.tier),
-                  color: "#fff",
-                  fontSize: "9px",
-                }}
-                data-testid="vcg-tier-badge"
-              >
-                T{sig.tier}
-              </span>
-            )}
-            {/* Bounce */}
-            {sig.bounce === 1 && (
-              <span
-                className="pill"
-                style={{
-                  background: "var(--signal-core, var(--positive))",
-                  color: "#000",
-                  fontSize: "9px",
-                  fontWeight: 700,
-                }}
-                data-testid="vcg-bounce-badge"
-              >
-                <TrendingUp size={10} style={{ marginRight: "3px" }} />
-                BOUNCE
-              </span>
-            )}
-            <span
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "9px",
-                color: "var(--text-muted)",
-              }}
-              data-testid="vcg-proxy"
-            >
-              {data.credit_proxy}
-            </span>
-            {lastSync && (
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "9px",
-                  color:
-                    data.basis === "live"
-                      ? "var(--positive)"
-                      : "var(--text-muted)",
-                }}
-                data-testid="vcg-live-time"
-              >
-                {data.basis === "live" ? "LIVE · " : ""}
-                {new Date(lastSync).toLocaleTimeString("en-US", {
-                  hour: "numeric",
-                  minute: "2-digit",
-                })}
-              </span>
-            )}
-          </div>
-        </div>
-
-        <div className="metrics-grid">
-          <div className="metric-card">
-            <div className="metric-label">VCG Z-Score</div>
-            <div
-              className="metric-value"
-              style={{ color: interpColor }}
-              data-testid="vcg-z-score"
-            >
-              {formatSignedNumber(sig.vcg)}
-            </div>
-            <div className="metric-change" style={{ color: interpColor }}>
               {interpretationLabel(sig.interpretation)}
-            </div>
+            </span>
           </div>
-          <div className="metric-card">
-            <div className="metric-label">VCG Adj (Panic-Adj)</div>
-            <div className="metric-value">
-              {formatSignedNumber(sig.vcg_adj)}
-            </div>
-            <div className="metric-change neutral">
-              {sig.pi_panic > 0
-                ? `π = ${sig.pi_panic.toFixed(2)} (panic-adjustment active)`
-                : "π = 0 (no panic adjustment)"}
-            </div>
-          </div>
-          <div className="metric-card">
-            <div className="metric-label">Credit 5d Return</div>
-            <div
-              className={`metric-value ${
-                sig.credit_5d_return_pct >= 0 ? "positive" : "negative"
-              }`}
-            >
-              {formatPercent(sig.credit_5d_return_pct)}
-            </div>
-            <div className="metric-change neutral">
-              {data.credit_proxy} @ ${formatNumber(sig.credit_price)}
-            </div>
-          </div>
-          <div className="metric-card">
-            <div className="metric-label">Residual</div>
-            <div className="metric-value">
-              {sig.residual != null ? sig.residual.toFixed(6) : "---"}
-            </div>
-            <div className="metric-change neutral">MODEL ε</div>
-          </div>
-        </div>
-      </div>
 
-      {/* ── Signal Detail + Attribution ─────────────────────── */}
-      <div className="section">
-        <div className="section-header">
-          <div className="section-title">
-            <Zap size={14} />
-            Signal Detail
-            <InfoTooltip text="Severity tier (1=critical, 2=high, 3=elevated), VVIX amplifier, and bounce conditions. Tier activates when ro=1 (Tier 1/2) or edr=1 (Tier 3)." />
-          </div>
-          <span
-            className="pill"
-            style={{
-              background: interpColor,
-              color:
-                sig.interpretation === "NORMAL" ||
-                sig.interpretation === "BOUNCE"
-                  ? "#000"
-                  : "#fff",
-              fontSize: "9px",
-            }}
-            data-testid="vcg-interpretation-pill"
+          <div
+            className="metrics-grid"
+            style={{ gridTemplateColumns: "1fr 1fr" }}
           >
-            {interpretationLabel(sig.interpretation)}
-          </span>
-        </div>
-
-        <div
-          className="metrics-grid"
-          style={{ gridTemplateColumns: "1fr 1fr" }}
-        >
-          {/* Left: Tier + VVIX severity + EDR/Bounce */}
-          <div className="metric-card" style={{ padding: "12px 16px" }}>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                paddingBottom: "8px",
-                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
-              }}
-            >
-              <span
+            {/* Left: Tier + VVIX severity + EDR/Bounce */}
+            <div className="metric-card" style={{ padding: "12px 16px" }}>
+              <div
                 style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "10px",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.08em",
-                  color: "var(--text-muted)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  paddingBottom: "8px",
+                  borderBottom: "1px solid var(--border-dim, var(--line-grid))",
                 }}
               >
-                Severity Tier
-              </span>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: tierColor(sig.tier),
-                  background:
-                    sig.tier != null
-                      ? `${tierColor(sig.tier)}18`
-                      : "transparent",
-                  padding: "2px 8px",
-                  borderRadius: "999px",
-                  border:
-                    sig.tier != null
-                      ? `1px solid ${tierColor(sig.tier)}40`
-                      : "none",
-                }}
-                data-testid="vcg-tier-label"
-              >
-                {tierLabel(sig.tier)}
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "8px 0",
-                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
-              }}
-            >
-              <div>
-                <div
+                <span
                   style={{
                     fontFamily: "var(--font-mono)",
                     fontSize: "10px",
@@ -465,44 +518,119 @@ export function VcgSubTabView({
                     color: "var(--text-muted)",
                   }}
                 >
-                  VVIX Severity
-                </div>
-                <div
+                  Severity Tier
+                </span>
+                <span
                   style={{
                     fontFamily: "var(--font-mono)",
-                    fontSize: "9px",
-                    color: "var(--text-muted)",
-                    marginTop: "2px",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color: tierColor(sig.tier),
+                    background:
+                      sig.tier != null
+                        ? `${tierColor(sig.tier)}18`
+                        : "transparent",
+                    padding: "2px 8px",
+                    borderRadius: "999px",
+                    border:
+                      sig.tier != null
+                        ? `1px solid ${tierColor(sig.tier)}40`
+                        : "none",
                   }}
+                  data-testid="vcg-tier-label"
                 >
-                  {vvixSeverityDesc(sig.vvix_severity)}
-                </div>
+                  {tierLabel(sig.tier)}
+                </span>
               </div>
-              <span
+              <div
                 style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: vvixSeverityColor(sig.vvix_severity),
-                  textTransform: "uppercase",
-                  marginLeft: "12px",
-                  flexShrink: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--border-dim, var(--line-grid))",
                 }}
-                data-testid="vcg-vvix-severity"
               >
-                {sig.vvix_severity}
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "8px 0",
-                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
-              }}
-            >
-              <div>
+                <div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "10px",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    VVIX Severity
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "9px",
+                      color: "var(--text-muted)",
+                      marginTop: "2px",
+                    }}
+                  >
+                    {vvixSeverityDesc(sig.vvix_severity)}
+                  </div>
+                </div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color: vvixSeverityColor(sig.vvix_severity),
+                    textTransform: "uppercase",
+                    marginLeft: "12px",
+                    flexShrink: 0,
+                  }}
+                  data-testid="vcg-vvix-severity"
+                >
+                  {sig.vvix_severity}
+                </span>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--border-dim, var(--line-grid))",
+                }}
+              >
+                <div>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "10px",
+                      color: "var(--text-muted)",
+                    }}
+                  >
+                    VIX 252d %ile
+                  </span>
+                  <InfoTooltip text="VIX level's 252-day rolling percentile rank (strict_lt tie rule). When BOTH VIX and VVIX percentile ranks clear 0.95, the v2 cascade fires RISK_OFF via the absolute-vol-stress override — bypassing the sign-discipline SUPPRESSED clause that masked PANIC days in v1." />
+                </div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color: pctRankColor(sig.vix_percentile_rank),
+                  }}
+                  data-testid="vcg-vix-pct-rank"
+                >
+                  {formatPctRank(sig.vix_percentile_rank)}
+                </span>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--border-dim, var(--line-grid))",
+                }}
+              >
                 <span
                   style={{
                     fontFamily: "var(--font-mono)",
@@ -510,256 +638,230 @@ export function VcgSubTabView({
                     color: "var(--text-muted)",
                   }}
                 >
-                  VIX 252d %ile
+                  VVIX 252d %ile
                 </span>
-                <InfoTooltip text="VIX level's 252-day rolling percentile rank (strict_lt tie rule). When BOTH VIX and VVIX percentile ranks clear 0.95, the v2 cascade fires RISK_OFF via the absolute-vol-stress override — bypassing the sign-discipline SUPPRESSED clause that masked PANIC days in v1." />
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color: pctRankColor(sig.vvix_percentile_rank),
+                  }}
+                  data-testid="vcg-vvix-pct-rank"
+                >
+                  {formatPctRank(sig.vvix_percentile_rank)}
+                </span>
               </div>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: pctRankColor(sig.vix_percentile_rank),
-                }}
-                data-testid="vcg-vix-pct-rank"
-              >
-                {formatPctRank(sig.vix_percentile_rank)}
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "8px 0",
-                borderBottom: "1px solid var(--border-dim, var(--line-grid))",
-              }}
-            >
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "10px",
-                  color: "var(--text-muted)",
-                }}
-              >
-                VVIX 252d %ile
-              </span>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: pctRankColor(sig.vvix_percentile_rank),
-                }}
-                data-testid="vcg-vvix-pct-rank"
-              >
-                {formatPctRank(sig.vvix_percentile_rank)}
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "8px 0",
-              }}
-            >
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "10px",
-                  color: "var(--text-muted)",
-                }}
-              >
-                EDR
-              </span>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: sig.edr === 1 ? "var(--warning)" : "var(--text-muted)",
-                }}
-                data-testid="vcg-edr-state"
-              >
-                {sig.edr === 1 ? "ACTIVE" : "INACTIVE"}
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                paddingTop: "0",
-              }}
-            >
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "10px",
-                  color: "var(--text-muted)",
-                }}
-              >
-                Bounce
-              </span>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color:
-                    sig.bounce === 1
-                      ? "var(--signal-core, var(--positive))"
-                      : "var(--text-muted)",
-                }}
-                data-testid="vcg-bounce-state"
-              >
-                {sig.bounce === 1 ? "DETECTED" : "—"}
-              </span>
-            </div>
-          </div>
-
-          {/* Right: Attribution bars */}
-          <div className="metric-card" style={{ padding: "12px 16px" }}>
-            <div
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "10px",
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
-                color: "var(--text-muted)",
-                marginBottom: "8px",
-              }}
-            >
-              Attribution
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                marginBottom: "8px",
-              }}
-            >
               <div
                 style={{
-                  flex: 1,
-                  height: "6px",
-                  borderRadius: "3px",
-                  background: "var(--bg-panel-raised, var(--bg-panel))",
-                  overflow: "hidden",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "8px 0",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "10px",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  EDR
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color:
+                      sig.edr === 1 ? "var(--warning)" : "var(--text-muted)",
+                  }}
+                  data-testid="vcg-edr-state"
+                >
+                  {sig.edr === 1 ? "ACTIVE" : "INACTIVE"}
+                </span>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  paddingTop: "0",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "10px",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  Bounce
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    fontWeight: 700,
+                    color:
+                      sig.bounce === 1
+                        ? "var(--signal-core, var(--positive))"
+                        : "var(--text-muted)",
+                  }}
+                  data-testid="vcg-bounce-state"
+                >
+                  {sig.bounce === 1 ? "DETECTED" : "—"}
+                </span>
+              </div>
+            </div>
+
+            {/* Right: Attribution bars */}
+            <div className="metric-card" style={{ padding: "12px 16px" }}>
+              <div
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "10px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  color: "var(--text-muted)",
+                  marginBottom: "8px",
+                }}
+              >
+                Attribution
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  marginBottom: "8px",
                 }}
               >
                 <div
                   style={{
-                    width: `${clampPct(attr.vvix_pct)}%`,
-                    height: "100%",
-                    background: "var(--extreme, var(--negative))",
+                    flex: 1,
+                    height: "6px",
                     borderRadius: "3px",
+                    background: "var(--bg-panel-raised, var(--bg-panel))",
+                    overflow: "hidden",
                   }}
-                  data-testid="vcg-attr-vvix-bar"
-                />
+                >
+                  <div
+                    style={{
+                      width: `${clampPct(attr.vvix_pct)}%`,
+                      height: "100%",
+                      background: "var(--extreme, var(--negative))",
+                      borderRadius: "3px",
+                    }}
+                    data-testid="vcg-attr-vvix-bar"
+                  />
+                </div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    color: "var(--text-primary)",
+                    minWidth: "60px",
+                  }}
+                >
+                  VVIX {clampPct(attr.vvix_pct).toFixed(0)}%
+                </span>
               </div>
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  color: "var(--text-primary)",
-                  minWidth: "60px",
-                }}
-              >
-                VVIX {clampPct(attr.vvix_pct).toFixed(0)}%
-              </span>
-            </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                marginBottom: "12px",
-              }}
-            >
               <div
                 style={{
-                  flex: 1,
-                  height: "6px",
-                  borderRadius: "3px",
-                  background: "var(--bg-panel-raised, var(--bg-panel))",
-                  overflow: "hidden",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  marginBottom: "12px",
                 }}
               >
                 <div
                   style={{
-                    width: `${clampPct(attr.vix_pct)}%`,
-                    height: "100%",
-                    background: "var(--signal-core, var(--positive))",
+                    flex: 1,
+                    height: "6px",
                     borderRadius: "3px",
+                    background: "var(--bg-panel-raised, var(--bg-panel))",
+                    overflow: "hidden",
                   }}
-                  data-testid="vcg-attr-vix-bar"
-                />
+                >
+                  <div
+                    style={{
+                      width: `${clampPct(attr.vix_pct)}%`,
+                      height: "100%",
+                      background: "var(--signal-core, var(--positive))",
+                      borderRadius: "3px",
+                    }}
+                    data-testid="vcg-attr-vix-bar"
+                  />
+                </div>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px",
+                    color: "var(--text-primary)",
+                    minWidth: "60px",
+                  }}
+                >
+                  VIX {clampPct(attr.vix_pct).toFixed(0)}%
+                </span>
               </div>
-              <span
+              <div
                 style={{
                   fontFamily: "var(--font-mono)",
-                  fontSize: "11px",
-                  color: "var(--text-primary)",
-                  minWidth: "60px",
+                  fontSize: "10px",
+                  color: "var(--text-muted)",
+                  borderTop: "1px solid var(--border-dim, var(--line-grid))",
+                  paddingTop: "8px",
                 }}
               >
-                VIX {clampPct(attr.vix_pct).toFixed(0)}%
-              </span>
-            </div>
-            <div
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "10px",
-                color: "var(--text-muted)",
-                borderTop: "1px solid var(--border-dim, var(--line-grid))",
-                paddingTop: "8px",
-              }}
-            >
-              β₁(VVIX) = {formatNumber(sig.beta1_vvix, 6)} | β₂(VIX) ={" "}
-              {formatNumber(sig.beta2_vix, 6)}
-              {sig.sign_suppressed && (
-                <span style={{ color: "var(--warning)", marginLeft: "8px" }}>
-                  SIGN REVERSED
-                </span>
-              )}
-            </div>
-            <div
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "10px",
-                color: "var(--text-muted)",
-                marginTop: "6px",
-              }}
-            >
-              VVIX {formatNumber(sig.vvix)} · VIX {formatNumber(sig.vix)}
+                β₁(VVIX) = {formatNumber(sig.beta1_vvix, 6)} | β₂(VIX) ={" "}
+                {formatNumber(sig.beta2_vix, 6)}
+                {sig.sign_suppressed && (
+                  <span style={{ color: "var(--warning)", marginLeft: "8px" }}>
+                    SIGN REVERSED
+                  </span>
+                )}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "10px",
+                  color: "var(--text-muted)",
+                  marginTop: "6px",
+                }}
+              >
+                VVIX {formatNumber(sig.vvix)} · VIX {formatNumber(sig.vix)}
+              </div>
             </div>
           </div>
         </div>
+
+        {/* ── Intraday small-multiples grid (basis='live' rows) ── */}
+        <VcgSeriesGrids />
+
+        {/* ── History table (sortable, folded by default) ─────── */}
+        <VcgHistorySection
+          history={history}
+          creditProxy={data.credit_proxy ?? "HYG"}
+        />
+
+        {/* ── All-time stress history (v2 backtest) ───────────── */}
+        <VcgStressHistorySection />
       </div>
-
-      {/* ── History table (sortable) ────────────────────────── */}
-      <div className="section">
-        <div className="section-header">
-          <div className="section-title">VCG History (20d)</div>
-        </div>
-        <div className="section-body table-wrap">
-          <VcgHistoryTable history={history} creditProxy={data.credit_proxy} />
-        </div>
-      </div>
-
-      {/* ── All-time stress history (v2 backtest) ───────────── */}
-      <VcgStressHistorySection />
-
-      {/* ── Intraday / daily small-multiples grids (basis='live' rows) ── */}
-      <VcgSeriesGrids />
     </div>
   );
 }
 
 export default function VcgSubTab() {
   const { data, syncing, syncNow } = useVcgLive();
-  return <VcgSubTabView data={data} syncing={syncing} onSyncNow={syncNow} />;
+  const { data: daily } = useVcgDaily(90);
+  return (
+    <VcgSubTabView
+      data={data}
+      daily={daily?.rows ?? null}
+      syncing={syncing}
+      onSyncNow={syncNow}
+    />
+  );
 }

--- a/web/components/regime/VolBackdropStrip.tsx
+++ b/web/components/regime/VolBackdropStrip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { fmtDecimal } from "@/lib/formatters";
+import CardSparkline from "./primitives/CardSparkline";
 import {
   quoteIsFresh,
   useRegimeQuotes,
@@ -69,16 +70,29 @@ export function VolBackdropStripView({
         : "backwardation"
       : data.term_structure_state;
 
+  // Daily VIX/VIX3M ratio series for the term-structure sparkline, joined by
+  // date (the two series can have mismatched holidays/backfill gaps).
+  const vix3mByDate = new Map(
+    (data.series.VIX3M ?? []).map((p) => [p.date, p.close]),
+  );
+  const ratioSeries = (data.series.VIX ?? []).map((p) => {
+    const v3 = vix3mByDate.get(p.date);
+    return v3 ? p.close / v3 : null;
+  });
+
+  const cardStyle = {
+    border: "1px solid var(--border-dim)",
+    background: "var(--bg-panel)",
+    padding: "10px 12px",
+    minWidth: 0,
+  } as const;
+
   return (
     <div
       style={{
         display: "grid",
         gridTemplateColumns: `repeat(${SYMBOLS.length + 1}, 1fr)`,
         gap: 8,
-        padding: "12px 16px",
-        borderTop: "1px solid var(--border-dim)",
-        borderBottom: "1px solid var(--border-dim)",
-        background: "var(--bg-panel)",
       }}
     >
       {SYMBOLS.map((s) => {
@@ -93,7 +107,7 @@ export function VolBackdropStripView({
             ? ((q.price - dailyClose) / dailyClose) * 100
             : pctChange(data.series[s]);
         return (
-          <div key={s} title={tooltips[s]}>
+          <div key={s} title={tooltips[s]} style={cardStyle}>
             <div
               style={{
                 fontSize: 10,
@@ -134,11 +148,15 @@ export function VolBackdropStripView({
                 ? `${chg >= 0 ? "+" : ""}${fmtDecimal(chg, 2)}%`
                 : "—"}
             </div>
+            <CardSparkline
+              values={(data.series[s] ?? []).map((p) => p.close)}
+              label={`${labels[s]} daily closes`}
+            />
           </div>
         );
       })}
 
-      <div>
+      <div style={cardStyle}>
         <div
           style={{
             fontSize: 10,
@@ -178,6 +196,11 @@ export function VolBackdropStripView({
         >
           {state ?? "—"}
         </div>
+        <CardSparkline
+          values={ratioSeries}
+          label="VIX/VIX3M daily ratio"
+          color="var(--accent-warm, #F5A623)"
+        />
       </div>
     </div>
   );

--- a/web/components/regime/VolBackdropStrip.tsx
+++ b/web/components/regime/VolBackdropStrip.tsx
@@ -2,6 +2,11 @@
 
 import { fmtDecimal } from "@/lib/formatters";
 import {
+  quoteIsFresh,
+  useRegimeQuotes,
+  type RegimeQuotesResponse,
+} from "@/lib/regime/useRegimeQuotes";
+import {
   useVolBackdrop,
   type VolBackdropData,
 } from "@/lib/regime/useVolBackdrop";
@@ -37,10 +42,31 @@ function pctChange(points: { close: number }[] | undefined): number | null {
 
 export function VolBackdropStripView({
   data,
+  quotes,
 }: {
   data: VolBackdropData | null;
+  quotes: RegimeQuotesResponse | null;
 }) {
   if (!data) return null;
+
+  // Live term structure when both legs are fresh; falls back to daily ratio.
+  const qv = quotes?.quotes?.VIX;
+  const q3 = quotes?.quotes?.VIX3M;
+  const liveRatio =
+    qv &&
+    q3 &&
+    quoteIsFresh(qv.quoted_at) &&
+    quoteIsFresh(q3.quoted_at) &&
+    q3.price
+      ? qv.price / q3.price
+      : null;
+  const ratio = liveRatio ?? data.term_structure_ratio;
+  const state =
+    ratio != null
+      ? ratio < 1
+        ? "contango"
+        : "backwardation"
+      : data.term_structure_state;
 
   return (
     <div
@@ -55,8 +81,16 @@ export function VolBackdropStripView({
       }}
     >
       {SYMBOLS.map((s) => {
-        const close = lastClose(data.series[s]);
-        const chg = pctChange(data.series[s]);
+        const q = quotes?.quotes?.[s];
+        const live = q != null && quoteIsFresh(q.quoted_at);
+        const dailyClose = lastClose(data.series[s]);
+        // Live: current quote with change vs last daily close (intraday
+        // ret_1d convention, same as TickerCards). Daily: close-over-close.
+        const close = live ? q.price : dailyClose;
+        const chg =
+          live && dailyClose
+            ? ((q.price - dailyClose) / dailyClose) * 100
+            : pctChange(data.series[s]);
         return (
           <div key={s} title={tooltips[s]}>
             <div
@@ -68,6 +102,11 @@ export function VolBackdropStripView({
               }}
             >
               {labels[s]}
+              {live && (
+                <span style={{ color: "var(--positive)", marginLeft: 4 }}>
+                  ●
+                </span>
+              )}
             </div>
             <div
               style={{
@@ -108,6 +147,9 @@ export function VolBackdropStripView({
           }}
         >
           Term Structure
+          {liveRatio != null && (
+            <span style={{ color: "var(--positive)", marginLeft: 4 }}>●</span>
+          )}
         </div>
         <div
           style={{
@@ -115,14 +157,12 @@ export function VolBackdropStripView({
             fontWeight: 600,
             fontFamily: "var(--font-mono)",
             color:
-              data.term_structure_state === "backwardation"
+              state === "backwardation"
                 ? "var(--warning)"
                 : "var(--text-primary)",
           }}
         >
-          {data.term_structure_ratio != null
-            ? fmtDecimal(data.term_structure_ratio, 3)
-            : "—"}
+          {ratio != null ? fmtDecimal(ratio, 3) : "—"}
         </div>
         <div
           style={{
@@ -130,12 +170,12 @@ export function VolBackdropStripView({
             textTransform: "uppercase",
             letterSpacing: "0.06em",
             color:
-              data.term_structure_state === "backwardation"
+              state === "backwardation"
                 ? "var(--warning)"
                 : "var(--text-secondary)",
           }}
         >
-          {data.term_structure_state ?? "—"}
+          {state ?? "—"}
         </div>
       </div>
     </div>
@@ -144,5 +184,6 @@ export function VolBackdropStripView({
 
 export default function VolBackdropStrip() {
   const { data } = useVolBackdrop();
-  return <VolBackdropStripView data={data ?? null} />;
+  const { data: quotes } = useRegimeQuotes();
+  return <VolBackdropStripView data={data ?? null} quotes={quotes ?? null} />;
 }

--- a/web/components/regime/VolBackdropStrip.tsx
+++ b/web/components/regime/VolBackdropStrip.tsx
@@ -50,13 +50,14 @@ export function VolBackdropStripView({
   if (!data) return null;
 
   // Live term structure when both legs are fresh; falls back to daily ratio.
+  const freshWindow = quotes?.fresh_within_seconds;
   const qv = quotes?.quotes?.VIX;
   const q3 = quotes?.quotes?.VIX3M;
   const liveRatio =
     qv &&
     q3 &&
-    quoteIsFresh(qv.quoted_at) &&
-    quoteIsFresh(q3.quoted_at) &&
+    quoteIsFresh(qv.quoted_at, freshWindow) &&
+    quoteIsFresh(q3.quoted_at, freshWindow) &&
     q3.price
       ? qv.price / q3.price
       : null;
@@ -82,7 +83,7 @@ export function VolBackdropStripView({
     >
       {SYMBOLS.map((s) => {
         const q = quotes?.quotes?.[s];
-        const live = q != null && quoteIsFresh(q.quoted_at);
+        const live = q != null && quoteIsFresh(q.quoted_at, freshWindow);
         const dailyClose = lastClose(data.series[s]);
         // Live: current quote with change vs last daily close (intraday
         // ret_1d convention, same as TickerCards). Daily: close-over-close.

--- a/web/components/regime/cri/CriHistoryTable.tsx
+++ b/web/components/regime/cri/CriHistoryTable.tsx
@@ -35,7 +35,7 @@ function fmtPctCell(v: number | null | undefined, dec = 2): string {
 export function CriHistoryTable({ history }: { history: CriHistoryEntry[] }) {
   const [sortCol, setSortCol] = useState<CriTableSortCol | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
 
   function onSort(col: CriTableSortCol) {
     if (sortCol === col) {

--- a/web/components/regime/cri/CriSeriesGrids.tsx
+++ b/web/components/regime/cri/CriSeriesGrids.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { MultiPanelGrid, type PanelSpec } from "../MultiPanelGrid";
+import {
+  useCriDaily,
+  useCriIntraday,
+  type CriDailyEntry,
+  type CriIntradayPoint,
+} from "@/lib/regime/useCriSeries";
+import { useMarketHours } from "@/lib/regime/useMarketHours";
+
+type AnyRow = CriIntradayPoint | CriDailyEntry;
+
+const PANELS: PanelSpec<AnyRow>[] = [
+  {
+    key: "cri_score",
+    label: "CRI",
+    color: "var(--accent-warm, #F5A623)",
+    get: (r) => r.cri_score,
+  },
+  { key: "vix", label: "VIX", get: (r) => r.vix },
+  {
+    key: "vvix",
+    label: "VVIX",
+    color: "var(--accent-vol, #8B5CF6)",
+    get: (r) => r.vvix,
+  },
+  { key: "vix3m", label: "VIX3M", get: (r) => r.vix3m },
+  { key: "spx", label: "SPX", color: "var(--text-primary)", get: (r) => r.spx },
+  { key: "cor1m", label: "COR1M", get: (r) => r.cor1m },
+  {
+    key: "vix_vix3m_ratio",
+    label: "VIX/VIX3M",
+    fmt: (v) => v.toFixed(3),
+    get: (r) => r.vix_vix3m_ratio,
+  },
+  { key: "realized_vol", label: "RVOL 20D", get: (r) => r.realized_vol },
+  { key: "vrp", label: "VRP", get: (r) => r.vrp },
+];
+
+export default function CriSeriesGrids() {
+  const marketState = useMarketHours();
+  const { data: intraday } = useCriIntraday(marketState);
+  const { data: daily } = useCriDaily(90);
+
+  const flatRows: CriIntradayPoint[] = [];
+  const dividers: number[] = [];
+  for (const s of intraday?.sessions ?? []) {
+    if (flatRows.length > 0) dividers.push(flatRows.length);
+    flatRows.push(...(s.points ?? []));
+  }
+
+  return (
+    <>
+      <MultiPanelGrid
+        title="CRI — Intraday, last 5 sessions"
+        panels={PANELS}
+        rows={flatRows}
+        dividers={dividers}
+        testId="cri-intraday-grid"
+      />
+      <MultiPanelGrid
+        title="CRI — Daily, 90 days"
+        panels={PANELS}
+        rows={daily?.rows ?? []}
+        dividers={[]}
+        testId="cri-daily-grid"
+      />
+    </>
+  );
+}

--- a/web/components/regime/cri/CriSeriesGrids.tsx
+++ b/web/components/regime/cri/CriSeriesGrids.tsx
@@ -2,14 +2,12 @@
 
 import { MultiPanelGrid, type PanelSpec } from "../MultiPanelGrid";
 import {
-  useCriDaily,
   useCriIntraday,
-  type CriDailyEntry,
   type CriIntradayPoint,
 } from "@/lib/regime/useCriSeries";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
 
-type AnyRow = CriIntradayPoint | CriDailyEntry;
+type AnyRow = CriIntradayPoint;
 
 const PANELS: PanelSpec<AnyRow>[] = [
   {
@@ -41,7 +39,6 @@ const PANELS: PanelSpec<AnyRow>[] = [
 export default function CriSeriesGrids() {
   const marketState = useMarketHours();
   const { data: intraday } = useCriIntraday(marketState);
-  const { data: daily } = useCriDaily(90);
 
   const flatRows: CriIntradayPoint[] = [];
   const dividers: number[] = [];
@@ -50,22 +47,15 @@ export default function CriSeriesGrids() {
     flatRows.push(...(s.points ?? []));
   }
 
+  // Daily 90d series now live as sparklines inside the CRI cards above —
+  // the standalone daily grid was removed in favour of that layout.
   return (
-    <>
-      <MultiPanelGrid
-        title="CRI — Intraday, last 5 sessions"
-        panels={PANELS}
-        rows={flatRows}
-        dividers={dividers}
-        testId="cri-intraday-grid"
-      />
-      <MultiPanelGrid
-        title="CRI — Daily, 90 days"
-        panels={PANELS}
-        rows={daily?.rows ?? []}
-        dividers={[]}
-        testId="cri-daily-grid"
-      />
-    </>
+    <MultiPanelGrid
+      title="CRI — Intraday, last 5 sessions"
+      panels={PANELS}
+      rows={flatRows}
+      dividers={dividers}
+      testId="cri-intraday-grid"
+    />
   );
 }

--- a/web/components/regime/cri/CriSeriesGrids.tsx
+++ b/web/components/regime/cri/CriSeriesGrids.tsx
@@ -7,9 +7,7 @@ import {
 } from "@/lib/regime/useCriSeries";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
 
-type AnyRow = CriIntradayPoint;
-
-const PANELS: PanelSpec<AnyRow>[] = [
+const PANELS: PanelSpec<CriIntradayPoint>[] = [
   {
     key: "cri_score",
     label: "CRI",

--- a/web/components/regime/primitives/CardSparkline.tsx
+++ b/web/components/regime/primitives/CardSparkline.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  finiteDomain,
+  linearScale,
+  pathFromNullablePoints,
+} from "@/lib/svgChart";
+
+const W = 200;
+const H = 30;
+
+/**
+ * Width-filling sparkline for regime cards/tiles. The viewBox is stretched
+ * (`preserveAspectRatio="none"`) so the line always fills the card width at a
+ * fixed pixel height; `vector-effect: non-scaling-stroke` keeps the stroke
+ * crisp under the non-uniform scale.
+ */
+export default function CardSparkline({
+  values,
+  label,
+  color = "var(--accent-bg, #05AD98)",
+  height = 28,
+}: {
+  values: ReadonlyArray<number | null | undefined>;
+  label: string;
+  color?: string;
+  height?: number;
+}) {
+  const domain = finiteDomain(values);
+  if (!domain) return null;
+  const x = linearScale([0, Math.max(values.length - 1, 1)], [1, W - 1]);
+  const y = linearScale([domain.lo, domain.hi], [H - 2, 2]);
+  const d = pathFromNullablePoints(
+    values.map((v, i): [number, number] | null =>
+      v == null || !Number.isFinite(v) ? null : [x(i), y(v)],
+    ),
+  );
+  return (
+    <svg
+      role="img"
+      aria-label={label}
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{
+        width: "100%",
+        height,
+        display: "block",
+        marginTop: 6,
+        opacity: 0.9,
+      }}
+    >
+      <path
+        d={d}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.2}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/web/components/regime/primitives/CardSparkline.tsx
+++ b/web/components/regime/primitives/CardSparkline.tsx
@@ -29,7 +29,12 @@ export default function CardSparkline({
   const domain = finiteDomain(values);
   if (!domain) return null;
   const x = linearScale([0, Math.max(values.length - 1, 1)], [1, W - 1]);
-  const y = linearScale([domain.lo, domain.hi], [H - 2, 2]);
+  // A constant series has zero span — center it rather than letting
+  // linearScale pin every point to the chart floor.
+  const y =
+    domain.hi === domain.lo
+      ? () => H / 2
+      : linearScale([domain.lo, domain.hi], [H - 2, 2]);
   const d = pathFromNullablePoints(
     values.map((v, i): [number, number] | null =>
       v == null || !Number.isFinite(v) ? null : [x(i), y(v)],

--- a/web/components/regime/vcg/VcgSeriesGrids.tsx
+++ b/web/components/regime/vcg/VcgSeriesGrids.tsx
@@ -2,14 +2,12 @@
 
 import { MultiPanelGrid, type PanelSpec } from "../MultiPanelGrid";
 import {
-  useVcgDaily,
   useVcgIntraday,
-  type VcgDailyEntry,
   type VcgIntradayPoint,
 } from "@/lib/regime/useVcgSeries";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
 
-type AnyRow = VcgIntradayPoint | VcgDailyEntry;
+type AnyRow = VcgIntradayPoint;
 
 const PANELS: PanelSpec<AnyRow>[] = [
   {
@@ -61,7 +59,6 @@ const PANELS: PanelSpec<AnyRow>[] = [
 export default function VcgSeriesGrids() {
   const marketState = useMarketHours();
   const { data: intraday } = useVcgIntraday(marketState);
-  const { data: daily } = useVcgDaily(90);
 
   const flatRows: VcgIntradayPoint[] = [];
   const dividers: number[] = [];
@@ -70,22 +67,15 @@ export default function VcgSeriesGrids() {
     flatRows.push(...(s.points ?? []));
   }
 
+  // Daily 90d series now live as sparklines inside the VCG cards above —
+  // the standalone daily grid was removed in favour of that layout.
   return (
-    <>
-      <MultiPanelGrid
-        title="VCG — Intraday, last 5 sessions"
-        panels={PANELS}
-        rows={flatRows}
-        dividers={dividers}
-        testId="vcg-intraday-grid"
-      />
-      <MultiPanelGrid
-        title="VCG — Daily, 90 days"
-        panels={PANELS}
-        rows={daily?.rows ?? []}
-        dividers={[]}
-        testId="vcg-daily-grid"
-      />
-    </>
+    <MultiPanelGrid
+      title="VCG — Intraday, last 5 sessions"
+      panels={PANELS}
+      rows={flatRows}
+      dividers={dividers}
+      testId="vcg-intraday-grid"
+    />
   );
 }

--- a/web/components/regime/vcg/VcgSeriesGrids.tsx
+++ b/web/components/regime/vcg/VcgSeriesGrids.tsx
@@ -7,9 +7,7 @@ import {
 } from "@/lib/regime/useVcgSeries";
 import { useMarketHours } from "@/lib/regime/useMarketHours";
 
-type AnyRow = VcgIntradayPoint;
-
-const PANELS: PanelSpec<AnyRow>[] = [
+const PANELS: PanelSpec<VcgIntradayPoint>[] = [
   {
     key: "vcg",
     label: "VCG Z",

--- a/web/components/regime/vcg/VcgSeriesGrids.tsx
+++ b/web/components/regime/vcg/VcgSeriesGrids.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { MultiPanelGrid, type PanelSpec } from "../MultiPanelGrid";
+import {
+  useVcgDaily,
+  useVcgIntraday,
+  type VcgDailyEntry,
+  type VcgIntradayPoint,
+} from "@/lib/regime/useVcgSeries";
+import { useMarketHours } from "@/lib/regime/useMarketHours";
+
+type AnyRow = VcgIntradayPoint | VcgDailyEntry;
+
+const PANELS: PanelSpec<AnyRow>[] = [
+  {
+    key: "vcg",
+    label: "VCG Z",
+    color: "var(--accent-warm, #F5A623)",
+    fmt: (v) => v.toFixed(2),
+    get: (r) => r.vcg,
+  },
+  {
+    key: "vcg_adj",
+    label: "VCG ADJ",
+    fmt: (v) => v.toFixed(2),
+    get: (r) => r.vcg_adj,
+  },
+  {
+    key: "credit_price",
+    label: "HYG",
+    color: "var(--text-primary)",
+    get: (r) => r.credit_price,
+  },
+  {
+    key: "credit_5d_return_pct",
+    label: "CREDIT 5D %",
+    fmt: (v) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}`,
+    get: (r) => r.credit_5d_return_pct,
+  },
+  {
+    key: "residual",
+    label: "RESIDUAL",
+    fmt: (v) => v.toFixed(5),
+    get: (r) => r.residual,
+  },
+  { key: "vix", label: "VIX", get: (r) => r.vix },
+  {
+    key: "vvix",
+    label: "VVIX",
+    color: "var(--accent-vol, #8B5CF6)",
+    get: (r) => r.vvix,
+  },
+  {
+    key: "beta1",
+    label: "β1 (VVIX)",
+    fmt: (v) => v.toFixed(5),
+    get: (r) => r.beta1,
+  },
+];
+
+export default function VcgSeriesGrids() {
+  const marketState = useMarketHours();
+  const { data: intraday } = useVcgIntraday(marketState);
+  const { data: daily } = useVcgDaily(90);
+
+  const flatRows: VcgIntradayPoint[] = [];
+  const dividers: number[] = [];
+  for (const s of intraday?.sessions ?? []) {
+    if (flatRows.length > 0) dividers.push(flatRows.length);
+    flatRows.push(...(s.points ?? []));
+  }
+
+  return (
+    <>
+      <MultiPanelGrid
+        title="VCG — Intraday, last 5 sessions"
+        panels={PANELS}
+        rows={flatRows}
+        dividers={dividers}
+        testId="vcg-intraday-grid"
+      />
+      <MultiPanelGrid
+        title="VCG — Daily, 90 days"
+        panels={PANELS}
+        rows={daily?.rows ?? []}
+        dividers={[]}
+        testId="vcg-daily-grid"
+      />
+    </>
+  );
+}

--- a/web/components/regime/vcg/VcgStressHistorySection.tsx
+++ b/web/components/regime/vcg/VcgStressHistorySection.tsx
@@ -23,7 +23,7 @@ type VcgValidationResponse = components["schemas"]["VcgValidationResponse"];
 export default function VcgStressHistorySection() {
   const [data, setData] = useState<VcgValidationResponse | null>(null);
   const [err, setErr] = useState<string | null>(null);
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;

--- a/web/lib/regime/api.ts
+++ b/web/lib/regime/api.ts
@@ -19,6 +19,17 @@ export const regimeApi = {
     `${API}/api/regime/gex/intraday?ticker=${encodeURIComponent(ticker)}&sessions=${sessions}`,
   gex_scan: (ticker: string) =>
     `${API}/api/regime/gex/scan?ticker=${encodeURIComponent(ticker)}`,
+  cri_live: () => `${API}/api/regime/cri/live`,
+  cri_intraday: (sessions: number = 5) =>
+    `${API}/api/regime/cri/intraday?sessions=${sessions}`,
+  cri_history: (days: number = 90) =>
+    `${API}/api/regime/cri/history?days=${days}`,
+  vcg_live: () => `${API}/api/regime/vcg/live`,
+  vcg_intraday: (sessions: number = 5) =>
+    `${API}/api/regime/vcg/intraday?sessions=${sessions}`,
+  vcg_history: (days: number = 90) =>
+    `${API}/api/regime/vcg/history?days=${days}`,
+  quotes: () => `${API}/api/regime/quotes`,
   vol_backdrop: () => `${API}/api/regime/vol-backdrop`,
   guidance: () => `${API}/api/regime/guidance`,
   validation: () => `${API}/api/regime/validation`,

--- a/web/lib/regime/useCriLive.ts
+++ b/web/lib/regime/useCriLive.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type CriLiveResponse = components["schemas"]["CriLiveResponse"];
+export type RegimeLiveQuote = components["schemas"]["RegimeLiveQuote"];
+
+export function useCriLive(): UseSyncReturn<CriLiveResponse> {
+  return useSyncHook<CriLiveResponse>(
+    {
+      endpoint: regimeApi.cri_live(),
+      // GET recomputes off the latest WS quotes; manual Sync Now still
+      // triggers an EOD scan via /api/regime/scan.
+      postEndpoint: regimeApi.cri_scan(),
+      interval: 10_000, // live recompute off the latest WS quotes
+      hasPost: true,
+      extractTimestamp: (d) => d.scan_time || null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "POST",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useCriLive.ts
+++ b/web/lib/regime/useCriLive.ts
@@ -11,15 +11,16 @@ export function useCriLive(): UseSyncReturn<CriLiveResponse> {
   return useSyncHook<CriLiveResponse>(
     {
       endpoint: regimeApi.cri_live(),
-      // GET recomputes off the latest WS quotes; manual Sync Now still
-      // triggers an EOD scan via /api/regime/scan.
-      postEndpoint: regimeApi.cri_scan(),
-      interval: 10_000, // live recompute off the latest WS quotes
-      hasPost: true,
+      // GET-only: every poll IS a live recompute server-side. hasPost MUST
+      // stay false — with hasPost the interval would POST /api/regime/scan
+      // every 10s, persisting an EOD snapshot per tick (Codex P1). EOD
+      // scans stay worker-owned; Sync Now just refreshes the live read.
+      interval: 10_000,
+      hasPost: false,
       extractTimestamp: (d) => d.scan_time || null,
       shouldRetry: () => false,
       retryIntervalMs: 60_000,
-      retryMethod: "POST",
+      retryMethod: "GET",
     },
     true,
   );

--- a/web/lib/regime/useCriSeries.ts
+++ b/web/lib/regime/useCriSeries.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { MarketState } from "./useMarketHours";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type CriIntradayData = components["schemas"]["CriIntradayResponse"];
+export type CriIntradayPoint = components["schemas"]["CriIntradayPoint"];
+export type CriDailyData = components["schemas"]["CriDailyHistoryResponse"];
+export type CriDailyEntry = components["schemas"]["CriDailyEntry"];
+
+export function useCriIntraday(
+  marketState: MarketState | null = null,
+  sessions: number = 5,
+): UseSyncReturn<CriIntradayData> {
+  const active = marketState === MarketState.CLOSED ? false : true;
+  return useSyncHook<CriIntradayData>(
+    {
+      endpoint: regimeApi.cri_intraday(sessions),
+      interval: marketState === MarketState.EXTENDED ? 300_000 : 60_000,
+      hasPost: false,
+      extractTimestamp: (d) => d.as_of ?? null,
+      shouldRetry: () => false,
+      retryIntervalMs: 5000,
+      retryMethod: "GET",
+    },
+    active,
+  );
+}
+
+export function useCriDaily(days: number = 90): UseSyncReturn<CriDailyData> {
+  return useSyncHook<CriDailyData>(
+    {
+      endpoint: regimeApi.cri_history(days),
+      interval: 3_600_000, // daily rows only move on the hourly EOD scan
+      hasPost: false,
+      extractTimestamp: () => null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "GET",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useRegimeQuotes.ts
+++ b/web/lib/regime/useRegimeQuotes.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type RegimeQuotesResponse =
+  components["schemas"]["RegimeQuotesResponse"];
+
+const FRESH_MS = 15 * 60 * 1000;
+
+export function quoteIsFresh(quotedAt: string | null | undefined): boolean {
+  if (!quotedAt) return false;
+  return Date.now() - new Date(quotedAt).getTime() < FRESH_MS;
+}
+
+export function useRegimeQuotes(): UseSyncReturn<RegimeQuotesResponse> {
+  return useSyncHook<RegimeQuotesResponse>(
+    {
+      endpoint: regimeApi.quotes(),
+      interval: 2_500, // matches the WS flush cadence + LiveSpotsProvider
+      hasPost: false,
+      extractTimestamp: (d) => d.as_of ?? null,
+      shouldRetry: () => false,
+      retryIntervalMs: 10_000,
+      retryMethod: "GET",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useRegimeQuotes.ts
+++ b/web/lib/regime/useRegimeQuotes.ts
@@ -7,11 +7,17 @@ import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
 export type RegimeQuotesResponse =
   components["schemas"]["RegimeQuotesResponse"];
 
-const FRESH_MS = 15 * 60 * 1000;
+// Fallback when the response hasn't arrived yet — matches the backend
+// default for REGIME_LIVE_QUOTE_MAX_AGE_SECONDS. The live value comes from
+// the response's fresh_within_seconds so client and server can't drift.
+const DEFAULT_FRESH_SECONDS = 900;
 
-export function quoteIsFresh(quotedAt: string | null | undefined): boolean {
+export function quoteIsFresh(
+  quotedAt: string | null | undefined,
+  freshWithinSeconds: number = DEFAULT_FRESH_SECONDS,
+): boolean {
   if (!quotedAt) return false;
-  return Date.now() - new Date(quotedAt).getTime() < FRESH_MS;
+  return Date.now() - new Date(quotedAt).getTime() < freshWithinSeconds * 1000;
 }
 
 export function useRegimeQuotes(): UseSyncReturn<RegimeQuotesResponse> {

--- a/web/lib/regime/useVcgLive.ts
+++ b/web/lib/regime/useVcgLive.ts
@@ -10,13 +10,14 @@ export function useVcgLive(): UseSyncReturn<VcgLiveResponse> {
   return useSyncHook<VcgLiveResponse>(
     {
       endpoint: regimeApi.vcg_live(),
-      postEndpoint: regimeApi.vcg_scan(),
+      // GET-only (see useCriLive) — hasPost would persist an EOD snapshot
+      // per 10s tick via /api/regime/vcg/scan.
       interval: 10_000,
-      hasPost: true,
+      hasPost: false,
       extractTimestamp: (d) => d.scan_time || null,
       shouldRetry: () => false,
       retryIntervalMs: 60_000,
-      retryMethod: "POST",
+      retryMethod: "GET",
     },
     true,
   );

--- a/web/lib/regime/useVcgLive.ts
+++ b/web/lib/regime/useVcgLive.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type VcgLiveResponse = components["schemas"]["VcgLiveResponse"];
+
+export function useVcgLive(): UseSyncReturn<VcgLiveResponse> {
+  return useSyncHook<VcgLiveResponse>(
+    {
+      endpoint: regimeApi.vcg_live(),
+      postEndpoint: regimeApi.vcg_scan(),
+      interval: 10_000,
+      hasPost: true,
+      extractTimestamp: (d) => d.scan_time || null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "POST",
+    },
+    true,
+  );
+}

--- a/web/lib/regime/useVcgSeries.ts
+++ b/web/lib/regime/useVcgSeries.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import type { components } from "../types";
+import { regimeApi } from "./api";
+import { MarketState } from "./useMarketHours";
+import { useSyncHook, type UseSyncReturn } from "./useSyncHook";
+
+export type VcgIntradayData = components["schemas"]["VcgIntradayResponse"];
+export type VcgIntradayPoint = components["schemas"]["VcgIntradayPoint"];
+export type VcgDailyData = components["schemas"]["VcgDailyHistoryResponse"];
+export type VcgDailyEntry = components["schemas"]["VcgDailyEntry"];
+
+export function useVcgIntraday(
+  marketState: MarketState | null = null,
+  sessions: number = 5,
+): UseSyncReturn<VcgIntradayData> {
+  const active = marketState === MarketState.CLOSED ? false : true;
+  return useSyncHook<VcgIntradayData>(
+    {
+      endpoint: regimeApi.vcg_intraday(sessions),
+      interval: marketState === MarketState.EXTENDED ? 300_000 : 60_000,
+      hasPost: false,
+      extractTimestamp: (d) => d.as_of ?? null,
+      shouldRetry: () => false,
+      retryIntervalMs: 5000,
+      retryMethod: "GET",
+    },
+    active,
+  );
+}
+
+export function useVcgDaily(days: number = 90): UseSyncReturn<VcgDailyData> {
+  return useSyncHook<VcgDailyData>(
+    {
+      endpoint: regimeApi.vcg_history(days),
+      interval: 3_600_000,
+      hasPost: false,
+      extractTimestamp: () => null,
+      shouldRetry: () => false,
+      retryIntervalMs: 60_000,
+      retryMethod: "GET",
+    },
+    true,
+  );
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4507,6 +4507,11 @@ export interface components {
             active_source?: string | null;
             /** As Of */
             as_of?: string | null;
+            /**
+             * Fresh Within Seconds
+             * @default 900
+             */
+            fresh_within_seconds: number;
         };
         /** RescanAllRequest */
         RescanAllRequest: {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -730,6 +730,130 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/regime/cri/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cri Live
+         * @description Request-time CRI with live quotes spliced as today's provisional
+         *     close. Does NOT persist (the 5-min regime_live_scan job owns writes).
+         *     Falls back to the latest basis='eod' snapshot when quotes are stale.
+         */
+        get: operations["get_cri_live_api_regime_cri_live_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/cri/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cri Intraday */
+        get: operations["get_cri_intraday_api_regime_cri_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/cri/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cri History */
+        get: operations["get_cri_history_api_regime_cri_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg Live */
+        get: operations["get_vcg_live_api_regime_vcg_live_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg Intraday */
+        get: operations["get_vcg_intraday_api_regime_vcg_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg History */
+        get: operations["get_vcg_history_api_regime_vcg_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/quotes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime Quotes */
+        get: operations["get_regime_quotes_api_regime_quotes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/regime/dealer": {
         parameters: {
             query?: never;
@@ -1668,6 +1792,41 @@ export interface components {
              */
             momentum: number;
         };
+        /** CriDailyEntry */
+        CriDailyEntry: {
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Cri Score */
+            cri_score?: number | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Spx */
+            spx?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+        };
+        /** CriDailyHistoryResponse */
+        CriDailyHistoryResponse: {
+            /** Rows */
+            rows?: components["schemas"]["CriDailyEntry"][];
+        };
         /** CriHistoryEntry */
         CriHistoryEntry: {
             /** Date */
@@ -1692,6 +1851,134 @@ export interface components {
             cor1m_5d_change?: number | null;
             /** Pullback 20D Pct */
             pullback_20d_pct?: number | null;
+        };
+        /** CriIntradayPoint */
+        CriIntradayPoint: {
+            /**
+             * Ts
+             * Format: date-time
+             */
+            ts: string;
+            /** Cri Score */
+            cri_score?: number | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Spx */
+            spx?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+        };
+        /** CriIntradayResponse */
+        CriIntradayResponse: {
+            /** Sessions */
+            sessions?: components["schemas"]["CriIntradaySession"][];
+            /** As Of */
+            as_of?: string | null;
+        };
+        /** CriIntradaySession */
+        CriIntradaySession: {
+            /**
+             * Et Date
+             * Format: date
+             */
+            et_date: string;
+            /** Points */
+            points?: components["schemas"]["CriIntradayPoint"][];
+        };
+        /**
+         * CriLiveResponse
+         * @description CRI computed at request time with live quotes spliced as today's
+         *     provisional close. ``basis='eod'`` means the live compute wasn't
+         *     possible (stale/no quotes) and the latest persisted EOD snapshot is
+         *     being served instead.
+         */
+        CriLiveResponse: {
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Date */
+            date?: string | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Vix 5D Roc */
+            vix_5d_roc?: number | null;
+            /** Vvix 5D Roc */
+            vvix_5d_roc?: number | null;
+            /** Vvix Vix Ratio */
+            vvix_vix_ratio?: number | null;
+            /** Spx 100D Ma */
+            spx_100d_ma?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
+            /** Vix Delta 3D */
+            vix_delta_3d?: number | null;
+            /** Spx Source */
+            spx_source?: ("SPX" | "SPY") | null;
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Spy Closes */
+            spy_closes?: number[];
+            /**
+             * Basis
+             * @default eod
+             * @enum {string}
+             */
+            basis: "live" | "eod";
+            /** Live Quotes */
+            live_quotes?: {
+                [key: string]: components["schemas"]["RegimeLiveQuote"];
+            };
+            /** Carried Forward */
+            carried_forward?: string[];
+            /** Active Source */
+            active_source?: string | null;
         };
         /**
          * CriResponse
@@ -4152,6 +4439,21 @@ export interface components {
             /** Ok */
             ok: boolean;
         };
+        /**
+         * RegimeLiveQuote
+         * @description One live WS quote echoed by the live endpoints / quotes strip.
+         */
+        RegimeLiveQuote: {
+            /** Price */
+            price: number;
+            /**
+             * Quoted At
+             * Format: date-time
+             */
+            quoted_at: string;
+            /** Source */
+            source?: string | null;
+        };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
             /**
@@ -4191,6 +4493,20 @@ export interface components {
             rvol_pctile?: string | null;
             /** Spy Corr 21 */
             spy_corr_21?: string | null;
+        };
+        /**
+         * RegimeQuotesResponse
+         * @description Lightweight live-quote projection for the regime header strip.
+         */
+        RegimeQuotesResponse: {
+            /** Quotes */
+            quotes?: {
+                [key: string]: components["schemas"]["RegimeLiveQuote"];
+            };
+            /** Active Source */
+            active_source?: string | null;
+            /** As Of */
+            as_of?: string | null;
         };
         /** RescanAllRequest */
         RescanAllRequest: {
@@ -5894,6 +6210,42 @@ export interface components {
              */
             model_implied: number;
         };
+        /** VcgDailyEntry */
+        VcgDailyEntry: {
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /** Residual */
+            residual?: number | null;
+            /** Credit Price */
+            credit_price?: number | null;
+            /** Credit 5D Return Pct */
+            credit_5d_return_pct?: number | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Beta1 */
+            beta1?: number | null;
+            /** Beta2 */
+            beta2?: number | null;
+        };
+        /** VcgDailyHistoryResponse */
+        VcgDailyHistoryResponse: {
+            /**
+             * Credit Proxy
+             * @default HYG
+             */
+            credit_proxy: string;
+            /** Rows */
+            rows?: components["schemas"]["VcgDailyEntry"][];
+        };
         /** VcgHistoryEntry */
         VcgHistoryEntry: {
             /** Date */
@@ -5949,6 +6301,92 @@ export interface components {
             n: number;
             /** Pct */
             pct: number;
+        };
+        /** VcgIntradayPoint */
+        VcgIntradayPoint: {
+            /**
+             * Ts
+             * Format: date-time
+             */
+            ts: string;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /** Residual */
+            residual?: number | null;
+            /** Credit Price */
+            credit_price?: number | null;
+            /** Credit 5D Return Pct */
+            credit_5d_return_pct?: number | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Beta1 */
+            beta1?: number | null;
+            /** Beta2 */
+            beta2?: number | null;
+        };
+        /** VcgIntradayResponse */
+        VcgIntradayResponse: {
+            /**
+             * Credit Proxy
+             * @default HYG
+             */
+            credit_proxy: string;
+            /** Sessions */
+            sessions?: components["schemas"]["VcgIntradaySession"][];
+            /** As Of */
+            as_of?: string | null;
+        };
+        /** VcgIntradaySession */
+        VcgIntradaySession: {
+            /**
+             * Et Date
+             * Format: date
+             */
+            et_date: string;
+            /** Points */
+            points?: components["schemas"]["VcgIntradayPoint"][];
+        };
+        /** VcgLiveResponse */
+        VcgLiveResponse: {
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Date */
+            date?: string | null;
+            /**
+             * Credit Proxy
+             * @default HYG
+             */
+            credit_proxy: string;
+            signal?: components["schemas"]["VcgSignal"];
+            /** History */
+            history?: components["schemas"]["VcgHistoryEntry"][];
+            /**
+             * Basis
+             * @default eod
+             * @enum {string}
+             */
+            basis: "live" | "eod";
+            /** Live Quotes */
+            live_quotes?: {
+                [key: string]: components["schemas"]["RegimeLiveQuote"];
+            };
+            /** Carried Forward */
+            carried_forward?: string[];
+            /** Active Source */
+            active_source?: string | null;
         };
         /** VcgNamedCrashEvent */
         VcgNamedCrashEvent: {
@@ -7828,6 +8266,205 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cri_live_api_regime_cri_live_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriLiveResponse"];
+                };
+            };
+        };
+    };
+    get_cri_intraday_api_regime_cri_intraday_get: {
+        parameters: {
+            query?: {
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriIntradayResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cri_history_api_regime_cri_history_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriDailyHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_live_api_regime_vcg_live_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgLiveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_intraday_api_regime_vcg_intraday_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgIntradayResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_history_api_regime_vcg_history_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgDailyHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_regime_quotes_api_regime_quotes_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimeQuotesResponse"];
                 };
             };
         };

--- a/web/tests/unit/CardSparkline.test.tsx
+++ b/web/tests/unit/CardSparkline.test.tsx
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CardSparkline from "@/components/regime/primitives/CardSparkline";
+
+describe("CardSparkline", () => {
+  it("renders an svg path for a finite series", () => {
+    const { container } = render(
+      <CardSparkline values={[1, 2, 3, 2.5]} label="test series" />,
+    );
+    const path = container.querySelector("svg path");
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute("d")).toMatch(/^M/);
+  });
+
+  it("breaks the path at null gaps instead of interpolating", () => {
+    const { container } = render(
+      <CardSparkline values={[1, 2, null, 4, 5]} label="gappy series" />,
+    );
+    const d = container.querySelector("svg path")!.getAttribute("d")!;
+    // Two sub-paths → two M commands.
+    expect(d.match(/M/g)?.length).toBe(2);
+  });
+
+  it("centers a constant series instead of pinning it to the floor", () => {
+    const { container } = render(
+      <CardSparkline values={[5, 5, 5]} label="flat series" />,
+    );
+    const d = container.querySelector("svg path")!.getAttribute("d")!;
+    // All y coordinates sit at mid-height (H/2 = 15), not the floor (28).
+    const ys = [...d.matchAll(/[ML][\d.]+,([\d.]+)/g)].map((m) =>
+      parseFloat(m[1]),
+    );
+    expect(ys.length).toBeGreaterThan(0);
+    for (const y of ys) expect(y).toBe(15);
+  });
+
+  it("renders nothing with fewer than 2 finite points", () => {
+    const { container } = render(
+      <CardSparkline values={[null, 7, null]} label="sparse" />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders nothing for an empty series", () => {
+    const { container } = render(<CardSparkline values={[]} label="empty" />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/web/tests/unit/CriSubTab.test.tsx
+++ b/web/tests/unit/CriSubTab.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 import { CriSubTabView } from "@/components/regime/CriSubTab";
@@ -176,12 +176,14 @@ describe("CriSubTabView", () => {
     ).not.toBeNull();
   });
 
-  it("renders the sortable history table beneath the charts", () => {
+  it("renders the history table folded by default, expandable via toggle", () => {
     render(<CriSubTabView data={POPULATED} />);
+    // Folded by default — only the toggle is visible.
+    expect(screen.queryByTestId("cri-history-table")).toBeNull();
+    const toggle = screen.getByTestId("cri-history-table-toggle");
+    fireEvent.click(toggle);
     const table = screen.getByTestId("cri-history-table");
-    expect(table).not.toBeNull();
     // Header row + 2 data rows from POPULATED.history
     expect(table.querySelectorAll("tbody tr").length).toBe(2);
-    expect(screen.getByTestId("cri-history-table-toggle")).not.toBeNull();
   });
 });

--- a/web/tests/unit/CriSubTab.test.tsx
+++ b/web/tests/unit/CriSubTab.test.tsx
@@ -3,10 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 import { CriSubTabView } from "@/components/regime/CriSubTab";
-import type { CriResponse } from "@/lib/regime/useCri";
+import type { CriLiveResponse } from "@/lib/regime/useCriLive";
 
-const POPULATED: CriResponse = {
+const POPULATED: CriLiveResponse = {
   status: "ok",
+  basis: "eod",
   scan_time: "2026-05-15T20:30:00+00:00",
   date: "2026-05-15",
   vix: 18.43,
@@ -68,7 +69,7 @@ const POPULATED: CriResponse = {
   spy_closes: [],
 };
 
-const FIRED_TRIGGER: CriResponse = {
+const FIRED_TRIGGER: CriLiveResponse = {
   ...POPULATED,
   cri: {
     score: 82.0,

--- a/web/tests/unit/GexLiveProfile.test.tsx
+++ b/web/tests/unit/GexLiveProfile.test.tsx
@@ -1,0 +1,72 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it } from "vitest";
+
+import { retagProfileForSpot } from "@/components/regime/GexSubTab";
+import type { GexBucket } from "@/lib/regime/useGex";
+
+function bucket(
+  strike: number,
+  tag: string | null = null,
+  net_gex = 1000,
+): GexBucket {
+  return { strike, call_gex: 0, put_gex: 0, net_gex, pct_from_spot: 0, tag };
+}
+
+function level(strike: number) {
+  return { strike, gamma: 1, distance: 0, distance_pct: 0 };
+}
+
+describe("retagProfileForSpot", () => {
+  const profile = [
+    bucket(7500, "MAX MAGNET"),
+    bucket(7425, "GEX FLIP"),
+    bucket(7400, "SPOT"),
+    bucket(7375),
+    bucket(7200, "MAX ACCELERATOR"),
+  ];
+  const levels = {
+    gex_flip: level(7425),
+    max_magnet: level(7500),
+    second_magnet: null,
+    max_accelerator: level(7200),
+    put_wall: null,
+    call_wall: null,
+  };
+
+  it("moves the SPOT tag to the strike nearest the live spot", () => {
+    const out = retagProfileForSpot(profile, 7380, levels);
+    expect(out.find((b) => b.tag === "SPOT")?.strike).toBe(7375);
+    // The stale snapshot SPOT row is cleared.
+    expect(out.find((b) => b.strike === 7400)?.tag).toBeNull();
+  });
+
+  it("keeps GEX FLIP precedence when spot sits on the flip strike", () => {
+    const out = retagProfileForSpot(profile, 7424, levels);
+    // Backend tag_profile: flip overwrites SPOT on the same strike.
+    expect(out.find((b) => b.strike === 7425)?.tag).toBe("GEX FLIP");
+    expect(out.some((b) => b.tag === "SPOT")).toBe(false);
+  });
+
+  it("recomputes pct_from_spot against the live spot", () => {
+    const out = retagProfileForSpot(profile, 7400, levels);
+    const b = out.find((x) => x.strike === 7500)!;
+    expect(b.pct_from_spot).toBeCloseTo(((7500 - 7400) / 7400) * 100, 6);
+  });
+
+  it("re-surfaces a level tag suppressed by the snapshot SPOT placement", () => {
+    // Snapshot had SPOT on 7400 suppressing nothing here, but if SPOT moves
+    // off a level strike, the level label must come back.
+    const withSpotOnLevel = [
+      bucket(7500, "SPOT"), // snapshot spot sat on the magnet strike
+      bucket(7425, "GEX FLIP"),
+      bucket(7375),
+    ];
+    const out = retagProfileForSpot(withSpotOnLevel, 7376, levels);
+    expect(out.find((b) => b.strike === 7500)?.tag).toBe("MAX MAGNET");
+    expect(out.find((b) => b.strike === 7375)?.tag).toBe("SPOT");
+  });
+
+  it("returns the input untouched when the profile is empty", () => {
+    expect(retagProfileForSpot([], 7400, levels)).toEqual([]);
+  });
+});

--- a/web/tests/unit/MultiPanelGrid.test.tsx
+++ b/web/tests/unit/MultiPanelGrid.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  MultiPanelGrid,
+  type PanelSpec,
+} from "@/components/regime/MultiPanelGrid";
+
+type Row = { a: number | null; b: number | null };
+
+const panels: PanelSpec<Row>[] = [
+  { key: "a", label: "ALPHA", get: (r) => r.a },
+  { key: "b", label: "BETA", get: (r) => r.b },
+];
+
+const rows: Row[] = [
+  { a: 1, b: 10 },
+  { a: 2, b: null },
+  { a: 3, b: 12 },
+  { a: 4, b: 13 },
+];
+
+describe("MultiPanelGrid", () => {
+  it("renders one mini chart per panel with latest value", () => {
+    render(
+      <MultiPanelGrid
+        title="INTRADAY — TEST"
+        panels={panels}
+        rows={rows}
+        dividers={[2]}
+        testId="grid-test"
+      />,
+    );
+    expect(screen.getByTestId("grid-test")).toBeTruthy();
+    expect(screen.getByText("ALPHA")).toBeTruthy();
+    expect(screen.getByText("BETA")).toBeTruthy();
+    expect(screen.getByText("4.00")).toBeTruthy(); // latest of series a
+    expect(screen.getByText("13.00")).toBeTruthy(); // latest non-null of b
+  });
+
+  it("renders empty state when no rows", () => {
+    render(
+      <MultiPanelGrid
+        title="DAILY — TEST"
+        panels={panels}
+        rows={[]}
+        dividers={[]}
+        testId="grid-empty"
+      />,
+    );
+    expect(screen.getByTestId("grid-empty-empty")).toBeTruthy();
+  });
+});

--- a/web/tests/unit/VcgSubTab.test.tsx
+++ b/web/tests/unit/VcgSubTab.test.tsx
@@ -3,10 +3,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { VcgSubTabView } from "@/components/regime/VcgSubTab";
-import type { VcgResponse } from "@/lib/regime/useVcg";
+import type { VcgLiveResponse } from "@/lib/regime/useVcgLive";
 
-const NORMAL: VcgResponse = {
+const NORMAL: VcgLiveResponse = {
   status: "ok",
+  basis: "eod",
   scan_time: "2026-05-15T20:30:00+00:00",
   date: "2026-05-15",
   credit_proxy: "HYG",
@@ -73,7 +74,7 @@ const NORMAL: VcgResponse = {
   ],
 };
 
-const RISK_OFF: VcgResponse = {
+const RISK_OFF: VcgLiveResponse = {
   ...NORMAL,
   signal: {
     ...NORMAL.signal!,
@@ -95,7 +96,7 @@ const RISK_OFF: VcgResponse = {
   },
 };
 
-const BOUNCE: VcgResponse = {
+const BOUNCE: VcgLiveResponse = {
   ...NORMAL,
   signal: {
     ...NORMAL.signal!,
@@ -108,7 +109,7 @@ const BOUNCE: VcgResponse = {
   },
 };
 
-const PANIC_ADJUSTED: VcgResponse = {
+const PANIC_ADJUSTED: VcgLiveResponse = {
   ...NORMAL,
   signal: {
     ...NORMAL.signal!,
@@ -127,7 +128,7 @@ describe("VcgSubTabView", () => {
   });
 
   it("renders empty placeholder when status is empty", () => {
-    const empty: VcgResponse = {
+    const empty: VcgLiveResponse = {
       ...NORMAL,
       status: "empty",
       signal: { ...NORMAL.signal!, vcg: null },

--- a/web/tests/unit/VcgSubTab.test.tsx
+++ b/web/tests/unit/VcgSubTab.test.tsx
@@ -194,10 +194,12 @@ describe("VcgSubTabView", () => {
     expect(screen.getByTestId("vcg-attr-vix-bar")).not.toBeNull();
   });
 
-  it("renders the sortable history table with header + data rows", () => {
+  it("renders the history table folded by default, expandable via toggle", () => {
     render(<VcgSubTabView data={NORMAL} />);
+    // Folded by default — only the toggle is visible.
+    expect(screen.queryByTestId("vcg-history-table")).toBeNull();
+    fireEvent.click(screen.getByTestId("vcg-history-toggle"));
     const table = screen.getByTestId("vcg-history-table");
-    expect(table).not.toBeNull();
     // 2 data rows from NORMAL.history
     expect(table.querySelectorAll("tbody tr").length).toBe(2);
     // 9 columns
@@ -206,6 +208,7 @@ describe("VcgSubTabView", () => {
 
   it("sorts the history table when a header is clicked", () => {
     render(<VcgSubTabView data={NORMAL} />);
+    fireEvent.click(screen.getByTestId("vcg-history-toggle"));
     const table = screen.getByTestId("vcg-history-table");
     const vcgHeader = Array.from(table.querySelectorAll("thead th")).find(
       (th) => (th.textContent ?? "").startsWith("VCG"),

--- a/web/tests/unit/volBackdropStrip.test.tsx
+++ b/web/tests/unit/volBackdropStrip.test.tsx
@@ -30,7 +30,7 @@ const sample = {
 
 describe("VolBackdropStripView", () => {
   it("renders all four tiles", () => {
-    render(<VolBackdropStripView data={sample} />);
+    render(<VolBackdropStripView data={sample} quotes={null} />);
     expect(screen.getByText("VIX")).toBeTruthy();
     expect(screen.getByText("VIX3M")).toBeTruthy();
     expect(screen.getByText("VVIX")).toBeTruthy();
@@ -38,12 +38,12 @@ describe("VolBackdropStripView", () => {
   });
 
   it("shows term-structure state badge", () => {
-    render(<VolBackdropStripView data={sample} />);
+    render(<VolBackdropStripView data={sample} quotes={null} />);
     expect(screen.getByText(/contango/i)).toBeTruthy();
   });
 
   it("renders nothing when data is null", () => {
-    const { container } = render(<VolBackdropStripView data={null} />);
+    const { container } = render(<VolBackdropStripView data={null} quotes={null} />);
     expect(container.firstChild).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- WS consumer always-subscribes `REGIME_WS_SYMBOLS` (VIX/VVIX/VIX3M/COR1M/SPX/HYG) beyond the watchlist
- `cri.run_live` / `vcg.run_live` splice live quotes as today's provisional close (carry-forward for quiet symbols, VIX3M included)
- 5-min `regime_live_scan` persists slim `basis='live'` rows into cri/vcg_snapshots; hourly scans stay `basis='eod'`; registration pinned to massive-0 (single writer)
- New endpoints: `/api/regime/{cri,vcg}/{live,intraday,history}` + `/api/regime/quotes` (incl. `fresh_within_seconds` so client freshness can't drift from the server window)
- Web: `LIVE · XENON` badges, 10s GET-only live polling, 2.5s header-strip quotes with live term structure, intraday/daily small-multiples grids (`MultiPanelGrid`)
- Nightly live-vs-lake close validation (03:40 ET, WARN > 0.5%), reading both snapshot tables
- Migration 070: `basis` column + chart generated columns on both snapshot tables (idempotent, verified by double-run)

## Review gate (tribunal: Codex + Gemini + Claude)
- **Fixed:** GET-only live polling (Codex P1 — `hasPost` would have POSTed an EOD scan every 10 s); single live-scan owner (Claude — `_is_primary_worker` matches index-0 of every role); configured credit proxy in the live job (Codex); validation reads vcg_snapshots too (Codex); VIX3M carry-forward (Claude); `fresh_within_seconds` contract (Codex+Claude)
- **Accepted tradeoff (documented in `vcg.run_live` docstring):** on a credit-ETF ex-div date the spliced raw last-price shows the distribution as a one-session credit return blip; self-heals when the lake re-adjusts overnight
- **Dismissed:** Gemini's `priorComponentScore` duplication (pre-existing, unchanged code) and `beta1_vvix→beta1` aliasing (intentional naming contract, weight 0.5)

## Verification (live, 2026-06-12 ~02:30 ET against the mini's xenon WS)
- All six regime symbols subscribed; VIX/VVIX/COR1M/SPX/HYG produced `intraday_quote` rows with `source='xenon_ws'` (VIX3M quiet pre-open → carry-forward path exercised)
- One real `regime_live_scan` tick persisted `basis='live'` CRI (score 16.8, session 2026-06-12) + VCG (2.856, HYG) rows alongside untouched EOD rows
- `/api/regime/cri/live` returned `basis='live'`, spliced values, `active_source='xenon_ws'`; intraday/history/quotes endpoints verified
- Browser: hero badge `LIVE · XENON`, daily 9-panel grid rendering (screenshots under `output/playwright/regime-live-{cri,vcg}.png`)
- `uv run pytest`: 1670 passed, 13 skipped; vitest 391 passed; typecheck + lint clean; migration double-run no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)