### PR TITLE
feat: VRP macro signal deploy slice — table + nightly job + read API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 
 - **uv only** — `uv run pytest`, never `pytest` directly
 - **Persist analytical results to Postgres** — vol/scan/regime outputs land in tables, never in-memory-only
+- **Persist every research/backtest trace before the process exits** — any sweep, backtest, or parameter search must save its *full* result set (every config + every metric, not just the headline) to a durable artifact: a Postgres table for productionized signals, or a committed file/notebook under `docs/research/` for exploratory runs. stdout-only is data loss — a number you can't reproduce from a saved trace did not happen. Always record the exact reproduce command (script path + args/seed). This rule exists because a believed-but-unsaved "Sharpe ~2.0" cost a day chasing a figure that the saved trace later proved was never real (the true headline is 1.65)
 - **No naked shorts** in any strategy/trade-plan code — defined-risk only
 - **Data source priority**: IB → UW → FMP → massive (OHLC). Yahoo is banned
 - **Massive WS bypasses system proxies** — `MassiveWsClient` passes `proxy=None` to `websockets.connect`; the market-data stream must never inherit macOS SOCKS/HTTP proxy settings (`python-socks` is not installed, so an inherited proxy kills every connect). The configured feed is ~15-min delayed, so WS-consumer health keys on `last_flush_at` (is the consumer alive?), not tick event time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- VRP macro signal deploy slice: nightly persistence + read API for the promoted bull-put-spread signal shipped in 0.2.1. New `vrp_macro_signal_daily` table (migration 083), `vrp_macro_signal_refresh` job (03:45 ET, Mon–Fri, primary worker — runs SPX/QQQ/IWM weekly readout + `backtest_laddered` headline and persists one row per name per snapshot date, with per-name failure isolation), and `GET /api/regime/vrp-macro-signal` returning the latest signal per name. Closes the persist-every-research-trace gap for the VRP macro engine.
+
 ## [0.2.1] — 2026-06-22
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 
 - **uv only** — `uv run pytest`, never `pytest` directly
 - **Persist analytical results to Postgres** — vol/scan/regime outputs land in tables, never in-memory-only
