### PR TITLE
feat(stock): per-stock Short-Vol card on Market Structure tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 | Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
+| Per-stock short-vol card (single-name sibling of macro short-vol) | `reports/stock_short_vol.py` (`decide_short_vol`/`build_short_vol`) + `models/stock.py` (`StockShortVol`, `SingleStockReport.short_vol`) + `web/components/stock/panels/ShortVolPanel.tsx` + `web/components/stock/tabs/MarketStructureTab.tsx`; read-time reshape of `vrp_daily` gated by `reports/vrp_gate.py`; plan `docs/superpowers/plans/2026-06-24-stock-short-vol-card.md` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |
 | Release pipeline (versioning + workflow) | `VERSION` + `CHANGELOG.md` + `scripts/release/{_lib.sh,version_sync_check.py,cut.sh}` + `.github/workflows/release.yml` |
 | Auto-deploy to the mini | `scripts/deploy/macmini-deploy-poller.sh` + `config/templates/com.argon.deploy-poller.plist.template` + `scripts/deploy/macmini-prod.sh`; runbook `docs/runbooks/release.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- Per-stock **Short-Vol card** on the stock page's Market Structure tab — the
+  single-name sibling of the SPX Macro Short-Vol card, placed third on the
+  Directional-Bias row. A TRADE/SKIP sell-premium readout derived at read time from
+  the latest persisted `vrp_daily` row (no new endpoint, job, or migration): TRADE
+  only when vol is rich (`vrp_z_20 ≥ 1.0`), the ticker's sector is in the sellable
+  set (`vrp_gate`), and a known next-earnings date is clear of the ~45-day hold
+  window; otherwise SKIP with a reason (`vol not rich` / `sector vol not sellable` /
+  `earnings inside hold window` / `earnings date unavailable`). On TRADE it models the
+  same flat-vol bull put spread (0.25Δ short / 0.125Δ wing, ~30-day hold) as the macro
+  signal, reusing `size_weight` + `build_bull_put_spread`; macro/ETF classes skip the
+  earnings gate (they don't report), mirroring `vrp_gate`'s asset-class split.
+  Non-finite `vrp_z_20` (short-history NaN) is normalized away, and the build is
+  wrapped so the card can never take down the stock page. New
+  `reports/stock_short_vol.py`, `StockShortVol` model + `SingleStockReport.short_vol`,
+  and `web/components/stock/panels/ShortVolPanel.tsx`. EOD basis (modeled off the
+  EOD-close spot). Plan `docs/superpowers/plans/2026-06-24-stock-short-vol-card.md`.
+
 ## [0.3.2] — 2026-06-24
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 | Gold Compass — research / sources docs | `docs/research/gold-sdf-framework/CLAUDE.md` (3-lens model, status vs. shipped, deferred sources) + `src/uw_scan/sources/CLAUDE.md` (per-source status + failure modes) |
 | Index dealer cockpit (SPX/SPY/QQQ/IWM) | `api/routers/cockpit.py` + `web/app/cockpit/[ticker]/page.tsx` |
 | Stock detail page | `web/app/stock/[ticker]/page.tsx` + `components/stock/tabs/*` |
+| Per-stock short-vol card (single-name sibling of macro short-vol) | `reports/stock_short_vol.py` (`decide_short_vol`/`build_short_vol`) + `models/stock.py` (`StockShortVol`, `SingleStockReport.short_vol`) + `web/components/stock/panels/ShortVolPanel.tsx` + `web/components/stock/tabs/MarketStructureTab.tsx`; read-time reshape of `vrp_daily` gated by `reports/vrp_gate.py`; plan `docs/superpowers/plans/2026-06-24-stock-short-vol-card.md` |
 | Watchlist landing | `web/app/page.tsx` + `components/watchlist/CardGrid.tsx` |
 | Trade Insights AI — orchestration | `src/uw_scan/worker/jobs/trade_insights_ai.py` (claim → dispatch → persist; RUNNERS registry, `provider_filter` param, per-provider heartbeats) |
 | Trade Insights AI — provider runners | `src/uw_scan/worker/jobs/trade_insights_ai_runners.py` (`AiProviderRunner` Protocol, `_format_runner_failure`, `_runner_child_env`), `trade_insights_codex_runner.py`, `trade_insights_claude_runner.py` |

--- a/docs/superpowers/plans/2026-06-24-stock-short-vol-card.md
+++ b/docs/superpowers/plans/2026-06-24-stock-short-vol-card.md
@@ -1,0 +1,903 @@
+# Per-Stock Short-Vol Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-ticker "Short-Vol" card to the stock detail page's Market Structure tab, mirroring the SPX Macro Short-Vol card, on the same row as Directional Bias.
+
+**Architecture:** Read-time derivation only. The analytical result (`vrp_daily`: per-ticker `iv`/`rv`/`vrp_z_20`, refreshed nightly) is already persisted. A new pure function reshapes the latest row into a TRADE/SKIP readout with a flat-vol-modeled bull-put-spread, gated by the existing sellable-by-sector rule. It is folded into the existing `SingleStockReport` payload (no new endpoint, no client poll, no job, no migration) and rendered by a server-side panel. The sizing function (`size_weight`) and the spread builder (`build_bull_put_spread`) are reused as-is from the macro path; the TRADE/SKIP *verdict* is intentionally **stricter** than macro's `weight>0` — single names additionally require `vrp_z ≥ RICH_Z (1.0)`, a sellable sector, and a known earnings date clear of the hold window (the approved design).
+
+**Tech Stack:** Python 3.13 (`uv`), FastAPI + Pydantic v2, Next.js 16 RSC + TypeScript, Vitest, pytest.
+
+## Global Constraints
+
+- `uv` only — `uv run pytest`, never bare `pytest`.
+- **No naked shorts** — bull put spread is defined-risk (long wing caps loss). OK.
+- **Persist analytical results to Postgres** — satisfied: `vrp_daily` is already persisted nightly; this card is a read-time reshape of it (same pattern as `build_vrp` on the Volatility tab). No new persistence.
+- **No synthetic data in tests** — fixtures use the real ticker **TSLA** at its real **2026-06-24** values (spot `382.35`, IV30 `0.473` from the live page). `vrp_z_20` is the variable under test, set per case.
+- **Decimal over float** for prices/IV/RV/Greeks in models (`models/stock.py`). FastAPI serializes `Decimal` as a JSON **string**; the web reads via `toNum`.
+- **Module size budget** <500 lines/file — new `reports/stock_short_vol.py` stays well under.
+- **API contract**: adding a schema requires regenerating `tests/integration/api/openapi.snapshot.json` and `web/lib/types.ts`. `types.ts` is "alphabetically frozen" — see Task 2 for the surgical path.
+- **Never commit without explicit user request** — this plan's commits are pre-authorized by the user's "execute" instruction; each task ends with one commit.
+- Branch: `feat/stock-vrp-z` (already checked out in this worktree).
+
+---
+
+### Task 1: `StockShortVol` model + `decide_short_vol`/`build_short_vol` (Python core)
+
+**Files:**
+- Modify: `src/uw_scan/models/stock.py` (add `StockShortVol`, register in `_preserve_public_module`)
+- Modify: `src/uw_scan/models/__init__.py` (export `StockShortVol`)
+- Create: `src/uw_scan/reports/stock_short_vol.py`
+- Test: `tests/unit/test_stock_short_vol.py`
+
+**Interfaces:**
+- Consumes: `size_weight`, `WINNER`, `MacroSignalConfig` from `reports.vrp_macro_signal`; `build_bull_put_spread` from `reports.vrp_structure`; `passes_gate`, `sellable_single_name_sectors`, `sellable_asset_classes` from `reports.vrp_gate`; `repo.fetch_vrp_daily_series(ticker, *, limit)` from `storage.volatility_v2`.
+- Produces (later tasks rely on these exact names/types):
+  - `StockShortVol` Pydantic model (fields below).
+  - `decide_short_vol(*, as_of, spot, iv, rv, vrp, vrp_z_20, gate_ok, next_earnings_date, require_earnings=True, risk_free_rate=RISK_FREE_RATE, cfg=WINNER) -> StockShortVol` — pure, no I/O. Normalizes non-finite inputs to None; unknown earnings → SKIP for single names (`require_earnings=True`), exempt for macro/ETF.
+  - `build_short_vol(repo, ticker, spot) -> StockShortVol | None` — I/O wrapper; reads the latest `vrp_daily` row + gate + a reliable next-earnings date (`repo.fetch_latest_next_earnings_date`); `None` iff the ticker has no `vrp_daily` history.
+
+- [ ] **Step 1: Add the `StockShortVol` model**
+
+In `src/uw_scan/models/stock.py`, add this class immediately after `VRPAssessment` (after line ~60):
+
+```python
+class StockShortVol(_UwBase):
+    """Per-ticker short-vol (sell-premium) readout for the Market Structure tab —
+    the single-name sibling of the SPX MacroSignal. EOD basis (latest vrp_daily row).
+    action=TRADE only when vol is rich (vrp_z_20 >= 1.0) AND the ticker's sector is in
+    the sellable set AND earnings are clear of the hold window; else SKIP with a reason.
+    Strikes/credit/max_loss are flat-vol modeled (conservative floor)."""
+
+    as_of: _date
+    basis: str = "eod"
+    action: str  # "TRADE" | "SKIP"
+    skip_reason: str | None = None
+    iv: Decimal | None = None
+    rv20: Decimal | None = None
+    vrp: Decimal | None = None
+    vrp_z: Decimal | None = None
+    weight: Decimal | None = None
+    short_put: Decimal | None = None
+    long_put: Decimal | None = None
+    put_width: Decimal | None = None
+    credit: Decimal | None = None
+    max_loss: Decimal | None = None
+    hold_days: int
+    short_delta: Decimal
+    wing_delta: Decimal
+```
+
+Add `short_vol: StockShortVol | None = None` to `SingleStockReport`, immediately after the `vrp: VRPAssessment` line (~line 96):
+
+```python
+    vrp: VRPAssessment
+    # Single-name short-vol readout (sell-premium TRADE/SKIP + modeled spread).
+    # Derived at read time from the latest vrp_daily row; None when no history.
+    short_vol: StockShortVol | None = None
+```
+
+Add `StockShortVol` to the `_preserve_public_module(...)` call at the bottom of the file (append it to the existing argument list).
+
+- [ ] **Step 2: Export the model**
+
+In `src/uw_scan/models/__init__.py`, add `StockShortVol` to the `from .stock import (...)` block (line ~127) and to `__all__` (alongside the other stock exports, e.g. after `"SingleStockReport",`).
+
+- [ ] **Step 3: Write the failing unit test**
+
+Create `tests/unit/test_stock_short_vol.py`:
+
+```python
+"""Per-ticker short-vol decision logic. Real TSLA 2026-06-24: spot 382.35, IV30 0.473."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.reports.stock_short_vol import build_short_vol, decide_short_vol
+
+AS_OF = date(2026, 6, 24)
+SPOT = 382.35
+IV = 0.473
+RV = 0.40
+CLEAR_EARNINGS = date(2026, 10, 1)  # well beyond AS_OF + 45d (2026-08-08)
+
+
+def test_trade_when_rich_sellable_and_earnings_clear():
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.073, vrp_z_20=1.6,
+        gate_ok=True, next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "TRADE"
+    assert sig.skip_reason is None
+    assert sig.short_put is not None and sig.short_put < Decimal(str(SPOT))
+    assert sig.long_put is not None and sig.long_put < sig.short_put
+    assert sig.credit is not None and sig.credit > 0
+    assert sig.max_loss is not None and sig.max_loss > 0
+    assert sig.weight is not None and sig.weight > 0
+    assert sig.short_delta == Decimal("0.25")
+    assert sig.wing_delta == Decimal("0.125")
+
+
+def test_skip_when_vol_not_rich():
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.01, vrp_z_20=0.3,
+        gate_ok=True, next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert "not rich" in (sig.skip_reason or "")
+    assert sig.weight == Decimal("0")
+    assert sig.short_put is None
+
+
+def test_skip_when_sector_not_sellable():
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.073, vrp_z_20=1.6,
+        gate_ok=False, next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "sector vol not sellable"
+
+
+def test_skip_when_earnings_unknown():
+    # passes_gate proves an earnings calendar EXISTS, but the next date is unknown →
+    # never sell vol blind (matches scanner.gates.earnings_gate: None → block).
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.073, vrp_z_20=1.6,
+        gate_ok=True, next_earnings_date=None,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "earnings date unavailable"
+
+
+def test_macro_class_trades_without_earnings():
+    # ETF/index sellable bucket: no earnings to clear, so unknown earnings must NOT
+    # block (mirrors vrp_gate exempting non-single_name classes).
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.073, vrp_z_20=1.6,
+        gate_ok=True, next_earnings_date=None, require_earnings=False,
+    )
+    assert sig.action == "TRADE"
+
+
+def test_skip_when_earnings_in_window():
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV, vrp=0.073, vrp_z_20=1.6,
+        gate_ok=True, next_earnings_date=date(2026, 7, 5),  # ~11 days out
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "earnings inside hold window"
+
+
+def test_skip_when_no_iv():
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=None, rv=RV, vrp=None, vrp_z_20=1.6,
+        gate_ok=True, next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "no usable IV/spot"
+
+
+def test_skip_and_no_decimal_nan_when_z_nonfinite():
+    # early rolling-window rows carry NaN vrp_z_20 → must NOT reach Decimal("NaN")
+    # (Pydantic rejects non-finite). Non-finite numerics normalize to None.
+    sig = decide_short_vol(
+        as_of=AS_OF, spot=SPOT, iv=IV, rv=RV,
+        vrp=float("nan"), vrp_z_20=float("nan"),
+        gate_ok=True, next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "insufficient vol history"
+    assert sig.vrp_z is None and sig.vrp is None
+
+
+class _StubRepo:
+    def __init__(self, series):
+        self._series = series
+
+    def fetch_vrp_daily_series(self, ticker, *, limit=60):
+        return self._series
+
+    def fetch_vrp_harvest_by_sector(self):
+        return []
+
+    def fetch_vrp_harvest_multihorizon(self):
+        return []
+
+    def fetch_watchlist_sector(self, ticker):
+        return "Technology"
+
+    def fetch_historical_earnings_dates(self, ticker):
+        return set()
+
+    def fetch_latest_next_earnings_date(self, ticker):
+        return CLEAR_EARNINGS
+
+
+def test_build_returns_none_without_history():
+    assert build_short_vol(_StubRepo([]), "TSLA", SPOT) is None
+
+
+def test_build_skips_when_gate_blocks():
+    series = [{"market_date": AS_OF, "iv": IV, "rv": RV, "vrp": 0.073, "vrp_z_20": 1.6}]
+    sig = build_short_vol(_StubRepo(series), "TSLA", SPOT)
+    # empty sellable sets → single_name gate returns None → SKIP
+    assert sig is not None and sig.action == "SKIP"
+    assert sig.skip_reason == "sector vol not sellable"
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_stock_short_vol.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'uw_scan.reports.stock_short_vol'`.
+
+- [ ] **Step 5: Write the implementation**
+
+Create `src/uw_scan/reports/stock_short_vol.py`:
+
+```python
+"""Per-ticker short-vol readout — single-name sibling of the SPX MacroSignal.
+
+Reshapes the latest persisted vrp_daily row (iv/rv/vrp_z_20) into a TRADE/SKIP
+action with a flat-vol-modeled bull put spread, gated by the sellable-by-sector
+rule. Pure read-time derivation: vrp_daily is the already-persisted analytical
+result, refreshed nightly by worker.volatility_jobs.nightly_vol_analytics_rollup.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date as _date
+from datetime import timedelta
+from decimal import Decimal
+
+from uw_scan.models import StockShortVol
+from uw_scan.reports.vrp_gate import (
+    passes_gate,
+    sellable_asset_classes,
+    sellable_single_name_sectors,
+)
+from uw_scan.reports.vrp_macro_signal import WINNER, MacroSignalConfig, size_weight
+from uw_scan.reports.vrp_structure import build_bull_put_spread
+
+RICH_Z = 1.0  # vol "rich enough" to sell — matches reports.vrp_markout.RICH_Z
+# ponytail: flat r mirrors settings.vrp_risk_free_rate default (config.py:311);
+# tiny effect at short DTE. Thread settings here only if r ever needs to be non-default.
+RISK_FREE_RATE = 0.04
+# 30 trading-day hold ≈ 6 calendar weeks; exclude a name whose next earnings prints
+# inside that window (the (entry, expiry] earnings landmine).
+HOLD_CAL_DAYS = 45
+
+
+def _finite(v: object) -> float | None:
+    """Coerce to a finite float, else None. Guards against NaN/inf — the rolling
+    vrp_z_20 window emits NaN on short histories (cards/vol_series.py), and Pydantic
+    rejects Decimal('NaN')."""
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _dec(v: float | None) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def decide_short_vol(
+    *,
+    as_of: _date,
+    spot: float | None,
+    iv: float | None,
+    rv: float | None,
+    vrp: float | None,
+    vrp_z_20: float | None,
+    gate_ok: bool,
+    next_earnings_date: _date | None,
+    require_earnings: bool = True,
+    risk_free_rate: float = RISK_FREE_RATE,
+    cfg: MacroSignalConfig = WINNER,
+) -> StockShortVol:
+    """Map one ticker's latest VRP row → TRADE/SKIP readout. Pure: no I/O.
+
+    `gate_ok` is the result of reports.vrp_gate.passes_gate (sellable bucket). TRADE
+    additionally requires vol rich (z>=RICH_Z) and a usable IV+spot. For single names
+    (`require_earnings=True`) it also requires a KNOWN next-earnings date outside the
+    hold window — unknown earnings conservatively SKIP (matches
+    scanner.gates.earnings_gate: None → block). Macro/ETF classes don't report
+    earnings (`require_earnings=False`), mirroring vrp_gate's own asset-class split.
+    """
+    spot = _finite(spot)
+    iv = _finite(iv)
+    rv = _finite(rv)
+    vrp = _finite(vrp)
+    z = _finite(vrp_z_20)
+
+    common = dict(
+        as_of=as_of,
+        iv=_dec(iv),
+        rv20=_dec(rv),
+        vrp=_dec(vrp),
+        vrp_z=_dec(z),
+        hold_days=cfg.hold_days,
+        short_delta=_dec(cfg.short_delta),
+        wing_delta=_dec(cfg.wing_delta),
+    )
+
+    usable = iv is not None and iv > 0 and spot is not None and spot > 0
+    rich = z is not None and z >= RICH_Z
+    window_end = as_of + timedelta(days=HOLD_CAL_DAYS)
+    earnings_clear = next_earnings_date is not None and next_earnings_date > window_end
+
+    if not usable:
+        reason: str | None = "no usable IV/spot"
+    elif z is None:
+        reason = "insufficient vol history"
+    elif not rich:
+        reason = f"vol not rich (vrp_z {z:.2f} < {RICH_Z:.1f})"
+    elif not gate_ok:
+        reason = "sector vol not sellable"
+    elif require_earnings and next_earnings_date is None:
+        reason = "earnings date unavailable"
+    elif require_earnings and not earnings_clear:
+        reason = "earnings inside hold window"
+    else:
+        reason = None
+
+    if reason is not None:
+        return StockShortVol(
+            action="SKIP", skip_reason=reason, weight=Decimal("0"), **common
+        )
+
+    # tradeable — spot/iv are finite & positive here. Build the modeled spread;
+    # degenerate strikes fall back to SKIP.
+    try:
+        st = build_bull_put_spread(
+            spot,
+            iv,
+            cfg.hold_days / 252.0,
+            risk_free_rate,
+            short_delta=cfg.short_delta,
+            wing_delta=cfg.wing_delta,
+        )
+    except ValueError:
+        return StockShortVol(
+            action="SKIP",
+            skip_reason="degenerate spread strikes",
+            weight=Decimal("0"),
+            **common,
+        )
+
+    return StockShortVol(
+        action="TRADE",
+        skip_reason=None,
+        weight=_dec(size_weight(z, cfg)),
+        short_put=_dec(st.short_put),
+        long_put=_dec(st.long_put),
+        put_width=_dec(st.put_width),
+        credit=_dec(st.credit),
+        max_loss=_dec(st.max_loss),
+        **common,
+    )
+
+
+def build_short_vol(repo, ticker: str, spot: float | None) -> StockShortVol | None:
+    """I/O wrapper: read the latest vrp_daily row, the sellable gate, and a reliable
+    next-earnings date, then decide. Returns None when the ticker has no vrp_daily
+    history (new/illiquid name).
+
+    Earnings come from repo.fetch_latest_next_earnings_date (most-recent reported
+    next-earnings across flow_events) — more reliable than the report's
+    current-top-alert promotion, which is often None even for names that report.
+    """
+    series = repo.fetch_vrp_daily_series(ticker, limit=1)
+    if not series:
+        return None
+    row = series[0]
+    gate = passes_gate(
+        repo,
+        ticker,
+        sellable_sectors=sellable_single_name_sectors(repo),
+        sellable_classes=sellable_asset_classes(repo, hold_days=WINNER.hold_days),
+    )
+    # Only single names carry the earnings landmine; indices/ETFs don't report
+    # (vrp_gate makes the same split).
+    require_earnings = gate is not None and gate.asset_class == "single_name"
+    return decide_short_vol(
+        as_of=row["market_date"],
+        spot=spot,
+        iv=row.get("iv"),
+        rv=row.get("rv"),
+        vrp=row.get("vrp"),
+        vrp_z_20=row.get("vrp_z_20"),
+        gate_ok=gate is not None,
+        next_earnings_date=repo.fetch_latest_next_earnings_date(ticker),
+        require_earnings=require_earnings,
+    )
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_stock_short_vol.py -v`
+Expected: PASS (10 tests).
+
+- [ ] **Step 7: Run the models export guard**
+
+Run: `uv run pytest tests/unit/test_models_exports.py -v`
+Expected: PASS (confirms `StockShortVol` export surface is consistent).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/uw_scan/models/stock.py src/uw_scan/models/__init__.py \
+        src/uw_scan/reports/stock_short_vol.py tests/unit/test_stock_short_vol.py
+git commit -m "feat(stock): per-ticker short-vol decision + StockShortVol model"
+```
+
+---
+
+### Task 2: Wire into the stock report + regen contract (snapshot + types.ts)
+
+**Files:**
+- Modify: `src/uw_scan/reports/single_stock.py` (import + compute `short_vol`, pass to `SingleStockReport`)
+- Modify: `tests/integration/api/openapi.snapshot.json` (regenerate)
+- Modify: `web/lib/types.ts` (add `StockShortVol` schema + `short_vol` field)
+
+**Interfaces:**
+- Consumes: `build_short_vol` from Task 1; `SingleStockReport.short_vol` field from Task 1.
+- Produces: `report.short_vol: StockShortVol | null` on the `/api/stock/{ticker}` payload (consumed by Task 3/4).
+
+- [ ] **Step 1: Add a module logger to `single_stock.py`**
+
+`single_stock.py` has no logger today. Add at the top (after the `import` block):
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Wire `build_short_vol` into the assembler (defensively)**
+
+In `src/uw_scan/reports/single_stock.py`, add the import near the other `reports` imports at the top:
+
+```python
+from uw_scan.reports.stock_short_vol import build_short_vol
+```
+
+In `assemble_single_stock_report`, after `market_structure` and `next_earnings_date` are computed and before `return SingleStockReport(`, add the call **wrapped** — the short-vol card is non-critical and must never take down the stock page (mirrors the `# noqa: BLE001` pattern at `pipeline.py:94`). Note the EOD-spot basis: `short_vol` is modeled off `market_structure.spot` (the EOD close at assembly time, consistent with the EOD `as_of` and the card's "EOD SNAPSHOT" label); the router's `_with_latest_spot` later patches only the *header* display spot, not the card.
+
+```python
+    try:
+        short_vol = build_short_vol(
+            repo,
+            ticker,
+            float(market_structure.spot) if market_structure.spot is not None else None,
+        )
+    except Exception as exc:  # noqa: BLE001 — short-vol card is non-critical; never break the page
+        logger.warning("short_vol build failed for %s: %s", ticker, repr(exc))
+        short_vol = None
+```
+
+In the `return SingleStockReport(...)` constructor call, add the kwarg next to `next_earnings_date=next_earnings_date,`:
+
+```python
+        next_earnings_date=next_earnings_date,
+        short_vol=short_vol,
+```
+
+- [ ] **Step 3: Keep the existing report-assembly test green**
+
+`tests/unit/test_report_assembly.py` exercises `assemble_single_stock_report` with a hand-rolled `_StubRepo`. The new call needs `fetch_vrp_daily_series` on that stub (returning `[]` so `build_short_vol` returns `None` without touching the gate). Add to `_StubRepo`:
+
+```python
+    def fetch_vrp_daily_series(self, ticker: str, *, limit: int = 60) -> list[dict]:
+        return []
+```
+
+And add an assertion to the assembly test that the new field defaults cleanly (find the test that builds the report and asserts on its sections; add):
+
+```python
+    assert report.short_vol is None
+```
+
+Run: `uv run pytest tests/unit/test_report_assembly.py -v`
+Expected: PASS (proves the new wiring degrades to `None` without a stub method explosion — not via exception-swallowing).
+
+- [ ] **Step 4: Confirm the OpenAPI snapshot test now fails (contract changed)**
+
+Run: `uv run pytest tests/integration/api/test_openapi_snapshot.py -v`
+Expected: FAIL — "OpenAPI schemas changed" (the new `StockShortVol` schema + `short_vol` property are not yet in the snapshot).
+
+- [ ] **Step 5: Regenerate the snapshot**
+
+The snapshot is the full `/openapi.json` dumped `sort_keys=True, indent=2` (deterministic → minimal diff). Run:
+
+```bash
+uv run python - <<'PY'
+import json
+from pathlib import Path
+from uw_scan.api.server import app
+spec = app.openapi()
+p = Path("tests/integration/api/openapi.snapshot.json")
+p.write_text(json.dumps(spec, indent=2, sort_keys=True, ensure_ascii=True) + "\n")
+print("wrote", p)
+PY
+```
+
+Verify the diff is small and only adds `StockShortVol` + `short_vol`:
+
+```bash
+git diff --stat tests/integration/api/openapi.snapshot.json
+```
+
+Expected: a modest `+N` insertion (the new schema block + one property ref). If the whole file churns, the original lacked a trailing newline — check `tail -c1 tests/integration/api/openapi.snapshot.json | xxd` and drop the `+ "\n"` to match. (The test asserts parsed-JSON equality, so it passes regardless of formatting; the formatting only keeps the diff reviewable.)
+
+- [ ] **Step 6: Re-run the snapshot test to verify it passes**
+
+Run: `uv run pytest tests/integration/api/test_openapi_snapshot.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Regenerate `web/lib/types.ts`**
+
+Primary path (API must be reachable on :8400 — start it with `bash scripts/dev.sh` or `make`-equivalent if not running):
+
+```bash
+cd web && npm run gen:types && cd ..
+git diff --stat web/lib/types.ts
+```
+
+**If the diff shows only the additions** (a `StockShortVol:` block + a `short_vol?:` line under `SingleStockReport`), keep it and skip to Step 6.
+
+**If the diff reorders hundreds/thousands of lines** (the known "alphabetically frozen" trap), discard and splice in only the two new pieces — extracted from a *fresh* generation so they match `openapi-typescript` output byte-for-byte (no hand-authoring, no JSDoc-orphan risk). Do it via a script (not the Edit tool — a prettier hook reflows tool-driven edits):
+
+```bash
+git checkout web/lib/types.ts
+cd web && npx openapi-typescript http://127.0.0.1:8400/openapi.json -o /tmp/types.new.ts && cd ..
+uv run python - <<'PY'
+import re
+from pathlib import Path
+
+new = Path("/tmp/types.new.ts").read_text()
+cur = Path("web/lib/types.ts").read_text()
+
+def extract_block(src, name):
+    """Full `        {name}: { ... };` block, including any preceding JSDoc comment."""
+    decl = re.search(rf"\n( *){name}: \{{", src)
+    assert decl, f"{name} not found in generated types"
+    indent = decl.group(1)
+    start = decl.start() + 1
+    cm = re.search(r"( *)/\*\*(?:(?!\*/).)*\*/\n\Z", src[:start], re.S)  # preceding /** */
+    block_start = cm.start() if cm else start
+    close = re.search(rf"\n{indent}}};\n", src[start:])
+    assert close, f"{name} block close not found"
+    return src[block_start:start + close.end()]
+
+sv_block = extract_block(new, "StockShortVol")
+fld = re.search(r"\n( *short_vol\?: [^\n]*\n)", new)
+assert fld, "short_vol field not found in generated types"
+field = fld.group(1)
+
+# Insert StockShortVol before StrikeExposureRow — and before ITS JSDoc comment.
+m = re.search(r"\n( *)StrikeExposureRow: \{", cur)
+assert m, "StrikeExposureRow anchor not found"
+istart = m.start() + 1
+cm = re.search(r"( *)/\*\*(?:(?!\*/).)*\*/\n\Z", cur[:istart], re.S)
+ins = cm.start() if cm else istart
+cur = cur[:ins] + sv_block + cur[ins:]
+
+# Insert short_vol field right after short_int_note in SingleStockReport.
+needle = re.search(r"\n *short_int_note: string;\n", cur)
+assert needle, "short_int_note anchor not found"
+cur = cur.replace(needle.group(0), needle.group(0) + field, 1)
+
+Path("web/lib/types.ts").write_text(cur)
+print("spliced StockShortVol schema + short_vol field")
+PY
+```
+
+This extracts the exact `StockShortVol` block and `short_vol` line from a throwaway full generation, so the spliced content is identical to what `gen:types` would emit — and it anchors the schema insert *before* `StrikeExposureRow`'s JSDoc comment so that comment stays attached to `StrikeExposureRow`. After running, `git diff --stat web/lib/types.ts` should show only the additions.
+
+- [ ] **Step 8: Verify types + typecheck**
+
+```bash
+cd web && npm run typecheck && cd ..
+```
+Expected: no errors. (Confirms `report.short_vol` and the `StockShortVol` schema resolve.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/uw_scan/reports/single_stock.py tests/unit/test_report_assembly.py \
+        tests/integration/api/openapi.snapshot.json web/lib/types.ts
+git commit -m "feat(stock): expose short_vol on SingleStockReport + regen contract"
+```
+
+---
+
+### Task 3: `ShortVolPanel` component (frontend, Vitest)
+
+**Files:**
+- Create: `web/components/stock/panels/ShortVolPanel.tsx`
+- Test: `web/tests/unit/ShortVolPanel.test.tsx`
+
+**Interfaces:**
+- Consumes: `components["schemas"]["SingleStockReport"]` (now with `short_vol`) from Task 2; `toNum` from `@/lib/formatters`.
+- Produces: `export function ShortVolPanel({ report }: { report: Report })` — a pure server-renderable panel (no hooks), consumed by Task 4. Test ids: `short-vol-panel`, `short-vol-action`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/tests/unit/ShortVolPanel.test.tsx`:
+
+```tsx
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ShortVolPanel } from "@/components/stock/panels/ShortVolPanel";
+import type { components } from "@/lib/types";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+// Real TSLA 2026-06-24 spot; short_vol shaped like the serialized API response
+// (Decimal → string).
+const base = { ticker: "TSLA" } as unknown as Report;
+const withShortVol = (sv: unknown): Report =>
+  ({ ...base, short_vol: sv }) as Report;
+
+const tradeSv = {
+  as_of: "2026-06-24", basis: "eod", action: "TRADE", skip_reason: null,
+  iv: "0.473", rv20: "0.40", vrp: "0.073", vrp_z: "1.6", weight: "1",
+  short_put: "360", long_put: "340", put_width: "20", credit: "4.2", max_loss: "15.8",
+  hold_days: 30, short_delta: "0.25", wing_delta: "0.125",
+};
+
+const skipSv = {
+  ...tradeSv, action: "SKIP", skip_reason: "sector vol not sellable", weight: "0",
+  short_put: null, long_put: null, put_width: null, credit: null, max_loss: null,
+};
+
+describe("ShortVolPanel", () => {
+  it("renders TRADE with spread strikes and the bull-put footer", () => {
+    render(<ShortVolPanel report={withShortVol(tradeSv)} />);
+    expect(screen.getByTestId("short-vol-action").textContent).toBe("TRADE");
+    expect(screen.getByText(/Sell 360 \/ buy 340 put/)).toBeTruthy();
+    expect(
+      screen.getByText(/Bull put spread 0\.25Δ\/0\.125Δ · ~30d hold/),
+    ).toBeTruthy();
+  });
+
+  it("renders SKIP with the reason and IV/RV", () => {
+    render(<ShortVolPanel report={withShortVol(skipSv)} />);
+    expect(screen.getByTestId("short-vol-action").textContent).toBe("SKIP");
+    expect(screen.getByText("sector vol not sellable")).toBeTruthy();
+    expect(screen.getByText(/IV 47\.3% \/ RV20 40\.0%/)).toBeTruthy();
+  });
+
+  it("renders a no-data state when short_vol is null", () => {
+    render(<ShortVolPanel report={withShortVol(null)} />);
+    expect(screen.getByTestId("short-vol-panel")).toBeTruthy();
+    expect(screen.getByText(/No vol data/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web && npm run test -- ShortVolPanel`
+Expected: FAIL — cannot resolve `@/components/stock/panels/ShortVolPanel`.
+
+- [ ] **Step 3: Write the component**
+
+Create `web/components/stock/panels/ShortVolPanel.tsx`:
+
+```tsx
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: 16,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+};
+
+const pct = (x: number | null) =>
+  x == null ? "—" : `${(x * 100).toFixed(1)}%`;
+const f = (x: number | null, d = 2) => (x == null ? "—" : x.toFixed(d));
+
+export function ShortVolPanel({ report }: { report: Report }) {
+  const s = report.short_vol;
+
+  const header = (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: 12,
+      }}
+    >
+      <span style={labelStyle}>SHORT-VOL · {report.ticker}</span>
+      <span style={{ ...labelStyle, fontSize: 9, letterSpacing: 0.5 }}>
+        EOD SNAPSHOT
+      </span>
+    </div>
+  );
+
+  if (!s) {
+    return (
+      <div style={panelStyle} data-testid="short-vol-panel">
+        {header}
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          No vol data yet.
+        </div>
+      </div>
+    );
+  }
+
+  const trade = s.action === "TRADE";
+  const color = trade ? "var(--positive)" : "var(--text-muted)";
+  const reasons = trade
+    ? [
+        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))} (size)`,
+        `Sell ${f(toNum(s.short_put), 0)} / buy ${f(toNum(s.long_put), 0)} put`,
+        `Credit ${f(toNum(s.credit))} · max loss ${f(toNum(s.max_loss))} per spread`,
+      ]
+    : [
+        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))}`,
+        `IV ${pct(toNum(s.iv))} / RV20 ${pct(toNum(s.rv20))}`,
+      ];
+
+  return (
+    <div style={panelStyle} data-testid="short-vol-panel">
+      {header}
+      <div
+        data-testid="short-vol-action"
+        style={{
+          color,
+          fontSize: 28,
+          fontWeight: 700,
+          letterSpacing: 1,
+          marginBottom: 10,
+        }}
+      >
+        {s.action}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {reasons.map((r, i) => (
+          <div key={i} style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+            {r}
+          </div>
+        ))}
+        {!trade && s.skip_reason ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+            {s.skip_reason}
+          </div>
+        ) : null}
+      </div>
+      <div
+        style={{
+          marginTop: 12,
+          paddingTop: 10,
+          borderTop: "1px solid var(--border-dim)",
+          color: "var(--text-muted)",
+          fontSize: 11,
+        }}
+      >
+        Bull put spread {toNum(s.short_delta)}Δ/{toNum(s.wing_delta)}Δ · ~
+        {s.hold_days}d hold
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web && npm run test -- ShortVolPanel`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/panels/ShortVolPanel.tsx web/tests/unit/ShortVolPanel.test.tsx
+git commit -m "feat(web): ShortVolPanel — per-stock short-vol card"
+```
+
+---
+
+### Task 4: Place `ShortVolPanel` on the Directional-Bias row
+
+**Files:**
+- Modify: `web/components/stock/tabs/MarketStructureTab.tsx`
+
+**Interfaces:**
+- Consumes: `ShortVolPanel` from Task 3.
+
+- [ ] **Step 1: Add the import**
+
+In `web/components/stock/tabs/MarketStructureTab.tsx`, add after the `DirectionalBiasPanel` import:
+
+```tsx
+import { ShortVolPanel } from "../panels/ShortVolPanel";
+```
+
+- [ ] **Step 2: Make the row a 3-column grid and add the panel**
+
+Change `gridTemplateColumns: "1fr 1fr"` to `gridTemplateColumns: "1fr 1fr 1fr"`, and add the panel as the third child after `DirectionalBiasPanel`:
+
+```tsx
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 12,
+        }}
+      >
+        <ExpectedRangeBar report={report} />
+        <DirectionalBiasPanel report={report} history={historyRows} />
+        <ShortVolPanel report={report} />
+      </div>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd web && npm run typecheck && cd ..`
+Expected: no errors.
+
+- [ ] **Step 4: Visual verification (real path)**
+
+Start the stack if not running (`bash scripts/dev.sh`), open a real ticker that has `vrp_daily` history (e.g. `http://localhost:3001/stock/TSLA`), Market Structure tab. Confirm the Short-Vol card renders as the third card on the Directional-Bias row, with a TRADE or SKIP verdict, `vrp_z · weight`, `IV / RV20`, and the bull-put footer (or `No vol data yet.` for a ticker without history). Screenshot to `output/playwright/stock-short-vol-card.png`.
+
+If the Expected-Range bar looks cramped at 1/3 width, change `gridTemplateColumns` to `"1.3fr 1fr 1fr"` and re-verify.
+
+**Operational note (not a code bug):** the TRADE verdict depends on the VRP research tables `vrp_harvest_by_sector` / `vrp_harvest_multihorizon` being populated (the sellable-by-sector gate). On the prod mini these are kept fresh by the existing VRP jobs (`vrp_candidates` uses the same gate). On a fresh local dev DB that hasn't run those jobs, the tables are empty → every name reads `SKIP — sector vol not sellable`. That's expected; verify against a ticker known to be in a sellable sector, or confirm on the mini.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/stock/tabs/MarketStructureTab.tsx
+git commit -m "feat(web): add Short-Vol card to Market Structure directional-bias row"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against the approved design):
+- "Same UI card, per stock" → Task 3 `ShortVolPanel` mirrors `MacroShortVolCard` content (verdict, `vrp_z·weight`, `IV/RV20`, bull-put footer) using the row's `panelStyle`. ✓
+- "Same line as Directional Bias" → Task 4, 2→3 column grid. ✓
+- "Full readout" (verdict + vrp_z + weight + IV/RV + concrete spread) → `decide_short_vol` TRADE branch builds strikes/credit/max_loss; panel renders them. ✓
+- "Sector gate + vrp_z" verdict → `decide_short_vol`: `rich (z≥RICH_Z) AND gate_ok AND known earnings clear of window`. ✓
+- Bull put spread reused (condor = noted upgrade path) → `build_bull_put_spread` reused. ✓
+- EOD basis, no new endpoint/job/migration → folded into `assemble_single_stock_report`; `basis="eod"`, EOD-close spot. ✓
+- Persist-results rule → `vrp_daily` already persisted; read-time reshape only. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full content; commands have expected output. ✓
+
+**3. Type consistency:** `decide_short_vol`/`build_short_vol` signatures match between Task 1 definition, the Task 1 test, and the Task 2 caller. `StockShortVol` field names match across model (Task 1), TS schema (Task 2), and panel reads (Task 3). `gate_ok` used consistently. ✓
+
+**4. Robustness (hardened after independent review):**
+- **Unknown earnings never TRADE** — `passes_gate` only proves a calendar *exists*; the next date is sourced from `fetch_latest_next_earnings_date` and `None` → SKIP "earnings date unavailable" (matches `scanner.gates.earnings_gate`). ✓
+- **Non-finite `vrp_z_20`/iv never reach Pydantic** — `_finite()` normalizes NaN/inf → None (the rolling z-window emits NaN on short histories); `Decimal("NaN")` can't form. ✓
+- **Card failure never breaks the page** — `build_short_vol` is wrapped in `try/except … # noqa: BLE001` in the assembler; logs + degrades to `short_vol=None`. ✓
+- **Existing `test_report_assembly.py` stays green** — Task 2 Step 3 adds `fetch_vrp_daily_series→[]` to its stub + asserts `short_vol is None` (clean degrade, not exception-swallow). ✓
+
+**Known risk flagged in-plan:** `web/lib/types.ts` regen may reorder the whole file — Task 2 Step 7 gives both the clean-diff path and a robust extract-and-splice fallback (content lifted from a fresh generation, anchored before `StrikeExposureRow`'s JSDoc). The OpenAPI snapshot test compares parsed JSON, so it is robust to formatting.

--- a/src/uw_scan/models/__init__.py
+++ b/src/uw_scan/models/__init__.py
@@ -129,6 +129,7 @@ from .stock import (
     SingleStockReport,
     StockHistoryResponse,
     StockHistoryRow,
+    StockShortVol,
     VolatilityProfile,
     VRPAssessment,
 )
@@ -294,6 +295,7 @@ __all__ = [
     "DealerRegime",
     "StockHistoryRow",
     "StockHistoryResponse",
+    "StockShortVol",
     "SingleStockReport",
     "VolHeaderBlock",
     "TermStructureExpiryRow",

--- a/src/uw_scan/models/stock.py
+++ b/src/uw_scan/models/stock.py
@@ -71,6 +71,7 @@ class StockShortVol(_UwBase):
     basis: str = "eod"
     action: str  # "TRADE" | "SKIP"
     skip_reason: str | None = None
+    spot: Decimal | None = None  # EOD-close basis the strikes are modeled off
     iv: Decimal | None = None
     rv20: Decimal | None = None
     vrp: Decimal | None = None

--- a/src/uw_scan/models/stock.py
+++ b/src/uw_scan/models/stock.py
@@ -60,6 +60,32 @@ class VRPAssessment(_UwBase):
     note: str
 
 
+class StockShortVol(_UwBase):
+    """Per-ticker short-vol (sell-premium) readout for the Market Structure tab —
+    the single-name sibling of the SPX MacroSignal. EOD basis (latest vrp_daily row).
+    action=TRADE only when vol is rich (vrp_z_20 >= 1.0) AND the ticker's sector is in
+    the sellable set AND earnings are clear of the hold window; else SKIP with a reason.
+    Strikes/credit/max_loss are flat-vol modeled (conservative floor)."""
+
+    as_of: _date
+    basis: str = "eod"
+    action: str  # "TRADE" | "SKIP"
+    skip_reason: str | None = None
+    iv: Decimal | None = None
+    rv20: Decimal | None = None
+    vrp: Decimal | None = None
+    vrp_z: Decimal | None = None
+    weight: Decimal | None = None
+    short_put: Decimal | None = None
+    long_put: Decimal | None = None
+    put_width: Decimal | None = None
+    credit: Decimal | None = None
+    max_loss: Decimal | None = None
+    hold_days: int
+    short_delta: Decimal
+    wing_delta: Decimal
+
+
 class StockHistoryRow(_UwBase):
     """One per-trading-day rollup of a ticker's market structure.
 
@@ -94,6 +120,9 @@ class SingleStockReport(_UwBase):
     volatility: VolatilityProfile
     flow: FlowSnapshot
     vrp: VRPAssessment
+    # Single-name short-vol readout (sell-premium TRADE/SKIP + modeled spread).
+    # Derived at read time from the latest vrp_daily row; None when no history.
+    short_vol: StockShortVol | None = None
     setup: SetupClassification | None = None
     dark_pool_notional: Decimal | None = None
     dark_pool_print_count: int = 0
@@ -125,6 +154,7 @@ _preserve_public_module(
     MarketStructure,
     VolatilityProfile,
     VRPAssessment,
+    StockShortVol,
     StockHistoryRow,
     StockHistoryResponse,
     SingleStockReport,

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -5,6 +5,7 @@ Pure function: reads from Repository (already-persisted tables), never the live 
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from datetime import date as _date
 from decimal import Decimal
@@ -30,6 +31,9 @@ from ..models import (
 )
 from ..storage.option_intraday_repository import OptionIntradayBucketRepository
 from ..storage.repository import Repository
+from .stock_short_vol import build_short_vol
+
+logger = logging.getLogger(__name__)
 
 # How many of the top OI movers (post-notional sort) we derive an intraday
 # tape profile for. Matches the OiMoversTable.tsx slice() cap on the UI.
@@ -406,6 +410,21 @@ def assemble_single_stock_report(
         None,
     )
 
+    # Per-ticker short-vol readout (sell-premium TRADE/SKIP + modeled spread).
+    # Modeled off the EOD-close market_structure.spot (consistent with the EOD
+    # vrp_daily as_of + the card's "EOD SNAPSHOT" label); the router's
+    # _with_latest_spot only patches the header display spot, not this card.
+    # Non-critical — never let it take down the page (cf. pipeline.py:94).
+    try:
+        short_vol = build_short_vol(
+            repo,
+            ticker,
+            float(market_structure.spot) if market_structure.spot is not None else None,
+        )
+    except Exception as exc:  # noqa: BLE001 — short-vol card is non-critical; never break the page
+        logger.warning("short_vol build failed for %s: %s", ticker, repr(exc))
+        short_vol = None
+
     # Dealer regime — same gather_inputs helper the /regime/dealer endpoint
     # uses, so both paths share one source of truth.
     dr_inputs = gather_inputs(repo, ticker=ticker)
@@ -466,5 +485,6 @@ def assemble_single_stock_report(
         strike_exposures=strike_exposures,
         exposures_summary=exposures_summary,
         next_earnings_date=next_earnings_date,
+        short_vol=short_vol,
         dealer_regime=dealer_regime_model,
     )

--- a/src/uw_scan/reports/stock_short_vol.py
+++ b/src/uw_scan/reports/stock_short_vol.py
@@ -1,0 +1,182 @@
+"""Per-ticker short-vol readout — single-name sibling of the SPX MacroSignal.
+
+Reshapes the latest persisted vrp_daily row (iv/rv/vrp_z_20) into a TRADE/SKIP
+action with a flat-vol-modeled bull put spread, gated by the sellable-by-sector
+rule. Pure read-time derivation: vrp_daily is the already-persisted analytical
+result, refreshed nightly by worker.volatility_jobs.nightly_vol_analytics_rollup.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date as _date
+from datetime import timedelta
+from decimal import Decimal
+
+from uw_scan.models import StockShortVol
+from uw_scan.reports.vrp_gate import (
+    passes_gate,
+    sellable_asset_classes,
+    sellable_single_name_sectors,
+)
+from uw_scan.reports.vrp_macro_signal import WINNER, MacroSignalConfig, size_weight
+from uw_scan.reports.vrp_structure import build_bull_put_spread
+
+RICH_Z = 1.0  # vol "rich enough" to sell — matches reports.vrp_markout.RICH_Z
+# ponytail: flat r mirrors settings.vrp_risk_free_rate default (config.py:311);
+# tiny effect at short DTE. Thread settings here only if r ever needs to be non-default.
+RISK_FREE_RATE = 0.04
+# 30 trading-day hold ≈ 6 calendar weeks; exclude a name whose next earnings prints
+# inside that window (the (entry, expiry] earnings landmine).
+HOLD_CAL_DAYS = 45
+
+
+def _finite(v: object) -> float | None:
+    """Coerce to a finite float, else None. Guards against NaN/inf — the rolling
+    vrp_z_20 window emits NaN on short histories (cards/vol_series.py), and Pydantic
+    rejects Decimal('NaN')."""
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _dec(v: float | None) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def decide_short_vol(
+    *,
+    as_of: _date,
+    spot: float | None,
+    iv: float | None,
+    rv: float | None,
+    vrp: float | None,
+    vrp_z_20: float | None,
+    gate_ok: bool,
+    next_earnings_date: _date | None,
+    require_earnings: bool = True,
+    risk_free_rate: float = RISK_FREE_RATE,
+    cfg: MacroSignalConfig = WINNER,
+) -> StockShortVol:
+    """Map one ticker's latest VRP row → TRADE/SKIP readout. Pure: no I/O.
+
+    `gate_ok` is the result of reports.vrp_gate.passes_gate (sellable bucket). TRADE
+    additionally requires vol rich (z>=RICH_Z) and a usable IV+spot. For single names
+    (`require_earnings=True`) it also requires a KNOWN next-earnings date outside the
+    hold window — unknown earnings conservatively SKIP (matches
+    scanner.gates.earnings_gate: None → block). Macro/ETF classes don't report
+    earnings (`require_earnings=False`), mirroring vrp_gate's own asset-class split.
+    """
+    spot = _finite(spot)
+    iv = _finite(iv)
+    rv = _finite(rv)
+    vrp = _finite(vrp)
+    z = _finite(vrp_z_20)
+
+    common = dict(
+        as_of=as_of,
+        iv=_dec(iv),
+        rv20=_dec(rv),
+        vrp=_dec(vrp),
+        vrp_z=_dec(z),
+        hold_days=cfg.hold_days,
+        short_delta=_dec(cfg.short_delta),
+        wing_delta=_dec(cfg.wing_delta),
+    )
+
+    usable = iv is not None and iv > 0 and spot is not None and spot > 0
+    rich = z is not None and z >= RICH_Z
+    window_end = as_of + timedelta(days=HOLD_CAL_DAYS)
+    earnings_clear = next_earnings_date is not None and next_earnings_date > window_end
+
+    if not usable:
+        reason: str | None = "no usable IV/spot"
+    elif z is None:
+        reason = "insufficient vol history"
+    elif not rich:
+        reason = f"vol not rich (vrp_z {z:.2f} < {RICH_Z:.1f})"
+    elif not gate_ok:
+        reason = "sector vol not sellable"
+    elif require_earnings and next_earnings_date is None:
+        reason = "earnings date unavailable"
+    elif require_earnings and not earnings_clear:
+        reason = "earnings inside hold window"
+    else:
+        reason = None
+
+    if reason is not None:
+        return StockShortVol(
+            action="SKIP", skip_reason=reason, weight=Decimal("0"), **common
+        )
+
+    # tradeable — spot/iv are finite & positive here. Build the modeled spread;
+    # degenerate strikes fall back to SKIP.
+    try:
+        st = build_bull_put_spread(
+            spot,
+            iv,
+            cfg.hold_days / 252.0,
+            risk_free_rate,
+            short_delta=cfg.short_delta,
+            wing_delta=cfg.wing_delta,
+        )
+    except ValueError:
+        return StockShortVol(
+            action="SKIP",
+            skip_reason="degenerate spread strikes",
+            weight=Decimal("0"),
+            **common,
+        )
+
+    return StockShortVol(
+        action="TRADE",
+        skip_reason=None,
+        weight=_dec(size_weight(z, cfg)),
+        short_put=_dec(st.short_put),
+        long_put=_dec(st.long_put),
+        put_width=_dec(st.put_width),
+        credit=_dec(st.credit),
+        max_loss=_dec(st.max_loss),
+        **common,
+    )
+
+
+def build_short_vol(repo, ticker: str, spot: float | None) -> StockShortVol | None:
+    """I/O wrapper: read the latest vrp_daily row, the sellable gate, and a reliable
+    next-earnings date, then decide. Returns None when the ticker has no vrp_daily
+    history (new/illiquid name).
+
+    Earnings come from repo.fetch_latest_next_earnings_date (most-recent reported
+    next-earnings across flow_events) — more reliable than the report's
+    current-top-alert promotion, which is often None even for names that report.
+    """
+    series = repo.fetch_vrp_daily_series(ticker, limit=1)
+    if not series:
+        return None
+    row = series[0]
+    gate = passes_gate(
+        repo,
+        ticker,
+        sellable_sectors=sellable_single_name_sectors(repo),
+        sellable_classes=sellable_asset_classes(repo, hold_days=WINNER.hold_days),
+    )
+    # Only single names carry the earnings landmine; indices/ETFs don't report
+    # (vrp_gate makes the same split).
+    require_earnings = gate is not None and gate.asset_class == "single_name"
+    return decide_short_vol(
+        as_of=row["market_date"],
+        spot=spot,
+        iv=row.get("iv"),
+        rv=row.get("rv"),
+        vrp=row.get("vrp"),
+        vrp_z_20=row.get("vrp_z_20"),
+        gate_ok=gate is not None,
+        next_earnings_date=repo.fetch_latest_next_earnings_date(ticker),
+        require_earnings=require_earnings,
+    )

--- a/src/uw_scan/reports/stock_short_vol.py
+++ b/src/uw_scan/reports/stock_short_vol.py
@@ -15,17 +15,14 @@ from datetime import timedelta
 from decimal import Decimal
 
 from uw_scan.models import StockShortVol
-from uw_scan.reports.vrp_gate import (
-    evaluate_gate,
-    sellable_asset_classes,
-    sellable_single_name_sectors,
-)
+from uw_scan.reports.vrp_gate import evaluate_gate
 from uw_scan.reports.vrp_macro_signal import WINNER, MacroSignalConfig, size_weight
+from uw_scan.reports.vrp_markout import RICH_Z  # single source for the richness cutoff
 from uw_scan.reports.vrp_structure import build_bull_put_spread
 
 log = logging.getLogger(__name__)
 
-RICH_Z = 1.0  # vol "rich enough" to sell — matches reports.vrp_markout.RICH_Z
+# RICH_Z (vol "rich enough" to sell) is imported from vrp_markout — one threshold.
 # ponytail: flat r mirrors settings.vrp_risk_free_rate default (config.py:311);
 # tiny effect at short DTE. Thread settings here only if r ever needs to be non-default.
 RISK_FREE_RATE = 0.04
@@ -92,6 +89,7 @@ def decide_short_vol(
 
     common = dict(
         as_of=as_of,
+        spot=_dec(spot),
         iv=_dec(iv),
         rv20=_dec(rv),
         vrp=_dec(vrp),
@@ -104,7 +102,6 @@ def decide_short_vol(
     usable = iv is not None and iv > 0 and spot is not None and spot > 0
     rich = z is not None and z >= RICH_Z
     window_end = as_of + timedelta(days=HOLD_CAL_DAYS)
-    earnings_clear = next_earnings_date is not None and next_earnings_date > window_end
 
     if not usable:
         reason: str | None = "no usable IV/spot"
@@ -114,11 +111,15 @@ def decide_short_vol(
         reason = f"vol not rich (vrp_z {z:.2f} < {RICH_Z:.1f})"
     elif not gate_ok:
         # gate_skip_reason distinguishes "sector not sellable" from "no earnings
-        # calendar" — both collapse passes_gate to None, but the user needs the real one.
+        # calendar" — both collapse the gate to None, but the user needs the real one.
         reason = gate_skip_reason or "sector vol not sellable"
     elif require_earnings and next_earnings_date is None:
-        reason = "earnings date unavailable"
-    elif require_earnings and not earnings_clear:
+        reason = "next earnings date unknown"
+    elif require_earnings and next_earnings_date < as_of:
+        # A past date is stale (the print already happened, the next is unknown) — not
+        # "inside the window". Surface that honestly rather than mislabeling it.
+        reason = "next earnings date stale"
+    elif require_earnings and next_earnings_date <= window_end:
         reason = "earnings inside hold window"
     else:
         reason = None
@@ -180,12 +181,9 @@ def build_short_vol(repo, ticker: str, spot: float | None) -> StockShortVol | No
         return None
     # series is market_date DESC → the first usable row is the most recent one.
     row = next((r for r in series if _usable_iv(r)), series[0])
-    gate, gate_skip_reason = evaluate_gate(
-        repo,
-        ticker,
-        sellable_sectors=sellable_single_name_sectors(repo),
-        sellable_classes=sellable_asset_classes(repo, hold_days=WINNER.hold_days),
-    )
+    # evaluate_gate computes only the sellable table this ticker's asset class needs
+    # (single_name → by_sector; macro → multihorizon), not both — one scan per page.
+    gate, gate_skip_reason = evaluate_gate(repo, ticker, hold_days=WINNER.hold_days)
     # Only single names carry the earnings landmine; indices/ETFs don't report
     # (vrp_gate makes the same split).
     require_earnings = gate is not None and gate.asset_class == "single_name"

--- a/src/uw_scan/reports/stock_short_vol.py
+++ b/src/uw_scan/reports/stock_short_vol.py
@@ -8,6 +8,7 @@ result, refreshed nightly by worker.volatility_jobs.nightly_vol_analytics_rollup
 
 from __future__ import annotations
 
+import logging
 import math
 from datetime import date as _date
 from datetime import timedelta
@@ -21,6 +22,8 @@ from uw_scan.reports.vrp_gate import (
 )
 from uw_scan.reports.vrp_macro_signal import WINNER, MacroSignalConfig, size_weight
 from uw_scan.reports.vrp_structure import build_bull_put_spread
+
+log = logging.getLogger(__name__)
 
 RICH_Z = 1.0  # vol "rich enough" to sell — matches reports.vrp_markout.RICH_Z
 # ponytail: flat r mirrors settings.vrp_risk_free_rate default (config.py:311);
@@ -39,7 +42,8 @@ def _finite(v: object) -> float | None:
         return None
     try:
         f = float(v)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        log.debug("non-finite coercion skipped: %s", repr(exc))
         return None
     return f if math.isfinite(f) else None
 
@@ -126,7 +130,8 @@ def decide_short_vol(
             short_delta=cfg.short_delta,
             wing_delta=cfg.wing_delta,
         )
-    except ValueError:
+    except ValueError as exc:
+        log.debug("degenerate short-vol spread strikes: %s", repr(exc))
         return StockShortVol(
             action="SKIP",
             skip_reason="degenerate spread strikes",

--- a/src/uw_scan/reports/stock_short_vol.py
+++ b/src/uw_scan/reports/stock_short_vol.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 
 from uw_scan.models import StockShortVol
 from uw_scan.reports.vrp_gate import (
-    passes_gate,
+    evaluate_gate,
     sellable_asset_classes,
     sellable_single_name_sectors,
 )
@@ -54,6 +54,12 @@ def _dec(v: float | None) -> Decimal | None:
     return Decimal(str(v))
 
 
+def _usable_iv(row: dict) -> bool:
+    """The walk-back predicate: a row is usable when its iv is finite and positive."""
+    iv = _finite(row.get("iv"))
+    return iv is not None and iv > 0
+
+
 def decide_short_vol(
     *,
     as_of: _date,
@@ -64,6 +70,7 @@ def decide_short_vol(
     vrp_z_20: float | None,
     gate_ok: bool,
     next_earnings_date: _date | None,
+    gate_skip_reason: str | None = None,
     require_earnings: bool = True,
     risk_free_rate: float = RISK_FREE_RATE,
     cfg: MacroSignalConfig = WINNER,
@@ -106,7 +113,9 @@ def decide_short_vol(
     elif not rich:
         reason = f"vol not rich (vrp_z {z:.2f} < {RICH_Z:.1f})"
     elif not gate_ok:
-        reason = "sector vol not sellable"
+        # gate_skip_reason distinguishes "sector not sellable" from "no earnings
+        # calendar" — both collapse passes_gate to None, but the user needs the real one.
+        reason = gate_skip_reason or "sector vol not sellable"
     elif require_earnings and next_earnings_date is None:
         reason = "earnings date unavailable"
     elif require_earnings and not earnings_clear:
@@ -153,19 +162,25 @@ def decide_short_vol(
 
 
 def build_short_vol(repo, ticker: str, spot: float | None) -> StockShortVol | None:
-    """I/O wrapper: read the latest vrp_daily row, the sellable gate, and a reliable
-    next-earnings date, then decide. Returns None when the ticker has no vrp_daily
-    history (new/illiquid name).
+    """I/O wrapper: read the most recent usable vrp_daily row, the sellable gate, and
+    a reliable next-earnings date, then decide. Returns None when the ticker has no
+    vrp_daily history (new/illiquid name).
+
+    The latest row can carry a NULL iv on a day the deriver had no data, so we walk
+    back to the most recent row with a usable IV (mirrors the macro sibling) rather
+    than going dead on a single bad day. as_of then reflects the row actually used,
+    so a stale read surfaces honestly on the card.
 
     Earnings come from repo.fetch_latest_next_earnings_date (most-recent reported
     next-earnings across flow_events) — more reliable than the report's
     current-top-alert promotion, which is often None even for names that report.
     """
-    series = repo.fetch_vrp_daily_series(ticker, limit=1)
+    series = repo.fetch_vrp_daily_series(ticker, limit=7)
     if not series:
         return None
-    row = series[0]
-    gate = passes_gate(
+    # series is market_date DESC → the first usable row is the most recent one.
+    row = next((r for r in series if _usable_iv(r)), series[0])
+    gate, gate_skip_reason = evaluate_gate(
         repo,
         ticker,
         sellable_sectors=sellable_single_name_sectors(repo),
@@ -183,5 +198,6 @@ def build_short_vol(repo, ticker: str, spot: float | None) -> StockShortVol | No
         vrp_z_20=row.get("vrp_z_20"),
         gate_ok=gate is not None,
         next_earnings_date=repo.fetch_latest_next_earnings_date(ticker),
+        gate_skip_reason=gate_skip_reason,
         require_earnings=require_earnings,
     )

--- a/src/uw_scan/reports/vrp_gate.py
+++ b/src/uw_scan/reports/vrp_gate.py
@@ -66,15 +66,24 @@ def evaluate_gate(
     repo,
     ticker: str,
     *,
-    sellable_sectors: set[str],
-    sellable_classes: set[str],
+    sellable_sectors: set[str] | None = None,
+    sellable_classes: set[str] | None = None,
+    hold_days: int | None = None,
 ) -> tuple[GateResult | None, str | None]:
     """Gate a ticker, returning (result, reason). result is the GateResult for an
     admissible ticker (reason None); otherwise result is None and reason is the
-    GATE_SKIP_* cause. Single source of truth — passes_gate delegates here."""
+    GATE_SKIP_* cause. Single source of truth — passes_gate delegates here.
+
+    Batch callers (backtest, candidate emitter) pass the pre-computed sellable sets.
+    A single-ticker caller can omit them: only the one table the ticker's asset class
+    needs is scanned, lazily (single_name → by_sector; macro → multihorizon at
+    hold_days). Omitting hold_days for an un-provided macro set excludes macro
+    conservatively (no horizon to match)."""
     sector = repo.fetch_watchlist_sector(ticker)
     ac = asset_class_baseline(ticker, sector=sector)["asset_class"]
     if ac == "single_name":
+        if sellable_sectors is None:
+            sellable_sectors = sellable_single_name_sectors(repo)
         key = sector or "unknown"
         if key not in sellable_sectors:
             return None, GATE_SKIP_SECTOR
@@ -84,6 +93,12 @@ def evaluate_gate(
             return None, GATE_SKIP_NO_EARNINGS_CALENDAR
         return GateResult(asset_class=ac, bucket_key=key), None
     # macro / sector_etf / credit: gated on the per-asset-class multihorizon verdict.
+    if sellable_classes is None:
+        sellable_classes = (
+            sellable_asset_classes(repo, hold_days=hold_days)
+            if hold_days is not None
+            else set()
+        )
     if ac not in sellable_classes:
         return None, GATE_SKIP_SECTOR
     return GateResult(asset_class=ac, bucket_key=ac), None

--- a/src/uw_scan/reports/vrp_gate.py
+++ b/src/uw_scan/reports/vrp_gate.py
@@ -56,6 +56,39 @@ def sellable_asset_classes(repo, *, hold_days: int) -> set[str]:
     return out
 
 
+# Gate-out reasons (display text for consumers that surface *why* a ticker is
+# excluded — e.g. the per-stock short-vol card). passes_gate itself drops these.
+GATE_SKIP_SECTOR = "sector vol not sellable"
+GATE_SKIP_NO_EARNINGS_CALENDAR = "no earnings calendar"
+
+
+def evaluate_gate(
+    repo,
+    ticker: str,
+    *,
+    sellable_sectors: set[str],
+    sellable_classes: set[str],
+) -> tuple[GateResult | None, str | None]:
+    """Gate a ticker, returning (result, reason). result is the GateResult for an
+    admissible ticker (reason None); otherwise result is None and reason is the
+    GATE_SKIP_* cause. Single source of truth — passes_gate delegates here."""
+    sector = repo.fetch_watchlist_sector(ticker)
+    ac = asset_class_baseline(ticker, sector=sector)["asset_class"]
+    if ac == "single_name":
+        key = sector or "unknown"
+        if key not in sellable_sectors:
+            return None, GATE_SKIP_SECTOR
+        # No earnings calendar → can't honor the (entry, expiry] exclusion → skip,
+        # else we'd manufacture a SELLABLE edge by ignoring earnings risk.
+        if not repo.fetch_historical_earnings_dates(ticker):
+            return None, GATE_SKIP_NO_EARNINGS_CALENDAR
+        return GateResult(asset_class=ac, bucket_key=key), None
+    # macro / sector_etf / credit: gated on the per-asset-class multihorizon verdict.
+    if ac not in sellable_classes:
+        return None, GATE_SKIP_SECTOR
+    return GateResult(asset_class=ac, bucket_key=ac), None
+
+
 def passes_gate(
     repo,
     ticker: str,
@@ -64,18 +97,10 @@ def passes_gate(
     sellable_classes: set[str],
 ) -> GateResult | None:
     """Return the GateResult for an admissible ticker, or None if it is gated out."""
-    sector = repo.fetch_watchlist_sector(ticker)
-    ac = asset_class_baseline(ticker, sector=sector)["asset_class"]
-    if ac == "single_name":
-        key = sector or "unknown"
-        if key not in sellable_sectors:
-            return None
-        # No earnings calendar → can't honor the (entry, expiry] exclusion → skip,
-        # else we'd manufacture a SELLABLE edge by ignoring earnings risk.
-        if not repo.fetch_historical_earnings_dates(ticker):
-            return None
-        return GateResult(asset_class=ac, bucket_key=key)
-    # macro / sector_etf / credit: gated on the per-asset-class multihorizon verdict.
-    if ac not in sellable_classes:
-        return None
-    return GateResult(asset_class=ac, bucket_key=ac)
+    result, _ = evaluate_gate(
+        repo,
+        ticker,
+        sellable_sectors=sellable_sectors,
+        sellable_classes=sellable_classes,
+    )
+    return result

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -14211,6 +14211,18 @@
             ],
             "title": "Skip Reason"
           },
+          "spot": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot"
+          },
           "vrp": {
             "anyOf": [
               {

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -13047,6 +13047,16 @@
             "title": "Short Int Note",
             "type": "string"
           },
+          "short_vol": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StockShortVol"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "spot_quoted_at": {
             "anyOf": [
               {
@@ -14078,6 +14088,179 @@
           "market_date"
         ],
         "title": "StockHistoryRow",
+        "type": "object"
+      },
+      "StockShortVol": {
+        "description": "Per-ticker short-vol (sell-premium) readout for the Market Structure tab \u2014\nthe single-name sibling of the SPX MacroSignal. EOD basis (latest vrp_daily row).\naction=TRADE only when vol is rich (vrp_z_20 >= 1.0) AND the ticker's sector is in\nthe sellable set AND earnings are clear of the hold window; else SKIP with a reason.\nStrikes/credit/max_loss are flat-vol modeled (conservative floor).",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "as_of": {
+            "format": "date",
+            "title": "As Of",
+            "type": "string"
+          },
+          "basis": {
+            "default": "eod",
+            "title": "Basis",
+            "type": "string"
+          },
+          "credit": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credit"
+          },
+          "hold_days": {
+            "title": "Hold Days",
+            "type": "integer"
+          },
+          "iv": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iv"
+          },
+          "long_put": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Long Put"
+          },
+          "max_loss": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Loss"
+          },
+          "put_width": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Put Width"
+          },
+          "rv20": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rv20"
+          },
+          "short_delta": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Short Delta",
+            "type": "string"
+          },
+          "short_put": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Put"
+          },
+          "skip_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skip Reason"
+          },
+          "vrp": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp"
+          },
+          "vrp_z": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrp Z"
+          },
+          "weight": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weight"
+          },
+          "wing_delta": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Wing Delta",
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of",
+          "action",
+          "hold_days",
+          "short_delta",
+          "wing_delta"
+        ],
+        "title": "StockShortVol",
         "type": "object"
       },
       "StrikeExposureRow": {
@@ -20579,7 +20762,7 @@
   },
   "info": {
     "title": "UW Watchlist API",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/unit/test_report_assembly.py
+++ b/tests/unit/test_report_assembly.py
@@ -123,6 +123,10 @@ class _StubRepo:
     def fetch_strike_exposures(self, run_id: int, ticker: str) -> list[dict]:
         return []
 
+    def fetch_vrp_daily_series(self, ticker: str, *, limit: int = 60) -> list[dict]:
+        # No VRP history → build_short_vol returns None (the gate path isn't reached).
+        return []
+
     def fetch_exposures_summary(self, run_id: int, ticker: str) -> list[dict]:
         return []
 
@@ -312,6 +316,10 @@ def test_assemble_single_stock_report_populates_sections():
     # VRP — IV 0.5 vs RV 0.4 → vrp 0.1 → rich
     assert report.vrp.vrp == Decimal("0.1")
     assert report.vrp.signal == "rich"
+
+    # Short-vol card degrades cleanly to None when the stub has no vrp_daily history
+    # (proves the new wiring doesn't blow up assembly — not via exception-swallowing).
+    assert report.short_vol is None
 
     # Dark pool + short data
     assert report.dark_pool_print_count == 100

--- a/tests/unit/test_stock_short_vol.py
+++ b/tests/unit/test_stock_short_vol.py
@@ -27,6 +27,7 @@ def test_trade_when_rich_sellable_and_earnings_clear():
     )
     assert sig.action == "TRADE"
     assert sig.skip_reason is None
