### PR TITLE
fix(release): re-lock uv.lock on bump so the deploy poller stops wedging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
+      # Runs BEFORE `uv sync` on purpose: `uv sync` auto-repairs uv.lock's editable
+      # self-version to match pyproject, which would mask a stale committed lock. We
+      # want CI to fail on the committed state. version_sync_check is stdlib-only, so
+      # system python3 (no uv) reads the lock exactly as committed.
+      - name: Version sync check (committed lock, pre-sync)
+        run: python3 scripts/release/version_sync_check.py
+
       - name: Sync deps
         run: uv sync --extra postgres
-
-      - name: Version sync check
-        run: uv run python scripts/release/version_sync_check.py
 
       - name: Ruff
         run: uv run ruff check src/ tests/ scripts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
+      # Runs BEFORE `uv sync` on purpose: `uv sync` auto-repairs uv.lock's editable
+      # self-version to match pyproject, which would mask a stale committed lock. We
+      # want the release to fail on the committed state. version_sync_check is
+      # stdlib-only, so system python3 (no uv) reads the lock exactly as committed.
+      - name: Version sync check (committed lock, pre-sync)
+        run: python3 scripts/release/version_sync_check.py
+
       - name: Sync deps
         run: uv sync --extra postgres
-
-      - name: Version sync check
-        run: uv run python scripts/release/version_sync_check.py
 
       - name: Assert tag matches VERSION (allow prerelease suffix)
         # Catches a hand-pushed mistag (e.g. v0.5.0 on a VERSION=0.1.0 commit),

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -6,8 +6,9 @@ Argon ships to the Mac mini via a tag-driven pipeline (no Docker; launchd stack)
 
 1. Land your feature PRs to `main` with CHANGELOG entries under `## [Unreleased]`.
 2. `scripts/release/cut.sh prepare [patch|minor|major]` — opens a `release/vX.Y.Z`
-   PR that bumps `VERSION` + `pyproject.toml` + `web/package.json` and promotes
-   the `[Unreleased]` block to `[X.Y.Z]`.
+   PR that bumps `VERSION` + `pyproject.toml` + `web/package.json`, re-locks
+   `uv.lock` (so its editable self-version tracks the bump), and promotes the
+   `[Unreleased]` block to `[X.Y.Z]`.
 3. Merge that PR after CI is green.
 4. `scripts/release/cut.sh tag` (on `main`) — tags `vX.Y.Z` and pushes the tag.
 
@@ -57,3 +58,14 @@ Resume the poller when done.
 clean across deploys. If the poller logs `ALERT: working tree dirty`, inspect
 `git status` on the mini and resolve (e.g. `git checkout -- <file>`) — never
 `git reset --hard`.
+
+Historically the recurring cause was `uv.lock`: `cut.sh` bumped the version files
+but never re-locked, so the committed lock's editable self-version lagged
+`VERSION`. The first `uv run` on the mini rewrote that one line, the tree went
+dirty, and the poller refused every deploy — silently pinning prod to the
+last-deployed release. `cut.sh prepare` now runs `uv lock` and commits it, and
+`version_sync_check` (run pre-`uv sync` in CI, so a stale committed lock can't be
+auto-repaired and hidden) fails the build if the lock self-version ever drifts
+from `VERSION` again. If you still see a dirty `uv.lock` on the mini, it means an
+out-of-band `uv` invocation re-resolved deps — `git checkout -- uv.lock` and
+investigate why the committed lock disagreed with the installed environment.

--- a/scripts/release/cut.sh
+++ b/scripts/release/cut.sh
@@ -87,9 +87,17 @@ assert updated != text, "CHANGELOG rewrite produced no change"
 open(path, "w").write(updated)
 PY
 
+  # Re-lock so uv.lock's editable self-version matches the bumped pyproject. Without
+  # this the committed lock lags (lock says $current, pyproject says $next); the first
+  # `uv run` on any host then rewrites that one line, dirtying the tree, and the
+  # mac-mini deploy poller refuses to deploy on a dirty tree — silently wedging prod on
+  # the last-deployed release. version_sync_check (below, and pre-sync in CI) enforces
+  # the match. See docs/runbooks/release.md.
+  uv lock
+
   uv run python scripts/release/version_sync_check.py || die "version_sync_check failed after bump"
 
