### PR TITLE
fix(storage): select canonical scan run by aggregates-presence, not a notes denylist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- Stock detail pages (Flow / Market Structure / GEX) no longer render empty
+  during US off-hours. `Repository.latest_run_id` selected the newest scan_run
+  via a hand-maintained `notes` denylist; the skew engine's `skew_swing_greeks`
+  side-channel runs were not on it and — having higher run_ids and no aggregates
+  — shadowed the real `full_scan`, blanking every ticker's detail page after
+  ~17:30 ET each day. The selector (and the `get_scan_duration_summary` health
+  metric) now key on the property the report actually needs —
+  `status='ok' AND aggregates IS NOT NULL` — so no future side-channel job can
+  re-break it. No data was lost; the fix is read-path only.
+
 ## [0.1.1] — 2026-06-17
 
 

--- a/src/uw_scan/storage/scan_runs.py
+++ b/src/uw_scan/storage/scan_runs.py
@@ -17,38 +17,37 @@ class _ScanRunsMixin:
     _schema: str
 
     def latest_run_id(self, ticker: str) -> int:
-        """Return the highest *successful* full-scan run_id for `ticker`, or 0 if none.
+        """Return the most recent *renderable* full-scan run_id for `ticker`, or 0.
 
-        Excludes runs created by side-channel jobs that populate only a
-        narrow slice of tables and would otherwise shadow the actual
-        full-scan run the report assembler needs (flow_alerts, oi_change_top,
-        GEX, volatility — all keyed by run_id). Excluded:
+        Selection keys on the property the report assembler actually depends
+        on — did this run persist its ``aggregates`` payload? — rather than on
+        a hand-maintained denylist of side-channel ``notes`` strings.
 
-        - ``flow_data_refresh`` (writes options_volume_daily + option_chain only)
-        - ``positioning_refresh`` (M4 trade-framework: uw_positioning only)
-        - ``intraday_refresh`` (OI movers intraday: option_chain_oi only)
-        - ``cockpit_daily_snapshot`` (SPX/SPY/QQQ/IWM greeks/skew only)
-        - ``gex_scan_*`` (SPX/SPY index-only GEX scanner running every 5 min)
-        - ``grg_scan`` (SPY/TLT gamma-rotation gap, grg_snapshots only)
+        Side-channel jobs (``flow_data_refresh``, ``positioning_refresh``,
+        ``intraday_refresh``, ``skew_swing_greeks``, ``cockpit_daily_snapshot``,
+        ``gex_scan_*``, ``grg_scan``, …) mint a ``scan_runs`` row only to tag
+        their UW fetches by ``run_id``; they never call ``set_aggregates``, so
+        ``aggregates`` stays NULL. Only a completed full_scan
+        (``pipeline.run_single_stock``, line 388) writes it. Keying on
+        ``aggregates IS NOT NULL`` is therefore self-enforcing: a *new*
+        side-channel job is ignored automatically (no denylist entry to
+        remember), and any run that legitimately carries the detail payload is
+        eligible automatically. This replaced a per-note denylist that
+        re-broke the stock detail page three times (PRs #106, #129, and the
+        skew engine — whose ``skew_swing_greeks`` runs, having higher run_ids
+        and no denylist entry, shadowed the real full_scan and blanked every
+        ticker's detail page after ~17:30 ET each day).
 
-        Also requires ``status = 'ok'`` — a failed full-scan (e.g. UW HTTP
-        429 daily-quota hit) commits the scan_runs row with status set to
-        a ``failed: …`` string but leaves exposures/aggregates/gex_curve
-        unwritten. Without this filter the report assembler resolves to
-        the failed run and joins on a run_id that has no detail rows,
-        producing an empty stock detail page.
+        ``status = 'ok'`` still excludes failed full-scans (e.g. a UW HTTP 429
+        daily-quota hit) that commit a ``failed: …`` row with no aggregates.
         """
         with self._conn.cursor() as cur:
             cur.execute(
                 f"SELECT run_id FROM {self._schema}.scan_runs "
                 "WHERE ticker = %s "
                 "  AND status = 'ok' "
-                "  AND (notes IS DISTINCT FROM 'flow_data_refresh') "
-                "  AND (notes IS DISTINCT FROM 'positioning_refresh') "
-                "  AND (notes IS DISTINCT FROM 'intraday_refresh') "
-                "  AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot') "
-                "  AND (notes IS DISTINCT FROM 'grg_scan') "
-                "  AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%') "
+                "  AND aggregates IS NOT NULL "
+                "  AND aggregates::text NOT IN ('{}', 'null') "
                 "ORDER BY run_id DESC LIMIT 1",
                 (ticker.upper(),),
             )
@@ -93,12 +92,14 @@ class _ScanRunsMixin:
                   AND finished_at IS NOT NULL
                   AND started_at IS NOT NULL
                   AND status = 'ok'
-                  AND (notes IS DISTINCT FROM 'flow_data_refresh')
-                  AND (notes IS DISTINCT FROM 'positioning_refresh')
-                  AND (notes IS DISTINCT FROM 'intraday_refresh')
-                  AND (notes IS DISTINCT FROM 'cockpit_daily_snapshot')
-                  AND (notes IS DISTINCT FROM 'discovery_scan')
-                  AND (notes IS NULL OR notes NOT LIKE 'gex_scan_%%')
+                  -- Count only canonical full scans (those that persisted their
+                  -- aggregates), the same property latest_run_id keys on. This
+                  -- replaces a per-note denylist so fast side-channel jobs
+                  -- (skew_swing_greeks, flow_data_refresh, gex_scan_*, …) never
+                  -- skew the duration metric, and no future job needs to be
+                  -- manually added to a list.
+                  AND aggregates IS NOT NULL
+                  AND aggregates::text NOT IN ('{{}}', 'null')
                 """,
                 (start, end),
             )

