### PR TITLE
feat(health): show deployed version tag in sidebar health panel

### DIFF
--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -12,11 +12,17 @@ from pydantic import BaseModel, Field
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository, provider_day_bounds
+from uw_scan.version import app_version
 from uw_scan.worker.schedule_expectations import expected_market_cron_fires_between
 
 router = APIRouter()
 
 HealthSource = Literal["uw", "massive"]
+
+# Captured once at import. Version is fixed for a process's lifetime (launchd
+# restarts the stack on deploy), so a constant is both correct and avoids
+# re-reading the VERSION file on every 5s health poll.
+APP_VERSION = app_version()
 
 
 def _source_label(source: HealthSource) -> str:
@@ -26,6 +32,10 @@ def _source_label(source: HealthSource) -> str:
 class HealthResponse(BaseModel):
     ok: bool
     db: str
+    # Running backend release version (repo-root VERSION file), e.g. "0.1.0".
+    # Defaulted from the module constant so every HealthResponse return site
+    # carries it without per-site wiring.
+    version: str = APP_VERSION
     scheduler_lag_seconds: float | None = None
     last_full_scan_at: datetime | None = None
     reason: str | None = None

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -26,25 +25,13 @@ from uw_scan.api.routers import (
     volatility,
     watchlist,
 )
+from uw_scan.version import app_version
 
 logger = logging.getLogger(__name__)
 
 
-def _app_version() -> str:
-    """Read the release version from the repo-root VERSION file.
-
-    server.py lives at src/uw_scan/api/server.py → repo root is parents[3].
-    Falls back to a sentinel if the file is missing (e.g. an odd packaging).
-    """
-    try:
-        return (Path(__file__).resolve().parents[3] / "VERSION").read_text().strip()
-    except OSError as exc:
-        logger.warning("VERSION file unreadable; using sentinel version: %s", repr(exc))
-        return "0.0.0+unknown"
-
-
 def create_app() -> FastAPI:
