### PR TITLE
feat(skew): Phase-2 increment-1 — strike-by-delta structure + RR-reversion store + index ETFs

### DIFF
--- a/docs/research/skew-mean-reversion-trade-structures-phase2.md
+++ b/docs/research/skew-mean-reversion-trade-structures-phase2.md
@@ -25,10 +25,17 @@ evidence-gated `directional_lean` is *already* non-neutral (`BEARISH_TILT` / `BU
   `deviation × tail` posture alone — see correction (A) below.
 - Defined-risk only; no naked legs; **no stock-assuming overlays** (no collar) — see (C).
 - Non-index only; hard earnings block; deterministic; **persisted** to Postgres.
-- Strikes by target delta are sourced by **joining the existing per-strike greeks store**
-  (`models/greeks.py` `GreekExposureRow.call_delta/put_delta`, table `greek_exposure_daily`,
-  migration 039). No Black-Scholes recompute, no new feed. The ~30-trading-day greeks
-  history limit is irrelevant here — proposal generation needs only *current* greeks.
+- Strikes by target delta are sourced from a dedicated **`skew_swing_greeks`** table
+  (migration 075) fed by a daily UW job (`worker/jobs/skew_swing_greeks.py`). **Real-data
+  finding (2026-06-16):** the existing per-strike greek stores (`exposures_by_expiry_strike`,
+  `greeks_by_expiry_strike`) hold **front-expiry-only** greeks for single-names (only
+  indices get multi-expiry via the cockpit), so the original "join the existing store" plan
+  returned `no_chain` for every eligible ticker. The new job pulls a ~30/45 DTE expiry per
+  single-name via UW **`/greeks`** (real per-contract option delta in [-1, 1] — NOT
+  `/greek-exposure`, whose `call_delta` is delta *exposure*, ≈0 for low-OI strikes and
+  unusable for target-delta selection). No Black-Scholes recompute. When no swing chain is
+  available the detail degrades gracefully to `no_chain` (the `express` family string still
+  shows; no naked/invalid legs are ever emitted).
 - The read body stays bound by spec §7/§11: stock direction lives only in `directional_lean`.
   We add detail to a field that is *already* gated, so we do not create a second
   recommendation surface (resolves the Codex "two competing surfaces" finding).

--- a/docs/research/skew-mean-reversion-trade-structures-phase2.md
+++ b/docs/research/skew-mean-reversion-trade-structures-phase2.md
@@ -24,7 +24,8 @@ evidence-gated `directional_lean` is *already* non-neutral (`BEARISH_TILT` / `BU
 - Structure selection follows the gated `lean` (V1's `_express_structure`), **never**
   `deviation × tail` posture alone — see correction (A) below.
 - Defined-risk only; no naked legs; **no stock-assuming overlays** (no collar) — see (C).
-- Non-index only; hard earnings block; deterministic; **persisted** to Postgres.
+- Single-names **and index ETFs** (index ETFs added post-ship — see *Post-ship updates*
+  below; originally scoped non-index); hard earnings block; deterministic; **persisted** to Postgres.
 - Strikes by target delta are sourced from a dedicated **`skew_swing_greeks`** table
   (migration 075) fed by a daily UW job (`worker/jobs/skew_swing_greeks.py`). **Real-data
   finding (2026-06-16):** the existing per-strike greek stores (`exposures_by_expiry_strike`,
@@ -80,6 +81,41 @@ un-persisted. Increment 1 turns it into a trigger:
   an effective naked short. Defined-risk, position-agnostic structures only.
 - **(D) Horizon:** phrase the product on the repo's swing semantics (1–2 week HOLD, 21–60
   DTE entry, exit before earnings), not "28–45 DTE matches T+20" — swing-HOLD ≠ swing-EXPIRY.
+
+### Post-ship updates (2026-06-16) — shipped in PR #137
+
+Increment-1 landed on `feat/skew-phase2` (8 commits, PR #137). Two changes were made *after*
+the hardening review above and are authoritative over the "non-index only" constraint and the
+basis layout described earlier.
+
+**Index ETFs now get the structure block (reverses "non-index only").** The original exclusion
+was a *product* call ("indices already get cockpit chains"), not an empirical one. `index_macro`
+is handled in three independent layers, and the reason it was treated differently varies by
+layer — this is the reference for "why isn't index here?":
+
+| Layer | index_macro? | Reason |
+|---|---|---|
+| Directional-lean verdict (produces the lean) | **included** | Research-validated — e.g. QQQ `TRADABLE_BEAR` from the `index_macro / NORMAL / STRUCTURAL / HIGH_VOL` bucket, n=181. |
+| RV mean-reversion **trigger** (1b) | **skipped** | Empirical — index skew is structural hedging demand; ΔRR ≈ +0.001, does **not** revert (this doc's markout table, "index" row). |
+| Strike-by-delta **structure block** (1a) | **now included** | Was excluded for cockpit-redundancy (a product call), not because the edge is absent. Since the lean is already research-validated, index ETFs now earn the same defined-risk expression as single-names. |
+
+- The `asset_class != "index_macro"` guard was dropped in `build_skew_snapshot_row`
+  (`reports/skew_analytics.py`); the `index_macro` skip was removed from
+  `worker/jobs/skew_swing_greeks.py`. Every watchlist `index_macro` ticker is an optionable
+  ETF — **DIA, GLD, IWM, QQQ, SLV, SPY, TLT** — and UW `/greeks` works on all of them. A future
+  true cash index (SPX/VIX) degrades gracefully to `no_chain` via the per-ticker try/except.
+- Verified live: QQQ → `PUT-DEBIT-SPREAD · 31DTE` (BUY PUT 709 Δ−0.25 / SELL PUT 674 Δ−0.12);
+  AMD (single-name) still `call_debit_spread`; NVDA (NEUTRAL) shows none. The genuine swing job
+  populated **13,368 rows / 98 tickers** via the real worker path.
+
+**EVIDENCE-panel polish.** In the Signal Detail card the leading `validated` status is lifted
+out of the basis prose into a right-aligned badge on the confidence row, and the gated-lean
+reason is split into two lines at its semicolon. NEUTRAL bases (plain reason strings, some
+containing " — ") are left intact — the badge triggers only on the literal `validated — ` prefix
+(`web/components/stock/panels/SkewSignalDetail.tsx`).
+
+**Migrations:** 074 (`skew_rv_reversion_verdicts`) + 075 (`skew_swing_greeks`), both idempotent.
+**Verification:** 63 skew backend tests, 417 web vitest, `ruff` / `eslint` / `tsc` clean, 0 console errors.
 
 ## The core reframe
 

--- a/docs/research/skew-mean-reversion-trade-structures-phase2.md
+++ b/docs/research/skew-mean-reversion-trade-structures-phase2.md
@@ -1,10 +1,78 @@
 # Skew Mean-Reversion → Trade Structures (Phase 2)
 
 **Date:** 2026-06-15
-**Status:** Phase-2 design notes — deferred. Captures the trade-idea discussion built on
-the V1 Tier-1 markout (`docs/research/skew-first-principles-markout-2026-06.md`). Not yet
-implemented; this is the operational target for turning the RR mean-reversion finding
-into surfaced, defined-risk structures.
+**Status:** Phase-2 design notes. Captures the trade-idea discussion built on
+the V1 Tier-1 markout (`docs/research/skew-first-principles-markout-2026-06.md`).
+**Hardened 2026-06-16** after a Codex (gpt-5.4) + Gemini + Claude design-review tribunal —
+the `## Hardening review` section below is authoritative over anything later that conflicts.
+
+## Hardening review (2026-06-16) — codex + gemini + claude tribunal
+
+A 3-reviewer design review ran before any plan was written. The bucket arithmetic in this
+note is faithful to the markout; the problems were *inferences and scope*. The corrections
+below are authoritative; sections later in this doc that conflict are explicitly superseded.
+
+### Increment 1 — the only thing built first (scope: "concretize the gated read + RR-trigger research")
+
+Two coupled workstreams, no new live-data dependency:
+
+**1a. Concretize the already-gated read (UI + backend + persistence).** When V1's
+evidence-gated `directional_lean` is *already* non-neutral (`BEARISH_TILT` / `BULLISH_TILT`
+— i.e. it already passed the borrow / earnings / regime gates), enrich the existing bounded
+`express` string with concrete **strike-by-delta legs** + a suggested **DTE**. Constraints:
+
+- Structure selection follows the gated `lean` (V1's `_express_structure`), **never**
+  `deviation × tail` posture alone — see correction (A) below.
+- Defined-risk only; no naked legs; **no stock-assuming overlays** (no collar) — see (C).
+- Non-index only; hard earnings block; deterministic; **persisted** to Postgres.
+- Strikes by target delta are sourced by **joining the existing per-strike greeks store**
+  (`models/greeks.py` `GreekExposureRow.call_delta/put_delta`, table `greek_exposure_daily`,
+  migration 039). No Black-Scholes recompute, no new feed. The ~30-trading-day greeks
+  history limit is irrelevant here — proposal generation needs only *current* greeks.
+- The read body stays bound by spec §7/§11: stock direction lives only in `directional_lean`.
+  We add detail to a field that is *already* gated, so we do not create a second
+  recommendation surface (resolves the Codex "two competing surfaces" finding).
+
+**1b. RR-as-tradeable-trigger research.** Today `run_skew_markout` computes the RV
+mean-reversion (ΔRR, primary hypothesis) only as a *descriptive* return value — un-gated,
+un-persisted. Increment 1 turns it into a trigger:
+
+- **Gate ΔRR into a persisted verdict store** (alongside the existing
+  `skew_directional_verdicts`), with the same per-time-window catastrophic-degradation gate.
+- **Re-run the markout split by `tail`** (put-skew vs call-skew). The big CHEAP ΔRR number
+  is partly extreme *call*-skew names (e.g. ALAB rr=−0.22), so a put-skew-specific edge may
+  not be claimed until the split confirms it.
+- **Walk-forward / holdout on the RR history only.** This is the *only* out-of-sample test
+  the data supports (RR history ≈ 1 year). **No spread-P&L, no net-of-cost claim** —
+  executable option-return replay is data-blocked (see (B)) and is split out.
+
+### Split out — separate later plans, NOT increment 1
+
+- **Net-of-cost / OOS trade-P&L validation.** BLOCKED on data: `option_chain_per_strike` is
+  ~5 trading days deep and UW per-strike greeks history is ~30 days; only RR history is ~1yr.
+  Executable spread-P&L replay needs a separate contract-history data project first.
+- **Delta-hedge sizing helper (Structure 3).** Needs live net-delta + a re-hedge policy the
+  tab does not have. Defer.
+- **Layer-2 cross-pillar gate.** Belongs in the **backend** trade-blast AI pipeline that
+  produces the `framework{}` object — **not** in `FrameworkTab.tsx`, which is a pure client
+  renderer. Separate plan; depends on tape/catalyst/gamma/IV inputs not wired to skew.
+
+### Corrections to the sections below (authoritative)
+
+- **(A) The "Layer 1 — skew-implied bias" `deviation × tail` table is SUPERSEDED.** It
+  re-introduces the exact naive map this doc itself calls "empirically wrong" (it ignores
+  `drive`, which flips the sign: CHEAP/CHASE is `TRADABLE_BULL`, CHEAP/PANIC is
+  `TRADABLE_BEAR`). Structure selection follows the gated `lean`, never posture alone, and
+  no put-skew-specific edge is claimed until the markout is re-run split by `tail`.
+- **(B) Structure 1 ("CHEAP → long put debit-spread") as written is a net-short-delta stock
+  bet**, contradicting the "this is NOT the stock price" framing. Increment 1 surfaces a
+  bear/bull structure only when the matching `lean` is *already* earned; it never maps
+  CHEAP → bear directly.
+- **(C) Structure 2's "hold the stock → collar / put-spread-collar" is REMOVED.** The Skew
+  tab is position-agnostic (no holdings fields in `models/skew.py`), so a surfaced collar is
+  an effective naked short. Defined-risk, position-agnostic structures only.
+- **(D) Horizon:** phrase the product on the repo's swing semantics (1–2 week HOLD, 21–60
+  DTE entry, exit before earnings), not "28–45 DTE matches T+20" — swing-HOLD ≠ swing-EXPIRY.
 
 ## The core reframe
 
@@ -60,8 +128,9 @@ RICH put-skew reverts down but weakly. Express short-the-rich-tail, never naked:
 
 - **No stock:** put debit-spread net-short the rich far-OTM tail (buy nearer put, sell
   the rich tail) — harvest tail richness, long put caps risk.
-- **Hold the stock:** collar / put-spread-collar — the short call is covered. Classic
-  "finance rich skew" (spec §3 idea #2). Valid only *with* the underlying.
+- ~~**Hold the stock:** collar / put-spread-collar~~ — **REMOVED (hardening 2026-06-16,
+  correction C):** the Skew tab is position-agnostic, so a surfaced collar is an effective
+  naked short. Use the position-agnostic put-spread above instead.
 
 Caveat: RICH skew often = genuine fear (PANIC, ρ<0, e.g. BE). Don't fade a real crash;
 size small.
@@ -122,9 +191,12 @@ failure mode.
 
 ### Two layers
 
-**Layer 1 — skew-implied bias (relative-value axis; already in V1, bounded).** The V1 RV
-bullet + `express` field already encode this: RICH → fade/finance the rich wing; CHEAP →
-own the cheap wing; NORMAL → no skew edge. Defined-risk structures only (no naked legs):
+**Layer 1 — skew-implied bias (relative-value axis).** **⚠️ The `deviation × tail` table
+below is SUPERSEDED — see hardening correction (A).** It fires on posture alone and ignores
+`drive`, re-introducing the empirically-wrong map. V1 already keys structure off the gated
+`lean` (`_express_structure`), which only emits a structure when the lean is non-neutral
+(empty for the ~72% NEUTRAL names) — that is the correct, bounded behavior. The table is
+retained only as the original (rejected) proposal:
 
 | Skew posture | Defined-risk expression | Rationale |
 |---|---|---|

--- a/docs/research/skew-rr-reversion-trigger-2026-06.md
+++ b/docs/research/skew-rr-reversion-trigger-2026-06.md
@@ -1,0 +1,83 @@
+# Skew RR Mean-Reversion → Trigger (Phase-2 increment-1)
+
+**Date:** 2026-06-16
+**Data:** `skew_analytics_snapshot` (basis='eod') on `option_wizard_local` — 16,890 snapshots,
+~100 watchlist tickers, 2025-06 → 2026-06. Harness: `reports/skew_markout.run_skew_markout`
+(`rv_reversion` output). RR forward series from `risk_reversal_skew_history` (delta=25, T+20
+trading days).
+**Status:** In-sample, single ~1yr window. The RV mean-reversion of the 25Δ risk-reversal is
+now **gated into a persisted verdict** (`skew_rv_reversion_verdicts`), distinct from the
+directional `skew_directional_verdicts`. **Descriptive RV axis only — no spread-P&L /
+net-of-cost claim** (executable option-return replay is data-blocked; see Limitations).
+
+## Method
+
+Per `(asset_class, deviation_class, tail)` bucket — `tail` derived from `sign(rr_25d)`
+(put_skew = rr>0, call_skew = rr<0) — collect forward ΔRR over T+20 (`rr[t+20] − rr[t]`).
+A bucket earns `REVERTS` only if ALL hold:
+
+1. **Expected sign** — CHEAP must re-richen (ΔRR > 0), RICH must flatten (ΔRR < 0).
+   NORMAL makes no reversion claim (`expected_sign = 0` → always NONE).
+2. **Magnitude** — `|mean ΔRR| ≥ 0.005` (full sample) and `≥ 0.003` on the holdout.
+3. **Walk-forward holdout** — time-ordered: the latest 40% of obs (by `market_date`) must
+   preserve the full-sample sign + meet the holdout magnitude floor. No leakage (train is
+   strictly earlier than holdout).
+4. **Per-quarter catastrophic-degradation gate** — no calendar quarter may reverse the
+   aggregate sign with *larger* magnitude (mirrors the directional `_survives_window_gate`;
+   standing rule: aggregate metrics hide sub-window blowups).
+
+`n` = full-sample obs, `n_holdout` = holdout obs. Thresholds live in `reports/skew_markout.py`
+(`RV_MIN_N=30`, `RV_HOLDOUT_FRAC=0.40`, `RV_SEP_THRESHOLD=0.005`, `RV_HOLDOUT_THRESHOLD=0.003`).
+
+## Results (run 2026-06-16, 16,890 snapshots → 17 RV buckets, 6 REVERTS)
+
+| bucket | verdict | mean ΔRR | holdout ΔRR | n | n_hold | walk-fwd | quarter-gate |
+|---|---|---:|---:|---:|---:|:--:|:--:|
+| single_name CHEAP **call_skew** | **REVERTS** | +0.1919 | +0.4463 | 1241 | 496 | ✅ | ✅ |
+| single_name CHEAP **put_skew** | **REVERTS** | +0.0320 | +0.0664 | 307 | 123 | ✅ | ✅ |
+| single_name RICH **put_skew** | **REVERTS** | −0.0406 | −0.1087 | 3162 | 1265 | ✅ | ✅ |
+| sector_etf CHEAP **call_skew** | **REVERTS** | +0.0710 | +0.1236 | 40 | 16 | ✅ | ✅ |
+| sector_etf RICH **put_skew** | **REVERTS** | −0.0103 | −0.0420 | 167 | 67 | ✅ | ✅ |
+| index_macro CHEAP **call_skew** | **REVERTS** | +0.0085 | +0.0151 | 52 | 21 | ✅ | ✅ |
+| single_name RICH call_skew | NONE | +0.0052 | +0.0209 | 1236 | 494 | ✗ (wrong sign) | — |
+| index_macro RICH call_skew | NONE | +0.0105 | +0.0265 | 125 | 50 | ✗ | ✅ |
+| index_macro RICH put_skew | NONE | −0.0020 | −0.0125 | 461 | 184 | ✗ | ✗ |
+| index_macro CHEAP put_skew | NONE | −0.0049 | −0.0040 | 52 | 21 | ✗ (wrong sign) | — |
+| NORMAL buckets (×5) | NONE | na | na | — | 0 | — | — |
+| sector_etf CHEAP put_skew | NONE | na | na | 28 | 0 | — (n<30) | — |
+
+## Read
+
+- **The tail-split is load-bearing.** `single_name CHEAP` splits into a huge **call_skew**
+  leg (mean +0.192, n=1241) and a modest **put_skew** leg (mean +0.032, n=307). The
+  aggregate "CHEAP re-richens +0.051" from the V1 markout was inflated by extreme
+  *call*-skew names (e.g. ALAB-type rr≈−0.22 that snap back hard but volatile). A
+  put-skew-specific claim is now isolated and far smaller.
+- **Both reversion legs confirm the textbook signature** after gating: CHEAP re-richens (+),
+  RICH flattens (−), for single-names and sector ETFs.
+- **The gates filter real noise.** `single_name RICH call_skew` (+0.0052, *wrong* sign for
+  RICH) and `index_macro RICH put_skew` (fails the quarter gate) are correctly NONE — the
+  aggregate would have looked tradeable.
+- **index_macro reversion is weak/small-n** — consistent with structural hedging demand
+  (the V1 finding that index skew does not mean-revert). The lone index REVERTS
+  (CHEAP/call_skew, n=52) is small and should be treated with caution.
+
+## Limitations (must stay loud)
+
+- **In-sample, one ~1yr window.** The walk-forward holdout and train share the same regime;
+  it is a sanity check against a single-window fit, **not** an out-of-sample forecast. Skew
+  effects decay (Xing-Zhang-Zhao; Cremers-Weinbaum). Treat as a tilt.
+- **No spread-P&L / net-of-cost.** This is reversion of the RR *shape*, not a tradeable
+  return. Executable option-return replay is **data-blocked**: `option_chain_per_strike` is
+  ~5 trading days deep and UW per-strike greeks history is ~30 days; only RR history is ~1yr.
+  That validation is a separate contract-history data project (split out — see
+  `skew-mean-reversion-trade-structures-phase2.md` § Hardening review).
+- **ΔRR ≠ stock direction.** The directional axis lives in `skew_directional_verdicts` /
+  `directional_lean` and can have the opposite sign (e.g. CHEAP/PANIC is `TRADABLE_BEAR`).
+  Do not read these RV verdicts as a stock-direction signal.
+- **Re-run** `run_skew_markout` after each backfill extension to refresh both verdict stores.
+
+## Cross-reference
+
+Primary directional numbers: `docs/research/skew-first-principles-markout-2026-06.md` (do not
+duplicate). Trade-structure framing + scope: `docs/research/skew-mean-reversion-trade-structures-phase2.md`.

--- a/docs/superpowers/plans/2026-06-16-skew-phase2-rv-trade-detail.md
+++ b/docs/superpowers/plans/2026-06-16-skew-phase2-rv-trade-detail.md
@@ -1,0 +1,1451 @@
+# Skew Phase-2 (Increment-1) Implementation Plan — RV-trigger research + concrete strike-by-delta detail
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two coupled, independently-testable increments on the shipped V1 Skew tab: (1b) turn the descriptive RR mean-reversion into a *persisted, tail-split, walk-forward-gated* verdict store + research note; (1a) when V1's already-gated `directional_lean` is non-neutral, enrich it with concrete **strike-by-delta** legs + suggested DTE, defined-risk and earnings-blocked, surfaced in the Signal Detail card.
+
+**Architecture:** Backend-first. 1b extends the existing `run_skew_markout` harness (no new live data) and adds one idempotent table. 1a adds one repo read (per-strike greeks already persisted in `exposures_by_expiry_strike`), one pure deriver (strike selection by target delta), wires it into the pure `build_skew_snapshot_row` via callers that fetch greeks, surfaces it through `read_json` + typed models + the React card. No new feed, no Black-Scholes recompute, no spread-P&L/net-of-cost claim (data-blocked — see hardened design doc §"Hardening review").
+
+**Tech Stack:** Python 3.13 (`uv` only), FastAPI + Pydantic v2, psycopg 3, pandas (markout), Next.js 16 + React 19 + TypeScript, Vitest + Playwright, pytest + pytest-postgresql. Types flow API → `web/lib/types.ts` via `npm run gen:types`.
+
+**Authoritative scope source:** `docs/research/skew-mean-reversion-trade-structures-phase2.md` → `## Hardening review (2026-06-16)`. Increment-1 = "concretize the gated read + RR-trigger research". Everything else (net-of-cost validation, delta-hedge helper, Layer-2 cross-pillar gate) is explicitly split out.
+
+**Standing rules in force:** uv only; persist analytical results to Postgres; no naked shorts (defined-risk only); idempotent migrations (`IF NOT EXISTS`); CI Guardrail 2 (every `except` must `log...repr(exc)`/`.exception`/`raise`); `Decimal` over float for price/IV/greeks; `<500` lines/file target; never commit without the user's request (milestone commits are pre-authorized for this build); never `git push origin main`.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/uw_scan/storage/migrations/074_skew_phase2.sql` — `skew_rv_reversion_verdicts` table (idempotent).
+- `tests/integration/reports/test_skew_rv_markout.py` — RV markout: tail-split keys, expected-sign gate, walk-forward holdout, idempotency.
+- `tests/unit/cards/test_skew_structure_legs.py` — pure strike-selection deriver tests.
+- `docs/research/skew-rr-reversion-trigger-2026-06.md` — research note; the empirical table is filled during execution by running the harness on `option_wizard_local`.
+
+**Modified files:**
+- `src/uw_scan/reports/skew_markout.py` — add `tail` dim + walk-forward + write RV verdicts; return RV stats.
+- `src/uw_scan/storage/skew.py` (`_SkewMixin`) — `upsert_skew_rv_reversion_verdict` + `get_skew_rv_reversion_verdict`.
+- `src/uw_scan/storage/options.py` (`_OptionsMixin`) — `fetch_latest_exposures_by_strike` (read `exposures_by_expiry_strike`).
+- `src/uw_scan/cards/skew_first_principles.py` — `structure_family()` (single source for the structure descriptor), refactor `_express_structure()` to derive its string from it, `select_structure_legs()` (pure strike-by-delta picker).
+- `src/uw_scan/models/skew.py` — `SkewStructureLeg`, `SkewStructureDetail`; add `structure_detail` to `SkewDirectionalLean`.
+- `src/uw_scan/models/__init__.py` — export the two new models.
+- `src/uw_scan/reports/skew_analytics.py` — accept `exposure_rows`, compute `structure_detail` when lean non-neutral, map into `SkewDirectionalLean`.
+- `src/uw_scan/worker/jobs/skew_analytics.py` — nightly rollup fetches latest exposures per ticker and passes them through; backfill passes `None`.
+- `tests/unit/cards/test_skew_first_principles.py` — `structure_family`/`_express_structure` parity.
+- `tests/unit/reports/test_skew_snapshot_row.py` — structure_detail present when non-neutral + exposures, absent otherwise.
+- `tests/integration/reports/test_skew_markout.py` — keep green after signature/return changes.
+- `web/lib/types.ts` — regenerated.
+- `tests/integration/api/openapi.snapshot.json` — regenerated.
+- `web/components/stock/panels/SkewSignalDetail.tsx` — render structure legs when present.
+- `web/tests/unit/SkewSignalDetail.test.tsx` — structure-detail render + absence.
+- `web/tests/e2e/skew-tab.spec.ts` — assert structure block when a non-neutral name is shown; tolerate NEUTRAL.
+
+**Milestone → commit seams:**
+- **M0** docs: hardened design doc + this plan.
+- **M1** 1b backend: migration + storage + markout tail-split/walk-forward + tests.
+- **M2** 1a backend: greeks read + deriver + models + assembler/worker wiring + tests.
+- **M3** 1a contract+UI: gen:types + openapi snapshot + React card + vitest + e2e.
+- **M4** research note (run harness) + full verification.
+
+---
+
+## Task 0: Milestone M0 — commit hardened design doc + this plan
+
+**Files:**
+- Modify (already edited): `docs/research/skew-mean-reversion-trade-structures-phase2.md`
+- Create: `docs/superpowers/plans/2026-06-16-skew-phase2-rv-trade-detail.md` (this file)
+
+- [ ] **Step 1: Verify the hardening edits are present**
+
+Run: `grep -c "Hardening review (2026-06-16)" docs/research/skew-mean-reversion-trade-structures-phase2.md`
+Expected: `1`
+
+- [ ] **Step 2: Commit docs**
+
+```bash
+git add docs/research/skew-mean-reversion-trade-structures-phase2.md docs/superpowers/plans/2026-06-16-skew-phase2-rv-trade-detail.md
+git commit -m "docs(skew): harden Phase-2 design + increment-1 plan (RV-trigger + strike detail)"
+```
+
+---
+
+## Task 1: Migration — `skew_rv_reversion_verdicts` (M1)
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/074_skew_phase2.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 074_skew_phase2.sql — Phase-2 increment-1.
+-- skew_rv_reversion_verdicts: per (asset_class, deviation_class, tail) conclusion of
+-- whether the 25d RR mean-reverts (descriptive RV axis, distinct from the directional
+-- skew_directional_verdicts). Gated by a time-ordered walk-forward holdout on the RR
+-- history (the only OOS test the ~1yr RR data supports). NO spread-P&L / net-of-cost.
+-- Idempotent.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.skew_rv_reversion_verdicts (
+  asset_class          TEXT NOT NULL,     -- index_macro | sector_etf | credit | single_name
+  deviation_class      TEXT NOT NULL,     -- RICH | CHEAP | NORMAL
+  tail                 TEXT NOT NULL,     -- put_skew | call_skew | flat
+  verdict              TEXT NOT NULL,     -- REVERTS | NONE
+  mean_drr             NUMERIC,           -- mean forward ΔRR (T+20) over the full sample
+  mean_drr_holdout     NUMERIC,           -- mean forward ΔRR over the time-ordered holdout
+  n                    INTEGER,
+  n_holdout            INTEGER,
+  survives_walkforward BOOLEAN,           -- holdout preserves the full-sample sign + magnitude
+  survives_window_gate BOOLEAN,           -- no calendar quarter reverses the aggregate with larger magnitude
+  as_of                DATE,
+  inserted_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (asset_class, deviation_class, tail)
+);
+
+COMMENT ON TABLE uw_scan.skew_rv_reversion_verdicts
+  IS 'Per-bucket RR mean-reversion conclusion (descriptive RV axis). REVERTS requires expected sign (CHEAP->+, RICH->-), |mean| over threshold, n over min, a time-ordered walk-forward holdout that preserves sign+magnitude, AND a per-calendar-quarter catastrophic-degradation gate (no sub-window reverses the aggregate with larger magnitude). In-sample over a single ~1yr window; NOT a P&L claim.';
+```
+
+- [ ] **Step 2: Apply against a scratch test DB and verify idempotency**
+
+Run: `bash scripts/migrate.sh && bash scripts/migrate.sh`
+Expected: both runs succeed; second run is a no-op (no errors). If `migrate.sh` targets local, confirm `option_wizard_local`; the table now exists.
+
+- [ ] **Step 3: Commit** (committed together at end of M1, Task 4 Step 5.)
+
+---
+
+## Task 2: Storage — RV reversion verdict upsert/get (M1)
+
+**Files:**
+- Modify: `src/uw_scan/storage/skew.py` (`_SkewMixin`)
+- Test: `tests/integration/storage/test_skew_storage.py` (extend)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/integration/storage/test_skew_storage.py`:
+
+```python
+def test_rv_reversion_verdict_roundtrip(repo):
+    from datetime import date
+    repo.upsert_skew_rv_reversion_verdict(
+        asset_class="single_name",
+        deviation_class="CHEAP",
+        tail="put_skew",
+        verdict="REVERTS",
+        mean_drr=0.0514,
+        mean_drr_holdout=0.041,
+        n=1472,
+        n_holdout=520,
+        survives_walkforward=True,
+        survives_window_gate=True,
+        as_of=date(2026, 6, 16),
+    )
+    repo.conn.commit()
+    got = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert got is not None
+    assert got["verdict"] == "REVERTS"
+    assert got["survives_walkforward"] is True
+    assert got["survives_window_gate"] is True
+    # upsert is idempotent on the PK
+    repo.upsert_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew",
+        verdict="NONE", mean_drr=0.0, mean_drr_holdout=0.0, n=1, n_holdout=0,
+        survives_walkforward=False, survives_window_gate=False, as_of=date(2026, 6, 16),
+    )
+    repo.conn.commit()
+    got2 = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert got2["verdict"] == "NONE"
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `uv run pytest tests/integration/storage/test_skew_storage.py::test_rv_reversion_verdict_roundtrip -v`
+Expected: FAIL — `AttributeError: 'Repository' object has no attribute 'upsert_skew_rv_reversion_verdict'`.
+
+- [ ] **Step 3: Implement the two methods**
+
+Add to `_SkewMixin` in `src/uw_scan/storage/skew.py` (after `get_skew_directional_verdict`):
+
+```python
+    def upsert_skew_rv_reversion_verdict(
+        self,
+        *,
+        asset_class: str,
+        deviation_class: str,
+        tail: str,
+        verdict: str,
+        mean_drr: Any,
+        mean_drr_holdout: Any,
+        n: int,
+        n_holdout: int,
+        survives_walkforward: bool,
+        survives_window_gate: bool,
+        as_of: _date,
+    ) -> None:
+        sql = (
+            f"INSERT INTO {self._schema}.skew_rv_reversion_verdicts "
+            "(asset_class, deviation_class, tail, verdict, mean_drr, mean_drr_holdout, "
+            " n, n_holdout, survives_walkforward, survives_window_gate, as_of, inserted_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now()) "
+            "ON CONFLICT (asset_class, deviation_class, tail) DO UPDATE SET "
+            "verdict=EXCLUDED.verdict, mean_drr=EXCLUDED.mean_drr, "
+            "mean_drr_holdout=EXCLUDED.mean_drr_holdout, n=EXCLUDED.n, "
+            "n_holdout=EXCLUDED.n_holdout, "
+            "survives_walkforward=EXCLUDED.survives_walkforward, "
+            "survives_window_gate=EXCLUDED.survives_window_gate, "
+            "as_of=EXCLUDED.as_of, inserted_at=now()"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    asset_class,
+                    deviation_class,
+                    tail,
+                    verdict,
+                    mean_drr,
+                    mean_drr_holdout,
+                    n,
+                    n_holdout,
+                    survives_walkforward,
+                    survives_window_gate,
+                    as_of,
+                ),
+            )
+
+    def get_skew_rv_reversion_verdict(
+        self, *, asset_class: str, deviation_class: str, tail: str
+    ) -> dict[str, Any] | None:
+        sql = (
+            f"SELECT * FROM {self._schema}.skew_rv_reversion_verdicts "
+            "WHERE asset_class=%s AND deviation_class=%s AND tail=%s"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (asset_class, deviation_class, tail))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [d.name for d in cur.description or []]
+            return dict(zip(cols, row, strict=False))
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `uv run pytest tests/integration/storage/test_skew_storage.py::test_rv_reversion_verdict_roundtrip -v`
+Expected: PASS.
+
+---
+
+## Task 3: Markout — tail-split + walk-forward + write RV verdicts (M1)
+
+**Files:**
+- Modify: `src/uw_scan/reports/skew_markout.py`
+- Test: `tests/integration/reports/test_skew_rv_markout.py` (create)
+
+**Background:** `run_skew_markout` already accumulates `meanrev[(asset_class, deviation_class)] = [ΔRR,...]` (lines ~92-100, 146-149). We (a) add `tail` from `sign(rr_25d)`, (b) keep `market_date` per obs for time-ordering, (c) compute a time-ordered holdout, (d) write RV verdicts. The directional (secondary) path is untouched.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/integration/reports/test_skew_rv_markout.py`. Mirror the `repo` fixture + seeding style of `tests/integration/reports/test_skew_markout.py` (verified: it uses the session `seeded_db_empty_cards` fixture and raw-cursor inserts; there is NO `seed_*` repo helper). Full file:
+
+```python
+from datetime import date, timedelta
+
+import pytest
+
+from uw_scan.reports.skew_markout import (
+    _expected_drr_sign,
+    _rv_walkforward,
+    run_skew_markout,
+)
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards):
+    return seeded_db_empty_cards
+
+
+def _seed_cheap_reverting_bucket(repo, ticker="QCOM"):
+    """A single_name CHEAP/put_skew bucket whose 25d RR climbs (re-richens) across the
+    whole window: forward ΔRR(T+20) is positive everywhere, so the time-ordered holdout
+    survives. Seeds BOTH the snapshot anchors AND risk_reversal_skew_history (the forward
+    RR series skew_markout._rr_series reads, delta=25). RR stays > 0 so every anchor
+    buckets as tail=put_skew."""
+    base = date(2025, 1, 2)
+    snaps = []
+    for i in range(80):
+        d = base + timedelta(days=i)
+        rr = 0.02 + 0.002 * i  # +0.02 .. +0.178, all put_skew, monotonically richening
+        snaps.append({
+            "ticker": ticker, "market_date": d, "basis": "eod",
+            "spot": 100.0 + i, "rr_25d": rr, "skew_25d": rr,
+            "deviation_class": "CHEAP", "skew_term_class": "flat",
+            "drive_class": "STRUCTURAL", "asset_class": "single_name",
+            "regime": "LOW_VOL", "borrow_flag": "normal",
+        })
+    repo.upsert_skew_analytics_snapshots(snaps)
+    with repo.conn.cursor() as cur:
+        for i in range(80):
+            d = base + timedelta(days=i)
+            rr = 0.02 + 0.002 * i
+            cur.execute(
+                "INSERT INTO uw_scan.risk_reversal_skew_history "
+                "(ticker, market_date, delta, expiry, risk_reversal) "
+                "VALUES (%s, %s, 25, %s, %s) ON CONFLICT DO NOTHING",
+                (ticker, d, base + timedelta(days=40), rr),
+            )
+    repo.conn.commit()
+
+
+def test_rv_markout_writes_reverting_verdict(repo):
+    _seed_cheap_reverting_bucket(repo)
+    out = run_skew_markout(repo=repo, min_n=1, sep_threshold=0.005)
+    assert "rv_reversion" in out and out["rv_verdicts_written"] >= 1
+    v = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert v is not None
+    assert v["verdict"] == "REVERTS"
+    assert float(v["mean_drr"]) > 0          # CHEAP re-richens => positive ΔRR
+    assert v["survives_walkforward"] is True
+    assert v["survives_window_gate"] is True  # single-quarter seed: no sub-window blowup
+
+
+def test_rv_markout_idempotent(repo):
+    _seed_cheap_reverting_bucket(repo)
+    run_skew_markout(repo=repo, min_n=1, sep_threshold=0.005)
+    run_skew_markout(repo=repo, min_n=1, sep_threshold=0.005)  # second run = no-op upsert
+    v = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert v["verdict"] == "REVERTS"
+```
+
+NOTE (verified Pass-1): `run_skew_markout`'s `min_n` only gates the DIRECTIONAL path; the RV path uses the module constants `RV_MIN_N=30` etc., so n=60 here passes regardless of `min_n=1`.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `uv run pytest tests/integration/reports/test_skew_rv_markout.py -v`
+Expected: FAIL — `KeyError: 'rv_reversion'` (and no verdict written).
+
+- [ ] **Step 3: Implement the walk-forward helper + tail key + verdict writes**
+
+In `src/uw_scan/reports/skew_markout.py`:
+
+(a) Add the constants + a pure helper near the top (after `HORIZON`):
+
+```python
+RV_HOLDOUT_FRAC = 0.40        # time-ordered tail fraction held out for OOS check
+RV_MIN_N = 30                 # min obs to even consider an RV verdict
+RV_SEP_THRESHOLD = 0.005      # |mean ΔRR| floor (full sample)
+RV_HOLDOUT_THRESHOLD = 0.003  # |mean ΔRR| floor on the holdout
+
+
+def _expected_drr_sign(deviation_class: str) -> int:
+    """CHEAP re-richens (+), RICH flattens (-), else no directional reversion claim."""
+    if deviation_class == "CHEAP":
+        return 1
+    if deviation_class == "RICH":
+        return -1
+    return 0
+
+
+def _rv_survives_window_gate(obs: list[dict], overall_mean: float) -> bool:
+    """Per-calendar-quarter catastrophic-degradation gate (mirrors the directional
+    _survives_window_gate; standing rule: feedback_per_regime_catastrophic_gate).
+    Fail if ANY quarter's mean ΔRR reverses the aggregate sign with LARGER magnitude —
+    i.e. the aggregate is hiding a sub-window blowup. obs items carry 'drr' + 'market_date'."""
+    if abs(overall_mean) < 1e-9:
+        return False
+    by_q: dict[tuple, list[float]] = {}
+    for o in obs:
+        d = o["market_date"]
+        by_q.setdefault((d.year, (d.month - 1) // 3), []).append(o["drr"])
+    for vals in by_q.values():
+        if not vals:
+            continue
+        m = sum(vals) / len(vals)
+        if m * overall_mean < 0 and abs(m) > abs(overall_mean):
+            return False
+    return True
+
+
+def _rv_walkforward(obs: list[dict], expected_sign: int) -> dict:
+    """obs: [{'drr': float, 'market_date': date}], any order. Returns the verdict dict.
+    REVERTS requires expected sign + magnitude (full & holdout) AND the quarterly
+    catastrophic-degradation gate. Holdout = the latest RV_HOLDOUT_FRAC of obs by
+    market_date (time-ordered, no leak)."""
+    n = len(obs)
+    if n < RV_MIN_N or expected_sign == 0:
+        return {"verdict": "NONE", "mean_drr": None, "mean_drr_holdout": None,
+                "n": n, "n_holdout": 0, "survives_walkforward": False,
+                "survives_window_gate": False}
+    ordered = sorted(obs, key=lambda o: o["market_date"])
+    cut = int(round(n * (1.0 - RV_HOLDOUT_FRAC)))
+    holdout = ordered[cut:]
+    mean_full = sum(o["drr"] for o in ordered) / n
+    mean_hold = (sum(o["drr"] for o in holdout) / len(holdout)) if holdout else 0.0
+    sign_ok = (mean_full * expected_sign > 0) and (mean_hold * expected_sign > 0)
+    mag_ok = abs(mean_full) >= RV_SEP_THRESHOLD and abs(mean_hold) >= RV_HOLDOUT_THRESHOLD
+    survives_wf = bool(sign_ok and mag_ok)
+    survives_window = _rv_survives_window_gate(ordered, mean_full)
+    reverts = bool(survives_wf and survives_window)
+    return {"verdict": "REVERTS" if reverts else "NONE",
+            "mean_drr": mean_full, "mean_drr_holdout": mean_hold,
+            "n": n, "n_holdout": len(holdout),
+            "survives_walkforward": survives_wf,
+            "survives_window_gate": survives_window}
+```
+
+(b) Change the meanrev accumulation to carry `tail` + `market_date`. Replace the meanrev block in the Pass-1 loop:
+
+```python
+            if fwd_rr is not None:
+                tail = "put_skew" if float(rr0) > 0 else (
+                    "call_skew" if float(rr0) < 0 else "flat")
+                meanrev[(s["asset_class"], s["deviation_class"], tail)].append(
+                    {"drr": fwd_rr - float(rr0), "market_date": s["market_date"]}
+                )
+```
+
+(c) After the directional-verdict write loop (after `written += 1`), add the RV verdict write loop and include RV stats in the return dict:
+
+```python
+    rv_written = 0
+    rv_report = {}
+    for (asset_class, deviation_class, tail), drr_obs in meanrev.items():
+        wf = _rv_walkforward(drr_obs, _expected_drr_sign(deviation_class))
+        repo.upsert_skew_rv_reversion_verdict(
+            asset_class=asset_class,
+            deviation_class=deviation_class,
+            tail=tail,
+            verdict=wf["verdict"],
+            mean_drr=wf["mean_drr"],
+            mean_drr_holdout=wf["mean_drr_holdout"],
+            n=wf["n"],
+            n_holdout=wf["n_holdout"],
+            survives_walkforward=wf["survives_walkforward"],
+            survives_window_gate=wf["survives_window_gate"],
+            as_of=today,
+        )
+        rv_written += 1
+        rv_report[f"{asset_class}/{deviation_class}/{tail}"] = wf
+```
+
+(d) Update `mean_reversion` (now keyed by the 3-tuple) and the return dict. Replace the old `mean_reversion = {...}` comprehension and the `return {...}`:
+
+```python
+    mean_reversion = {
+        f"{a}/{d}/{t}": {
+            "mean_dRR": (sum(o["drr"] for o in v) / len(v) if v else None),
+            "n": len(v),
+        }
+        for (a, d, t), v in meanrev.items()
+    }
+    repo.conn.commit()
+    log.info(
+        "run_skew_markout wrote %d directional + %d rv verdicts over %d snapshots",
+        written, rv_written, len(snaps),
+    )
+    return {
+        "verdicts_written": written,
+        "rv_verdicts_written": rv_written,
+        "snapshots": len(snaps),
+        "mean_reversion": mean_reversion,   # PRIMARY hypothesis, descriptive
+        "rv_reversion": rv_report,          # PRIMARY hypothesis, now gated + walk-forward
+    }
+```
+
+- [ ] **Step 4: Run the new + existing markout tests**
+
+Run: `uv run pytest tests/integration/reports/test_skew_rv_markout.py tests/integration/reports/test_skew_markout.py -v`
+Expected: all PASS. (If `test_skew_markout.py` asserted on the old 2-tuple `mean_reversion` keys, update those assertions to the 3-tuple form — that is the only allowed edit there.)
+
+- [ ] **Step 5: Add a unit test for the pure walk-forward helper**
+
+Append to `tests/integration/reports/test_skew_rv_markout.py` (pure, no DB; `_rv_walkforward`/`_expected_drr_sign`/`date` are already imported at the top of the file):
+
+```python
+def test_walkforward_rejects_when_holdout_flips():
+    # full-sample positive but the recent holdout goes negative => NONE
+    obs = [{"drr": 0.02, "market_date": date(2025, 1, 1) + timedelta(days=i)}
+           for i in range(40)]
+    obs += [{"drr": -0.03, "market_date": date(2025, 3, 1) + timedelta(days=i)}
+            for i in range(40)]
+    out = _rv_walkforward(obs, _expected_drr_sign("CHEAP"))
+    assert out["verdict"] == "NONE"
+    assert out["survives_walkforward"] is False
+
+
+def test_walkforward_skips_normal_and_small_n():
+    assert _rv_walkforward([], _expected_drr_sign("NORMAL"))["verdict"] == "NONE"
+    tiny = [{"drr": 0.05, "market_date": date(2025, 1, 1)}]
+    assert _rv_walkforward(tiny, _expected_drr_sign("CHEAP"))["verdict"] == "NONE"
+
+
+def test_walkforward_rejects_when_a_quarter_blows_up():
+    # full-sample AND holdout positive, but Q2 reverses harder than the aggregate ->
+    # catastrophic-degradation gate fails -> NONE (mirrors the directional AC-F4 gate).
+    obs = [{"drr": 0.05, "market_date": date(2025, 1, 1) + timedelta(days=i)}
+           for i in range(40)]                                            # Q1 +0.05
+    obs += [{"drr": -0.20, "market_date": date(2025, 4, 1) + timedelta(days=i)}
+            for i in range(10)]                                           # Q2 big negative
+    obs += [{"drr": 0.05, "market_date": date(2025, 7, 1) + timedelta(days=i)}
+            for i in range(40)]                                           # Q3 +0.05 (holdout)
+    out = _rv_walkforward(obs, _expected_drr_sign("CHEAP"))
+    assert out["survives_walkforward"] is True      # holdout (Q3) is clean
+    assert out["survives_window_gate"] is False      # Q2 blowup caught
+    assert out["verdict"] == "NONE"
+```
+
+Run: `uv run pytest tests/integration/reports/test_skew_rv_markout.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit M1**
+
+```bash
+git add src/uw_scan/storage/migrations/074_skew_phase2.sql src/uw_scan/storage/skew.py \
+        src/uw_scan/reports/skew_markout.py \
+        tests/integration/storage/test_skew_storage.py \
+        tests/integration/reports/test_skew_rv_markout.py \
+        tests/integration/reports/test_skew_markout.py
+git commit -m "feat(skew): RR mean-reversion verdict store — tail-split + walk-forward gate"
+```
+
+---
+
+## Task 4: Storage — `fetch_latest_exposures_by_strike` (M2)
+
+**Files:**
+- Modify: `src/uw_scan/storage/options.py` (`_OptionsMixin`)
+- Test: `tests/integration/storage/test_skew_storage.py` (extend) — OR `tests/integration/storage/test_options_*.py` if one exists for that table (check first).
+
+**Background:** per-strike greeks with delta are persisted in `exposures_by_expiry_strike` (written by `insert_greek_exposure_rows`; cols `run_id, ticker, market_date, expiry, strike, dte, call_delta, put_delta, call_gex, put_gex, call_vanna, put_vanna, call_charm, put_charm`). There is no read for it yet.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/integration/storage/test_skew_storage.py` (verified Pass-1: that file already defines `def repo(seeded_db_empty_cards)`; the real run-creation helper is `insert_scan_run(ticker, notes="")`; `insert_greek_exposure_rows` maps `GreekExposureRow.date → market_date`). Add `from decimal import Decimal` and `from uw_scan import models` at the file's import block if absent:
+
+```python
+def test_fetch_latest_exposures_by_strike(repo):
+    from datetime import date
+    run_id = repo.insert_scan_run(ticker="QCOM")
+    rows = [
+        models.GreekExposureRow(
+            date=date(2026, 6, 15), expiry=date(2026, 7, 18), strike=Decimal("95"),
+            dte=33, call_delta=Decimal("0.62"), put_delta=Decimal("-0.38")),
+        models.GreekExposureRow(
+            date=date(2026, 6, 15), expiry=date(2026, 7, 18), strike=Decimal("90"),
+            dte=33, call_delta=Decimal("0.74"), put_delta=Decimal("-0.26")),
+    ]
+    repo.insert_greek_exposure_rows(run_id, "QCOM", rows)
+    repo.conn.commit()
+    got = repo.fetch_latest_exposures_by_strike("QCOM", dte_max=70)
+    assert len(got) == 2
+    assert {r["strike"] for r in got} == {Decimal("95"), Decimal("90")}
+    assert all("put_delta" in r and "dte" in r for r in got)
+
+
+def test_fetch_latest_exposures_reads_only_the_newest_run(repo):
+    from datetime import date
+    ex = date(2026, 7, 18)
+    # two runs on the SAME market_date — the later run (higher run_id) wins.
+    old = repo.insert_scan_run(ticker="QCOM")
+    repo.insert_greek_exposure_rows(old, "QCOM", [
+        models.GreekExposureRow(date=date(2026, 6, 15), expiry=ex, strike=Decimal("70"),
+                                dte=33, put_delta=Decimal("-0.20"))])
+    new = repo.insert_scan_run(ticker="QCOM")
+    repo.insert_greek_exposure_rows(new, "QCOM", [
+        models.GreekExposureRow(date=date(2026, 6, 15), expiry=ex, strike=Decimal("95"),
+                                dte=33, put_delta=Decimal("-0.26"))])
+    repo.conn.commit()
+    got = repo.fetch_latest_exposures_by_strike("QCOM", dte_max=70)
+    assert {r["strike"] for r in got} == {Decimal("95")}   # only the newest run's chain
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `uv run pytest tests/integration/storage/test_skew_storage.py::test_fetch_latest_exposures_by_strike -v`
+Expected: FAIL — no `fetch_latest_exposures_by_strike`.
+
+- [ ] **Step 3: Implement the read (latest market_date for the ticker, within DTE bound)**
+
+Add to `_OptionsMixin` in `src/uw_scan/storage/options.py`:
+
+```python
+    def fetch_latest_exposures_by_strike(
+        self, ticker: str, *, dte_max: int = 70
+    ) -> list[dict[str, Any]]:
+        """Per-strike greeks (incl. call/put delta) for the ticker's most recent
+        exposures RUN, within `dte_max`. Keyed on max(run_id) — NOT max(market_date) —
+        so two scan runs on the same date never stitch two chains together (the table
+        is run-keyed: PK (run_id, ticker, expiry, strike)). Source for skew
+        strike-by-delta selection. Ordered by expiry, strike ASC. Empty list if none."""
+        sql = (
+            "SELECT expiry, strike, dte, call_delta, put_delta "
+            f"FROM {self._schema}.exposures_by_expiry_strike "
+            "WHERE ticker = %s "
+            "  AND run_id = ("
+            f"    SELECT max(run_id) FROM {self._schema}.exposures_by_expiry_strike "
+            "      WHERE ticker = %s) "
+            "  AND (dte IS NULL OR dte <= %s) "
+            "ORDER BY expiry ASC, strike ASC"
+        )
+        t = ticker.upper()
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (t, t, dte_max))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+```
+
+Confirm `from typing import Any` is imported in `options.py` (it is used throughout; add if missing).
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `uv run pytest tests/integration/storage/test_skew_storage.py::test_fetch_latest_exposures_by_strike -v`
+Expected: PASS.
+
+---
+
+## Task 5: Models — `SkewStructureLeg` + `SkewStructureDetail` (M2)
+
+**Files:**
+- Modify: `src/uw_scan/models/skew.py`
+- Modify: `src/uw_scan/models/__init__.py`
+- Test: `tests/unit/test_models_exports.py` (already enforces export surface — no edit, must stay green)
+
+- [ ] **Step 1: Add the models**
+
+In `src/uw_scan/models/skew.py`, add before `class SkewDirectionalLean`:
+
+```python
+class SkewStructureLeg(_UwBase):
+    action: str = ""          # BUY | SELL
+    right: str = ""           # PUT | CALL
+    strike: Decimal | None = None
+    target_delta: Decimal | None = None   # the delta we aimed for (e.g. -0.25)
+    actual_delta: Decimal | None = None    # delta of the chosen strike
+    expiry: _date | None = None
+    dte: int | None = None
+
+
+class SkewStructureDetail(_UwBase):
+    kind: str = ""            # put_debit_spread | call_debit_spread
+    legs: list[SkewStructureLeg] = []
+    dte_target: int | None = None
+    status: str = "ready"     # ready | no_chain | suppressed
+    note: str = ""            # e.g. "defined risk; exit before earnings 2026-07-18"
+```
+
+Add `structure_detail` to `SkewDirectionalLean`:
+
+```python
+class SkewDirectionalLean(_UwBase):
+    lean: str = "NEUTRAL"
+    confidence: str = "low"
+    basis: str = ""
+    express: str = ""
+    structure_detail: SkewStructureDetail | None = None
+```
+
+Add both new classes to the `_preserve_public_module(...)` call at the bottom.
+
+- [ ] **Step 2: Export from the package root**
+
+In `src/uw_scan/models/__init__.py`, add `SkewStructureLeg` and `SkewStructureDetail` to the `.skew` import block and to `__all__` (keep alphabetical/grouped as the file does).
+
+- [ ] **Step 3: Add an export-verification block (the existing test won't otherwise check the new models)**
+
+`tests/unit/test_models_exports.py`'s `PUBLIC_MODEL_EXPORTS` is a hand-maintained subset; simply running it would NOT verify the new models. Append a dedicated block mirroring `test_new_exposure_models_exported` (verified to exist at lines 161-171):
+
+```python
+def test_new_skew_structure_models_exported():
+    assert "SkewStructureLeg" in models.__all__
+    assert "SkewStructureDetail" in models.__all__
+    # _preserve_public_module rewrites __module__ so OpenAPI component names stay stable
+    assert models.SkewStructureLeg.__module__ == "uw_scan.models"
+    assert models.SkewStructureDetail.__module__ == "uw_scan.models"
+```
+
+Run: `uv run pytest tests/unit/test_models_exports.py -v`
+Expected: PASS — new names importable from `uw_scan.models`, in `__all__`, `__module__` preserved. (FAIL first if Step 1/2 are incomplete.)
+
+---
+
+## Task 6: Deriver — `structure_family` + `select_structure_legs` (M2)
+
+**Files:**
+- Modify: `src/uw_scan/cards/skew_first_principles.py`
+- Test: `tests/unit/cards/test_skew_structure_legs.py` (create)
+- Test: `tests/unit/cards/test_skew_first_principles.py` (extend — express parity)
+
+**Design:** `structure_family(lean)` is the single source of the structure descriptor; `_express_structure` derives its string from it (keep V1's existing strings for the bear/bull debit-spread cases). `select_structure_legs` is pure: given the family's target deltas + exposure rows + a DTE window, pick the nearest strike per leg.
+
+- [ ] **Step 1: Write the failing deriver test**
+
+Create `tests/unit/cards/test_skew_structure_legs.py`:
+
+```python
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards import skew_first_principles as sk
+
+
+def _exposures():
+    # one expiry at dte=33; put_delta spans the wing range we need
+    ex = date(2026, 7, 18)
+    return [
+        {"expiry": ex, "strike": Decimal("105"), "dte": 33, "put_delta": Decimal("-0.50")},
+        {"expiry": ex, "strike": Decimal("100"), "dte": 33, "put_delta": Decimal("-0.38")},
+        {"expiry": ex, "strike": Decimal("95"), "dte": 33, "put_delta": Decimal("-0.26")},
+        {"expiry": ex, "strike": Decimal("88"), "dte": 33, "put_delta": Decimal("-0.13")},
+        {"expiry": ex, "strike": Decimal("80"), "dte": 33, "put_delta": Decimal("-0.05")},
+    ]
+
+
+def test_bearish_picks_put_debit_spread_by_delta():
+    fam = sk.structure_family({"lean": "BEARISH_TILT"})
+    assert fam["kind"] == "put_debit_spread"
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=_exposures(), dte_lo=21, dte_hi=60, dte_pref=35)
+    assert detail["status"] == "ready"
+    assert detail["kind"] == "put_debit_spread"
+    legs = detail["legs"]
+    assert len(legs) == 2
+    buy, sell = legs[0], legs[1]
+    assert buy["action"] == "BUY" and buy["right"] == "PUT"
+    assert buy["strike"] == Decimal("95")    # closest to -0.25
+    assert sell["action"] == "SELL" and sell["strike"] == Decimal("88")  # closest to -0.12
+    # defined-risk: long wing strike strictly above the short wing strike
+    assert buy["strike"] > sell["strike"]
+
+
+def test_no_chain_when_exposures_empty():
+    fam = sk.structure_family({"lean": "BULLISH_TILT"})
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=[], dte_lo=21, dte_hi=60, dte_pref=35)
+    assert detail["status"] == "no_chain"
+    assert detail["legs"] == []
+
+
+def test_neutral_has_no_family():
+    assert sk.structure_family({"lean": "NEUTRAL"}) is None
+
+
+def test_inverted_put_chain_yields_no_chain():
+    # non-monotonic chain: the -0.25-target leg lands on a LOWER strike than the
+    # -0.12-target leg -> would be a credit (short-premium) spread -> rejected.
+    ex = date(2026, 7, 18)
+    bad = [
+        {"expiry": ex, "strike": Decimal("95"), "dte": 33, "put_delta": Decimal("-0.12")},
+        {"expiry": ex, "strike": Decimal("88"), "dte": 33, "put_delta": Decimal("-0.26")},
+    ]
+    fam = sk.structure_family({"lean": "BEARISH_TILT"})
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=bad, dte_lo=21, dte_hi=60, dte_pref=35)
+    assert detail["status"] == "no_chain"
+    assert detail["legs"] == []
+
+
+def test_bullish_picks_call_debit_spread_by_delta():
+    ex = date(2026, 7, 18)
+    chain = [
+        {"expiry": ex, "strike": Decimal("100"), "dte": 33, "call_delta": Decimal("0.50")},
+        {"expiry": ex, "strike": Decimal("105"), "dte": 33, "call_delta": Decimal("0.26")},
+        {"expiry": ex, "strike": Decimal("112"), "dte": 33, "call_delta": Decimal("0.13")},
+        {"expiry": ex, "strike": Decimal("120"), "dte": 33, "call_delta": Decimal("0.05")},
+    ]
+    fam = sk.structure_family({"lean": "BULLISH_TILT"})
+    assert fam["kind"] == "call_debit_spread"
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=chain, dte_lo=21, dte_hi=60, dte_pref=35)
+    assert detail["status"] == "ready"
+    buy, sell = detail["legs"]
+    assert buy["action"] == "BUY" and buy["right"] == "CALL"
+    assert buy["strike"] == Decimal("105")     # closest to +0.25
+    assert sell["strike"] == Decimal("112")    # closest to +0.12
+    assert buy["strike"] < sell["strike"]      # defined-risk bull call (debit) spread
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `uv run pytest tests/unit/cards/test_skew_structure_legs.py -v`
+Expected: FAIL — no `structure_family` / `select_structure_legs`.
+
+- [ ] **Step 3: Implement the family descriptor + refactor `_express_structure`**
+
+In `src/uw_scan/cards/skew_first_principles.py`, add above `_express_structure`:
+
+```python
+# Defined-risk structure families keyed on the EVIDENCE-GATED lean (never on
+# deviation×tail posture — see Phase-2 hardening correction A). Both are long-premium
+# debit spreads: max loss = net debit, no naked leg. Target deltas pick the wings.
+_STRUCTURE_FAMILIES: dict[str, dict] = {
+    "BEARISH_TILT": {
+        "kind": "put_debit_spread",
+        "legs": [
+            {"action": "BUY", "right": "PUT", "target_delta": -0.25},
+            {"action": "SELL", "right": "PUT", "target_delta": -0.12},
+        ],
+    },
+    "BULLISH_TILT": {
+        "kind": "call_debit_spread",
+        "legs": [
+            {"action": "BUY", "right": "CALL", "target_delta": 0.25},
+            {"action": "SELL", "right": "CALL", "target_delta": 0.12},
+        ],
+    },
+}
+
+_FAMILY_PHRASE = {
+    "put_debit_spread": "put-debit-spread — defined risk",
+    "call_debit_spread": "call-debit-spread — defined risk",
+}
+
+
+def structure_family(directional_lean: dict) -> dict | None:
+    """Structure descriptor for an already-gated lean. None for NEUTRAL — V1's
+    anti-overtrading default. Single source consumed by both _express_structure
+    (the string) and select_structure_legs (the concrete strikes)."""
+    return _STRUCTURE_FAMILIES.get((directional_lean or {}).get("lean") or "")
+```
+
+Replace the body of `_express_structure` so it derives from the family (preserves the existing strings' intent — defined-risk debit spread per lean):
+
+```python
+def _express_structure(deviation_class: str, lean: str) -> str:
+    """Defined-risk structure string. NO naked shorts: every structure is a debit
+    vertical (long premium, max loss = net debit). Derived from structure_family so
+    the string and the concrete legs never drift."""
+    fam = structure_family({"lean": lean})
+    if fam is None:
+        return ""
+    return _FAMILY_PHRASE.get(fam["kind"], "")
+```
+
+Then add the pure strike picker:
+
+```python
+def select_structure_legs(
+    *,
+    family: dict | None,
+    exposure_rows: list[dict],
+    dte_lo: int = 21,
+    dte_hi: int = 60,
+    dte_pref: int = 35,
+    earnings_note: str = "",
+) -> dict:
+    """Pick concrete legs for `family` by nearest target delta within one expiry.
+    Pure — exposure_rows: dicts with expiry, strike, dte, put_delta/call_delta.
+    Returns a structure_detail dict (kind, legs, dte_target, status, note)."""
+    if family is None:
+        return {"kind": "", "legs": [], "dte_target": None,
+                "status": "suppressed", "note": ""}
+    # candidate expiries inside the swing window; prefer the one nearest dte_pref
+    by_expiry: dict = {}
+    for r in exposure_rows or []:
+        dte = r.get("dte")
+        if dte is None or not (dte_lo <= int(dte) <= dte_hi):
+            continue
+        by_expiry.setdefault(r["expiry"], []).append(r)
+    if not by_expiry:
+        return {"kind": family["kind"], "legs": [], "dte_target": None,
+                "status": "no_chain", "note": ""}
+    expiry = min(by_expiry, key=lambda e: abs(int(by_expiry[e][0]["dte"]) - dte_pref))
+    chain = by_expiry[expiry]
+    dte_target = int(chain[0]["dte"])
+    delta_key = "put_delta" if family["legs"][0]["right"] == "PUT" else "call_delta"
+
+    legs: list[dict] = []
+    for leg in family["legs"]:
+        target = leg["target_delta"]
+        cands = [r for r in chain if r.get(delta_key) is not None]
+        if not cands:
+            return {"kind": family["kind"], "legs": [], "dte_target": dte_target,
+                    "status": "no_chain", "note": ""}
+        best = min(cands, key=lambda r: abs(float(r[delta_key]) - target))
+        legs.append({
+            "action": leg["action"], "right": leg["right"],
+            "strike": best["strike"], "target_delta": target,
+            "actual_delta": best[delta_key], "expiry": expiry, "dte": dte_target,
+        })
+    # Defined-risk guard (standing rule: no naked shorts). The long (first) and short
+    # (second) legs must form a DEBIT spread in the intended direction — the long wing
+    # nearer ATM than the short wing. PUT debit: long strike > short strike. CALL debit:
+    # long strike < short strike. A degenerate/non-monotonic chain that would invert this
+    # (turning it into a short-premium credit spread) yields no_chain instead.
+    long_leg, short_leg = legs[0], legs[1]
+    ok = (
+        long_leg["strike"] > short_leg["strike"]
+        if long_leg["right"] == "PUT"
+        else long_leg["strike"] < short_leg["strike"]
+    )
+    if not ok:
+        return {"kind": family["kind"], "legs": [], "dte_target": dte_target,
+                "status": "no_chain", "note": ""}
+    note = "defined risk; long-premium debit spread"
+    if earnings_note:
+        note += f"; {earnings_note}"
+    return {"kind": family["kind"], "legs": legs, "dte_target": dte_target,
+            "status": "ready", "note": note}
+```
+
+- [ ] **Step 4: Run deriver tests**
+
+Run: `uv run pytest tests/unit/cards/test_skew_structure_legs.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update + run the existing express test for parity**
+
+In `tests/unit/cards/test_skew_first_principles.py`, the existing assertions on `_express_structure` strings may have expected `"put-debit-spread (sell the lower put wing to finance) — defined risk"` or `"call-debit-spread or put-credit-spread — defined risk"`. Update them to the new single-source strings (`"put-debit-spread — defined risk"`, `"call-debit-spread — defined risk"`) and add:
+
+```python
+def test_express_matches_structure_family():
+    from uw_scan.cards import skew_first_principles as sk
+    assert sk._express_structure("RICH", "BEARISH_TILT") == "put-debit-spread — defined risk"
+    assert sk._express_structure("CHEAP", "BULLISH_TILT") == "call-debit-spread — defined risk"
+    assert sk._express_structure("NORMAL", "NEUTRAL") == ""
+    assert sk.structure_family({"lean": "NEUTRAL"}) is None
+```
+
+Run: `uv run pytest tests/unit/cards/test_skew_first_principles.py -v`
+Expected: PASS.
+
+---
+
+## Task 7: Assembler + worker wiring — attach `structure_detail` (M2)
+
+**Files:**
+- Modify: `src/uw_scan/reports/skew_analytics.py`
+- Modify: `src/uw_scan/worker/jobs/skew_analytics.py`
+- Test: `tests/unit/reports/test_skew_snapshot_row.py` (extend)
+- Test: `tests/integration/api/test_skew.py` (keep green; optionally assert field presence)
+
+**Design:** `build_skew_snapshot_row` stays pure but gains an `exposure_rows` param. When `lean != NEUTRAL` AND `asset_class != "index_macro"` AND `earnings_gate != "block"` AND `exposure_rows` provided, compute `structure_detail` and attach to the lean dict. Callers fetch exposures.
+
+- [ ] **Step 1: Write the failing assembler-row test**
+
+Append to `tests/unit/reports/test_skew_snapshot_row.py`. Verified Pass-1: reuse the file's existing `_rr_series()` / `_rv_series()` helpers and the EXACT bearish kwargs from `test_build_row_bearish_with_seeded_verdict` (NVDA → single_name; `next_earnings_date=None` → egate `unknown` ≠ `block`; the seeded verdict has NO `regime` key, so `resolve_directional_lean`'s regime-gate is skipped → lean = BEARISH_TILT). Add `from decimal import Decimal` to the imports:
+
+```python
+def test_structure_detail_present_when_non_neutral_with_exposures():
+    rr = _rr_series()
+    ex = date(2026, 8, 1)
+    exposures = [
+        {"expiry": ex, "strike": Decimal("95"), "dte": 33, "put_delta": Decimal("-0.26")},
+        {"expiry": ex, "strike": Decimal("88"), "dte": 33, "put_delta": Decimal("-0.13")},
+    ]
+    row = build_skew_snapshot_row(
+        ticker="NVDA",
+        market_date=rr[-1]["market_date"],
+        rr_series=rr,
+        expiry_rows=[{"expiry": date(2026, 8, 1), "risk_reversal": 0.05}],
+        rv_series=_rv_series(),
+        spy_rv_series=_rv_series(),
+        positioning={"si_fee_rate": 0.25, "si_days_to_cover": 1.2},
+        next_earnings_date=None,
+        verdict={
+            "verdict": "TRADABLE_BEAR", "confidence": "med", "forward_sep": -0.02,
+            "borrow_clean": True, "survives_gate": True,
+        },
+        sector=None,
+        today=rr[-1]["market_date"],
+        exposure_rows=exposures,
+    )
+    assert row["directional_lean"] == "BEARISH_TILT"  # precondition: lean is gated on
+    sd = row["read_json"]["directional_lean"]["structure_detail"]
+    assert sd is not None and sd["status"] == "ready"
+    assert sd["kind"] == "put_debit_spread"
+    assert len(sd["legs"]) == 2
+    assert sd["legs"][0]["action"] == "BUY" and sd["legs"][0]["strike"] == Decimal("95")
+
+
+def test_structure_detail_absent_when_neutral():
+    # The existing NEUTRAL happy-path kwargs (verdict=None) must yield NO structure even
+    # if exposures are supplied — increment-1 gates on a non-neutral lean.
+    rr = _rr_series()
+    row = build_skew_snapshot_row(
+        ticker="NVDA",
+        market_date=rr[-1]["market_date"],
+        rr_series=rr,
+        expiry_rows=[{"expiry": date(2026, 8, 1), "risk_reversal": 0.05}],
+        rv_series=_rv_series(),
+        spy_rv_series=_rv_series(),
+        positioning={"si_fee_rate": 0.25, "si_days_to_cover": 1.2},
+        next_earnings_date=None,
+        verdict=None,
+        sector=None,
+        today=rr[-1]["market_date"],
+        exposure_rows=[{"expiry": date(2026, 8, 1), "strike": Decimal("95"),
+                        "dte": 33, "put_delta": Decimal("-0.26")}],
+    )
+    assert row["directional_lean"] == "NEUTRAL"
+    assert row["read_json"]["directional_lean"]["structure_detail"] is None
+```
+
+NOTE: the existing two tests in this file omit `exposure_rows`; the new kwarg MUST default to `None` (Task 7 Step 3) so they stay green unchanged.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `uv run pytest tests/unit/reports/test_skew_snapshot_row.py -v`
+Expected: FAIL — `build_skew_snapshot_row` has no `exposure_rows` kwarg / no `structure_detail` key.
+
+- [ ] **Step 3: Implement in `build_skew_snapshot_row`**
+
+Add `exposure_rows: list[dict] | None = None` to the signature (keyword-only, after `today`). After `lean = sk.resolve_directional_lean(...)` and before `tail = sk.skew_sign_label(rr_25d)`, insert:
+
+```python
+    # Concrete strike-by-delta detail — ONLY when the lean is already gated non-neutral
+    # (Phase-2 increment-1). Non-index only; suppressed during an earnings block.
+    fam = sk.structure_family(lean)
+    if (
+        fam is not None
+        and cls["asset_class"] != "index_macro"
+        and egate != "block"
+        and exposure_rows
+    ):
+        earn_note = (
+            f"exit before earnings {next_earnings_date.isoformat()}"
+            if next_earnings_date is not None
+            else "swing hold; exit before next earnings"
+        )
+        lean["structure_detail"] = sk.select_structure_legs(
+            family=fam, exposure_rows=exposure_rows, earnings_note=earn_note
+        )
+    else:
+        lean["structure_detail"] = None
+```
+
+(`build_read` already receives `directional_lean=lean`, so the detail rides into `read_json["directional_lean"]`.)
+
+- [ ] **Step 4: Map `structure_detail` into the typed response**
+
+In `assemble_skew_analysis`, where it builds `SkewDirectionalLean(...)` (around line 298-303), add the mapping. First fetch exposures before the second `build_skew_snapshot_row` call:
+
+```python
+    exposures = repo.fetch_latest_exposures_by_strike(t, dte_max=70)
+```
+
+Pass `exposure_rows=exposures` into the SECOND `build_skew_snapshot_row(...)` call (the one with the real `verdict`). Then where `SkewDirectionalLean(...)` is constructed, add:
+
+```python
+        directional_lean=SkewDirectionalLean(
+            lean=lean["lean"],
+            confidence=lean["confidence"],
+            basis=lean["basis"],
+            express=lean["express"],
+            structure_detail=_to_structure_detail(lean.get("structure_detail")),
+        ),
+```
+
+Add a small typed mapper near `_dec` in `skew_analytics.py`:
+
+```python
+from uw_scan.models import SkewStructureDetail, SkewStructureLeg  # add to existing import
+
+
+def _to_structure_detail(d: dict | None) -> SkewStructureDetail | None:
+    if not d:
+        return None
+    return SkewStructureDetail(
+        kind=d.get("kind", ""),
+        dte_target=d.get("dte_target"),
+        status=d.get("status", "ready"),
+        note=d.get("note", ""),
+        legs=[
+            SkewStructureLeg(
+                action=g.get("action", ""), right=g.get("right", ""),
+                strike=_dec(g.get("strike")), target_delta=_dec(g.get("target_delta")),
+                actual_delta=_dec(g.get("actual_delta")),
+                expiry=g.get("expiry"), dte=g.get("dte"),
+            )
+            for g in d.get("legs", [])
+        ],
+    )
+```
+
+- [ ] **Step 5: Wire the nightly worker rollup to pass exposures**
+
+In `src/uw_scan/worker/jobs/skew_analytics.py`, `_build_for_date` signature: add `exposure_rows: list[dict] | None = None` and pass it into BOTH `build_skew_snapshot_row` calls. In `nightly_skew_analytics_rollup`, before calling `_build_for_date`, fetch once per ticker:
+
+```python
+        exposures = repo.fetch_latest_exposures_by_strike(ticker, dte_max=70)
+```
+
+and pass `exposure_rows=exposures`. In `skew_analytics_backfill`, pass `exposure_rows=None` (historical days have no point-in-time chain — structure detail is a live-only enrichment; documented).
+
+- [ ] **Step 5b: Make `read_json` JSON-safe at persistence (structure_detail adds Decimal/date)**
+
+`build_skew_snapshot_row` puts the in-memory read dict (now containing `Decimal` strikes/deltas and a `_date` expiry inside `structure_detail`) into `read_json`, and `upsert_skew_analytics_snapshots` wraps it with `Jsonb(...)`, whose default `json.dumps` raises on `Decimal`/`date`. Fix the wrap (the in-memory `row["read_json"]` used by `assemble_skew_analysis` for the typed response is UNAFFECTED — only the persisted JSON is stringified, and nothing reads structure_detail back from the persisted JSON).
+
+In `src/uw_scan/storage/skew.py`, add near the imports:
+
+```python
+import json
+from functools import partial
+
+_json_safe_dumps = partial(json.dumps, default=str)  # Decimal/date -> str for JSONB
+```
+
+In `upsert_skew_analytics_snapshots`, change the `read_json` wrap:
+
+```python
+            tail = tuple(
+                Jsonb(r.get(c), dumps=_json_safe_dumps)
+                if c == "read_json" and r.get(c) is not None
+                else r.get(c)
+                for c in _SNAP_COLUMNS
+            )
+```
+
+Write the failing integration test FIRST in `tests/integration/storage/test_skew_storage.py`:
+
+```python
+def test_snapshot_persists_structure_detail_with_decimal_and_date(repo):
+    from datetime import date
+    from decimal import Decimal
+    row = {
+        "ticker": "QCOM", "market_date": date(2026, 6, 16), "basis": "eod",
+        "deviation_class": "CHEAP", "directional_lean": "BEARISH_TILT",
+        "read_summary": "x",
+        "read_json": {
+            "directional_lean": {
+                "lean": "BEARISH_TILT",
+                "structure_detail": {
+                    "kind": "put_debit_spread", "dte_target": 33, "status": "ready",
+                    "note": "defined risk",
+                    "legs": [{"action": "BUY", "right": "PUT", "strike": Decimal("95"),
+                              "target_delta": Decimal("-0.25"),
+                              "actual_delta": Decimal("-0.26"),
+                              "expiry": date(2026, 7, 18), "dte": 33}],
+                },
+            },
+        },
+    }
+    repo.upsert_skew_analytics_snapshots([row])   # must NOT raise on Decimal/date
+    repo.conn.commit()
+    got = repo.get_skew_analytics_latest("QCOM")
+    sd = got["read_json"]["directional_lean"]["structure_detail"]
+    assert sd["legs"][0]["strike"] in ("95", "95.00", "95")  # stringified by default=str
+    assert sd["legs"][0]["expiry"] == "2026-07-18"
+```
+
+Run: `uv run pytest tests/integration/storage/test_skew_storage.py::test_snapshot_persists_structure_detail_with_decimal_and_date -v`
+Expected: FAIL first (psycopg `TypeError: Object of type Decimal is not JSON serializable`), PASS after the `dumps=_json_safe_dumps` change.
+
+- [ ] **Step 6: Run backend tests**
+
+Run: `uv run pytest tests/unit/reports/test_skew_snapshot_row.py tests/integration/api/test_skew.py tests/integration/worker/test_skew_jobs.py tests/integration/storage/test_skew_storage.py -v`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit M2**
+
+```bash
+git add src/uw_scan/storage/options.py src/uw_scan/storage/skew.py \
+        src/uw_scan/models/skew.py src/uw_scan/models/__init__.py \
+        src/uw_scan/cards/skew_first_principles.py src/uw_scan/reports/skew_analytics.py \
+        src/uw_scan/worker/jobs/skew_analytics.py \
+        tests/unit/cards/test_skew_structure_legs.py tests/unit/cards/test_skew_first_principles.py \
+        tests/unit/reports/test_skew_snapshot_row.py tests/integration/storage/test_skew_storage.py \
+        tests/unit/test_models_exports.py
+git commit -m "feat(skew): concrete strike-by-delta detail on the gated directional lean"
+```
+
+---
+
+## Task 8: API contract — regenerate types + OpenAPI snapshot (M3)
+
+**Files:**
+- Modify: `web/lib/types.ts` (generated)
+- Modify: `tests/integration/api/openapi.snapshot.json` (generated)
+
+- [ ] **Step 1: Confirm the snapshot drifts (test fails) after the model change**
+
+Run: `uv run pytest tests/integration/api/test_openapi_snapshot.py -v`
+Expected: FAIL — `components.schemas` changed (new `SkewStructureDetail` / `SkewStructureLeg`, new `structure_detail` property). This proves the contract grew.
+
+- [ ] **Step 2: Regenerate the committed snapshot** (verified format: `indent=2, sort_keys=True`, trailing newline; produced via `create_app().openapi()` — no DB, no TestClient needed)
+
+```bash
+uv run python -c "
+import json
+from uw_scan.api.server import create_app
+spec = create_app().openapi()
+with open('tests/integration/api/openapi.snapshot.json', 'w') as f:
+    json.dump(spec, f, indent=2, sort_keys=True)
+    f.write('\n')
+"
+uv run pytest tests/integration/api/test_openapi_snapshot.py -v   # now PASS
+```
+
+- [ ] **Step 3: Regenerate TypeScript types** (the `gen:types` script targets the LIVE API at `http://127.0.0.1:8400`, so the API must be running)
+
+```bash
+# in one shell: bring up the API (or the full stack) — e.g. bash scripts/dev.sh
+cd web && npm run gen:types
+```
+Expected: `lib/types.ts` diff adds `SkewStructureDetail`, `SkewStructureLeg`, and `structure_detail` on the lean type. If the API is not runnable in this environment, generate from the local spec instead: `cd web && npx openapi-typescript ../tests/integration/api/openapi.snapshot.json -o lib/types.ts` (same source of truth, just regenerated above).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: PASS (no drift, no unused-type errors).
+
+---
+
+## Task 9: UI — render structure legs in the Signal Detail card (M3)
+
+**Files:**
+- Modify: `web/components/stock/panels/SkewSignalDetail.tsx`
+- Test: `web/tests/unit/SkewSignalDetail.test.tsx` (extend)
+
+**Design:** below the existing Evidence rows (after the `express` row, inside the right `metric-card`), render a compact, defined-risk structure block when `lean.structure_detail?.status === "ready"`. Keep the VCG/mono aesthetic. When absent or not "ready", render nothing new (NEUTRAL names look exactly like V1).
+
+- [ ] **Step 1: Write the failing vitest**
+
+Append to `web/tests/unit/SkewSignalDetail.test.tsx` (mirror the existing render-helper + mock-data pattern in that file):
+
+```tsx
+it("renders the defined-risk structure legs when status is ready", () => {
+  const data = makeData({
+    read: {
+      directional_lean: {
+        lean: "BEARISH_TILT", confidence: "high", basis: "validated …",
+        express: "put-debit-spread — defined risk",
+        structure_detail: {
+          kind: "put_debit_spread", dte_target: 33, status: "ready",
+          note: "defined risk; exit before earnings 2026-07-18",
+          legs: [
+            { action: "BUY", right: "PUT", strike: "95", target_delta: "-0.25",
+              actual_delta: "-0.26", expiry: "2026-07-18", dte: 33 },
+            { action: "SELL", right: "PUT", strike: "88", target_delta: "-0.12",
+              actual_delta: "-0.13", expiry: "2026-07-18", dte: 33 },
+          ],
+        },
+      },
+    },
+  });
+  render(<SkewSignalDetail data={data} />);
+  expect(screen.getByTestId("skew-structure-detail")).toBeInTheDocument();
+  expect(screen.getByText(/put-debit-spread/i)).toBeInTheDocument();
+  expect(screen.getByText(/BUY/)).toBeInTheDocument();
+  expect(screen.getByText(/95/)).toBeInTheDocument();
+  expect(screen.getByText(/defined risk/i)).toBeInTheDocument();
+});
+
+it("renders no structure block for a NEUTRAL lean", () => {
+  const data = makeData({
+    read: { directional_lean: { lean: "NEUTRAL", structure_detail: null } },
+  });
+  render(<SkewSignalDetail data={data} />);
+  expect(screen.queryByTestId("skew-structure-detail")).not.toBeInTheDocument();
+});
+```
+
+(Use the file's existing `makeData` deep-merge helper; if it shallow-merges, extend the mock object fully.)
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd web && npm run test -- SkewSignalDetail`
+Expected: FAIL — no `skew-structure-detail` testid.
+
+- [ ] **Step 3: Implement the structure block**
+
+In `SkewSignalDetail.tsx`, add a presentational helper above `SkewSignalDetail`:
+
+```tsx
+function StructureDetail({
+  detail,
+}: {
+  detail: NonNullable<SkewAnalysisResponse["read"]["directional_lean"]["structure_detail"]>;
+}) {
+  if (detail.status !== "ready" || !detail.legs?.length) return null;
+  return (
+    <div
+      data-testid="skew-structure-detail"
+      style={{
+        borderTop: "1px solid var(--border-dim, var(--line-grid))",
+        marginTop: "8px",
+        paddingTop: "8px",
+      }}
+    >
+      <div style={{ ...labelStyle, marginBottom: "6px" }}>
+        Structure · {detail.kind.replace(/_/g, "-")}
+        {detail.dte_target ? ` · ${detail.dte_target}DTE` : ""}
+      </div>
+      {detail.legs.map((leg, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontFamily: "var(--font-mono)",
+            fontSize: "11px",
+            padding: "2px 0",
+          }}
+        >
+          <span style={{ color: "var(--text-muted)" }}>
+            {leg.action} {leg.right}
+          </span>
+          <span style={{ color: "var(--text-secondary)" }}>
+            {leg.strike != null ? String(leg.strike) : "—"}
+            {leg.actual_delta != null ? ` (Δ ${fmtSigned(toNum(leg.actual_delta) ?? 0, 2)})` : ""}
+          </span>
+        </div>
+      ))}
+      {detail.note ? (
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "10px",
+            color: "var(--text-muted)",
+            marginTop: "5px",
+            lineHeight: 1.4,
+          }}
+        >
+          {detail.note}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+Render it inside the right `metric-card`, immediately after the closing `</div>` of the evidence-rows block (after the `regime` `EvidenceRow`), still inside the bordered evidence container:
+
+```tsx
+            <EvidenceRow label="regime" value={data.regime} />
+            {lean.structure_detail ? (
+              <StructureDetail detail={lean.structure_detail} />
+            ) : null}
+```
+
+- [ ] **Step 4: Run vitest + typecheck**
+
+Run: `cd web && npm run test -- SkewSignalDetail && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit M3**
+
+```bash
+git add web/lib/types.ts tests/integration/api/openapi.snapshot.json \
+        web/components/stock/panels/SkewSignalDetail.tsx web/tests/unit/SkewSignalDetail.test.tsx
+git commit -m "feat(skew): surface concrete strike-by-delta structure in the Signal Detail card"
+```
+
+---
+
+## Task 10: E2E — extend the Skew tab spec (M3/M4)
+
+**Files:**
+- Modify: `web/tests/e2e/skew-tab.spec.ts`
+
+**Design:** the e2e hits a real running stack. Most names are NEUTRAL (no structure block) — assert the structure block is *optional but well-formed when present*: if `skew-lean-pill` is not NEUTRAL, `skew-structure-detail` must exist and show ≥2 legs; if NEUTRAL, it must be absent. Pick a ticker likely to be non-neutral if the suite already targets one; otherwise keep it tolerant.
+
+- [ ] **Step 1: Add the conditional assertion**
+
+Append to `web/tests/e2e/skew-tab.spec.ts` (inside the existing Skew-tab describe, reuse its navigation/setup):
+
+```ts
+test("structure detail appears only for a non-neutral lean", async ({ page }) => {
+  // navigate to the skew tab (reuse the spec's existing helper / beforeEach)
+  const pill = page.getByTestId("skew-lean-pill");
+  await expect(pill).toBeVisible();
+  const lean = (await pill.textContent())?.trim() ?? "";
+  const block = page.getByTestId("skew-structure-detail");
+  if (lean === "NEUTRAL") {
+    await expect(block).toHaveCount(0);
+  } else {
+    await expect(block).toBeVisible();
+    await expect(block).toContainText(/-spread/);
+    // at least two legs (BUY + SELL lines)
+    await expect(block.getByText(/BUY|SELL/)).toHaveCount(2);
+  }
+});
+```
+
+- [ ] **Step 2: Run e2e if a stack is available**
+
+Run (from repo root, with API+web up — `bash scripts/dev.sh` or the e2e's own webServer): `cd web && npm run test:e2e -- skew-tab`
+Expected: PASS. If no stack/data is available in the execution environment, record this as the one explicitly-unverified item and run it during the final verification step against the running dev stack.
+
+---
+
+## Task 11: Milestone M4 — research note + full verification
+
+**Files:**
+- Create: `docs/research/skew-rr-reversion-trigger-2026-06.md`
+
+- [ ] **Step 1: Run the RV markout harness on real local data**
+
+The backfill already populated `skew_analytics_snapshot` on `option_wizard_local` (per the V1 markout note). Run the harness and capture the RV reversion output:
+
+`_repo` in `scheduler.py` is a CONTEXT MANAGER (`@contextmanager def _repo(settings) -> Iterator[Repository]`), so it must be entered with `with`:
+
+```bash
+uv run python -c "
+import json
+from uw_scan.config import Settings
+from uw_scan.worker.scheduler import _repo
+from uw_scan.reports.skew_markout import run_skew_markout
+with _repo(Settings()) as repo:
+    out = run_skew_markout(repo=repo)
+print(json.dumps(out['rv_reversion'], indent=2, default=str))
+"
+```
+
+This runs against whatever DB the env points at — confirm it is `option_wizard_local` (the three-tier tripwire blocks a mini host + local name, so a stray `.env` mistake fails loudly rather than writing prod).
+
+- [ ] **Step 2: Write the research note**
+
+Create `docs/research/skew-rr-reversion-trigger-2026-06.md` with: method (tail-split keys, expected-sign gate, time-ordered 40% holdout, thresholds), the captured per-bucket table (verdict / mean_drr / mean_drr_holdout / n / survives_walkforward), and the loud limitations (single ~1yr in-sample window; holdout and train share regime; descriptive RV axis, **no spread-P&L / net-of-cost** — that validation is data-blocked and split out). Cross-reference `docs/research/skew-first-principles-markout-2026-06.md` for the primary numbers (do not duplicate the directional table).
+
+- [ ] **Step 3: Full backend test sweep**
+
+Run: `uv run pytest tests/unit/cards/ tests/unit/reports/ tests/integration/reports/test_skew_markout.py tests/integration/reports/test_skew_rv_markout.py tests/integration/storage/test_skew_storage.py tests/integration/api/test_skew.py tests/integration/worker/test_skew_jobs.py tests/unit/test_models_exports.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: CI guardrail + migration idempotency + web suite**
+
+Run: `uv run python scripts/_lint_except.py src` → expect "ok: no banned except patterns".
+Run: `bash scripts/migrate.sh && bash scripts/migrate.sh` → both succeed (idempotent).
+Run: `cd web && npm run typecheck && npm run test` → PASS.
+
+- [ ] **Step 5: Browser/e2e verification**
+
+Bring up the dev stack and open a stock page → Skew tab for both a NEUTRAL and (if available) a non-neutral name; confirm the structure block renders legs + the defined-risk note for the non-neutral one and is absent for NEUTRAL. Capture a screenshot under `output/playwright/`. Run `cd web && npm run test:e2e -- skew-tab`.
+
+- [ ] **Step 6: Commit M4**
+
+```bash
+git add docs/research/skew-rr-reversion-trigger-2026-06.md web/tests/e2e/skew-tab.spec.ts
+git commit -m "docs(skew): RR mean-reversion trigger research note + e2e structure assertion"
+```
+
+---
+
+## Verification matrix (fill during execution)
+
+| Claim | Evidence | How to re-verify |
+|---|---|---|
+| RV verdict store gated by walk-forward | `test_skew_rv_markout.py` green + `_rv_walkforward` unit cases | `uv run pytest tests/integration/reports/test_skew_rv_markout.py -v` |
+| Tail-split keys persisted | `skew_rv_reversion_verdicts` rows keyed (asset_class, deviation_class, tail) | `psql -c "select * from uw_scan.skew_rv_reversion_verdicts"` |
+| Strikes picked by target delta | `test_skew_structure_legs.py` green | `uv run pytest tests/unit/cards/test_skew_structure_legs.py -v` |
+| Structure only on non-neutral lean | assembler-row tests + vitest absence test | `uv run pytest tests/unit/reports/test_skew_snapshot_row.py -v` |
+| No naked legs | both families are debit spreads; deriver asserts distinct strikes | inspect `_STRUCTURE_FAMILIES` + `select_structure_legs` |
+| Contract in sync | `gen:types` diff + openapi snapshot test green | `cd web && npm run gen:types` (empty diff) |
+| Migration idempotent | two `migrate.sh` runs no-op | `bash scripts/migrate.sh && bash scripts/migrate.sh` |
+| UI renders legs | vitest + e2e + screenshot | `cd web && npm run test -- SkewSignalDetail` |
+| No P&L/net-of-cost claim made | research note states it explicitly; no such code path | read `docs/research/skew-rr-reversion-trigger-2026-06.md` |
+
+## Out of scope (split-out follow-on plans — do NOT build here)
+- Net-of-cost / OOS spread-P&L validation (data-blocked: chain ~5d, greeks ~30d history).
+- Delta-hedge sizing helper (Structure 3).
+- Layer-2 cross-pillar gate in the backend trade-blast AI pipeline (`framework{}`), not `FrameworkTab.tsx`.
+- Wiring the RV reversion verdict to *also* unlock structure detail for NEUTRAL-lean names (deliberate: needs the walk-forward to validate first).

--- a/src/uw_scan/cards/skew_first_principles.py
+++ b/src/uw_scan/cards/skew_first_principles.py
@@ -149,22 +149,142 @@ def skew_sign_label(rr: float | None, *, eps: float = 1e-6) -> str:
     return "flat"
 
 
+# Defined-risk structure families keyed on the EVIDENCE-GATED lean (never on
+# deviation×tail posture — see Phase-2 hardening correction A). Both are long-premium
+# debit spreads: max loss = net debit, no naked leg. Target deltas pick the wings.
+_STRUCTURE_FAMILIES: dict[str, dict] = {
+    "BEARISH_TILT": {
+        "kind": "put_debit_spread",
+        "legs": [
+            {"action": "BUY", "right": "PUT", "target_delta": -0.25},
+            {"action": "SELL", "right": "PUT", "target_delta": -0.12},
+        ],
+    },
+    "BULLISH_TILT": {
+        "kind": "call_debit_spread",
+        "legs": [
+            {"action": "BUY", "right": "CALL", "target_delta": 0.25},
+            {"action": "SELL", "right": "CALL", "target_delta": 0.12},
+        ],
+    },
+}
+
+_FAMILY_PHRASE = {
+    "put_debit_spread": "put-debit-spread — defined risk",
+    "call_debit_spread": "call-debit-spread — defined risk",
+}
+
+
+def structure_family(directional_lean: dict) -> dict | None:
+    """Structure descriptor for an already-gated lean. None for NEUTRAL — V1's
+    anti-overtrading default. Single source consumed by both _express_structure
+    (the string) and select_structure_legs (the concrete strikes)."""
+    return _STRUCTURE_FAMILIES.get((directional_lean or {}).get("lean") or "")
+
+
 def _express_structure(deviation_class: str, lean: str) -> str:
-    """Defined-risk structure expressing the lean. NO naked shorts (standing rule):
-    every structure is a vertical spread or a long option — never a bare short
-    call/put and never a stock-assuming 'collar'."""
-    if lean == "BEARISH_TILT":
-        if deviation_class == "RICH":
-            # finance by selling the lower (cheaper) put wing INSIDE a debit spread
-            return (
-                "put-debit-spread (sell the lower put wing to finance) — defined risk"
-            )
-        return "put-debit-spread — defined risk"
-    if lean == "BULLISH_TILT":
-        if deviation_class == "CHEAP":
-            return "call-debit-spread (cheap downside hedge available) — defined risk"
-        return "call-debit-spread or put-credit-spread — defined risk"
-    return ""
+    """Defined-risk structure string. NO naked shorts: every structure is a debit
+    vertical (long premium, max loss = net debit). Derived from structure_family so the
+    string and the concrete legs (select_structure_legs) never drift."""
+    fam = structure_family({"lean": lean})
+    if fam is None:
+        return ""
+    return _FAMILY_PHRASE.get(fam["kind"], "")
+
+
+def select_structure_legs(
+    *,
+    family: dict | None,
+    exposure_rows: list[dict],
+    dte_lo: int = 21,
+    dte_hi: int = 60,
+    dte_pref: int = 35,
+    earnings_note: str = "",
+) -> dict:
+    """Pick concrete legs for `family` by nearest target delta within one expiry.
+    Pure — exposure_rows: dicts with expiry, strike, dte, put_delta/call_delta.
+    Returns a structure_detail dict (kind, legs, dte_target, status, note)."""
+    if family is None:
+        return {
+            "kind": "",
+            "legs": [],
+            "dte_target": None,
+            "status": "suppressed",
+            "note": "",
+        }
+    # candidate expiries inside the swing window; prefer the one nearest dte_pref
+    by_expiry: dict = {}
+    for r in exposure_rows or []:
+        dte = r.get("dte")
+        if dte is None or not (dte_lo <= int(dte) <= dte_hi):
+            continue
+        by_expiry.setdefault(r["expiry"], []).append(r)
+    if not by_expiry:
+        return {
+            "kind": family["kind"],
+            "legs": [],
+            "dte_target": None,
+            "status": "no_chain",
+            "note": "",
+        }
+    expiry = min(by_expiry, key=lambda e: abs(int(by_expiry[e][0]["dte"]) - dte_pref))
+    chain = by_expiry[expiry]
+    dte_target = int(chain[0]["dte"])
+    delta_key = "put_delta" if family["legs"][0]["right"] == "PUT" else "call_delta"
+
+    legs: list[dict] = []
+    for leg in family["legs"]:
+        target = leg["target_delta"]
+        cands = [r for r in chain if r.get(delta_key) is not None]
+        if not cands:
+            return {
+                "kind": family["kind"],
+                "legs": [],
+                "dte_target": dte_target,
+                "status": "no_chain",
+                "note": "",
+            }
+        best = min(cands, key=lambda r: abs(float(r[delta_key]) - target))
+        legs.append(
+            {
+                "action": leg["action"],
+                "right": leg["right"],
+                "strike": best["strike"],
+                "target_delta": target,
+                "actual_delta": best[delta_key],
+                "expiry": expiry,
+                "dte": dte_target,
+            }
+        )
+    # Defined-risk guard (standing rule: no naked shorts). The long (first) and short
+    # (second) legs must form a DEBIT spread in the intended direction — the long wing
+    # nearer ATM than the short wing. PUT debit: long strike > short strike. CALL debit:
+    # long strike < short strike. A degenerate/non-monotonic chain that would invert this
+    # (turning it into a short-premium credit spread) yields no_chain instead.
+    long_leg, short_leg = legs[0], legs[1]
+    ok = (
+        long_leg["strike"] > short_leg["strike"]
+        if long_leg["right"] == "PUT"
+        else long_leg["strike"] < short_leg["strike"]
+    )
+    if not ok:
+        return {
+            "kind": family["kind"],
+            "legs": [],
+            "dte_target": dte_target,
+            "status": "no_chain",
+            "note": "",
+        }
+    note = "defined risk; long-premium debit spread"
+    if earnings_note:
+        note += f"; {earnings_note}"
+    return {
+        "kind": family["kind"],
+        "legs": legs,
+        "dte_target": dte_target,
+        "status": "ready",
+        "note": note,
+    }
 
 
 def resolve_directional_lean(

--- a/src/uw_scan/models/__init__.py
+++ b/src/uw_scan/models/__init__.py
@@ -121,6 +121,8 @@ from .skew import (
     SkewRhoPoint,
     SkewSmileExpiryCurve,
     SkewSmilePoint,
+    SkewStructureDetail,
+    SkewStructureLeg,
 )
 from .stock import (
     MarketStructure,
@@ -305,6 +307,8 @@ __all__ = [
     "SkewExpiryPoint",
     "SkewSmilePoint",
     "SkewSmileExpiryCurve",
+    "SkewStructureLeg",
+    "SkewStructureDetail",
     "SkewDirectionalLean",
     "SkewReadBullet",
     "SkewRead",

--- a/src/uw_scan/models/skew.py
+++ b/src/uw_scan/models/skew.py
@@ -36,11 +36,30 @@ class SkewSmileExpiryCurve(_UwBase):
     points: list[SkewSmilePoint] = []
 
 
+class SkewStructureLeg(_UwBase):
+    action: str = ""  # BUY | SELL
+    right: str = ""  # PUT | CALL
+    strike: Decimal | None = None
+    target_delta: Decimal | None = None  # the delta we aimed for (e.g. -0.25)
+    actual_delta: Decimal | None = None  # delta of the chosen strike
+    expiry: _date | None = None
+    dte: int | None = None
+
+
+class SkewStructureDetail(_UwBase):
+    kind: str = ""  # put_debit_spread | call_debit_spread
+    legs: list[SkewStructureLeg] = []
+    dte_target: int | None = None
+    status: str = "ready"  # ready | no_chain | suppressed
+    note: str = ""  # e.g. "defined risk; exit before earnings 2026-07-18"
+
+
 class SkewDirectionalLean(_UwBase):
     lean: str = "NEUTRAL"  # BULLISH_TILT | BEARISH_TILT | NEUTRAL
     confidence: str = "low"  # low | med | high
     basis: str = ""
     express: str = ""
+    structure_detail: SkewStructureDetail | None = None
 
 
 class SkewReadBullet(_UwBase):
@@ -101,6 +120,8 @@ _preserve_public_module(
     SkewExpiryPoint,
     SkewSmilePoint,
     SkewSmileExpiryCurve,
+    SkewStructureLeg,
+    SkewStructureDetail,
     SkewDirectionalLean,
     SkewReadBullet,
     SkewRead,

--- a/src/uw_scan/reports/skew_analytics.py
+++ b/src/uw_scan/reports/skew_analytics.py
@@ -139,14 +139,13 @@ def build_skew_snapshot_row(
         verdict=verdict,
     )
     # Concrete strike-by-delta detail — ONLY when the lean is already gated non-neutral
-    # (Phase-2 increment-1). Non-index only; suppressed during an earnings block.
+    # (Phase-2 increment-1). Suppressed during an earnings block. Index ETFs are
+    # included: their directional lean is research-validated (index_macro verdict
+    # buckets), so they earn the same defined-risk expression as single-names. The
+    # mean-reversion *trigger* is the only surface that skips indices (index skew is
+    # structural and does not revert). Renders only when a swing chain exists.
     fam = sk.structure_family(lean)
-    if (
-        fam is not None
-        and cls["asset_class"] != "index_macro"
-        and egate != "block"
-        and exposure_rows
-    ):
+    if fam is not None and egate != "block" and exposure_rows:
         earn_note = (
             f"exit before earnings {next_earnings_date.isoformat()}"
             if next_earnings_date is not None

--- a/src/uw_scan/reports/skew_analytics.py
+++ b/src/uw_scan/reports/skew_analytics.py
@@ -25,6 +25,8 @@ from uw_scan.models import (
     SkewRhoPoint,
     SkewSmileExpiryCurve,
     SkewSmilePoint,
+    SkewStructureDetail,
+    SkewStructureLeg,
 )
 from uw_scan.scanner.gates import earnings_gate as _earnings_gate
 from uw_scan.storage.repository import Repository
@@ -42,6 +44,29 @@ def _dec(v: Any) -> Decimal | None:
     except Exception as exc:  # noqa: BLE001
         log.debug("decimal coercion skipped for %r: %s", v, repr(exc))
         return None
+
+
+def _to_structure_detail(d: dict | None) -> SkewStructureDetail | None:
+    if not d:
+        return None
+    return SkewStructureDetail(
+        kind=d.get("kind", ""),
+        dte_target=d.get("dte_target"),
+        status=d.get("status", "ready"),
+        note=d.get("note", ""),
+        legs=[
+            SkewStructureLeg(
+                action=g.get("action", ""),
+                right=g.get("right", ""),
+                strike=_dec(g.get("strike")),
+                target_delta=_dec(g.get("target_delta")),
+                actual_delta=_dec(g.get("actual_delta")),
+                expiry=g.get("expiry"),
+                dte=g.get("dte"),
+            )
+            for g in d.get("legs", [])
+        ],
+    )
 
 
 def _price_trend(rv_series: list[dict], *, window: int = 20) -> float | None:
@@ -67,6 +92,7 @@ def build_skew_snapshot_row(
     verdict: dict | None,
     sector: str | None,
     today: _date,
+    exposure_rows: list[dict] | None = None,
 ) -> dict:
     """Pure stitch: raw series + verdict in, snapshot column dict out. No I/O."""
     rr_vals = [r.get("risk_reversal") for r in rr_series]
@@ -112,6 +138,25 @@ def build_skew_snapshot_row(
         earnings_gate=egate,
         verdict=verdict,
     )
+    # Concrete strike-by-delta detail — ONLY when the lean is already gated non-neutral
+    # (Phase-2 increment-1). Non-index only; suppressed during an earnings block.
+    fam = sk.structure_family(lean)
+    if (
+        fam is not None
+        and cls["asset_class"] != "index_macro"
+        and egate != "block"
+        and exposure_rows
+    ):
+        earn_note = (
+            f"exit before earnings {next_earnings_date.isoformat()}"
+            if next_earnings_date is not None
+            else "swing hold; exit before next earnings"
+        )
+        lean["structure_detail"] = sk.select_structure_legs(
+            family=fam, exposure_rows=exposure_rows, earnings_note=earn_note
+        )
+    else:
+        lean["structure_detail"] = None
     tail = sk.skew_sign_label(rr_25d)
     rho_confirms = (deviation == "RICH" and rho_sign < 0) or (
         deviation == "CHEAP" and rho_sign > 0
@@ -226,6 +271,9 @@ def assemble_skew_analysis(
         drive_class=pre["drive_class"],
         regime=pre["regime"],
     )
+    # Live per-strike greeks for strike-by-delta structure detail (only consumed when
+    # the lean is non-neutral). max(run_id) chain; empty list when none persisted.
+    exposures = repo.fetch_latest_exposures_by_strike(t, dte_max=70)
     row = build_skew_snapshot_row(
         ticker=t,
         market_date=market_date,
@@ -238,6 +286,7 @@ def assemble_skew_analysis(
         verdict=verdict,
         sector=sector,
         today=today,
+        exposure_rows=exposures,
     )
 
     if persist:
@@ -300,6 +349,7 @@ def assemble_skew_analysis(
             confidence=lean["confidence"],
             basis=lean["basis"],
             express=lean["express"],
+            structure_detail=_to_structure_detail(lean.get("structure_detail")),
         ),
     )
     return SkewAnalysisResponse(

--- a/src/uw_scan/reports/skew_analytics.py
+++ b/src/uw_scan/reports/skew_analytics.py
@@ -271,9 +271,9 @@ def assemble_skew_analysis(
         drive_class=pre["drive_class"],
         regime=pre["regime"],
     )
-    # Live per-strike greeks for strike-by-delta structure detail (only consumed when
-    # the lean is non-neutral). max(run_id) chain; empty list when none persisted.
-    exposures = repo.fetch_latest_exposures_by_strike(t, dte_max=70)
+    # Swing-DTE per-strike greeks for strike-by-delta structure detail (only consumed
+    # when the lean is non-neutral). Empty list when no swing chain persisted yet.
+    exposures = repo.fetch_latest_swing_greeks_by_strike(t)
     row = build_skew_snapshot_row(
         ticker=t,
         market_date=market_date,

--- a/src/uw_scan/reports/skew_markout.py
+++ b/src/uw_scan/reports/skew_markout.py
@@ -29,6 +29,79 @@ log = logging.getLogger(__name__)
 
 HORIZON = 20  # trading days for the canonical separation horizon
 
+RV_HOLDOUT_FRAC = 0.40  # time-ordered tail fraction held out for the OOS check
+RV_MIN_N = 30  # min obs to even consider an RV verdict
+RV_SEP_THRESHOLD = 0.005  # |mean ΔRR| floor (full sample)
+RV_HOLDOUT_THRESHOLD = 0.003  # |mean ΔRR| floor on the holdout
+
+
+def _expected_drr_sign(deviation_class: str) -> int:
+    """CHEAP re-richens (+), RICH flattens (-), else no directional reversion claim."""
+    if deviation_class == "CHEAP":
+        return 1
+    if deviation_class == "RICH":
+        return -1
+    return 0
+
+
+def _rv_survives_window_gate(obs: list[dict], overall_mean: float) -> bool:
+    """Per-calendar-quarter catastrophic-degradation gate (mirrors the directional
+    _survives_window_gate; standing rule: feedback_per_regime_catastrophic_gate).
+    Fail if ANY quarter's mean ΔRR reverses the aggregate sign with LARGER magnitude —
+    i.e. the aggregate is hiding a sub-window blowup. obs carry 'drr' + 'market_date'."""
+    if abs(overall_mean) < 1e-9:
+        return False
+    by_q: dict[tuple, list[float]] = defaultdict(list)
+    for o in obs:
+        d = o["market_date"]
+        by_q[(d.year, (d.month - 1) // 3)].append(o["drr"])
+    for vals in by_q.values():
+        if not vals:
+            continue
+        m = sum(vals) / len(vals)
+        if m * overall_mean < 0 and abs(m) > abs(overall_mean):
+            return False
+    return True
+
+
+def _rv_walkforward(obs: list[dict], expected_sign: int) -> dict:
+    """obs: [{'drr': float, 'market_date': date}], any order. Returns the verdict dict.
+    REVERTS requires expected sign + magnitude (full & holdout) AND the quarterly
+    catastrophic-degradation gate. Holdout = the latest RV_HOLDOUT_FRAC of obs by
+    market_date (time-ordered, no leak)."""
+    n = len(obs)
+    if n < RV_MIN_N or expected_sign == 0:
+        return {
+            "verdict": "NONE",
+            "mean_drr": None,
+            "mean_drr_holdout": None,
+            "n": n,
+            "n_holdout": 0,
+            "survives_walkforward": False,
+            "survives_window_gate": False,
+        }
+    ordered = sorted(obs, key=lambda o: o["market_date"])
+    cut = int(round(n * (1.0 - RV_HOLDOUT_FRAC)))
+    holdout = ordered[cut:]
+    mean_full = sum(o["drr"] for o in ordered) / n
+    mean_hold = (sum(o["drr"] for o in holdout) / len(holdout)) if holdout else 0.0
+    sign_ok = (mean_full * expected_sign > 0) and (mean_hold * expected_sign > 0)
+    mag_ok = (
+        abs(mean_full) >= RV_SEP_THRESHOLD and abs(mean_hold) >= RV_HOLDOUT_THRESHOLD
+    )
+    survives_wf = bool(sign_ok and mag_ok)
+    survives_window = _rv_survives_window_gate(ordered, mean_full)
+    reverts = bool(survives_wf and survives_window)
+    return {
+        "verdict": "REVERTS" if reverts else "NONE",
+        "mean_drr": mean_full,
+        "mean_drr_holdout": mean_hold,
+        "n": n,
+        "n_holdout": len(holdout),
+        "survives_walkforward": survives_wf,
+        "survives_window_gate": survives_window,
+    }
+
 
 def _forward_value_at(
     series: list[tuple[_date, float]], anchor: _date, n: int
@@ -66,7 +139,7 @@ def run_skew_markout(
     # Pass 1: raw forward return per obs + accumulate the daily cross-section.
     raw_obs: list[dict] = []
     by_date_returns: dict[_date, list[float]] = defaultdict(list)
-    meanrev: dict[tuple, list[float]] = defaultdict(list)  # primary (reported)
+    meanrev: dict[tuple, list[dict]] = defaultdict(list)  # primary (RV; tail-split)
     for s in snaps:
         spot = s.get("spot")
         if spot is not None and float(spot) != 0:
@@ -95,8 +168,13 @@ def run_skew_markout(
                 rr_by_ticker.get(s["ticker"], []), s["market_date"], HORIZON
             )
             if fwd_rr is not None:
-                meanrev[(s["asset_class"], s["deviation_class"])].append(
-                    fwd_rr - float(rr0)
+                tail = (
+                    "put_skew"
+                    if float(rr0) > 0
+                    else ("call_skew" if float(rr0) < 0 else "flat")
+                )
+                meanrev[(s["asset_class"], s["deviation_class"], tail)].append(
+                    {"drr": fwd_rr - float(rr0), "market_date": s["market_date"]}
                 )
 
     # Pass 2: cross-sectional demean — excess = raw - mean(all raw on that date).
@@ -143,18 +221,48 @@ def run_skew_markout(
         )
         written += 1
 
+    # RV mean-reversion (primary hypothesis), now GATED into a persisted verdict per
+    # (asset_class, deviation_class, tail) with the walk-forward + catastrophic gate.
+    rv_written = 0
+    rv_report: dict[str, dict] = {}
+    for (asset_class, deviation_class, tail), drr_obs in meanrev.items():
+        wf = _rv_walkforward(drr_obs, _expected_drr_sign(deviation_class))
+        repo.upsert_skew_rv_reversion_verdict(
+            asset_class=asset_class,
+            deviation_class=deviation_class,
+            tail=tail,
+            verdict=wf["verdict"],
+            mean_drr=wf["mean_drr"],
+            mean_drr_holdout=wf["mean_drr_holdout"],
+            n=wf["n"],
+            n_holdout=wf["n_holdout"],
+            survives_walkforward=wf["survives_walkforward"],
+            survives_window_gate=wf["survives_window_gate"],
+            as_of=today,
+        )
+        rv_written += 1
+        rv_report[f"{asset_class}/{deviation_class}/{tail}"] = wf
+
     mean_reversion = {
-        f"{a}/{d}": {"mean_dRR": (sum(v) / len(v) if v else None), "n": len(v)}
-        for (a, d), v in meanrev.items()
+        f"{a}/{d}/{t}": {
+            "mean_dRR": (sum(o["drr"] for o in v) / len(v) if v else None),
+            "n": len(v),
+        }
+        for (a, d, t), v in meanrev.items()
     }
     repo.conn.commit()
     log.info(
-        "run_skew_markout wrote %d verdicts over %d snapshots", written, len(snaps)
+        "run_skew_markout wrote %d directional + %d rv verdicts over %d snapshots",
+        written,
+        rv_written,
+        len(snaps),
     )
     return {
         "verdicts_written": written,
+        "rv_verdicts_written": rv_written,
         "snapshots": len(snaps),
         "mean_reversion": mean_reversion,  # PRIMARY hypothesis, descriptive
+        "rv_reversion": rv_report,  # PRIMARY hypothesis, now gated + walk-forward
     }
 
 

--- a/src/uw_scan/storage/migrations/074_skew_phase2.sql
+++ b/src/uw_scan/storage/migrations/074_skew_phase2.sql
@@ -1,0 +1,27 @@
+-- 074_skew_phase2.sql — Phase-2 increment-1.
+-- skew_rv_reversion_verdicts: per (asset_class, deviation_class, tail) conclusion of
+-- whether the 25d RR mean-reverts (descriptive RV axis, distinct from the directional
+-- skew_directional_verdicts). Gated by a time-ordered walk-forward holdout AND a
+-- per-calendar-quarter catastrophic-degradation gate on the RR history (the only OOS
+-- test the ~1yr RR data supports). NO spread-P&L / net-of-cost. Idempotent.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.skew_rv_reversion_verdicts (
+  asset_class          TEXT NOT NULL,     -- index_macro | sector_etf | credit | single_name
+  deviation_class      TEXT NOT NULL,     -- RICH | CHEAP | NORMAL
+  tail                 TEXT NOT NULL,     -- put_skew | call_skew | flat
+  verdict              TEXT NOT NULL,     -- REVERTS | NONE
+  mean_drr             NUMERIC,           -- mean forward ΔRR (T+20) over the full sample
+  mean_drr_holdout     NUMERIC,           -- mean forward ΔRR over the time-ordered holdout
+  n                    INTEGER,
+  n_holdout            INTEGER,
+  survives_walkforward BOOLEAN,           -- holdout preserves the full-sample sign + magnitude
+  survives_window_gate BOOLEAN,           -- no calendar quarter reverses the aggregate with larger magnitude
+  as_of                DATE,
+  inserted_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (asset_class, deviation_class, tail)
+);
+
+COMMENT ON TABLE uw_scan.skew_rv_reversion_verdicts
+  IS 'Per-bucket RR mean-reversion conclusion (descriptive RV axis). REVERTS requires expected sign (CHEAP->+, RICH->-), |mean| over threshold, n over min, a time-ordered walk-forward holdout that preserves sign+magnitude, AND a per-calendar-quarter catastrophic-degradation gate (no sub-window reverses the aggregate with larger magnitude). In-sample over a single ~1yr window; NOT a P&L claim.';

--- a/src/uw_scan/storage/migrations/075_skew_swing_greeks.sql
+++ b/src/uw_scan/storage/migrations/075_skew_swing_greeks.sql
@@ -1,0 +1,27 @@
+-- 075_skew_swing_greeks.sql — Phase-2 increment-1 (swing-DTE greeks source).
+-- Per-strike call/put delta for a SWING expiry (~21-60 DTE) per single-name, so the
+-- Skew tab's strike-by-delta structure detail can pick wings. The GEX/cockpit
+-- exposures_by_expiry_strike table holds front-expiry-only greeks for single-names
+-- (only indices get multi-expiry via the cockpit), so this dedicated table avoids a
+-- run_id race and keeps the swing chain readable independent of full_scan/cockpit runs.
+-- Idempotent. One snapshot per (ticker, market_date, expiry, strike).
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.skew_swing_greeks (
+  ticker       TEXT NOT NULL,
+  market_date  DATE NOT NULL,
+  expiry       DATE NOT NULL,
+  strike       NUMERIC NOT NULL,
+  dte          INTEGER,
+  call_delta   NUMERIC,
+  put_delta    NUMERIC,
+  inserted_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (ticker, market_date, expiry, strike)
+);
+
+CREATE INDEX IF NOT EXISTS ix_skew_swing_greeks_ticker_date
+  ON uw_scan.skew_swing_greeks (ticker, market_date DESC);
+
+COMMENT ON TABLE uw_scan.skew_swing_greeks
+  IS 'Per-strike call/put delta for a swing expiry (~21-60 DTE), single-names only. Source for the Skew tab strike-by-delta structure detail. Refreshed daily by worker/jobs/skew_swing_greeks.skew_swing_greeks_refresh.';

--- a/src/uw_scan/storage/migrations/075_skew_swing_greeks.sql
+++ b/src/uw_scan/storage/migrations/075_skew_swing_greeks.sql
@@ -1,9 +1,9 @@
 -- 075_skew_swing_greeks.sql — Phase-2 increment-1 (swing-DTE greeks source).
--- Per-strike call/put delta for a SWING expiry (~21-60 DTE) per single-name, so the
--- Skew tab's strike-by-delta structure detail can pick wings. The GEX/cockpit
--- exposures_by_expiry_strike table holds front-expiry-only greeks for single-names
--- (only indices get multi-expiry via the cockpit), so this dedicated table avoids a
--- run_id race and keeps the swing chain readable independent of full_scan/cockpit runs.
+-- Per-strike call/put delta for a SWING expiry (~21-60 DTE) per ticker (single-names
+-- and index ETFs), so the Skew tab's strike-by-delta structure detail can pick wings.
+-- The GEX/cockpit exposures_by_expiry_strike table holds front-expiry-only greeks for
+-- single-names (only indices get multi-expiry via the cockpit), so this dedicated table
+-- avoids a run_id race and keeps the swing chain readable independent of full_scan runs.
 -- Idempotent. One snapshot per (ticker, market_date, expiry, strike).
 
 SET search_path TO uw_scan, public;
@@ -24,4 +24,4 @@ CREATE INDEX IF NOT EXISTS ix_skew_swing_greeks_ticker_date
   ON uw_scan.skew_swing_greeks (ticker, market_date DESC);
 
 COMMENT ON TABLE uw_scan.skew_swing_greeks
-  IS 'Per-strike call/put delta for a swing expiry (~21-60 DTE), single-names only. Source for the Skew tab strike-by-delta structure detail. Refreshed daily by worker/jobs/skew_swing_greeks.skew_swing_greeks_refresh.';
+  IS 'Per-strike call/put delta for a swing expiry (~21-60 DTE), single-names and index ETFs. Source for the Skew tab strike-by-delta structure detail. Refreshed daily by worker/jobs/skew_swing_greeks.skew_swing_greeks_refresh.';

--- a/src/uw_scan/storage/options.py
+++ b/src/uw_scan/storage/options.py
@@ -338,30 +338,6 @@ class _OptionsMixin:
             cur.executemany(sql, params)
         return len(rows)
 
-    def fetch_latest_exposures_by_strike(
-        self, ticker: str, *, dte_max: int = 70
-    ) -> list[dict[str, Any]]:
-        """Per-strike greeks (incl. call/put delta) for the ticker's most recent
-        exposures RUN, within `dte_max`. Keyed on max(run_id) — NOT max(market_date) —
-        so two scan runs on the same date never stitch two chains together (the table
-        is run-keyed: PK (run_id, ticker, expiry, strike)). Source for skew
-        strike-by-delta selection. Ordered by expiry, strike ASC. Empty list if none."""
-        sql = (
-            "SELECT expiry, strike, dte, call_delta, put_delta "
-            f"FROM {self._schema}.exposures_by_expiry_strike "
-            "WHERE ticker = %s "
-            "  AND run_id = ("
-            f"    SELECT max(run_id) FROM {self._schema}.exposures_by_expiry_strike "
-            "      WHERE ticker = %s) "
-            "  AND (dte IS NULL OR dte <= %s) "
-            "ORDER BY expiry ASC, strike ASC"
-        )
-        t = ticker.upper()
-        with self._conn.cursor() as cur:
-            cur.execute(sql, (t, t, dte_max))
-            cols = [d.name for d in cur.description or []]
-            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
-
     def insert_greeks_rows(
         self, run_id: int, ticker: str, rows: Iterable[models.GreeksRow]
     ) -> int:

--- a/src/uw_scan/storage/options.py
+++ b/src/uw_scan/storage/options.py
@@ -338,6 +338,30 @@ class _OptionsMixin:
             cur.executemany(sql, params)
         return len(rows)
 
+    def fetch_latest_exposures_by_strike(
+        self, ticker: str, *, dte_max: int = 70
+    ) -> list[dict[str, Any]]:
+        """Per-strike greeks (incl. call/put delta) for the ticker's most recent
+        exposures RUN, within `dte_max`. Keyed on max(run_id) — NOT max(market_date) —
+        so two scan runs on the same date never stitch two chains together (the table
+        is run-keyed: PK (run_id, ticker, expiry, strike)). Source for skew
+        strike-by-delta selection. Ordered by expiry, strike ASC. Empty list if none."""
+        sql = (
+            "SELECT expiry, strike, dte, call_delta, put_delta "
+            f"FROM {self._schema}.exposures_by_expiry_strike "
+            "WHERE ticker = %s "
+            "  AND run_id = ("
+            f"    SELECT max(run_id) FROM {self._schema}.exposures_by_expiry_strike "
+            "      WHERE ticker = %s) "
+            "  AND (dte IS NULL OR dte <= %s) "
+            "ORDER BY expiry ASC, strike ASC"
+        )
+        t = ticker.upper()
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (t, t, dte_max))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
     def insert_greeks_rows(
         self, run_id: int, ticker: str, rows: Iterable[models.GreeksRow]
     ) -> int:

--- a/src/uw_scan/storage/skew.py
+++ b/src/uw_scan/storage/skew.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 from datetime import date as _date
+from functools import partial
 from typing import Any
 
 import psycopg
 from psycopg.types.json import Jsonb
+
+# read_json now embeds structure_detail with Decimal strikes/deltas and date expiries;
+# the default json encoder raises on those, so coerce them to str for JSONB. The
+# in-memory read dict used to build the typed response is unaffected (only the persisted
+# JSON is stringified, and nothing reads structure_detail back from the persisted JSON).
+_json_safe_dumps = partial(json.dumps, default=str)
 
 _SNAP_COLUMNS: tuple[str, ...] = (
     "spot",
@@ -57,7 +65,7 @@ class _SkewMixin:
         for r in rows:
             head = (r["ticker"], r["market_date"], r.get("basis", "eod"))
             tail = tuple(
-                Jsonb(r.get(c))
+                Jsonb(r.get(c), dumps=_json_safe_dumps)
                 if c == "read_json" and r.get(c) is not None
                 else r.get(c)
                 for c in _SNAP_COLUMNS
@@ -149,6 +157,67 @@ class _SkewMixin:
         )
         with self._conn.cursor() as cur:
             cur.execute(sql, (asset_class, deviation_class, drive_class, regime))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [d.name for d in cur.description or []]
+            return dict(zip(cols, row, strict=False))
+
+    def upsert_skew_rv_reversion_verdict(
+        self,
+        *,
+        asset_class: str,
+        deviation_class: str,
+        tail: str,
+        verdict: str,
+        mean_drr: Any,
+        mean_drr_holdout: Any,
+        n: int,
+        n_holdout: int,
+        survives_walkforward: bool,
+        survives_window_gate: bool,
+        as_of: _date,
+    ) -> None:
+        sql = (
+            f"INSERT INTO {self._schema}.skew_rv_reversion_verdicts "
+            "(asset_class, deviation_class, tail, verdict, mean_drr, mean_drr_holdout, "
+            " n, n_holdout, survives_walkforward, survives_window_gate, as_of, inserted_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now()) "
+            "ON CONFLICT (asset_class, deviation_class, tail) DO UPDATE SET "
+            "verdict=EXCLUDED.verdict, mean_drr=EXCLUDED.mean_drr, "
+            "mean_drr_holdout=EXCLUDED.mean_drr_holdout, n=EXCLUDED.n, "
+            "n_holdout=EXCLUDED.n_holdout, "
+            "survives_walkforward=EXCLUDED.survives_walkforward, "
+            "survives_window_gate=EXCLUDED.survives_window_gate, "
+            "as_of=EXCLUDED.as_of, inserted_at=now()"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    asset_class,
+                    deviation_class,
+                    tail,
+                    verdict,
+                    mean_drr,
+                    mean_drr_holdout,
+                    n,
+                    n_holdout,
+                    survives_walkforward,
+                    survives_window_gate,
+                    as_of,
+                ),
+            )
+
+    def get_skew_rv_reversion_verdict(
+        self, *, asset_class: str, deviation_class: str, tail: str
+    ) -> dict[str, Any] | None:
+        sql = (
+            f"SELECT * FROM {self._schema}.skew_rv_reversion_verdicts "
+            "WHERE asset_class=%s AND deviation_class=%s AND tail=%s"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (asset_class, deviation_class, tail))
             row = cur.fetchone()
             if row is None:
                 return None

--- a/src/uw_scan/storage/skew.py
+++ b/src/uw_scan/storage/skew.py
@@ -224,6 +224,66 @@ class _SkewMixin:
             cols = [d.name for d in cur.description or []]
             return dict(zip(cols, row, strict=False))
 
+    def upsert_skew_swing_greeks(
+        self, ticker: str, market_date: _date, rows: Iterable[dict[str, Any]]
+    ) -> int:
+        """Replace the swing-expiry per-strike greeks for (ticker, market_date).
+        rows: dicts with expiry, strike, dte, call_delta, put_delta. Delete-then-insert
+        so a re-run drops strikes that left the chain (clean daily snapshot)."""
+        t = ticker.upper()
+        rows = list(rows)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {self._schema}.skew_swing_greeks "
+                "WHERE ticker=%s AND market_date=%s",
+                (t, market_date),
+            )
+            if not rows:
+                return 0
+            cur.executemany(
+                f"INSERT INTO {self._schema}.skew_swing_greeks "
+                "(ticker, market_date, expiry, strike, dte, call_delta, put_delta, "
+                " inserted_at) VALUES (%s, %s, %s, %s, %s, %s, %s, now()) "
+                "ON CONFLICT (ticker, market_date, expiry, strike) DO UPDATE SET "
+                "dte=EXCLUDED.dte, call_delta=EXCLUDED.call_delta, "
+                "put_delta=EXCLUDED.put_delta, inserted_at=now()",
+                [
+                    (
+                        t,
+                        market_date,
+                        r["expiry"],
+                        r["strike"],
+                        r.get("dte"),
+                        r.get("call_delta"),
+                        r.get("put_delta"),
+                    )
+                    for r in rows
+                ],
+            )
+        return len(rows)
+
+    def fetch_latest_swing_greeks_by_strike(
+        self, ticker: str, *, dte_lo: int = 21, dte_hi: int = 60
+    ) -> list[dict[str, Any]]:
+        """Swing-expiry per-strike greeks (incl. call/put delta) for the ticker's most
+        recent market_date, within [dte_lo, dte_hi]. Source for skew strike-by-delta
+        structure selection. Ordered by expiry, strike ASC. Empty list if none."""
+        sql = (
+            "SELECT expiry, strike, dte, call_delta, put_delta "
+            f"FROM {self._schema}.skew_swing_greeks "
+            "WHERE ticker = %s "
+            "  AND market_date = ("
+            f"    SELECT max(market_date) FROM {self._schema}.skew_swing_greeks "
+            "      WHERE ticker = %s) "
+            "  AND dte IS NOT NULL AND dte BETWEEN %s AND %s "
+            "ORDER BY expiry ASC, strike ASC"
+        )
+        t = ticker.upper()
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (t, t, dte_lo, dte_hi))
+            cols = [d.name for d in cur.description or []]
+            return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
+
     def fetch_latest_next_earnings_date(self, ticker: str) -> _date | None:
         sql = (
             f"SELECT next_earnings_date FROM {self._schema}.flow_events "

--- a/src/uw_scan/worker/jobs/skew_analytics.py
+++ b/src/uw_scan/worker/jobs/skew_analytics.py
@@ -23,6 +23,7 @@ def _build_for_date(
     sector: str | None,
     next_earnings_date: _date | None,
     positioning: dict | None,
+    exposure_rows: list[dict] | None = None,
 ) -> dict | None:
     # positioning is passed in (fetched once per ticker by the caller) — it is the
     # latest snapshot regardless of market_date (current-borrow limitation, spec §11),
@@ -66,6 +67,7 @@ def _build_for_date(
         verdict=verdict,
         sector=sector,
         today=today,
+        exposure_rows=exposure_rows,
     )
 
 
@@ -88,6 +90,7 @@ def nightly_skew_analytics_rollup(*, repo: Repository) -> None:
             continue
         next_er = repo.fetch_latest_next_earnings_date(ticker)
         positioning = repo.get_uw_positioning(ticker)
+        exposures = repo.fetch_latest_exposures_by_strike(ticker, dte_max=70)
         row = _build_for_date(
             repo,
             ticker,
@@ -99,6 +102,7 @@ def nightly_skew_analytics_rollup(*, repo: Repository) -> None:
             card.sector,
             next_er,
             positioning,
+            exposures,
         )
         if row is not None:
             repo.upsert_skew_analytics_snapshots([row])

--- a/src/uw_scan/worker/jobs/skew_analytics.py
+++ b/src/uw_scan/worker/jobs/skew_analytics.py
@@ -90,7 +90,7 @@ def nightly_skew_analytics_rollup(*, repo: Repository) -> None:
             continue
         next_er = repo.fetch_latest_next_earnings_date(ticker)
         positioning = repo.get_uw_positioning(ticker)
-        exposures = repo.fetch_latest_exposures_by_strike(ticker, dte_max=70)
+        exposures = repo.fetch_latest_swing_greeks_by_strike(ticker)
         row = _build_for_date(
             repo,
             ticker,

--- a/src/uw_scan/worker/jobs/skew_swing_greeks.py
+++ b/src/uw_scan/worker/jobs/skew_swing_greeks.py
@@ -1,11 +1,12 @@
 """Skew swing-DTE greeks refresh.
 
-Per-strike call/put delta for a swing expiry (~21-60 DTE), single-names only. The
-GEX/cockpit ``exposures_by_expiry_strike`` table holds front-expiry-only greeks for
-single-names (only indices get multi-expiry via the cockpit), so the Skew tab's
-strike-by-delta structure detail had no swing chain to pick wings from. This job
-reuses the proven cockpit fetchers (``fetch_option_contracts`` → ``pick_target_expiries``
-→ ``fetch_greeks``) and persists into the dedicated ``skew_swing_greeks`` table.
+Per-strike call/put delta for a swing expiry (~21-60 DTE), for every watchlist
+ticker (single-names and index ETFs alike). The GEX/cockpit
+``exposures_by_expiry_strike`` table holds front-expiry-only greeks for single-names,
+so the Skew tab's strike-by-delta structure detail had no swing chain to pick wings
+from. This job reuses the proven cockpit fetchers (``fetch_option_contracts`` →
+``pick_target_expiries`` → ``fetch_greeks``) and persists into the dedicated
+``skew_swing_greeks`` table.
 
 NOTE: it uses ``fetch_greeks`` (the ``/greeks`` endpoint — real per-contract OPTION delta
 in [-1, 1]), NOT ``fetch_greek_exposure`` (``/greek-exposure`` returns delta *exposure*,
@@ -19,7 +20,6 @@ from datetime import date as _date
 
 from uw_scan.api.client import UwClient
 from uw_scan.cards.option_chain import pick_target_expiries
-from uw_scan.cards.skew_first_principles import asset_class_baseline
 from uw_scan.sources.uw import fetch_greeks, fetch_option_contracts
 from uw_scan.storage.repository import Repository
 
@@ -32,17 +32,17 @@ _CONTRACTS_LIMIT = 500
 
 
 def skew_swing_greeks_refresh(*, repo: Repository, client: UwClient) -> int:
-    """One swing-expiry per-strike greeks snapshot per non-index watchlist ticker.
+    """One swing-expiry per-strike greeks snapshot per watchlist ticker.
     Idempotent per (ticker, market_date) via delete-then-insert. Returns rows written."""
     cards = repo.list_watchlist_cards()
     today = _date.today()
     written = 0
     for card in cards:
         ticker = card.ticker
-        cls = asset_class_baseline(ticker, sector=card.sector)
-        if cls["asset_class"] == "index_macro":
-            # Structure detail is non-index only; indices already get cockpit chains.
-            continue
+        # Index ETFs are included — their directional lean is research-validated, so
+        # the strike-by-delta structure block applies to them too. A non-optionable
+        # symbol (e.g. a future true cash index) simply yields no chain and is skipped
+        # by the per-ticker guard below.
         try:
             run_id = repo.insert_scan_run(ticker, notes="skew_swing_greeks")
             contracts = fetch_option_contracts(

--- a/src/uw_scan/worker/jobs/skew_swing_greeks.py
+++ b/src/uw_scan/worker/jobs/skew_swing_greeks.py
@@ -31,11 +31,19 @@ SWING_TARGET_DTES: tuple[int, ...] = (30, 45)
 _CONTRACTS_LIMIT = 500
 
 
-def skew_swing_greeks_refresh(*, repo: Repository, client: UwClient) -> int:
+def skew_swing_greeks_refresh(
+    *, repo: Repository, client: UwClient, today: _date | None = None
+) -> int:
     """One swing-expiry per-strike greeks snapshot per watchlist ticker.
-    Idempotent per (ticker, market_date) via delete-then-insert. Returns rows written."""
+    Idempotent per (ticker, market_date) via delete-then-insert. Returns rows written.
+
+    ``today`` is the ET market date and stamps every row + drives the DTE math. The
+    scheduler passes ``datetime.now(rth_tz).date()`` so a non-ET host (e.g. HKT dev/
+    deploy) does not stamp the next calendar day at the 17:30-ET run. Falls back to
+    host-local only for ad-hoc callers."""
     cards = repo.list_watchlist_cards()
-    today = _date.today()
+    if today is None:
+        today = _date.today()
     written = 0
     for card in cards:
         ticker = card.ticker

--- a/src/uw_scan/worker/jobs/skew_swing_greeks.py
+++ b/src/uw_scan/worker/jobs/skew_swing_greeks.py
@@ -1,0 +1,75 @@
+"""Skew swing-DTE greeks refresh.
+
+Per-strike call/put delta for a swing expiry (~21-60 DTE), single-names only. The
+GEX/cockpit ``exposures_by_expiry_strike`` table holds front-expiry-only greeks for
+single-names (only indices get multi-expiry via the cockpit), so the Skew tab's
+strike-by-delta structure detail had no swing chain to pick wings from. This job
+reuses the proven cockpit fetchers (``fetch_option_contracts`` → ``pick_target_expiries``
+→ ``fetch_greeks``) and persists into the dedicated ``skew_swing_greeks`` table.
+
+NOTE: it uses ``fetch_greeks`` (the ``/greeks`` endpoint — real per-contract OPTION delta
+in [-1, 1]), NOT ``fetch_greek_exposure`` (``/greek-exposure`` returns delta *exposure*,
+≈0 for low-OI strikes — unusable for target-delta strike selection).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as _date
+
+from uw_scan.api.client import UwClient
+from uw_scan.cards.option_chain import pick_target_expiries
+from uw_scan.cards.skew_first_principles import asset_class_baseline
+from uw_scan.sources.uw import fetch_greeks, fetch_option_contracts
+from uw_scan.storage.repository import Repository
+
+log = logging.getLogger(__name__)
+
+# Pick expiries bracketing the swing window so at least one usually lands in the
+# deriver's [21, 60] DTE filter. One UW greek-exposure call per chosen expiry.
+SWING_TARGET_DTES: tuple[int, ...] = (30, 45)
+_CONTRACTS_LIMIT = 500
+
+
+def skew_swing_greeks_refresh(*, repo: Repository, client: UwClient) -> int:
+    """One swing-expiry per-strike greeks snapshot per non-index watchlist ticker.
+    Idempotent per (ticker, market_date) via delete-then-insert. Returns rows written."""
+    cards = repo.list_watchlist_cards()
+    today = _date.today()
+    written = 0
+    for card in cards:
+        ticker = card.ticker
+        cls = asset_class_baseline(ticker, sector=card.sector)
+        if cls["asset_class"] == "index_macro":
+            # Structure detail is non-index only; indices already get cockpit chains.
+            continue
+        try:
+            run_id = repo.insert_scan_run(ticker, notes="skew_swing_greeks")
+            contracts = fetch_option_contracts(
+                client, repo, run_id, ticker, limit=_CONTRACTS_LIMIT
+            )
+            expiries = pick_target_expiries(
+                contracts, target_dtes=SWING_TARGET_DTES, today=today
+            )
+            rows: list[dict] = []
+            for expiry in expiries:
+                dte = (expiry - today).days  # GreeksRow has no dte; derive from expiry
+                for r in fetch_greeks(client, repo, run_id, ticker, expiry.isoformat()):
+                    rows.append(
+                        {
+                            "expiry": r.expiry,
+                            "strike": r.strike,
+                            "dte": dte,
+                            "call_delta": r.call_delta,
+                            "put_delta": r.put_delta,
+                        }
+                    )
+            n = repo.upsert_skew_swing_greeks(ticker, today, rows)
+            repo.finish_scan_run(run_id, status="ok")
+            repo.conn.commit()
+            written += n
+        except Exception as exc:  # noqa: BLE001 — one bad ticker must not kill the job
+            repo.conn.rollback()
+            log.warning("skew_swing_greeks_refresh: %s skipped: %s", ticker, repr(exc))
+    log.info("skew_swing_greeks_refresh wrote %d swing-greek rows", written)
+    return written

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -50,6 +50,7 @@ from uw_scan.worker.jobs.positioning_jobs import positioning_refresh_once
 from uw_scan.worker.jobs.rates_jobs import rates_fred_ingest_job
 from uw_scan.worker.jobs.rescan_loop import rescan_tick
 from uw_scan.worker.jobs.skew_analytics import nightly_skew_analytics_rollup
+from uw_scan.worker.jobs.skew_swing_greeks import skew_swing_greeks_refresh
 from uw_scan.worker.jobs.trade_insight_outcome_backfill import (
     trade_insight_outcome_backfill_once,
 )
@@ -453,6 +454,16 @@ def main() -> int:
                 with _repo(settings) as repo:
                     cockpit_daily_snapshot(repo=repo, client=uw, settings=settings)
 
+    def _skew_swing_greeks_refresh() -> None:
+        with _external_api_recorder(settings) as recorder:
+            with _uw_client(
+                settings,
+                telemetry_recorder=recorder,
+                job_name="skew_swing_greeks",
+            ) as uw:
+                with _repo(settings) as repo:
+                    skew_swing_greeks_refresh(repo=repo, client=uw)
+
     def _trade_insights_ai_tick_any() -> None:
         trade_insights_ai_tick(settings, provider_filter=None)
 
@@ -828,6 +839,17 @@ def main() -> int:
                 ),
                 id="cockpit_daily_snapshot",
                 name="Cockpit 6-dim matrix daily snapshot",
+            )
+            # Skew swing-DTE greeks at 17:30 ET — UW-bound, single-names only, before
+            # the 18:30 skew rollup so the strike-by-delta structure detail has a fresh
+            # swing chain. Primary-uw-only to avoid duplicate UW spend across shards.
+            sched.add_job(
+                _skew_swing_greeks_refresh,
+                CronTrigger.from_crontab("30 17 * * 0-4", timezone=settings.rth_tz),
+                id="skew_swing_greeks_refresh",
+                name="Skew swing-DTE greeks refresh",
+                max_instances=1,
+                coalesce=True,
             )
             # Regime / GEX scan — refreshes gex_snapshots every N minutes.
             # Primary-uw-only to avoid duplicate UW spend across shards.

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -169,6 +169,20 @@ def _should_schedule_pipeline_benchmark(settings: Settings) -> bool:
     return role == "all" or (role == "uw" and settings.worker_index == 0)
 
 
+def _should_schedule_skew_swing_greeks(settings: Settings) -> bool:
+    """Exactly one process owns the swing-greeks refresh.
+
+    It is a UW-bound watchlist loop with no advisory lock (unlike the cockpit
+    snapshot, which single-flights via pg_try_advisory_lock). _is_primary_worker is
+    true for index-0 of EVERY role (uw-0, massive-0, ai-*-0), so scheduling it there
+    would run it N times -> duplicate UW /greeks spend (429 risk) + racing
+    delete-then-insert on skew_swing_greeks. Pin to uw-0 (the UW role), following the
+    rates-FRED / pipeline-benchmark precedent.
+    """
+    role = settings.worker_role.lower()
+    return role == "all" or (role == "uw" and settings.worker_index == 0)
+
+
 def _should_schedule_regime_live(settings: Settings) -> bool:
     """Exactly one process owns the 5-min live snapshot writes.
 
@@ -455,6 +469,8 @@ def main() -> int:
                     cockpit_daily_snapshot(repo=repo, client=uw, settings=settings)
 
     def _skew_swing_greeks_refresh() -> None:
+        # ET market date (not host-local) so a non-ET host doesn't stamp +1 day.
+        market_date = datetime.now(ZoneInfo(settings.rth_tz)).date()
         with _external_api_recorder(settings) as recorder:
             with _uw_client(
                 settings,
@@ -462,7 +478,7 @@ def main() -> int:
                 job_name="skew_swing_greeks",
             ) as uw:
                 with _repo(settings) as repo:
-                    skew_swing_greeks_refresh(repo=repo, client=uw)
+                    skew_swing_greeks_refresh(repo=repo, client=uw, today=market_date)
 
     def _trade_insights_ai_tick_any() -> None:
         trade_insights_ai_tick(settings, provider_filter=None)
@@ -840,17 +856,20 @@ def main() -> int:
                 id="cockpit_daily_snapshot",
                 name="Cockpit 6-dim matrix daily snapshot",
             )
-            # Skew swing-DTE greeks at 17:30 ET — UW-bound, single-names only, before
-            # the 18:30 skew rollup so the strike-by-delta structure detail has a fresh
-            # swing chain. Primary-uw-only to avoid duplicate UW spend across shards.
-            sched.add_job(
-                _skew_swing_greeks_refresh,
-                CronTrigger.from_crontab("30 17 * * 0-4", timezone=settings.rth_tz),
-                id="skew_swing_greeks_refresh",
-                name="Skew swing-DTE greeks refresh",
-                max_instances=1,
-                coalesce=True,
-            )
+            # Skew swing-DTE greeks at 17:30 ET — UW-bound watchlist loop, before the
+            # 18:30 skew rollup so the strike-by-delta structure detail has a fresh swing
+            # chain. Pinned to uw-0 (NOT _is_primary_worker, which is true for index-0 of
+            # every role) because it has no advisory lock: scheduling it per role-0 would
+            # run N copies -> duplicate UW spend + racing delete-then-insert.
+            if _should_schedule_skew_swing_greeks(settings):
+                sched.add_job(
+                    _skew_swing_greeks_refresh,
+                    CronTrigger.from_crontab("30 17 * * 0-4", timezone=settings.rth_tz),
+                    id="skew_swing_greeks_refresh",
+                    name="Skew swing-DTE greeks refresh",
+                    max_instances=1,
+                    coalesce=True,
+                )
             # Regime / GEX scan — refreshes gex_snapshots every N minutes.
             # Primary-uw-only to avoid duplicate UW spend across shards.
             sched.add_job(

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -13405,6 +13405,16 @@
             "default": "NEUTRAL",
             "title": "Lean",
             "type": "string"
+          },
+          "structure_detail": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SkewStructureDetail"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "title": "SkewDirectionalLean",
@@ -13660,6 +13670,121 @@
           "strike"
         ],
         "title": "SkewSmilePoint",
+        "type": "object"
+      },
+      "SkewStructureDetail": {
+        "properties": {
+          "dte_target": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dte Target"
+          },
+          "kind": {
+            "default": "",
+            "title": "Kind",
+            "type": "string"
+          },
+          "legs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SkewStructureLeg"
+            },
+            "title": "Legs",
+            "type": "array"
+          },
+          "note": {
+            "default": "",
+            "title": "Note",
+            "type": "string"
+          },
+          "status": {
+            "default": "ready",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "SkewStructureDetail",
+        "type": "object"
+      },
+      "SkewStructureLeg": {
+        "properties": {
+          "action": {
+            "default": "",
+            "title": "Action",
+            "type": "string"
+          },
+          "actual_delta": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actual Delta"
+          },
+          "dte": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dte"
+          },
+          "expiry": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry"
+          },
+          "right": {
+            "default": "",
+            "title": "Right",
+            "type": "string"
+          },
+          "strike": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strike"
+          },
+          "target_delta": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Delta"
+          }
+        },
+        "title": "SkewStructureLeg",
         "type": "object"
       },
       "SmileExpiryCurve": {

--- a/tests/integration/reports/test_skew_rv_markout.py
+++ b/tests/integration/reports/test_skew_rv_markout.py
@@ -1,0 +1,129 @@
+"""RV mean-reversion verdict: tail-split keys + walk-forward + catastrophic gate."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from uw_scan.reports.skew_markout import (
+    _expected_drr_sign,
+    _rv_walkforward,
+    run_skew_markout,
+)
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards):
+    return seeded_db_empty_cards
+
+
+def _seed_cheap_reverting_bucket(repo, ticker="QCOM"):
+    """A single_name CHEAP/put_skew bucket whose 25d RR climbs (re-richens) across the
+    whole window: forward ΔRR(T+20) is positive everywhere, so the time-ordered holdout
+    survives. Seeds BOTH the snapshot anchors AND risk_reversal_skew_history (the forward
+    RR series skew_markout._rr_series reads, delta=25). RR stays > 0 so every anchor
+    buckets as tail=put_skew."""
+    base = date(2025, 1, 2)
+    snaps = []
+    for i in range(80):
+        d = base + timedelta(days=i)
+        rr = 0.02 + 0.002 * i  # +0.02 .. +0.178, all put_skew, monotonically richening
+        snaps.append(
+            {
+                "ticker": ticker,
+                "market_date": d,
+                "basis": "eod",
+                "spot": 100.0 + i,
+                "rr_25d": rr,
+                "skew_25d": rr,
+                "deviation_class": "CHEAP",
+                "skew_term_class": "flat",
+                "drive_class": "STRUCTURAL",
+                "asset_class": "single_name",
+                "regime": "LOW_VOL",
+                "borrow_flag": "normal",
+            }
+        )
+    repo.upsert_skew_analytics_snapshots(snaps)
+    with repo.conn.cursor() as cur:
+        for i in range(80):
+            d = base + timedelta(days=i)
+            rr = 0.02 + 0.002 * i
+            cur.execute(
+                "INSERT INTO uw_scan.risk_reversal_skew_history "
+                "(ticker, market_date, delta, expiry, risk_reversal) "
+                "VALUES (%s, %s, 25, %s, %s) ON CONFLICT DO NOTHING",
+                (ticker, d, base + timedelta(days=40), rr),
+            )
+    repo.conn.commit()
+
+
+def test_rv_markout_writes_reverting_verdict(repo):
+    _seed_cheap_reverting_bucket(repo)
+    out = run_skew_markout(repo=repo, min_n=1, sep_threshold=0.005)
+    assert "rv_reversion" in out and out["rv_verdicts_written"] >= 1
+    v = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert v is not None
+    assert v["verdict"] == "REVERTS"
+    assert float(v["mean_drr"]) > 0  # CHEAP re-richens => positive ΔRR
+    assert v["survives_walkforward"] is True
+    assert (
+        v["survives_window_gate"] is True
+    )  # single-quarter seed: no sub-window blowup
+
+
+def test_rv_markout_idempotent(repo):
+    _seed_cheap_reverting_bucket(repo)
+    run_skew_markout(repo=repo, min_n=1, sep_threshold=0.005)
+    run_skew_markout(
+        repo=repo, min_n=1, sep_threshold=0.005
+    )  # second run = no-op upsert
+    v = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert v["verdict"] == "REVERTS"
+
+
+def test_walkforward_rejects_when_holdout_flips():
+    # full-sample positive but the recent holdout goes negative => NONE
+    obs = [
+        {"drr": 0.02, "market_date": date(2025, 1, 1) + timedelta(days=i)}
+        for i in range(40)
+    ]
+    obs += [
+        {"drr": -0.03, "market_date": date(2025, 3, 1) + timedelta(days=i)}
+        for i in range(40)
+    ]
+    out = _rv_walkforward(obs, _expected_drr_sign("CHEAP"))
+    assert out["verdict"] == "NONE"
+    assert out["survives_walkforward"] is False
+
+
+def test_walkforward_skips_normal_and_small_n():
+    assert _rv_walkforward([], _expected_drr_sign("NORMAL"))["verdict"] == "NONE"
+    tiny = [{"drr": 0.05, "market_date": date(2025, 1, 1)}]
+    assert _rv_walkforward(tiny, _expected_drr_sign("CHEAP"))["verdict"] == "NONE"
+
+
+def test_walkforward_rejects_when_a_quarter_blows_up():
+    # full-sample AND holdout positive, but Q2 reverses harder than the aggregate ->
+    # catastrophic-degradation gate fails -> NONE (mirrors the directional AC-F4 gate).
+    obs = [
+        {"drr": 0.05, "market_date": date(2025, 1, 1) + timedelta(days=i)}
+        for i in range(40)
+    ]  # Q1 +0.05
+    obs += [
+        {"drr": -0.20, "market_date": date(2025, 4, 1) + timedelta(days=i)}
+        for i in range(10)
+    ]  # Q2 big negative
+    obs += [
+        {"drr": 0.05, "market_date": date(2025, 7, 1) + timedelta(days=i)}
+        for i in range(40)
+    ]  # Q3 +0.05 (holdout)
+    out = _rv_walkforward(obs, _expected_drr_sign("CHEAP"))
+    assert out["survives_walkforward"] is True  # holdout (Q3) is clean
+    assert out["survives_window_gate"] is False  # Q2 blowup caught
+    assert out["verdict"] == "NONE"

--- a/tests/integration/storage/test_skew_storage.py
+++ b/tests/integration/storage/test_skew_storage.py
@@ -7,8 +7,6 @@ from decimal import Decimal
 
 import pytest
 
-from uw_scan import models
-
 
 @pytest.fixture
 def repo(seeded_db_empty_cards):
@@ -174,68 +172,103 @@ def test_rv_reversion_verdict_roundtrip(repo):
     assert got2["verdict"] == "NONE"
 
 
-def test_fetch_latest_exposures_by_strike(repo):
-    run_id = repo.insert_scan_run(ticker="QCOM")
+def test_swing_greeks_roundtrip(repo):
     rows = [
-        models.GreekExposureRow(
-            date=date(2026, 6, 15),
-            expiry=date(2026, 7, 18),
-            strike=Decimal("95"),
-            dte=33,
-            call_delta=Decimal("0.62"),
-            put_delta=Decimal("-0.38"),
-        ),
-        models.GreekExposureRow(
-            date=date(2026, 6, 15),
-            expiry=date(2026, 7, 18),
-            strike=Decimal("90"),
-            dte=33,
-            call_delta=Decimal("0.74"),
-            put_delta=Decimal("-0.26"),
-        ),
+        {
+            "expiry": date(2026, 7, 18),
+            "strike": Decimal("95"),
+            "dte": 33,
+            "call_delta": Decimal("0.62"),
+            "put_delta": Decimal("-0.38"),
+        },
+        {
+            "expiry": date(2026, 7, 18),
+            "strike": Decimal("90"),
+            "dte": 33,
+            "call_delta": Decimal("0.74"),
+            "put_delta": Decimal("-0.26"),
+        },
     ]
-    repo.insert_greek_exposure_rows(run_id, "QCOM", rows)
+    n = repo.upsert_skew_swing_greeks("QCOM", date(2026, 6, 16), rows)
     repo.conn.commit()
-    got = repo.fetch_latest_exposures_by_strike("QCOM", dte_max=70)
-    assert len(got) == 2
+    assert n == 2
+    got = repo.fetch_latest_swing_greeks_by_strike("QCOM")
     assert {r["strike"] for r in got} == {Decimal("95"), Decimal("90")}
     assert all("put_delta" in r and "dte" in r for r in got)
 
 
-def test_fetch_latest_exposures_reads_only_the_newest_run(repo):
-    ex = date(2026, 7, 18)
-    # two runs on the SAME market_date — the later run (higher run_id) wins.
-    old = repo.insert_scan_run(ticker="ABCD")
-    repo.insert_greek_exposure_rows(
-        old,
+def test_swing_greeks_filters_dte_window_and_latest_date(repo):
+    # older date present but only the latest market_date is read; out-of-[21,60] excluded.
+    repo.upsert_skew_swing_greeks(
         "ABCD",
+        date(2026, 6, 10),
         [
-            models.GreekExposureRow(
-                date=date(2026, 6, 15),
-                expiry=ex,
-                strike=Decimal("70"),
-                dte=33,
-                put_delta=Decimal("-0.20"),
-            )
+            {
+                "expiry": date(2026, 6, 20),
+                "strike": Decimal("50"),
+                "dte": 10,
+                "put_delta": Decimal("-0.20"),
+            }
         ],
     )
-    new = repo.insert_scan_run(ticker="ABCD")
-    repo.insert_greek_exposure_rows(
-        new,
+    repo.upsert_skew_swing_greeks(
         "ABCD",
+        date(2026, 6, 16),
         [
-            models.GreekExposureRow(
-                date=date(2026, 6, 15),
-                expiry=ex,
-                strike=Decimal("95"),
-                dte=33,
-                put_delta=Decimal("-0.26"),
-            )
+            {
+                "expiry": date(2026, 7, 20),
+                "strike": Decimal("95"),
+                "dte": 34,
+                "put_delta": Decimal("-0.26"),
+            },
+            {
+                "expiry": date(2026, 8, 30),
+                "strike": Decimal("80"),
+                "dte": 75,
+                "put_delta": Decimal("-0.10"),
+            },
+        ],
+    )  # 75 DTE -> out of window
+    repo.conn.commit()
+    got = repo.fetch_latest_swing_greeks_by_strike("ABCD")
+    assert {r["strike"] for r in got} == {Decimal("95")}
+
+
+def test_swing_greeks_delete_then_insert_drops_stale(repo):
+    repo.upsert_skew_swing_greeks(
+        "EFGH",
+        date(2026, 6, 16),
+        [
+            {
+                "expiry": date(2026, 7, 18),
+                "strike": Decimal("95"),
+                "dte": 33,
+                "put_delta": Decimal("-0.26"),
+            },
+            {
+                "expiry": date(2026, 7, 18),
+                "strike": Decimal("88"),
+                "dte": 33,
+                "put_delta": Decimal("-0.13"),
+            },
+        ],
+    )
+    # re-run same date with only one strike -> stale 88 dropped
+    repo.upsert_skew_swing_greeks(
+        "EFGH",
+        date(2026, 6, 16),
+        [
+            {
+                "expiry": date(2026, 7, 18),
+                "strike": Decimal("95"),
+                "dte": 33,
+                "put_delta": Decimal("-0.26"),
+            }
         ],
     )
     repo.conn.commit()
-    got = repo.fetch_latest_exposures_by_strike("ABCD", dte_max=70)
-    assert {r["strike"] for r in got} == {Decimal("95")}  # only the newest run's chain
+    got = repo.fetch_latest_swing_greeks_by_strike("EFGH")
+    assert {r["strike"] for r in got} == {Decimal("95")}
 
 
 def test_snapshot_persists_structure_detail_with_decimal_and_date(repo):

--- a/tests/integration/storage/test_skew_storage.py
+++ b/tests/integration/storage/test_skew_storage.py
@@ -127,3 +127,46 @@ def test_fetch_watchlist_sector(repo):
     repo.conn.commit()
     assert repo.fetch_watchlist_sector("ZZTOP") == "Macro"
     assert repo.fetch_watchlist_sector("NOPE") is None
+
+
+def test_rv_reversion_verdict_roundtrip(repo):
+    repo.upsert_skew_rv_reversion_verdict(
+        asset_class="single_name",
+        deviation_class="CHEAP",
+        tail="put_skew",
+        verdict="REVERTS",
+        mean_drr=0.0514,
+        mean_drr_holdout=0.041,
+        n=1472,
+        n_holdout=520,
+        survives_walkforward=True,
+        survives_window_gate=True,
+        as_of=date(2026, 6, 16),
+    )
+    repo.conn.commit()
+    got = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert got is not None
+    assert got["verdict"] == "REVERTS"
+    assert got["survives_walkforward"] is True
+    assert got["survives_window_gate"] is True
+    # upsert is idempotent on the PK
+    repo.upsert_skew_rv_reversion_verdict(
+        asset_class="single_name",
+        deviation_class="CHEAP",
+        tail="put_skew",
+        verdict="NONE",
+        mean_drr=0.0,
+        mean_drr_holdout=0.0,
+        n=1,
+        n_holdout=0,
+        survives_walkforward=False,
+        survives_window_gate=False,
+        as_of=date(2026, 6, 16),
+    )
+    repo.conn.commit()
+    got2 = repo.get_skew_rv_reversion_verdict(
+        asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
+    )
+    assert got2["verdict"] == "NONE"

--- a/tests/integration/storage/test_skew_storage.py
+++ b/tests/integration/storage/test_skew_storage.py
@@ -7,6 +7,8 @@ from decimal import Decimal
 
 import pytest
 
+from uw_scan import models
+
 
 @pytest.fixture
 def repo(seeded_db_empty_cards):
@@ -170,3 +172,106 @@ def test_rv_reversion_verdict_roundtrip(repo):
         asset_class="single_name", deviation_class="CHEAP", tail="put_skew"
     )
     assert got2["verdict"] == "NONE"
+
+
+def test_fetch_latest_exposures_by_strike(repo):
+    run_id = repo.insert_scan_run(ticker="QCOM")
+    rows = [
+        models.GreekExposureRow(
+            date=date(2026, 6, 15),
+            expiry=date(2026, 7, 18),
+            strike=Decimal("95"),
+            dte=33,
+            call_delta=Decimal("0.62"),
+            put_delta=Decimal("-0.38"),
+        ),
+        models.GreekExposureRow(
+            date=date(2026, 6, 15),
+            expiry=date(2026, 7, 18),
+            strike=Decimal("90"),
+            dte=33,
+            call_delta=Decimal("0.74"),
+            put_delta=Decimal("-0.26"),
+        ),
+    ]
+    repo.insert_greek_exposure_rows(run_id, "QCOM", rows)
+    repo.conn.commit()
+    got = repo.fetch_latest_exposures_by_strike("QCOM", dte_max=70)
+    assert len(got) == 2
+    assert {r["strike"] for r in got} == {Decimal("95"), Decimal("90")}
+    assert all("put_delta" in r and "dte" in r for r in got)
+
+
+def test_fetch_latest_exposures_reads_only_the_newest_run(repo):
+    ex = date(2026, 7, 18)
+    # two runs on the SAME market_date — the later run (higher run_id) wins.
+    old = repo.insert_scan_run(ticker="ABCD")
+    repo.insert_greek_exposure_rows(
+        old,
+        "ABCD",
+        [
+            models.GreekExposureRow(
+                date=date(2026, 6, 15),
+                expiry=ex,
+                strike=Decimal("70"),
+                dte=33,
+                put_delta=Decimal("-0.20"),
+            )
+        ],
+    )
+    new = repo.insert_scan_run(ticker="ABCD")
+    repo.insert_greek_exposure_rows(
+        new,
+        "ABCD",
+        [
+            models.GreekExposureRow(
+                date=date(2026, 6, 15),
+                expiry=ex,
+                strike=Decimal("95"),
+                dte=33,
+                put_delta=Decimal("-0.26"),
+            )
+        ],
+    )
+    repo.conn.commit()
+    got = repo.fetch_latest_exposures_by_strike("ABCD", dte_max=70)
+    assert {r["strike"] for r in got} == {Decimal("95")}  # only the newest run's chain
+
+
+def test_snapshot_persists_structure_detail_with_decimal_and_date(repo):
+    row = {
+        "ticker": "QCOM",
+        "market_date": date(2026, 6, 16),
+        "basis": "eod",
+        "deviation_class": "CHEAP",
+        "directional_lean": "BEARISH_TILT",
+        "read_summary": "x",
+        "read_json": {
+            "directional_lean": {
+                "lean": "BEARISH_TILT",
+                "structure_detail": {
+                    "kind": "put_debit_spread",
+                    "dte_target": 33,
+                    "status": "ready",
+                    "note": "defined risk",
+                    "legs": [
+                        {
+                            "action": "BUY",
+                            "right": "PUT",
+                            "strike": Decimal("95"),
+                            "target_delta": Decimal("-0.25"),
+                            "actual_delta": Decimal("-0.26"),
+                            "expiry": date(2026, 7, 18),
+                            "dte": 33,
+                        }
+                    ],
+                },
+            },
+        },
+    }
+    repo.upsert_skew_analytics_snapshots([row])  # must NOT raise on Decimal/date
+    repo.conn.commit()
+    got = repo.get_skew_analytics_latest("QCOM")
+    sd = got["read_json"]["directional_lean"]["structure_detail"]
+    assert sd["legs"][0]["strike"] == "95"  # stringified by default=str
+    assert sd["legs"][0]["expiry"] == "2026-07-18"

--- a/tests/integration/worker/test_skew_jobs.py
+++ b/tests/integration/worker/test_skew_jobs.py
@@ -66,7 +66,7 @@ def test_backfill_writes_multiple_dates(repo):
     assert len(rows) >= 1
 
 
-def test_swing_greeks_refresh_persists_singlename_skips_index(repo, monkeypatch):
+def test_swing_greeks_refresh_persists_singlename_and_index_etf(repo, monkeypatch):
     import uw_scan.worker.jobs.skew_swing_greeks as job
 
     with repo.conn.cursor() as cur:
@@ -97,5 +97,7 @@ def test_swing_greeks_refresh_persists_singlename_skips_index(repo, monkeypatch)
     assert n >= 1
     got = repo.fetch_latest_swing_greeks_by_strike("NVDA")
     assert {r["strike"] for r in got} == {Decimal("100")}
-    # SPY is index_macro -> skipped entirely (no swing rows persisted)
-    assert repo.fetch_latest_swing_greeks_by_strike("SPY") == []
+    # SPY is an index ETF -> now INCLUDED (structure block extended to index ETFs);
+    # its directional lean is research-validated, so it earns the same expression.
+    got_spy = repo.fetch_latest_swing_greeks_by_strike("SPY")
+    assert {r["strike"] for r in got_spy} == {Decimal("100")}

--- a/tests/integration/worker/test_skew_jobs.py
+++ b/tests/integration/worker/test_skew_jobs.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from decimal import Decimal
 
 import pytest
 
+from uw_scan import models
 from uw_scan.worker.jobs.skew_analytics import (
     nightly_skew_analytics_rollup,
     skew_analytics_backfill,
@@ -62,3 +64,38 @@ def test_backfill_writes_multiple_dates(repo):
     assert written >= 1
     rows = repo.fetch_skew_analytics_history("AAPL", days=4000)
     assert len(rows) >= 1
+
+
+def test_swing_greeks_refresh_persists_singlename_skips_index(repo, monkeypatch):
+    import uw_scan.worker.jobs.skew_swing_greeks as job
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.watchlist (ticker, sector) "
+            "VALUES ('NVDA','Tech'),('SPY','Macro') ON CONFLICT (ticker) DO NOTHING"
+        )
+    repo.conn.commit()
+    expiry = date(2026, 8, 1)
+    monkeypatch.setattr(job, "fetch_option_contracts", lambda *a, **k: [])
+    monkeypatch.setattr(job, "pick_target_expiries", lambda *a, **k: [expiry])
+    monkeypatch.setattr(
+        job,
+        "fetch_greeks",
+        lambda *a, **k: [
+            models.GreeksRow(
+                date=expiry,
+                expiry=expiry,
+                strike=Decimal("100"),
+                call_delta=Decimal("0.40"),
+                put_delta=Decimal("-0.30"),
+            )
+        ],
+    )
+    # The fixture pre-seeds the full watchlist; the stub returns one strike per
+    # non-index ticker, so n >= 1 and NVDA specifically gets persisted.
+    n = job.skew_swing_greeks_refresh(repo=repo, client=None)
+    assert n >= 1
+    got = repo.fetch_latest_swing_greeks_by_strike("NVDA")
+    assert {r["strike"] for r in got} == {Decimal("100")}
+    # SPY is index_macro -> skipped entirely (no swing rows persisted)
+    assert repo.fetch_latest_swing_greeks_by_strike("SPY") == []

--- a/tests/integration/worker/test_skew_jobs.py
+++ b/tests/integration/worker/test_skew_jobs.py
@@ -92,11 +92,20 @@ def test_swing_greeks_refresh_persists_singlename_and_index_etf(repo, monkeypatc
         ],
     )
     # The fixture pre-seeds the full watchlist; the stub returns one strike per
-    # non-index ticker, so n >= 1 and NVDA specifically gets persisted.
-    n = job.skew_swing_greeks_refresh(repo=repo, client=None)
+    # non-index ticker, so n >= 1 and NVDA specifically gets persisted. Pass an
+    # explicit ET market date — the scheduler supplies datetime.now(rth_tz).date()
+    # so a non-ET host doesn't stamp +1 day (TZ fix).
+    et_date = date(2026, 7, 1)
+    n = job.skew_swing_greeks_refresh(repo=repo, client=None, today=et_date)
     assert n >= 1
     got = repo.fetch_latest_swing_greeks_by_strike("NVDA")
     assert {r["strike"] for r in got} == {Decimal("100")}
+    # The passed market date stamps the rows (not host-local).
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT market_date FROM uw_scan.skew_swing_greeks WHERE ticker='NVDA'"
+        )
+        assert [r[0] for r in cur.fetchall()] == [et_date]
     # SPY is an index ETF -> now INCLUDED (structure block extended to index ETFs);
     # its directional lean is research-validated, so it earns the same expression.
     got_spy = repo.fetch_latest_swing_greeks_by_strike("SPY")

--- a/tests/unit/cards/test_skew_first_principles.py
+++ b/tests/unit/cards/test_skew_first_principles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 import pytest
+
 from uw_scan.cards import skew_first_principles as sk
 
 
@@ -281,3 +282,18 @@ def test_build_read_summary_handles_raw_sign_label_form():
     )
     assert "call-skew" in read["summary_line"]
     assert "call_skew" not in read["summary_line"]
+
+
+def test_express_matches_structure_family():
+    # _express_structure is now derived from structure_family — single source, no drift.
+    assert (
+        sk._express_structure("RICH", "BEARISH_TILT")
+        == "put-debit-spread — defined risk"
+    )
+    assert (
+        sk._express_structure("CHEAP", "BULLISH_TILT")
+        == "call-debit-spread — defined risk"
+    )
+    assert sk._express_structure("NORMAL", "NEUTRAL") == ""
+    assert sk.structure_family({"lean": "NEUTRAL"}) is None
+    assert sk.structure_family({"lean": "BEARISH_TILT"})["kind"] == "put_debit_spread"

--- a/tests/unit/cards/test_skew_structure_legs.py
+++ b/tests/unit/cards/test_skew_structure_legs.py
@@ -1,0 +1,145 @@
+"""Pure strike-by-delta structure selection (defined-risk, lean-gated)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.cards import skew_first_principles as sk
+
+
+def _exposures():
+    # one expiry at dte=33; put_delta spans the wing range we need
+    ex = date(2026, 7, 18)
+    return [
+        {
+            "expiry": ex,
+            "strike": Decimal("105"),
+            "dte": 33,
+            "put_delta": Decimal("-0.50"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("100"),
+            "dte": 33,
+            "put_delta": Decimal("-0.38"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("95"),
+            "dte": 33,
+            "put_delta": Decimal("-0.26"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("88"),
+            "dte": 33,
+            "put_delta": Decimal("-0.13"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("80"),
+            "dte": 33,
+            "put_delta": Decimal("-0.05"),
+        },
+    ]
+
+
+def test_bearish_picks_put_debit_spread_by_delta():
+    fam = sk.structure_family({"lean": "BEARISH_TILT"})
+    assert fam["kind"] == "put_debit_spread"
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=_exposures(), dte_lo=21, dte_hi=60, dte_pref=35
+    )
+    assert detail["status"] == "ready"
+    assert detail["kind"] == "put_debit_spread"
+    legs = detail["legs"]
+    assert len(legs) == 2
+    buy, sell = legs[0], legs[1]
+    assert buy["action"] == "BUY" and buy["right"] == "PUT"
+    assert buy["strike"] == Decimal("95")  # closest to -0.25
+    assert sell["action"] == "SELL" and sell["strike"] == Decimal(
+        "88"
+    )  # closest to -0.12
+    # defined-risk: long wing strike strictly above the short wing strike
+    assert buy["strike"] > sell["strike"]
+
+
+def test_no_chain_when_exposures_empty():
+    fam = sk.structure_family({"lean": "BULLISH_TILT"})
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=[], dte_lo=21, dte_hi=60, dte_pref=35
+    )
+    assert detail["status"] == "no_chain"
+    assert detail["legs"] == []
+
+
+def test_neutral_has_no_family():
+    assert sk.structure_family({"lean": "NEUTRAL"}) is None
+
+
+def test_inverted_put_chain_yields_no_chain():
+    # non-monotonic chain: the -0.25-target leg lands on a LOWER strike than the
+    # -0.12-target leg -> would be a credit (short-premium) spread -> rejected.
+    ex = date(2026, 7, 18)
+    bad = [
+        {
+            "expiry": ex,
+            "strike": Decimal("95"),
+            "dte": 33,
+            "put_delta": Decimal("-0.12"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("88"),
+            "dte": 33,
+            "put_delta": Decimal("-0.26"),
+        },
+    ]
+    fam = sk.structure_family({"lean": "BEARISH_TILT"})
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=bad, dte_lo=21, dte_hi=60, dte_pref=35
+    )
+    assert detail["status"] == "no_chain"
+    assert detail["legs"] == []
+
+
+def test_bullish_picks_call_debit_spread_by_delta():
+    ex = date(2026, 7, 18)
+    chain = [
+        {
+            "expiry": ex,
+            "strike": Decimal("100"),
+            "dte": 33,
+            "call_delta": Decimal("0.50"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("105"),
+            "dte": 33,
+            "call_delta": Decimal("0.26"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("112"),
+            "dte": 33,
+            "call_delta": Decimal("0.13"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("120"),
+            "dte": 33,
+            "call_delta": Decimal("0.05"),
+        },
+    ]
+    fam = sk.structure_family({"lean": "BULLISH_TILT"})
+    assert fam["kind"] == "call_debit_spread"
+    detail = sk.select_structure_legs(
+        family=fam, exposure_rows=chain, dte_lo=21, dte_hi=60, dte_pref=35
+    )
+    assert detail["status"] == "ready"
+    buy, sell = detail["legs"]
+    assert buy["action"] == "BUY" and buy["right"] == "CALL"
+    assert buy["strike"] == Decimal("105")  # closest to +0.25
+    assert sell["strike"] == Decimal("112")  # closest to +0.12
+    assert buy["strike"] < sell["strike"]  # defined-risk bull call (debit) spread

--- a/tests/unit/reports/test_skew_snapshot_row.py
+++ b/tests/unit/reports/test_skew_snapshot_row.py
@@ -138,6 +138,53 @@ def test_structure_detail_present_when_non_neutral_with_exposures():
     assert sd["legs"][0]["action"] == "BUY" and sd["legs"][0]["strike"] == Decimal("95")
 
 
+def test_structure_detail_present_for_index_etf():
+    # sector="Macro" -> asset_class index_macro. The structure block used to be
+    # suppressed for index_macro; it is now extended to index ETFs because their
+    # directional lean is research-validated. A non-neutral verdict + a swing chain
+    # must therefore produce a ready structure detail.
+    rr = _rr_series()
+    ex = date(2026, 8, 1)
+    row = build_skew_snapshot_row(
+        ticker="QQQ",
+        market_date=rr[-1]["market_date"],
+        rr_series=rr,
+        expiry_rows=[{"expiry": date(2026, 8, 1), "risk_reversal": 0.05}],
+        rv_series=_rv_series(),
+        spy_rv_series=_rv_series(),
+        positioning={"si_fee_rate": 0.25, "si_days_to_cover": 1.2},
+        next_earnings_date=None,
+        verdict={
+            "verdict": "TRADABLE_BEAR",
+            "confidence": "med",
+            "forward_sep": -0.02,
+            "borrow_clean": True,
+            "survives_gate": True,
+        },
+        sector="Macro",
+        today=rr[-1]["market_date"],
+        exposure_rows=[
+            {
+                "expiry": ex,
+                "strike": Decimal("95"),
+                "dte": 33,
+                "put_delta": Decimal("-0.26"),
+            },
+            {
+                "expiry": ex,
+                "strike": Decimal("88"),
+                "dte": 33,
+                "put_delta": Decimal("-0.13"),
+            },
+        ],
+    )
+    assert row["asset_class"] == "index_macro"
+    assert row["directional_lean"] == "BEARISH_TILT"
+    sd = row["read_json"]["directional_lean"]["structure_detail"]
+    assert sd is not None and sd["status"] == "ready"
+    assert sd["kind"] == "put_debit_spread"
+
+
 def test_structure_detail_absent_when_neutral():
     rr = _rr_series()
     row = build_skew_snapshot_row(

--- a/tests/unit/reports/test_skew_snapshot_row.py
+++ b/tests/unit/reports/test_skew_snapshot_row.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
+from decimal import Decimal
 
 from uw_scan.reports.skew_analytics import build_skew_snapshot_row
 
@@ -90,3 +91,75 @@ def test_build_row_bearish_with_seeded_verdict():
     )
     assert row["directional_lean"] == "BEARISH_TILT"
     assert row["lean_confidence"] == "med"
+
+
+def test_structure_detail_present_when_non_neutral_with_exposures():
+    rr = _rr_series()
+    ex = date(2026, 8, 1)
+    exposures = [
+        {
+            "expiry": ex,
+            "strike": Decimal("95"),
+            "dte": 33,
+            "put_delta": Decimal("-0.26"),
+        },
+        {
+            "expiry": ex,
+            "strike": Decimal("88"),
+            "dte": 33,
+            "put_delta": Decimal("-0.13"),
+        },
+    ]
+    row = build_skew_snapshot_row(
+        ticker="NVDA",
+        market_date=rr[-1]["market_date"],
+        rr_series=rr,
+        expiry_rows=[{"expiry": date(2026, 8, 1), "risk_reversal": 0.05}],
+        rv_series=_rv_series(),
+        spy_rv_series=_rv_series(),
+        positioning={"si_fee_rate": 0.25, "si_days_to_cover": 1.2},
+        next_earnings_date=None,
+        verdict={
+            "verdict": "TRADABLE_BEAR",
+            "confidence": "med",
+            "forward_sep": -0.02,
+            "borrow_clean": True,
+            "survives_gate": True,
+        },
+        sector=None,
+        today=rr[-1]["market_date"],
+        exposure_rows=exposures,
+    )
+    assert row["directional_lean"] == "BEARISH_TILT"  # precondition: lean is gated on
+    sd = row["read_json"]["directional_lean"]["structure_detail"]
+    assert sd is not None and sd["status"] == "ready"
+    assert sd["kind"] == "put_debit_spread"
+    assert len(sd["legs"]) == 2
+    assert sd["legs"][0]["action"] == "BUY" and sd["legs"][0]["strike"] == Decimal("95")
+
+
+def test_structure_detail_absent_when_neutral():
+    rr = _rr_series()
+    row = build_skew_snapshot_row(
+        ticker="NVDA",
+        market_date=rr[-1]["market_date"],
+        rr_series=rr,
+        expiry_rows=[{"expiry": date(2026, 8, 1), "risk_reversal": 0.05}],
+        rv_series=_rv_series(),
+        spy_rv_series=_rv_series(),
+        positioning={"si_fee_rate": 0.25, "si_days_to_cover": 1.2},
+        next_earnings_date=None,
+        verdict=None,
+        sector=None,
+        today=rr[-1]["market_date"],
+        exposure_rows=[
+            {
+                "expiry": date(2026, 8, 1),
+                "strike": Decimal("95"),
+                "dte": 33,
+                "put_delta": Decimal("-0.26"),
+            }
+        ],
+    )
+    assert row["directional_lean"] == "NEUTRAL"
+    assert row["read_json"]["directional_lean"]["structure_detail"] is None

--- a/tests/unit/test_models_exports.py
+++ b/tests/unit/test_models_exports.py
@@ -169,3 +169,13 @@ def test_new_exposure_models_exported():
     # accidentally drifting back to the implementation module.
     assert models.StrikeExposureRow.__module__ == "uw_scan.models"
     assert models.ExposuresSummaryRow.__module__ == "uw_scan.models"
+
+
+def test_new_skew_structure_models_exported():
+    from uw_scan import models
+
+    assert "SkewStructureLeg" in models.__all__
+    assert "SkewStructureDetail" in models.__all__
+    # _preserve_public_module rewrites __module__ so OpenAPI component names stay stable.
+    assert models.SkewStructureLeg.__module__ == "uw_scan.models"
+    assert models.SkewStructureDetail.__module__ == "uw_scan.models"

--- a/tests/unit/worker/test_scheduler.py
+++ b/tests/unit/worker/test_scheduler.py
@@ -17,6 +17,7 @@ from uw_scan.worker.scheduler import (
     _run_rates_fred_ingest,
     _should_schedule_pipeline_benchmark,
     _should_schedule_rates_fred_ingest,
+    _should_schedule_skew_swing_greeks,
     _uw_auto_request_allowed,
     _worker_heartbeat_name,
 )
@@ -157,7 +158,9 @@ def test_rates_fred_ingest_helper_uses_unwrapped_key_and_recorder(monkeypatch) -
         calls.append(kwargs)
         kwargs["record_request"]("fred", {"params": {"series_id": "DGS10"}})
 
-    monkeypatch.setattr("uw_scan.worker.scheduler._external_api_recorder", fake_recorder)
+    monkeypatch.setattr(
+        "uw_scan.worker.scheduler._external_api_recorder", fake_recorder
+    )
     monkeypatch.setattr("uw_scan.worker.scheduler.rates_fred_ingest_job", fake_job)
 
     settings = Settings(api_key="uw", fred_api_key=SecretStr("fred-secret"))
@@ -197,6 +200,25 @@ def test_rates_fred_ingest_schedules_only_on_all_or_primary_uw_worker() -> None:
     )
     assert not _should_schedule_rates_fred_ingest(
         Settings(api_key="uw", worker_role="ai", worker_index=0, worker_count=1)
+    )
+
+
+def test_skew_swing_greeks_schedules_only_on_all_or_primary_uw_worker() -> None:
+    # Must NOT use _is_primary_worker (true for index-0 of EVERY role) — that would
+    # run the lock-less UW loop in ~5 processes (duplicate spend + racing writes).
+    assert _should_schedule_skew_swing_greeks(Settings(api_key="uw", worker_role="all"))
+    assert _should_schedule_skew_swing_greeks(
+        Settings(api_key="uw", worker_role="uw", worker_index=0, worker_count=3)
+    )
+    assert not _should_schedule_skew_swing_greeks(
+        Settings(api_key="uw", worker_role="uw", worker_index=1, worker_count=3)
+    )
+    # index-0 of other roles must be excluded (this is the bug being fixed).
+    assert not _should_schedule_skew_swing_greeks(
+        Settings(api_key="uw", worker_role="massive", worker_index=0, worker_count=1)
+    )
+    assert not _should_schedule_skew_swing_greeks(
+        Settings(api_key="uw", worker_role="ai-codex", worker_index=0, worker_count=1)
     )
 
 

--- a/web/components/stock/panels/SkewSignalDetail.tsx
+++ b/web/components/stock/panels/SkewSignalDetail.tsx
@@ -32,6 +32,24 @@ function rvLabel(cls: string): string {
   return "NO EDGE";
 }
 
+// A gated-lean basis is always "validated — <clause>; <clause>". Lift the
+// leading "validated" status into a right-aligned badge on the confidence row,
+// and break the reason at its semicolon into two readable lines. NEUTRAL bases
+// are plain reason strings (some of which contain " — "), so the badge triggers
+// only on the literal "validated — " prefix — those render as a single line.
+function parseEvidenceBasis(basis: string): {
+  status: string | null;
+  lines: string[];
+} {
+  const prefix = "validated — ";
+  if (!basis.startsWith(prefix)) return { status: null, lines: [basis] };
+  const rest = basis.slice(prefix.length).trim();
+  const semi = rest.indexOf("; ");
+  const lines =
+    semi >= 0 ? [rest.slice(0, semi + 1), rest.slice(semi + 2)] : [rest];
+  return { status: "validated", lines };
+}
+
 const labelStyle: React.CSSProperties = {
   fontFamily: "var(--font-mono)",
   fontSize: "10px",
@@ -206,6 +224,7 @@ export function SkewSignalDetail({ data }: { data: SkewAnalysisResponse }) {
   }
   const z = toNum(data.rr_z_180d);
   const pct = toNum(data.rr_pct_252d);
+  const evidence = parseEvidenceBasis(lean.basis ?? "");
 
   return (
     <div className="section" data-testid="skew-signal-detail">
@@ -298,6 +317,28 @@ export function SkewSignalDetail({ data }: { data: SkewAnalysisResponse }) {
             >
               confidence: {lean.confidence}
             </span>
+            {evidence.status ? (
+              <span
+                data-testid="skew-lean-status"
+                style={{
+                  marginLeft: "auto",
+                  flexShrink: 0,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "9px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "var(--positive)",
+                  background:
+                    "color-mix(in srgb, var(--positive) 14%, transparent)",
+                  border:
+                    "1px solid color-mix(in srgb, var(--positive) 40%, transparent)",
+                  borderRadius: "3px",
+                  padding: "1px 6px",
+                }}
+              >
+                {evidence.status}
+              </span>
+            ) : null}
           </div>
           <div
             style={{
@@ -310,7 +351,9 @@ export function SkewSignalDetail({ data }: { data: SkewAnalysisResponse }) {
             }}
             data-testid="skew-lean-basis"
           >
-            {lean.basis}
+            {evidence.lines.map((line, i) => (
+              <div key={i}>{line}</div>
+            ))}
           </div>
           <div
             style={{

--- a/web/components/stock/panels/SkewSignalDetail.tsx
+++ b/web/components/stock/panels/SkewSignalDetail.tsx
@@ -134,6 +134,66 @@ function EvidenceRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function StructureDetail({
+  detail,
+}: {
+  detail: NonNullable<
+    SkewAnalysisResponse["read"]["directional_lean"]["structure_detail"]
+  >;
+}) {
+  if (detail.status !== "ready" || !detail.legs?.length) return null;
+  return (
+    <div
+      data-testid="skew-structure-detail"
+      style={{
+        borderTop: "1px solid var(--border-dim, var(--line-grid))",
+        marginTop: "8px",
+        paddingTop: "8px",
+      }}
+    >
+      <div style={{ ...labelStyle, marginBottom: "6px" }}>
+        Structure · {detail.kind.replace(/_/g, "-")}
+        {detail.dte_target ? ` · ${detail.dte_target}DTE` : ""}
+      </div>
+      {detail.legs.map((leg, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            fontFamily: "var(--font-mono)",
+            fontSize: "11px",
+            padding: "2px 0",
+          }}
+        >
+          <span style={{ color: "var(--text-muted)" }}>
+            {leg.action} {leg.right}
+          </span>
+          <span style={{ color: "var(--text-secondary)" }}>
+            {leg.strike != null ? String(leg.strike) : "—"}
+            {leg.actual_delta != null
+              ? ` (Δ ${fmtSigned(toNum(leg.actual_delta) ?? 0, 2)})`
+              : ""}
+          </span>
+        </div>
+      ))}
+      {detail.note ? (
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "10px",
+            color: "var(--text-muted)",
+            marginTop: "5px",
+            lineHeight: 1.4,
+          }}
+        >
+          {detail.note}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function SkewSignalDetail({ data }: { data: SkewAnalysisResponse }) {
   const read = data.read;
   const lean = read.directional_lean;
@@ -262,6 +322,9 @@ export function SkewSignalDetail({ data }: { data: SkewAnalysisResponse }) {
             <EvidenceRow label="earnings" value={read.earnings_gate} />
             <EvidenceRow label="express" value={lean.express || "—"} />
             <EvidenceRow label="regime" value={data.regime} />
+            {lean.structure_detail ? (
+              <StructureDetail detail={lean.structure_detail} />
+            ) : null}
           </div>
         </div>
       </div>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4,6 +4,176 @@
  */
 
 export interface paths {
+    "/api/cockpit/{ticker}/dealer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Dealer */
+        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/flow-im": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Flow Im */
+        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit State */
+        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/surface": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Surface */
+        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/cockpit/{ticker}/vrp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cockpit Vrp */
+        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/gauge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gauge */
+        get: operations["get_gauge_api_gold_gauge_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/inputs/{series_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Input Series */
+        get: operations["get_input_series_api_gold_inputs__series_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/lenses/{lens_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Lens */
+        get: operations["get_lens_api_gold_lenses__lens_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Replay */
+        get: operations["get_replay_api_gold_replay_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/gold/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get State */
+        get: operations["get_state_api_gold_state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -55,40 +225,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist": {
+    "/api/jobs/{job_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Watchlist */
-        get: operations["get_watchlist_api_watchlist_get"];
-        put?: never;
-        /** Post Watchlist */
-        post: operations["post_watchlist_api_watchlist_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/queue": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Watchlist Queue
-         * @description Lightweight queue snapshot for the dashboard's QueueProgress widget.
-         *
-         *     Returns only the rescan-queue summary — no card joins, no meta. Designed
-         *     for the 2.5s polling loop in QueueProgress so the dashboard doesn't
-         *     refetch the full watchlist payload every tick.
-         */
-        get: operations["get_watchlist_queue_api_watchlist_queue_get"];
+        /** Get Job */
+        get: operations["get_job_api_jobs__job_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -97,23 +242,15 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist/spots": {
+    "/api/ohlc/{ticker}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * Get Watchlist Spots
-         * @description Live spot snapshot for the dashboard's LiveSpotsProvider poller.
-         *
-         *     The spot WS consumer (xenon primary / massive fallback) rewrites
-         *     watchlist_card.spot every ~1s; this projection lets the browser tick
-         *     prices without refetching the full watchlist payload (same pattern as
-         *     /watchlist/queue for QueueProgress).
-         */
-        get: operations["get_watchlist_spots_api_watchlist_spots_get"];
+        /** Get Ohlc */
+        get: operations["get_ohlc_api_ohlc__ticker__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -122,7 +259,284 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/watchlist/{ticker}": {
+    "/api/provider-usage/endpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Endpoints */
+        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Requests */
+        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Summary */
+        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider-usage/tickers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Provider Usage Tickers */
+        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/rates/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Rates Snapshot */
+        get: operations["rates_snapshot_api_rates_snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime */
+        get: operations["get_regime_api_regime_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Canary Latest */
+        get: operations["get_canary_latest_api_regime_canary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Canary History */
+        get: operations["get_canary_history_api_regime_canary_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/canary/validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Canary Validation
+         * @description v0.4 patch I4 + C6: use the existing `find_latest_run` (which already
+         *     filters on `completed_at IS NOT NULL`) and post-filter for the winning
+         *     form in summary JSON. composite_version is stringified at the DB boundary.
+         */
+        get: operations["get_canary_validation_api_regime_canary_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/cri/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cri History */
+        get: operations["get_cri_history_api_regime_cri_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/cri/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Cri Intraday */
+        get: operations["get_cri_intraday_api_regime_cri_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/cri/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Cri Live
+         * @description Request-time CRI with live quotes spliced as today's provisional
+         *     close. Does NOT persist (the 5-min regime_live_scan job owns writes).
+         *     Falls back to the latest basis='eod' snapshot when quotes are stale.
+         */
+        get: operations["get_cri_live_api_regime_cri_live_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/dealer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dealer Regime
+         * @description Per-ticker dealer Greek regime — feeds the Magnet/Gamma summary bar
+         *     and the Volatility tab regime panel. Uses the same `gather_inputs`
+         *     helper the report assembler uses so both paths see the same upstream.
+         */
+        get: operations["get_dealer_regime_api_regime_dealer_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Gex */
+        get: operations["get_gex_api_regime_gex_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Gex Intraday
+         * @description Last N RTH sessions of intraday gex_snapshots for ``ticker``.
+         *
+         *     Drives the intraday line chart on the GEX tab. Sessions are ET-anchored
+         *     (UTC `data_date` straddles sessions). Empty `sessions` array is a valid
+         *     response when no rows exist for the ticker.
+         */
+        get: operations["get_gex_intraday_api_regime_gex_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/gex/scan": {
         parameters: {
             query?: never;
             header?: never;
@@ -131,13 +545,312 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        post?: never;
-        /** Delete Watchlist */
-        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
+        /**
+         * Trigger Gex Scan
+         * @description Run a GEX scan synchronously against UW and persist.
+         */
+        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        delete?: never;
         options?: never;
         head?: never;
-        /** Patch Watchlist */
-        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/grg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Grg
+         * @description Latest GRG snapshot (self-contained: embeds 90-session history).
+         *
+         *     GRG is EOD/periodic-rescan — the worker owns UW fetches; this read is
+         *     cheap (one snapshot row). No per-request UW spend.
+         */
+        get: operations["get_grg_api_regime_grg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/grg/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Grg Scan
+         * @description Run a GRG scan synchronously against UW and persist a snapshot.
+         */
+        post: operations["trigger_grg_scan_api_regime_grg_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/guidance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Guidance */
+        get: operations["get_guidance_api_regime_guidance_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/quotes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Regime Quotes */
+        get: operations["get_regime_quotes_api_regime_quotes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Cri Scan
+         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_cri_scan_api_regime_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Validation
+         * @description Latest completed CRI backtest run, rendered to markdown.
+         *
+         *     Source of truth is uw_scan.regime_backtest_runs. The previous file
+         *     fallback (cri-backtest.md/.csv + oos-summary.json on disk) was removed
+         *     after the prod gate in
+         *     docs/superpowers/archive/specs/2026-05-24-regime-research-closure-design.md §10.4
+         *     was satisfied. If no completed run exists at the current
+         *     cri_scorers.COMPOSITE_VERSION, returns 503 — operators should run
+         *     scripts/backtest_cri.py to seed the table.
+         */
+        get: operations["get_validation_api_regime_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg */
+        get: operations["get_vcg_api_regime_vcg_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg-validation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Vcg Validation
+         * @description Latest completed VCG backtest run, rendered to markdown + structured.
+         *
+         *     Source of truth is uw_scan.regime_backtest_runs (migration 057). Returns
+         *     503 with an actionable message if no completed run exists at the current
+         *     vcg_scoring.COMPOSITE_VERSION — operators should run scripts/backtest_vcg.py.
+         *
+         *     Persisted JSON shape (from scripts/backtest_vcg.py):
+         *         summary.extras.named_crash_window: dict[iso_str, list[dict]] where
+         *         each inner dict has offset_d (NOT offset_days), vcg, vcg_adj, beta1,
+         *         beta2, sign_ok, interpretation, vix. Event labels live in
+         *         NAMED_CRASH_DATES, not the persisted JSON.
+         */
+        get: operations["get_vcg_validation_api_regime_vcg_validation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg History */
+        get: operations["get_vcg_history_api_regime_vcg_history_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/intraday": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg Intraday */
+        get: operations["get_vcg_intraday_api_regime_vcg_intraday_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vcg Live */
+        get: operations["get_vcg_live_api_regime_vcg_live_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vcg/scan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Vcg Scan
+         * @description Run a VCG scan synchronously off the warm store; persist a snapshot.
+         */
+        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/regime/vol-backdrop": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Vol Backdrop */
+        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scanner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Scanner */
+        get: operations["get_scanner_api_scanner_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/scanner/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Scanner Discover
+         * @description Thin read of the latest persisted discovery snapshot (compute is the job).
+         */
+        get: operations["get_scanner_discover_api_scanner_discover_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/stock/{ticker}": {
@@ -214,179 +927,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/ohlc/{ticker}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ohlc */
-        get: operations["get_ohlc_api_ohlc__ticker__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit State */
-        get: operations["get_cockpit_state_api_cockpit__ticker__state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/dealer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Dealer */
-        get: operations["get_cockpit_dealer_api_cockpit__ticker__dealer_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/surface": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Surface */
-        get: operations["get_cockpit_surface_api_cockpit__ticker__surface_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/flow-im": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Flow Im */
-        get: operations["get_cockpit_flow_im_api_cockpit__ticker__flow_im_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/cockpit/{ticker}/vrp": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cockpit Vrp */
-        get: operations["get_cockpit_vrp_api_cockpit__ticker__vrp_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/{ticker}/rescan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Enqueue Rescan */
-        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/watchlist/rescan-all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Enqueue Rescan All
-         * @description Enqueue a rescan job for every active watchlist ticker.
-         */
-        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Job */
-        get: operations["get_job_api_jobs__job_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/stock/{ticker}/volatility/series": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Volatility Series */
-        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/stock/{ticker}/skew": {
         parameters: {
             query?: never;
@@ -396,74 +936,6 @@ export interface paths {
         };
         /** Get Skew Analysis */
         get: operations["get_skew_analysis_api_stock__ticker__skew_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Summary */
-        get: operations["provider_usage_summary_api_provider_usage_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/endpoints": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Endpoints */
-        get: operations["provider_usage_endpoints_api_provider_usage_endpoints_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/tickers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Tickers */
-        get: operations["provider_usage_tickers_api_provider_usage_tickers_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/provider-usage/requests": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Provider Usage Requests */
-        get: operations["provider_usage_requests_api_provider_usage_requests_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -562,6 +1034,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/stock/{ticker}/volatility/series": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Volatility Series */
+        get: operations["get_volatility_series_api_stock__ticker__volatility_series_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/trade-insights/priors": {
         parameters: {
             query?: never;
@@ -595,24 +1084,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex": {
+    "/api/watchlist": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Gex */
-        get: operations["get_gex_api_regime_gex_get"];
+        /** Get Watchlist */
+        get: operations["get_watchlist_api_watchlist_get"];
         put?: never;
-        post?: never;
+        /** Post Watchlist */
+        post: operations["post_watchlist_api_watchlist_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex/intraday": {
+    "/api/watchlist/queue": {
         parameters: {
             query?: never;
             header?: never;
@@ -620,14 +1110,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Gex Intraday
-         * @description Last N RTH sessions of intraday gex_snapshots for ``ticker``.
+         * Get Watchlist Queue
+         * @description Lightweight queue snapshot for the dashboard's QueueProgress widget.
          *
-         *     Drives the intraday line chart on the GEX tab. Sessions are ET-anchored
-         *     (UTC `data_date` straddles sessions). Empty `sessions` array is a valid
-         *     response when no rows exist for the ticker.
+         *     Returns only the rescan-queue summary — no card joins, no meta. Designed
+         *     for the 2.5s polling loop in QueueProgress so the dashboard doesn't
+         *     refetch the full watchlist payload every tick.
          */
-        get: operations["get_gex_intraday_api_regime_gex_intraday_get"];
+        get: operations["get_watchlist_queue_api_watchlist_queue_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -636,7 +1126,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime/gex/scan": {
+    "/api/watchlist/rescan-all": {
         parameters: {
             query?: never;
             header?: never;
@@ -646,25 +1136,33 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Trigger Gex Scan
-         * @description Run a GEX scan synchronously against UW and persist.
+         * Enqueue Rescan All
+         * @description Enqueue a rescan job for every active watchlist ticker.
          */
-        post: operations["trigger_gex_scan_api_regime_gex_scan_post"];
+        post: operations["enqueue_rescan_all_api_watchlist_rescan_all_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/regime/vol-backdrop": {
+    "/api/watchlist/spots": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /** Get Vol Backdrop */
-        get: operations["get_vol_backdrop_api_regime_vol_backdrop_get"];
+        /**
+         * Get Watchlist Spots
+         * @description Live spot snapshot for the dashboard's LiveSpotsProvider poller.
+         *
+         *     The spot WS consumer (xenon primary / massive fallback) rewrites
+         *     watchlist_card.spot every ~1s; this projection lets the browser tick
+         *     prices without refetching the full watchlist payload (same pattern as
+         *     /watchlist/queue for QueueProgress).
+         */
+        get: operations["get_watchlist_spots_api_watchlist_spots_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -673,24 +1171,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/regime": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Regime */
-        get: operations["get_regime_api_regime_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/scan": {
+    "/api/watchlist/{ticker}": {
         parameters: {
             query?: never;
             header?: never;
@@ -699,35 +1180,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Trigger Cri Scan
-         * @description Run a CRI scan synchronously off the warm store; persist a snapshot.
-         */
-        post: operations["trigger_cri_scan_api_regime_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg */
-        get: operations["get_vcg_api_regime_vcg_get"];
-        put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Watchlist */
+        delete: operations["delete_watchlist_api_watchlist__ticker__delete"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Patch Watchlist */
+        patch: operations["patch_watchlist_api_watchlist__ticker__patch"];
         trace?: never;
     };
-    "/api/regime/vcg/scan": {
+    "/api/watchlist/{ticker}/rescan": {
         parameters: {
             query?: never;
             header?: never;
@@ -736,470 +1198,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Trigger Vcg Scan
-         * @description Run a VCG scan synchronously off the warm store; persist a snapshot.
-         */
-        post: operations["trigger_vcg_scan_api_regime_vcg_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/cri/live": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Cri Live
-         * @description Request-time CRI with live quotes spliced as today's provisional
-         *     close. Does NOT persist (the 5-min regime_live_scan job owns writes).
-         *     Falls back to the latest basis='eod' snapshot when quotes are stale.
-         */
-        get: operations["get_cri_live_api_regime_cri_live_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/cri/intraday": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cri Intraday */
-        get: operations["get_cri_intraday_api_regime_cri_intraday_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/cri/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Cri History */
-        get: operations["get_cri_history_api_regime_cri_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg/live": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg Live */
-        get: operations["get_vcg_live_api_regime_vcg_live_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg/intraday": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg Intraday */
-        get: operations["get_vcg_intraday_api_regime_vcg_intraday_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Vcg History */
-        get: operations["get_vcg_history_api_regime_vcg_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/grg": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Grg
-         * @description Latest GRG snapshot (self-contained: embeds 90-session history).
-         *
-         *     GRG is EOD/periodic-rescan — the worker owns UW fetches; this read is
-         *     cheap (one snapshot row). No per-request UW spend.
-         */
-        get: operations["get_grg_api_regime_grg_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/grg/scan": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Trigger Grg Scan
-         * @description Run a GRG scan synchronously against UW and persist a snapshot.
-         */
-        post: operations["trigger_grg_scan_api_regime_grg_scan_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/quotes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Regime Quotes */
-        get: operations["get_regime_quotes_api_regime_quotes_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/dealer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Dealer Regime
-         * @description Per-ticker dealer Greek regime — feeds the Magnet/Gamma summary bar
-         *     and the Volatility tab regime panel. Uses the same `gather_inputs`
-         *     helper the report assembler uses so both paths see the same upstream.
-         */
-        get: operations["get_dealer_regime_api_regime_dealer_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Canary Latest */
-        get: operations["get_canary_latest_api_regime_canary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary/history": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Canary History */
-        get: operations["get_canary_history_api_regime_canary_history_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/canary/validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Canary Validation
-         * @description v0.4 patch I4 + C6: use the existing `find_latest_run` (which already
-         *     filters on `completed_at IS NOT NULL`) and post-filter for the winning
-         *     form in summary JSON. composite_version is stringified at the DB boundary.
-         */
-        get: operations["get_canary_validation_api_regime_canary_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/guidance": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Guidance */
-        get: operations["get_guidance_api_regime_guidance_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Validation
-         * @description Latest completed CRI backtest run, rendered to markdown.
-         *
-         *     Source of truth is uw_scan.regime_backtest_runs. The previous file
-         *     fallback (cri-backtest.md/.csv + oos-summary.json on disk) was removed
-         *     after the prod gate in
-         *     docs/superpowers/archive/specs/2026-05-24-regime-research-closure-design.md §10.4
-         *     was satisfied. If no completed run exists at the current
-         *     cri_scorers.COMPOSITE_VERSION, returns 503 — operators should run
-         *     scripts/backtest_cri.py to seed the table.
-         */
-        get: operations["get_validation_api_regime_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/regime/vcg-validation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Vcg Validation
-         * @description Latest completed VCG backtest run, rendered to markdown + structured.
-         *
-         *     Source of truth is uw_scan.regime_backtest_runs (migration 057). Returns
-         *     503 with an actionable message if no completed run exists at the current
-         *     vcg_scoring.COMPOSITE_VERSION — operators should run scripts/backtest_vcg.py.
-         *
-         *     Persisted JSON shape (from scripts/backtest_vcg.py):
-         *         summary.extras.named_crash_window: dict[iso_str, list[dict]] where
-         *         each inner dict has offset_d (NOT offset_days), vcg, vcg_adj, beta1,
-         *         beta2, sign_ok, interpretation, vix. Event labels live in
-         *         NAMED_CRASH_DATES, not the persisted JSON.
-         */
-        get: operations["get_vcg_validation_api_regime_vcg_validation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/gauge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Gauge */
-        get: operations["get_gauge_api_gold_gauge_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/inputs/{series_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Input Series */
-        get: operations["get_input_series_api_gold_inputs__series_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get State */
-        get: operations["get_state_api_gold_state_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/lenses/{lens_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Lens */
-        get: operations["get_lens_api_gold_lenses__lens_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/gold/replay": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Replay */
-        get: operations["get_replay_api_gold_replay_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/rates/snapshot": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Rates Snapshot */
-        get: operations["rates_snapshot_api_rates_snapshot_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scanner": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Scanner */
-        get: operations["get_scanner_api_scanner_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scanner/discover": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Scanner Discover
-         * @description Thin read of the latest persisted discovery snapshot (compute is the job).
-         */
-        get: operations["get_scanner_discover_api_scanner_discover_get"];
-        put?: never;
-        post?: never;
+        /** Enqueue Rescan */
+        post: operations["enqueue_rescan_api_watchlist__ticker__rescan_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1212,11 +1212,15 @@ export interface components {
     schemas: {
         /** BenchmarkCurrentResponse */
         BenchmarkCurrentResponse: {
+            bottleneck?: components["schemas"]["BenchmarkReasonResponse"] | null;
             /**
              * Captured At
              * Format: date-time
              */
             captured_at: string;
+            metrics: components["schemas"]["BenchmarkMetricsResponse"];
+            /** Reasons */
+            reasons?: components["schemas"]["BenchmarkReasonResponse"][];
             /** Score */
             score: number;
             /**
@@ -1225,10 +1229,6 @@ export interface components {
              */
             status: "OK" | "DEGRADED" | "CRITICAL";
             subscores: components["schemas"]["BenchmarkSubscoresResponse"];
-            metrics: components["schemas"]["BenchmarkMetricsResponse"];
-            bottleneck?: components["schemas"]["BenchmarkReasonResponse"] | null;
-            /** Reasons */
-            reasons?: components["schemas"]["BenchmarkReasonResponse"][];
         };
         /** BenchmarkHistoryResponse */
         BenchmarkHistoryResponse: {
@@ -1237,83 +1237,88 @@ export interface components {
         };
         /** BenchmarkMetricsResponse */
         BenchmarkMetricsResponse: {
-            /** Watchlist Size */
-            watchlist_size?: number | null;
-            /** Scanner Fresh Count */
-            scanner_fresh_count?: number | null;
-            /** Scanner Stale Count */
-            scanner_stale_count?: number | null;
-            /** Scanner Dead Count */
-            scanner_dead_count?: number | null;
-            /** Scanner Never Scanned Count */
-            scanner_never_scanned_count?: number | null;
+            /** Failing Record Tables */
+            failing_record_tables?: string[];
             /** Last Full Scan Age Seconds */
             last_full_scan_age_seconds?: number | null;
+            /** Massive Worker Expected Count */
+            massive_worker_expected_count?: number | null;
+            /** Massive Worker Online Count */
+            massive_worker_online_count?: number | null;
+            /** Oldest Queue Age Seconds */
+            oldest_queue_age_seconds?: number | null;
+            /** Queue Depth */
+            queue_depth?: number | null;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
             /** Scan Duration Avg Seconds */
             scan_duration_avg_seconds?: number | null;
             /** Scan Duration P95 Seconds */
             scan_duration_p95_seconds?: number | null;
-            /** Queue Depth */
-            queue_depth?: number | null;
-            /** Oldest Queue Age Seconds */
-            oldest_queue_age_seconds?: number | null;
-            /** Queue Drain Rate Per Minute */
-            queue_drain_rate_per_minute?: number | null;
-            /** Uw Latency P95 Ms */
-            uw_latency_p95_ms?: number | null;
+            /** Scanner Dead Count */
+            scanner_dead_count?: number | null;
+            /** Scanner Fresh Count */
+            scanner_fresh_count?: number | null;
+            /** Scanner Never Scanned Count */
+            scanner_never_scanned_count?: number | null;
+            /** Scanner Stale Count */
+            scanner_stale_count?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
             /** Uw Http 429 */
             uw_http_429?: number | null;
             /** Uw Http 4Xx */
             uw_http_4xx?: number | null;
             /** Uw Http 5Xx */
             uw_http_5xx?: number | null;
-            /** Requests Per Minute */
-            requests_per_minute?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Uw Worker Online Count */
-            uw_worker_online_count?: number | null;
+            /** Uw Latency P95 Ms */
+            uw_latency_p95_ms?: number | null;
             /** Uw Worker Expected Count */
             uw_worker_expected_count?: number | null;
-            /** Massive Worker Online Count */
-            massive_worker_online_count?: number | null;
-            /** Massive Worker Expected Count */
-            massive_worker_expected_count?: number | null;
+            /** Uw Worker Online Count */
+            uw_worker_online_count?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
             /** Ws Tick Age Seconds */
             ws_tick_age_seconds?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
-            /** Failing Record Tables */
-            failing_record_tables?: string[];
         };
         /** BenchmarkReasonResponse */
         BenchmarkReasonResponse: {
             /** Component */
             component: string;
+            /** Message */
+            message: string;
+            /** Penalty */
+            penalty: number;
             /**
              * Severity
              * @enum {string}
              */
             severity: "degraded" | "critical";
-            /** Message */
-            message: string;
-            /** Penalty */
-            penalty: number;
         };
         /** BenchmarkSnapshotResponse */
         BenchmarkSnapshotResponse: {
-            /** Id */
-            id: number;
-            /**
-             * Captured At
-             * Format: date-time
-             */
-            captured_at: string;
             /**
              * Capture Bucket
              * Format: date-time
              */
             capture_bucket: string;
+            /**
+             * Captured At
+             * Format: date-time
+             */
+            captured_at: string;
+            /** Details Jsonb */
+            details_jsonb?: {
+                [key: string]: unknown;
+            };
+            /** Id */
+            id: number;
+            metrics: components["schemas"]["BenchmarkMetricsResponse"];
             /** Score */
             score: number;
             /**
@@ -1322,26 +1327,21 @@ export interface components {
              */
             status: "OK" | "DEGRADED" | "CRITICAL";
             subscores: components["schemas"]["BenchmarkSubscoresResponse"];
-            metrics: components["schemas"]["BenchmarkMetricsResponse"];
-            /** Details Jsonb */
-            details_jsonb?: {
-                [key: string]: unknown;
-            };
         };
         /** BenchmarkSubscoresResponse */
         BenchmarkSubscoresResponse: {
-            /** Freshness */
-            freshness: number;
             /** Coverage */
             coverage: number;
-            /** Throughput */
-            throughput: number;
-            /** Provider */
-            provider: number;
-            /** Worker */
-            worker: number;
+            /** Freshness */
+            freshness: number;
             /** Persistence */
             persistence: number;
+            /** Provider */
+            provider: number;
+            /** Throughput */
+            throughput: number;
+            /** Worker */
+            worker: number;
         };
         /** CanaryHistoryResponse */
         CanaryHistoryResponse: {
@@ -1351,76 +1351,78 @@ export interface components {
         /** CanaryHistoryRow */
         CanaryHistoryRow: {
             /**
+             * Band
+             * @enum {string}
+             */
+            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
+            /**
              * Data Date
              * Format: date
              */
             data_date: string;
             /** Score */
             score: number;
-            /**
-             * Band
-             * @enum {string}
-             */
-            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
-            /** Tactical Score */
-            tactical_score: number;
-            /** Structural Score */
-            structural_score: number;
             /** Speed Score */
             speed_score: number;
+            /** Spx Close */
+            spx_close?: number | null;
+            /** Structural Score */
+            structural_score: number;
+            /** Tactical Score */
+            tactical_score: number;
             /**
              * Warning State
              * @enum {string}
              */
             warning_state: "NONE" | "CONFIRMED_CANARY_ACTIVE" | "BUY_THE_DIP_ACTIVE" | "BOTH_ACTIVE_AMBIGUOUS";
-            /** Spx Close */
-            spx_close?: number | null;
         };
         /** CanaryLatestResponse */
         CanaryLatestResponse: {
+            /**
+             * Band
+             * @enum {string}
+             */
+            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
+            /** Composite Version */
+            composite_version: number;
             /**
              * Data Date
              * Format: date
              */
             data_date: string;
-            /** Composite Version */
-            composite_version: number;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+            /** Raw Score */
+            raw_score: number;
+            /** Score */
+            score: number;
             /**
              * Score Form
              * @enum {string}
              */
             score_form: "linear" | "convex" | "concave" | "sigmoid";
-            /** Score */
-            score: number;
-            /** Raw Score */
-            raw_score: number;
-            /**
-             * Band
-             * @enum {string}
-             */
-            band: "NONE" | "WATCH" | "BUY" | "STRONG_BUY";
-            /** Tactical Score */
-            tactical_score: number;
-            /** Structural Score */
-            structural_score: number;
             /** Speed Score */
             speed_score: number;
+            /** Structural Score */
+            structural_score: number;
+            /** Tactical Score */
+            tactical_score: number;
             /**
              * Warning State
              * @enum {string}
              */
             warning_state: "NONE" | "CONFIRMED_CANARY_ACTIVE" | "BUY_THE_DIP_ACTIVE" | "BOTH_ACTIVE_AMBIGUOUS";
-            /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
         };
         /** CanaryValidationResponse */
         CanaryValidationResponse: {
-            /** Run Id */
-            run_id: number;
             /** Composite Version */
             composite_version: number;
+            /** Rendered Markdown */
+            rendered_markdown: string;
+            /** Run Id */
+            run_id: number;
             /**
              * Score Form
              * @enum {string}
@@ -1430,87 +1432,78 @@ export interface components {
             summary: {
                 [key: string]: unknown;
             };
-            /** Rendered Markdown */
-            rendered_markdown: string;
         };
         /** CandidateStructure */
         CandidateStructure: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Thesis */
-            thesis: string;
-            /** Expression Type */
-            expression_type: string;
-            /**
-             * Legs
-             * @default []
-             */
-            legs: components["schemas"]["InsightLeg"][];
-            /** Net Credit Debit */
-            net_credit_debit?: string | null;
-            /** Max Profit */
-            max_profit?: string | null;
-            /** Max Loss */
-            max_loss?: string | null;
             /**
              * Breakevens
              * @default []
              */
             breakevens: string[];
             /**
-             * Profit Zone
+             * Dte Band
              * @default
              */
-            profit_zone: string;
+            dte_band: string;
             /**
              * Edge Source
              * @default
              */
             edge_source: string;
             /**
+             * Expression Delta
+             * @default
+             */
+            expression_delta: string;
+            /** Expression Type */
+            expression_type: string;
+            /** Idea Id */
+            idea_id: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["InsightLeg"][];
+            /** Max Loss */
+            max_loss?: string | null;
+            /** Max Profit */
+            max_profit?: string | null;
+            /** Net Credit Debit */
+            net_credit_debit?: string | null;
+            /**
+             * Profit Zone
+             * @default
+             */
+            profit_zone: string;
+            /** Rank */
+            rank: number;
+            /**
              * Risk Flags
              * @default []
              */
             risk_flags: string[];
-            /** Rank */
-            rank: number;
             /**
              * Status
              * @default candidate
              */
             status: string;
-            /**
-             * Dte Band
-             * @default
-             */
-            dte_band: string;
-            /**
-             * Expression Delta
-             * @default
-             */
-            expression_delta: string;
+            /** Structure */
+            structure: string;
+            /** Thesis */
+            thesis: string;
         };
         /** ChainFlowReadRow */
         ChainFlowReadRow: {
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
             /** Call Open Interest */
             call_open_interest?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
             /** Call Put Volume Ratio */
             call_put_volume_ratio?: string | null;
-            /**
-             * Volume Oi Note
-             * @default
-             */
-            volume_oi_note: string;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
             /**
              * Read
              * @default
@@ -1521,99 +1514,104 @@ export interface components {
              * @default false
              */
             requires_t1_oi_confirmation: boolean;
+            /** Strike */
+            strike: string;
+            /**
+             * Volume Oi Note
+             * @default
+             */
+            volume_oi_note: string;
         };
         /** ClosestLevel */
         ClosestLevel: {
-            /** Label */
-            label: string;
             /** Direction */
             direction?: ("up" | "down" | "flip") | null;
-            /** Role */
-            role?: ("support" | "resistance" | "accelerator" | "flip") | null;
-            /** Strike */
-            strike: number;
             /** Distance Pct */
             distance_pct: number;
             /** Gamma */
             gamma?: number | null;
+            /** Label */
+            label: string;
             /**
              * Rank Kind
              * @default nearest
              * @enum {string}
              */
             rank_kind: "nearest" | "dominant";
+            /** Role */
+            role?: ("support" | "resistance" | "accelerator" | "flip") | null;
+            /** Strike */
+            strike: number;
         };
         /** CockpitDealerMetrics */
         CockpitDealerMetrics: {
-            /** Pin Candidate Strike */
-            pin_candidate_strike?: string | null;
-            /** Pin Candidate Expiry */
-            pin_candidate_expiry?: string | null;
-            /** Pin Source Date */
-            pin_source_date?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
-            /** Pin Regime Flag */
-            pin_regime_flag?: boolean | null;
-            /** Dealer Net Vanna Proxy */
-            dealer_net_vanna_proxy?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
+            /** Charm Stress Override */
+            charm_stress_override?: boolean | null;
             /** Dealer Net Charm Proxy */
             dealer_net_charm_proxy?: string | null;
+            /** Dealer Net Vanna Proxy */
+            dealer_net_vanna_proxy?: string | null;
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /** Flow Call Premium 3D */
+            flow_call_premium_3d?: string | null;
             /** Flow Color Lookback 3D */
             flow_color_lookback_3d?: ("put_heavy" | "call_heavy" | "neutral") | null;
             /** Flow Put Premium 3D */
             flow_put_premium_3d?: string | null;
-            /** Flow Call Premium 3D */
-            flow_call_premium_3d?: string | null;
+            /** Gamma Regime */
+            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
             /** Iv 30D Delta 5D */
             iv_30d_delta_5d?: string | null;
             /** Net Gamma */
             net_gamma?: string | null;
             /** Net Gamma Sign */
             net_gamma_sign?: ("positive" | "negative" | "neutral") | null;
-            /** Gamma Regime */
-            gamma_regime?: ("long_gamma" | "short_gamma" | "neutral") | null;
+            /** Pin Candidate Expiry */
+            pin_candidate_expiry?: string | null;
+            /** Pin Candidate Strike */
+            pin_candidate_strike?: string | null;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Pin Regime Flag */
+            pin_regime_flag?: boolean | null;
+            /** Pin Source Date */
+            pin_source_date?: string | null;
             /** Vanna Conditional Reading */
             vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
             /** Vanna Oi Change Bias */
             vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /** Charm Stress Override */
-            charm_stress_override?: boolean | null;
         };
         /** CockpitDealerPoint */
         CockpitDealerPoint: {
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Vanna */
-            call_vanna?: string | null;
-            /** Put Vanna */
-            put_vanna?: string | null;
-            /** Call Charm */
-            call_charm?: string | null;
-            /** Put Charm */
-            put_charm?: string | null;
-            /** Exposure Call Vanna */
-            exposure_call_vanna?: string | null;
-            /** Exposure Put Vanna */
-            exposure_put_vanna?: string | null;
             /** Exposure Call Charm */
             exposure_call_charm?: string | null;
+            /** Exposure Call Vanna */
+            exposure_call_vanna?: string | null;
             /** Exposure Put Charm */
             exposure_put_charm?: string | null;
+            /** Exposure Put Vanna */
+            exposure_put_vanna?: string | null;
+            /** Put Charm */
+            put_charm?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** CockpitDealerResponse */
         CockpitDealerResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1622,99 +1620,99 @@ export interface components {
             metrics?: components["schemas"]["CockpitDealerMetrics"];
             /** Points */
             points?: components["schemas"]["CockpitDealerPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitFlowAlert */
         CockpitFlowAlert: {
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
             /** Alert Id */
             alert_id: string;
-            /** Option Chain */
-            option_chain?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Option Type */
-            option_type?: string | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Option Type */
+            option_type?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Volume */
+            volume?: number | null;
         };
         /** CockpitFlowImResponse */
         CockpitFlowImResponse: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
             /** Alerts */
             alerts?: components["schemas"]["CockpitFlowAlert"][];
             /** Implied Moves */
             implied_moves?: components["schemas"]["CockpitImPoint"][];
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitImPoint */
         CockpitImPoint: {
+            /** Days */
+            days: number;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Days */
-            days: number;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
             /** Percentile */
             percentile?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitSkewPoint */
         CockpitSkewPoint: {
+            /** Expiry */
+            expiry?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Expiry */
-            expiry?: string | null;
             /** Risk Reversal */
             risk_reversal?: string | null;
         };
         /** CockpitStateResponse */
         CockpitStateResponse: {
-            state: components["schemas"]["MatrixState"];
             freshness: components["schemas"]["MatrixSourceFreshness"];
+            state: components["schemas"]["MatrixState"];
         };
         /** CockpitSurfaceResponse */
         CockpitSurfaceResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1724,43 +1722,43 @@ export interface components {
             skew?: components["schemas"]["CockpitSkewPoint"][];
             /** Term */
             term?: components["schemas"]["CockpitTermPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CockpitTermPoint */
         CockpitTermPoint: {
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Volatility */
-            volatility?: string | null;
-            /** Implied Move Perc */
-            implied_move_perc?: string | null;
             /** Implied Move Expected Abs */
             implied_move_expected_abs?: string | null;
+            /** Implied Move Perc */
+            implied_move_perc?: string | null;
+            /** Volatility */
+            volatility?: string | null;
         };
         /** CockpitVrpPoint */
         CockpitVrpPoint: {
+            /** Iv */
+            iv?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
             /**
              * Market Date
              * Format: date
              */
             market_date: string;
-            /** Iv */
-            iv?: string | null;
             /** Rv */
             rv?: string | null;
             /** Vrp */
             vrp?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
         };
         /** CockpitVrpResponse */
         CockpitVrpResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Market Date
              * Format: date
@@ -1768,9 +1766,12 @@ export interface components {
             market_date: string;
             /** Points */
             points?: components["schemas"]["CockpitVrpPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** CrashTriggerBlock */
         CrashTriggerBlock: {
+            conditions?: components["schemas"]["CrashTriggerConditions"];
             /**
              * Fired
              * @default false
@@ -1781,66 +1782,55 @@ export interface components {
              * @default false
              */
             triggered: boolean;
-            conditions?: components["schemas"]["CrashTriggerConditions"];
             values?: components["schemas"]["CrashTriggerValues"];
         };
         /** CrashTriggerConditions */
         CrashTriggerConditions: {
             /**
-             * Spx Below 100D Ma
+             * Cor1M Gt 60
              * @default false
              */
-            spx_below_100d_ma: boolean;
+            cor1m_gt_60: boolean;
             /**
              * Realized Vol Gt 25
              * @default false
              */
             realized_vol_gt_25: boolean;
             /**
-             * Cor1M Gt 60
+             * Spx Below 100D Ma
              * @default false
              */
-            cor1m_gt_60: boolean;
+            spx_below_100d_ma: boolean;
         };
         /** CrashTriggerValues */
         CrashTriggerValues: {
-            /** Realized Vol */
-            realized_vol?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
         };
         /** CriBlock */
         CriBlock: {
-            /**
-             * Score
-             * @default 0
-             */
-            score: number;
+            components?: components["schemas"]["CriComponents"];
+            /** Composite Version */
+            composite_version?: (1 | 2 | 3) | null;
             /**
              * Level
              * @default LOW
              * @enum {string}
              */
             level: "LOW" | "ELEVATED" | "HIGH" | "CRITICAL";
-            /** Composite Version */
-            composite_version?: (1 | 2 | 3) | null;
-            components?: components["schemas"]["CriComponents"];
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
         };
         /**
          * CriComponents
          * @description Four 0-25 component scores summed into the composite 0-100.
          */
         CriComponents: {
-            /**
-             * Vix
-             * @default 0
-             */
-            vix: number;
-            /**
-             * Vvix
-             * @default 0
-             */
-            vvix: number;
             /**
              * Correlation
              * @default 0
@@ -1851,36 +1841,46 @@ export interface components {
              * @default 0
              */
             momentum: number;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
+            /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
         };
         /** CriDailyEntry */
         CriDailyEntry: {
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cri Score */
+            cri_score?: number | null;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Cri Score */
-            cri_score?: number | null;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spx */
-            spx?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
-            /** Vix3M */
-            vix3m?: number | null;
             /** Realized Vol */
             realized_vol?: number | null;
-            /** Vrp */
-            vrp?: number | null;
-            /** Vix Zscore 30D */
-            vix_zscore_30d?: number | null;
-            /** Vix Vix3M Ratio */
-            vix_vix3m_ratio?: number | null;
+            /** Spx */
+            spx?: number | null;
             /** Spx Distance Pct */
             spx_distance_pct?: number | null;
+            /** Vix */
+            vix?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vvix */
+            vvix?: number | null;
         };
         /** CriDailyHistoryResponse */
         CriDailyHistoryResponse: {
@@ -1889,65 +1889,65 @@ export interface components {
         };
         /** CriHistoryEntry */
         CriHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
             /** Cor1M */
             cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Date */
+            date: string;
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
             /** Realized Vol */
             realized_vol?: number | null;
             /** Spx Vs Ma Pct */
             spx_vs_ma_pct?: number | null;
+            /** Spy */
+            spy?: number | null;
+            /** Vix */
+            vix?: number | null;
             /** Vix 5D Roc */
             vix_5d_roc?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix 5D Roc */
             vvix_5d_roc?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Pullback 20D Pct */
-            pullback_20d_pct?: number | null;
         };
         /** CriIntradayPoint */
         CriIntradayPoint: {
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cri Score */
+            cri_score?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /** Spx */
+            spx?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
             /**
              * Ts
              * Format: date-time
              */
             ts: string;
-            /** Cri Score */
-            cri_score?: number | null;
             /** Vix */
             vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spx */
-            spx?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
             /** Vix3M */
             vix3m?: number | null;
-            /** Realized Vol */
-            realized_vol?: number | null;
-            /** Vrp */
-            vrp?: number | null;
-            /** Vix Zscore 30D */
-            vix_zscore_30d?: number | null;
             /** Vix Vix3M Ratio */
             vix_vix3m_ratio?: number | null;
-            /** Spx Distance Pct */
-            spx_distance_pct?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vvix */
+            vvix?: number | null;
         };
         /** CriIntradayResponse */
         CriIntradayResponse: {
-            /** Sessions */
-            sessions?: components["schemas"]["CriIntradaySession"][];
             /** As Of */
             as_of?: string | null;
+            /** Sessions */
+            sessions?: components["schemas"]["CriIntradaySession"][];
         };
         /** CriIntradaySession */
         CriIntradaySession: {
@@ -1967,180 +1967,180 @@ export interface components {
          *     being served instead.
          */
         CriLiveResponse: {
-            /**
-             * Status
-             * @default empty
-             * @enum {string}
-             */
-            status: "ok" | "empty";
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Date */
-            date?: string | null;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
-            /** Vix 5D Roc */
-            vix_5d_roc?: number | null;
-            /** Vvix 5D Roc */
-            vvix_5d_roc?: number | null;
-            /** Vvix Vix Ratio */
-            vvix_vix_ratio?: number | null;
-            /** Spx 100D Ma */
-            spx_100d_ma?: number | null;
-            /** Spx Distance Pct */
-            spx_distance_pct?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
-            /** Cor1M Previous Close */
-            cor1m_previous_close?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Realized Vol */
-            realized_vol?: number | null;
-            /** Vix3M */
-            vix3m?: number | null;
-            /** Vrp */
-            vrp?: number | null;
-            /** Vix Zscore 30D */
-            vix_zscore_30d?: number | null;
-            /** Vix Vix3M Ratio */
-            vix_vix3m_ratio?: number | null;
-            /** Pullback 20D Pct */
-            pullback_20d_pct?: number | null;
-            /** Vix Delta 3D */
-            vix_delta_3d?: number | null;
-            /** Spx Source */
-            spx_source?: ("SPX" | "SPY") | null;
-            cri?: components["schemas"]["CriBlock"];
-            cta?: components["schemas"]["CtaBlock"];
-            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
-            /** History */
-            history?: components["schemas"]["CriHistoryEntry"][];
-            /** Spy Closes */
-            spy_closes?: number[];
+            /** Active Source */
+            active_source?: string | null;
             /**
              * Basis
              * @default eod
              * @enum {string}
              */
             basis: "live" | "eod";
+            /** Carried Forward */
+            carried_forward?: string[];
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
             /** Live Quotes */
             live_quotes?: {
                 [key: string]: components["schemas"]["RegimeLiveQuote"];
             };
-            /** Carried Forward */
-            carried_forward?: string[];
-            /** Active Source */
-            active_source?: string | null;
-        };
-        /**
-         * CriResponse
-         * @description Crash Risk Indicator snapshot (latest scan).
-         */
-        CriResponse: {
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            /** Spx 100D Ma */
+            spx_100d_ma?: number | null;
+            /** Spx Distance Pct */
+            spx_distance_pct?: number | null;
+            /** Spx Source */
+            spx_source?: ("SPX" | "SPY") | null;
+            /** Spy */
+            spy?: number | null;
+            /** Spy Closes */
+            spy_closes?: number[];
             /**
              * Status
              * @default empty
              * @enum {string}
              */
             status: "ok" | "empty";
+            /** Vix */
+            vix?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Vix 5D Roc */
+            vix_5d_roc?: number | null;
+            /** Vix Delta 3D */
+            vix_delta_3d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Vvix 5D Roc */
+            vvix_5d_roc?: number | null;
+            /** Vvix Vix Ratio */
+            vvix_vix_ratio?: number | null;
+        };
+        /**
+         * CriResponse
+         * @description Crash Risk Indicator snapshot (latest scan).
+         */
+        CriResponse: {
+            /** Cor1M */
+            cor1m?: number | null;
+            /** Cor1M 5D Change */
+            cor1m_5d_change?: number | null;
+            /** Cor1M Previous Close */
+            cor1m_previous_close?: number | null;
+            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
+            cri?: components["schemas"]["CriBlock"];
+            cta?: components["schemas"]["CtaBlock"];
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Pullback 20D Pct */
+            pullback_20d_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
             /**
              * Scan Time
              * @default
              */
             scan_time: string;
-            /** Date */
-            date?: string | null;
-            /** Vix */
-            vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
-            /** Spy */
-            spy?: number | null;
-            /** Vix 5D Roc */
-            vix_5d_roc?: number | null;
-            /** Vvix 5D Roc */
-            vvix_5d_roc?: number | null;
-            /** Vvix Vix Ratio */
-            vvix_vix_ratio?: number | null;
             /** Spx 100D Ma */
             spx_100d_ma?: number | null;
             /** Spx Distance Pct */
             spx_distance_pct?: number | null;
-            /** Cor1M */
-            cor1m?: number | null;
-            /** Cor1M Previous Close */
-            cor1m_previous_close?: number | null;
-            /** Cor1M 5D Change */
-            cor1m_5d_change?: number | null;
-            /** Realized Vol */
-            realized_vol?: number | null;
-            /** Vix3M */
-            vix3m?: number | null;
-            /** Vrp */
-            vrp?: number | null;
-            /** Vix Zscore 30D */
-            vix_zscore_30d?: number | null;
-            /** Vix Vix3M Ratio */
-            vix_vix3m_ratio?: number | null;
-            /** Pullback 20D Pct */
-            pullback_20d_pct?: number | null;
-            /** Vix Delta 3D */
-            vix_delta_3d?: number | null;
             /** Spx Source */
             spx_source?: ("SPX" | "SPY") | null;
-            cri?: components["schemas"]["CriBlock"];
-            cta?: components["schemas"]["CtaBlock"];
-            crash_trigger?: components["schemas"]["CrashTriggerBlock"];
-            /** History */
-            history?: components["schemas"]["CriHistoryEntry"][];
+            /** Spy */
+            spy?: number | null;
             /** Spy Closes */
             spy_closes?: number[];
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
+            /** Vix */
+            vix?: number | null;
+            /** Vix3M */
+            vix3m?: number | null;
+            /** Vix 5D Roc */
+            vix_5d_roc?: number | null;
+            /** Vix Delta 3D */
+            vix_delta_3d?: number | null;
+            /** Vix Vix3M Ratio */
+            vix_vix3m_ratio?: number | null;
+            /** Vix Zscore 30D */
+            vix_zscore_30d?: number | null;
+            /** Vrp */
+            vrp?: number | null;
+            /** Vvix */
+            vvix?: number | null;
+            /** Vvix 5D Roc */
+            vvix_5d_roc?: number | null;
+            /** Vvix Vix Ratio */
+            vvix_vix_ratio?: number | null;
         };
         /**
          * CriScanResponse
          * @description Response body for POST /api/regime/scan.
          */
         CriScanResponse: {
-            /**
-             * Status
-             * @default ok
-             * @enum {string}
-             */
-            status: "ok" | "skipped";
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default cri
              * @constant
              */
             scanner: "cri";
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
         };
         /** CtaBlock */
         CtaBlock: {
-            /** Realized Vol */
-            realized_vol?: number | null;
+            /** Est Selling Bn */
+            est_selling_bn?: number | null;
             /** Exposure Pct */
             exposure_pct?: number | null;
-            /** Forced Reduction Pct */
-            forced_reduction_pct?: number | null;
             /**
              * Forced Reduction
              * @default false
              */
             forced_reduction: boolean;
-            /** Est Selling Bn */
-            est_selling_bn?: number | null;
+            /** Forced Reduction Pct */
+            forced_reduction_pct?: number | null;
+            /** Realized Vol */
+            realized_vol?: number | null;
             /** Selling Usd B */
             selling_usd_b?: number | null;
         };
@@ -2153,49 +2153,69 @@ export interface components {
          */
         DealerRegime: {
             /**
-             * Label
-             * @default neutral
-             */
-            label: string;
-            /**
-             * Score
+             * Charm Score
              * @default 0
              */
-            score: string;
+            charm_score: string;
             /**
              * Gamma Score
              * @default 0
              */
             gamma_score: string;
             /**
-             * Vanna Score
-             * @default 0
-             */
-            vanna_score: string;
-            /**
-             * Charm Score
-             * @default 0
-             */
-            charm_score: string;
-            /**
              * Headline
              * @default
              */
             headline: string;
             /**
-             * Subtitle
-             * @default
+             * Label
+             * @default neutral
              */
-            subtitle: string;
-            /** Prev Close Net Gex */
-            prev_close_net_gex?: string | null;
+            label: string;
             /** Odte Net Gex */
             odte_net_gex?: string | null;
             /** Odte Share Pct */
             odte_share_pct?: string | null;
+            /** Prev Close Net Gex */
+            prev_close_net_gex?: string | null;
+            /**
+             * Score
+             * @default 0
+             */
+            score: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /**
+             * Vanna Score
+             * @default 0
+             */
+            vanna_score: string;
         };
         /** DealerRegimeResponse */
         DealerRegimeResponse: {
+            /** Closest Levels */
+            closest_levels?: components["schemas"]["ClosestLevel"][];
+            /** Gamma Decay */
+            gamma_decay?: components["schemas"]["GammaDecayBucket"][];
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Odte Gex */
+            odte_gex?: number | null;
+            /** Odte Share Pct */
+            odte_share_pct?: number | null;
+            /** Prev Close Net Gex */
+            prev_close_net_gex?: number | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            signal?: components["schemas"]["DealerRegimeSignal"];
+            /** Spot */
+            spot?: number | null;
             /**
              * Status
              * @default empty
@@ -2207,32 +2227,27 @@ export interface components {
              * @default
              */
             ticker: string;
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Spot */
-            spot?: number | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Prev Close Net Gex */
-            prev_close_net_gex?: number | null;
-            signal?: components["schemas"]["DealerRegimeSignal"];
-            /** Closest Levels */
-            closest_levels?: components["schemas"]["ClosestLevel"][];
-            /** Odte Gex */
-            odte_gex?: number | null;
-            /** Odte Share Pct */
-            odte_share_pct?: number | null;
-            /** Gamma Decay */
-            gamma_decay?: components["schemas"]["GammaDecayBucket"][];
         };
         /**
          * DealerRegimeSignal
          * @description Per-ticker dealer regime classification (Γ-driven, with V/C support).
          */
         DealerRegimeSignal: {
+            /**
+             * Charm Score
+             * @default 0
+             */
+            charm_score: number;
+            /**
+             * Gamma Score
+             * @default 0
+             */
+            gamma_score: number;
+            /**
+             * Headline
+             * @default
+             */
+            headline: string;
             /**
              * Label
              * @default neutral
@@ -2245,30 +2260,15 @@ export interface components {
              */
             score: number;
             /**
-             * Gamma Score
-             * @default 0
+             * Subtitle
+             * @default
              */
-            gamma_score: number;
+            subtitle: string;
             /**
              * Vanna Score
              * @default 0
              */
             vanna_score: number;
-            /**
-             * Charm Score
-             * @default 0
-             */
-            charm_score: number;
-            /**
-             * Headline
-             * @default
-             */
-            headline: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
         };
         /**
          * DiscoveryCandidate
@@ -2279,8 +2279,11 @@ export interface components {
          *     (promote to the watchlist).
          */
         DiscoveryCandidate: {
-            /** Ticker */
-            ticker: string;
+            /**
+             * Alert Count
+             * @default 0
+             */
+            alert_count: number;
             /**
              * Bias
              * @enum {string}
@@ -2288,21 +2291,17 @@ export interface components {
             bias: "bullish" | "bearish" | "neutral" | "mixed";
             /** Bias Strength */
             bias_strength?: ("strong" | "moderate" | "weak") | null;
+            /**
+             * Confluence
+             * @default false
+             */
+            confluence: boolean;
             /** Direction */
             direction?: ("long" | "short") | null;
-            /** Score */
-            score: string;
-            /** Score Model */
-            score_model: string;
-            /**
-             * Score Breakdown
-             * @default {}
-             */
-            score_breakdown: {
-                [key: string]: unknown;
-            };
             /** Dp Direction */
             dp_direction?: ("ACCUMULATION" | "DISTRIBUTION" | "NEUTRAL" | "NO_DATA") | null;
+            /** Dp Status */
+            dp_status?: string | null;
             /** Dp Strength */
             dp_strength?: string | null;
             /**
@@ -2310,38 +2309,46 @@ export interface components {
              * @default 0
              */
             dp_sustained_days: number;
+            /** Latest Alert At */
+            latest_alert_at?: string | null;
+            /** Score */
+            score: string;
             /**
-             * Confluence
-             * @default false
+             * Score Breakdown
+             * @default {}
              */
-            confluence: boolean;
-            /** Vol Oi */
-            vol_oi?: string | null;
+            score_breakdown: {
+                [key: string]: unknown;
+            };
+            /** Score Model */
+            score_model: string;
+            /** Scored At */
+            scored_at?: string | null;
+            /** Sector */
+            sector?: string | null;
+            /** Spot */
+            spot?: string | null;
             /**
              * Sweeps
              * @default 0
              */
             sweeps: number;
-            /**
-             * Alert Count
-             * @default 0
-             */
-            alert_count: number;
-            /** Spot */
-            spot?: string | null;
-            /** Dp Status */
-            dp_status?: string | null;
-            /** Sector */
-            sector?: string | null;
-            /** Scored At */
-            scored_at?: string | null;
-            /** Latest Alert At */
-            latest_alert_at?: string | null;
+            /** Ticker */
+            ticker: string;
+            /** Vol Oi */
+            vol_oi?: string | null;
         };
         /** DiscoveryResponse */
         DiscoveryResponse: {
+            /** Alerts Pulled */
+            alerts_pulled: number;
             /** Candidates */
             candidates: components["schemas"]["DiscoveryCandidate"][];
+            /**
+             * Earnings Unknown Dropped
+             * @default 0
+             */
+            earnings_unknown_dropped: number;
             /**
              * Fetched At
              * Format: date-time
@@ -2355,13 +2362,6 @@ export interface components {
              * @constant
              */
             source: "scanner_candidate_snapshots";
-            /** Alerts Pulled */
-            alerts_pulled: number;
-            /**
-             * Earnings Unknown Dropped
-             * @default 0
-             */
-            earnings_unknown_dropped: number;
         };
         /** DivergencePoint */
         DivergencePoint: {
@@ -2382,143 +2382,143 @@ export interface components {
          *     persisted to uw_scan.exposures_summary.
          */
         ExposuresSummaryRow: {
+            /** Charm Above Sum */
+            charm_above_sum?: string | null;
+            /** Charm Below Sum */
+            charm_below_sum?: string | null;
+            /** Charm Flip */
+            charm_flip?: string | null;
+            /** Charm Headline */
+            charm_headline?: string | null;
+            /** Charm Imbalance Pct */
+            charm_imbalance_pct?: string | null;
+            /** Charm Pin Strike */
+            charm_pin_strike?: string | null;
+            /** Charm Signal Quality */
+            charm_signal_quality?: string | null;
+            /** Charm Subtitle */
+            charm_subtitle?: string | null;
+            /** Delta Shock 1Pt Iv */
+            delta_shock_1pt_iv?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Spot */
-            spot?: string | null;
+            /** Net Charm */
+            net_charm?: string | null;
             /** Net Vanna */
             net_vanna?: string | null;
+            /** Spot */
+            spot?: string | null;
             /** Top Vanna Strike */
             top_vanna_strike?: string | null;
             /** Top Vanna Value */
             top_vanna_value?: string | null;
-            /** Delta Shock 1Pt Iv */
-            delta_shock_1pt_iv?: string | null;
-            /** Vanna Regime */
-            vanna_regime?: string | null;
             /** Vanna Flip */
             vanna_flip?: string | null;
             /** Vanna Headline */
             vanna_headline?: string | null;
+            /** Vanna Regime */
+            vanna_regime?: string | null;
             /** Vanna Subtitle */
             vanna_subtitle?: string | null;
-            /** Net Charm */
-            net_charm?: string | null;
-            /** Charm Pin Strike */
-            charm_pin_strike?: string | null;
-            /** Charm Above Sum */
-            charm_above_sum?: string | null;
-            /** Charm Below Sum */
-            charm_below_sum?: string | null;
-            /** Charm Imbalance Pct */
-            charm_imbalance_pct?: string | null;
-            /** Charm Signal Quality */
-            charm_signal_quality?: string | null;
-            /** Charm Flip */
-            charm_flip?: string | null;
-            /** Charm Headline */
-            charm_headline?: string | null;
-            /** Charm Subtitle */
-            charm_subtitle?: string | null;
         };
         /** FlowAlert */
         FlowAlert: {
-            /** Id */
-            id: string;
-            /** Ticker */
-            ticker: string;
-            /** Option Chain */
-            option_chain?: string | null;
-            /** Type */
-            type?: string | null;
+            /** Aggressor Label Confidence */
+            aggressor_label_confidence?: string | null;
+            /** Alert Rule */
+            alert_rule?: string | null;
+            /** All Opening Trades */
+            all_opening_trades?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
             /** Expiry */
             expiry?: string | null;
-            /** Strike */
-            strike?: string | null;
-            /** Price */
-            price?: string | null;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            /** Total Size */
-            total_size?: number | null;
-            /** Total Premium */
-            total_premium?: string | null;
-            /** Total Ask Side Prem */
-            total_ask_side_prem?: string | null;
-            /** Total Bid Side Prem */
-            total_bid_side_prem?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Volume Oi Ratio */
-            volume_oi_ratio?: string | null;
-            /** Has Sweep */
-            has_sweep?: boolean | null;
+            /** Flow Footprint Label */
+            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
             /** Has Floor */
             has_floor?: boolean | null;
             /** Has Multileg */
             has_multileg?: boolean | null;
-            /** All Opening Trades */
-            all_opening_trades?: boolean | null;
-            /** Iv Start */
-            iv_start?: string | null;
+            /** Has Sweep */
+            has_sweep?: boolean | null;
+            /** Id */
+            id: string;
+            /** Issue Type */
+            issue_type?: string | null;
             /** Iv End */
             iv_end?: string | null;
-            /** Alert Rule */
-            alert_rule?: string | null;
-            /** Flow Footprint Label */
-            flow_footprint_label?: ("directional_whale" | "hedge_flow" | "dealer_hedge" | "gamma_scalper" | "unclassified") | null;
-            /** Aggressor Label Confidence */
-            aggressor_label_confidence?: string | null;
+            /** Iv Start */
+            iv_start?: string | null;
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Option Chain */
+            option_chain?: string | null;
+            /** Price */
+            price?: string | null;
             /** Rule Id */
             rule_id?: string | null;
             /** Sector */
             sector?: string | null;
-            /** Issue Type */
-            issue_type?: string | null;
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            /** Created At */
-            created_at?: string | null;
+            /** Strike */
+            strike?: string | null;
+            /** Ticker */
+            ticker: string;
+            /** Total Ask Side Prem */
+            total_ask_side_prem?: string | null;
+            /** Total Bid Side Prem */
+            total_bid_side_prem?: string | null;
+            /** Total Premium */
+            total_premium?: string | null;
+            /** Total Size */
+            total_size?: number | null;
+            /** Type */
+            type?: string | null;
+            /** Underlying Price */
+            underlying_price?: string | null;
+            /** Volume */
+            volume?: number | null;
+            /** Volume Oi Ratio */
+            volume_oi_ratio?: string | null;
         };
         /** FlowSnapshot */
         FlowSnapshot: {
-            /** Ticker */
-            ticker: string;
+            /** Ask Side Premium */
+            ask_side_premium: string;
+            /** Bear Premium */
+            bear_premium: string;
+            /** Bid Side Premium */
+            bid_side_premium: string;
+            /** Bull Premium */
+            bull_premium: string;
             /** Flow Count */
             flow_count: number;
-            /**
-             * Flow Count Is Limited
-             * @default false
-             */
-            flow_count_is_limited: boolean;
             /** Flow Count 30D Avg */
             flow_count_30d_avg?: string | null;
-            /** Flow Count Vs 30D Avg */
-            flow_count_vs_30d_avg?: string | null;
             /**
              * Flow Count 30D Days
              * @default 0
              */
             flow_count_30d_days: number;
-            /** Top Alert Rule */
-            top_alert_rule?: string | null;
+            /**
+             * Flow Count Is Limited
+             * @default false
+             */
+            flow_count_is_limited: boolean;
+            /** Flow Count Vs 30D Avg */
+            flow_count_vs_30d_avg?: string | null;
             /** Net Premium */
             net_premium: string;
-            /** Bull Premium */
-            bull_premium: string;
-            /** Bear Premium */
-            bear_premium: string;
-            /** Ask Side Premium */
-            ask_side_premium: string;
-            /** Bid Side Premium */
-            bid_side_premium: string;
+            /** Ticker */
+            ticker: string;
+            /** Top Alert Rule */
+            top_alert_rule?: string | null;
             /**
              * Top Alerts
              * @default []
@@ -2527,18 +2527,18 @@ export interface components {
         };
         /** GammaBlock */
         GammaBlock: {
+            /** Expiring Date */
+            expiring_date?: string | null;
+            /** Expiring Pct */
+            expiring_pct?: string | null;
             /** Flip Distance */
             flip_distance?: string | null;
             /** Flip Price */
             flip_price?: string | null;
-            /** Per 1Pct Move */
-            per_1pct_move?: string | null;
             /** Max Strike */
             max_strike?: string | null;
-            /** Expiring Pct */
-            expiring_pct?: string | null;
-            /** Expiring Date */
-            expiring_date?: string | null;
+            /** Per 1Pct Move */
+            per_1pct_move?: string | null;
         };
         /** GammaDecayBucket */
         GammaDecayBucket: {
@@ -2546,49 +2546,49 @@ export interface components {
             dte: number;
             /** Expiry */
             expiry: string;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Share Pct */
-            share_pct?: number | null;
             /** Gross Abs Gex */
             gross_abs_gex?: number | null;
             /** Gross Share Pct */
             gross_share_pct?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Share Pct */
+            share_pct?: number | null;
         };
         /** GexBias */
         GexBias: {
-            /** Direction */
-            direction?: string | null;
-            /** Reasons */
-            reasons?: string[];
             /** Days Above Flip */
             days_above_flip?: number | null;
+            /** Direction */
+            direction?: string | null;
             /** Flip Migration */
             flip_migration?: components["schemas"]["GexFlipMigrationEntry"][];
+            /** Reasons */
+            reasons?: string[];
         };
         /** GexBucket */
         GexBucket: {
-            /** Strike */
-            strike?: number | null;
             /** Call Gex */
             call_gex?: number | null;
-            /** Put Gex */
-            put_gex?: number | null;
             /** Net Gex */
             net_gex?: number | null;
             /** Pct From Spot */
             pct_from_spot?: number | null;
+            /** Put Gex */
+            put_gex?: number | null;
+            /** Strike */
+            strike?: number | null;
             /** Tag */
             tag?: string | null;
         };
         /** GexExpectedRange */
         GexExpectedRange: {
-            /** Low */
-            low?: number | null;
             /** High */
             high?: number | null;
             /** Iv 1D */
             iv_1d?: number | null;
+            /** Low */
+            low?: number | null;
         };
         /** GexFlipMigrationEntry */
         GexFlipMigrationEntry: {
@@ -2599,41 +2599,41 @@ export interface components {
         };
         /** GexHistoryEntry */
         GexHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Gex Flip */
-            gex_flip?: number | null;
-            /** Spot */
-            spot?: number | null;
             /** Atm Iv */
             atm_iv?: number | null;
-            /** Vol Pc */
-            vol_pc?: number | null;
             /** Bias */
             bias?: string | null;
+            /** Date */
+            date: string;
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Spot */
+            spot?: number | null;
+            /** Vol Pc */
+            vol_pc?: number | null;
         };
         /**
          * GexIntradayPoint
          * @description One row from gex_snapshots inside a single ET trading session.
          */
         GexIntradayPoint: {
+            /** Gex Flip */
+            gex_flip?: number | null;
+            /** Iv30D */
+            iv30d?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Spot */
+            spot?: number | null;
             /**
              * Ts
              * Format: date-time
              */
             ts: string;
-            /** Spot */
-            spot?: number | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Gex Flip */
-            gex_flip?: number | null;
-            /** Iv30D */
-            iv30d?: number | null;
         };
         /**
          * GexIntradayResponse
@@ -2643,12 +2643,12 @@ export interface components {
          *     Points within each session are also ASC by ``ts``.
          */
         GexIntradayResponse: {
-            /** Ticker */
-            ticker: string;
-            /** Sessions */
-            sessions?: components["schemas"]["GexIntradaySession"][];
             /** As Of */
             as_of?: string | null;
+            /** Sessions */
+            sessions?: components["schemas"]["GexIntradaySession"][];
+            /** Ticker */
+            ticker: string;
         };
         /** GexIntradaySession */
         GexIntradaySession: {
@@ -2662,12 +2662,12 @@ export interface components {
         };
         /** GexIvData */
         GexIvData: {
+            /** Hv30 */
+            hv30?: number | null;
             /** Iv30D */
             iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: number | null;
-            /** Hv30 */
-            hv30?: number | null;
             /** Mq Iv30D */
             mq_iv30d?: number | null;
             /** Mq Iv Rank */
@@ -2677,130 +2677,130 @@ export interface components {
         };
         /** GexLevels */
         GexLevels: {
-            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_accelerator?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__api__schemas__GexLevel"] | null;
         };
         /** GexMqLevels */
         GexMqLevels: {
-            /** Source Date */
-            source_date?: string | null;
-            /** Spot */
-            spot?: number | null;
-            /** Hvl */
-            hvl?: number | null;
-            /** Call Resistance All */
-            call_resistance_all?: number | null;
             /** Call Resistance 0Dte */
             call_resistance_0dte?: number | null;
-            /** Put Support All */
-            put_support_all?: number | null;
-            /** Put Support 0Dte */
-            put_support_0dte?: number | null;
+            /** Call Resistance All */
+            call_resistance_all?: number | null;
+            /** Distance To Hvl Pct */
+            distance_to_hvl_pct?: string | null;
             /** Expected High */
             expected_high?: number | null;
             /** Expected Low */
             expected_low?: number | null;
-            /** Distance To Hvl Pct */
-            distance_to_hvl_pct?: string | null;
-            /** Iv30D */
-            iv30d?: number | null;
             /** Hv30 */
             hv30?: number | null;
+            /** Hvl */
+            hvl?: number | null;
+            /** Iv30D */
+            iv30d?: number | null;
             /** Iv Rank */
             iv_rank?: string | null;
+            /** Put Support 0Dte */
+            put_support_0dte?: number | null;
+            /** Put Support All */
+            put_support_all?: number | null;
+            /** Source Date */
+            source_date?: string | null;
+            /** Spot */
+            spot?: number | null;
             /** Top Gex Strikes */
             top_gex_strikes?: number[];
         };
         /** GexResponse */
         GexResponse: {
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
+            /** Atm Iv */
+            atm_iv?: number | null;
+            bias?: components["schemas"]["GexBias"];
+            /** Close */
+            close?: number | null;
+            /** Data Date */
+            data_date?: string | null;
+            /** Day Change */
+            day_change?: number | null;
+            /** Day Change Pct */
+            day_change_pct?: number | null;
+            expected_range?: components["schemas"]["GexExpectedRange"];
+            /** History */
+            history?: components["schemas"]["GexHistoryEntry"][];
+            iv?: components["schemas"]["GexIvData"] | null;
+            levels?: components["schemas"]["GexLevels"];
             /**
              * Market Open
              * @default false
              */
             market_open: boolean;
+            /** Market Time */
+            market_time?: string | null;
+            mq?: components["schemas"]["GexMqLevels"] | null;
+            /** Net Dex */
+            net_dex?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Prev Close */
+            prev_close?: number | null;
+            /** Profile */
+            profile?: components["schemas"]["GexBucket"][];
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            source_delta?: components["schemas"]["GexSourceDelta"] | null;
+            /** Spot */
+            spot?: number | null;
+            /** Spot Source */
+            spot_source?: string | null;
+            /** Tape Time */
+            tape_time?: string | null;
             /**
              * Ticker
              * @default SPX
              */
             ticker: string;
-            /** Spot */
-            spot?: number | null;
-            /** Close */
-            close?: number | null;
-            /** Prev Close */
-            prev_close?: number | null;
-            /** Market Time */
-            market_time?: string | null;
-            /** Tape Time */
-            tape_time?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /** Day Change */
-            day_change?: number | null;
-            /** Day Change Pct */
-            day_change_pct?: number | null;
-            /** Data Date */
-            data_date?: string | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Net Dex */
-            net_dex?: number | null;
-            /** Atm Iv */
-            atm_iv?: number | null;
             /** Vol Pc */
             vol_pc?: number | null;
-            levels?: components["schemas"]["GexLevels"];
-            /** Profile */
-            profile?: components["schemas"]["GexBucket"][];
-            expected_range?: components["schemas"]["GexExpectedRange"];
-            bias?: components["schemas"]["GexBias"];
-            /** History */
-            history?: components["schemas"]["GexHistoryEntry"][];
-            iv?: components["schemas"]["GexIvData"] | null;
-            mq?: components["schemas"]["GexMqLevels"] | null;
-            source_delta?: components["schemas"]["GexSourceDelta"] | null;
         };
         /** GexSourceDelta */
         GexSourceDelta: {
-            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
-            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
             call_wall_vs_resistance_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            call_wall_vs_resistance_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            flip_vs_hvl?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_0dte?: components["schemas"]["GexSourceDeltaEntry"] | null;
+            put_wall_vs_support_all?: components["schemas"]["GexSourceDeltaEntry"] | null;
         };
         /** GexSourceDeltaEntry */
         GexSourceDeltaEntry: {
-            /** Uw */
-            uw?: number | null;
-            /** Mq */
-            mq?: number | null;
             /** Delta */
             delta?: number | null;
+            /** Mq */
+            mq?: number | null;
+            /** Uw */
+            uw?: number | null;
         };
         /** GoldCbCountryHistory */
         GoldCbCountryHistory: {
+            /** Bucket */
+            bucket: string;
             /** Country Iso3 */
             country_iso3: string;
             /** Country Name */
             country_name: string;
-            /** Bucket */
-            bucket: string;
-            /** Latest Reserves T */
-            latest_reserves_t?: string | null;
             /**
              * History
              * @default []
              */
             history: components["schemas"]["GoldHistoryPoint"][];
+            /** Latest Reserves T */
+            latest_reserves_t?: string | null;
         };
         /** GoldCorrelationBand */
         GoldCorrelationBand: {
@@ -2843,19 +2843,8 @@ export interface components {
         };
         /** GoldCyclicalPostureModel */
         GoldCyclicalPostureModel: {
-            /** Zone Label */
-            zone_label?: string | null;
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
             /** Cpi Yoy */
             cpi_yoy?: string | null;
-            /** T5Yifr */
-            t5yifr?: string | null;
-            /** T5Yifr Pct 52W */
-            t5yifr_pct_52w?: string | null;
             /** Dfii10 */
             dfii10?: string | null;
             /** Dfii10 60D Change Bps */
@@ -2864,10 +2853,6 @@ export interface components {
             dxy?: string | null;
             /** Dxy 60D Sigma */
             dxy_60d_sigma?: string | null;
-            /** Gpr Value */
-            gpr_value?: string | null;
-            /** Gpr Pct 52W */
-            gpr_pct_52w?: string | null;
             /**
              * Factors
              * @default {}
@@ -2875,9 +2860,24 @@ export interface components {
             factors: {
                 [key: string]: number;
             };
-            two_force_text: components["schemas"]["GoldTwoForceText"];
+            /** Gpr Pct 52W */
+            gpr_pct_52w?: string | null;
+            /** Gpr Value */
+            gpr_value?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** T5Yifr */
+            t5yifr?: string | null;
+            /** T5Yifr Pct 52W */
+            t5yifr_pct_52w?: string | null;
+            two_force_text: components["schemas"]["GoldTwoForceText"];
+            /** Zone Label */
+            zone_label?: string | null;
         };
         /**
          * GoldDataFreshnessSource
@@ -2902,15 +2902,15 @@ export interface components {
          * @description One row of the Tier 5 lens-decomposition bars.
          */
         GoldDecompositionRow: {
+            /** Contribution */
+            contribution: string;
+            /** Factor */
+            factor: string;
             /**
              * Lens
              * @enum {string}
              */
             lens: "L1" | "L2" | "L3";
-            /** Factor */
-            factor: string;
-            /** Contribution */
-            contribution: string;
         };
         /** GoldGaugeResponse */
         GoldGaugeResponse: {
@@ -2920,16 +2920,16 @@ export interface components {
         };
         /** GoldGaugeState */
         GoldGaugeState: {
-            /** Corr 60D */
-            corr_60d?: string | null;
             /** Corr 126D */
             corr_126d?: string | null;
             /** Corr 252D */
             corr_252d?: string | null;
-            /** Corr 504D */
-            corr_504d?: string | null;
             /** Corr 252D Returns */
             corr_252d_returns?: string | null;
+            /** Corr 504D */
+            corr_504d?: string | null;
+            /** Corr 60D */
+            corr_60d?: string | null;
             /**
              * State
              * @enum {string}
@@ -2938,13 +2938,13 @@ export interface components {
         };
         /** GoldGaugeTimeSeriesPoint */
         GoldGaugeTimeSeriesPoint: {
+            /** Corr 252D */
+            corr_252d: string | null;
             /**
              * Obs Date
              * Format: date
              */
             obs_date: string;
-            /** Corr 252D */
-            corr_252d: string | null;
         };
         /** GoldHistoryPoint */
         GoldHistoryPoint: {
@@ -2959,45 +2959,49 @@ export interface components {
         /** GoldInputProvenance */
         GoldInputProvenance: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /**
              * As Of
              * Format: date-time
              */
             as_of: string;
+            /**
+             * Obs Date
+             * Format: date
+             */
+            obs_date: string;
         };
         /** GoldInputSeriesPoint */
         GoldInputSeriesPoint: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /** Value */
-            value: string;
-            /**
              * As Of
              * Format: date-time
              */
             as_of: string;
+            /**
+             * Obs Date
+             * Format: date
+             */
+            obs_date: string;
             /** Release Date */
             release_date?: string | null;
+            /** Value */
+            value: string;
         };
         /** GoldInputSeriesResponse */
         GoldInputSeriesResponse: {
-            /** Series Id */
-            series_id: string;
             /** Points */
             points: components["schemas"]["GoldInputSeriesPoint"][];
+            /** Series Id */
+            series_id: string;
         };
         /**
          * GoldLensResponse
          * @description Detail payload for one lens (richer than the summary in GoldStateResponse).
          */
         GoldLensResponse: {
+            /** Detail */
+            detail: {
+                [key: string]: components["schemas"]["GoldInputSeriesPoint"][];
+            };
             /**
              * Lens Id
              * @enum {string}
@@ -3005,24 +3009,20 @@ export interface components {
             lens_id: "structural" | "cyclical" | "valuation";
             /** Posture */
             posture: components["schemas"]["GoldStructuralPostureModel"] | components["schemas"]["GoldCyclicalPostureModel"] | components["schemas"]["GoldValuationPostureModel"];
-            /** Detail */
-            detail: {
-                [key: string]: components["schemas"]["GoldInputSeriesPoint"][];
-            };
         };
         /**
          * GoldSpotTile
          * @description XAU/USD snapshot used by the Tier 1 KPI strip.
          */
         GoldSpotTile: {
-            /** Last */
-            last: string;
             /** Delta Abs */
             delta_abs: string;
             /** Delta Pct */
             delta_pct: string;
             /** High */
             high: string;
+            /** Last */
+            last: string;
             /** Low */
             low: string;
             /** Open */
@@ -3031,24 +3031,19 @@ export interface components {
         /** GoldStateResponse */
         GoldStateResponse: {
             /**
-             * Obs Date
-             * Format: date
-             */
-            obs_date: string;
-            /**
              * Computed At
              * Format: date-time
              */
             computed_at: string;
-            gauge: components["schemas"]["GoldGaugeState"];
-            spot: components["schemas"]["GoldSpotTile"];
-            structural: components["schemas"]["GoldStructuralPostureModel"];
+            /**
+             * @default {
+             *       "gold_dfii10": [],
+             *       "gold_dxy": [],
+             *       "gold_gpr": []
+             *     }
+             */
+            correlation_history: components["schemas"]["GoldCorrelationHistory"];
             cyclical: components["schemas"]["GoldCyclicalPostureModel"];
-            valuation: components["schemas"]["GoldValuationPostureModel"];
-            /** Inputs Used */
-            inputs_used: {
-                [key: string]: components["schemas"]["GoldInputProvenance"];
-            };
             /**
              * Data Freshness
              * @default []
@@ -3059,69 +3054,74 @@ export interface components {
              * @default []
              */
             decomposition_rows: components["schemas"]["GoldDecompositionRow"][];
+            gauge: components["schemas"]["GoldGaugeState"];
+            /** Inputs Used */
+            inputs_used: {
+                [key: string]: components["schemas"]["GoldInputProvenance"];
+            };
             /**
-             * @default {
-             *       "gold_dfii10": [],
-             *       "gold_dxy": [],
-             *       "gold_gpr": []
-             *     }
+             * Obs Date
+             * Format: date
              */
-            correlation_history: components["schemas"]["GoldCorrelationHistory"];
+            obs_date: string;
+            spot: components["schemas"]["GoldSpotTile"];
+            structural: components["schemas"]["GoldStructuralPostureModel"];
+            valuation: components["schemas"]["GoldValuationPostureModel"];
         };
         /** GoldStructuralPostureModel */
         GoldStructuralPostureModel: {
-            /** State Label */
-            state_label?: string | null;
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
-            /** Cb Strategic 12M Sum T */
-            cb_strategic_12m_sum_t?: string | null;
-            /** Cb Tactical 12M Sum T */
-            cb_tactical_12m_sum_t?: string | null;
-            /** Cb Diversifier 12M Sum T */
-            cb_diversifier_12m_sum_t?: string | null;
             /** Cb 52W Pct */
             cb_52w_pct?: string | null;
-            /** Gld Holdings T */
-            gld_holdings_t?: string | null;
-            /** Gld 30D Net Flow T */
-            gld_30d_net_flow_t?: string | null;
-            /** Comex Registered Oz */
-            comex_registered_oz?: string | null;
-            /** Comex 20D Roc Pct */
-            comex_20d_roc_pct?: string | null;
-            /** Lbma 30D Momentum T */
-            lbma_30d_momentum_t?: string | null;
-            /** Cot Mm Net Pct */
-            cot_mm_net_pct?: string | null;
-            /** Cot Mm 4W Change Sigma */
-            cot_mm_4w_change_sigma?: string | null;
-            /** Uw 25D Skew Sigma */
-            uw_25d_skew_sigma?: string | null;
-            /** Fx Basket Dxy Z */
-            fx_basket_dxy_z?: string | null;
-            /** Xau Cny Premium Pct */
-            xau_cny_premium_pct?: string | null;
-            /**
-             * Gld History
-             * @default []
-             */
-            gld_history: components["schemas"]["GoldHistoryPoint"][];
-            /**
-             * Gold History
-             * @default []
-             */
-            gold_history: components["schemas"]["GoldHistoryPoint"][];
             /**
              * Cb Country History
              * @default []
              */
             cb_country_history: components["schemas"]["GoldCbCountryHistory"][];
+            /** Cb Diversifier 12M Sum T */
+            cb_diversifier_12m_sum_t?: string | null;
+            /** Cb Strategic 12M Sum T */
+            cb_strategic_12m_sum_t?: string | null;
+            /** Cb Tactical 12M Sum T */
+            cb_tactical_12m_sum_t?: string | null;
+            /** Comex 20D Roc Pct */
+            comex_20d_roc_pct?: string | null;
+            /** Comex Registered Oz */
+            comex_registered_oz?: string | null;
+            /** Cot Mm 4W Change Sigma */
+            cot_mm_4w_change_sigma?: string | null;
+            /** Cot Mm Net Pct */
+            cot_mm_net_pct?: string | null;
+            /** Fx Basket Dxy Z */
+            fx_basket_dxy_z?: string | null;
+            /** Gld 30D Net Flow T */
+            gld_30d_net_flow_t?: string | null;
+            /**
+             * Gld History
+             * @default []
+             */
+            gld_history: components["schemas"]["GoldHistoryPoint"][];
+            /** Gld Holdings T */
+            gld_holdings_t?: string | null;
+            /**
+             * Gold History
+             * @default []
+             */
+            gold_history: components["schemas"]["GoldHistoryPoint"][];
+            /** Lbma 30D Momentum T */
+            lbma_30d_momentum_t?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** State Label */
+            state_label?: string | null;
+            /** Uw 25D Skew Sigma */
+            uw_25d_skew_sigma?: string | null;
+            /** Xau Cny Premium Pct */
+            xau_cny_premium_pct?: string | null;
         };
         /** GoldTwoForceText */
         GoldTwoForceText: {
@@ -3137,13 +3137,6 @@ export interface components {
              * @enum {string}
              */
             flag: "Low" | "Moderate" | "High" | "Severe";
-            /**
-             * Posture Chip
-             * @enum {string}
-             */
-            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
-            /** Real Price Percentile */
-            real_price_percentile?: string | null;
             /** Gold M2 Ratio Percentile */
             gold_m2_ratio_percentile?: string | null;
             /** Gold Oil Ratio Percentile */
@@ -3152,35 +3145,42 @@ export interface components {
             gold_spx_ratio_percentile?: string | null;
             /** Narrative Text */
             narrative_text: string;
+            /**
+             * Posture Chip
+             * @enum {string}
+             */
+            posture_chip: "FAVORABLE" | "NEUTRAL" | "STRETCHED" | "SUSPENDED" | "DEGRADED";
+            /** Real Price Percentile */
+            real_price_percentile?: string | null;
         };
         /** GrgAsset */
         GrgAsset: {
-            /** Ticker */
-            ticker: string;
-            /** Spot */
-            spot?: number | null;
             /** Data Date */
             data_date?: string | null;
-            /** Net Gamma */
-            net_gamma?: number | null;
-            /** Net Gex */
-            net_gex?: number | null;
-            /** Gamma Z */
-            gamma_z?: number | null;
+            /** Flip */
+            flip?: number | null;
             /** Gamma 1D Change */
             gamma_1d_change?: number | null;
             /** Gamma 3D Change */
             gamma_3d_change?: number | null;
+            /** Gamma Z */
+            gamma_z?: number | null;
+            /** Net Gamma */
+            net_gamma?: number | null;
+            /** Net Gex */
+            net_gex?: number | null;
+            /** Spot */
+            spot?: number | null;
+            /** Spot Vs Flip Pct */
+            spot_vs_flip_pct?: number | null;
             /**
              * State
              * @default NEUTRAL
              * @enum {string}
              */
             state: "CUSHION" | "WHIP" | "NEUTRAL";
-            /** Flip */
-            flip?: number | null;
-            /** Spot Vs Flip Pct */
-            spot_vs_flip_pct?: number | null;
+            /** Ticker */
+            ticker: string;
         };
         /** GrgAssets */
         GrgAssets: {
@@ -3203,37 +3203,37 @@ export interface components {
         GrgEvent: {
             /** Date */
             date: string;
+            /** Extreme Gap Pct */
+            extreme_gap_pct?: number | null;
+            /** Fwd 20D Pct */
+            fwd_20d_pct?: number | null;
             /** Grg Z */
             grg_z?: number | null;
+            /** Lead Sessions */
+            lead_sessions?: number | null;
             /**
              * Pair State
              * @default NEUTRAL
              */
             pair_state: string;
-            /** Tier */
-            tier?: number | null;
             /** Spy Net Gamma */
             spy_net_gamma?: number | null;
+            /** Tier */
+            tier?: number | null;
             /** Tlt Net Gamma */
             tlt_net_gamma?: number | null;
-            /** Fwd 20D Pct */
-            fwd_20d_pct?: number | null;
-            /** Lead Sessions */
-            lead_sessions?: number | null;
-            /** Extreme Gap Pct */
-            extreme_gap_pct?: number | null;
         };
         /** GrgEventSideStats */
         GrgEventSideStats: {
+            /** Median Extreme Gap Pct */
+            median_extreme_gap_pct?: number | null;
+            /** Median Lead Sessions */
+            median_lead_sessions?: number | null;
             /**
              * N
              * @default 0
              */
             n: number;
-            /** Median Lead Sessions */
-            median_lead_sessions?: number | null;
-            /** Median Extreme Gap Pct */
-            median_extreme_gap_pct?: number | null;
         };
         /**
          * GrgEventStats
@@ -3245,24 +3245,29 @@ export interface components {
          *     LEAD — GRG watch events are not coincident turn markers.
          */
         GrgEventStats: {
+            bottoms?: components["schemas"]["GrgEventSideStats"];
             /**
              * Fwd Window
              * @default 0
              */
             fwd_window: number;
             tops?: components["schemas"]["GrgEventSideStats"];
-            bottoms?: components["schemas"]["GrgEventSideStats"];
         };
         /** GrgEvents */
         GrgEvents: {
-            /** Tops */
-            tops?: components["schemas"]["GrgEvent"][];
             /** Bottoms */
             bottoms?: components["schemas"]["GrgEvent"][];
             stats?: components["schemas"]["GrgEventStats"];
+            /** Tops */
+            tops?: components["schemas"]["GrgEvent"][];
         };
         /** GrgGate */
         GrgGate: {
+            /**
+             * Copy
+             * @default
+             */
+            copy: string;
             /** Id */
             id: string;
             /** Label */
@@ -3273,32 +3278,27 @@ export interface components {
              * @enum {string}
              */
             status: "PASS" | "WATCH" | "FAIL";
-            /**
-             * Copy
-             * @default
-             */
-            copy: string;
         };
         /** GrgHistoryEntry */
         GrgHistoryEntry: {
             /** Date */
             date: string;
-            /** Spy Price */
-            spy_price?: number | null;
-            /** Spy Net Gamma */
-            spy_net_gamma?: number | null;
-            /** Tlt Net Gamma */
-            tlt_net_gamma?: number | null;
-            /** Spy Gamma Z */
-            spy_gamma_z?: number | null;
-            /** Tlt Gamma Z */
-            tlt_gamma_z?: number | null;
             /** Grg Z */
             grg_z?: number | null;
             /** Raw Spread */
             raw_spread?: number | null;
+            /** Spy Gamma Z */
+            spy_gamma_z?: number | null;
+            /** Spy Net Gamma */
+            spy_net_gamma?: number | null;
+            /** Spy Price */
+            spy_price?: number | null;
             /** State */
             state?: string | null;
+            /** Tlt Gamma Z */
+            tlt_gamma_z?: number | null;
+            /** Tlt Net Gamma */
+            tlt_net_gamma?: number | null;
         };
         /**
          * GrgResponse
@@ -3306,78 +3306,102 @@ export interface components {
          *     YTD history (z-scored over the full ≈1Y fetched series).
          */
         GrgResponse: {
-            /**
-             * Status
-             * @default empty
-             * @enum {string}
-             */
-            status: "ok" | "empty";
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /**
-             * Market Open
-             * @default false
-             */
-            market_open: boolean;
-            /** Data Date */
-            data_date?: string | null;
-            /**
-             * Source
-             * @default Unusual Whales
-             */
-            source: string;
-            /**
-             * Lookback Days
-             * @default 0
-             */
-            lookback_days: number;
-            /**
-             * Z Window
-             * @default 63
-             */
-            z_window: number;
+            assets?: components["schemas"]["GrgAssets"] | null;
             /**
              * Basis
              * @default eod
              * @enum {string}
              */
             basis: "live" | "eod";
-            signal?: components["schemas"]["GrgSignal"];
-            assets?: components["schemas"]["GrgAssets"] | null;
+            /** Data Date */
+            data_date?: string | null;
+            events?: components["schemas"]["GrgEvents"];
             /** Gates */
             gates?: components["schemas"]["GrgGate"][];
             /** History */
             history?: components["schemas"]["GrgHistoryEntry"][];
-            events?: components["schemas"]["GrgEvents"];
+            /**
+             * Lookback Days
+             * @default 0
+             */
+            lookback_days: number;
+            /**
+             * Market Open
+             * @default false
+             */
+            market_open: boolean;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            signal?: components["schemas"]["GrgSignal"];
+            /**
+             * Source
+             * @default Unusual Whales
+             */
+            source: string;
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
             top_bottom?: components["schemas"]["GrgTopBottom"];
+            /**
+             * Z Window
+             * @default 63
+             */
+            z_window: number;
         };
         /**
          * GrgScanResponse
          * @description Response body for POST /api/regime/grg/scan.
          */
         GrgScanResponse: {
-            /**
-             * Status
-             * @default ok
-             * @enum {string}
-             */
-            status: "ok" | "skipped";
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default grg
              * @constant
              */
             scanner: "grg";
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Status
+             * @default ok
+             * @enum {string}
+             */
+            status: "ok" | "skipped";
         };
         /** GrgSignal */
         GrgSignal: {
+            /**
+             * Bottom Score
+             * @default 0
+             */
+            bottom_score: number;
+            /**
+             * Bottom Watch
+             * @default false
+             */
+            bottom_watch: boolean;
+            /** Grg Z */
+            grg_z?: number | null;
+            /**
+             * Interpretation
+             * @default NORMAL
+             * @enum {string}
+             */
+            interpretation: "TOP_WATCH" | "BOTTOM_WATCH" | "RISK_ON" | "RISK_OFF" | "DUAL_WHIP" | "CUSHION" | "NORMAL";
+            /** Raw Spread */
+            raw_spread?: number | null;
+            /** Spy 3D Gamma Change */
+            spy_3d_gamma_change?: number | null;
+            /** Spy Gamma Z */
+            spy_gamma_z?: number | null;
             /**
              * State
              * @default NEUTRAL
@@ -3390,55 +3414,31 @@ export interface components {
              */
             state_label: string;
             /**
-             * Interpretation
-             * @default NORMAL
-             * @enum {string}
+             * Summary
+             * @default
              */
-            interpretation: "TOP_WATCH" | "BOTTOM_WATCH" | "RISK_ON" | "RISK_OFF" | "DUAL_WHIP" | "CUSHION" | "NORMAL";
+            summary: string;
             /** Tier */
             tier?: number | null;
-            /**
-             * Top Watch
-             * @default false
-             */
-            top_watch: boolean;
-            /**
-             * Bottom Watch
-             * @default false
-             */
-            bottom_watch: boolean;
+            /** Tlt 3D Gamma Change */
+            tlt_3d_gamma_change?: number | null;
+            /** Tlt Gamma Z */
+            tlt_gamma_z?: number | null;
             /**
              * Top Score
              * @default 0
              */
             top_score: number;
             /**
-             * Bottom Score
-             * @default 0
+             * Top Watch
+             * @default false
              */
-            bottom_score: number;
-            /** Grg Z */
-            grg_z?: number | null;
-            /** Raw Spread */
-            raw_spread?: number | null;
-            /** Spy Gamma Z */
-            spy_gamma_z?: number | null;
-            /** Tlt Gamma Z */
-            tlt_gamma_z?: number | null;
-            /** Spy 3D Gamma Change */
-            spy_3d_gamma_change?: number | null;
-            /** Tlt 3D Gamma Change */
-            tlt_3d_gamma_change?: number | null;
-            /**
-             * Summary
-             * @default
-             */
-            summary: string;
+            top_watch: boolean;
         };
         /** GrgTopBottom */
         GrgTopBottom: {
-            top?: components["schemas"]["GrgTopBottomSide"];
             bottom?: components["schemas"]["GrgTopBottomSide"];
+            top?: components["schemas"]["GrgTopBottomSide"];
         };
         /** GrgTopBottomSide */
         GrgTopBottomSide: {
@@ -3455,17 +3455,17 @@ export interface components {
         };
         /** GuidanceResponse */
         GuidanceResponse: {
-            /** State */
-            state: string;
+            /** Body Md */
+            body_md: string;
+            /** Matched Condition */
+            matched_condition: string;
             /**
              * Posture
              * @enum {string}
              */
             posture: "opportunistic" | "neutral" | "cautious" | "defensive";
-            /** Body Md */
-            body_md: string;
-            /** Matched Condition */
-            matched_condition: string;
+            /** State */
+            state: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -3474,72 +3474,72 @@ export interface components {
         };
         /** HealthResponse */
         HealthResponse: {
-            /** Ok */
-            ok: boolean;
+            /** Avg Scan Duration Seconds */
+            avg_scan_duration_seconds?: number | null;
+            /** Cache Hit Pct */
+            cache_hit_pct?: number | null;
             /** Db */
             db: string;
-            /** Scheduler Lag Seconds */
-            scheduler_lag_seconds?: number | null;
+            /** Http 2Xx */
+            http_2xx?: number | null;
+            /** Http 429 */
+            http_429?: number | null;
+            /** Http 4Xx */
+            http_4xx?: number | null;
+            /** Http 5Xx */
+            http_5xx?: number | null;
             /** Last Full Scan At */
             last_full_scan_at?: string | null;
-            /** Reason */
-            reason?: string | null;
-            /** Worker Lag Seconds */
-            worker_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Lag Seconds */
-            scheduler_heartbeat_lag_seconds?: number | null;
-            /** Scheduler Heartbeat Name */
-            scheduler_heartbeat_name?: string | null;
-            /** Rescan Heartbeat Lag Seconds */
-            rescan_heartbeat_lag_seconds?: number | null;
-            /** Spot Refresh Heartbeat Lag Seconds */
-            spot_refresh_heartbeat_lag_seconds?: number | null;
-            /** Spot Quote Lag Seconds */
-            spot_quote_lag_seconds?: number | null;
+            /** Latency P95 Ms */
+            latency_p95_ms?: number | null;
             /** Latest Spot Quote At */
             latest_spot_quote_at?: string | null;
             /** Latest Spot Quote Fetched At */
             latest_spot_quote_fetched_at?: string | null;
-            /** Watchlist Size */
-            watchlist_size?: number | null;
+            /** Ok */
+            ok: boolean;
+            /** Queue Drain Rate Per Minute */
+            queue_drain_rate_per_minute?: number | null;
+            /** Reason */
+            reason?: string | null;
+            /** Record Health */
+            record_health?: components["schemas"]["RecordHealthCheck"][];
+            /** Record Health Ok */
+            record_health_ok?: boolean | null;
+            /** Requests Per Minute */
+            requests_per_minute?: number | null;
+            /** Rescan Heartbeat Lag Seconds */
+            rescan_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Lag Seconds */
+            scheduler_heartbeat_lag_seconds?: number | null;
+            /** Scheduler Heartbeat Name */
+            scheduler_heartbeat_name?: string | null;
+            /** Scheduler Lag Seconds */
+            scheduler_lag_seconds?: number | null;
             /**
              * Source
              * @default UnusualWhales
              */
             source: string;
-            /** Latency P95 Ms */
-            latency_p95_ms?: number | null;
-            /** Http 2Xx */
-            http_2xx?: number | null;
-            /** Http 4Xx */
-            http_4xx?: number | null;
-            /** Http 5Xx */
-            http_5xx?: number | null;
-            /** Uw Today */
-            uw_today?: number | null;
-            /** Cache Hit Pct */
-            cache_hit_pct?: number | null;
+            /** Spot Quote Lag Seconds */
+            spot_quote_lag_seconds?: number | null;
+            /** Spot Refresh Heartbeat Lag Seconds */
+            spot_refresh_heartbeat_lag_seconds?: number | null;
             /**
              * Throughput Window Minutes
              * @default 0
              */
             throughput_window_minutes: number;
-            /** Requests Per Minute */
-            requests_per_minute?: number | null;
-            /** Http 429 */
-            http_429?: number | null;
-            /** Avg Scan Duration Seconds */
-            avg_scan_duration_seconds?: number | null;
-            /** Queue Drain Rate Per Minute */
-            queue_drain_rate_per_minute?: number | null;
-            /** Record Health Ok */
-            record_health_ok?: boolean | null;
-            /** Record Health */
-            record_health?: components["schemas"]["RecordHealthCheck"][];
+            trade_insights_ai?: components["schemas"]["TradeInsightsAiHealth"] | null;
+            /** Uw Today */
+            uw_today?: number | null;
+            /** Watchlist Size */
+            watchlist_size?: number | null;
+            /** Worker Lag Seconds */
+            worker_lag_seconds?: number | null;
             /** Workers */
             workers?: components["schemas"]["WorkerHealth"][];
             ws_consumer?: components["schemas"]["WsConsumerHealth"] | null;
-            trade_insights_ai?: components["schemas"]["TradeInsightsAiHealth"] | null;
         };
         /** InsightBadge */
         InsightBadge: {
@@ -3555,41 +3555,48 @@ export interface components {
         };
         /** InsightLeg */
         InsightLeg: {
-            /** Side */
-            side: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Option Right */
-            option_right: string;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
             /** Mid */
             mid?: string | null;
+            /** Option Right */
+            option_right: string;
+            /** Option Symbol */
+            option_symbol: string;
+            /** Side */
+            side: string;
+            /** Strike */
+            strike: string;
         };
         /** InsightSignalRow */
         InsightSignalRow: {
-            /** Lens */
-            lens: string;
-            /** Read */
-            read: string;
-            /**
-             * Evidence
-             * @default []
-             */
-            evidence: string[];
             /**
              * Conflicts
              * @default []
              */
             conflicts: string[];
+            /**
+             * Evidence
+             * @default []
+             */
+            evidence: string[];
+            /** Lens */
+            lens: string;
+            /** Read */
+            read: string;
         };
         /** InsightsSynthesis */
         InsightsSynthesis: {
+            /**
+             * Avoid
+             * @default []
+             */
+            avoid: string[];
+            /** Best Risk Reward Idea Id */
+            best_risk_reward_idea_id?: string | null;
             /**
              * Dominant Story
              * @default
@@ -3597,13 +3604,6 @@ export interface components {
             dominant_story: string;
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
-            /** Best Risk Reward Idea Id */
-            best_risk_reward_idea_id?: string | null;
-            /**
-             * Avoid
-             * @default []
-             */
-            avoid: string[];
             /**
              * Required Before Sizing
              * @default []
@@ -3612,12 +3612,12 @@ export interface components {
         };
         /** IvHistogramBin */
         IvHistogramBin: {
-            /** Lo */
-            lo: string;
-            /** Hi */
-            hi: string;
             /** Count */
             count: number;
+            /** Hi */
+            hi: string;
+            /** Lo */
+            lo: string;
         };
         /** IvHvPoint */
         IvHvPoint: {
@@ -3657,26 +3657,26 @@ export interface components {
         };
         /** JobStatus */
         JobStatus: {
-            /** Job Id */
-            job_id: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "done" | "failed";
-            /** Run Id */
-            run_id?: number | null;
             /** Error */
             error?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Job Id */
+            job_id: string;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
+            /** Run Id */
+            run_id?: number | null;
             /** Started At */
             started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
         };
         /**
          * MarketAggregates
@@ -3686,51 +3686,43 @@ export interface components {
          *     sub-models. Feeds the watchlist card POSITIONING and SKEW blocks.
          */
         MarketAggregates: {
+            /** Aum */
+            aum?: string | null;
             /** Call Oi Total */
             call_oi_total?: number | null;
-            /** Put Oi Total */
-            put_oi_total?: number | null;
-            /** Call Volume Total */
-            call_volume_total?: number | null;
-            /** Put Volume Total */
-            put_volume_total?: number | null;
             /** Call Volume Ask Side */
             call_volume_ask_side?: number | null;
             /** Call Volume Bid Side */
             call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Pcr Oi */
-            pcr_oi?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
+            /** Call Volume Total */
+            call_volume_total?: number | null;
             /** Iv30D */
             iv30d?: string | null;
             /** Market Cap */
             market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
+            /** Pcr Oi */
+            pcr_oi?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Put Oi Total */
+            put_oi_total?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
+            /** Put Volume Total */
+            put_volume_total?: number | null;
         };
         /** MarketStructure */
         MarketStructure: {
-            /** Spot */
-            spot?: string | null;
-            /** Nearest Expiry */
-            nearest_expiry?: string | null;
-            /** Total Call Gex */
-            total_call_gex?: string | null;
-            /** Total Put Gex */
-            total_put_gex?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Total Call Dex Oi */
-            total_call_dex_oi?: string | null;
-            /** Total Put Dex Oi */
-            total_put_dex_oi?: string | null;
             /** Max Pain */
             max_pain?: string | null;
+            /** Nearest Expiry */
+            nearest_expiry?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Spot */
+            spot?: string | null;
             /**
              * Top Call Oi Strikes
              * @default []
@@ -3741,6 +3733,14 @@ export interface components {
              * @default []
              */
             top_put_oi_strikes: string[];
+            /** Total Call Dex Oi */
+            total_call_dex_oi?: string | null;
+            /** Total Call Gex */
+            total_call_gex?: string | null;
+            /** Total Put Dex Oi */
+            total_put_dex_oi?: string | null;
+            /** Total Put Gex */
+            total_put_gex?: string | null;
         };
         /**
          * MarketStructureLevels
@@ -3755,152 +3755,154 @@ export interface components {
          *       - max_accel: strike with most-negative net_gex below the flip (movement accelerator)
          */
         MarketStructureLevels: {
-            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             call_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
-            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            gex_flip?: components["schemas"]["uw_scan__models__GexLevel"] | null;
             max_accel?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            max_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            put_wall?: components["schemas"]["uw_scan__models__GexLevel"] | null;
+            second_magnet?: components["schemas"]["uw_scan__models__GexLevel"] | null;
         };
         /** MatrixSourceFreshness */
         MatrixSourceFreshness: {
-            /** Vanna Charm */
-            vanna_charm?: string | null;
+            /** Im Vrp */
+            im_vrp?: string | null;
+            /** Oi */
+            oi?: string | null;
             /** Skew */
             skew?: string | null;
             /** Term */
             term?: string | null;
-            /** Im Vrp */
-            im_vrp?: string | null;
+            /** Vanna Charm */
+            vanna_charm?: string | null;
             /** Vrp Rv */
             vrp_rv?: string | null;
-            /** Oi */
-            oi?: string | null;
         };
         /** MatrixState */
         MatrixState: {
-            /** Ticker */
-            ticker: string;
-            /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /**
-             * Threshold Version
-             * @default 1
-             */
-            threshold_version: number;
-            /**
-             * Vanna State
-             * @enum {string}
-             */
-            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Atm Straddle Mid */
+            atm_straddle_mid?: string | null;
+            /** Back Iv */
+            back_iv?: string | null;
+            /** Charm Regime */
+            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
             /**
              * Charm State
              * @enum {string}
              */
             charm_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
+             * Charm Stress Override
+             * @default false
+             */
+            charm_stress_override: boolean;
+            /** Cluster Coverage Ok */
+            cluster_coverage_ok: boolean;
+            /**
+             * Consistency Tier
+             * @enum {string}
+             */
+            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
+            /** Directional Imbalance 3D */
+            directional_imbalance_3d?: string | null;
+            /**
+             * Flow State
+             * @enum {string}
+             */
+            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Front Back Spread */
+            front_back_spread?: string | null;
+            /** Front Iv */
+            front_iv?: string | null;
+            /** Full Curve Slope Pct */
+            full_curve_slope_pct?: string | null;
+            /**
+             * Im State
+             * @enum {string}
+             */
+            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Implied Move Event Percentile */
+            implied_move_event_percentile?: string | null;
+            /** Implied Move Expected Abs */
+            implied_move_expected_abs?: string | null;
+            /** Implied Move Pct */
+            implied_move_pct?: string | null;
+            /** Iv Atm 30D */
+            iv_atm_30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Pin Distance Sigma */
+            pin_distance_sigma?: string | null;
+            /** Rv 30D */
+            rv_30d?: string | null;
+            /** Single Point Bump Pct */
+            single_point_bump_pct?: string | null;
+            /** Skew 25D 5D Change */
+            skew_25d_5d_change?: string | null;
+            /** Skew 25D Zscore 180D */
+            skew_25d_zscore_180d?: string | null;
+            /** Skew Regime */
+            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
+            /**
              * Skew State
              * @enum {string}
              */
             skew_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            /** Skew Term Structure */
+            skew_term_structure?: string | null;
+            /** Term Classification */
+            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
+            /** Term Johnson Slope Pc1 */
+            term_johnson_slope_pc1?: string | null;
             /**
              * Term State
              * @enum {string}
              */
             term_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /**
-             * Im State
-             * @enum {string}
+             * Threshold Version
+             * @default 1
              */
-            im_state: "vol_up" | "vol_down" | "neutral" | "stale";
+            threshold_version: number;
+            /** Ticker */
+            ticker: string;
+            /** Vanna Conditional Reading */
+            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
+            /** Vanna Oi Change Bias */
+            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
             /**
-             * Flow State
+             * Vanna State
              * @enum {string}
              */
-            flow_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Vrp State
-             * @enum {string}
-             */
-            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
-            /**
-             * Consistency Tier
-             * @enum {string}
-             */
-            consistency_tier: "strict" | "strong" | "weak" | "no_trade" | "insufficient_data";
-            /** Cluster Coverage Ok */
-            cluster_coverage_ok: boolean;
-            /** Term Classification */
-            term_classification?: ("contango" | "event_back" | "liquidity_back" | "mixed") | null;
-            /** Skew 25D Zscore 180D */
-            skew_25d_zscore_180d?: string | null;
-            /** Iv Atm 30D */
-            iv_atm_30d?: string | null;
-            /** Rv 30D */
-            rv_30d?: string | null;
+            vanna_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp */
             vrp?: string | null;
-            /** Vrp Zscore 60D */
-            vrp_zscore_60d?: string | null;
-            /** Implied Move Pct */
-            implied_move_pct?: string | null;
-            /** Front Iv */
-            front_iv?: string | null;
-            /** Back Iv */
-            back_iv?: string | null;
-            /** Front Back Spread */
-            front_back_spread?: string | null;
-            /** Pin Distance Sigma */
-            pin_distance_sigma?: string | null;
+            /**
+             * Vrp Sign Flip Aligned Days
+             * @default 0
+             */
+            vrp_sign_flip_aligned_days: number;
             /**
              * Vrp Sign Flip Status
              * @default insufficient_history
              */
             vrp_sign_flip_status: boolean | "insufficient_history";
             /**
-             * Vrp Sign Flip Aligned Days
-             * @default 0
+             * Vrp State
+             * @enum {string}
              */
-            vrp_sign_flip_aligned_days: number;
-            /** Vanna Conditional Reading */
-            vanna_conditional_reading?: ("grind_up" | "reverse_selloff" | "reflexive_sell_pressure" | "weak_noise") | null;
-            /** Directional Imbalance 3D */
-            directional_imbalance_3d?: string | null;
-            /** Vanna Oi Change Bias */
-            vanna_oi_change_bias?: ("call_oi_build" | "put_oi_build" | "mixed") | null;
-            /** Charm Regime */
-            charm_regime?: ("operative_magnet" | "broken_magnet" | "opex_vortex" | "neutral") | null;
-            /**
-             * Charm Stress Override
-             * @default false
-             */
-            charm_stress_override: boolean;
-            /** Skew 25D 5D Change */
-            skew_25d_5d_change?: string | null;
-            /** Skew Regime */
-            skew_regime?: ("smirk" | "accelerated" | "crash_smile" | "neutral") | null;
-            /** Skew Term Structure */
-            skew_term_structure?: string | null;
-            /** Single Point Bump Pct */
-            single_point_bump_pct?: string | null;
-            /** Full Curve Slope Pct */
-            full_curve_slope_pct?: string | null;
-            /** Term Johnson Slope Pc1 */
-            term_johnson_slope_pc1?: string | null;
-            /** Atm Straddle Mid */
-            atm_straddle_mid?: string | null;
-            /** Implied Move Expected Abs */
-            implied_move_expected_abs?: string | null;
-            /** Implied Move Event Percentile */
-            implied_move_event_percentile?: string | null;
+            vrp_state: "vol_up" | "vol_down" | "neutral" | "stale";
             /** Vrp Zscore 252D */
             vrp_zscore_252d?: string | null;
+            /** Vrp Zscore 60D */
+            vrp_zscore_60d?: string | null;
         };
         /** MaxPainRow */
         MaxPainRow: {
+            /** Close */
+            close?: string | null;
             /**
              * Expiry
              * Format: date
@@ -3908,126 +3910,124 @@ export interface components {
             expiry: string;
             /** Max Pain */
             max_pain?: string | null;
-            /** Close */
-            close?: string | null;
-            /** Open */
-            open?: string | null;
-            /** Next Upper Strike */
-            next_upper_strike?: string | null;
             /** Next Lower Strike */
             next_lower_strike?: string | null;
+            /** Next Upper Strike */
+            next_upper_strike?: string | null;
+            /** Open */
+            open?: string | null;
         };
         /** OhlcRow */
         OhlcRow: {
+            /** Close */
+            close: string;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Open */
-            open?: string | null;
             /** High */
             high?: string | null;
             /** Low */
             low?: string | null;
-            /** Close */
-            close: string;
+            /** Open */
+            open?: string | null;
             /** Volume */
             volume?: number | null;
         };
         /** OiChangeRow */
         OiChangeRow: {
-            /** Underlying Symbol */
-            underlying_symbol: string;
-            /** Option Symbol */
-            option_symbol: string;
-            /** Curr Date */
-            curr_date?: string | null;
-            /** Last Date */
-            last_date?: string | null;
-            /** Curr Oi */
-            curr_oi?: number | null;
-            /** Last Oi */
-            last_oi?: number | null;
-            /** Oi Diff Plain */
-            oi_diff_plain?: number | null;
-            /** Oi Change */
-            oi_change?: string | null;
-            /** Volume */
-            volume?: number | null;
-            /** Trades */
-            trades?: number | null;
+            /** Ask Volume */
+            ask_volume?: number | null;
             /** Avg Price */
             avg_price?: string | null;
-            /** Last Fill */
-            last_fill?: string | null;
+            /** Bid Volume */
+            bid_volume?: number | null;
+            /** Curr Date */
+            curr_date?: string | null;
+            /** Curr Oi */
+            curr_oi?: number | null;
             /** Days Of Oi Increases */
             days_of_oi_increases?: number | null;
             /** Days Of Vol Greater Than Oi */
             days_of_vol_greater_than_oi?: number | null;
+            /** Last Ask */
+            last_ask?: string | null;
+            /** Last Bid */
+            last_bid?: string | null;
+            /** Last Date */
+            last_date?: string | null;
+            /** Last Fill */
+            last_fill?: string | null;
+            /** Last Oi */
+            last_oi?: number | null;
+            /** Mid Volume */
+            mid_volume?: number | null;
+            /** No Side Volume */
+            no_side_volume?: number | null;
+            /** Oi Change */
+            oi_change?: string | null;
+            /** Oi Diff Plain */
+            oi_diff_plain?: number | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Percentage Of Total */
             percentage_of_total?: string | null;
-            /** Rnk */
-            rnk?: number | null;
             /** Prev Ask Volume */
             prev_ask_volume?: number | null;
             /** Prev Bid Volume */
             prev_bid_volume?: number | null;
             /** Prev Mid Volume */
             prev_mid_volume?: number | null;
-            /** Prev Neutral Volume */
-            prev_neutral_volume?: number | null;
             /** Prev Multi Leg Volume */
             prev_multi_leg_volume?: number | null;
+            /** Prev Neutral Volume */
+            prev_neutral_volume?: number | null;
             /** Prev Stock Multi Leg Volume */
             prev_stock_multi_leg_volume?: number | null;
             /** Prev Total Premium */
             prev_total_premium?: string | null;
-            /** Last Ask */
-            last_ask?: string | null;
-            /** Last Bid */
-            last_bid?: string | null;
-            /** Ask Volume */
-            ask_volume?: number | null;
-            /** Bid Volume */
-            bid_volume?: number | null;
-            /** Mid Volume */
-            mid_volume?: number | null;
-            /** No Side Volume */
-            no_side_volume?: number | null;
+            /** Rnk */
+            rnk?: number | null;
+            /** Trades */
+            trades?: number | null;
+            /** Underlying Symbol */
+            underlying_symbol: string;
+            /** Volume */
+            volume?: number | null;
         };
         /** OosLabel */
         OosLabel: {
-            /** Name */
-            name: string;
             /** Definition */
             definition: string;
+            /** Name */
+            name: string;
         };
         /** OosScore */
         OosScore: {
-            /** Model */
-            model: string;
+            /** Auc Dd10 */
+            auc_dd10?: number | null;
             /** Auc Dd5 */
             auc_dd5?: number | null;
             /** Auc Vix30 */
             auc_vix30?: number | null;
-            /** Auc Dd10 */
-            auc_dd10?: number | null;
+            /** Model */
+            model: string;
         };
         /** OosSummary */
         OosSummary: {
             /** As Of */
             as_of: string;
-            /** Notebook */
-            notebook: string;
-            /** Method */
-            method: string;
-            /** Labels */
-            labels: components["schemas"]["OosLabel"][];
-            /** Scores */
-            scores: components["schemas"]["OosScore"][];
             /** Interpretation */
             interpretation: string;
+            /** Labels */
+            labels: components["schemas"]["OosLabel"][];
+            /** Method */
+            method: string;
+            /** Notebook */
+            notebook: string;
+            /** Scores */
+            scores: components["schemas"]["OosScore"][];
         };
         /**
          * OptionChainPerStrikeRow
@@ -4036,21 +4036,21 @@ export interface components {
          *     Backs both strike-profile charts (Volume and OI variants).
          */
         OptionChainPerStrikeRow: {
+            /** Call Oi */
+            call_oi?: number | null;
+            /** Call Volume */
+            call_volume?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Strike */
-            strike: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Oi */
-            call_oi?: number | null;
             /** Put Oi */
             put_oi?: number | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * OptionIntradayProfile
@@ -4063,33 +4063,33 @@ export interface components {
          *     minute bars the contract actually had.
          */
         OptionIntradayProfile: {
-            /** Option Symbol */
-            option_symbol: string;
-            /**
-             * Trade Date
-             * Format: date
-             */
-            trade_date: string;
-            /**
-             * Total Volume
-             * @default 0
-             */
-            total_volume: number;
             /** First Trade Time */
             first_trade_time?: string | null;
             /** Last Trade Time */
             last_trade_time?: string | null;
-            /** Peak Window Start */
-            peak_window_start?: string | null;
+            /** Option Symbol */
+            option_symbol: string;
             /** Peak Window End */
             peak_window_end?: string | null;
             /** Peak Window Share Pct */
             peak_window_share_pct?: string | null;
+            /** Peak Window Start */
+            peak_window_start?: string | null;
             /**
              * Sparkline
              * @default []
              */
             sparkline: number[];
+            /**
+             * Total Volume
+             * @default 0
+             */
+            total_volume: number;
+            /**
+             * Trade Date
+             * Format: date
+             */
+            trade_date: string;
         };
         /**
          * OptionsDailyRow
@@ -4099,39 +4099,10 @@ export interface components {
          *     alert-scoped :class:`FlowSnapshot.bull_premium`. Do not cross-plot.
          */
         OptionsDailyRow: {
-            /**
-             * Date
-             * Format: date
-             */
-            date: string;
-            /** Call Volume */
-            call_volume?: number | null;
-            /** Put Volume */
-            put_volume?: number | null;
-            /** Call Volume Ask Side */
-            call_volume_ask_side?: number | null;
-            /** Call Volume Bid Side */
-            call_volume_bid_side?: number | null;
-            /** Put Volume Ask Side */
-            put_volume_ask_side?: number | null;
-            /** Put Volume Bid Side */
-            put_volume_bid_side?: number | null;
-            /** Call Premium */
-            call_premium?: string | null;
-            /** Put Premium */
-            put_premium?: string | null;
-            /** Net Call Premium */
-            net_call_premium?: string | null;
-            /** Net Put Premium */
-            net_put_premium?: string | null;
-            /** Bullish Premium */
-            bullish_premium?: string | null;
-            /** Bearish Premium */
-            bearish_premium?: string | null;
-            /** Call Open Interest */
-            call_open_interest?: number | null;
-            /** Put Open Interest */
-            put_open_interest?: number | null;
+            /** Avg 30 Day Call Volume */
+            avg_30_day_call_volume?: string | null;
+            /** Avg 30 Day Put Volume */
+            avg_30_day_put_volume?: string | null;
             /** Avg 3 Day Call Volume */
             avg_3_day_call_volume?: string | null;
             /** Avg 3 Day Put Volume */
@@ -4140,45 +4111,70 @@ export interface components {
             avg_7_day_call_volume?: string | null;
             /** Avg 7 Day Put Volume */
             avg_7_day_put_volume?: string | null;
-            /** Avg 30 Day Call Volume */
-            avg_30_day_call_volume?: string | null;
-            /** Avg 30 Day Put Volume */
-            avg_30_day_put_volume?: string | null;
+            /** Bearish Premium */
+            bearish_premium?: string | null;
+            /** Bullish Premium */
+            bullish_premium?: string | null;
+            /** Call Open Interest */
+            call_open_interest?: number | null;
+            /** Call Premium */
+            call_premium?: string | null;
+            /** Call Volume */
+            call_volume?: number | null;
+            /** Call Volume Ask Side */
+            call_volume_ask_side?: number | null;
+            /** Call Volume Bid Side */
+            call_volume_bid_side?: number | null;
+            /**
+             * Date
+             * Format: date
+             */
+            date: string;
+            /** Net Call Premium */
+            net_call_premium?: string | null;
+            /** Net Put Premium */
+            net_put_premium?: string | null;
+            /** Put Open Interest */
+            put_open_interest?: number | null;
+            /** Put Premium */
+            put_premium?: string | null;
+            /** Put Volume */
+            put_volume?: number | null;
+            /** Put Volume Ask Side */
+            put_volume_ask_side?: number | null;
+            /** Put Volume Bid Side */
+            put_volume_bid_side?: number | null;
         };
         /** PositioningBlock */
         PositioningBlock: {
             /** Call Oi */
             call_oi?: number | null;
-            /** Put Oi */
-            put_oi?: number | null;
+            /** Pcr Delta 30D */
+            pcr_delta_30d?: string | null;
             /** Pcr Oi */
             pcr_oi?: string | null;
             /** Pcr Vol */
             pcr_vol?: string | null;
-            /** Pcr Delta 30D */
-            pcr_delta_30d?: string | null;
+            /** Put Oi */
+            put_oi?: number | null;
         };
         /** ProviderUsageBreakdownResponse */
         ProviderUsageBreakdownResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageBreakdownRow"][];
         };
         /** ProviderUsageBreakdownRow */
         ProviderUsageBreakdownRow: {
-            /** Key */
-            key: string | null;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -4187,53 +4183,29 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
+            /** Key */
+            key: string | null;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
         };
         /** ProviderUsageRequestRow */
         ProviderUsageRequestRow: {
-            /** Request Id */
-            request_id: number;
-            /** Provider */
-            provider: string;
-            /** Endpoint Key */
-            endpoint_key: string;
-            /** Method */
-            method: string;
-            /** Path */
-            path: string;
-            /** Ticker */
-            ticker: string | null;
-            /** Params */
-            params: {
-                [key: string]: unknown;
-            };
-            /** Status Code */
-            status_code: number | null;
-            /** Status Family */
-            status_family: string;
-            /**
-             * Request Started At
-             * Format: date-time
-             */
-            request_started_at: string;
-            /**
-             * Request Finished At
-             * Format: date-time
-             */
-            request_finished_at: string;
-            /** Latency Ms */
-            latency_ms: number;
             /** Attempt */
             attempt: number;
-            /** Run Id */
-            run_id: number | null;
+            /** Endpoint Key */
+            endpoint_key: string;
+            /** Error Message */
+            error_message: string | null;
             /** Job Name */
             job_name: string | null;
-            /** Provider Request Id */
-            provider_request_id: string | null;
+            /** Latency Ms */
+            latency_ms: number;
+            /** Method */
+            method: string;
             /** Official Daily Count */
             official_daily_count: number | null;
             /** Official Daily Limit */
@@ -4242,40 +4214,56 @@ export interface components {
             official_minute_remaining: number | null;
             /** Official Minute Reset */
             official_minute_reset: string | null;
-            /** Error Message */
-            error_message: string | null;
+            /** Params */
+            params: {
+                [key: string]: unknown;
+            };
+            /** Path */
+            path: string;
+            /** Provider */
+            provider: string;
+            /** Provider Request Id */
+            provider_request_id: string | null;
+            /**
+             * Request Finished At
+             * Format: date-time
+             */
+            request_finished_at: string;
+            /** Request Id */
+            request_id: number;
+            /**
+             * Request Started At
+             * Format: date-time
+             */
+            request_started_at: string;
+            /** Run Id */
+            run_id: number | null;
+            /** Status Code */
+            status_code: number | null;
+            /** Status Family */
+            status_family: string;
+            /** Ticker */
+            ticker: string | null;
         };
         /** ProviderUsageRequestsResponse */
         ProviderUsageRequestsResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
+            /** Limit */
+            limit: number;
             /**
              * Provider Day End
              * Format: date-time
              */
             provider_day_end: string;
-            /** Limit */
-            limit: number;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
             /** Rows */
             rows: components["schemas"]["ProviderUsageRequestRow"][];
         };
         /** ProviderUsageSummaryResponse */
         ProviderUsageSummaryResponse: {
-            /**
-             * Provider Day Start
-             * Format: date-time
-             */
-            provider_day_start: string;
-            /**
-             * Provider Day End
-             * Format: date-time
-             */
-            provider_day_end: string;
-            /** Total Requests */
-            total_requests: number;
             /** Http 2Xx */
             http_2xx: number;
             /** Http 3Xx */
@@ -4284,10 +4272,22 @@ export interface components {
             http_4xx: number;
             /** Http 5Xx */
             http_5xx: number;
-            /** Transport Errors */
-            transport_errors: number;
             /** Latency P95 Ms */
             latency_p95_ms: number | null;
+            /**
+             * Provider Day End
+             * Format: date-time
+             */
+            provider_day_end: string;
+            /**
+             * Provider Day Start
+             * Format: date-time
+             */
+            provider_day_start: string;
+            /** Total Requests */
+            total_requests: number;
+            /** Transport Errors */
+            transport_errors: number;
             /** Uw Latest Daily Count */
             uw_latest_daily_count: number | null;
             /** Uw Latest Daily Limit */
@@ -4297,11 +4297,6 @@ export interface components {
         QueueStatus: {
             /** Job Id */
             job_id: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "done" | "failed";
             /** Queue Position */
             queue_position: number;
             /**
@@ -4311,14 +4306,16 @@ export interface components {
             requested_at: string;
             /** Started At */
             started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "done" | "failed";
         };
         /** QueueSummary */
         QueueSummary: {
-            /**
-             * Total
-             * @default 0
-             */
-            total: number;
+            /** Oldest Requested At */
+            oldest_requested_at?: string | null;
             /**
              * Queued
              * @default 0
@@ -4329,8 +4326,11 @@ export interface components {
              * @default 0
              */
             running: number;
-            /** Oldest Requested At */
-            oldest_requested_at?: string | null;
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
         };
         /** RatesCrossMarketPanel */
         RatesCrossMarketPanel: {
@@ -4345,26 +4345,26 @@ export interface components {
         };
         /** RatesCurvePoint */
         RatesCurvePoint: {
-            /** Tenor */
-            tenor: string;
-            /** Series Id */
-            series_id: string;
-            /** Value */
-            value?: number | null;
             /** Delta 1D Bps */
             delta_1d_bps?: number | null;
-            /** Delta 1W Bps */
-            delta_1w_bps?: number | null;
             /** Delta 1M Bps */
             delta_1m_bps?: number | null;
+            /** Delta 1W Bps */
+            delta_1w_bps?: number | null;
             /** Obs Date */
             obs_date?: string | null;
+            /** Series Id */
+            series_id: string;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tenor */
+            tenor: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesCurveSection */
         RatesCurveSection: {
@@ -4375,93 +4375,93 @@ export interface components {
         };
         /** RatesDecomposition */
         RatesDecomposition: {
-            /** Nominal 10Y */
-            nominal_10y?: number | null;
-            /** Real 10Y */
-            real_10y?: number | null;
+            /** Attribution */
+            attribution?: components["schemas"]["RatesDecompositionAttribution"][];
             /** Breakeven 10Y */
             breakeven_10y?: number | null;
-            /** Forward Inflation 5Y5Y */
-            forward_inflation_5y5y?: number | null;
-            /** Term Forward Compensation */
-            term_forward_compensation?: number | null;
             /** Clarida Model Date */
             clarida_model_date?: string | null;
-            /** Model Real Yield 10Y */
-            model_real_yield_10y?: number | null;
-            /** Expected Short Real Rate 10Y */
-            expected_short_real_rate_10y?: number | null;
             /** Expected Short Inflation 10Y */
             expected_short_inflation_10y?: number | null;
-            /** Real Term Premium 10Y */
-            real_term_premium_10y?: number | null;
+            /** Expected Short Real Rate 10Y */
+            expected_short_real_rate_10y?: number | null;
+            /** Forward Inflation 5Y5Y */
+            forward_inflation_5y5y?: number | null;
+            /** Fred Model Residual 10Y */
+            fred_model_residual_10y?: number | null;
             /** Inflation Risk Premium 10Y */
             inflation_risk_premium_10y?: number | null;
             /** Model Nominal 10Y */
             model_nominal_10y?: number | null;
-            /** Fred Model Residual 10Y */
-            fred_model_residual_10y?: number | null;
+            /** Model Real Yield 10Y */
+            model_real_yield_10y?: number | null;
             /** Model Source */
             model_source?: string | null;
             /** Model Url */
             model_url?: string | null;
+            /** Nominal 10Y */
+            nominal_10y?: number | null;
+            /** Real 10Y */
+            real_10y?: number | null;
+            /** Real Term Premium 10Y */
+            real_term_premium_10y?: number | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Attribution */
-            attribution?: components["schemas"]["RatesDecompositionAttribution"][];
+            /** Term Forward Compensation */
+            term_forward_compensation?: number | null;
         };
         /** RatesDecompositionAttribution */
         RatesDecompositionAttribution: {
+            /** Breakeven 10Y Bps */
+            breakeven_10y_bps?: number | null;
+            /** Driver */
+            driver?: string | null;
+            /** Expected Short Inflation Bps */
+            expected_short_inflation_bps?: number | null;
+            /** Expected Short Real Bps */
+            expected_short_real_bps?: number | null;
+            /** Fred Model Residual Bps */
+            fred_model_residual_bps?: number | null;
+            /** Inflation Risk Premium Bps */
+            inflation_risk_premium_bps?: number | null;
+            /** Model Nominal 10Y Bps */
+            model_nominal_10y_bps?: number | null;
+            /** Nominal 10Y Bps */
+            nominal_10y_bps?: number | null;
+            /** Real 10Y Bps */
+            real_10y_bps?: number | null;
+            /** Real Term Premium Bps */
+            real_term_premium_bps?: number | null;
+            /** Residual Bps */
+            residual_bps?: number | null;
+            /**
+             * Status
+             * @default partial
+             * @enum {string}
+             */
+            status: "ok" | "missing" | "partial" | "stale";
             /**
              * Window
              * @enum {string}
              */
             window: "1D" | "1W" | "1M" | "YTD";
-            /** Nominal 10Y Bps */
-            nominal_10y_bps?: number | null;
-            /** Real 10Y Bps */
-            real_10y_bps?: number | null;
-            /** Breakeven 10Y Bps */
-            breakeven_10y_bps?: number | null;
-            /** Residual Bps */
-            residual_bps?: number | null;
-            /** Model Nominal 10Y Bps */
-            model_nominal_10y_bps?: number | null;
-            /** Expected Short Real Bps */
-            expected_short_real_bps?: number | null;
-            /** Expected Short Inflation Bps */
-            expected_short_inflation_bps?: number | null;
-            /** Real Term Premium Bps */
-            real_term_premium_bps?: number | null;
-            /** Inflation Risk Premium Bps */
-            inflation_risk_premium_bps?: number | null;
-            /** Fred Model Residual Bps */
-            fred_model_residual_bps?: number | null;
-            /** Driver */
-            driver?: string | null;
-            /**
-             * Status
-             * @default partial
-             * @enum {string}
-             */
-            status: "ok" | "missing" | "partial" | "stale";
         };
         /** RatesEventItem */
         RatesEventItem: {
             /** Event Date */
             event_date?: string | null;
-            /** Label */
-            label: string;
             /**
              * Importance
              * @default medium
              * @enum {string}
              */
             importance: "low" | "medium" | "high";
+            /** Label */
+            label: string;
             /** Source */
             source?: string | null;
             /**
@@ -4473,16 +4473,14 @@ export interface components {
         };
         /** RatesPolicyMeeting */
         RatesPolicyMeeting: {
+            /** Action */
+            action?: string | null;
             /** Event Date */
             event_date?: string | null;
             /** Event End Date */
             event_end_date?: string | null;
             /** Label */
             label: string;
-            /** Action */
-            action?: string | null;
-            /** Vote Split */
-            vote_split?: string | null;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -4491,76 +4489,71 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Vote Split */
+            vote_split?: string | null;
         };
         /** RatesPolicyPanel */
         RatesPolicyPanel: {
-            /** Target Range */
-            target_range?: string | null;
-            /** Target Lower */
-            target_lower?: number | null;
-            /** Target Upper */
-            target_upper?: number | null;
             /** Effr */
             effr?: number | null;
-            /** Sofr */
-            sofr?: number | null;
-            last_meeting?: components["schemas"]["RatesPolicyMeeting"] | null;
             /** Implied Path */
             implied_path?: components["schemas"]["RatesPolicyPathPoint"][];
-            /** Plumbing */
-            plumbing?: components["schemas"]["RatesPolicyPlumbingMetric"][];
-            /** Policy Read */
-            policy_read?: string | null;
+            last_meeting?: components["schemas"]["RatesPolicyMeeting"] | null;
             /** Path Read */
             path_read?: string | null;
+            /** Plumbing */
+            plumbing?: components["schemas"]["RatesPolicyPlumbingMetric"][];
             /** Plumbing Read */
             plumbing_read?: string | null;
+            /** Policy Read */
+            policy_read?: string | null;
+            /** Sofr */
+            sofr?: number | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Target Lower */
+            target_lower?: number | null;
+            /** Target Range */
+            target_range?: string | null;
+            /** Target Upper */
+            target_upper?: number | null;
         };
         /** RatesPolicyPathPoint */
         RatesPolicyPathPoint: {
+            /** Label */
+            label: string;
             /**
              * Meeting Date
              * Format: date
              */
             meeting_date: string;
-            /** Label */
-            label: string;
             /** Probability */
             probability?: number | null;
+            /** Source */
+            source?: string | null;
             /**
              * Stance
              * @default UNKNOWN
              * @enum {string}
              */
             stance: "CUT" | "HOLD" | "HIKE" | "UNKNOWN";
-            /** Target Range */
-            target_range?: string | null;
-            /** Source */
-            source?: string | null;
             /**
              * Status
              * @default partial
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Target Range */
+            target_range?: string | null;
         };
         /** RatesPolicyPlumbingMetric */
         RatesPolicyPlumbingMetric: {
             /** Label */
             label: string;
-            /** Value */
-            value?: number | null;
-            /**
-             * Unit
-             * @default
-             */
-            unit: string;
             /** Qualifier */
             qualifier?: string | null;
             /**
@@ -4569,15 +4562,22 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /**
+             * Unit
+             * @default
+             */
+            unit: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesPositioningPanel */
         RatesPositioningPanel: {
-            /** Rows */
-            rows?: components["schemas"]["RatesSummaryTile"][];
             /** Details */
             details?: components["schemas"]["RatesPositioningRow"][];
             /** Positioning Read */
             positioning_read?: string | null;
+            /** Rows */
+            rows?: components["schemas"]["RatesSummaryTile"][];
             /**
              * Status
              * @default missing
@@ -4587,30 +4587,28 @@ export interface components {
         };
         /** RatesPositioningRow */
         RatesPositioningRow: {
-            /** Contract Code */
-            contract_code: string;
-            /** Contract Name */
-            contract_name: string;
-            /** Tenor Bucket */
-            tenor_bucket: string;
-            /** Obs Date */
-            obs_date?: string | null;
-            /** Release Date */
-            release_date?: string | null;
-            /** Open Interest */
-            open_interest?: number | null;
-            /** Dealer Net */
-            dealer_net?: number | null;
-            /** Dealer Net Pct Oi */
-            dealer_net_pct_oi?: number | null;
             /** Asset Mgr Net */
             asset_mgr_net?: number | null;
             /** Asset Mgr Net Pct Oi */
             asset_mgr_net_pct_oi?: number | null;
+            /** Contract Code */
+            contract_code: string;
+            /** Contract Name */
+            contract_name: string;
+            /** Dealer Net */
+            dealer_net?: number | null;
+            /** Dealer Net Pct Oi */
+            dealer_net_pct_oi?: number | null;
             /** Lev Money Net */
             lev_money_net?: number | null;
             /** Lev Money Net Pct Oi */
             lev_money_net_pct_oi?: number | null;
+            /** Obs Date */
+            obs_date?: string | null;
+            /** Open Interest */
+            open_interest?: number | null;
+            /** Release Date */
+            release_date?: string | null;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -4619,17 +4617,13 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tenor Bucket */
+            tenor_bucket: string;
         };
         /** RatesScorecard */
         RatesScorecard: {
             /** Composite Score */
             composite_score?: number | null;
-            /**
-             * Duration Stance
-             * @default NEUTRAL
-             * @enum {string}
-             */
-            duration_stance: "BUY" | "SELL" | "NEUTRAL";
             /** Curve Score */
             curve_score?: number | null;
             /**
@@ -4638,6 +4632,12 @@ export interface components {
              * @enum {string}
              */
             curve_stance: "STEEP" | "FLAT" | "NEUTRAL";
+            /**
+             * Duration Stance
+             * @default NEUTRAL
+             * @enum {string}
+             */
+            duration_stance: "BUY" | "SELL" | "NEUTRAL";
             /** Groups */
             groups?: components["schemas"]["RatesScorecardGroup"][];
         };
@@ -4645,27 +4645,27 @@ export interface components {
         RatesScorecardFactor: {
             /** Label */
             label: string;
-            /** Value */
-            value?: string | null;
             /** Score */
             score?: number | null;
+            /** Source */
+            source?: string | null;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Source */
-            source?: string | null;
+            /** Value */
+            value?: string | null;
         };
         /** RatesScorecardGroup */
         RatesScorecardGroup: {
+            /** Factors */
+            factors?: components["schemas"]["RatesScorecardFactor"][];
             /** Id */
             id: string;
             /** Label */
             label: string;
-            /** Weight */
-            weight: number;
             /** Score */
             score?: number | null;
             /**
@@ -4674,21 +4674,21 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
-            /** Factors */
-            factors?: components["schemas"]["RatesScorecardFactor"][];
+            /** Weight */
+            weight: number;
         };
         /** RatesSlopeMetric */
         RatesSlopeMetric: {
             /** Label */
             label: string;
-            /** Value Bps */
-            value_bps?: number | null;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Value Bps */
+            value_bps?: number | null;
         };
         /** RatesSnapshotResponse */
         RatesSnapshotResponse: {
@@ -4702,20 +4702,20 @@ export interface components {
              * Format: date-time
              */
             computed_at: string;
-            /** Summary */
-            summary?: components["schemas"]["RatesSummaryTile"][];
+            cross_market?: components["schemas"]["RatesCrossMarketPanel"];
             curve?: components["schemas"]["RatesCurveSection"];
             decomposition?: components["schemas"]["RatesDecomposition"];
-            scorecard?: components["schemas"]["RatesScorecard"];
-            policy?: components["schemas"]["RatesPolicyPanel"];
-            supply?: components["schemas"]["RatesSupplyPanel"];
-            positioning?: components["schemas"]["RatesPositioningPanel"];
-            cross_market?: components["schemas"]["RatesCrossMarketPanel"];
             /** Events */
             events?: components["schemas"]["RatesEventItem"][];
-            synthesis: components["schemas"]["RatesSynthesisPanel"];
+            policy?: components["schemas"]["RatesPolicyPanel"];
+            positioning?: components["schemas"]["RatesPositioningPanel"];
+            scorecard?: components["schemas"]["RatesScorecard"];
             /** Source Freshness */
             source_freshness?: components["schemas"]["RatesSourceFreshness"][];
+            /** Summary */
+            summary?: components["schemas"]["RatesSummaryTile"][];
+            supply?: components["schemas"]["RatesSupplyPanel"];
+            synthesis: components["schemas"]["RatesSynthesisPanel"];
         };
         /** RatesSourceFreshness */
         RatesSourceFreshness: {
@@ -4723,10 +4723,10 @@ export interface components {
             id: string;
             /** Label */
             label: string;
-            /** Latest Obs Date */
-            latest_obs_date?: string | null;
             /** Last Seen At */
             last_seen_at?: string | null;
+            /** Latest Obs Date */
+            latest_obs_date?: string | null;
             /**
              * Status
              * @default missing
@@ -4736,53 +4736,51 @@ export interface components {
         };
         /** RatesSummaryTile */
         RatesSummaryTile: {
-            /** Label */
-            label: string;
-            /** Value */
-            value?: number | null;
-            /**
-             * Unit
-             * @default
-             */
-            unit: string;
             /** Delta 1D */
             delta_1d?: number | null;
+            /** Label */
+            label: string;
             /**
              * Status
              * @default ok
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /**
+             * Unit
+             * @default
+             */
+            unit: string;
+            /** Value */
+            value?: number | null;
         };
         /** RatesSupplyAuctionRow */
         RatesSupplyAuctionRow: {
-            /** Cusip */
-            cusip: string;
-            /** Security Type */
-            security_type: string;
-            /** Security Term */
-            security_term: string;
             /**
              * Auction Date
              * Format: date
              */
             auction_date: string;
+            /** Bid To Cover */
+            bid_to_cover?: number | null;
+            /** Cusip */
+            cusip: string;
+            /** Direct Bidder Pct */
+            direct_bidder_pct?: number | null;
+            /** High Rate */
+            high_rate?: number | null;
+            /** Indirect Bidder Pct */
+            indirect_bidder_pct?: number | null;
             /** Issue Date */
             issue_date?: string | null;
             /** Offering Amount */
             offering_amount?: number | null;
-            /** High Rate */
-            high_rate?: number | null;
-            /** Bid To Cover */
-            bid_to_cover?: number | null;
-            /** Direct Bidder Pct */
-            direct_bidder_pct?: number | null;
-            /** Indirect Bidder Pct */
-            indirect_bidder_pct?: number | null;
             /** Primary Dealer Pct */
             primary_dealer_pct?: number | null;
-            /** Tail Indicator */
-            tail_indicator?: string | null;
+            /** Security Term */
+            security_term: string;
+            /** Security Type */
+            security_type: string;
             /** Source Url */
             source_url?: string | null;
             /**
@@ -4791,37 +4789,53 @@ export interface components {
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Tail Indicator */
+            tail_indicator?: string | null;
         };
         /** RatesSupplyPanel */
         RatesSupplyPanel: {
             /** Auctions */
             auctions?: components["schemas"]["RatesSummaryTile"][];
-            /** Recent Auctions */
-            recent_auctions?: components["schemas"]["RatesSupplyAuctionRow"][];
             /** Fiscal */
             fiscal?: components["schemas"]["RatesSummaryTile"][];
             /** Notes */
             notes?: string[];
-            /** Supply Read */
-            supply_read?: string | null;
+            /** Recent Auctions */
+            recent_auctions?: components["schemas"]["RatesSupplyAuctionRow"][];
             /**
              * Status
              * @default missing
              * @enum {string}
              */
             status: "ok" | "missing" | "partial" | "stale";
+            /** Supply Read */
+            supply_read?: string | null;
         };
         /** RatesSynthesisPanel */
         RatesSynthesisPanel: {
-            /** Duration View */
-            duration_view: string;
             /** Curve View */
             curve_view: string;
+            /** Duration View */
+            duration_view: string;
             /** Risks */
             risks?: string[];
         };
         /** RecordHealthCheck */
         RecordHealthCheck: {
+            /** Actual Rows */
+            actual_rows: number;
+            /** Actual Tickers */
+            actual_tickers: number;
+            /** Expected Min Rows */
+            expected_min_rows: number;
+            /** Expected Min Tickers */
+            expected_min_tickers: number;
+            /** Expected Tickers */
+            expected_tickers: number;
+            /** Latest At */
+            latest_at?: string | null;
+            /** Ok */
+            ok: boolean;
             /** Table */
             table: string;
             /**
@@ -4829,20 +4843,6 @@ export interface components {
              * Format: date-time
              */
             window_start: string;
-            /** Expected Tickers */
-            expected_tickers: number;
-            /** Expected Min Tickers */
-            expected_min_tickers: number;
-            /** Actual Tickers */
-            actual_tickers: number;
-            /** Expected Min Rows */
-            expected_min_rows: number;
-            /** Actual Rows */
-            actual_rows: number;
-            /** Latest At */
-            latest_at?: string | null;
-            /** Ok */
-            ok: boolean;
         };
         /**
          * RegimeLiveQuote
@@ -4861,14 +4861,14 @@ export interface components {
         };
         /** RegimeQuadrantBlock */
         RegimeQuadrantBlock: {
+            /** Cutoff Corr */
+            cutoff_corr?: string | null;
+            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
             /**
              * Points
              * @default []
              */
             points: components["schemas"]["RegimeQuadrantPoint"][];
-            latest?: components["schemas"]["RegimeQuadrantLatest"] | null;
-            /** Cutoff Corr */
-            cutoff_corr?: string | null;
         };
         /** RegimeQuadrantLatest */
         RegimeQuadrantLatest: {
@@ -4904,10 +4904,6 @@ export interface components {
          * @description Lightweight live-quote projection for the regime header strip.
          */
         RegimeQuotesResponse: {
-            /** Quotes */
-            quotes?: {
-                [key: string]: components["schemas"]["RegimeLiveQuote"];
-            };
             /** Active Source */
             active_source?: string | null;
             /** As Of */
@@ -4917,6 +4913,10 @@ export interface components {
              * @default 900
              */
             fresh_within_seconds: number;
+            /** Quotes */
+            quotes?: {
+                [key: string]: components["schemas"]["RegimeLiveQuote"];
+            };
         };
         /** RescanAllRequest */
         RescanAllRequest: {
@@ -4934,10 +4934,10 @@ export interface components {
         ReturnsBlock: {
             /** D1 */
             d1?: string | null;
-            /** W1 */
-            w1?: string | null;
             /** D30 */
             d30?: string | null;
+            /** W1 */
+            w1?: string | null;
         };
         /** RvCorrPoint */
         RvCorrPoint: {
@@ -4953,23 +4953,6 @@ export interface components {
         };
         /** ScannerCandidate */
         ScannerCandidate: {
-            /** Ticker */
-            ticker: string;
-            /** Spot */
-            spot: string | null;
-            /** Is Type F */
-            is_type_f: boolean;
-            /** Raw Score */
-            raw_score: string;
-            /** Confluence Score */
-            confluence_score: string;
-            /** Final Score */
-            final_score: string;
-            /** Hits */
-            hits: components["schemas"]["ScannerSignalHit"][];
-            /** Context Flags */
-            context_flags: components["schemas"]["ScannerContextFlag"][];
-            gates: components["schemas"]["ScannerGatesStatus"];
             /**
              * Bias
              * @enum {string}
@@ -4977,6 +4960,24 @@ export interface components {
             bias: "bullish" | "bearish" | "neutral" | "mixed";
             /** Bias Strength */
             bias_strength?: ("strong" | "moderate" | "weak") | null;
+            /** Confluence Score */
+            confluence_score: string;
+            /** Context Flags */
+            context_flags: components["schemas"]["ScannerContextFlag"][];
+            /** Final Score */
+            final_score: string;
+            gates: components["schemas"]["ScannerGatesStatus"];
+            /** Hits */
+            hits: components["schemas"]["ScannerSignalHit"][];
+            /** Is Type F */
+            is_type_f: boolean;
+            /** Raw Score */
+            raw_score: string;
+            /**
+             * Scanned At
+             * Format: date-time
+             */
+            scanned_at: string;
             /**
              * Setup
              * @enum {string}
@@ -4984,37 +4985,36 @@ export interface components {
             setup: "ready" | "caution" | "blocked";
             /** Setup Reason */
             setup_reason?: string | null;
-            /**
-             * Scanned At
-             * Format: date-time
-             */
-            scanned_at: string;
+            /** Spot */
+            spot: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** ScannerContextFlag */
         ScannerContextFlag: {
+            /** Label */
+            label: string;
             /**
              * Layer
              * @constant
              */
             layer: "pcr_sentiment";
-            /** Label */
-            label: string;
             /** Value */
             value: string | null;
         };
         /** ScannerGatedTicker */
         ScannerGatedTicker: {
-            /** Ticker */
-            ticker: string;
+            /** Blocking Chip */
+            blocking_chip?: ("SUSPENDED" | "DEGRADED") | null;
             /**
              * Reason
              * @enum {string}
              */
             reason: "regime_block" | "stale_scan";
-            /** Blocking Chip */
-            blocking_chip?: ("SUSPENDED" | "DEGRADED") | null;
             /** Scanned At */
             scanned_at: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** ScannerGatesStatus */
         ScannerGatesStatus: {
@@ -5036,12 +5036,10 @@ export interface components {
         };
         /** ScannerResponse */
         ScannerResponse: {
-            /** Scanned Universe Size */
-            scanned_universe_size: number;
-            /** Candidates With Hits */
-            candidates_with_hits: number;
             /** Candidates */
             candidates: components["schemas"]["ScannerCandidate"][];
+            /** Candidates With Hits */
+            candidates_with_hits: number;
             /** Gated */
             gated: components["schemas"]["ScannerGatedTicker"][];
             /**
@@ -5049,9 +5047,22 @@ export interface components {
              * Format: date-time
              */
             generated_at: string;
+            /** Scanned Universe Size */
+            scanned_universe_size: number;
         };
         /** ScannerSignalHit */
         ScannerSignalHit: {
+            /** Evidence */
+            evidence: {
+                [key: string]: unknown;
+            };
+            /**
+             * Freshness
+             * @enum {string}
+             */
+            freshness: "live" | "stale" | "unavailable";
+            /** Score */
+            score: string;
             /**
              * Signal Type
              * @enum {string}
@@ -5062,55 +5073,52 @@ export interface components {
              * @enum {integer}
              */
             tier: 1 | 2;
-            /** Score */
-            score: string;
-            /** Evidence */
-            evidence: {
-                [key: string]: unknown;
-            };
-            /**
-             * Freshness
-             * @enum {string}
-             */
-            freshness: "live" | "stale" | "unavailable";
         };
         /** SetupBlock */
         SetupBlock: {
-            /** Type */
-            type?: string | null;
             /** Direction */
             direction?: string | null;
             /** Score */
             score?: string | null;
+            /** Type */
+            type?: string | null;
         };
         /** SetupClassification */
         SetupClassification: {
-            /** Setup Type */
-            setup_type: string;
-            /** Label */
-            label: string;
-            /** Direction */
-            direction: string;
-            /** Score */
-            score: string;
             /**
              * Confirmations
              * @default []
              */
             confirmations: string[];
-            /**
-             * Warnings
-             * @default []
-             */
-            warnings: string[];
+            /** Direction */
+            direction: string;
+            /** Label */
+            label: string;
             /**
              * Notes
              * @default
              */
             notes: string;
+            /** Score */
+            score: string;
+            /** Setup Type */
+            setup_type: string;
+            /**
+             * Warnings
+             * @default []
+             */
+            warnings: string[];
         };
         /** ShortDataRow */
         ShortDataRow: {
+            /** Fee Rate */
+            fee_rate?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Rebate Rate */
+            rebate_rate?: string | null;
+            /** Short Shares Available */
+            short_shares_available?: number | null;
             /** Symbol */
             symbol: string;
             /**
@@ -5118,40 +5126,10 @@ export interface components {
              * Format: date-time
              */
             timestamp: string;
-            /** Name */
-            name?: string | null;
-            /** Short Shares Available */
-            short_shares_available?: number | null;
-            /** Fee Rate */
-            fee_rate?: string | null;
-            /** Rebate Rate */
-            rebate_rate?: string | null;
         };
         /** SingleStockReport */
         SingleStockReport: {
-            /** Run Id */
-            run_id: number;
-            /** Ticker */
-            ticker: string;
-            /**
-             * Generated At
-             * Format: date-time
-             */
-            generated_at: string;
-            /** Spot Quoted At */
-            spot_quoted_at?: string | null;
-            /** Spot Source */
-            spot_source?: string | null;
-            /**
-             * Short Int Note
-             * @default n/a (UW endpoint does not expose %)
-             */
-            short_int_note: string;
-            market_structure: components["schemas"]["MarketStructure"];
-            volatility: components["schemas"]["VolatilityProfile"];
-            flow: components["schemas"]["FlowSnapshot"];
-            vrp: components["schemas"]["VRPAssessment"];
-            setup?: components["schemas"]["SetupClassification"] | null;
+            aggregates?: components["schemas"]["MarketAggregates"] | null;
             /** Dark Pool Notional */
             dark_pool_notional?: string | null;
             /**
@@ -5159,184 +5137,206 @@ export interface components {
              * @default 0
              */
             dark_pool_print_count: number;
-            short_data?: components["schemas"]["ShortDataRow"] | null;
+            dealer_regime?: components["schemas"]["DealerRegime"] | null;
+            /**
+             * Exposures Summary
+             * @default []
+             */
+            exposures_summary: components["schemas"]["ExposuresSummaryRow"][];
+            flow: components["schemas"]["FlowSnapshot"];
+            /**
+             * Generated At
+             * Format: date-time
+             */
+            generated_at: string;
+            market_structure: components["schemas"]["MarketStructure"];
+            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
             /**
              * Max Pain Rows
              * @default []
              */
             max_pain_rows: components["schemas"]["MaxPainRow"][];
+            /** Next Earnings Date */
+            next_earnings_date?: string | null;
+            /**
+             * Oi Change Intraday Profiles
+             * @default []
+             */
+            oi_change_intraday_profiles: components["schemas"]["OptionIntradayProfile"][];
             /**
              * Oi Change Top
              * @default []
              */
             oi_change_top: components["schemas"]["OiChangeRow"][];
             /**
-             * Oi Change Intraday Profiles
+             * Option Chain Per Strike
              * @default []
              */
-            oi_change_intraday_profiles: components["schemas"]["OptionIntradayProfile"][];
-            aggregates?: components["schemas"]["MarketAggregates"] | null;
-            /**
-             * Strike Gex Curve
-             * @default []
-             */
-            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
-            market_structure_levels?: components["schemas"]["MarketStructureLevels"] | null;
+            option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
             /**
              * Options Timeline
              * @default []
              */
             options_timeline: components["schemas"]["OptionsDailyRow"][];
+            /** Run Id */
+            run_id: number;
+            setup?: components["schemas"]["SetupClassification"] | null;
+            short_data?: components["schemas"]["ShortDataRow"] | null;
             /**
-             * Option Chain Per Strike
-             * @default []
+             * Short Int Note
+             * @default n/a (UW endpoint does not expose %)
              */
-            option_chain_per_strike: components["schemas"]["OptionChainPerStrikeRow"][];
+            short_int_note: string;
+            /** Spot Quoted At */
+            spot_quoted_at?: string | null;
+            /** Spot Source */
+            spot_source?: string | null;
             /**
              * Strike Exposures
              * @default []
              */
             strike_exposures: components["schemas"]["StrikeExposureRow"][];
             /**
-             * Exposures Summary
+             * Strike Gex Curve
              * @default []
              */
-            exposures_summary: components["schemas"]["ExposuresSummaryRow"][];
-            /** Next Earnings Date */
-            next_earnings_date?: string | null;
-            dealer_regime?: components["schemas"]["DealerRegime"] | null;
+            strike_gex_curve: components["schemas"]["StrikeGexBucket"][];
+            /** Ticker */
+            ticker: string;
+            volatility: components["schemas"]["VolatilityProfile"];
+            vrp: components["schemas"]["VRPAssessment"];
         };
         /** SkewAnalysisResponse */
         SkewAnalysisResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * As Of
              * Format: date
              */
             as_of: string;
             /**
+             * Asset Class
+             * @default single_name
+             */
+            asset_class: string;
+            /** Back Rr */
+            back_rr?: string | null;
+            /**
              * Backfill Status
              * @default ready
              */
             backfill_status: string;
-            /** Spot */
-            spot?: string | null;
-            /** Rr 25D */
-            rr_25d?: string | null;
-            /** Rr Z 180D */
-            rr_z_180d?: string | null;
-            /** Rr Pct 252D */
-            rr_pct_252d?: string | null;
+            /** Borrow Fee Rate */
+            borrow_fee_rate?: string | null;
+            /**
+             * Borrow Flag
+             * @default unknown
+             */
+            borrow_flag: string;
+            /**
+             * Class Expected Sign
+             * @default mixed
+             */
+            class_expected_sign: string;
+            /** Days To Cover */
+            days_to_cover?: string | null;
             /**
              * Deviation Class
              * @default NORMAL
              */
             deviation_class: string;
             /**
-             * Skew Term Class
-             * @default flat
+             * Directional Lean
+             * @default NEUTRAL
              */
-            skew_term_class: string;
-            /** Front Rr */
-            front_rr?: string | null;
-            /** Back Rr */
-            back_rr?: string | null;
-            /** Rho Spotvol 63D */
-            rho_spotvol_63d?: string | null;
-            /** Rho Spotvol 21D */
-            rho_spotvol_21d?: string | null;
-            /** Rho Sign */
-            rho_sign?: number | null;
+            directional_lean: string;
             /**
              * Drive Class
              * @default STRUCTURAL
              */
             drive_class: string;
             /**
-             * Asset Class
-             * @default single_name
-             */
-            asset_class: string;
-            /**
-             * Class Expected Sign
-             * @default mixed
-             */
-            class_expected_sign: string;
-            /**
-             * Borrow Flag
-             * @default unknown
-             */
-            borrow_flag: string;
-            /** Borrow Fee Rate */
-            borrow_fee_rate?: string | null;
-            /** Days To Cover */
-            days_to_cover?: string | null;
-            /**
              * Earnings Gate
              * @default unknown
              */
             earnings_gate: string;
-            /**
-             * Regime
-             * @default UNKNOWN
-             */
-            regime: string;
-            /**
-             * Directional Lean
-             * @default NEUTRAL
-             */
-            directional_lean: string;
-            /**
-             * Lean Confidence
-             * @default low
-             */
-            lean_confidence: string;
-            /**
-             * Lean Basis
-             * @default
-             */
-            lean_basis: string;
-            /**
-             * @default {
-             *       "tail": "",
-             *       "rho_confirms": false,
-             *       "drive": "",
-             *       "deviation_class": "",
-             *       "class_context": "",
-             *       "borrow_context": "",
-             *       "earnings_gate": "",
-             *       "summary_line": "",
-             *       "summary_bullets": [],
-             *       "directional_lean": {
-             *         "basis": "",
-             *         "confidence": "low",
-             *         "express": "",
-             *         "lean": "NEUTRAL"
-             *       }
-             *     }
-             */
-            read: components["schemas"]["SkewRead"];
+            /** Front Rr */
+            front_rr?: string | null;
             /**
              * History
              * @default []
              */
             history: components["schemas"]["SkewHistoryPoint"][];
             /**
+             * Lean Basis
+             * @default
+             */
+            lean_basis: string;
+            /**
+             * Lean Confidence
+             * @default low
+             */
+            lean_confidence: string;
+            /**
+             * @default {
+             *       "borrow_context": "",
+             *       "class_context": "",
+             *       "deviation_class": "",
+             *       "directional_lean": {
+             *         "basis": "",
+             *         "confidence": "low",
+             *         "express": "",
+             *         "lean": "NEUTRAL"
+             *       },
+             *       "drive": "",
+             *       "earnings_gate": "",
+             *       "rho_confirms": false,
+             *       "summary_bullets": [],
+             *       "summary_line": "",
+             *       "tail": ""
+             *     }
+             */
+            read: components["schemas"]["SkewRead"];
+            /**
+             * Regime
+             * @default UNKNOWN
+             */
+            regime: string;
+            /**
              * Rho Series
              * @default []
              */
             rho_series: components["schemas"]["SkewRhoPoint"][];
+            /** Rho Sign */
+            rho_sign?: number | null;
+            /** Rho Spotvol 21D */
+            rho_spotvol_21d?: string | null;
+            /** Rho Spotvol 63D */
+            rho_spotvol_63d?: string | null;
+            /** Rr 25D */
+            rr_25d?: string | null;
+            /** Rr Pct 252D */
+            rr_pct_252d?: string | null;
+            /** Rr Z 180D */
+            rr_z_180d?: string | null;
             /**
-             * Term Structure
-             * @default []
+             * Skew Term Class
+             * @default flat
              */
-            term_structure: components["schemas"]["SkewExpiryPoint"][];
+            skew_term_class: string;
             /**
              * Smile
              * @default []
              */
             smile: components["schemas"]["SkewSmileExpiryCurve"][];
+            /** Spot */
+            spot?: string | null;
+            /**
+             * Term Structure
+             * @default []
+             */
+            term_structure: components["schemas"]["SkewExpiryPoint"][];
+            /** Ticker */
+            ticker: string;
         };
         /** SkewBlock */
         SkewBlock: {
@@ -5346,28 +5346,31 @@ export interface components {
         /** SkewDirectionalLean */
         SkewDirectionalLean: {
             /**
-             * Lean
-             * @default NEUTRAL
+             * Basis
+             * @default
              */
-            lean: string;
+            basis: string;
             /**
              * Confidence
              * @default low
              */
             confidence: string;
             /**
-             * Basis
-             * @default
-             */
-            basis: string;
-            /**
              * Express
              * @default
              */
             express: string;
+            /**
+             * Lean
+             * @default NEUTRAL
+             */
+            lean: string;
+            structure_detail?: components["schemas"]["SkewStructureDetail"] | null;
         };
         /** SkewExpiryPoint */
         SkewExpiryPoint: {
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
@@ -5375,8 +5378,6 @@ export interface components {
             expiry: string;
             /** Rr */
             rr?: string | null;
-            /** Dte */
-            dte?: number | null;
         };
         /** SkewHistoryPoint */
         SkewHistoryPoint: {
@@ -5385,20 +5386,49 @@ export interface components {
              * Format: date
              */
             date: string;
+            /** Pct */
+            pct?: string | null;
             /** Rr */
             rr?: string | null;
             /** Z */
             z?: string | null;
-            /** Pct */
-            pct?: string | null;
         };
         /** SkewRead */
         SkewRead: {
             /**
-             * Tail
+             * Borrow Context
              * @default
              */
-            tail: string;
+            borrow_context: string;
+            /**
+             * Class Context
+             * @default
+             */
+            class_context: string;
+            /**
+             * Deviation Class
+             * @default
+             */
+            deviation_class: string;
+            /**
+             * @default {
+             *       "basis": "",
+             *       "confidence": "low",
+             *       "express": "",
+             *       "lean": "NEUTRAL"
+             *     }
+             */
+            directional_lean: components["schemas"]["SkewDirectionalLean"];
+            /**
+             * Drive
+             * @default
+             */
+            drive: string;
+            /**
+             * Earnings Gate
+             * @default
+             */
+            earnings_gate: string;
             /** Rho */
             rho?: string | null;
             /**
@@ -5407,62 +5437,33 @@ export interface components {
              */
             rho_confirms: boolean;
             /**
-             * Drive
-             * @default
+             * Summary Bullets
+             * @default []
              */
-            drive: string;
-            /**
-             * Deviation Class
-             * @default
-             */
-            deviation_class: string;
-            /**
-             * Class Context
-             * @default
-             */
-            class_context: string;
-            /**
-             * Borrow Context
-             * @default
-             */
-            borrow_context: string;
-            /**
-             * Earnings Gate
-             * @default
-             */
-            earnings_gate: string;
+            summary_bullets: components["schemas"]["SkewReadBullet"][];
             /**
              * Summary Line
              * @default
              */
             summary_line: string;
             /**
-             * Summary Bullets
-             * @default []
+             * Tail
+             * @default
              */
-            summary_bullets: components["schemas"]["SkewReadBullet"][];
-            /**
-             * @default {
-             *       "lean": "NEUTRAL",
-             *       "confidence": "low",
-             *       "basis": "",
-             *       "express": ""
-             *     }
-             */
-            directional_lean: components["schemas"]["SkewDirectionalLean"];
+            tail: string;
         };
         /** SkewReadBullet */
         SkewReadBullet: {
-            /**
-             * Label
-             * @default
-             */
-            label: string;
             /**
              * Body
              * @default
              */
             body: string;
+            /**
+             * Label
+             * @default
+             */
+            label: string;
         };
         /** SkewRhoPoint */
         SkewRhoPoint: {
@@ -5489,10 +5490,58 @@ export interface components {
         };
         /** SkewSmilePoint */
         SkewSmilePoint: {
-            /** Strike */
-            strike: string;
             /** Iv */
             iv?: string | null;
+            /** Strike */
+            strike: string;
+        };
+        /** SkewStructureDetail */
+        SkewStructureDetail: {
+            /** Dte Target */
+            dte_target?: number | null;
+            /**
+             * Kind
+             * @default
+             */
+            kind: string;
+            /**
+             * Legs
+             * @default []
+             */
+            legs: components["schemas"]["SkewStructureLeg"][];
+            /**
+             * Note
+             * @default
+             */
+            note: string;
+            /**
+             * Status
+             * @default ready
+             */
+            status: string;
+        };
+        /** SkewStructureLeg */
+        SkewStructureLeg: {
+            /**
+             * Action
+             * @default
+             */
+            action: string;
+            /** Actual Delta */
+            actual_delta?: string | null;
+            /** Dte */
+            dte?: number | null;
+            /** Expiry */
+            expiry?: string | null;
+            /**
+             * Right
+             * @default
+             */
+            right: string;
+            /** Strike */
+            strike?: string | null;
+            /** Target Delta */
+            target_delta?: string | null;
         };
         /** SmileExpiryCurve */
         SmileExpiryCurve: {
@@ -5509,18 +5558,18 @@ export interface components {
         };
         /** SmilePoint */
         SmilePoint: {
-            /** Strike */
-            strike: string;
             /** Iv */
             iv?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** SourceReconciliation */
         SourceReconciliation: {
             /**
-             * Status
-             * @default UNKNOWN
+             * Decision
+             * @default Use deterministic data only where source agreement is understood.
              */
-            status: string;
+            decision: string;
             /**
              * Headline
              * @default Source reconciliation unavailable
@@ -5536,48 +5585,48 @@ export interface components {
              */
             rows: components["schemas"]["SourceReconciliationRow"][];
             /**
-             * Decision
-             * @default Use deterministic data only where source agreement is understood.
+             * Status
+             * @default UNKNOWN
              */
-            decision: string;
+            status: string;
         };
         /** SourceReconciliationRow */
         SourceReconciliationRow: {
-            /** Source Pair */
-            source_pair: string;
             /**
-             * Price Agreement
+             * Decision
              * @default
              */
-            price_agreement: string;
+            decision: string;
             /**
              * Iv Agreement
              * @default
              */
             iv_agreement: string;
+            /** Iv Diff */
+            iv_diff?: string | null;
             /**
-             * Decision
+             * Price Agreement
              * @default
              */
-            decision: string;
-            /** Strike */
-            strike?: string | null;
+            price_agreement: string;
             /** Source A Call Iv */
             source_a_call_iv?: string | null;
             /** Source B Call Iv */
             source_b_call_iv?: string | null;
-            /** Iv Diff */
-            iv_diff?: string | null;
+            /** Source Pair */
+            source_pair: string;
+            /** Strike */
+            strike?: string | null;
         };
         /** StockHistoryResponse */
         StockHistoryResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * Rows
              * @default []
              */
             rows: components["schemas"]["StockHistoryRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /**
          * StockHistoryRow
@@ -5589,27 +5638,27 @@ export interface components {
          */
         StockHistoryRow: {
             /**
-             * Market Date
-             * Format: date
-             */
-            market_date: string;
-            /** Spot */
-            spot?: string | null;
-            /** Gex Flip */
-            gex_flip?: string | null;
-            /** Net Gex */
-            net_gex?: string | null;
-            /** Net Dex */
-            net_dex?: string | null;
-            /** Iv30D */
-            iv30d?: string | null;
-            /** Pcr Vol */
-            pcr_vol?: string | null;
-            /**
              * Bias
              * @default NEUTRAL
              */
             bias: string;
+            /** Gex Flip */
+            gex_flip?: string | null;
+            /** Iv30D */
+            iv30d?: string | null;
+            /**
+             * Market Date
+             * Format: date
+             */
+            market_date: string;
+            /** Net Dex */
+            net_dex?: string | null;
+            /** Net Gex */
+            net_gex?: string | null;
+            /** Pcr Vol */
+            pcr_vol?: string | null;
+            /** Spot */
+            spot?: string | null;
         };
         /**
          * StrikeExposureRow
@@ -5618,31 +5667,31 @@ export interface components {
          *     Net + Call/Put curves without an extra fetch.
          */
         StrikeExposureRow: {
-            /** Strike */
-            strike: string;
+            /** Call Charm */
+            call_charm?: string | null;
+            /** Call Vanna */
+            call_vanna?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Call Vanna */
-            call_vanna?: string | null;
-            /** Put Vanna */
-            put_vanna?: string | null;
-            /** Call Charm */
-            call_charm?: string | null;
             /** Put Charm */
             put_charm?: string | null;
+            /** Put Vanna */
+            put_vanna?: string | null;
+            /** Strike */
+            strike: string;
         };
         /**
          * StrikeGexBucket
          * @description One row of the per-strike, per-expiry GEX curve persisted on each scan run.
          */
         StrikeGexBucket: {
-            /** Strike */
-            strike: string;
+            /** Call Gex */
+            call_gex?: string | null;
             /**
              * Expiry
              * Format: date
@@ -5650,26 +5699,26 @@ export interface components {
             expiry: string;
             /** Net Gex */
             net_gex?: string | null;
-            /** Call Gex */
-            call_gex?: string | null;
             /** Put Gex */
             put_gex?: string | null;
+            /** Strike */
+            strike: string;
         };
         /** TermMoveRow */
         TermMoveRow: {
+            /** Atm Straddle */
+            atm_straddle?: string | null;
+            /** Daily Implied Move Perc */
+            daily_implied_move_perc?: string | null;
+            /** Dte */
+            dte?: number | null;
             /**
              * Expiry
              * Format: date
              */
             expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /** Atm Straddle */
-            atm_straddle?: string | null;
             /** Implied Move Perc */
             implied_move_perc?: string | null;
-            /** Daily Implied Move Perc */
-            daily_implied_move_perc?: string | null;
             /**
              * Read
              * @default
@@ -5679,19 +5728,19 @@ export interface components {
         /** TermStructureExpiryRow */
         TermStructureExpiryRow: {
             /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
-            /** Dte */
-            dte?: number | null;
-            /**
              * By Strike
              * @default {}
              */
             by_strike: {
                 [key: string]: string;
             };
+            /** Dte */
+            dte?: number | null;
+            /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
             /**
              * Strikes
              * @default {}
@@ -5702,24 +5751,26 @@ export interface components {
         };
         /** TradeFramework */
         TradeFramework: {
-            header: components["schemas"]["TradeFrameworkHeader"];
-            three_axis: components["schemas"]["TradeFrameworkThreeAxis"];
-            gamma: components["schemas"]["TradeFrameworkGamma"];
-            catalyst: components["schemas"]["TradeFrameworkCatalyst"];
-            conviction: components["schemas"]["TradeFrameworkConviction"];
-            confluence: components["schemas"]["TradeFrameworkConfluence"];
-            /** Pitfalls */
-            pitfalls?: components["schemas"]["TradeFrameworkPitfall"][];
-            /** Candidates */
-            candidates?: components["schemas"]["TradeFrameworkCandidate"][];
             best_setup: components["schemas"]["TradeFrameworkBestSetup"];
-            /** What Changes */
-            what_changes?: components["schemas"]["TradeFrameworkWhatChanges"][];
             /** Bottom Line */
             bottom_line: string;
+            /** Candidates */
+            candidates?: components["schemas"]["TradeFrameworkCandidate"][];
+            catalyst: components["schemas"]["TradeFrameworkCatalyst"];
+            confluence: components["schemas"]["TradeFrameworkConfluence"];
+            conviction: components["schemas"]["TradeFrameworkConviction"];
+            gamma: components["schemas"]["TradeFrameworkGamma"];
+            header: components["schemas"]["TradeFrameworkHeader"];
+            /** Pitfalls */
+            pitfalls?: components["schemas"]["TradeFrameworkPitfall"][];
+            three_axis: components["schemas"]["TradeFrameworkThreeAxis"];
+            /** What Changes */
+            what_changes?: components["schemas"]["TradeFrameworkWhatChanges"][];
         };
         /** TradeFrameworkAsymmetry */
         TradeFrameworkAsymmetry: {
+            /** Prose */
+            prose: string;
             /** Rule On */
             rule_on: boolean;
             /**
@@ -5727,63 +5778,61 @@ export interface components {
              * @enum {string}
              */
             structure_family: "directional_defined_risk" | "pin_vega";
-            /** Prose */
-            prose: string;
         };
         /** TradeFrameworkBestSetup */
         TradeFrameworkBestSetup: {
-            /** Structure */
-            structure: string;
-            /** Legs */
-            legs?: string[];
             /** Cost */
             cost?: string | null;
+            /** Invalidation */
+            invalidation: string;
+            /** Legs */
+            legs?: string[];
             /** Max Risk */
             max_risk?: string | null;
             /** Rationale */
             rationale: string;
+            /** Structure */
+            structure: string;
             /**
              * Why Not Alternatives
              * @default
              */
             why_not_alternatives: string;
-            /** Invalidation */
-            invalidation: string;
         };
         /** TradeFrameworkCandidate */
         TradeFrameworkCandidate: {
-            /** Name */
-            name: string;
-            /** Legs */
-            legs?: string[];
             /** Debit Credit */
             debit_credit?: string | null;
+            /** Defined Risk */
+            defined_risk: boolean;
+            /** Legs */
+            legs?: string[];
+            /** Name */
+            name: string;
             /** Net Delta */
             net_delta?: string | null;
             /** Net Vega */
             net_vega?: string | null;
-            /** Pnl Bull */
-            pnl_bull?: string | null;
             /** Pnl Base */
             pnl_base?: string | null;
             /** Pnl Bear */
             pnl_bear?: string | null;
-            /** Defined Risk */
-            defined_risk: boolean;
+            /** Pnl Bull */
+            pnl_bull?: string | null;
         };
         /** TradeFrameworkCatalyst */
         TradeFrameworkCatalyst: {
-            /** Next Er Date */
-            next_er_date?: string | null;
             /** Dte To Er */
             dte_to_er?: number | null;
-            /** Implied Move */
-            implied_move?: string | null;
             /**
              * Handling
              * @enum {string}
              */
             handling: "no_conflict" | "exit_before_print" | "stand_aside" | "hold_through_leaps";
+            /** Implied Move */
+            implied_move?: string | null;
+            /** Next Er Date */
+            next_er_date?: string | null;
             /** Prose */
             prose: string;
         };
@@ -5791,18 +5840,16 @@ export interface components {
         TradeFrameworkConfluence: {
             /** Aligned */
             aligned: boolean;
-            /** Signals */
-            signals?: components["schemas"]["TradeFrameworkSignal"][];
             /**
              * Prose
              * @default
              */
             prose: string;
+            /** Signals */
+            signals?: components["schemas"]["TradeFrameworkSignal"][];
         };
         /** TradeFrameworkConviction */
         TradeFrameworkConviction: {
-            /** Score */
-            score: number;
             /** Factors */
             factors: components["schemas"]["TradeFrameworkFactor"][];
             /**
@@ -5810,52 +5857,54 @@ export interface components {
              * @default
              */
             prose: string;
+            /** Score */
+            score: number;
         };
         /** TradeFrameworkDirection */
         TradeFrameworkDirection: {
+            /** Prose */
+            prose: string;
             /**
              * Verdict
              * @enum {string}
              */
             verdict: "bull" | "bear" | "neutral";
-            /** Prose */
-            prose: string;
         };
         /** TradeFrameworkFactor */
         TradeFrameworkFactor: {
             /** Name */
             name: string;
             /**
-             * Status
-             * @enum {string}
-             */
-            status: "yes" | "no" | "na";
-            /**
              * Note
              * @default
              */
             note: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "yes" | "no" | "na";
         };
         /** TradeFrameworkGamma */
         TradeFrameworkGamma: {
+            /** Call Wall */
+            call_wall?: string | null;
+            /** Flip Strike */
+            flip_strike?: string | null;
+            /** Prose */
+            prose: string;
+            /** Put Wall */
+            put_wall?: string | null;
             /**
              * Regime
              * @enum {string}
              */
             regime: "short" | "long";
-            /** Flip Strike */
-            flip_strike?: string | null;
-            /** Call Wall */
-            call_wall?: string | null;
-            /** Put Wall */
-            put_wall?: string | null;
-            /** Prose */
-            prose: string;
         };
         /** TradeFrameworkHeader */
         TradeFrameworkHeader: {
-            /** Thesis One Liner */
-            thesis_one_liner: string;
+            /** Conviction N */
+            conviction_n: number;
             /**
              * Position Type
              * @enum {string}
@@ -5863,56 +5912,56 @@ export interface components {
             position_type: "swing" | "leaps" | "stand_aside";
             /** Spot */
             spot?: string | null;
-            /** Conviction N */
-            conviction_n: number;
+            /** Thesis One Liner */
+            thesis_one_liner: string;
         };
         /** TradeFrameworkPitfall */
         TradeFrameworkPitfall: {
             /** Id */
             id: string;
-            /** Title */
-            title: string;
-            /** Triggered */
-            triggered: boolean;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Title */
+            title: string;
+            /** Triggered */
+            triggered: boolean;
         };
         /** TradeFrameworkSignal */
         TradeFrameworkSignal: {
-            /** Name */
-            name: string;
             /** Direction */
             direction: string;
+            /** Name */
+            name: string;
         };
         /** TradeFrameworkThreeAxis */
         TradeFrameworkThreeAxis: {
+            asymmetry: components["schemas"]["TradeFrameworkAsymmetry"];
             direction: components["schemas"]["TradeFrameworkDirection"];
             vega: components["schemas"]["TradeFrameworkVega"];
-            asymmetry: components["schemas"]["TradeFrameworkAsymmetry"];
         };
         /** TradeFrameworkVega */
         TradeFrameworkVega: {
+            /** Ivr */
+            ivr?: string | null;
+            /** Prose */
+            prose: string;
             /**
              * Regime
              * @enum {string}
              */
             regime: "event_iv" | "demand_iv" | "low_iv";
-            /** Ivr */
-            ivr?: string | null;
             /** Term Slope */
             term_slope?: string | null;
-            /** Prose */
-            prose: string;
         };
         /** TradeFrameworkWhatChanges */
         TradeFrameworkWhatChanges: {
-            /** Signal */
-            signal: string;
             /** Effect */
             effect: string;
+            /** Signal */
+            signal: string;
         };
         /**
          * TradeInsightAiAnalysisEnqueueResponse
@@ -5939,50 +5988,50 @@ export interface components {
              * Format: uuid
              */
             analysis_id: string;
-            /** Ticker */
-            ticker: string;
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
+            /** Error Message */
+            error_message?: string | null;
+            /** Finished At */
+            finished_at?: string | null;
+            /** Markdown */
+            markdown?: string | null;
             /** Model */
             model: string;
+            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
+            /** Produced At */
+            produced_at?: string | null;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Provider
              * @default codex
              * @enum {string}
              */
             provider: "codex" | "claude" | "deepseek";
-            /** Prompt Version */
-            prompt_version: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "queued" | "running" | "succeeded" | "failed";
-            /** Produced At */
-            produced_at?: string | null;
-            outcome?: components["schemas"]["TradeInsightAiOutcome"] | null;
-            /** Markdown */
-            markdown?: string | null;
-            /** Error Message */
-            error_message?: string | null;
             /**
              * Requested At
              * Format: date-time
              */
             requested_at: string;
-            /** Started At */
-            started_at?: string | null;
-            /** Finished At */
-            finished_at?: string | null;
             /**
              * Reused
              * @default false
              */
             reused: boolean;
+            /** Run Id */
+            run_id: number;
+            /** Started At */
+            started_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Ticker */
+            ticker: string;
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /**
          * TradeInsightAiAnalysisStub
@@ -5990,24 +6039,24 @@ export interface components {
          */
         TradeInsightAiAnalysisStub: {
             /**
-             * Provider
-             * @enum {string}
-             */
-            provider: "codex" | "claude" | "deepseek";
-            /**
              * Analysis Id
              * Format: uuid
              */
             analysis_id: string;
+            /** Model */
+            model: string;
+            /**
+             * Provider
+             * @enum {string}
+             */
+            provider: "codex" | "claude" | "deepseek";
+            /** Reused */
+            reused: boolean;
             /**
              * Status
              * @enum {string}
              */
             status: "queued" | "running" | "succeeded" | "failed";
-            /** Reused */
-            reused: boolean;
-            /** Model */
-            model: string;
         };
         /**
          * TradeInsightAiAntiPin
@@ -6022,26 +6071,10 @@ export interface components {
          */
         TradeInsightAiAntiPin: {
             /**
-             * Invoked
-             * @default false
+             * Cap Reason
+             * @default
              */
-            invoked: boolean;
-            /**
-             * Direction
-             * @default none
-             * @enum {string}
-             */
-            direction: "upside" | "downside" | "none";
-            /**
-             * Score
-             * @default 0
-             */
-            score: number;
-            /**
-             * Max Score
-             * @default 4
-             */
-            max_score: number;
+            cap_reason: string;
             /** Conditions Met */
             conditions_met?: string[];
             /**
@@ -6050,86 +6083,112 @@ export interface components {
              */
             conviction_cap_applied: boolean;
             /**
-             * Cap Reason
-             * @default
+             * Direction
+             * @default none
+             * @enum {string}
              */
-            cap_reason: string;
+            direction: "upside" | "downside" | "none";
+            /**
+             * Invoked
+             * @default false
+             */
+            invoked: boolean;
+            /**
+             * Max Score
+             * @default 4
+             */
+            max_score: number;
+            /**
+             * Score
+             * @default 0
+             */
+            score: number;
         };
         /** TradeInsightAiBestExpression */
         TradeInsightAiBestExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Role */
-            role: string;
-            /** Why */
-            why: string;
             /** Caveats */
             caveats?: string[];
-            /** Status Observed */
-            status_observed: string;
+            /** Idea Id */
+            idea_id: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Role */
+            role: string;
+            /** Status Observed */
+            status_observed: string;
+            /** Structure */
+            structure: string;
+            /** Why */
+            why: string;
         };
         /** TradeInsightAiConflict */
         TradeInsightAiConflict: {
+            /** Affected Idea Ids */
+            affected_idea_ids?: string[];
+            /** Description */
+            description: string;
             /** Lens */
             lens: string;
             /** Severity */
             severity: string;
-            /** Description */
-            description: string;
-            /** Affected Idea Ids */
-            affected_idea_ids?: string[];
         };
         /** TradeInsightAiDominantRead */
         TradeInsightAiDominantRead: {
-            /** Headline */
-            headline: string;
-            /** Summary */
-            summary: string;
             /** Confidence Commentary */
             confidence_commentary: string;
             /** Data Quality Commentary */
             data_quality_commentary: string;
+            /** Headline */
+            headline: string;
+            /** Summary */
+            summary: string;
         };
         /** TradeInsightAiGuardrails */
         TradeInsightAiGuardrails: {
-            /** Statuses Preserved */
-            statuses_preserved: boolean;
-            /** Risk Flags Preserved */
-            risk_flags_preserved: boolean;
             /** No Executable Recommendations */
             no_executable_recommendations: boolean;
+            /** Risk Flags Preserved */
+            risk_flags_preserved: boolean;
+            /** Statuses Preserved */
+            statuses_preserved: boolean;
         };
         /** TradeInsightAiHeadline */
         TradeInsightAiHeadline: {
-            /**
-             * Trade Intent
-             * @enum {string}
-             */
-            trade_intent: "directional_swing" | "range_income";
+            /** Conviction */
+            conviction: string;
+            /** Conviction Label */
+            conviction_label: string;
             /**
              * Directional Bias
              * @enum {string}
              */
             directional_bias: "LONG_DELTA" | "SHORT_DELTA" | "WAIT";
             /**
-             * Entry State
-             * @enum {string}
-             */
-            entry_state: "ACTIVE" | "CONDITIONAL" | "NO_ENTRY";
-            /**
-             * Underlying Path
-             * @enum {string}
-             */
-            underlying_path: "bullish_continuation" | "bearish_rejection" | "downside_break" | "pinned_no_directional_entry" | "data_insufficient";
-            /**
              * Dte Band
              * @enum {string}
              */
             dte_band: "momentum" | "standard" | "trend";
+            /**
+             * Entry State
+             * @enum {string}
+             */
+            entry_state: "ACTIVE" | "CONDITIONAL" | "NO_ENTRY";
+            /** Primary Risk */
+            primary_risk: string;
+            /** Score */
+            score: number;
+            /**
+             * Score Scale
+             * @default 100
+             */
+            score_scale: number;
+            /**
+             * Stance
+             * @enum {string}
+             */
+            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
+            /** Stance Label */
+            stance_label: string;
             /**
              * Thesis Archetype
              * @default data_insufficient
@@ -6138,28 +6197,18 @@ export interface components {
             thesis_archetype: "resistance_rejection" | "support_breakdown" | "breakout_continuation" | "pin_no_trade" | "data_insufficient";
             /** Title */
             title: string;
-            /**
-             * Stance
-             * @enum {string}
-             */
-            stance: "bullish" | "bearish" | "neutral" | "mixed" | "wait";
-            /** Stance Label */
-            stance_label: string;
-            /** Score */
-            score: number;
-            /**
-             * Score Scale
-             * @default 100
-             */
-            score_scale: number;
-            /** Conviction */
-            conviction: string;
-            /** Conviction Label */
-            conviction_label: string;
             /** Top Reason */
             top_reason: string;
-            /** Primary Risk */
-            primary_risk: string;
+            /**
+             * Trade Intent
+             * @enum {string}
+             */
+            trade_intent: "directional_swing" | "range_income";
+            /**
+             * Underlying Path
+             * @enum {string}
+             */
+            underlying_path: "bullish_continuation" | "bearish_rejection" | "downside_break" | "pinned_no_directional_entry" | "data_insufficient";
             /** Watch Trigger */
             watch_trigger: string;
         };
@@ -6167,15 +6216,15 @@ export interface components {
         TradeInsightAiHighlight: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /**
          * TradeInsightAiLatestPair
@@ -6195,54 +6244,54 @@ export interface components {
          *     follow-up PR adds a [DeepSeek] tab.
          */
         TradeInsightAiLatestPair: {
-            /** Current Prompt Version */
-            current_prompt_version: string;
+            claude?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
+            codex?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
             /** Current Prompt Label */
             current_prompt_label?: string | null;
-            codex?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
-            claude?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
+            /** Current Prompt Version */
+            current_prompt_version: string;
             deepseek?: components["schemas"]["TradeInsightAiAnalysisResponse"] | null;
             provider_consensus?: components["schemas"]["TradeInsightAiProviderConsensus"];
         };
         /** TradeInsightAiLevel */
         TradeInsightAiLevel: {
-            /** Price */
-            price: string;
-            /** Kind */
-            kind: string;
-            /** Value */
-            value: string;
             /**
              * Importance
              * @default normal
              */
             importance: string;
-            /** Source Path */
-            source_path?: string | null;
+            /** Kind */
+            kind: string;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Price */
+            price: string;
+            /** Source Path */
+            source_path?: string | null;
+            /** Value */
+            value: string;
         };
         /** TradeInsightAiMetricCard */
         TradeInsightAiMetricCard: {
             /** Label */
             label: string;
-            /** Value */
-            value: string;
-            /**
-             * Tone
-             * @default neutral
-             */
-            tone: string;
-            /** Source Path */
-            source_path?: string | null;
             /**
              * Note
              * @default
              */
             note: string;
+            /** Source Path */
+            source_path?: string | null;
+            /**
+             * Tone
+             * @default neutral
+             */
+            tone: string;
+            /** Value */
+            value: string;
         };
         /**
          * TradeInsightAiOptionLeg
@@ -6263,6 +6312,11 @@ export interface components {
          */
         TradeInsightAiOptionLeg: {
             /**
+             * Expiry
+             * Format: date
+             */
+            expiry: string;
+            /**
              * Option Type
              * @enum {string}
              */
@@ -6274,101 +6328,96 @@ export interface components {
             side: "long" | "short";
             /** Strike */
             strike: string;
-            /**
-             * Expiry
-             * Format: date
-             */
-            expiry: string;
         };
         /** TradeInsightAiOutcome */
         TradeInsightAiOutcome: {
-            /** Schema Version */
-            schema_version: string;
             /**
              * Analysis Produced At
              * Format: date-time
              */
             analysis_produced_at: string;
-            /** Ticker */
-            ticker: string;
-            /** Underlying Price */
-            underlying_price?: string | null;
-            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
-            headline: components["schemas"]["TradeInsightAiHeadline"];
-            /** Metric Cards */
-            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
-            /** Scenario Cards */
-            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
-            /** Score Breakdown */
-            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
-            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
-            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
-            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
-            trigger_evidence?: components["schemas"]["TradeInsightAiTriggerEvidence"];
             anti_pin?: components["schemas"]["TradeInsightAiAntiPin"];
-            target_feasibility?: components["schemas"]["TradeInsightAiTargetFeasibility"];
-            thesis_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            entry_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            invalidation?: components["schemas"]["TradeInsightAiTriggerComponent"];
-            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
             /** Best Expressions */
             best_expressions?: components["schemas"]["TradeInsightAiBestExpression"][];
             /** Conflicts */
             conflicts?: components["schemas"]["TradeInsightAiConflict"][];
-            /** Required Checks */
-            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
-            /** Rejected Ideas */
-            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
+            dominant_read: components["schemas"]["TradeInsightAiDominantRead"];
+            entry_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            framework?: components["schemas"]["TradeFramework"] | null;
+            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
+            headline: components["schemas"]["TradeInsightAiHeadline"];
+            invalidation?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            /** Metric Cards */
+            metric_cards: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Missing Data */
             missing_data?: string[];
+            preferred_expression?: components["schemas"]["TradeInsightAiPreferredExpression"] | null;
+            /** Rejected Ideas */
+            rejected_ideas?: components["schemas"]["TradeInsightAiRejectedIdea"][];
             rendering: components["schemas"]["TradeInsightAiRendering"];
-            guardrails: components["schemas"]["TradeInsightAiGuardrails"];
-            framework?: components["schemas"]["TradeFramework"] | null;
+            /** Required Checks */
+            required_checks?: components["schemas"]["TradeInsightAiRequiredCheck"][];
+            /** Scenario Cards */
+            scenario_cards: components["schemas"]["TradeInsightAiScenarioCard"][];
+            /** Schema Version */
+            schema_version: string;
+            /** Score Breakdown */
+            score_breakdown: components["schemas"]["TradeInsightAiScoreBreakdown"][];
+            section_cards: components["schemas"]["TradeInsightAiSectionCards"];
+            snapshot: components["schemas"]["TradeInsightAiSnapshotMeta"];
+            target_feasibility?: components["schemas"]["TradeInsightAiTargetFeasibility"];
+            thesis_trigger?: components["schemas"]["TradeInsightAiTriggerComponent"];
+            /** Ticker */
+            ticker: string;
+            trigger_evidence?: components["schemas"]["TradeInsightAiTriggerEvidence"];
+            /** Underlying Price */
+            underlying_price?: string | null;
+            vrp_assessment?: components["schemas"]["TradeInsightAiVrpAssessment"] | null;
         };
         /** TradeInsightAiPreferredExpression */
         TradeInsightAiPreferredExpression: {
-            /** Idea Id */
-            idea_id: string;
-            /** Structure */
-            structure: string;
-            /** Title */
-            title: string;
-            /**
-             * Subtitle
-             * @default
-             */
-            subtitle: string;
             /**
              * Estimated Entry
              * @default
              */
             estimated_entry: string;
-            /**
-             * Max Profit Observed
-             * @default
-             */
-            max_profit_observed: string;
+            /** Idea Id */
+            idea_id: string;
+            /** Legs */
+            legs?: components["schemas"]["TradeInsightAiOptionLeg"][];
+            /** Management Notes */
+            management_notes?: string[];
             /**
              * Max Loss Observed
              * @default
              */
             max_loss_observed: string;
             /**
+             * Max Profit Observed
+             * @default
+             */
+            max_profit_observed: string;
+            /**
              * Reward Risk
              * @default
              */
             reward_risk: string;
-            /** Why */
-            why: string;
-            /** Management Notes */
-            management_notes?: string[];
-            /** Status Observed */
-            status_observed: string;
             /** Risk Flags Observed */
             risk_flags_observed?: string[];
+            /** Status Observed */
+            status_observed: string;
             strike_role?: components["schemas"]["TradeInsightAiStrikeRole"];
-            /** Legs */
-            legs?: components["schemas"]["TradeInsightAiOptionLeg"][];
+            /** Structure */
+            structure: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            subtitle: string;
+            /** Title */
+            title: string;
+            /** Why */
+            why: string;
         };
         /**
          * TradeInsightAiPriorRow
@@ -6380,33 +6429,33 @@ export interface components {
          *     no outcomes have resolved yet.
          */
         TradeInsightAiPriorRow: {
+            /** Directional Bias */
+            directional_bias?: string | null;
+            /** Entry State */
+            entry_state?: string | null;
+            /** Expired No Resolution Count */
+            expired_no_resolution_count: number;
+            /** Hit Rate Pct */
+            hit_rate_pct?: string | null;
+            /** Invalidation Hit Count */
+            invalidation_hit_count: number;
+            /** Median Days To Resolution */
+            median_days_to_resolution?: string | null;
+            /** Pending Count */
+            pending_count: number;
+            /** Prompt Version */
+            prompt_version: string;
             /**
              * Provider
              * @enum {string}
              */
             provider: "codex" | "claude" | "deepseek";
-            /** Prompt Version */
-            prompt_version: string;
-            /** Thesis Archetype */
-            thesis_archetype?: string | null;
-            /** Directional Bias */
-            directional_bias?: string | null;
-            /** Entry State */
-            entry_state?: string | null;
             /** Sample Count */
             sample_count: number;
             /** Target Hit Count */
             target_hit_count: number;
-            /** Invalidation Hit Count */
-            invalidation_hit_count: number;
-            /** Pending Count */
-            pending_count: number;
-            /** Expired No Resolution Count */
-            expired_no_resolution_count: number;
-            /** Hit Rate Pct */
-            hit_rate_pct?: string | null;
-            /** Median Days To Resolution */
-            median_days_to_resolution?: string | null;
+            /** Thesis Archetype */
+            thesis_archetype?: string | null;
         };
         /**
          * TradeInsightAiPriorsResponse
@@ -6428,15 +6477,26 @@ export interface components {
          */
         TradeInsightAiProviderConsensus: {
             /**
+             * Actionable Disagreement
+             * @default
+             */
+            actionable_disagreement: string;
+            /**
              * Bias Agreement
              * @default false
              */
             bias_agreement: boolean;
             /**
-             * Structure Agreement
+             * Consensus Grade
+             * @default missing
+             * @enum {string}
+             */
+            consensus_grade: "full" | "partial" | "divergent" | "missing";
+            /**
+             * Dte Band Agreement
              * @default false
              */
-            structure_agreement: boolean;
+            dte_band_agreement: boolean;
             /**
              * Entry State Agreement
              * @default false
@@ -6448,49 +6508,38 @@ export interface components {
              */
             path_agreement: boolean;
             /**
-             * Dte Band Agreement
+             * Structure Agreement
              * @default false
              */
-            dte_band_agreement: boolean;
-            /**
-             * Consensus Grade
-             * @default missing
-             * @enum {string}
-             */
-            consensus_grade: "full" | "partial" | "divergent" | "missing";
-            /**
-             * Actionable Disagreement
-             * @default
-             */
-            actionable_disagreement: string;
+            structure_agreement: boolean;
         };
         /** TradeInsightAiRejectedIdea */
         TradeInsightAiRejectedIdea: {
             /** Idea Id */
             idea_id: string;
-            /** Structure */
-            structure: string;
             /** Reason */
             reason: string;
+            /** Structure */
+            structure: string;
         };
         /** TradeInsightAiRendering */
         TradeInsightAiRendering: {
-            /** Disclaimer */
-            disclaimer: string;
             /** Card Order */
             card_order?: string[];
+            /** Disclaimer */
+            disclaimer: string;
         };
         /** TradeInsightAiRequiredCheck */
         TradeInsightAiRequiredCheck: {
-            /** Check */
-            check: string;
-            /** Reason */
-            reason: string;
             /**
              * Blocks Sizing
              * @default true
              */
             blocks_sizing: boolean;
+            /** Check */
+            check: string;
+            /** Reason */
+            reason: string;
             /**
              * Source
              * @default
@@ -6501,59 +6550,55 @@ export interface components {
         TradeInsightAiScenarioCard: {
             /** Case */
             case: ("upside" | "base" | "downside") | string;
+            /** Description */
+            description: string;
+            /** Title */
+            title: string;
             /**
              * Tone
              * @default neutral
              */
             tone: string;
-            /** Title */
-            title: string;
-            /** Description */
-            description: string;
         };
         /** TradeInsightAiScoreBreakdown */
         TradeInsightAiScoreBreakdown: {
-            /** Section */
-            section: string;
-            /** Score */
-            score: number;
             /** Max Score */
             max_score: number;
+            /** Score */
+            score: number;
+            /** Section */
+            section: string;
             /** Summary */
             summary: string;
         };
         /** TradeInsightAiSectionCard */
         TradeInsightAiSectionCard: {
-            /** Title */
-            title: string;
-            /** Score */
-            score?: number | null;
-            /** Max Score */
-            max_score?: number | null;
-            /** Summary */
-            summary: string;
-            /** Highlights */
-            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
-            /** Levels */
-            levels?: components["schemas"]["TradeInsightAiLevel"][];
             /**
              * Data Quality
              * @default unknown
              */
             data_quality: string;
+            /** Highlights */
+            highlights?: components["schemas"]["TradeInsightAiHighlight"][];
+            /** Levels */
+            levels?: components["schemas"]["TradeInsightAiLevel"][];
+            /** Max Score */
+            max_score?: number | null;
+            /** Score */
+            score?: number | null;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightAiSectionCards */
         TradeInsightAiSectionCards: {
+            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
             market_structure: components["schemas"]["TradeInsightAiSectionCard"];
             volatility: components["schemas"]["TradeInsightAiSectionCard"];
-            flow_positioning: components["schemas"]["TradeInsightAiSectionCard"];
         };
         /** TradeInsightAiSnapshotMeta */
         TradeInsightAiSnapshotMeta: {
-            /** Run Id */
-            run_id: number;
-            /** Trade Insights Input Hash */
-            trade_insights_input_hash: string;
             /** Analysis Input Hash */
             analysis_input_hash: string;
             /** Data As Of */
@@ -6563,8 +6608,12 @@ export interface components {
              * @default unknown
              */
             freshness_label: string;
+            /** Run Id */
+            run_id: number;
             /** Source Notes */
             source_notes?: string[];
+            /** Trade Insights Input Hash */
+            trade_insights_input_hash: string;
         };
         /**
          * TradeInsightAiStrikeRole
@@ -6579,6 +6628,13 @@ export interface components {
          *     level to a specific key in the deterministic payload.
          */
         TradeInsightAiStrikeRole: {
+            /** Invalid Level */
+            invalid_level?: string | null;
+            /**
+             * Invalid Source Path
+             * @default
+             */
+            invalid_source_path: string;
             /**
              * Long Leg Role
              * @default n/a
@@ -6591,27 +6647,20 @@ export interface components {
              * @enum {string}
              */
             short_leg_role: "target_level" | "next_call_wall" | "second_magnet" | "next_put_wall" | "next_downside_target" | "n/a";
-            /** Trigger Level */
-            trigger_level?: string | null;
             /** Target Level */
             target_level?: string | null;
-            /** Invalid Level */
-            invalid_level?: string | null;
-            /**
-             * Trigger Source Path
-             * @default
-             */
-            trigger_source_path: string;
             /**
              * Target Source Path
              * @default
              */
             target_source_path: string;
+            /** Trigger Level */
+            trigger_level?: string | null;
             /**
-             * Invalid Source Path
+             * Trigger Source Path
              * @default
              */
-            invalid_source_path: string;
+            trigger_source_path: string;
         };
         /**
          * TradeInsightAiTargetFeasibility
@@ -6663,6 +6712,15 @@ export interface components {
          *     against their own evidence rules.
          */
         TradeInsightAiTriggerComponent: {
+            /** Evidence Close */
+            evidence_close?: string | null;
+            /** Evidence Date */
+            evidence_date?: string | null;
+            /**
+             * Fired
+             * @default false
+             */
+            fired: boolean;
             /** Level */
             level?: string | null;
             /**
@@ -6670,15 +6728,6 @@ export interface components {
              * @default
              */
             meaning: string;
-            /**
-             * Fired
-             * @default false
-             */
-            fired: boolean;
-            /** Evidence Close */
-            evidence_close?: string | null;
-            /** Evidence Date */
-            evidence_date?: string | null;
             /**
              * Source Path
              * @default
@@ -6701,19 +6750,6 @@ export interface components {
          *     the validator rejects (or auto-downgrades) to CONDITIONAL.
          */
         TradeInsightAiTriggerEvidence: {
-            /**
-             * Trigger Fired
-             * @default false
-             */
-            trigger_fired: boolean;
-            /**
-             * Trigger Type
-             * @default unknown
-             * @enum {string}
-             */
-            trigger_type: "daily_close" | "two_session_hold" | "unknown";
-            /** Trigger Level */
-            trigger_level?: string | null;
             /** Evidence Close */
             evidence_close?: string | null;
             /** Evidence Close Date */
@@ -6723,24 +6759,37 @@ export interface components {
              * @default
              */
             source_path: string;
+            /**
+             * Trigger Fired
+             * @default false
+             */
+            trigger_fired: boolean;
+            /** Trigger Level */
+            trigger_level?: string | null;
+            /**
+             * Trigger Type
+             * @default unknown
+             * @enum {string}
+             */
+            trigger_type: "daily_close" | "two_session_hold" | "unknown";
         };
         /** TradeInsightAiVrpAssessment */
         TradeInsightAiVrpAssessment: {
-            /** Signal */
-            signal: string;
-            /** Title */
-            title: string;
-            /** Summary */
-            summary: string;
             /** Metrics */
             metrics?: components["schemas"]["TradeInsightAiMetricCard"][];
             /** Reason */
             reason: string;
+            /** Signal */
+            signal: string;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
         };
         /** TradeInsightsAiHealth */
         TradeInsightsAiHealth: {
-            codex: components["schemas"]["TradeInsightsAiProviderHealth"];
             claude: components["schemas"]["TradeInsightsAiProviderHealth"];
+            codex: components["schemas"]["TradeInsightsAiProviderHealth"];
             deepseek: components["schemas"]["TradeInsightsAiProviderHealth"];
         };
         /**
@@ -6748,27 +6797,22 @@ export interface components {
          * @description Per-provider AI worker pool status.
          */
         TradeInsightsAiProviderHealth: {
+            /** Last Beat At */
+            last_beat_at?: string | null;
+            /** Queued Depth */
+            queued_depth: number;
             /** Workers Expected */
             workers_expected: number;
             /** Workers Healthy */
             workers_healthy: number;
-            /** Queued Depth */
-            queued_depth: number;
-            /** Last Beat At */
-            last_beat_at?: string | null;
         };
         /** TradeInsightsHeader */
         TradeInsightsHeader: {
             /**
-             * Dominant Bias
-             * @default NEUTRAL
+             * Badges
+             * @default []
              */
-            dominant_bias: string;
-            /**
-             * Primary Setup
-             * @default NO_CLEAR_SETUP
-             */
-            primary_setup: string;
+            badges: components["schemas"]["InsightBadge"][];
             /**
              * Confidence Label
              * @default LOW
@@ -6780,6 +6824,11 @@ export interface components {
              */
             data_quality_label: string;
             /**
+             * Dominant Bias
+             * @default NEUTRAL
+             */
+            dominant_bias: string;
+            /**
              * Idea Count
              * @default 0
              */
@@ -6787,101 +6836,106 @@ export interface components {
             /** Preferred Idea Id */
             preferred_idea_id?: string | null;
             /**
-             * Badges
-             * @default []
+             * Primary Setup
+             * @default NO_CLEAR_SETUP
              */
-            badges: components["schemas"]["InsightBadge"][];
+            primary_setup: string;
         };
         /** TradeInsightsResponse */
         TradeInsightsResponse: {
-            /** Ticker */
-            ticker: string;
             /** As Of */
             as_of?: string | null;
-            /**
-             * Mode
-             * @default research
-             */
-            mode: string;
-            header: components["schemas"]["TradeInsightsHeader"];
-            /**
-             * @default {
-             *       "status": "UNKNOWN",
-             *       "headline": "Source reconciliation unavailable",
-             *       "rows": [],
-             *       "decision": "Use deterministic data only where source agreement is understood."
-             *     }
-             */
-            source_reconciliation: components["schemas"]["SourceReconciliation"];
-            /**
-             * Signal Stack
-             * @default []
-             */
-            signal_stack: components["schemas"]["InsightSignalRow"][];
-            /**
-             * Flow Table
-             * @default []
-             */
-            flow_table: components["schemas"]["ChainFlowReadRow"][];
-            /**
-             * Term Structure Table
-             * @default []
-             */
-            term_structure_table: components["schemas"]["TermMoveRow"][];
             /**
              * Candidate Structures
              * @default []
              */
             candidate_structures: components["schemas"]["CandidateStructure"][];
             /**
+             * Flow Table
+             * @default []
+             */
+            flow_table: components["schemas"]["ChainFlowReadRow"][];
+            header: components["schemas"]["TradeInsightsHeader"];
+            /**
+             * Mode
+             * @default research
+             */
+            mode: string;
+            /**
+             * Signal Stack
+             * @default []
+             */
+            signal_stack: components["schemas"]["InsightSignalRow"][];
+            /**
              * @default {
-             *       "dominant_story": "",
+             *       "decision": "Use deterministic data only where source agreement is understood.",
+             *       "headline": "Source reconciliation unavailable",
+             *       "rows": [],
+             *       "status": "UNKNOWN"
+             *     }
+             */
+            source_reconciliation: components["schemas"]["SourceReconciliation"];
+            /**
+             * @default {
              *       "avoid": [],
+             *       "dominant_story": "",
              *       "required_before_sizing": []
              *     }
              */
             synthesis: components["schemas"]["InsightsSynthesis"];
+            /**
+             * Term Structure Table
+             * @default []
+             */
+            term_structure_table: components["schemas"]["TermMoveRow"][];
+            /** Ticker */
+            ticker: string;
         };
         /** VRPAssessment */
         VRPAssessment: {
-            /** Vrp */
-            vrp?: string | null;
-            /** Signal */
-            signal: string;
             /** Note */
             note: string;
+            /** Signal */
+            signal: string;
+            /** Vrp */
+            vrp?: string | null;
         };
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
         };
         /**
          * ValidationResponse
          * @description Combined warm-store backtest + OOS notebook summary.
          */
         ValidationResponse: {
-            /** Backtest Md */
-            backtest_md: string;
             /** Backtest Csv Rows */
             backtest_csv_rows: number;
+            /** Backtest Md */
+            backtest_md: string;
             oos?: components["schemas"]["OosSummary"] | null;
         };
         /** VcgAttribution */
         VcgAttribution: {
             /**
-             * Vvix Pct
+             * Model Implied
              * @default 0
              */
-            vvix_pct: number;
+            model_implied: number;
+            /**
+             * Vix Component
+             * @default 0
+             */
+            vix_component: number;
             /**
              * Vix Pct
              * @default 0
@@ -6893,41 +6947,36 @@ export interface components {
              */
             vvix_component: number;
             /**
-             * Vix Component
+             * Vvix Pct
              * @default 0
              */
-            vix_component: number;
-            /**
-             * Model Implied
-             * @default 0
-             */
-            model_implied: number;
+            vvix_pct: number;
         };
         /** VcgDailyEntry */
         VcgDailyEntry: {
+            /** Beta1 */
+            beta1?: number | null;
+            /** Beta2 */
+            beta2?: number | null;
+            /** Credit 5D Return Pct */
+            credit_5d_return_pct?: number | null;
+            /** Credit Price */
+            credit_price?: number | null;
             /**
              * Date
              * Format: date
              */
             date: string;
+            /** Residual */
+            residual?: number | null;
             /** Vcg */
             vcg?: number | null;
             /** Vcg Adj */
             vcg_adj?: number | null;
-            /** Residual */
-            residual?: number | null;
-            /** Credit Price */
-            credit_price?: number | null;
-            /** Credit 5D Return Pct */
-            credit_5d_return_pct?: number | null;
             /** Vix */
             vix?: number | null;
             /** Vvix */
             vvix?: number | null;
-            /** Beta1 */
-            beta1?: number | null;
-            /** Beta2 */
-            beta2?: number | null;
         };
         /** VcgDailyHistoryResponse */
         VcgDailyHistoryResponse: {
@@ -6941,18 +6990,40 @@ export interface components {
         };
         /** VcgHistoryEntry */
         VcgHistoryEntry: {
-            /** Date */
-            date: string;
-            /** Residual */
-            residual?: number | null;
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Beta1 */
             beta1?: number | null;
             /** Beta2 */
             beta2?: number | null;
+            /**
+             * Bounce
+             * @default 0
+             */
+            bounce: number;
+            /**
+             * Credit
+             * @default 0
+             */
+            credit: number;
+            /** Date */
+            date: string;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /** Residual */
+            residual?: number | null;
+            /**
+             * Ro
+             * @default 0
+             */
+            ro: number;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
             /**
              * Vix
              * @default 0
@@ -6963,28 +7034,6 @@ export interface components {
              * @default 0
              */
             vvix: number;
-            /**
-             * Credit
-             * @default 0
-             */
-            credit: number;
-            /**
-             * Ro
-             * @default 0
-             */
-            ro: number;
-            /**
-             * Edr
-             * @default 0
-             */
-            edr: number;
-            /** Tier */
-            tier?: number | null;
-            /**
-             * Bounce
-             * @default 0
-             */
-            bounce: number;
         };
         /** VcgInterpretationCount */
         VcgInterpretationCount: {
@@ -6997,6 +7046,16 @@ export interface components {
         };
         /** VcgIntradayPoint */
         VcgIntradayPoint: {
+            /** Beta1 */
+            beta1?: number | null;
+            /** Beta2 */
+            beta2?: number | null;
+            /** Credit 5D Return Pct */
+            credit_5d_return_pct?: number | null;
+            /** Credit Price */
+            credit_price?: number | null;
+            /** Residual */
+            residual?: number | null;
             /**
              * Ts
              * Format: date-time
@@ -7006,23 +7065,15 @@ export interface components {
             vcg?: number | null;
             /** Vcg Adj */
             vcg_adj?: number | null;
-            /** Residual */
-            residual?: number | null;
-            /** Credit Price */
-            credit_price?: number | null;
-            /** Credit 5D Return Pct */
-            credit_5d_return_pct?: number | null;
             /** Vix */
             vix?: number | null;
             /** Vvix */
             vvix?: number | null;
-            /** Beta1 */
-            beta1?: number | null;
-            /** Beta2 */
-            beta2?: number | null;
         };
         /** VcgIntradayResponse */
         VcgIntradayResponse: {
+            /** As Of */
+            as_of?: string | null;
             /**
              * Credit Proxy
              * @default HYG
@@ -7030,8 +7081,6 @@ export interface components {
             credit_proxy: string;
             /** Sessions */
             sessions?: components["schemas"]["VcgIntradaySession"][];
-            /** As Of */
-            as_of?: string | null;
         };
         /** VcgIntradaySession */
         VcgIntradaySession: {
@@ -7045,41 +7094,41 @@ export interface components {
         };
         /** VcgLiveResponse */
         VcgLiveResponse: {
-            /**
-             * Status
-             * @default empty
-             * @enum {string}
-             */
-            status: "ok" | "empty";
-            /**
-             * Scan Time
-             * @default
-             */
-            scan_time: string;
-            /** Date */
-            date?: string | null;
-            /**
-             * Credit Proxy
-             * @default HYG
-             */
-            credit_proxy: string;
-            signal?: components["schemas"]["VcgSignal"];
-            /** History */
-            history?: components["schemas"]["VcgHistoryEntry"][];
+            /** Active Source */
+            active_source?: string | null;
             /**
              * Basis
              * @default eod
              * @enum {string}
              */
             basis: "live" | "eod";
+            /** Carried Forward */
+            carried_forward?: string[];
+            /**
+             * Credit Proxy
+             * @default HYG
+             */
+            credit_proxy: string;
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["VcgHistoryEntry"][];
             /** Live Quotes */
             live_quotes?: {
                 [key: string]: components["schemas"]["RegimeLiveQuote"];
             };
-            /** Carried Forward */
-            carried_forward?: string[];
-            /** Active Source */
-            active_source?: string | null;
+            /**
+             * Scan Time
+             * @default
+             */
+            scan_time: string;
+            signal?: components["schemas"]["VcgSignal"];
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
         };
         /** VcgNamedCrashEvent */
         VcgNamedCrashEvent: {
@@ -7095,20 +7144,20 @@ export interface components {
          * @description One row of the ±5d named-crash window for a single event.
          */
         VcgNamedCrashOffset: {
-            /** Offset Days */
-            offset_days: number;
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Beta1 */
             beta1?: number | null;
             /** Beta2 */
             beta2?: number | null;
-            /** Sign Ok */
-            sign_ok?: boolean | null;
             /** Interpretation */
             interpretation?: string | null;
+            /** Offset Days */
+            offset_days: number;
+            /** Sign Ok */
+            sign_ok?: boolean | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
         };
         /**
          * VcgResponse
@@ -7116,26 +7165,26 @@ export interface components {
          */
         VcgResponse: {
             /**
-             * Status
-             * @default empty
-             * @enum {string}
+             * Credit Proxy
+             * @default HYG
              */
-            status: "ok" | "empty";
+            credit_proxy: string;
+            /** Date */
+            date?: string | null;
+            /** History */
+            history?: components["schemas"]["VcgHistoryEntry"][];
             /**
              * Scan Time
              * @default
              */
             scan_time: string;
-            /** Date */
-            date?: string | null;
-            /**
-             * Credit Proxy
-             * @default HYG
-             */
-            credit_proxy: string;
             signal?: components["schemas"]["VcgSignal"];
-            /** History */
-            history?: components["schemas"]["VcgHistoryEntry"][];
+            /**
+             * Status
+             * @default empty
+             * @enum {string}
+             */
+            status: "ok" | "empty";
         };
         /**
          * VcgScanResponse
@@ -7143,11 +7192,14 @@ export interface components {
          */
         VcgScanResponse: {
             /**
-             * Status
-             * @default ok
-             * @enum {string}
+             * Proxy
+             * @default HYG
              */
-            status: "ok" | "skipped";
+            proxy: string;
+            /** Reason */
+            reason?: string | null;
+            /** Row Id */
+            row_id?: number | null;
             /**
              * Scanner
              * @default vcg
@@ -7155,82 +7207,47 @@ export interface components {
              */
             scanner: "vcg";
             /**
-             * Proxy
-             * @default HYG
+             * Status
+             * @default ok
+             * @enum {string}
              */
-            proxy: string;
-            /** Row Id */
-            row_id?: number | null;
-            /** Reason */
-            reason?: string | null;
+            status: "ok" | "skipped";
         };
         /** VcgSignal */
         VcgSignal: {
-            /** Vcg */
-            vcg?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
-            /** Residual */
-            residual?: number | null;
+            /** Alpha */
+            alpha?: number | null;
+            attribution?: components["schemas"]["VcgAttribution"];
             /** Beta1 Vvix */
             beta1_vvix?: number | null;
             /** Beta2 Vix */
             beta2_vix?: number | null;
-            /** Alpha */
-            alpha?: number | null;
-            /**
-             * Vix
-             * @default 0
-             */
-            vix: number;
-            /**
-             * Vvix
-             * @default 0
-             */
-            vvix: number;
-            /**
-             * Credit Price
-             * @default 0
-             */
-            credit_price: number;
-            /**
-             * Credit 5D Return Pct
-             * @default 0
-             */
-            credit_5d_return_pct: number;
-            /**
-             * Ro
-             * @default 0
-             */
-            ro: number;
-            /**
-             * Edr
-             * @default 0
-             */
-            edr: number;
-            /** Tier */
-            tier?: number | null;
             /**
              * Bounce
              * @default 0
              */
             bounce: number;
             /**
-             * Vvix Severity
-             * @default moderate
+             * Credit 5D Return Pct
+             * @default 0
+             */
+            credit_5d_return_pct: number;
+            /**
+             * Credit Price
+             * @default 0
+             */
+            credit_price: number;
+            /**
+             * Edr
+             * @default 0
+             */
+            edr: number;
+            /**
+             * Interpretation
+             * @default NORMAL
              * @enum {string}
              */
-            vvix_severity: "extreme" | "elevated" | "moderate";
-            /**
-             * Sign Ok
-             * @default true
-             */
-            sign_ok: boolean;
-            /**
-             * Sign Suppressed
-             * @default false
-             */
-            sign_suppressed: boolean;
+            interpretation: "RISK_OFF" | "EDR" | "WATCH" | "BOUNCE" | "NORMAL" | "SUPPRESSED" | "PANIC" | "INSUFFICIENT_DATA";
             /**
              * Pi Panic
              * @default 0
@@ -7242,23 +7259,55 @@ export interface components {
              * @enum {string}
              */
             regime: "PANIC" | "TRANSITION" | "DIVERGENCE";
+            /** Residual */
+            residual?: number | null;
             /**
-             * Interpretation
-             * @default NORMAL
-             * @enum {string}
+             * Ro
+             * @default 0
              */
-            interpretation: "RISK_OFF" | "EDR" | "WATCH" | "BOUNCE" | "NORMAL" | "SUPPRESSED" | "PANIC" | "INSUFFICIENT_DATA";
+            ro: number;
+            /**
+             * Sign Ok
+             * @default true
+             */
+            sign_ok: boolean;
+            /**
+             * Sign Suppressed
+             * @default false
+             */
+            sign_suppressed: boolean;
+            /** Tier */
+            tier?: number | null;
+            /** Vcg */
+            vcg?: number | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
+            /**
+             * Vix
+             * @default 0
+             */
+            vix: number;
             /**
              * Vix Percentile Rank
              * @description VIX level's 252-day rolling percentile rank (strict_lt tie rule). Used by the v2 absolute-vol-stress override gate. None during the 252-bar warmup or for v=1 payloads.
              */
             vix_percentile_rank?: number | null;
             /**
+             * Vvix
+             * @default 0
+             */
+            vvix: number;
+            /**
              * Vvix Percentile Rank
              * @description VVIX level's 252-day rolling percentile rank (strict_lt tie rule). Used by the v2 absolute-vol-stress override gate.
              */
             vvix_percentile_rank?: number | null;
-            attribution?: components["schemas"]["VcgAttribution"];
+            /**
+             * Vvix Severity
+             * @default moderate
+             * @enum {string}
+             */
+            vvix_severity: "extreme" | "elevated" | "moderate";
         };
         /**
          * VcgStressHistoryEntry
@@ -7269,33 +7318,33 @@ export interface components {
         VcgStressHistoryEntry: {
             /** Date */
             date: string;
+            /** Fwd 20D Pct */
+            fwd_20d_pct?: number | null;
+            /** Fwd 5D Pct */
+            fwd_5d_pct?: number | null;
+            /** Fwd 60D Pct */
+            fwd_60d_pct?: number | null;
             /**
              * Interpretation
              * @enum {string}
              */
             interpretation: "PANIC" | "RISK_OFF" | "EDR";
-            /** Score */
-            score?: number | null;
-            /** Vcg Adj */
-            vcg_adj?: number | null;
             /** Pi Panic */
             pi_panic?: number | null;
+            /** Score */
+            score?: number | null;
             /** Sign Ok */
             sign_ok?: boolean | null;
+            /** Vcg Adj */
+            vcg_adj?: number | null;
             /** Vix */
             vix?: number | null;
-            /** Vvix */
-            vvix?: number | null;
             /** Vix Percentile Rank */
             vix_percentile_rank?: number | null;
+            /** Vvix */
+            vvix?: number | null;
             /** Vvix Percentile Rank */
             vvix_percentile_rank?: number | null;
-            /** Fwd 5D Pct */
-            fwd_5d_pct?: number | null;
-            /** Fwd 20D Pct */
-            fwd_20d_pct?: number | null;
-            /** Fwd 60D Pct */
-            fwd_60d_pct?: number | null;
         };
         /**
          * VcgStressHistorySummary
@@ -7316,14 +7365,14 @@ export interface components {
              * @enum {string}
              */
             interpretation: "PANIC" | "RISK_OFF" | "EDR";
-            /** N */
-            n: number;
-            /** Mean Fwd 5D Pct */
-            mean_fwd_5d_pct?: number | null;
             /** Mean Fwd 20D Pct */
             mean_fwd_20d_pct?: number | null;
+            /** Mean Fwd 5D Pct */
+            mean_fwd_5d_pct?: number | null;
             /** Mean Fwd 60D Pct */
             mean_fwd_60d_pct?: number | null;
+            /** N */
+            n: number;
             /** Winrate 20D Pct */
             winrate_20d_pct?: number | null;
             /** Winrate 60D Pct */
@@ -7336,14 +7385,14 @@ export interface components {
         VcgValidationResponse: {
             /** Backtest Md */
             backtest_md: string;
-            /** N Days */
-            n_days: number;
             /** Composite Version */
             composite_version: string;
             /** Credit Proxy */
             credit_proxy: string;
             /** Interpretation Distribution */
             interpretation_distribution: components["schemas"]["VcgInterpretationCount"][];
+            /** N Days */
+            n_days: number;
             /** Named Crash Window */
             named_crash_window: components["schemas"]["VcgNamedCrashEvent"][];
             /**
@@ -7355,19 +7404,21 @@ export interface components {
         };
         /** VolBackdropPoint */
         VolBackdropPoint: {
+            /** Close */
+            close: number;
             /**
              * Date
              * Format: date
              */
             date: string;
-            /** Close */
-            close: number;
         };
         /**
          * VolBackdropResponse
          * @description Vol-complex time series + VIX term-structure (regime page header strip).
          */
         VolBackdropResponse: {
+            /** As Of */
+            as_of?: string | null;
             /** Series */
             series?: {
                 [key: string]: components["schemas"]["VolBackdropPoint"][];
@@ -7376,68 +7427,66 @@ export interface components {
             term_structure_ratio?: number | null;
             /** Term Structure State */
             term_structure_state?: string | null;
-            /** As Of */
-            as_of?: string | null;
         };
         /** VolHeaderBlock */
         VolHeaderBlock: {
+            /** Implied Move 30D Perc */
+            implied_move_30d_perc?: string | null;
             /** Iv */
             iv?: string | null;
-            /** Rv */
-            rv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
             /** Iv Rank */
             iv_rank?: string | null;
             /** Iv Rank 1Y */
             iv_rank_1y?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
+            /** Rv */
+            rv?: string | null;
             /** Rv High 52W */
             rv_high_52w?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
-            /** Implied Move 30D Perc */
-            implied_move_30d_perc?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /** Vrp */
             vrp?: string | null;
             /**
-             * Vrp Signal
-             * @default
-             */
-            vrp_signal: string;
-            /**
              * Vrp Note
              * @default
              */
             vrp_note: string;
+            /**
+             * Vrp Signal
+             * @default
+             */
+            vrp_signal: string;
         };
         /** VolatilityProfile */
         VolatilityProfile: {
-            /** Iv */
-            iv?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Iv Low 52W */
-            iv_low_52w?: string | null;
-            /** Iv High 52W */
-            iv_high_52w?: string | null;
-            /** Rv */
-            rv?: string | null;
-            /** Rv Low 52W */
-            rv_low_52w?: string | null;
-            /** Rv High 52W */
-            rv_high_52w?: string | null;
-            /** Iv Rank 1Y */
-            iv_rank_1y?: string | null;
-            /** Iv Percentile 30D */
-            iv_percentile_30d?: string | null;
             /** Implied Move 30D Perc */
             implied_move_30d_perc?: string | null;
+            /** Iv */
+            iv?: string | null;
+            /** Iv High 52W */
+            iv_high_52w?: string | null;
+            /** Iv Low 52W */
+            iv_low_52w?: string | null;
+            /** Iv Percentile 30D */
+            iv_percentile_30d?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Iv Rank 1Y */
+            iv_rank_1y?: string | null;
+            /** Rv */
+            rv?: string | null;
+            /** Rv High 52W */
+            rv_high_52w?: string | null;
+            /** Rv Low 52W */
+            rv_low_52w?: string | null;
             /** Skew 25D */
             skew_25d?: string | null;
             /**
@@ -7451,8 +7500,6 @@ export interface components {
         };
         /** VolatilitySeriesResponse */
         VolatilitySeriesResponse: {
-            /** Ticker */
-            ticker: string;
             /**
              * As Of
              * Format: date
@@ -7460,44 +7507,6 @@ export interface components {
             as_of: string;
             /** Backfill Status */
             backfill_status: string;
-            header: components["schemas"]["VolHeaderBlock"];
-            /**
-             * Term Structure
-             * @default []
-             */
-            term_structure: components["schemas"]["TermStructureExpiryRow"][];
-            /**
-             * Smile
-             * @default []
-             */
-            smile: components["schemas"]["SmileExpiryCurve"][];
-            /**
-             * Hv Iv History
-             * @default []
-             */
-            hv_iv_history: components["schemas"]["IvHvPoint"][];
-            /**
-             * @default {
-             *       "bins": []
-             *     }
-             */
-            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
-            /**
-             * Iv Of Iv
-             * @default []
-             */
-            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
-            /**
-             * Rv Spy Corr
-             * @default []
-             */
-            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
-            /**
-             * @default {
-             *       "points": []
-             *     }
-             */
-            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
             /**
              * Divergence
              * @default []
@@ -7508,6 +7517,48 @@ export interface components {
              * @default
              */
             divergence_headline: string;
+            header: components["schemas"]["VolHeaderBlock"];
+            /**
+             * Hv Iv History
+             * @default []
+             */
+            hv_iv_history: components["schemas"]["IvHvPoint"][];
+            /**
+             * Iv Of Iv
+             * @default []
+             */
+            iv_of_iv: components["schemas"]["IvOfIvPoint"][];
+            /**
+             * @default {
+             *       "bins": []
+             *     }
+             */
+            iv_percentile_distribution: components["schemas"]["IvPercentileDistribution"];
+            /**
+             * @default {
+             *       "points": []
+             *     }
+             */
+            regime_quadrant: components["schemas"]["RegimeQuadrantBlock"];
+            /**
+             * Rv Spy Corr
+             * @default []
+             */
+            rv_spy_corr: components["schemas"]["RvCorrPoint"][];
+            /**
+             * Smile
+             * @default []
+             */
+            smile: components["schemas"]["SmileExpiryCurve"][];
+            /** Spot */
+            spot?: string | null;
+            /**
+             * Term Structure
+             * @default []
+             */
+            term_structure: components["schemas"]["TermStructureExpiryRow"][];
+            /** Ticker */
+            ticker: string;
             /**
              * Vrp Spread
              * @default []
@@ -7518,8 +7569,6 @@ export interface components {
              * @default
              */
             vrp_spread_headline: string;
-            /** Spot */
-            spot?: string | null;
         };
         /** VrpDailyPoint */
         VrpDailyPoint: {
@@ -7535,12 +7584,28 @@ export interface components {
         };
         /** WatchlistCard */
         WatchlistCard: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
+            /** Aggression Pct */
+            aggression_pct?: string | null;
+            /** Aum */
+            aum?: string | null;
+            gamma: components["schemas"]["GammaBlock"];
+            /** Iv Atm */
+            iv_atm?: string | null;
+            /** Iv Rank */
+            iv_rank?: string | null;
+            /** Market Cap */
+            market_cap?: string | null;
             /** Pinned */
             pinned: boolean;
+            positioning: components["schemas"]["PositioningBlock"];
+            queue?: components["schemas"]["QueueStatus"] | null;
+            returns: components["schemas"]["ReturnsBlock"];
+            /** Scanned At */
+            scanned_at?: string | null;
+            /** Sector */
+            sector: string;
+            setup: components["schemas"]["SetupBlock"];
+            skew: components["schemas"]["SkewBlock"];
             /** Sort Rank */
             sort_rank: number;
             /** Spot */
@@ -7549,31 +7614,11 @@ export interface components {
             spot_quoted_at?: string | null;
             /** Spot Source */
             spot_source?: string | null;
-            /** Scanned At */
-            scanned_at?: string | null;
-            /** Iv Atm */
-            iv_atm?: string | null;
-            /** Iv Rank */
-            iv_rank?: string | null;
-            /** Market Cap */
-            market_cap?: string | null;
-            /** Aum */
-            aum?: string | null;
-            setup: components["schemas"]["SetupBlock"];
-            /** Aggression Pct */
-            aggression_pct?: string | null;
-            returns: components["schemas"]["ReturnsBlock"];
-            gamma: components["schemas"]["GammaBlock"];
-            skew: components["schemas"]["SkewBlock"];
-            positioning: components["schemas"]["PositioningBlock"];
-            queue?: components["schemas"]["QueueStatus"] | null;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistMutation */
         WatchlistMutation: {
-            /** Ticker */
-            ticker: string;
-            /** Sector */
-            sector: string;
             /** Notes */
             notes?: string | null;
             /**
@@ -7581,32 +7626,36 @@ export interface components {
              * @default false
              */
             pinned: boolean;
+            /** Sector */
+            sector: string;
             /**
              * Sort Rank
              * @default 0
              */
             sort_rank: number;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistPatch */
         WatchlistPatch: {
-            /** Sector */
-            sector?: string | null;
             /** Notes */
             notes?: string | null;
             /** Pinned */
             pinned?: boolean | null;
+            /** Sector */
+            sector?: string | null;
             /** Sort Rank */
             sort_rank?: number | null;
         };
         /** WatchlistResponse */
         WatchlistResponse: {
-            /** Scanned At Min */
-            scanned_at_min?: string | null;
+            queue?: components["schemas"]["QueueSummary"];
             /** Scanned At Max */
             scanned_at_max?: string | null;
+            /** Scanned At Min */
+            scanned_at_min?: string | null;
             /** Scheduler Lag Seconds */
             scheduler_lag_seconds?: number | null;
-            queue?: components["schemas"]["QueueSummary"];
             /** Tickers */
             tickers: components["schemas"]["WatchlistCard"][];
         };
@@ -7616,14 +7665,14 @@ export interface components {
          *     writes spot every ~1s; this projection avoids the full dashboard join.
          */
         WatchlistSpot: {
-            /** Ticker */
-            ticker: string;
             /** Spot */
             spot?: string | null;
             /** Spot Quoted At */
             spot_quoted_at?: string | null;
             /** Spot Source */
             spot_source?: string | null;
+            /** Ticker */
+            ticker: string;
         };
         /** WatchlistSpotsResponse */
         WatchlistSpotsResponse: {
@@ -7632,21 +7681,21 @@ export interface components {
         };
         /** WorkerHealth */
         WorkerHealth: {
+            /** Heartbeat Name */
+            heartbeat_name: string;
+            /** Index */
+            index: number;
             /** Label */
             label: string;
+            /** Lag Seconds */
+            lag_seconds?: number | null;
+            /** Last Beat At */
+            last_beat_at?: string | null;
             /**
              * Role
              * @enum {string}
              */
             role: "uw" | "massive" | "ai";
-            /** Index */
-            index: number;
-            /** Heartbeat Name */
-            heartbeat_name: string;
-            /** Lag Seconds */
-            lag_seconds?: number | null;
-            /** Last Beat At */
-            last_beat_at?: string | null;
         };
         /**
          * WsConsumerHealth
@@ -7663,43 +7712,43 @@ export interface components {
          *     displays under the row.
          */
         WsConsumerHealth: {
+            /** Active Source */
+            active_source?: string | null;
+            /** Connection Started At */
+            connection_started_at?: string | null;
             /** Healthy */
             healthy: boolean;
-            /** Last Tick At */
-            last_tick_at?: string | null;
-            /** Last Tick Age Seconds */
-            last_tick_age_seconds?: number | null;
+            /** Last Error */
+            last_error?: string | null;
             /** Last Flush At */
             last_flush_at?: string | null;
-            /**
-             * Ticks Received
-             * @default 0
-             */
-            ticks_received: number;
+            /** Last Tick Age Seconds */
+            last_tick_age_seconds?: number | null;
+            /** Last Tick At */
+            last_tick_at?: string | null;
+            /** Reason */
+            reason?: string | null;
             /**
              * Ticks Flushed
              * @default 0
              */
             ticks_flushed: number;
-            /** Connection Started At */
-            connection_started_at?: string | null;
-            /** Last Error */
-            last_error?: string | null;
-            /** Active Source */
-            active_source?: string | null;
-            /** Reason */
-            reason?: string | null;
+            /**
+             * Ticks Received
+             * @default 0
+             */
+            ticks_received: number;
         };
         /** GexLevel */
         uw_scan__api__schemas__GexLevel: {
-            /** Strike */
-            strike?: number | null;
-            /** Gamma */
-            gamma?: number | null;
             /** Distance */
             distance?: number | null;
             /** Distance Pct */
             distance_pct?: number | null;
+            /** Gamma */
+            gamma?: number | null;
+            /** Strike */
+            strike?: number | null;
         };
         /**
          * GexLevel
@@ -7709,14 +7758,14 @@ export interface components {
          *     figure on the tile — the dollar value of dealer hedging triggered by a $1 move.
          */
         uw_scan__models__GexLevel: {
-            /** Strike */
-            strike: string;
+            /** Gamma Per Dollar */
+            gamma_per_dollar?: string | null;
             /** Net Gex */
             net_gex?: string | null;
             /** Pct From Spot */
             pct_from_spot?: string | null;
-            /** Gamma Per Dollar */
-            gamma_per_dollar?: string | null;
+            /** Strike */
+            strike: string;
         };
     };
     responses: never;
@@ -7727,6 +7776,308 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitDealerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitFlowImResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_state_api_cockpit__ticker__state_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_surface_api_cockpit__ticker__surface_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
+        parameters: {
+            query?: {
+                asof?: string | null;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CockpitVrpResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gauge_api_gold_gauge_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldGaugeResponse"];
+                };
+            };
+        };
+    };
+    get_input_series_api_gold_inputs__series_id__get: {
+        parameters: {
+            query?: {
+                from?: string | null;
+                to?: string | null;
+            };
+            header?: never;
+            path: {
+                series_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldInputSeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_lens_api_gold_lenses__lens_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                lens_id: "structural" | "cyclical" | "valuation";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldLensResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_replay_api_gold_replay_get: {
+        parameters: {
+            query: {
+                /** @description Reconstruct posture for this obs_date */
+                as_of: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_state_api_gold_state_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GoldStateResponse"];
+                };
+            };
+        };
+    };
     health_api_health_get: {
         parameters: {
             query?: {
@@ -7812,13 +8163,855 @@ export interface operations {
             };
         };
     };
-    get_watchlist_api_watchlist_get: {
+    get_job_api_jobs__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ohlc_api_ohlc__ticker__get: {
         parameters: {
             query?: {
+                days?: number;
+            };
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OhlcRow"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_endpoints_api_provider_usage_endpoints_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_requests_api_provider_usage_requests_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+                ticker?: string | null;
+                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_summary_api_provider_usage_summary_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    provider_usage_tickers_api_provider_usage_tickers_get: {
+        parameters: {
+            query?: {
+                provider?: "uw" | "massive" | "all";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rates_snapshot_api_rates_snapshot_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RatesSnapshotResponse"];
+                };
+            };
+        };
+    };
+    get_regime_api_regime_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriResponse"];
+                };
+            };
+        };
+    };
+    get_canary_latest_api_regime_canary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryLatestResponse"];
+                };
+            };
+        };
+    };
+    get_canary_history_api_regime_canary_history_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_canary_validation_api_regime_canary_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CanaryValidationResponse"];
+                };
+            };
+        };
+    };
+    get_cri_history_api_regime_cri_history_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriDailyHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cri_intraday_api_regime_cri_intraday_get: {
+        parameters: {
+            query?: {
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriIntradayResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_cri_live_api_regime_cri_live_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriLiveResponse"];
+                };
+            };
+        };
+    };
+    get_dealer_regime_api_regime_dealer_get: {
+        parameters: {
+            query: {
+                ticker: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DealerRegimeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gex_api_regime_gex_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_gex_intraday_api_regime_gex_intraday_get: {
+        parameters: {
+            query?: {
+                ticker?: string;
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GexIntradayResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_gex_scan_api_regime_gex_scan_post: {
+        parameters: {
+            query?: {
+                ticker?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_grg_api_regime_grg_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrgResponse"];
+                };
+            };
+        };
+    };
+    trigger_grg_scan_api_regime_grg_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrgScanResponse"];
+                };
+            };
+        };
+    };
+    get_guidance_api_regime_guidance_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GuidanceResponse"];
+                };
+            };
+        };
+    };
+    get_regime_quotes_api_regime_quotes_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegimeQuotesResponse"];
+                };
+            };
+        };
+    };
+    trigger_cri_scan_api_regime_scan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CriScanResponse"];
+                };
+            };
+        };
+    };
+    get_validation_api_regime_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationResponse"];
+                };
+            };
+        };
+    };
+    get_vcg_api_regime_vcg_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_validation_api_regime_vcg_validation_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgValidationResponse"];
+                };
+            };
+        };
+    };
+    get_vcg_history_api_regime_vcg_history_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgDailyHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_intraday_api_regime_vcg_intraday_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+                sessions?: number;
+                rth_only?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgIntradayResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vcg_live_api_regime_vcg_live_get: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgLiveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_vcg_scan_api_regime_vcg_scan_post: {
+        parameters: {
+            query?: {
+                proxy?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VcgScanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_vol_backdrop_api_regime_vol_backdrop_get: {
+        parameters: {
+            query?: {
+                days?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolBackdropResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_scanner_api_scanner_get: {
+        parameters: {
+            query?: {
+                tier_1_only?: boolean;
+                type_f_only?: boolean;
                 sector?: string | null;
-                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
-                setup?: string | null;
-                fresh_within_minutes?: number | null;
+                freshness_hours?: number | null;
             };
             header?: never;
             path?: never;
@@ -7832,7 +9025,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WatchlistResponse"];
+                    "application/json": components["schemas"]["ScannerResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7846,44 +9039,11 @@ export interface operations {
             };
         };
     };
-    post_watchlist_api_watchlist_post: {
+    get_scanner_discover_api_scanner_discover_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistMutation"];
+            query?: {
+                limit?: number;
             };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_watchlist_queue_api_watchlist_queue_get: {
-        parameters: {
-            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -7896,84 +9056,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["QueueSummary"];
-                };
-            };
-        };
-    };
-    get_watchlist_spots_api_watchlist_spots_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["WatchlistSpotsResponse"];
-                };
-            };
-        };
-    };
-    delete_watchlist_api_watchlist__ticker__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    patch_watchlist_api_watchlist__ticker__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["WatchlistPatch"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["DiscoveryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -8114,330 +9197,6 @@ export interface operations {
             };
         };
     };
-    get_ohlc_api_ohlc__ticker__get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["OhlcRow"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_state_api_cockpit__ticker__state_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitStateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_dealer_api_cockpit__ticker__dealer_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitDealerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_surface_api_cockpit__ticker__surface_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitSurfaceResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_flow_im_api_cockpit__ticker__flow_im_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitFlowImResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cockpit_vrp_api_cockpit__ticker__vrp_get: {
-        parameters: {
-            query?: {
-                asof?: string | null;
-            };
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CockpitVrpResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_api_watchlist__ticker__rescan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    enqueue_rescan_all_api_watchlist_rescan_all_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["RescanAllRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_job_api_jobs__job_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobStatus"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_volatility_series_api_stock__ticker__volatility_series_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ticker: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_skew_analysis_api_stock__ticker__skew_get: {
         parameters: {
             query?: never;
@@ -8456,133 +9215,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SkewAnalysisResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_summary_api_provider_usage_summary_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageSummaryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_endpoints_api_provider_usage_endpoints_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_tickers_api_provider_usage_tickers_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageBreakdownResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    provider_usage_requests_api_provider_usage_requests_get: {
-        parameters: {
-            query?: {
-                provider?: "uw" | "massive" | "all";
-                ticker?: string | null;
-                status_family?: ("2xx" | "3xx" | "4xx" | "5xx" | "transport_error") | null;
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProviderUsageRequestsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -8729,6 +9361,37 @@ export interface operations {
             };
         };
     };
+    get_volatility_series_api_stock__ticker__volatility_series_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VolatilitySeriesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_trade_insight_priors_api_trade_insights_priors_get: {
         parameters: {
             query?: {
@@ -8764,10 +9427,13 @@ export interface operations {
             };
         };
     };
-    get_gex_api_regime_gex_get: {
+    get_watchlist_api_watchlist_get: {
         parameters: {
             query?: {
-                ticker?: string;
+                sector?: string | null;
+                /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
+                setup?: string | null;
+                fresh_within_minutes?: number | null;
             };
             header?: never;
             path?: never;
@@ -8781,7 +9447,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GexResponse"];
+                    "application/json": components["schemas"]["WatchlistResponse"];
                 };
             };
             /** @description Validation Error */
@@ -8795,52 +9461,21 @@ export interface operations {
             };
         };
     };
-    get_gex_intraday_api_regime_gex_intraday_get: {
+    post_watchlist_api_watchlist_post: {
         parameters: {
-            query?: {
-                ticker?: string;
-                sessions?: number;
-                rth_only?: boolean;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GexIntradayResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistMutation"];
             };
         };
-    };
-    trigger_gex_scan_api_regime_gex_scan_post: {
-        parameters: {
-            query?: {
-                ticker?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
         responses: {
             /** @description Successful Response */
-            202: {
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8861,38 +9496,7 @@ export interface operations {
             };
         };
     };
-    get_vol_backdrop_api_regime_vol_backdrop_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VolBackdropResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_regime_api_regime_get: {
+    get_watchlist_queue_api_watchlist_queue_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -8907,19 +9511,23 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriResponse"];
+                    "application/json": components["schemas"]["QueueSummary"];
                 };
             };
         };
     };
-    trigger_cri_scan_api_regime_scan_post: {
+    enqueue_rescan_all_api_watchlist_rescan_all_post: {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RescanAllRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             202: {
@@ -8927,29 +9535,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriScanResponse"];
-                };
-            };
-        };
-    };
-    get_vcg_api_regime_vcg_get: {
-        parameters: {
-            query?: {
-                proxy?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgResponse"];
+                    "application/json": components["schemas"]["JobStatus"][];
                 };
             };
             /** @description Validation Error */
@@ -8963,38 +9549,7 @@ export interface operations {
             };
         };
     };
-    trigger_vcg_scan_api_regime_vcg_scan_post: {
-        parameters: {
-            query?: {
-                proxy?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgScanResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cri_live_api_regime_cri_live_get: {
+    get_watchlist_spots_api_watchlist_spots_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -9009,249 +9564,28 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CriLiveResponse"];
+                    "application/json": components["schemas"]["WatchlistSpotsResponse"];
                 };
             };
         };
     };
-    get_cri_intraday_api_regime_cri_intraday_get: {
-        parameters: {
-            query?: {
-                sessions?: number;
-                rth_only?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CriIntradayResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_cri_history_api_regime_cri_history_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CriDailyHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_vcg_live_api_regime_vcg_live_get: {
-        parameters: {
-            query?: {
-                proxy?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgLiveResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_vcg_intraday_api_regime_vcg_intraday_get: {
-        parameters: {
-            query?: {
-                proxy?: string;
-                sessions?: number;
-                rth_only?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgIntradayResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_vcg_history_api_regime_vcg_history_get: {
-        parameters: {
-            query?: {
-                proxy?: string;
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgDailyHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_grg_api_regime_grg_get: {
+    delete_watchlist_api_watchlist__ticker__delete: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GrgResponse"];
-                };
-            };
-        };
-    };
-    trigger_grg_scan_api_regime_grg_scan_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GrgScanResponse"];
-                };
-            };
-        };
-    };
-    get_regime_quotes_api_regime_quotes_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RegimeQuotesResponse"];
-                };
-            };
-        };
-    };
-    get_dealer_regime_api_regime_dealer_get: {
-        parameters: {
-            query: {
+            path: {
                 ticker: string;
             };
-            header?: never;
-            path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["DealerRegimeResponse"];
-                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -9264,221 +9598,20 @@ export interface operations {
             };
         };
     };
-    get_canary_latest_api_regime_canary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryLatestResponse"];
-                };
-            };
-        };
-    };
-    get_canary_history_api_regime_canary_history_get: {
-        parameters: {
-            query?: {
-                days?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryHistoryResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_canary_validation_api_regime_canary_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CanaryValidationResponse"];
-                };
-            };
-        };
-    };
-    get_guidance_api_regime_guidance_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GuidanceResponse"];
-                };
-            };
-        };
-    };
-    get_validation_api_regime_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationResponse"];
-                };
-            };
-        };
-    };
-    get_vcg_validation_api_regime_vcg_validation_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["VcgValidationResponse"];
-                };
-            };
-        };
-    };
-    get_gauge_api_gold_gauge_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldGaugeResponse"];
-                };
-            };
-        };
-    };
-    get_input_series_api_gold_inputs__series_id__get: {
-        parameters: {
-            query?: {
-                from?: string | null;
-                to?: string | null;
-            };
-            header?: never;
-            path: {
-                series_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldInputSeriesResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_state_api_gold_state_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldStateResponse"];
-                };
-            };
-        };
-    };
-    get_lens_api_gold_lenses__lens_id__get: {
+    patch_watchlist_api_watchlist__ticker__patch: {
         parameters: {
             query?: never;
             header?: never;
             path: {
-                lens_id: "structural" | "cyclical" | "valuation";
+                ticker: string;
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistPatch"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -9486,7 +9619,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GoldLensResponse"];
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -9500,110 +9635,24 @@ export interface operations {
             };
         };
     };
-    get_replay_api_gold_replay_get: {
-        parameters: {
-            query: {
-                /** @description Reconstruct posture for this obs_date */
-                as_of: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GoldStateResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    rates_snapshot_api_rates_snapshot_get: {
+    enqueue_rescan_api_watchlist__ticker__rescan_post: {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                ticker: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RatesSnapshotResponse"];
-                };
-            };
-        };
-    };
-    get_scanner_api_scanner_get: {
-        parameters: {
-            query?: {
-                tier_1_only?: boolean;
-                type_f_only?: boolean;
-                sector?: string | null;
-                freshness_hours?: number | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScannerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_scanner_discover_api_scanner_discover_get: {
-        parameters: {
-            query?: {
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DiscoveryResponse"];
+                    "application/json": components["schemas"]["JobStatus"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/e2e/skew-tab.spec.ts
+++ b/web/tests/e2e/skew-tab.spec.ts
@@ -40,6 +40,18 @@ test("Skew tab renders the signal-detail card, lean, and the spectrum", async ({
   await expect(page.getByText("FRONT vs BACK")).toBeVisible(); // skew-term panel
   await expect(page.getByText("WHERE IT SITS")).toBeVisible(); // asset-class spectrum
 
+  // Structure detail (Phase-2): present iff the lean is non-neutral. A NEUTRAL name
+  // (the ~72% default) shows no structure block; a gated name shows >=2 defined-risk legs.
+  const leanText = ((await lean.textContent()) ?? "").trim();
+  const structure = page.getByTestId("skew-structure-detail");
+  if (leanText === "NEUTRAL") {
+    await expect(structure).toHaveCount(0);
+  } else {
+    await expect(structure).toBeVisible();
+    await expect(structure).toContainText(/-spread/);
+    await expect(structure.getByText(/^(BUY|SELL) (PUT|CALL)$/)).toHaveCount(2);
+  }
+
   // No NaN leaks anywhere on the page.
   const body = await page.locator("body").innerText();
   expect(body).not.toMatch(/NaN/);

--- a/web/tests/e2e/skew-tab.spec.ts
+++ b/web/tests/e2e/skew-tab.spec.ts
@@ -40,14 +40,15 @@ test("Skew tab renders the signal-detail card, lean, and the spectrum", async ({
   await expect(page.getByText("FRONT vs BACK")).toBeVisible(); // skew-term panel
   await expect(page.getByText("WHERE IT SITS")).toBeVisible(); // asset-class spectrum
 
-  // Structure detail (Phase-2): present iff the lean is non-neutral. A NEUTRAL name
-  // (the ~72% default) shows no structure block; a gated name shows >=2 defined-risk legs.
+  // Structure detail (Phase-2): a NEUTRAL name (the ~72% default) shows no block.
+  // A non-neutral lean shows the block ONLY when a swing chain exists — a valid
+  // no_chain state (or a DB where the swing-greeks refresh hasn't run yet) shows
+  // none. So tolerate absence, but if present it must be a 2-leg defined-risk spread.
   const leanText = ((await lean.textContent()) ?? "").trim();
   const structure = page.getByTestId("skew-structure-detail");
   if (leanText === "NEUTRAL") {
     await expect(structure).toHaveCount(0);
-  } else {
-    await expect(structure).toBeVisible();
+  } else if ((await structure.count()) > 0) {
     await expect(structure).toContainText(/-spread/);
     await expect(structure.getByText(/^(BUY|SELL) (PUT|CALL)$/)).toHaveCount(2);
   }

--- a/web/tests/unit/SkewSignalDetail.test.tsx
+++ b/web/tests/unit/SkewSignalDetail.test.tsx
@@ -57,6 +57,37 @@ describe("SkewSignalDetail", () => {
     expect(screen.getByText("put-debit-spread — defined risk")).toBeTruthy();
   });
 
+  it("lifts the validated status into a right-aligned badge and splits the basis at the semicolon", () => {
+    const data = makeData({
+      read: {
+        rho_confirms: true,
+        earnings_gate: "pass",
+        directional_lean: {
+          lean: "BULLISH_TILT",
+          confidence: "high",
+          basis:
+            "validated — NORMAL single_name bucket separated +2.6%/20d " +
+            "(survived regime gate); borrow normal → edge not a borrow artifact",
+          express: "call-debit-spread — defined risk",
+        },
+        summary_bullets: [],
+      },
+    } as unknown as Partial<SkewAnalysisResponse>);
+    render(<SkewSignalDetail data={data} />);
+    // "validated" is now a standalone badge, not part of the prose basis.
+    const badge = screen.getByTestId("skew-lean-status");
+    expect(badge.textContent).toBe("validated");
+    const basis = screen.getByTestId("skew-lean-basis");
+    expect(basis.textContent).not.toContain("validated");
+    // The reason is broken into two lines at the semicolon.
+    const lines = basis.querySelectorAll("div");
+    expect(lines.length).toBe(2);
+    expect(lines[0].textContent).toContain("(survived regime gate);");
+    expect(lines[1].textContent).toBe(
+      "borrow normal → edge not a borrow artifact",
+    );
+  });
+
   it("shows NEUTRAL and NOT CONFIRMED when there is no edge", () => {
     render(
       <SkewSignalDetail
@@ -81,6 +112,8 @@ describe("SkewSignalDetail", () => {
     expect(screen.getByText("NO EDGE")).toBeTruthy();
     // Empty express renders the em-dash placeholder.
     expect(screen.getByText("—")).toBeTruthy();
+    // A NEUTRAL basis is a plain reason string — no validated badge.
+    expect(screen.queryByTestId("skew-lean-status")).toBeNull();
   });
 
   it("renders the defined-risk structure legs when status is ready", () => {

--- a/web/tests/unit/SkewSignalDetail.test.tsx
+++ b/web/tests/unit/SkewSignalDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SkewSignalDetail } from "@/components/stock/panels/SkewSignalDetail";
@@ -81,5 +81,72 @@ describe("SkewSignalDetail", () => {
     expect(screen.getByText("NO EDGE")).toBeTruthy();
     // Empty express renders the em-dash placeholder.
     expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders the defined-risk structure legs when status is ready", () => {
+    const data = makeData({
+      read: {
+        rho_confirms: true,
+        earnings_gate: "pass",
+        directional_lean: {
+          lean: "BEARISH_TILT",
+          confidence: "high",
+          basis: "validated — RICH single_name bucket separated -4.5%/20d",
+          express: "put-debit-spread — defined risk",
+          structure_detail: {
+            kind: "put_debit_spread",
+            dte_target: 33,
+            status: "ready",
+            note: "defined risk; exit before earnings 2026-07-18",
+            legs: [
+              {
+                action: "BUY",
+                right: "PUT",
+                strike: "95",
+                target_delta: "-0.25",
+                actual_delta: "-0.26",
+                expiry: "2026-07-18",
+                dte: 33,
+              },
+              {
+                action: "SELL",
+                right: "PUT",
+                strike: "88",
+                target_delta: "-0.12",
+                actual_delta: "-0.13",
+                expiry: "2026-07-18",
+                dte: 33,
+              },
+            ],
+          },
+        },
+        summary_bullets: [],
+      },
+    } as unknown as Partial<SkewAnalysisResponse>);
+    render(<SkewSignalDetail data={data} />);
+    const block = screen.getByTestId("skew-structure-detail");
+    expect(within(block).getByText(/put-debit-spread/i)).toBeTruthy();
+    expect(within(block).getByText("BUY PUT")).toBeTruthy();
+    expect(within(block).getByText(/95/)).toBeTruthy();
+    expect(within(block).getByText(/defined risk/i)).toBeTruthy();
+  });
+
+  it("renders no structure block for a NEUTRAL lean", () => {
+    const data = makeData({
+      read: {
+        rho_confirms: false,
+        earnings_gate: "pass",
+        directional_lean: {
+          lean: "NEUTRAL",
+          confidence: "low",
+          basis: "no edge",
+          express: "",
+          structure_detail: null,
+        },
+        summary_bullets: [],
+      },
+    } as unknown as Partial<SkewAnalysisResponse>);
+    render(<SkewSignalDetail data={data} />);
+    expect(screen.queryByTestId("skew-structure-detail")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase-2 increment-1 of the Skew first-principles tab (V1 shipped in #136): turn the
evidence-gated directional lean into a concrete, defined-risk trade **structure**, and
persist a tail-split **RR mean-reversion verdict store** — plus two follow-ons
(EVIDENCE-panel polish, index-ETF coverage).

## What's in this PR

### 1a — Strike-by-delta structure detail on the gated lean
- New `SkewStructureDetail` / `SkewStructureLeg` models; `structure_detail` on `SkewDirectionalLean`.
- `select_structure_legs` picks wings by target delta (−0.25/−0.12 put, +0.25/+0.12 call) with a
  **defined-risk ordering guard** (long wing nearer ATM than short, else `no_chain`).
- Rendered in the Signal Detail card: `STRUCTURE · <kind> · <dte>DTE` + legs (Δ) + note.

### Swing-DTE greeks source (feeds 1a)
- New `skew_swing_greeks` table + nightly job (`30 17 * * 0-4`, primary-UW-only) pulling **real
  per-contract option delta** from UW `/greeks` at ~30/45 DTE. The warm store held front-expiry-only
  greeks for single-names, so there was no swing chain to pick wings from.
  (NB: `/greek-exposure` returns delta *exposure* ≈0 for low-OI strikes — unusable for target-delta.)

### 1b — RR mean-reversion verdict store
- New `skew_rv_reversion_verdicts` table: per `(asset_class, deviation_class, tail)` verdict with
  tail-split markout, walk-forward holdout, and a **per-quarter catastrophic-degradation gate**.
  (Research/persistence layer — no UI surface yet.)

### Follow-ons
- **EVIDENCE-panel polish**: `validated` lifted into a right-aligned badge on the confidence row;
  the gated-lean basis split into two lines at the semicolon. NEUTRAL bases left intact (the badge
  triggers only on the literal `validated — ` prefix).
- **Index-ETF structure**: extended the structure block to index ETFs (QQQ/SPY/IWM/DIA/GLD/SLV/TLT).
  Their directional lean is research-validated (`index_macro` verdict buckets), so they earn the same
  defined-risk expression as single-names. Only the mean-reversion *trigger* still skips indices
  (index skew is structural and does not revert). True cash indices degrade gracefully via `no_chain`.

## Migrations (idempotent)
- `074_skew_phase2.sql` — `skew_rv_reversion_verdicts`
- `075_skew_swing_greeks.sql` — `skew_swing_greeks`

## Verification
- **63** skew backend tests pass; **417** web vitest pass; `tsc` + `ruff` + `eslint` clean.
- Live browser: AMD (single-name → call-debit-spread) and QQQ (index ETF → put-debit-spread) render
  the structure block; NVDA (NEUTRAL) correctly shows none; **0 console errors**.
- Genuine swing job populated **13,368 rows / 98 tickers** via the real worker path.

## Standing-rule checks
- ✅ Analytical results persisted to Postgres (verdict stores + swing greeks).
- ✅ Defined-risk only — long-premium debit spreads; ordering guard enforces it. No naked shorts.
- ✅ Migrations idempotent (`IF NOT EXISTS`).
- ✅ No Yahoo; UW `/greeks` is the delta source.
