### PR TITLE
fix(vrp): make iteration-4 CI green — except-handler guardrail + skip real-data tests on CI

### DIFF
--- a/src/uw_scan/reports/vrp_robustness.py
+++ b/src/uw_scan/reports/vrp_robustness.py
@@ -11,6 +11,7 @@ No new deps — stdlib statistics + random only. Every result returns a dict the
 from __future__ import annotations
 
 import dataclasses
+import logging
 import math
 import random
 from datetime import date as _date
@@ -24,6 +25,8 @@ from uw_scan.reports.vrp_capital_account import (
 )
 from uw_scan.reports.vrp_macro_signal import MacroSignalConfig
 from uw_scan.reports.vrp_structure import build_bull_put_spread
+
+log = logging.getLogger(__name__)
 
 CONTRACT_MULTIPLIER = 100
 
@@ -77,7 +80,8 @@ def min_viable_capital(
                 short_delta=short_delta,
                 wing_delta=short_delta * wing_frac,
             )
-        except ValueError:
+        except ValueError as exc:  # degenerate strikes
+            log.debug("min-capital bull-put build skipped %s: %s", d, repr(exc))
             continue
         mlpc = st.max_loss * CONTRACT_MULTIPLIER
         if first_mlpc is None:

--- a/tests/integration/reports/test_vrp_capital_account_db.py
+++ b/tests/integration/reports/test_vrp_capital_account_db.py
@@ -33,6 +33,17 @@ def repo_settings():
         pytest.skip("needs UW_SCAN_DB_HOST/NAME pointing at a vol_index_daily DB")
     settings = Settings.from_env()
     conn = psycopg.connect(settings.db_dsn())
+    # Real-data checks: read the lake-synced vol_index_daily on a persistent DB
+    # (local dev / mini). CI points UW_SCAN_DB_NAME at an empty option_wizard_local
+    # with no migrations or data, so probe for the table and skip cleanly when
+    # absent rather than erroring on UndefinedTable.
+    qualified = f"{settings.db_schema}.vol_index_daily"
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (qualified,))
+        table_exists = cur.fetchone()[0] is not None
+    if not table_exists:
+        conn.close()
+        pytest.skip(f"{qualified} absent — needs a lake-populated DB (CI skips)")
     try:
         yield Repository(conn, schema=settings.db_schema), settings
     finally:


### PR DESCRIPTION
## Why

PR #162 (squash `fe7100b`) merged with **two** CI failures that were masked because I merged before all shards reported. This fixes both, forward.

### 1. `lint + unit` — CI Guardrail 2
`reports/vrp_robustness.py:80` had a silent `except ValueError: continue`. Ruff passed, but `scripts/_lint_except.py` (Guardrail 2: every `src/` handler must log `repr(exc)`/`.exception()` or re-raise) failed. **Fix:** module logger + `log.debug(... repr(exc))`, matching the sibling at `vrp_capital_account.py:243`. Skip behaviour unchanged.

### 2. `integration (4/4)` — real-data tests run against CI's empty DB
`tests/integration/reports/test_vrp_capital_account_db.py` connects to the **working DB** (`Settings.from_env()` → `UW_SCAN_DB_NAME=option_wizard_local`), not the pytest-postgresql test DB that conftest migrates. CI creates `option_wizard_local` empty (no migrations, no lake data), so `uw_scan.vol_index_daily` doesn't exist → `UndefinedTable`. The skip guard only checked that env vars were *set* (CI sets them). **Fix:** probe `to_regclass(%s)` and `pytest.skip` when the table is absent — these are real-data smoke checks that only run where the lake data lives (local dev / mini).

## Verification (full `lint + unit` job reproduced locally, all green)
- version-sync ✅ · ruff ✅ · `_lint_except.py src` ✅ · guardrail greps ✅ · migration guard ✅
- `pytest tests/unit/`: **1171 passed**
- the 2 integration tests against local lake DB: **2 passed** (happy path intact)
- `to_regclass` on an absent relation returns NULL → clean skip on CI (confirmed)

No new deps. No behaviour change. Fixes unreleased iteration-4 code that never shipped (no changelog entry).