### PR TITLE
feat: option-surface ~30-day historical backfill seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- Option-surface historical backfill: `option_surface_backfill` function and
+  `scripts/option_surface_backfill.py` runner seed `option_surface_grid_daily`
+  for up to 30 past trading days in one shot. UW `/greek-exposure/expiry` and
+  `/greeks` both accept an optional `date=` param (now forwarded by the fetchers);
+  dates already in the table are skipped. Run promptly after first deploy — UW
+  403s beyond ~30 trading days.
+
 ## [0.3.0] — 2026-06-23
 
 

--- a/scripts/option_surface_backfill.py
+++ b/scripts/option_surface_backfill.py
@@ -1,0 +1,60 @@
+"""One-time backfill for option_surface_grid_daily.
+
+Fills per-strike IV/greeks for recent weekdays not yet captured.
+UW returns 403 beyond ~30 trading days so run this promptly after first deploy.
+
+Run: uv run python scripts/option_surface_backfill.py [--days-back 30]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import psycopg
+
+from uw_scan.api.client import UwClient
+from uw_scan.config import Settings
+from uw_scan.storage.repository import Repository
+from uw_scan.worker.jobs.option_surface_capture import option_surface_backfill
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    log = logging.getLogger(__name__)
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--days-back",
+        type=int,
+        default=30,
+        help="trading days to look back (default 30)",
+    )
+    args = p.parse_args()
+
+    settings = Settings.from_env()
+    log.info(
+        "host=%s db=%s schema=%s days_back=%d",
+        settings.db_host,
+        settings.db_name,
+        settings.db_schema,
+        args.days_back,
+    )
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        repo = Repository(conn, schema=settings.db_schema)
+        client = UwClient(
+            api_key=settings.api_key.get_secret_value(),
+            base_url=settings.base_url,
+            timeout=settings.request_timeout_seconds,
+            job_name="option_surface_backfill",
+        )
+        n = option_surface_backfill(repo=repo, client=client, days_back=args.days_back)
+
+    log.info("done: %d rows written", n)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uw_scan/sources/uw.py
+++ b/src/uw_scan/sources/uw.py
@@ -222,6 +222,7 @@ def fetch_greek_exposure_by_expiry(
     repo: Repository,
     run_id: int,
     ticker: str,
+    date: str | None = None,
 ) -> list[GreekExposureByExpiryRow]:
     """Fetch /api/stock/{ticker}/greek-exposure/expiry — all expiries in one call.
 
@@ -236,6 +237,7 @@ def fetch_greek_exposure_by_expiry(
         run_id,
         EndpointSlug.GREEK_EXPOSURE_BY_EXPIRY,
         ticker,
+        params={"date": date} if date is not None else None,
     )
     return normalize.normalize_greek_exposure_by_expiry(body)
 
@@ -338,15 +340,12 @@ def fetch_greeks(
     run_id: int,
     ticker: str,
     expiry: str,
+    date: str | None = None,
 ) -> list[GreeksRow]:
-    body = _fetch_json(
-        client,
-        repo,
-        run_id,
-        EndpointSlug.GREEKS,
-        ticker,
-        params={"expiry": expiry},
-    )
+    params: dict[str, Any] = {"expiry": expiry}
+    if date is not None:
+        params["date"] = date
+    body = _fetch_json(client, repo, run_id, EndpointSlug.GREEKS, ticker, params=params)
     return normalize.normalize_greeks(body)
 
 

--- a/src/uw_scan/worker/jobs/option_surface_capture.py
+++ b/src/uw_scan/worker/jobs/option_surface_capture.py
@@ -1,5 +1,5 @@
 # src/uw_scan/worker/jobs/option_surface_capture.py
-"""Full-chain option-surface capture.
+"""Full-chain option-surface capture (nightly) and one-time historical backfill.
 
 Forward-accumulates a durable per-strike IV/greeks grid for every watchlist ticker into
 option_surface_grid_daily. UW returns 403 for per-strike history beyond ~30 days, so this
@@ -15,12 +15,55 @@ from __future__ import annotations
 
 import logging
 from datetime import date as _date
+from datetime import timedelta
 
 from uw_scan.api.client import UwClient
 from uw_scan.sources.uw import fetch_greek_exposure_by_expiry, fetch_greeks
 from uw_scan.storage.repository import Repository
 
 log = logging.getLogger(__name__)