--- a/tests/integration/api/test_trade_insights_ai_endpoint.py
+++ b/tests/integration/api/test_trade_insights_ai_endpoint.py
@@ -14,6 +14,7 @@ from uw_scan.models import (
     CandidateStructure,
     FlowSnapshot,
     InsightLeg,
+    MarketAggregates,
     MarketStructure,
     SingleStockReport,
     TradeInsightsHeader,
@@ -85,6 +86,11 @@ def _client_for_settings(settings: Settings) -> TestClient:
 
 def _seed_run(repo: Repository) -> int:
     run_id = repo.insert_scan_run("TSLA")
+    # Realistic full_scan: persist aggregates so latest_run_id treats this as
+    # the canonical renderable run (see scan_runs.latest_run_id).
+    repo.set_aggregates(
+        run_id, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
     repo.finish_scan_run(run_id, status="ok")
     repo.conn.commit()
     return run_id

--- a/tests/integration/benchmark/test_pipeline_inputs.py
+++ b/tests/integration/benchmark/test_pipeline_inputs.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from uw_scan.benchmark.collector import build_pipeline_benchmark_inputs
 from uw_scan.benchmark.pipeline import compute_component_scores
 from uw_scan.config import Settings
+from uw_scan.models import MarketAggregates
 
 
 def test_build_pipeline_benchmark_inputs_from_warm_store(
@@ -105,7 +106,11 @@ def _insert_finished_scan(
             (ticker, started_at, finished_at),
         )
         row = cur.fetchone()
-    return int(row[0])
+    run_id = int(row[0])
+    # A real full/scanner scan persists aggregates; the duration metric and
+    # latest_run_id both key on that to count it as a canonical run.
+    repo.set_aggregates(run_id, MarketAggregates(call_oi_total=1000))
+    return run_id
 
 
 def _insert_flow_refresh_scan(repo, ticker: str, finished_at: datetime) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,6 +31,7 @@ import psycopg
 import pytest
 
 from uw_scan.config import Settings
+from uw_scan.models import MarketAggregates
 from uw_scan.storage.migrate_runner import apply_migrations
 from uw_scan.storage.repository import Repository
 
@@ -126,7 +127,7 @@ def _reset_to_baseline(
                 copy.write(data)
         for s, (last_value, is_called) in sequences.items():
             cur.execute(
-                f'SELECT setval(\'uw_scan."{s}"\', %s, %s)',
+                f"SELECT setval('uw_scan.\"{s}\"', %s, %s)",
                 (last_value, is_called),
             )
 
@@ -155,6 +156,11 @@ def seeded_db_with_cards(seeded_db_empty_cards) -> Repository:
     """
     repo = seeded_db_empty_cards
     run_id = repo.insert_scan_run(ticker="TSLA")
+    # A real full_scan persists its aggregates; latest_run_id keys on this to
+    # distinguish canonical runs from side-channel ones (see scan_runs.py).
+    repo.set_aggregates(
+        run_id, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
     repo.finish_scan_run(run_id, status="ok")
     repo.upsert_watchlist_card(
         ticker="TSLA",

--- a/tests/integration/storage/test_flow_tab.py
+++ b/tests/integration/storage/test_flow_tab.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from uw_scan.models import OptionChainPerStrikeRow, OptionsDailyRow
+from uw_scan.models import MarketAggregates, OptionChainPerStrikeRow, OptionsDailyRow
 
 
 def test_options_volume_daily_round_trip(seeded_db_empty_cards) -> None:
@@ -73,6 +73,9 @@ def test_latest_run_id_skips_flow_data_refresh_runs(seeded_db_empty_cards) -> No
     """
     repo = seeded_db_empty_cards
     full_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.set_aggregates(
+        full_run, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
     repo.finish_scan_run(full_run, status="ok")
     refresh_run = repo.insert_scan_run("GOOGL", notes="flow_data_refresh")
     repo.finish_scan_run(refresh_run, status="ok")
@@ -92,6 +95,9 @@ def test_latest_run_id_skips_failed_runs(seeded_db_empty_cards) -> None:
     """
     repo = seeded_db_empty_cards
     full_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.set_aggregates(
+        full_run, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
     repo.finish_scan_run(full_run, status="ok")
     failed_run = repo.insert_scan_run("GOOGL", notes="full_scan")
     repo.finish_scan_run(failed_run, status="failed: UwHTTPError('UW HTTP 429')")
@@ -109,6 +115,9 @@ def test_latest_run_id_skips_side_channel_refresh_runs(seeded_db_empty_cards) ->
     """
     repo = seeded_db_empty_cards
     full_run = repo.insert_scan_run("GOOGL", notes="full_scan")
+    repo.set_aggregates(
+        full_run, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
     repo.finish_scan_run(full_run, status="ok")
     for note in ("positioning_refresh", "intraday_refresh", "cockpit_daily_snapshot"):
         shadow = repo.insert_scan_run("GOOGL", notes=note)

--- a/tests/integration/storage/test_scan_runs_canonical_selection.py
+++ b/tests/integration/storage/test_scan_runs_canonical_selection.py
@@ -1,0 +1,91 @@
+"""latest_run_id selects the most recent run that actually persisted its
+aggregates — regardless of the scan_runs.notes label.
+
+This is the property-based guard that replaces the per-note denylist. Any run
+that did not write the per-ticker detail payload (``aggregates``) must never
+shadow a real full_scan run — *including* a brand-new side-channel job that
+nobody has taught the selector about yet. The denylist re-broke this three
+times (PRs #106, #129, and the skew engine); keying on data presence instead
+of a hand-maintained list of notes closes the class of bug.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from uw_scan.models import MarketAggregates
+
+
+def _full_scan(db, ticker: str) -> int:
+    """A completed full_scan run that persisted its aggregates (the canonical run)."""
+    run_id = db.insert_scan_run(ticker, notes="")
+    db.set_aggregates(
+        run_id, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30"))
+    )
+    db.finish_scan_run(run_id, status="ok")
+    return run_id
+
+
+def _side_channel(db, ticker: str, notes: str) -> int:
+    """A completed side-channel run that wrote NO aggregates."""
+    run_id = db.insert_scan_run(ticker, notes=notes)
+    db.finish_scan_run(run_id, status="ok")
+    return run_id
+
+
+def test_skew_swing_greeks_run_does_not_shadow_full_scan(seeded_db_empty_cards):
+    """The exact regression: a later skew_swing_greeks run must not win."""
+    db = seeded_db_empty_cards
+    full = _full_scan(db, "QQQ")
+    _side_channel(db, "QQQ", notes="skew_swing_greeks")  # higher run_id, no aggregates
+    assert db.latest_run_id("QQQ") == full
+
+
+def test_unknown_future_side_channel_note_is_ignored(seeded_db_empty_cards):
+    """The property generalises: a note the selector was never taught about
+    is still ignored because it carries no aggregates."""
+    db = seeded_db_empty_cards
+    full = _full_scan(db, "AVGO")
+    _side_channel(db, "AVGO", notes="some_future_job_2027")
+    assert db.latest_run_id("AVGO") == full
+
+
+def test_ticker_with_only_empty_aggregate_runs_resolves_to_zero(seeded_db_empty_cards):
+    """A ticker whose only runs wrote no aggregates is not renderable -> 0 (404)."""
+    db = seeded_db_empty_cards
+    _side_channel(db, "NVDA", notes="skew_swing_greeks")
+    assert db.latest_run_id("NVDA") == 0
+
+
+def _scan_with_duration(db, ticker, notes, seconds, *, aggregates):
+    """Insert a completed run with an explicit duration; optionally persist aggregates."""
+    finished = datetime.now(timezone.utc)
+    started = finished - timedelta(seconds=seconds)
+    with db.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {db._schema}.scan_runs "
+            "(ticker, started_at, finished_at, status, notes) "
+            "VALUES (%s, %s, %s, 'ok', %s) RETURNING run_id",
+            (ticker, started, finished, notes),
+        )
+        run_id = int(cur.fetchone()[0])
+    if aggregates:
+        db.set_aggregates(run_id, MarketAggregates(call_oi_total=1000))
+    db.conn.commit()
+    return run_id
+
+
+def test_scan_duration_summary_excludes_runs_without_aggregates(seeded_db_empty_cards):
+    """The duration health metric counts only canonical full scans (those that
+    wrote aggregates) — a fast skew_swing_greeks run must not drag the average
+    down. Same property guard as latest_run_id, applied to the twin selector."""
+    db = seeded_db_empty_cards
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = datetime.now(timezone.utc) + timedelta(minutes=1)
+    _scan_with_duration(db, "QQQ", "", 60, aggregates=True)  # real full_scan
+    _scan_with_duration(
+        db, "QQQ", "skew_swing_greeks", 1, aggregates=False
+    )  # side-channel
+    summary = db.get_scan_duration_summary(window_start, window_end)
+    assert summary.avg_seconds == 60.0

--- a/tests/integration/storage/test_scan_runs_grg_exclusion.py
+++ b/tests/integration/storage/test_scan_runs_grg_exclusion.py
@@ -1,16 +1,27 @@
-"""latest_run_id must ignore grg_scan side-channel runs (defense-in-depth)."""
+"""latest_run_id ignores grg_scan side-channel runs.
+
+Now enforced via the aggregates-presence property (grg_scan writes no
+aggregates) rather than a named denylist entry — see
+test_scan_runs_canonical_selection.py for the general guard.
+"""
 
 from __future__ import annotations
+
+from decimal import Decimal
+
+from uw_scan.models import MarketAggregates
 
 
 def test_latest_run_id_ignores_grg_scan(seeded_db_empty_cards):
     db = seeded_db_empty_cards
-    # A real SPY full-scan, then a later GRG audit row (synthetic ticker).
+    # A real SPY full-scan persists its aggregates...
     full = db.insert_scan_run("SPY", notes="")
+    db.set_aggregates(full, MarketAggregates(call_oi_total=1000, iv30d=Decimal("0.30")))
     db.finish_scan_run(full, status="ok")
+    # ...then a later GRG audit row (synthetic ticker) that writes no aggregates.
     grg = db.insert_scan_run("GRG", notes="grg_scan")
     db.finish_scan_run(grg, status="ok")
     # SPY resolves to the real full-scan, not the GRG row.
     assert db.latest_run_id("SPY") == full
-    # The synthetic GRG ticker is also excluded for its own ticker.
+    # The synthetic GRG ticker has no renderable run of its own.
     assert db.latest_run_id("GRG") == 0


### PR DESCRIPTION
## Problem

Stock detail pages (Flow / Market Structure / GEX) rendered **completely empty** during US off-hours — `$0` premiums, `—` GEX, no dark pool / OI / max-pain — for **every** watchlist ticker. Spot and the watchlist cards stayed fine.

## Root cause

`Repository.latest_run_id` selects the scan run the detail report reads from, excluding side-channel jobs via a hand-maintained **denylist** of `scan_runs.notes` values. The skew engine's `skew_swing_greeks` job (PR #138) writes a `status='ok'` row per ticker with **no aggregates**, but was never added to the denylist. Running ~17:30 ET for all 101 tickers, its higher `run_id` shadowed the real `full_scan` run, so the assembler joined an empty run → blank page until the next scan. This is the **3rd** time the denylist rotted (`#106`, `#129`, now).

**No data was lost** — the full_scan rows were intact the whole time; it was a read-path selection bug.

## Fix

Replace the denylist with a **property-based filter**: `status='ok' AND aggregates IS NOT NULL`. Only a completed `full_scan` calls `set_aggregates` (`pipeline.py:388`), so any *future* side-channel job is excluded automatically — nothing to maintain. The same rot existed in `get_scan_duration_summary` (skew runs deflated the avg-scan-duration health metric); converted it identically.

## Verification

- ✅ Full suite: **1791 passed**, 13 skipped.
- ✅ Property-based TDD guard: an empty-aggregate run is ignored **regardless of notes** (not just `skew_swing_greeks`).
- ✅ Read-only simulation on the **production DB**: new selector picks the populated `full_scan` run for QQQ/AVGO/NVDA/SPY/IWM (old picked the empty skew run).
- ✅ **Playwright** on the fixed code against prod data: QQQ Market Structure + Flow tabs render fully populated (screenshots in `output/playwright/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)