### PR TITLE
fix(test): date-relative dark-pool seeding in discovery-scan test

### DIFF
--- a/tests/integration/worker/test_discovery_scan_job.py
+++ b/tests/integration/worker/test_discovery_scan_job.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 from uw_scan.models import DarkPoolPrint, FlowAlert
@@ -57,7 +57,10 @@ def test_discovery_scan_persists_snapshots_and_dp(seeded_db_empty_cards, monkeyp
             DarkPoolPrint(
                 ticker=ticker,
                 tracking_id=abs(hash((ticker, i))) % 1_000_000,
-                executed_at=datetime(2026, 6, 15, 13, i, tzinfo=timezone.utc),
+                # Relative to NOW so the prints always fall inside
+                # fetch_dark_pool_window's 5-day rolling window (was a fixed
+                # 2026-06-15 date-bomb that broke once the calendar passed it).
+                executed_at=datetime.now(timezone.utc) - timedelta(minutes=i),
                 price=Decimal("10.00"),
                 size=5000,
                 premium=Decimal("50000"),


### PR DESCRIPTION
## Fix a date-bomb test that's currently breaking CI on every branch

`tests/integration/worker/test_discovery_scan_job.py::test_discovery_scan_persists_snapshots_and_dp`
seeds fake dark-pool prints at a **hardcoded** `executed_at=datetime(2026, 6, 15, …)`,
but `SignalsRepository.fetch_dark_pool_window` filters `executed_at >= NOW() - 5 days`.

Once the calendar passed **2026-06-20**, the 06-15 prints fell outside the 5-day
rolling window, so the fetch returned `[]` and the assertion `len(zaaa_dp) == 3`
failed with `assert 0 == 3`. This breaks the `integration` check (and its rollup)
for **every** PR opened on or after 2026-06-21 — it is unrelated to any feature work.

### Fix
Seed the prints relative to `NOW()` (`datetime.now(timezone.utc) - timedelta(minutes=i)`)
so they always land inside the window — the correct pattern for testing a `NOW()`-relative
query. Minute offsets preserve the `executed_at DESC` ordering the fetch relies on.

### Verification
`tests/integration/worker/test_discovery_scan_job.py` — 3 passed locally (was 1 failed, 2 passed).