+- **Persist every research/backtest trace before the process exits** — any sweep, backtest, or parameter search must save its *full* result set (every config + every metric, not just the headline) to a durable artifact: a Postgres table for productionized signals, or a committed file/notebook under `docs/research/` for exploratory runs. stdout-only is data loss — a number you can't reproduce from a saved trace did not happen. Always record the exact reproduce command (script path + args/seed). This rule exists because a believed-but-unsaved "Sharpe ~2.0" cost a day chasing a figure that the saved trace later proved was never real (the true headline is 1.65)
 - **No naked shorts** in any strategy/trade-plan code — defined-risk only
 - **Data source priority**: IB → UW → FMP → massive (OHLC). Yahoo is banned
 - **Massive WS bypasses system proxies** — `MassiveWsClient` passes `proxy=None` to `websockets.connect`; the market-data stream must never inherit macOS SOCKS/HTTP proxy settings (`python-socks` is not installed, so an inherited proxy kills every connect). The configured feed is ~15-min delayed, so WS-consumer health keys on `last_flush_at` (is the consumer alive?), not tick event time

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -51,6 +51,8 @@ from uw_scan.api.schemas import (
     VolBackdropResponse,
     VrpHarvestResponse,
     VrpHarvestVerdict,
+    VrpMacroSignalResponse,
+    VrpMacroSignalRow,
 )
 from uw_scan.cards.canary_calibration import (
     COMPOSITE_VERSION as CANARY_COMPOSITE_VERSION,
@@ -247,6 +249,16 @@ def get_vrp_harvest(
     store written by the nightly vrp_markout job."""
     rows = repo.fetch_vrp_harvest_verdicts()
     return VrpHarvestResponse(verdicts=[VrpHarvestVerdict(**r) for r in rows])
+
+
+@router.get("/vrp-macro-signal", response_model=VrpMacroSignalResponse)
+def get_vrp_macro_signal(
+    repo: Annotated[Repository, Depends(get_repo)],
+) -> VrpMacroSignalResponse:
+    """Latest VRP macro short-vol signal per index (SPX/QQQ/IWM). Read-only over
+    the daily snapshot written by the nightly vrp_macro_signal_refresh job."""
+    rows = repo.fetch_latest_vrp_macro_signals()
+    return VrpMacroSignalResponse(signals=[VrpMacroSignalRow(**r) for r in rows])
 
 
 # ─── CRI (live) ──────────────────────────────────────────────────

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -313,6 +313,43 @@ class VrpHarvestResponse(BaseModel):
     verdicts: list[VrpHarvestVerdict] = Field(default_factory=list)
 
 
+class VrpMacroSignalRow(BaseModel):
+    """Latest VRP macro short-vol signal for one index. action=TRADE iff weight>0
+    (ramp+ vrp-z sizing); strikes/credit/max_loss are flat-vol modeled (conservative
+    floor — real put skew pays more). Compare `as_of` to `snapshot_date` for staleness:
+    `as_of` is the vol-data date, `snapshot_date` is when the job ran."""
+
+    name: str
+    snapshot_date: date
+    as_of: date
+    spot: float
+    iv: float
+    rv20: float | None = None
+    vrp: float | None = None
+    vrp_z: float | None = None
+    weight: float
+    action: str  # "TRADE" | "SKIP"
+    short_put: float | None = None
+    long_put: float | None = None
+    put_width: float | None = None
+    credit: float | None = None
+    max_loss: float | None = None
+    hold_days: int
+    short_delta: float
+    wing_delta: float
+    bt_n: int | None = None
+    bt_sharpe: float | None = None
+    bt_maxdd: float | None = None
+    bt_annror: float | None = None
+    bt_calmar: float | None = None
+
+
+class VrpMacroSignalResponse(BaseModel):
+    """Latest VRP macro short-vol signal per tracked index (one row each)."""
+
+    signals: list[VrpMacroSignalRow] = Field(default_factory=list)
+
+
 # ─── CRI (Crash Risk Indicator) ──────────────────────────────────
 
 

--- a/src/uw_scan/storage/migrations/083_vrp_macro_signal_daily.sql
+++ b/src/uw_scan/storage/migrations/083_vrp_macro_signal_daily.sql
@@ -1,0 +1,43 @@
+-- 083_vrp_macro_signal_daily.sql
+-- VRP macro short-vol signal daily snapshot (Layer-3 deploy of reports/vrp_macro_signal.py).
+-- One row per (name, snapshot_date): the weekly bull-put-spread readout (TRADE/SKIP +
+-- modeled strikes/credit/max-loss) plus the full-history backtest headline as of that run.
+-- Persisting the trace is mandatory (CLAUDE.md: never leave research/backtest output in
+-- memory-only). Idempotent; never wiped — a daily snapshot accumulates a track record.
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS uw_scan.vrp_macro_signal_daily (
+    name            TEXT NOT NULL,        -- SPX | QQQ | IWM
+    snapshot_date   DATE NOT NULL,        -- compute date (ET) the job ran for
+    as_of           DATE NOT NULL,        -- vol-data date the signal is based on (reveals staleness vs snapshot_date)
+    spot            NUMERIC NOT NULL,
+    iv              NUMERIC NOT NULL,
+    rv20            NUMERIC,
+    vrp             NUMERIC,
+    vrp_z           NUMERIC,
+    weight          NUMERIC NOT NULL,     -- ramp+ size multiplier in [0,1]
+    action          TEXT NOT NULL,        -- TRADE | SKIP
+    short_put       NUMERIC,              -- NULL on SKIP
+    long_put        NUMERIC,
+    put_width       NUMERIC,
+    credit          NUMERIC,              -- flat-vol modeled floor; real put skew pays more
+    max_loss        NUMERIC,
+    hold_days       INTEGER NOT NULL,
+    short_delta     NUMERIC NOT NULL,
+    wing_delta      NUMERIC NOT NULL,
+    bt_n            INTEGER,              -- backtest_laddered headline as of this run
+    bt_sharpe       NUMERIC,             -- NULL when non-finite (nan/inf)
+    bt_maxdd        NUMERIC,
+    bt_annror       NUMERIC,
+    bt_calmar       NUMERIC,
+    config_jsonb    JSONB,               -- MacroSignalConfig used (provenance)
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (name, snapshot_date)
+);
+
+COMMENT ON TABLE uw_scan.vrp_macro_signal_daily
+    IS 'Daily VRP macro short-vol signal snapshot (Layer-3 of reports/vrp_macro_signal.py). action=TRADE iff weight>0 (ramp+ vrp-z sizing); strikes/credit/max_loss are flat-vol modeled. Latest row per name = current signal; compare snapshot_date vs as_of for staleness.';
+
+COMMIT;

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -71,6 +71,7 @@ from .skew import _SkewMixin
 from .trade_insights_ai import _TradeInsightsAiMixin
 from .volatility_raw import _VolatilityRawMixin
 from .volatility_v2 import _VolatilityV2Mixin
+from .vrp_macro_signal import _VrpMacroSignalMixin
 from .vrp_markout import _VrpMarkoutMixin
 from .vrp_research import _VrpResearchMixin
 from .vrp_trading import _VrpTradingMixin
@@ -127,6 +128,7 @@ class Repository(
     _TradeInsightsAiMixin,
     _VolatilityRawMixin,
     _VolatilityV2Mixin,
+    _VrpMacroSignalMixin,
     _VrpMarkoutMixin,
     _VrpResearchMixin,
     _VrpTradingMixin,

--- a/src/uw_scan/storage/vrp_macro_signal.py
+++ b/src/uw_scan/storage/vrp_macro_signal.py
@@ -1,0 +1,138 @@
+"""VRP macro short-vol signal daily-snapshot persistence (Layer-3 of
+reports/vrp_macro_signal.py). One row per (name, snapshot_date)."""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+_COLUMNS = (
+    "name",
+    "snapshot_date",
+    "as_of",
+    "spot",
+    "iv",
+    "rv20",
+    "vrp",
+    "vrp_z",
+    "weight",
+    "action",
+    "short_put",
+    "long_put",
+    "put_width",
+    "credit",
+    "max_loss",
+    "hold_days",
+    "short_delta",
+    "wing_delta",
+    "bt_n",
+    "bt_sharpe",
+    "bt_maxdd",
+    "bt_annror",
+    "bt_calmar",
+    "config_jsonb",
+)
+
+
+class _VrpMacroSignalMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def upsert_vrp_macro_signal(
+        self,
+        *,
+        name: str,
+        snapshot_date: _date,
+        as_of: _date,
+        spot: float,
+        iv: float,
+        rv20: float | None,
+        vrp: float | None,
+        vrp_z: float | None,
+        weight: float,
+        action: str,
+        short_put: float | None,
+        long_put: float | None,
+        put_width: float | None,
+        credit: float | None,
+        max_loss: float | None,
+        hold_days: int,
+        short_delta: float,
+        wing_delta: float,
+        bt_n: int | None,
+        bt_sharpe: float | None,
+        bt_maxdd: float | None,
+        bt_annror: float | None,
+        bt_calmar: float | None,
+        config: dict[str, Any] | None,
+    ) -> None:
+        """Insert/update the (name, snapshot_date) signal snapshot. Idempotent —
+        re-running the job same-day overwrites the row in place."""
+        placeholders = ", ".join(["%s"] * len(_COLUMNS))
+        cols = ", ".join(_COLUMNS)
+        updates = ", ".join(
+            f"{c} = EXCLUDED.{c}"
+            for c in _COLUMNS
+            if c not in ("name", "snapshot_date")
+        )
+        sql = (
+            f"INSERT INTO {self._schema}.vrp_macro_signal_daily ({cols}) "
+            f"VALUES ({placeholders}) "
+            "ON CONFLICT (name, snapshot_date) DO UPDATE SET "
+            f"{updates}, created_at = now()"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (
+                    name,
+                    snapshot_date,
+                    as_of,
+                    spot,
+                    iv,
+                    rv20,
+                    vrp,
+                    vrp_z,
+                    weight,
+                    action,
+                    short_put,
+                    long_put,
+                    put_width,
+                    credit,
+                    max_loss,
+                    hold_days,
+                    short_delta,
+                    wing_delta,
+                    bt_n,
+                    bt_sharpe,
+                    bt_maxdd,
+                    bt_annror,
+                    bt_calmar,
+                    Jsonb(config) if config is not None else None,
+                ),
+            )
+
+    def fetch_latest_vrp_macro_signals(
+        self, names: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        """Latest snapshot per name (one row each), newest first by name. Pass
+        `names` to restrict; None returns every tracked name."""
+        select_cols = ", ".join(_COLUMNS) + ", created_at"
+        where = ""
+        params: tuple[Any, ...] = ()
+        if names:
+            where = "WHERE name = ANY(%s) "
+            params = ([n.upper() for n in names],)
+        sql = (
+            f"SELECT DISTINCT ON (name) {select_cols} "
+            f"FROM {self._schema}.vrp_macro_signal_daily "
+            f"{where}"
+            "ORDER BY name, snapshot_date DESC"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            keys = [d.name for d in cur.description or []]
+            return [dict(zip(keys, row, strict=False)) for row in cur.fetchall()]

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -68,6 +68,7 @@ Set `UW_SCAN_WORKER_ROLE=uw|massive|ai|all`, `UW_SCAN_WORKER_INDEX`, and
 | `vrp_paper_open` | cron | `30 19 * * 0-4` (massive-0; open paper positions for today's candidates) |
 | `vrp_paper_mark` | cron | `40 19 * * 0-4` (massive-0; mark/close open paper positions, net of modeled cost) |
 | `vrp_backtest_refresh` | cron | `0 20 * * 6` (massive-0; weekly full-universe model-repriced condor backtest) |
+| `vrp_macro_signal_refresh` | cron | `45 3 * * 0-4` (massive-0; daily VRP macro short-vol signal snapshot — runs after `vol_index_lake_sync` at 03:15 so it reads the freshest EOD vol) |
 
 Intraday spot is no longer a scheduler job — it streams from the
 WebSocket consumer in `uw_scan.worker.massive_ws_consumer` (started as

--- a/src/uw_scan/worker/jobs/vrp_macro_signal.py
+++ b/src/uw_scan/worker/jobs/vrp_macro_signal.py
@@ -1,0 +1,111 @@
+"""VRP macro short-vol signal refresh job (Layer-3 deploy) — thin orchestration
+that runs reports/vrp_macro_signal.py over the tracked names and persists the
+daily snapshot. The engine module stays persistence-free; this worker layer is
+the seam that knows both reports and storage.
+
+Runs at 03:45 ET (after vol_index_lake_sync at 03:15) so it reads the freshest
+synced EOD vol. SPX (VIX) is the live name; QQQ/IWM (VXN/RVX) are wired but their
+vol-index feed may lag — the row's as_of vs snapshot_date reveals staleness."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from datetime import date as _date
+from datetime import datetime
+from math import isfinite
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from uw_scan.config import Settings
+from uw_scan.reports.vrp_macro_drawdown import load_index_vol
+from uw_scan.reports.vrp_macro_signal import (
+    WINNER,
+    MacroSignalConfig,
+    backtest_laddered,
+    current_macro_signal,
+)
+from uw_scan.storage.repository import Repository
+
+log = logging.getLogger(__name__)
+
+DEFAULT_NAMES: tuple[str, ...] = ("SPX", "QQQ", "IWM")
+
+
+def _finite(x: float | None) -> float | None:
+    """Postgres NUMERIC chokes on nan/inf; map non-finite backtest stats to NULL.
+    Sharpe is nan when the monthly series has zero variance; Calmar is inf when
+    maxDD is zero."""
+    return x if (x is not None and isfinite(x)) else None
+
+
+def vrp_macro_signal_refresh(
+    *,
+    repo: Repository,
+    settings: Settings,
+    snapshot_date: _date | None = None,
+    names: tuple[str, ...] | list[str] = DEFAULT_NAMES,
+    cfg: MacroSignalConfig = WINNER,
+) -> dict[str, Any]:
+    """For each name: compute the current weekly signal + the full-history backtest
+    headline and upsert a (name, snapshot_date) row. Per-name isolation — one name's
+    stale/missing vol data never blocks the others. Single commit at the end so
+    readers never see a partial set. Idempotent (re-run same day overwrites)."""
+    if snapshot_date is None:
+        snapshot_date = datetime.now(ZoneInfo(settings.rth_tz)).date()
+    config = asdict(cfg)
+    persisted = 0
+    failed: list[str] = []
+    for name in names:
+        try:
+            loaded = load_index_vol(repo, name)
+            bt = backtest_laddered(loaded, settings, cfg)
+            sig = current_macro_signal(repo, settings, name, cfg)
+            repo.upsert_vrp_macro_signal(
+                name=name,
+                snapshot_date=snapshot_date,
+                as_of=sig.as_of,
+                spot=sig.spot,
+                iv=sig.iv,
+                rv20=sig.rv20,
+                vrp=sig.vrp,
+                vrp_z=sig.vrp_z,
+                weight=sig.weight,
+                action=sig.action,
+                short_put=sig.short_put,
+                long_put=sig.long_put,
+                put_width=sig.put_width,
+                credit=sig.credit,
+                max_loss=sig.max_loss,
+                hold_days=sig.hold_days,
+                short_delta=sig.short_delta,
+                wing_delta=sig.wing_delta,
+                bt_n=bt.get("n"),
+                bt_sharpe=_finite(bt.get("sharpe")),
+                bt_maxdd=_finite(bt.get("maxdd")),
+                bt_annror=_finite(bt.get("annror")),
+                bt_calmar=_finite(bt.get("calmar")),
+                config=config,
+            )
+            persisted += 1
+            log.info(
+                "vrp_macro_signal %s: as_of=%s action=%s weight=%.3f sharpe=%s",
+                name,
+                sig.as_of,
+                sig.action,
+                sig.weight,
+                _finite(bt.get("sharpe")),
+            )
+        except Exception as exc:  # noqa: BLE001 - per-name isolation; log and continue
+            failed.append(name)
+            log.warning("vrp_macro_signal %s: skipped — %s", name, repr(exc))
+    repo.conn.commit()
+    counts = {"persisted": persisted, "failed": failed, "snapshot_date": snapshot_date}
+    log.info(
+        "vrp_macro_signal_refresh: %d persisted, %d failed (%s) for %s",
+        persisted,
+        len(failed),
+        ",".join(failed) or "none",
+        snapshot_date,
+    )
+    return counts

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -60,6 +60,7 @@ from uw_scan.worker.jobs.trade_insight_outcome_backfill import (
 )
 from uw_scan.worker.jobs.trade_insights_ai import trade_insights_ai_tick
 from uw_scan.worker.jobs.vol_index_lake_sync import run_vol_index_lake_sync
+from uw_scan.worker.jobs.vrp_macro_signal import vrp_macro_signal_refresh
 from uw_scan.worker.jobs.vrp_markout import vrp_markout_refresh
 from uw_scan.worker.jobs.vrp_research_jobs import vrp_research_refresh
 from uw_scan.worker.jobs.vrp_trading_jobs import (
@@ -441,6 +442,10 @@ def main() -> int:
     def _vrp_markout_refresh() -> None:
         with _repo(settings) as repo:
             vrp_markout_refresh(repo=repo)
+
+    def _vrp_macro_signal_refresh() -> None:
+        with _repo(settings) as repo:
+            vrp_macro_signal_refresh(repo=repo, settings=settings)
 
     def _corporate_actions_refresh() -> None:
         provider = _fundamentals_provider(settings)
@@ -1133,6 +1138,18 @@ def main() -> int:
             CronTrigger(hour=3, minute=15, timezone=settings.rth_tz),
             id="vol_index_lake_sync",
             name="Vol-complex parquet lake sync",
+            max_instances=1,
+            coalesce=True,
+        )
+        # VRP macro short-vol signal at 03:45 ET — AFTER vol_index_lake_sync
+        # (03:15) so it reads the freshest synced EOD vol. Computes the weekly
+        # bull-put-spread readout + full-history backtest headline per name and
+        # persists the daily snapshot. Pure DB-read math; idempotent.
+        sched.add_job(
+            _vrp_macro_signal_refresh,
+            CronTrigger.from_crontab("45 3 * * 0-4", timezone=settings.rth_tz),
+            id="vrp_macro_signal_refresh",
+            name="VRP macro short-vol signal refresh",
             max_instances=1,
             coalesce=True,
         )

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -19239,6 +19239,224 @@
         "title": "VrpHarvestVerdict",
         "type": "object"
       },
+      "VrpMacroSignalResponse": {
+        "description": "Latest VRP macro short-vol signal per tracked index (one row each).",
+        "properties": {
+          "signals": {
+            "items": {
+              "$ref": "#/components/schemas/VrpMacroSignalRow"
+            },
+            "title": "Signals",
+            "type": "array"
+          }
+        },
+        "title": "VrpMacroSignalResponse",
+        "type": "object"
+      },
+      "VrpMacroSignalRow": {
+        "description": "Latest VRP macro short-vol signal for one index. action=TRADE iff weight>0\n(ramp+ vrp-z sizing); strikes/credit/max_loss are flat-vol modeled (conservative\nfloor \u2014 real put skew pays more). Compare `as_of` to `snapshot_date` for staleness:\n`as_of` is the vol-data date, `snapshot_date` is when the job ran.",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "bt_annror": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bt Annror"
+          },
+          "bt_calmar": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bt Calmar"
+          },
+          "bt_maxdd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bt Maxdd"
+          },
+          "bt_n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bt N"
+          },
+          "bt_sharpe": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bt Sharpe"
+          },
+          "credit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit"
+          },
+          "hold_days": {
+            "title": "Hold Days",
+            "type": "integer"
+          },
+          "iv": {
+            "title": "Iv",
+            "type": "number"
+          },
+          "long_put": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Long Put"
+          },
+          "max_loss": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Loss"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "put_width": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Width"
+          },
+          "rv20": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv20"
+          },
+          "short_delta": {
+            "title": "Short Delta",
+            "type": "number"
+          },
+          "short_put": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Put"
+          },
+          "snapshot_date": {
+            "format": "date",
+            "title": "Snapshot Date",
+            "type": "string"
+          },
+          "spot": {
+            "title": "Spot",
+            "type": "number"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vrp_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp Z"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          },
+          "wing_delta": {
+            "title": "Wing Delta",
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "snapshot_date",
+          "as_of",
+          "spot",
+          "iv",
+          "weight",
+          "action",
+          "hold_days",
+          "short_delta",
+          "wing_delta"
+        ],
+        "title": "VrpMacroSignalRow",
+        "type": "object"
+      },
       "VrpPaperPositionRow": {
         "properties": {
           "contracts": {
@@ -20053,7 +20271,7 @@
   },
   "info": {
     "title": "UW Watchlist API",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -21988,6 +22206,28 @@
           }
         },
         "summary": "Get Vrp Harvest",
+        "tags": [
+          "regime"
+        ]
+      }
+    },
+    "/api/regime/vrp-macro-signal": {
+      "get": {
+        "description": "Latest VRP macro short-vol signal per index (SPX/QQQ/IWM). Read-only over\nthe daily snapshot written by the nightly vrp_macro_signal_refresh job.",
+        "operationId": "get_vrp_macro_signal_api_regime_vrp_macro_signal_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VrpMacroSignalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Vrp Macro Signal",
         "tags": [
           "regime"
         ]

--- a/tests/integration/api/test_vrp_macro_signal_endpoint.py
+++ b/tests/integration/api/test_vrp_macro_signal_endpoint.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+
+def _seed_spx_skip(repo) -> None:
+    # Real frozen SPX readout (observed 2026-06-22): vol cheap → ramp+ → SKIP.
+    repo.upsert_vrp_macro_signal(
+        name="SPX",
+        snapshot_date=date(2026, 6, 22),
+        as_of=date(2026, 5, 21),
+        spot=7445.72,
+        iv=0.164,
+        rv20=0.1612,
+        vrp=0.0028,
+        vrp_z=-1.953,
+        weight=0.0,
+        action="SKIP",
+        short_put=None,
+        long_put=None,
+        put_width=None,
+        credit=None,
+        max_loss=None,
+        hold_days=30,
+        short_delta=0.25,
+        wing_delta=0.125,
+        bt_n=522,
+        bt_sharpe=1.6524,
+        bt_maxdd=-0.796,
+        bt_annror=0.53,
+        bt_calmar=0.67,
+        config={"sizing": "ramp+"},
+    )
+    repo.conn.commit()
+
+
+def test_vrp_macro_signal_endpoint_returns_seeded_row(
+    client: TestClient, seeded_db_empty_cards
+) -> None:
+    _seed_spx_skip(seeded_db_empty_cards)
+
+    res = client.get("/api/regime/vrp-macro-signal")
+    assert res.status_code == 200
+    body = res.json()
+    assert "signals" in body
+    assert len(body["signals"]) == 1
+    s = body["signals"][0]
+    assert s["name"] == "SPX"
+    assert s["action"] == "SKIP"
+    assert s["weight"] == 0.0
+    assert s["as_of"] == "2026-05-21"
+    assert s["snapshot_date"] == "2026-06-22"
+    assert s["bt_sharpe"] == 1.6524
+    assert s["short_put"] is None  # SKIP → no modeled structure
+
+
+def test_vrp_macro_signal_endpoint_empty_is_ok(
+    client: TestClient, seeded_db_empty_cards
+) -> None:
+    res = client.get("/api/regime/vrp-macro-signal")
+    assert res.status_code == 200
+    assert res.json() == {"signals": []}

--- a/tests/integration/storage/test_vrp_macro_signal_storage.py
+++ b/tests/integration/storage/test_vrp_macro_signal_storage.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date
+
+# Real frozen VRP macro signal readouts — computed by reports/vrp_macro_signal.py
+# from real VIX/SPX/VXN history (observed 2026-06-22). Hardcoded fixtures; tests
+# never recompute or hit the network.
+SPX_SKIP = dict(
+    name="SPX",
+    as_of=date(2026, 5, 21),
+    spot=7445.72,
+    iv=0.164,
+    rv20=0.1612,
+    vrp=0.0028,
+    vrp_z=-1.953,
+    weight=0.0,
+    action="SKIP",
+    short_put=None,
+    long_put=None,
+    put_width=None,
+    credit=None,
+    max_loss=None,
+    hold_days=30,
+    short_delta=0.25,
+    wing_delta=0.125,
+    bt_n=522,
+    bt_sharpe=1.6524,
+    bt_maxdd=-0.796,
+    bt_annror=0.53,
+    bt_calmar=0.67,
+    config={"sizing": "ramp+", "short_delta": 0.25},
+)
+QQQ_TRADE = dict(
+    name="QQQ",
+    as_of=date(2026, 5, 15),
+    spot=708.93,
+    iv=0.2533,
+    rv20=0.1672,
+    vrp=0.0861,
+    vrp_z=0.530,
+    weight=1.0,
+    action="TRADE",
+    short_put=674.11,
+    long_put=646.65,
+    put_width=27.46,
+    credit=5.67,
+    max_loss=21.79,
+    hold_days=30,
+    short_delta=0.25,
+    wing_delta=0.125,
+    bt_n=422,
+    bt_sharpe=1.0065,
+    bt_maxdd=-0.7527,
+    bt_annror=0.3543,
+    bt_calmar=0.47,
+    config={"sizing": "ramp+", "short_delta": 0.25},
+)
+
+
+def test_upsert_and_fetch_latest_per_name(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    repo.upsert_vrp_macro_signal(snapshot_date=date(2026, 6, 22), **SPX_SKIP)
+    repo.upsert_vrp_macro_signal(snapshot_date=date(2026, 6, 22), **QQQ_TRADE)
+    repo.conn.commit()
+
+    by = {r["name"]: r for r in repo.fetch_latest_vrp_macro_signals()}
+    assert set(by) == {"SPX", "QQQ"}
+    assert by["SPX"]["action"] == "SKIP"
+    assert float(by["SPX"]["weight"]) == 0.0
+    assert float(by["SPX"]["bt_sharpe"]) == 1.6524
+    assert by["SPX"]["short_put"] is None  # SKIP carries no structure
+    assert by["QQQ"]["action"] == "TRADE"
+    assert float(by["QQQ"]["credit"]) == 5.67
+    assert by["QQQ"]["config_jsonb"] == {"sizing": "ramp+", "short_delta": 0.25}
+
+
+def test_upsert_is_idempotent_same_day(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    snap = date(2026, 6, 22)
+    repo.upsert_vrp_macro_signal(snapshot_date=snap, **SPX_SKIP)
+    # same (name, snapshot_date) re-run overwrites in place — flip SKIP→TRADE
+    repo.upsert_vrp_macro_signal(
+        snapshot_date=snap, **{**SPX_SKIP, "action": "TRADE", "weight": 1.0}
+    )
+    repo.conn.commit()
+
+    rows = repo.fetch_latest_vrp_macro_signals(names=["SPX"])
+    assert len(rows) == 1  # one PK, not two
+    assert rows[0]["action"] == "TRADE"
+    assert float(rows[0]["weight"]) == 1.0
+
+
+def test_fetch_latest_returns_newest_snapshot(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    repo.upsert_vrp_macro_signal(snapshot_date=date(2026, 6, 19), **SPX_SKIP)
+    repo.upsert_vrp_macro_signal(
+        snapshot_date=date(2026, 6, 22),
+        **{**SPX_SKIP, "action": "TRADE", "weight": 1.0},
+    )
+    repo.conn.commit()
+
+    rows = repo.fetch_latest_vrp_macro_signals(names=["spx"])  # case-insensitive
+    assert len(rows) == 1
+    assert rows[0]["snapshot_date"] == date(2026, 6, 22)  # newest wins
+    assert rows[0]["action"] == "TRADE"
+
+
+def test_fetch_latest_empty_is_empty_list(seeded_db_empty_cards) -> None:
+    assert seeded_db_empty_cards.fetch_latest_vrp_macro_signals() == []

--- a/tests/integration/worker/test_vrp_macro_signal_job.py
+++ b/tests/integration/worker/test_vrp_macro_signal_job.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import date
+
+from uw_scan.config import Settings
+from uw_scan.worker.jobs.vrp_macro_signal import vrp_macro_signal_refresh
+
+# The happy path (SPX/QQQ/IWM compute → persist) is verified end-to-end against
+# the real dev DB — a faithful in-test happy path would need a ~273-row real
+# VIX/SPX fixture (the rv/z windows are 20/252), which we don't fabricate. These
+# tests pin the production-critical property instead: a name with missing/stale
+# vol data must fail gracefully without crashing the scheduler.
+
+
+def test_refresh_isolates_missing_vol_data(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    settings = Settings.from_env()
+
+    out = vrp_macro_signal_refresh(
+        repo=repo, settings=settings, snapshot_date=date(2026, 6, 22)
+    )
+
+    # Empty vol_index_daily → every name's compute fails, but the job returns a
+    # clean per-name accounting and never raises.
+    assert out["persisted"] == 0
+    assert set(out["failed"]) == {"SPX", "QQQ", "IWM"}
+    assert out["snapshot_date"] == date(2026, 6, 22)
+    assert repo.fetch_latest_vrp_macro_signals() == []
+
+
+def test_refresh_is_safe_to_rerun(seeded_db_empty_cards) -> None:
+    repo = seeded_db_empty_cards
+    settings = Settings.from_env()
+
+    out = None
+    for _ in range(2):
+        out = vrp_macro_signal_refresh(
+            repo=repo, settings=settings, snapshot_date=date(2026, 6, 22)
+        )
+
+    assert out is not None
+    assert out["persisted"] == 0
+    assert repo.fetch_latest_vrp_macro_signals() == []

--- a/uv.lock
+++ b/uv.lock
@@ -1207,7 +1207,7 @@ wheels = [
 
 [[package]]
 name = "uw-scan"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## What

Layer-3 deploy slice for the VRP macro signal (the promoted bull-put-spread
winner shipped as engine code in v0.2.1). Adds the persistence + read path the
signal was missing — it now lands in Postgres nightly instead of living only in
research-layer return values.

Multi-name capable (SPX / QQQ / IWM); **SPX is the live/actionable one** (QQQ/IWM
depend on the VXN/RVX vol feed which is currently stale ~May 15 — tracked
separately).

## Changes

| Layer | File |
|---|---|
| Migration 083 | `vrp_macro_signal_daily` (PK `(name, snapshot_date)`, 25 cols: readout + backtest headline + config provenance) |
| Storage | `storage/vrp_macro_signal.py` — `_VrpMacroSignalMixin`: `upsert_vrp_macro_signal` (idempotent), `fetch_latest_vrp_macro_signals` (DISTINCT ON name) |
| Job | `worker/jobs/vrp_macro_signal.py` — `vrp_macro_signal_refresh`: per-name `load_index_vol → backtest_laddered → current_macro_signal → upsert`, per-name failure isolation, single commit |
| Scheduler | `03:45 ET` daily Mon–Fri, primary-worker, after `vol_index_lake_sync` (03:15) |
| API | `GET /api/regime/vrp-macro-signal` → latest per name |
| Rule | `CLAUDE.md` + `AGENTS.md`: persist every research/backtest trace before exit |

## Verification

- Migration idempotent — `migrate.sh` ran twice clean (25 cols)
- Storage round-trip + idempotency + latest-per-name — `pytest tests/integration/storage/test_vrp_macro_signal_storage.py` (4 passed)
- API contract — OpenAPI snapshot +2 schemas / +1 path, nothing removed; `test_openapi_snapshot.py` green
- Endpoint — seeded + empty cases (`test_vrp_macro_signal_endpoint.py`, 2 passed)
- Job per-name isolation — missing vol → `persisted=0, failed=[SPX,QQQ,IWM]`, no raise (`test_vrp_macro_signal_job.py`, 2 passed)
- Job happy path verified against real dev DB: **3 persisted, SPX SKIP @ Sharpe 1.6524** (matches verdict doc bit-for-bit)
- 26 regression tests green (regime router, harvest, models-export, contract)

## Not in this PR

- `web/lib/types.ts` regen + UI card — deferred (no UI consumer this slice; OpenAPI snapshot is the contract guard)
- Job happy-path automated test — would need a fabricated ~273-row VIX/SPX fixture; covered by the real dev-DB run instead (no synthetic market data)

🤖 Tests: real frozen tickers/prices, no network at runtime.
