### PR TITLE
feat(surface): blend nightly backfill into option_surface_capture job

### DIFF
--- a/scripts/option_surface_backfill.py
+++ b/scripts/option_surface_backfill.py
@@ -1,9 +1,10 @@
 """One-time backfill for option_surface_grid_daily.
 
 Fills per-strike IV/greeks for recent weekdays not yet captured.
-UW returns 403 beyond ~30 trading days so run this promptly after first deploy.
+UW historical data is available for ~180 calendar days. Use --days-back 130
+to capture the full window from today.
 
-Run: uv run python scripts/option_surface_backfill.py [--days-back 30]
+Run: uv run python scripts/option_surface_backfill.py [--days-back 130] [--quota-limit 20000]
 """
 
 from __future__ import annotations
@@ -29,8 +30,8 @@ def main() -> None:
     p.add_argument(
         "--days-back",
         type=int,
-        default=30,
-        help="trading days to look back (default 30)",
+        default=130,
+        help="trading days to look back (default 130, ~180 calendar days)",
     )
     p.add_argument(
         "--end-date",

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -292,6 +292,7 @@ class Settings(BaseModel):
     r2_endpoint_override: str | None = None
     # Option surface capture (durable full-chain IV/greeks grid) + IB-vs-UW IV canary
     option_surface_capture_enabled: bool = True
+    option_surface_backfill_days: int = 4
     option_surface_iv_canary_enabled: bool = True
     option_surface_iv_canary_warn_threshold: float = 0.02
     xenon_query_api_url: str = "http://127.0.0.1:8421"
@@ -672,6 +673,9 @@ class Settings(BaseModel):
             ),
             option_surface_capture_enabled=_env_bool(
                 "OPTION_SURFACE_CAPTURE_ENABLED", True
+            ),
+            option_surface_backfill_days=int(
+                os.environ.get("OPTION_SURFACE_BACKFILL_DAYS", "4")
             ),
             option_surface_iv_canary_enabled=_env_bool(
                 "OPTION_SURFACE_IV_CANARY_ENABLED", True

--- a/src/uw_scan/worker/jobs/option_surface_capture.py
+++ b/src/uw_scan/worker/jobs/option_surface_capture.py
@@ -2,10 +2,9 @@
 """Full-chain option-surface capture (nightly) and one-time historical backfill.
 
 Forward-accumulates a durable per-strike IV/greeks grid for every watchlist ticker into
-option_surface_grid_daily. UW returns 403 for per-strike history beyond ~30 days, so this
-nightly capture is the only way the surface ever exists for future SVI/dislocation/
-curvature work — every uncaptured night is permanently lost. Full chain: ALL expiries,
-ALL strikes, no clip.
+option_surface_grid_daily. UW historical data is available for ~180 calendar days; after
+that the only record is what was captured nightly — every uncaptured night is permanently
+lost. Full chain: ALL expiries, ALL strikes, no clip.
 
 One UW /greeks call per (ticker, expiry). Idempotent upsert (never delete) so a partial
 re-run only adds. Per-ticker failure is isolated.
@@ -67,12 +66,19 @@ def _build_ticker_rows(
 
 
 def option_surface_capture(
-    *, repo: Repository, client: UwClient, today: _date | None = None
+    *,
+    repo: Repository,
+    client: UwClient,
+    today: _date | None = None,
+    backfill_days: int = 0,
 ) -> int:
     """Capture the full option-chain IV/greeks grid for every watchlist ticker.
 
     Returns total rows written. ``today`` is the ET market date (the scheduler passes
     ``datetime.now(rth_tz).date()`` so a non-ET host does not stamp the next day).
+    If backfill_days > 0, after today's capture the job fills that many additional
+    oldest-uncaptured trading days (up to ~180 calendar days back), skipping any date
+    already fully in the DB. Set via OPTION_SURFACE_BACKFILL_DAYS env var (default 4).
     """
     cards = repo.list_watchlist_cards()
     if today is None:
@@ -101,6 +107,13 @@ def option_surface_capture(
             if run_id is not None:
                 repo.finish_scan_run(run_id, status="failed")
     log.info("option_surface_capture wrote %d surface-grid rows", written)
+    if backfill_days > 0:
+        written += option_surface_backfill(
+            repo=repo,
+            client=client,
+            days_back=130,  # ~180 calendar days
+            max_dates=backfill_days,
+        )
     return written
 
 
@@ -108,17 +121,18 @@ def option_surface_backfill(
     *,
     repo: Repository,
     client: UwClient,
-    days_back: int = 30,
+    days_back: int = 130,
     end_date: _date | None = None,
     quota_limit: int | None = None,
+    max_dates: int | None = None,
 ) -> int:
     """Fill option_surface_grid_daily for recent past weekdays not yet captured.
 
-    Skips any market_date that already has rows in the table (idempotent).
-    end_date (inclusive) caps which dates are processed — useful to avoid burning
-    the full daily UW quota when planning a follow-up run.
+    Skips any market_date already fully captured (idempotent, per-ticker).
+    end_date (inclusive) caps which dates are processed.
     quota_limit stops after the UW daily request counter reaches that value.
-    UW 403s beyond ~30 trading days; individual ticker/expiry 403s are logged and skipped.
+    max_dates stops after N dates that needed work (already-complete dates don't count).
+    UW historical data is available for ~180 calendar days (~130 trading days).
     Returns total rows written.
     """
     today = _date.today()
@@ -136,6 +150,7 @@ def option_surface_backfill(
         dates = [d for d in dates if d <= end_date]
 
     written = 0
+    dates_filled = 0
     for market_date in dates:
         date_iso = market_date.isoformat()
         with repo.conn.cursor() as cur:
@@ -147,6 +162,10 @@ def option_surface_backfill(
         if len(done) >= len(cards):
             log.info("backfill: %s fully captured — skipping", date_iso)
             continue
+        if max_dates is not None and dates_filled >= max_dates:
+            log.info("backfill: max_dates=%d reached — stopping", max_dates)
+            return written
+        dates_filled += 1
         log.info(
             "backfill: capturing %s (%d/%d tickers remaining)",
             date_iso,

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -550,7 +550,12 @@ def main() -> int:
                 settings, telemetry_recorder=recorder, job_name="option_surface_capture"
             ) as uw:
                 with _repo(settings) as repo:
-                    option_surface_capture(repo=repo, client=uw, today=market_date)
+                    option_surface_capture(
+                        repo=repo,
+                        client=uw,
+                        today=market_date,
+                        backfill_days=settings.option_surface_backfill_days,
+                    )
 
     def _option_surface_iv_canary() -> None:
         if not settings.option_surface_iv_canary_enabled:

--- a/tests/unit/test_settings_option_surface.py
+++ b/tests/unit/test_settings_option_surface.py
@@ -15,6 +15,7 @@ def test_settings_reads_option_surface_flags(monkeypatch, tmp_path):
     s = Settings.from_env(env_path=env)
 
     assert s.option_surface_capture_enabled is False
+    assert s.option_surface_backfill_days == 4  # default
     assert s.option_surface_iv_canary_enabled is True  # default
     assert s.option_surface_iv_canary_warn_threshold == 0.05
     assert s.xenon_query_api_url == "http://127.0.0.1:8421"  # default


### PR DESCRIPTION
## Summary

- After capturing today's surface, the nightly job fills the **4 oldest uncaptured trading days** automatically (`OPTION_SURFACE_BACKFILL_DAYS`, default 4; set to 0 to disable)
- Already-complete dates are skipped via per-ticker DB check — idempotent
- UW historical window is **~180 calendar days** (~130 trading days), not 30 as previously documented; at 4 dates/night the full history fills in ~30 nightly runs with no manual ops

### Changes

| File | Change |
|------|--------|
| `option_surface_capture.py` | `max_dates` param on `option_surface_backfill`; `backfill_days` param on `option_surface_capture` |
| `config.py` | `OPTION_SURFACE_BACKFILL_DAYS` env var, default 4 |
| `scheduler.py` | passes `backfill_days=settings.option_surface_backfill_days` |
| `scripts/option_surface_backfill.py` | default `--days-back` updated to 130; docstring corrected |
| `tests/unit/test_settings_option_surface.py` | asserts new field default |

### Quota impact

Today's capture: ~101 tickers × 18 calls = ~1,818 calls. Backfill 4 dates: ~7,272 calls. Total ~9,090/night = ~23% of the 40k daily quota.

## Test plan

- [ ] Unit tests pass (`uv run pytest tests/unit/test_settings_option_surface.py`)
- [ ] `OPTION_SURFACE_BACKFILL_DAYS=0` disables the backfill leg (no regression)
- [ ] CI green before merge