-    app = FastAPI(title="UW Watchlist API", version=_app_version())
+    app = FastAPI(title="UW Watchlist API", version=app_version())
     app.add_middleware(
         CORSMiddleware,
         # CORS is URL-agnostic by design: the real trust boundary is the

--- a/src/uw_scan/version.py
+++ b/src/uw_scan/version.py
@@ -1,0 +1,29 @@
+"""Single source of truth for the running release version.
+
+Both the FastAPI app factory (`api/server.py`) and the health router import
+`app_version()` from here. Keeping it in a neutral leaf module avoids the
+circular import that would arise if a router imported it back from
+`api/server.py` (which imports the routers).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# version.py lives at src/uw_scan/version.py → repo root is parents[2].
+_VERSION_FILE = Path(__file__).resolve().parents[2] / "VERSION"
+
+
+def app_version() -> str:
+    """Read the release version from the repo-root VERSION file.
+
+    Falls back to a sentinel if the file is missing (e.g. an odd packaging).
+    """
+    try:
+        return _VERSION_FILE.read_text().strip()
+    except OSError as exc:
+        logger.warning("VERSION file unreadable; using sentinel version: %s", repr(exc))
+        return "0.0.0+unknown"

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -7608,6 +7608,11 @@
             ],
             "title": "Uw Today"
           },
+          "version": {
+            "default": "0.1.0",
+            "title": "Version",
+            "type": "string"
+          },
           "watchlist_size": {
             "anyOf": [
               {

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -10,6 +10,7 @@ import pytest
 import uw_scan.api.routers.health as health_router
 from uw_scan.api.routers.health import _record_health_cache_clear_for_tests, health
 from uw_scan.config import Settings
+from uw_scan.version import app_version
 
 
 @pytest.fixture(autouse=True)
@@ -30,6 +31,14 @@ def test_health_ok_when_recent_scan(client, seeded_db_with_cards):
     assert body["scheduler_lag_seconds"] is not None
     assert body["last_full_scan_at"] is not None
     assert body["worker_lag_seconds"] is not None
+
+
+def test_health_reports_deployed_version(client, seeded_db_empty_cards):
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    version = r.json()["version"]
+    assert version, "version must be a non-empty string"
+    assert version == app_version()
 
 
 def test_health_uses_dedicated_worker_heartbeat(client, seeded_db_empty_cards):

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -526,6 +526,18 @@ export function HealthPanel() {
           />
           <span style={{ color: "var(--text-muted)" }}>Status</span>
           <span style={valStyle}>{summary.label}</span>
+          {h?.version && (
+            <span
+              style={{
+                color: "var(--text-muted)",
+                textTransform: "none",
+                letterSpacing: 0,
+              }}
+              title={`Deployed backend version v${h.version}`}
+            >
+              v{h.version}
+            </span>
+          )}
         </span>
         <span aria-hidden="true">{collapsed ? "▸" : "▾"}</span>
       </button>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -3533,6 +3533,11 @@ export interface components {
             trade_insights_ai?: components["schemas"]["TradeInsightsAiHealth"] | null;
             /** Uw Today */
             uw_today?: number | null;
+            /**
+             * Version
+             * @default 0.1.0
+             */
+            version: string;
             /** Watchlist Size */
             watchlist_size?: number | null;
             /** Worker Lag Seconds */

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -68,6 +68,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
       watchlist_size: 97,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: 88,
       http_2xx: 120,
       http_4xx: 0,
@@ -142,6 +143,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
       watchlist_size: 97,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: 88,
       http_2xx: 120,
       http_4xx: 0,
@@ -181,6 +183,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
       watchlist_size: 97,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: 88,
       http_2xx: 120,
       http_4xx: 3,
@@ -280,6 +283,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: null,
       watchlist_size: null,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: null,
       http_2xx: null,
       http_4xx: null,
@@ -319,6 +323,7 @@ describe("HealthPanel", () => {
         latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
         watchlist_size: 97,
         source: "UnusualWhales",
+        version: "0.0.0-test",
         latency_p95_ms: 88,
         http_2xx: 120,
         http_4xx: 3,
@@ -345,6 +350,7 @@ describe("HealthPanel", () => {
         latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
         watchlist_size: 97,
         source: "Massive.com",
+        version: "0.0.0-test",
         latency_p95_ms: 55,
         http_2xx: 10,
         http_4xx: 0,
@@ -398,6 +404,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
       watchlist_size: 97,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: 88,
       http_2xx: 120,
       http_4xx: 0,
@@ -449,6 +456,7 @@ describe("HealthPanel", () => {
       latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
       watchlist_size: 97,
       source: "UnusualWhales",
+      version: "0.0.0-test",
       latency_p95_ms: 88,
       http_2xx: 120,
       http_4xx: 0,
@@ -482,5 +490,22 @@ describe("HealthPanel", () => {
       expect(screen.queryByText("Query Coverage")).toBeNull(),
     );
     expect(window.localStorage.getItem("uw_health_collapsed")).toBe("1");
+  });
+
+  it("shows the deployed version tag in the collapsed header", async () => {
+    vi.mocked(api.health).mockResolvedValue({
+      ok: true,
+      db: "up",
+      version: "1.2.3",
+      source: "UnusualWhales",
+      throughput_window_minutes: 15,
+    });
+
+    render(<HealthPanel />);
+
+    // Tag rides the always-visible header — no need to expand the panel.
+    const toggle = await screen.findByRole("button", { name: /status/i });
+    await waitFor(() => expect(toggle.textContent).toContain("v1.2.3"));
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
 });


### PR DESCRIPTION
## What

Surface the running backend's release version (repo-root `VERSION`) as a tag next to the **Status** dot in the sidebar `HealthPanel` — always visible, collapsed or expanded.

```
● Status  OK  v0.1.0      ▸
```

## Why

There was no in-app way to confirm which release is actually deployed. The version of the *running* API process is the truthful signal (not a stale build constant), and the `HealthPanel` already polls `/api/health` every 5s — so the tag rides that poll with no new endpoint.

## How

- **`uw_scan/version.py` (new)** — extract the `VERSION`-file reader into `app_version()`, a neutral leaf module both `api/server.py` and the health router can import (the router can't import it back from `server.py`, which imports the routers → circular).
- **`HealthResponse.version`** — defaulted from an import-time `APP_VERSION` constant. Version is fixed for a process's lifetime (launchd restarts the stack on deploy), so a constant is correct and avoids re-reading the file on every poll; as a field default it reaches all five `HealthResponse` return sites with no per-site wiring.
- **`HealthPanel.tsx`** — renders `v{version}` in the collapsed header, muted/non-uppercase, only when present (gracefully absent while loading / API offline).
- Regenerated only the `version` slice of `web/lib/types.ts` and `openapi.snapshot.json` (both files are alphabetically frozen from older tooling; a full regen would reorder ~9.6k lines and bury the change).

## Out of scope (YAGNI)

git SHA, build timestamp, deploy time, web-bundle build version.

## Tests

- **pytest**: `/api/health` returns a non-empty `version` matching `app_version()`. Full health + snapshot suite: `28 passed`.
- **vitest**: tag renders in the collapsed header. HealthPanel suite: `8 passed`.
- `tsc` + `eslint` clean.