-  git add VERSION pyproject.toml web/package.json CHANGELOG.md
+  git add VERSION pyproject.toml web/package.json CHANGELOG.md uv.lock
   git commit -m "release: v$next"
   git push -u origin "$branch"
   gh pr create --base main --head "$branch" \

--- a/scripts/release/version_sync_check.py
+++ b/scripts/release/version_sync_check.py
@@ -1,8 +1,19 @@
-"""Fail if VERSION, pyproject [project].version, and web/package.json disagree.
+"""Fail if VERSION, pyproject [project].version, web/package.json, or uv.lock disagree.
 
 VERSION is the source of truth. Argon has no root package.json (all Node deps
 live under web/), so web/package.json is the only tracked Node package; it
 versions in lockstep with the Python package.
+
+uv.lock pins the editable root package (`source = { editable = "." }`) at the
+pyproject version. If the committed lock lags VERSION, the first `uv run` on any
+host rewrites that one line, dirtying the working tree — which makes the mac-mini
+deploy poller refuse to deploy (it never `reset --hard`s) and silently wedges
+prod on the last-deployed release. cut.sh re-locks on every bump; this check is
+the regression guard. It compares only the editable self-version string, so it
+is immune to uv-version-dependent formatting drift elsewhere in the lock.
+
+Run it against the *committed* lock — before any `uv sync`, which auto-repairs
+the lock and would mask the drift.
 """
 
 from __future__ import annotations
@@ -12,6 +23,24 @@ import json
 import sys
 import tomllib
 from pathlib import Path
+
+
+def _editable_lock_version(lock_path: Path) -> str | None:
+    """Version of the editable root package in uv.lock, or None if not uniquely found.
+
+    The project itself is the single `[[package]]` whose source is the editable
+    root (`source = { editable = "." }`). Returns None on zero or multiple such
+    packages so the caller reports a loud mismatch rather than guessing.
+    """
+    data = tomllib.loads(lock_path.read_text())
+    editable = [
+        pkg
+        for pkg in data.get("package", [])
+        if isinstance(pkg.get("source"), dict) and pkg["source"].get("editable") == "."
+    ]
+    if len(editable) != 1:
+        return None
+    return editable[0].get("version", "")
 
 
 def check(root: Path) -> list[tuple[str, str]]:
@@ -29,6 +58,16 @@ def check(root: Path) -> list[tuple[str, str]]:
         pkg_version = json.loads(web_pkg.read_text()).get("version", "")
         if pkg_version != version:
             mismatches.append(("web/package.json", pkg_version))
+
+    uv_lock = root / "uv.lock"
+    if uv_lock.exists():
+        lock_version = _editable_lock_version(uv_lock)
+        if lock_version is None:
+            mismatches.append(
+                ("uv.lock editable root package (not uniquely found)", "<none>")
+            )
+        elif lock_version != version:
+            mismatches.append(("uv.lock editable self-version", lock_version))
 
     return mismatches
 

--- a/tests/unit/test_release_version_sync.py
+++ b/tests/unit/test_release_version_sync.py
@@ -23,6 +23,25 @@ def _setup(root: Path, *, version="1.2.3", py="1.2.3", web="1.2.3") -> None:
     (web_dir / "package.json").write_text(json.dumps({"name": "w", "version": web}))
 
 
+def _write_lock(root: Path, *, editable_version: str | None = "1.2.3") -> None:
+    """Write a minimal uv.lock with one registry dep and (optionally) the editable root.
+
+    Mirrors the real uv.lock shape: the project itself is the single package whose
+    source is `{ editable = "." }`. `editable_version=None` omits the editable
+    package entirely (simulates a malformed/unexpected lock).
+    """
+    blocks = [
+        '[[package]]\nname = "apscheduler"\nversion = "3.10.4"\n'
+        'source = { registry = "https://pypi.org/simple" }\n'
+    ]
+    if editable_version is not None:
+        blocks.append(
+            f'[[package]]\nname = "x"\nversion = "{editable_version}"\n'
+            'source = { editable = "." }\n'
+        )
+    (root / "uv.lock").write_text("\n".join(blocks))
+
+
 def _run(root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--root", str(root)],
@@ -50,3 +69,38 @@ def test_web_package_mismatch_fails(tmp_path):
     r = _run(tmp_path)
     assert r.returncode == 1
     assert "web/package.json" in r.stderr
+
+
+def test_uv_lock_match_passes(tmp_path):
+    _setup(tmp_path)
+    _write_lock(tmp_path, editable_version="1.2.3")
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "OK: 1.2.3" in r.stdout
+
+
+def test_uv_lock_mismatch_fails(tmp_path):
+    # This is the prod-wedging case: lock self-version lags VERSION/pyproject.
+    _setup(tmp_path)
+    _write_lock(tmp_path, editable_version="1.2.2")
+    r = _run(tmp_path)
+    assert r.returncode == 1
+    assert "uv.lock editable self-version" in r.stderr
+    assert "1.2.2" in r.stderr
+
+
+def test_uv_lock_no_editable_root_fails(tmp_path):
+    # A lock with no editable root package is unexpected — fail loudly, don't pass.
+    _setup(tmp_path)
+    _write_lock(tmp_path, editable_version=None)
+    r = _run(tmp_path)
+    assert r.returncode == 1
+    assert "uv.lock editable root package (not uniquely found)" in r.stderr
+
+
+def test_uv_lock_absent_is_skipped(tmp_path):
+    # No uv.lock present (e.g. a non-uv checkout) → lock check is skipped, others still run.
+    _setup(tmp_path)
+    assert not (tmp_path / "uv.lock").exists()
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1207,7 +1207,7 @@ wheels = [
 
 [[package]]
 name = "uw-scan"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Problem

`cut.sh prepare` bumps `VERSION` / `pyproject.toml` / `web/package.json` but never re-locks `uv.lock`. So the committed lock's editable self-version lags the bump (lock says `0.2.1` while `VERSION=0.2.2`). The **first `uv run` on any host** rewrites that one line → working tree dirty → the mac-mini `com.argon.deploy-poller` **refuses to deploy a dirty tree** (it never `reset --hard`s, per CLAUDE.md) → prod silently pins to the last-deployed release.

This actually happened: the mini sat on **v0.1.2 for 4 days** while v0.2.0, v0.2.1, and v0.2.2 all published. (Unwedged manually; this PR fixes the root cause.)

## Fix

1. **`cut.sh prepare`** runs `uv lock` after the bump and commits `uv.lock` — so the committed lock never lags. Verified the re-lock is a **1-line, dep-bump-free** diff.
2. **`version_sync_check.py`** now asserts `uv.lock`'s editable self-version (`source = { editable = "." }`) == `VERSION`. String compare only → immune to uv-version-dependent formatting drift elsewhere in the lock (unlike `uv sync --locked`, which would be brittle against floating CI uv versions).
3. **`ci.yml` + `release.yml`** run that check via **system `python3` BEFORE `uv sync`** — `uv sync` auto-repairs the lock on disk and would mask a stale *committed* lock, so the check must read the committed file first. `version_sync_check.py` is stdlib-only.
4. Re-locked the current baseline (`uw-scan 0.2.1 -> 0.2.2`) so `main` is consistent and the new guard passes.

## Evidence

- `ruff check` clean; `pytest tests/unit/test_release_version_sync.py` → **7 passed** (3 existing + 4 new).
- Guard **fails** (exit 1) on the stale committed lock: `uv.lock editable self-version='0.2.1'`; **passes** (`OK: 0.2.2`) after re-lock.
- `bash -n cut.sh` OK; both workflow YAMLs parse.

## Follow-ups (not in this PR)

- QQQ/IWM `TypeError("'>=' not supported between NoneType and date")` in the VRP macro signal lake path (SPX unaffected; per-name isolation contained it).