### PR TITLE
chore: update uv.lock for v0.1.2 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1207,7 +1207,7 @@ wheels = [
 
 [[package]]
 name = "uw-scan"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Lock file was updated locally when cut.sh ran uv during the release prepare, but was not staged in the release commit. This lands the 0.1.1→0.1.2 self-reference in uv.lock.