+    assert sig.spot == Decimal(str(SPOT))  # modeled basis surfaced on the card
     assert sig.short_put is not None and sig.short_put < Decimal(str(SPOT))
     assert sig.long_put is not None and sig.long_put < sig.short_put
     assert sig.credit is not None and sig.credit > 0
@@ -82,7 +83,24 @@ def test_skip_when_earnings_unknown():
         next_earnings_date=None,
     )
     assert sig.action == "SKIP"
-    assert sig.skip_reason == "earnings date unavailable"
+    assert sig.skip_reason == "next earnings date unknown"
+
+
+def test_skip_when_earnings_date_is_stale():
+    # a stored next-earnings date in the past is stale, not "inside the window" —
+    # the next print already happened and the real next one is unknown.
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=date(2026, 5, 1),  # before AS_OF
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "next earnings date stale"
 
 
 def test_macro_class_trades_without_earnings():

--- a/tests/unit/test_stock_short_vol.py
+++ b/tests/unit/test_stock_short_vol.py
@@ -1,0 +1,185 @@
+"""Per-ticker short-vol decision logic. Real TSLA 2026-06-24: spot 382.35, IV30 0.473."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from uw_scan.reports.stock_short_vol import build_short_vol, decide_short_vol
+
+AS_OF = date(2026, 6, 24)
+SPOT = 382.35
+IV = 0.473
+RV = 0.40
+CLEAR_EARNINGS = date(2026, 10, 1)  # well beyond AS_OF + 45d (2026-08-08)
+
+
+def test_trade_when_rich_sellable_and_earnings_clear():
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "TRADE"
+    assert sig.skip_reason is None
+    assert sig.short_put is not None and sig.short_put < Decimal(str(SPOT))
+    assert sig.long_put is not None and sig.long_put < sig.short_put
+    assert sig.credit is not None and sig.credit > 0
+    assert sig.max_loss is not None and sig.max_loss > 0
+    assert sig.weight is not None and sig.weight > 0
+    assert sig.short_delta == Decimal("0.25")
+    assert sig.wing_delta == Decimal("0.125")
+
+
+def test_skip_when_vol_not_rich():
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.01,
+        vrp_z_20=0.3,
+        gate_ok=True,
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert "not rich" in (sig.skip_reason or "")
+    assert sig.weight == Decimal("0")
+    assert sig.short_put is None
+
+
+def test_skip_when_sector_not_sellable():
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=False,
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "sector vol not sellable"
+
+
+def test_skip_when_earnings_unknown():
+    # passes_gate proves an earnings calendar EXISTS, but the next date is unknown →
+    # never sell vol blind (matches scanner.gates.earnings_gate: None → block).
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=None,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "earnings date unavailable"
+
+
+def test_macro_class_trades_without_earnings():
+    # ETF/index sellable bucket: no earnings to clear, so unknown earnings must NOT
+    # block (mirrors vrp_gate exempting non-single_name classes).
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=None,
+        require_earnings=False,
+    )
+    assert sig.action == "TRADE"
+
+
+def test_skip_when_earnings_in_window():
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=date(2026, 7, 5),  # ~11 days out
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "earnings inside hold window"
+
+
+def test_skip_when_no_iv():
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=None,
+        rv=RV,
+        vrp=None,
+        vrp_z_20=1.6,
+        gate_ok=True,
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "no usable IV/spot"
+
+
+def test_skip_and_no_decimal_nan_when_z_nonfinite():
+    # early rolling-window rows carry NaN vrp_z_20 → must NOT reach Decimal("NaN")
+    # (Pydantic rejects non-finite). Non-finite numerics normalize to None.
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=float("nan"),
+        vrp_z_20=float("nan"),
+        gate_ok=True,
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "insufficient vol history"
+    assert sig.vrp_z is None and sig.vrp is None
+
+
+class _StubRepo:
+    def __init__(self, series):
+        self._series = series
+
+    def fetch_vrp_daily_series(self, ticker, *, limit=60):
+        return self._series
+
+    def fetch_vrp_harvest_by_sector(self):
+        return []
+
+    def fetch_vrp_harvest_multihorizon(self):
+        return []
+
+    def fetch_watchlist_sector(self, ticker):
+        return "Technology"
+
+    def fetch_historical_earnings_dates(self, ticker):
+        return set()
+
+    def fetch_latest_next_earnings_date(self, ticker):
+        return CLEAR_EARNINGS
+
+
+def test_build_returns_none_without_history():
+    assert build_short_vol(_StubRepo([]), "TSLA", SPOT) is None
+
+
+def test_build_skips_when_gate_blocks():
+    series = [{"market_date": AS_OF, "iv": IV, "rv": RV, "vrp": 0.073, "vrp_z_20": 1.6}]
+    sig = build_short_vol(_StubRepo(series), "TSLA", SPOT)
+    # empty sellable sets → single_name gate returns None → SKIP
+    assert sig is not None and sig.action == "SKIP"
+    assert sig.skip_reason == "sector vol not sellable"

--- a/tests/unit/test_stock_short_vol.py
+++ b/tests/unit/test_stock_short_vol.py
@@ -150,15 +150,42 @@ def test_skip_and_no_decimal_nan_when_z_nonfinite():
     assert sig.vrp_z is None and sig.vrp is None
 
 
+def test_skip_uses_gate_skip_reason_when_provided():
+    # "no earnings calendar" must not masquerade as "sector vol not sellable".
+    sig = decide_short_vol(
+        as_of=AS_OF,
+        spot=SPOT,
+        iv=IV,
+        rv=RV,
+        vrp=0.073,
+        vrp_z_20=1.6,
+        gate_ok=False,
+        gate_skip_reason="no earnings calendar",
+        next_earnings_date=CLEAR_EARNINGS,
+    )
+    assert sig.action == "SKIP"
+    assert sig.skip_reason == "no earnings calendar"
+
+
 class _StubRepo:
-    def __init__(self, series):
+    def __init__(self, series, *, sellable_sector=None, has_earnings_calendar=False):
         self._series = series
+        self._sellable_sector = sellable_sector
+        self._has_earnings = has_earnings_calendar
 
     def fetch_vrp_daily_series(self, ticker, *, limit=60):
         return self._series
 
     def fetch_vrp_harvest_by_sector(self):
-        return []
+        if self._sellable_sector is None:
+            return []
+        return [
+            {
+                "sector": self._sellable_sector,
+                "deviation_class": "RICH",
+                "verdict": "HARVEST_SELLABLE",
+            }
+        ]
 
     def fetch_vrp_harvest_multihorizon(self):
         return []
@@ -167,19 +194,52 @@ class _StubRepo:
         return "Technology"
 
     def fetch_historical_earnings_dates(self, ticker):
-        return set()
+        return {date(2026, 1, 15)} if self._has_earnings else set()
 
     def fetch_latest_next_earnings_date(self, ticker):
         return CLEAR_EARNINGS
+
+
+def _row(d, iv=IV):
+    return {"market_date": d, "iv": iv, "rv": RV, "vrp": 0.073, "vrp_z_20": 1.6}
 
 
 def test_build_returns_none_without_history():
     assert build_short_vol(_StubRepo([]), "TSLA", SPOT) is None
 
 
-def test_build_skips_when_gate_blocks():
-    series = [{"market_date": AS_OF, "iv": IV, "rv": RV, "vrp": 0.073, "vrp_z_20": 1.6}]
-    sig = build_short_vol(_StubRepo(series), "TSLA", SPOT)
-    # empty sellable sets → single_name gate returns None → SKIP
+def test_build_skips_when_sector_not_sellable():
+    sig = build_short_vol(_StubRepo([_row(AS_OF)]), "TSLA", SPOT)
+    # empty sellable sets → single_name gate returns None → SKIP with the sector reason
     assert sig is not None and sig.action == "SKIP"
     assert sig.skip_reason == "sector vol not sellable"
+
+
+def test_build_skips_with_no_earnings_calendar_reason():
+    # sellable sector but no historical earnings → distinct, honest reason (not "sector")
+    repo = _StubRepo([_row(AS_OF)], sellable_sector="Technology")
+    sig = build_short_vol(repo, "TSLA", SPOT)
+    assert sig is not None and sig.action == "SKIP"
+    assert sig.skip_reason == "no earnings calendar"
+
+
+def test_build_trades_through_real_gate_path():
+    # sellable sector + earnings calendar + clear next print → populated TRADE row.
+    repo = _StubRepo(
+        [_row(AS_OF)], sellable_sector="Technology", has_earnings_calendar=True
+    )
+    sig = build_short_vol(repo, "TSLA", SPOT)
+    assert sig is not None and sig.action == "TRADE"
+    assert sig.short_put is not None and sig.long_put is not None
+    assert sig.as_of == AS_OF
+
+
+def test_build_walks_back_past_null_iv_latest_row():
+    # newest row has NULL iv; the card must use the most recent usable row, not go dead.
+    newer, older = date(2026, 6, 24), date(2026, 6, 23)
+    series = [_row(newer, iv=None), _row(older, iv=IV)]  # DESC, like the real query
+    repo = _StubRepo(series, sellable_sector="Technology", has_earnings_calendar=True)
+    sig = build_short_vol(repo, "TSLA", SPOT)
+    assert sig is not None and sig.action == "TRADE"  # did NOT skip "no usable IV/spot"
+    assert sig.as_of == older  # as_of reflects the row actually used
+    assert sig.iv == Decimal(str(IV))

--- a/web/components/stock/panels/ShortVolPanel.tsx
+++ b/web/components/stock/panels/ShortVolPanel.tsx
@@ -25,6 +25,9 @@ const f = (x: number | null, d = 2) => (x == null ? "—" : x.toFixed(d));
 
 export function ShortVolPanel({ report }: { report: Report }) {
   const s = report.short_vol;
+  // Show the row's actual date so a stale vrp_daily read (pipeline gap) is visible,
+  // rather than a hardcoded badge that looks identically fresh.
+  const badge = s ? `EOD · ${s.as_of}` : "EOD SNAPSHOT";
 
   const header = (
     <div
@@ -37,7 +40,7 @@ export function ShortVolPanel({ report }: { report: Report }) {
     >
       <span style={labelStyle}>SHORT-VOL · {report.ticker}</span>
       <span style={{ ...labelStyle, fontSize: 9, letterSpacing: 0.5 }}>
-        EOD SNAPSHOT
+        {badge}
       </span>
     </div>
   );
@@ -55,14 +58,16 @@ export function ShortVolPanel({ report }: { report: Report }) {
 
   const trade = s.action === "TRADE";
   const color = trade ? "var(--positive)" : "var(--text-muted)";
+  // weight is structurally pinned (1.0 on every TRADE, 0 on every SKIP), so it carries
+  // no information — vrp_z is the real richness signal.
   const reasons = trade
     ? [
-        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))} (size)`,
+        `vrp_z ${f(toNum(s.vrp_z))}`,
         `Sell ${f(toNum(s.short_put), 0)} / buy ${f(toNum(s.long_put), 0)} put`,
         `Credit ${f(toNum(s.credit))} · max loss ${f(toNum(s.max_loss))} per spread`,
       ]
     : [
-        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))}`,
+        `vrp_z ${f(toNum(s.vrp_z))}`,
         `IV ${pct(toNum(s.iv))} / RV20 ${pct(toNum(s.rv20))}`,
       ];
 

--- a/web/components/stock/panels/ShortVolPanel.tsx
+++ b/web/components/stock/panels/ShortVolPanel.tsx
@@ -1,5 +1,5 @@
 import type { components } from "@/lib/types";
-import { toNum } from "@/lib/formatters";
+import { fmtDecimal, fmtPct, toNum } from "@/lib/formatters";
 
 type Report = components["schemas"]["SingleStockReport"];
 
@@ -18,10 +18,6 @@ const labelStyle: React.CSSProperties = {
   textTransform: "uppercase",
   color: "var(--text-muted)",
 };
-
-const pct = (x: number | null) =>
-  x == null ? "—" : `${(x * 100).toFixed(1)}%`;
-const f = (x: number | null, d = 2) => (x == null ? "—" : x.toFixed(d));
 
 export function ShortVolPanel({ report }: { report: Report }) {
   const s = report.short_vol;
@@ -62,13 +58,13 @@ export function ShortVolPanel({ report }: { report: Report }) {
   // no information — vrp_z is the real richness signal.
   const reasons = trade
     ? [
-        `vrp_z ${f(toNum(s.vrp_z))}`,
-        `Sell ${f(toNum(s.short_put), 0)} / buy ${f(toNum(s.long_put), 0)} put`,
-        `Credit ${f(toNum(s.credit))} · max loss ${f(toNum(s.max_loss))} per spread`,
+        `vrp_z ${fmtDecimal(toNum(s.vrp_z), 2)}`,
+        `Sell ${fmtDecimal(toNum(s.short_put), 0)} / buy ${fmtDecimal(toNum(s.long_put), 0)} put`,
+        `Credit ${fmtDecimal(toNum(s.credit), 2)} · max loss ${fmtDecimal(toNum(s.max_loss), 2)} per spread`,
       ]
     : [
-        `vrp_z ${f(toNum(s.vrp_z))}`,
-        `IV ${pct(toNum(s.iv))} / RV20 ${pct(toNum(s.rv20))}`,
+        `vrp_z ${fmtDecimal(toNum(s.vrp_z), 2)}`,
+        `IV ${fmtPct(toNum(s.iv), 1)} / RV20 ${fmtPct(toNum(s.rv20), 1)}`,
       ];
 
   return (
@@ -109,6 +105,7 @@ export function ShortVolPanel({ report }: { report: Report }) {
       >
         Bull put spread {toNum(s.short_delta)}Δ/{toNum(s.wing_delta)}Δ · ~
         {s.hold_days}d hold
+        {toNum(s.spot) != null ? ` · spot ${fmtDecimal(toNum(s.spot), 2)}` : ""}
       </div>
     </div>
   );

--- a/web/components/stock/panels/ShortVolPanel.tsx
+++ b/web/components/stock/panels/ShortVolPanel.tsx
@@ -1,0 +1,110 @@
+import type { components } from "@/lib/types";
+import { toNum } from "@/lib/formatters";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+const panelStyle: React.CSSProperties = {
+  background: "var(--bg-panel)",
+  border: "1px solid var(--border-dim)",
+  borderRadius: 4,
+  padding: 16,
+  fontFamily: "var(--font-mono)",
+  minWidth: 0,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10,
+  letterSpacing: 1.5,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+};
+
+const pct = (x: number | null) =>
+  x == null ? "—" : `${(x * 100).toFixed(1)}%`;
+const f = (x: number | null, d = 2) => (x == null ? "—" : x.toFixed(d));
+
+export function ShortVolPanel({ report }: { report: Report }) {
+  const s = report.short_vol;
+
+  const header = (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: 12,
+      }}
+    >
+      <span style={labelStyle}>SHORT-VOL · {report.ticker}</span>
+      <span style={{ ...labelStyle, fontSize: 9, letterSpacing: 0.5 }}>
+        EOD SNAPSHOT
+      </span>
+    </div>
+  );
+
+  if (!s) {
+    return (
+      <div style={panelStyle} data-testid="short-vol-panel">
+        {header}
+        <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+          No vol data yet.
+        </div>
+      </div>
+    );
+  }
+
+  const trade = s.action === "TRADE";
+  const color = trade ? "var(--positive)" : "var(--text-muted)";
+  const reasons = trade
+    ? [
+        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))} (size)`,
+        `Sell ${f(toNum(s.short_put), 0)} / buy ${f(toNum(s.long_put), 0)} put`,
+        `Credit ${f(toNum(s.credit))} · max loss ${f(toNum(s.max_loss))} per spread`,
+      ]
+    : [
+        `vrp_z ${f(toNum(s.vrp_z))} · weight ${f(toNum(s.weight))}`,
+        `IV ${pct(toNum(s.iv))} / RV20 ${pct(toNum(s.rv20))}`,
+      ];
+
+  return (
+    <div style={panelStyle} data-testid="short-vol-panel">
+      {header}
+      <div
+        data-testid="short-vol-action"
+        style={{
+          color,
+          fontSize: 28,
+          fontWeight: 700,
+          letterSpacing: 1,
+          marginBottom: 10,
+        }}
+      >
+        {s.action}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {reasons.map((r, i) => (
+          <div key={i} style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+            {r}
+          </div>
+        ))}
+        {!trade && s.skip_reason ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 12 }}>
+            {s.skip_reason}
+          </div>
+        ) : null}
+      </div>
+      <div
+        style={{
+          marginTop: 12,
+          paddingTop: 10,
+          borderTop: "1px solid var(--border-dim)",
+          color: "var(--text-muted)",
+          fontSize: 11,
+        }}
+      >
+        Bull put spread {toNum(s.short_delta)}Δ/{toNum(s.wing_delta)}Δ · ~
+        {s.hold_days}d hold
+      </div>
+    </div>
+  );
+}

--- a/web/components/stock/tabs/MarketStructureTab.tsx
+++ b/web/components/stock/tabs/MarketStructureTab.tsx
@@ -25,7 +25,9 @@ export async function MarketStructureTab({ report }: { report: Report }) {
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
+          // Three-up on normal/wide; wraps to 2 then 1 on narrow viewports instead
+          // of squeezing the range bar / directional-bias content below legibility.
+          gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
           gap: 12,
         }}
       >

--- a/web/components/stock/tabs/MarketStructureTab.tsx
+++ b/web/components/stock/tabs/MarketStructureTab.tsx
@@ -3,6 +3,7 @@ import { api } from "@/lib/api";
 import { GexLevelTiles } from "../panels/GexLevelTiles";
 import { ExpectedRangeBar } from "../panels/ExpectedRangeBar";
 import { DirectionalBiasPanel } from "../panels/DirectionalBiasPanel";
+import { ShortVolPanel } from "../panels/ShortVolPanel";
 import { MarketStructureHistoryTable } from "../panels/MarketStructureHistoryTable";
 import { GreekSubTabs } from "../panels/greeks/GreekSubTabs";
 import { MaxPainTable } from "../panels/MaxPainTable";
@@ -24,12 +25,13 @@ export async function MarketStructureTab({ report }: { report: Report }) {
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr",
+          gridTemplateColumns: "1fr 1fr 1fr",
           gap: 12,
         }}
       >
         <ExpectedRangeBar report={report} />
         <DirectionalBiasPanel report={report} history={historyRows} />
+        <ShortVolPanel report={report} />
       </div>
       <GreekSubTabs report={report} />
       <MarketStructureHistoryTable rows={historyRows} />

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5189,6 +5189,7 @@ export interface components {
              * @default n/a (UW endpoint does not expose %)
              */
             short_int_note: string;
+            short_vol?: components["schemas"]["StockShortVol"] | null;
             /** Spot Quoted At */
             spot_quoted_at?: string | null;
             /** Spot Source */
@@ -5661,6 +5662,56 @@ export interface components {
             pcr_vol?: string | null;
             /** Spot */
             spot?: string | null;
+        };
+        /**
+         * StockShortVol
+         * @description Per-ticker short-vol (sell-premium) readout for the Market Structure tab —
+         *     the single-name sibling of the SPX MacroSignal. EOD basis (latest vrp_daily row).
+         *     action=TRADE only when vol is rich (vrp_z_20 >= 1.0) AND the ticker's sector is in
+         *     the sellable set AND earnings are clear of the hold window; else SKIP with a reason.
+         *     Strikes/credit/max_loss are flat-vol modeled (conservative floor).
+         */
+        StockShortVol: {
+            /**
+             * As Of
+             * Format: date
+             */
+            as_of: string;
+            /**
+             * Basis
+             * @default eod
+             */
+            basis: string;
+            /** Action */
+            action: string;
+            /** Skip Reason */
+            skip_reason?: string | null;
+            /** Iv */
+            iv?: string | null;
+            /** Rv20 */
+            rv20?: string | null;
+            /** Vrp */
+            vrp?: string | null;
+            /** Vrp Z */
+            vrp_z?: string | null;
+            /** Weight */
+            weight?: string | null;
+            /** Short Put */
+            short_put?: string | null;
+            /** Long Put */
+            long_put?: string | null;
+            /** Put Width */
+            put_width?: string | null;
+            /** Credit */
+            credit?: string | null;
+            /** Max Loss */
+            max_loss?: string | null;
+            /** Hold Days */
+            hold_days: number;
+            /** Short Delta */
+            short_delta: string;
+            /** Wing Delta */
+            wing_delta: string;
         };
         /**
          * StrikeExposureRow

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5686,6 +5686,8 @@ export interface components {
             action: string;
             /** Skip Reason */
             skip_reason?: string | null;
+            /** Spot */
+            spot?: string | null;
             /** Iv */
             iv?: string | null;
             /** Rv20 */

--- a/web/tests/unit/ShortVolPanel.test.tsx
+++ b/web/tests/unit/ShortVolPanel.test.tsx
@@ -1,0 +1,70 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ShortVolPanel } from "@/components/stock/panels/ShortVolPanel";
+import type { components } from "@/lib/types";
+
+type Report = components["schemas"]["SingleStockReport"];
+
+// Real TSLA 2026-06-24 spot; short_vol shaped like the serialized API response
+// (Decimal → string).
+const base = { ticker: "TSLA" } as unknown as Report;
+const withShortVol = (sv: unknown): Report =>
+  ({ ...base, short_vol: sv }) as Report;
+
+const tradeSv = {
+  as_of: "2026-06-24",
+  basis: "eod",
+  action: "TRADE",
+  skip_reason: null,
+  iv: "0.473",
+  rv20: "0.40",
+  vrp: "0.073",
+  vrp_z: "1.6",
+  weight: "1",
+  short_put: "360",
+  long_put: "340",
+  put_width: "20",
+  credit: "4.2",
+  max_loss: "15.8",
+  hold_days: 30,
+  short_delta: "0.25",
+  wing_delta: "0.125",
+};
+
+const skipSv = {
+  ...tradeSv,
+  action: "SKIP",
+  skip_reason: "sector vol not sellable",
+  weight: "0",
+  short_put: null,
+  long_put: null,
+  put_width: null,
+  credit: null,
+  max_loss: null,
+};
+
+describe("ShortVolPanel", () => {
+  it("renders TRADE with spread strikes and the bull-put footer", () => {
+    render(<ShortVolPanel report={withShortVol(tradeSv)} />);
+    expect(screen.getByTestId("short-vol-action").textContent).toBe("TRADE");
+    expect(screen.getByText(/Sell 360 \/ buy 340 put/)).toBeTruthy();
+    expect(
+      screen.getByText(/Bull put spread 0\.25Δ\/0\.125Δ · ~30d hold/),
+    ).toBeTruthy();
+  });
+
+  it("renders SKIP with the reason and IV/RV", () => {
+    render(<ShortVolPanel report={withShortVol(skipSv)} />);
+    expect(screen.getByTestId("short-vol-action").textContent).toBe("SKIP");
+    expect(screen.getByText("sector vol not sellable")).toBeTruthy();
+    expect(screen.getByText(/IV 47\.3% \/ RV20 40\.0%/)).toBeTruthy();
+  });
+
+  it("renders a no-data state when short_vol is null", () => {
+    render(<ShortVolPanel report={withShortVol(null)} />);
+    expect(screen.getByTestId("short-vol-panel")).toBeTruthy();
+    expect(screen.getByText(/No vol data/)).toBeTruthy();
+  });
+});

--- a/web/tests/unit/ShortVolPanel.test.tsx
+++ b/web/tests/unit/ShortVolPanel.test.tsx
@@ -18,6 +18,7 @@ const tradeSv = {
   basis: "eod",
   action: "TRADE",
   skip_reason: null,
+  spot: "382.35",
   iv: "0.473",
   rv20: "0.40",
   vrp: "0.073",
@@ -57,6 +58,8 @@ describe("ShortVolPanel", () => {
     expect(screen.getByText("EOD · 2026-06-24")).toBeTruthy();
     // [8] the structurally-pinned weight tile is gone
     expect(screen.queryByText(/weight/i)).toBeNull();
+    // [3] modeled EOD spot basis is shown so strikes aren't read vs the live header
+    expect(screen.getByText(/spot 382\.35/)).toBeTruthy();
   });
 
   it("renders SKIP with the reason and IV/RV", () => {

--- a/web/tests/unit/ShortVolPanel.test.tsx
+++ b/web/tests/unit/ShortVolPanel.test.tsx
@@ -53,6 +53,10 @@ describe("ShortVolPanel", () => {
     expect(
       screen.getByText(/Bull put spread 0\.25Δ\/0\.125Δ · ~30d hold/),
     ).toBeTruthy();
+    // [5] as_of surfaces in the badge so a stale row is visible
+    expect(screen.getByText("EOD · 2026-06-24")).toBeTruthy();
+    // [8] the structurally-pinned weight tile is gone
+    expect(screen.queryByText(/weight/i)).toBeNull();
   });
 
   it("renders SKIP with the reason and IV/RV", () => {


### PR DESCRIPTION
## What

Adds a per-stock **Short-Vol card** to the stock page's Market Structure tab — the single-name sibling of the SPX Macro Short-Vol regime card — placed third on the Directional-Bias row.

## Why / behavior

A TRADE/SKIP sell-premium readout, derived **at read time** from the already-persisted `vrp_daily` row. No new endpoint, job, or migration — it folds into the existing `SingleStockReport`.

- **TRADE** only when: vol is rich (`vrp_z_20 ≥ 1.0`) **AND** the ticker's sector is in the sellable set (`vrp_gate`) **AND** a known next-earnings date is clear of the ~45-day hold window.
- **SKIP** otherwise, with a reason: `vol not rich` / `sector vol not sellable` / `earnings inside hold window` / `earnings date unavailable`.
- On TRADE it models the **same** flat-vol bull put spread (0.25Δ / 0.125Δ, ~30-day hold) as the macro signal, reusing `size_weight` + `build_bull_put_spread`.
- Macro/ETF classes skip the earnings gate (they don't report), mirroring `vrp_gate`'s asset-class split.

The verdict is **intentionally stricter** than the macro card's `weight>0` — single names need the sector gate + earnings-clear, per the project's own "single-name vol is sellable by sector" research and the no-hold-through-earnings rule.

## Hardening (from the review pass)

- **Unknown earnings never TRADE** — sourced from `fetch_latest_next_earnings_date`; `None` → SKIP (matches `scanner.gates.earnings_gate`).
- **Non-finite `vrp_z_20`** (short-history NaN) normalized away before it can reach `Decimal("NaN")`.
- **Card can never break the page** — the build is wrapped (`# noqa: BLE001`, logs + degrades to `None`).

## Files

- `src/uw_scan/reports/stock_short_vol.py` (new) — `decide_short_vol` (pure) + `build_short_vol` (I/O).
- `src/uw_scan/models/stock.py` — `StockShortVol` model + `SingleStockReport.short_vol`.
- `src/uw_scan/reports/single_stock.py` — defensive wiring.
- `web/components/stock/panels/ShortVolPanel.tsx` (new) + `MarketStructureTab.tsx` (2→3 col row).
- Contract: `openapi.snapshot.json` + `web/lib/types.ts` (surgical splice — avoided the full-file churn).

## Verification (evidence)

- Python: 10 unit tests (`test_stock_short_vol.py`) + `test_report_assembly` + `test_models_exports` + OpenAPI snapshot (real Postgres) — all green.
- Web: 3 vitest (`ShortVolPanel`) + `tsc` clean.
- **Live, against the local DB**: `/api/stock/WFC` → TRADE (vrp_z 1.70, sell 79/buy 75, credit 0.79); `TSLA` → SKIP (vol not rich); `BAC` → SKIP (earnings inside window); `TLT` → SKIP (sector not sellable). Screenshots captured of both TRADE and SKIP card states on the row.

EOD basis (modeled off the EOD-close spot). Plan: `docs/superpowers/plans/2026-06-24-stock-short-vol-card.md`.
