### PR TITLE
fix(config): correct XENON_QUERY_API_URL port and document XENON_QUERY_API_KEY requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,11 @@ R2_ENDPOINT_OVERRIDE=
 OPTION_SURFACE_CAPTURE_ENABLED=true
 OPTION_SURFACE_IV_CANARY_ENABLED=true
 OPTION_SURFACE_IV_CANARY_WARN_THRESHOLD=0.02
-# xenon read-only query API (canary only; localhost-bypass on the mini where xenon runs)
-XENON_QUERY_API_URL=http://127.0.0.1:8421
-# XENON_QUERY_API_KEY=   # required only for non-localhost callers
+# xenon read-only query API (IV canary + VRP macro entry-capture IB quotes)
+# MacBook dev → keep default; mini prod → set XENON_QUERY_API_KEY (required even on localhost;
+# missing/wrong key → HTTP 401, IB path silently no-ops to source='uw').
+XENON_QUERY_API_URL=http://127.0.0.1:8321
+# XENON_QUERY_API_KEY=your-xenon-api-key-here
+
+# VRP macro entry-capture (forward markout recorder — 8×/day, 30-cal-day EOD taper)
+UW_SCAN_VRP_MACRO_ENTRY_CAPTURE_ENABLED=true


### PR DESCRIPTION
## Summary

- Fixes `XENON_QUERY_API_URL` default from dead port `:8421` → `:8321` (the mini's authenticated xenon query API port)
- Corrects the `XENON_QUERY_API_KEY` comment: the key is **required even on localhost** — missing/wrong → HTTP 401, IB path silently no-ops to `source='uw'`
- Adds `UW_SCAN_VRP_MACRO_ENTRY_CAPTURE_ENABLED=true` to document the VRP macro entry-capture gate (landed in #169)

## Deploy note

On the mini, set `XENON_QUERY_API_KEY` in argon's `.env` before this release deploys, or the IB quoting path (entry-capture + IV canary) will silently fall back to UW for every leg.

## Test plan

- [ ] Verify `.env.example` renders correctly (no garbled chars, correct URL)
- [ ] Confirm no Python/test files changed — pure docs fix