+
+
+def _build_ticker_rows(
+    *,
+    client: UwClient,
+    repo: Repository,
+    run_id: int,
+    ticker: str,
+    market_date: _date,
+    date_iso: str | None,
+) -> list[dict]:
+    """Fetch full-chain greeks for one ticker on market_date. date_iso=None → today."""
+    gex_by_expiry = fetch_greek_exposure_by_expiry(
+        client, repo, run_id, ticker, date=date_iso
+    )
+    expiries = sorted({r.expiry for r in gex_by_expiry if r.expiry >= market_date})
+    rows: list[dict] = []
+    for expiry in expiries:
+        for r in fetch_greeks(
+            client, repo, run_id, ticker, expiry.isoformat(), date=date_iso
+        ):
+            rows.append(
+                {
+                    "expiry": r.expiry,
+                    "strike": r.strike,
+                    "call_iv": r.call_volatility,
+                    "put_iv": r.put_volatility,
+                    "call_delta": r.call_delta,
+                    "put_delta": r.put_delta,
+                    "call_gamma": r.call_gamma,
+                    "put_gamma": r.put_gamma,
+                    "call_vega": r.call_vega,
+                    "put_vega": r.put_vega,
+                    "call_theta": r.call_theta,
+                    "put_theta": r.put_theta,
+                    "call_vanna": r.call_vanna,
+                    "put_vanna": r.put_vanna,
+                    "call_charm": r.call_charm,
+                    "put_charm": r.put_charm,
+                }
+            )
+    return rows
 
 
 def option_surface_capture(
@@ -39,34 +82,14 @@ def option_surface_capture(
         ticker = card.ticker
         try:
             run_id = repo.insert_scan_run(ticker, notes="option_surface_capture")
-            # Enumerate the FULL term structure from greek-exposure/expiry (one row
-            # per listed expiry). NOT /option-contracts — UW caps that at the 500
-            # highest-VOLUME contracts, dropping long-dated expiries (SPX 28/53 missing).
-            gex_by_expiry = fetch_greek_exposure_by_expiry(client, repo, run_id, ticker)
-            expiries = sorted({r.expiry for r in gex_by_expiry if r.expiry >= today})
-            rows: list[dict] = []
-            for expiry in expiries:
-                for r in fetch_greeks(client, repo, run_id, ticker, expiry.isoformat()):
-                    rows.append(
-                        {
-                            "expiry": r.expiry,
-                            "strike": r.strike,
-                            "call_iv": r.call_volatility,
-                            "put_iv": r.put_volatility,
-                            "call_delta": r.call_delta,
-                            "put_delta": r.put_delta,
-                            "call_gamma": r.call_gamma,
-                            "put_gamma": r.put_gamma,
-                            "call_vega": r.call_vega,
-                            "put_vega": r.put_vega,
-                            "call_theta": r.call_theta,
-                            "put_theta": r.put_theta,
-                            "call_vanna": r.call_vanna,
-                            "put_vanna": r.put_vanna,
-                            "call_charm": r.call_charm,
-                            "put_charm": r.put_charm,
-                        }
-                    )
+            rows = _build_ticker_rows(
+                client=client,
+                repo=repo,
+                run_id=run_id,
+                ticker=ticker,
+                market_date=today,
+                date_iso=None,
+            )
             n = repo.upsert_option_surface_grid(ticker, today, card.spot, rows)
             repo.finish_scan_run(run_id, status="ok")
             repo.conn.commit()
@@ -75,4 +98,60 @@ def option_surface_capture(
             repo.conn.rollback()
             log.warning("option_surface_capture: %s skipped: %s", ticker, repr(exc))
     log.info("option_surface_capture wrote %d surface-grid rows", written)
+    return written
+
+
+def option_surface_backfill(
+    *, repo: Repository, client: UwClient, days_back: int = 30
+) -> int:
+    """Fill option_surface_grid_daily for recent past weekdays not yet captured.
+
+    Skips any market_date that already has rows in the table (idempotent).
+    UW 403s beyond ~30 trading days; individual ticker/expiry 403s are logged and skipped.
+    Returns total rows written.
+    """
+    today = _date.today()
+    cards = repo.list_watchlist_cards()
+
+    # Collect up to days_back weekdays ending yesterday, oldest first.
+    dates: list[_date] = []
+    d = today - timedelta(days=1)
+    while len(dates) < days_back:
+        if d.weekday() < 5:  # Mon–Fri
+            dates.append(d)
+        d -= timedelta(days=1)
+    dates.reverse()
+
+    written = 0
+    for market_date in dates:
+        date_iso = market_date.isoformat()
+        with repo.conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM option_surface_grid_daily WHERE market_date=%s LIMIT 1",
+                (market_date,),
+            )
+            if cur.fetchone():
+                log.info("backfill: %s already captured — skipping", date_iso)
+                continue
+        log.info("backfill: capturing %s (%d tickers)", date_iso, len(cards))
+        for card in cards:
+            ticker = card.ticker
+            try:
+                run_id = repo.insert_scan_run(ticker, notes="option_surface_backfill")
+                rows = _build_ticker_rows(
+                    client=client,
+                    repo=repo,
+                    run_id=run_id,
+                    ticker=ticker,
+                    market_date=market_date,
+                    date_iso=date_iso,
+                )
+                n = repo.upsert_option_surface_grid(ticker, market_date, None, rows)
+                repo.finish_scan_run(run_id, status="ok")
+                repo.conn.commit()
+                written += n
+            except Exception as exc:  # noqa: BLE001 — isolate per ticker
+                repo.conn.rollback()
+                log.warning("backfill: %s/%s skipped: %s", date_iso, ticker, repr(exc))
+    log.info("option_surface_backfill wrote %d rows total", written)
     return written

--- a/tests/integration/worker/test_option_surface_capture.py
+++ b/tests/integration/worker/test_option_surface_capture.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import date as _date
 from decimal import Decimal
 
 import uw_scan.worker.jobs.option_surface_capture as job
@@ -9,20 +10,24 @@ from uw_scan.models import GreekExposureByExpiryRow, GreeksRow
 
 
 def _stub_sources(monkeypatch, *, raise_for: str | None = None):
-    def fake_gex_by_expiry(client, repo, run_id, ticker):
+    def fake_gex_by_expiry(client, repo, run_id, ticker, date=None):  # noqa: ARG001
         # Full term structure — one row per listed expiry (no volume cap).
         return [
-            GreekExposureByExpiryRow(date=date(2026, 6, 19), expiry=date(2026, 7, 17)),
-            GreekExposureByExpiryRow(date=date(2026, 6, 19), expiry=date(2026, 8, 21)),
+            GreekExposureByExpiryRow(
+                date=_date(2026, 6, 19), expiry=_date(2026, 7, 17)
+            ),
+            GreekExposureByExpiryRow(
+                date=_date(2026, 6, 19), expiry=_date(2026, 8, 21)
+            ),
         ]
 
-    def fake_greeks(client, repo, run_id, ticker, expiry_iso):
+    def fake_greeks(client, repo, run_id, ticker, expiry_iso, date=None):  # noqa: ARG001
         if raise_for is not None and ticker == raise_for:
             raise RuntimeError("boom")
-        e = date.fromisoformat(expiry_iso)
+        e = _date.fromisoformat(expiry_iso)
         return [
             GreeksRow(
-                date=date(2026, 6, 19),
+                date=_date(2026, 6, 19),
                 expiry=e,
                 strike=Decimal("250"),
                 call_volatility=Decimal("0.50"),


### PR DESCRIPTION
## Summary

- Adds optional `date=` param to `fetch_greeks` and `fetch_greek_exposure_by_expiry` (both UW endpoints accept it per spec — verified in OpenAPI yaml)
- Extracts inner per-ticker row-building logic into `_build_ticker_rows` so the nightly capture and new backfill share the same code path
- Adds `option_surface_backfill(repo, client, days_back=30)` — loops weekdays oldest-first, skips dates already in the table, isolates per-ticker failures
- Adds `scripts/option_surface_backfill.py` runner: `uv run python scripts/option_surface_backfill.py [--days-back 30]`

## Test plan

- [ ] 2 existing integration tests pass (updated stubs to accept new `date=` kwarg)
- [ ] 1132 unit tests pass
- [ ] After v0.3.0 deploys to the mini: `uv run python scripts/option_surface_backfill.py` against the mini DB (needs `UW_SCAN_DB_HOST=100.66.147.98 UW_SCAN_DB_NAME=option_wizard`)
- [ ] Run promptly — UW 403s beyond ~30 trading days so every day of delay narrows the window