### PR TITLE
chore: populate CHANGELOG [Unreleased] for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- VRP macro signal engine (`reports/vrp_macro_signal.py`): promoted bull-put-spread winner config (Δ0.25 short, ramp+ vrp-z sizing, 30 trd-day hold) into first-class engine code with `WINNER` constant, `backtest_laddered` (SPX Sharpe 1.65 / QQQ OOS 1.00), and `current_macro_signal` weekly readout (TRADE/SKIP + modeled strikes/credit/max-loss)
+- VRP macro research expansion (`reports/vrp_{candidates,backtest,directional,harvest_axes,gate,rv_validation}.py`): corrected-measurement engine, sector/horizon/directional/ΔVRP sweep axes, per-ticker iron-condor candidates, paper ledger, model-repriced weekly backtest
+- Corporate actions refresh job (nightly 17:35 ET) for exact-RV split/dividend adjustment
+
 ## [0.2.0] — 2026-06-21
 
 


### PR DESCRIPTION
Pre-flight for the v0.2.1 release. Fills the empty [Unreleased] section so `scripts/release/cut.sh prepare patch` can run.

Covers work merged since v0.2.0:
- VRP macro signal engine (PR #150) — promoted winner config into first-class engine code
- VRP research expansion (PR #149) — corrected-measurement engine, sector/horizon/directional sweep axes, paper ledger
- Corporate actions refresh job