### PR TITLE
fix(vol): fill RV from price in nightly rollup so vrp_daily stops freezing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`vrp_daily` silently froze for ~90% of the watchlist** (2026-05-22 onward).
+  UW's realized-volatility endpoint began returning `null` for the
+  `realized_volatility` column while `price` + `implied_volatility` stayed fresh;
+  the nightly `nightly_vol_analytics_rollup` fed the raw null RV into
+  `compute_vrp_series`, so `vrp = iv − rv` was `NaN` and `persist_vrp_daily`
+  wrote nothing (the same loop's RV-independent `stock_analytics_daily` kept
+  updating, masking the gap). The rollup now applies `_fill_rv_from_price` —
+  deriving RV from the fresh price column, the same convention the stock-page
+  read path already used — before computing VRP. Added
+  `scripts/backfill_vrp_daily.py` (pure DB→DB, zero UW calls, idempotent) to
+  recover the historical gap; one run restored `vrp_daily` from 9 → 104/104
+  active tickers fresh. Regression test added in
+  `tests/integration/worker/test_volatility_jobs.py`.
+
 ## [0.3.3] — 2026-06-24
 
 

--- a/scripts/backfill_vrp_daily.py
+++ b/scripts/backfill_vrp_daily.py
@@ -1,0 +1,41 @@
+"""One-shot backfill: re-derive vrp_daily (+ stock_analytics_daily) for the
+active watchlist by invoking the fixed nightly vol-analytics rollup once.
+
+Recovers the 2026-05-22+ vrp_daily freeze: UW's realized_volatility column went
+null, which made vrp = iv - rv NaN, so persist_vrp_daily wrote nothing for ~90%
+of the watchlist. The rollup now fills RV from the fresh price column
+(_fill_rv_from_price). This runner just calls the rollup — it reads
+realized_volatility_history + SPY OHLC from the DB and upserts vrp_daily.
+
+Pure DB->DB: ZERO UW/massive calls. Idempotent (upserts) — safe to re-run, and
+the nightly 18:00 ET cron will keep it fresh going forward.
+
+Reproduce (targets whatever .env.local points at — for the mini that is
+100.66.147.98/option_wizard, the allowed prodlike combo):
+  cd /Users/chenxi/projects/argon
+  set -a; source .env.local; set +a
+  uv run python scripts/backfill_vrp_daily.py
+"""
+
+from __future__ import annotations
+
+import logging
+
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.storage.repository import Repository
+from uw_scan.worker.volatility_jobs import nightly_vol_analytics_rollup
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def main() -> None:
+    settings = Settings.from_env()
+    with psycopg.connect(settings.db_dsn()) as conn:
+        repo = Repository(conn, schema=settings.db_schema)
+        nightly_vol_analytics_rollup(repo=repo)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uw_scan/worker/volatility_jobs.py
+++ b/src/uw_scan/worker/volatility_jobs.py
@@ -48,6 +48,7 @@ def nightly_vol_analytics_rollup(*, repo: Repository) -> None:
     spy_history = repo.fetch_index_ohlc_series("SPY")
     # Inline import — avoids circular at module load (worker → reports → worker).
     from uw_scan.reports.volatility_series import (
+        _fill_rv_from_price,
         persist_stock_analytics,
         persist_vrp_daily,
     )
@@ -56,6 +57,11 @@ def nightly_vol_analytics_rollup(*, repo: Repository) -> None:
         rv_history = repo.fetch_realized_vol_history(ticker, days=365)
         if not rv_history:
             continue
+        # UW's realized_volatility column trails by weeks (null since ~2026-05-22),
+        # which made vrp = iv - rv NaN and silently froze vrp_daily for ~90% of the
+        # watchlist. Fill RV from the fresh price column — same convention the report
+        # read-path (volatility_series) already uses — before deriving VRP.
+        rv_history = _fill_rv_from_price(rv_history)
         vrp_df = vol_series.compute_vrp_series(rv_history)
         iv_of_iv_df = vol_series.compute_iv_of_iv(rv_history)
         rvol_df = vol_series.compute_rvol_and_percentile(

--- a/tests/integration/worker/test_volatility_jobs.py
+++ b/tests/integration/worker/test_volatility_jobs.py
@@ -84,3 +84,35 @@ def test_nightly_vol_analytics_rollup_persists_for_watchlist_tickers(
     assert len(vrp) > 0
     stock_an = repo.fetch_stock_analytics_series("TSLA", limit=100)
     assert len(stock_an) > 0
+
+
+def test_nightly_vol_analytics_rollup_fills_rv_when_uw_rv_null(
+    seeded_db_with_cards,
+):
+    """Regression: UW's realized_volatility column trails for weeks (stored
+    NULL). That made vrp = iv - rv NaN and silently froze vrp_daily for ~90% of
+    the watchlist (2026-05-22 onward). The rollup must fill RV from the fresh
+    price column so vrp_daily is still written."""
+    repo = seeded_db_with_cards
+
+    today = date.today()
+    base = today - timedelta(days=60)
+    # IV + price present, but realized_volatility is NULL — the UW gap condition.
+    rv_rows = [
+        RealizedVolRow(
+            date=base + timedelta(days=i),
+            price=Decimal(str(100 + i * 0.3)),
+            implied_volatility=Decimal("0.50"),
+            realized_volatility=None,
+        )
+        for i in range(60)
+    ]
+    repo.upsert_realized_vol_rows("TSLA", rv_rows)
+    repo.conn.commit()
+
+    nightly_vol_analytics_rollup(repo=repo)
+
+    vrp = repo.fetch_vrp_daily_series("TSLA", limit=100)
+    assert len(vrp) > 0, (
+        "vrp_daily must populate even when UW realized_volatility is NULL"
+    )


### PR DESCRIPTION
## Problem

`vrp_daily` silently froze for **~90% of the watchlist since 2026-05-22** — fresh for only **9 of 104** active tickers. Found while auditing warm-store coverage.

**Root cause:** UW's realized-volatility endpoint began returning `null` for the `realized_volatility` column while `price` + `implied_volatility` stayed fresh. `nightly_vol_analytics_rollup` fed the raw null RV into `compute_vrp_series`, so `vrp = iv − rv` was `NaN` and `persist_vrp_daily` wrote nothing. The same loop's RV-independent `stock_analytics_daily` kept updating, which is why only the VRP half froze and it went unnoticed.

The stock-page read path already handled this via `_fill_rv_from_price` (derive RV from the fresh price column); the rollup just never applied it.

## Fix

- `nightly_vol_analytics_rollup` now applies `_fill_rv_from_price` before `compute_vrp_series` — one-line wiring of an existing helper.
- `scripts/backfill_vrp_daily.py`: one-shot runner (pure DB→DB, **zero UW calls**, idempotent) to recover the historical gap.
- Regression test: rollup populates `vrp_daily` even when stored `realized_volatility` is NULL.

## Verification

- Pure-python: null-RV input → 0/60 non-NaN VRP **before**, 39/60 **after**.
- Integration tests pass on real Postgres (3 passed).
- **Backfill run against prod (mini): `vrp_daily` recovered 9 → 104/104 active tickers, all fresh to 2026-06-23.**

Does not address `greek_exposure_daily` (separate 05-20 freeze — investigating next) or the deliberate `iv_rank_history` deprecation.