### PR TITLE
fix(vrp-entry): remove synthetic pre-birth entry legs from preview endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
+- **Macro short-vol "Tracked entry" showed fabricated strikes/mids.** Pre-birth
+  (no cohort captured today), the entry preview fell back to `_bs_indicative_legs`
+  — a synthetic 5-pt SPX strike grid (e.g. 7095/7090, which aren't listed strikes)
+  priced with flat-vol Black-Scholes, rendered in the card as if they were market
+  quotes. A fake number is worse than none. Removed the synthetic path entirely:
+  the `/vrp-macro-signal/entry/preview` endpoint now serves persisted-cohort legs
+  (real strikes + NBBO) or **empty legs** with no fabricated ETD — the card shows
+  "No entry preview yet" / "ETD —" until a real cohort exists. Pairs with the
+  grid-cache fix below, which is what lets a real cohort actually get born.
+
 - **VRP macro entry-capture never persisted** — the daily SPX auto-birth
   (`_birth_auto`) enumerated the listed strike grid via two live UW calls inside
   the 10:00–15:00 ET birth crons, but the UW daily quota is reliably exhausted by

--- a/scripts/option_surface_backfill.py
+++ b/scripts/option_surface_backfill.py
@@ -47,6 +47,13 @@ def main() -> None:
         metavar="N",
         help="stop when UW daily request count reaches N (e.g. 20000)",
     )
+    p.add_argument(
+        "--max-dates",
+        type=int,
+        default=None,
+        metavar="N",
+        help="stop after filling N dates (e.g. 4 to mirror the nightly backfill budget)",
+    )
     args = p.parse_args()
 
     settings = Settings.from_env()
@@ -72,6 +79,7 @@ def main() -> None:
             days_back=args.days_back,
             end_date=args.end_date,
             quota_limit=args.quota_limit,
+            max_dates=args.max_dates,
         )
 
     log.info("done: %d rows written", n)

--- a/src/uw_scan/api/models/vrp_macro_entry.py
+++ b/src/uw_scan/api/models/vrp_macro_entry.py
@@ -12,9 +12,10 @@ from typing import Literal
 from pydantic import BaseModel
 
 LegName = Literal["short_above", "short_below", "wing_above", "wing_below"]
-# Persisted quote rows are xenon_ib|uw; the preview adds 'modeled' (BS-indicative,
-# pre-birth) — never written to vrp_macro_entry_quote.
-LegSource = Literal["xenon_ib", "uw", "modeled"]
+# Every leg's NBBO is real: xenon/IB-primary, UW fallback. There is no synthetic
+# source — the preview serves persisted legs or none (a fake quote is worse than
+# no quote), so 'modeled' is intentionally NOT a permitted source.
+LegSource = Literal["xenon_ib", "uw"]
 GreeksSource = Literal["bs", "none"]
 
 

--- a/src/uw_scan/api/routers/regime.py
+++ b/src/uw_scan/api/routers/regime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Annotated
 from zoneinfo import ZoneInfo
 
@@ -66,18 +66,10 @@ from uw_scan.cards.canary_calibration import (
 )
 from uw_scan.cards.dealer_regime import compute_dealer_regime, gather_inputs
 from uw_scan.config import Settings
-from uw_scan.reports.vrp_macro_entry import resolve_entry_contracts
 from uw_scan.reports.vrp_macro_signal import (
     WINNER,
     current_macro_signal,
     current_macro_signal_live,
-)
-from uw_scan.reports.vrp_structure import (
-    bs_delta,
-    bs_gamma,
-    bs_price,
-    bs_theta,
-    bs_vega,
 )
 from uw_scan.scanners import cri as cri_scanner
 from uw_scan.scanners import gex as gex_scanner
@@ -435,52 +427,6 @@ def _persisted_preview_legs(quotes: list[dict]) -> list[VrpMacroEntryLeg]:
     return legs
 
 
-def _bs_indicative_legs(sig, settings: Settings) -> list[VrpMacroEntryLeg]:
-    """Pre-birth BS-indicative legs off a synthetic 5-pt SPX grid (ZERO UW)."""
-    spot, sigma = float(sig.spot), float(sig.iv)
-    t_years = sig.hold_days / 252.0
-    r = settings.vrp_risk_free_rate
-    base = round(spot / 5.0) * 5.0
-    grid = sorted(
-        {base - 5.0 * i for i in range(1, 600)} | {base + 5.0 * i for i in range(0, 20)}
-    )
-    grid = [g for g in grid if g > 0]
-    ec = resolve_entry_contracts(
-        spot=spot,
-        sigma=sigma,
-        T=t_years,
-        r=r,
-        listed_strikes=grid,
-        short_delta=sig.short_delta,
-        wing_delta=sig.wing_delta,
-    )
-    legs: list[VrpMacroEntryLeg] = []
-    for name, strike in (
-        ("short_above", ec.short_above),
-        ("short_below", ec.short_below),
-        ("wing_above", ec.wing_above),
-        ("wing_below", ec.wing_below),
-    ):
-        price = bs_price(spot, strike, t_years, r, sigma, is_call=False)
-        legs.append(
-            VrpMacroEntryLeg(
-                leg=name,
-                strike=strike,
-                nbbo_bid=price,
-                nbbo_ask=price,
-                iv=sigma,
-                delta=bs_delta(spot, strike, t_years, r, sigma, is_call=False),
-                gamma=bs_gamma(spot, strike, t_years, r, sigma),
-                vega=bs_vega(spot, strike, t_years, r, sigma),
-                theta=bs_theta(spot, strike, t_years, r, sigma, is_call=False),
-                und_spot=spot,
-                source="modeled",
-                greeks_source="bs",
-            )
-        )
-    return legs
-
-
 def _leg_mid(leg: VrpMacroEntryLeg) -> float | None:
     if leg.nbbo_bid is not None and leg.nbbo_ask is not None:
         return (leg.nbbo_bid + leg.nbbo_ask) / 2.0
@@ -505,10 +451,11 @@ def get_vrp_macro_entry_preview(
     repo: Annotated[Repository, Depends(get_repo)],
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> VrpMacroEntryPreview:
-    """Indicative SPX entry preview. ZERO IB, ZERO new UW, ZERO writes — browser-
-    polled. Serves today's persisted auto-cohort snapshot legs if present, else
-    BS-indicative 'modeled' legs off the live/EOD signal. Degrades to action=None +
-    empty legs when no signal resolves (never 500)."""
+    """SPX entry preview. ZERO IB, ZERO new UW, ZERO writes — browser-polled.
+    Serves today's persisted auto-cohort snapshot legs (real strikes + NBBO) if
+    present, else empty legs — never a fabricated indicative grid (a synthetic
+    strike/mid is worse than none). Degrades to action=None + empty legs when no
+    signal resolves (never 500)."""
     today_et = datetime.now(ZoneInfo(settings.rth_tz)).date()
     sig = _live_or_eod_macro_signal(repo, settings)
     today_cohort = next(
@@ -540,18 +487,18 @@ def get_vrp_macro_entry_preview(
         )
     if sig is None:
         return VrpMacroEntryPreview(name="SPX", legs=[])
-    legs = _bs_indicative_legs(sig, settings)
+    # No cohort born/captured today → no real strikes or quotes exist yet. Do NOT
+    # fabricate an indicative grid: synthetic strikes + flat-vol BS mids are not
+    # market data, and a fake number is worse than none. Surface the real signal
+    # context with empty legs; the card renders "No entry preview yet" + "ETD —".
     return VrpMacroEntryPreview(
         name="SPX",
-        as_of=None,
         spot=float(sig.spot),
-        expiry=today_et + timedelta(days=43),  # indicative ETD pre-birth
         hold_days=sig.hold_days,
         action=sig.action,
         vrp_z=float(sig.vrp_z) if sig.vrp_z is not None else None,
         weight=float(sig.weight),
-        modeled_credit=_modeled_credit(legs),
-        legs=legs,
+        legs=[],
     )
 
 

--- a/src/uw_scan/reports/vrp_macro_entry.py
+++ b/src/uw_scan/reports/vrp_macro_entry.py
@@ -86,7 +86,7 @@ class LegQuote:
     vega: float
     theta: float
     und_spot: Any
-    source: str  # 'xenon_ib' | 'uw'  (preview adds 'modeled', never persisted)
+    source: str  # 'xenon_ib' | 'uw'  (always a real NBBO; never synthetic)
     greeks_source: str  # 'bs' | 'none'
     source_asof: Any
 

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -19645,8 +19645,7 @@
           "source": {
             "enum": [
               "xenon_ib",
-              "uw",
-              "modeled"
+              "uw"
             ],
             "title": "Source",
             "type": "string"
@@ -22876,7 +22875,7 @@
     },
     "/api/regime/vrp-macro-signal/entry/preview": {
       "get": {
-        "description": "Indicative SPX entry preview. ZERO IB, ZERO new UW, ZERO writes \u2014 browser-\npolled. Serves today's persisted auto-cohort snapshot legs if present, else\nBS-indicative 'modeled' legs off the live/EOD signal. Degrades to action=None +\nempty legs when no signal resolves (never 500).",
+        "description": "SPX entry preview. ZERO IB, ZERO new UW, ZERO writes \u2014 browser-polled.\nServes today's persisted auto-cohort snapshot legs (real strikes + NBBO) if\npresent, else empty legs \u2014 never a fabricated indicative grid (a synthetic\nstrike/mid is worse than none). Degrades to action=None + empty legs when no\nsignal resolves (never 500).",
         "operationId": "get_vrp_macro_entry_preview_api_regime_vrp_macro_signal_entry_preview_get",
         "responses": {
           "200": {

--- a/tests/integration/api/test_regime_entry_api.py
+++ b/tests/integration/api/test_regime_entry_api.py
@@ -1,7 +1,7 @@
 """/regime/vrp-macro-signal/entry — preview (no IB / no UW) + capture (IB).
 
-Preview serves persisted cohort legs or BS-indicative 'modeled' legs; it must
-make zero UW/IB calls (asserted by raising in those fetchers). Capture stubs the
+Preview serves persisted cohort legs or empty legs (never a fabricated grid); it
+must make zero UW/IB calls (asserted by raising in those fetchers). Capture stubs the
 job's UW + quote seams so no network, and asserts a one-shot button cohort + 4
 quote rows persist.
 """
@@ -111,9 +111,12 @@ def test_preview_serves_persisted_cohort_without_uw_or_ib(
     assert eid > 0
 
 
-def test_preview_pre_birth_returns_modeled_legs(
+def test_preview_pre_birth_returns_no_legs(
     client: TestClient, seeded_db_empty_cards, monkeypatch
 ):
+    """Pre-birth (no cohort today) the preview serves the real signal context but
+    ZERO legs — never a fabricated indicative strike grid. A synthetic strike/mid
+    is worse than none, so the card shows 'No entry preview yet' + 'ETD —'."""
     _seed_spx_vix_varied(
         seeded_db_empty_cards
     )  # EOD vol so current_macro_signal resolves
@@ -130,14 +133,10 @@ def test_preview_pre_birth_returns_modeled_legs(
     res = client.get("/api/regime/vrp-macro-signal/entry/preview")
     assert res.status_code == 200
     body = res.json()
-    assert len(body["legs"]) == 4
-    assert all(
-        leg["source"] == "modeled" and leg["greeks_source"] == "bs"
-        for leg in body["legs"]
-    )
-    # bull-put-spread ordering: wing strikes strictly below short strikes
-    by = {leg["leg"]: leg for leg in body["legs"]}
-    assert by["wing_above"]["strike"] < by["short_below"]["strike"]
+    assert body["legs"] == []  # no fabricated legs
+    assert body["expiry"] is None  # no fabricated ETD pre-birth
+    assert body["modeled_credit"] is None
+    assert body["action"] in {"TRADE", "SKIP"}  # real signal context still served
 
 
 def _fake_quote_leg(

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -7809,7 +7809,7 @@ export interface components {
              * Source
              * @enum {string}
              */
-            source: "xenon_ib" | "uw" | "modeled";
+            source: "xenon_ib" | "uw";
             /**
              * Greeks Source
              * @enum {string}

--- a/web/tests/unit/MacroShortVolEntryGuidance.test.tsx
+++ b/web/tests/unit/MacroShortVolEntryGuidance.test.tsx
@@ -1,100 +1,113 @@
 /* @vitest-environment jsdom */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mutable holders so individual tests can swap the hook payloads (default =
+// a persisted cohort with real legs; the empty-pre-birth test overrides them).
+const h = vi.hoisted(() => ({
+  live: null as unknown,
+  preview: null as unknown,
+}));
 
 vi.mock("@/lib/regime/useVrpMacroLive", () => ({
-  useVrpMacroLive: () => ({
-    data: {
-      status: "ok",
-      basis: "eod",
-      active_source: null,
-      live_quotes: {},
-      signal: {
-        name: "SPX",
-        snapshot_date: "2026-06-24",
-        as_of: "2026-06-23",
-        spot: 7500,
-        iv: 0.16,
-        rv20: 0.12,
-        vrp: 0.04,
-        vrp_z: -1.95,
-        weight: 0,
-        action: "SKIP",
-        short_put: null,
-        long_put: null,
-        put_width: null,
-        credit: null,
-        max_loss: null,
-        hold_days: 30,
-        short_delta: 0.25,
-        wing_delta: 0.125,
-      },
-    },
-    loading: false,
-    error: null,
-  }),
+  useVrpMacroLive: () => ({ data: h.live, loading: false, error: null }),
 }));
 
 vi.mock("@/lib/regime/useVrpMacroEntryPreview", () => ({
   useVrpMacroEntryPreview: () => ({
-    data: {
-      name: "SPX",
-      as_of: null,
-      spot: 7500,
-      expiry: "2026-08-07",
-      hold_days: 30,
-      action: "SKIP",
-      vrp_z: -1.95,
-      weight: 0,
-      modeled_credit: 30,
-      legs: [
-        {
-          leg: "short_above",
-          strike: 6900,
-          nbbo_bid: 40,
-          nbbo_ask: 41,
-          delta: -0.25,
-          source: "modeled",
-          greeks_source: "bs",
-        },
-        {
-          leg: "short_below",
-          strike: 6890,
-          nbbo_bid: 39,
-          nbbo_ask: 40,
-          delta: -0.255,
-          source: "modeled",
-          greeks_source: "bs",
-        },
-        {
-          leg: "wing_above",
-          strike: 6600,
-          nbbo_bid: 20,
-          nbbo_ask: 21,
-          delta: -0.125,
-          source: "modeled",
-          greeks_source: "bs",
-        },
-        {
-          // deepest-OTM wing: no NBBO from IB or UW, so no IV could be marked
-          // and greeks were never computed (the real "unquoted" shape)
-          leg: "wing_below",
-          strike: 6590,
-          nbbo_bid: null,
-          nbbo_ask: null,
-          iv: null,
-          delta: 0,
-          source: "uw",
-          greeks_source: "none",
-        },
-      ],
-    },
+    data: h.preview,
     loading: false,
     error: null,
   }),
 }));
 
 import MacroShortVolEntryGuidance from "@/components/regime/MacroShortVolEntryGuidance";
+
+const liveSkip = {
+  status: "ok",
+  basis: "eod",
+  active_source: null,
+  live_quotes: {},
+  signal: {
+    name: "SPX",
+    snapshot_date: "2026-06-24",
+    as_of: "2026-06-23",
+    spot: 7500,
+    iv: 0.16,
+    rv20: 0.12,
+    vrp: 0.04,
+    vrp_z: -1.95,
+    weight: 0,
+    action: "SKIP",
+    short_put: null,
+    long_put: null,
+    put_width: null,
+    credit: null,
+    max_loss: null,
+    hold_days: 30,
+    short_delta: 0.25,
+    wing_delta: 0.125,
+  },
+};
+
+// A persisted cohort: real legs (xenon_ib/uw), never the deleted "modeled" source.
+const previewWithLegs = {
+  name: "SPX",
+  as_of: "2026-06-24T14:00:00Z",
+  spot: 7500,
+  expiry: "2026-08-07",
+  hold_days: 30,
+  action: "SKIP",
+  vrp_z: -1.95,
+  weight: 0,
+  modeled_credit: 30,
+  legs: [
+    {
+      leg: "short_above",
+      strike: 6900,
+      nbbo_bid: 40,
+      nbbo_ask: 41,
+      delta: -0.25,
+      source: "xenon_ib",
+      greeks_source: "bs",
+    },
+    {
+      leg: "short_below",
+      strike: 6890,
+      nbbo_bid: 39,
+      nbbo_ask: 40,
+      delta: -0.255,
+      source: "xenon_ib",
+      greeks_source: "bs",
+    },
+    {
+      leg: "wing_above",
+      strike: 6600,
+      nbbo_bid: 20,
+      nbbo_ask: 21,
+      delta: -0.125,
+      source: "xenon_ib",
+      greeks_source: "bs",
+    },
+    {
+      // deepest-OTM wing: no NBBO from IB or UW, so no IV could be marked
+      // and greeks were never computed (the real "unquoted" shape)
+      leg: "wing_below",
+      strike: 6590,
+      nbbo_bid: null,
+      nbbo_ask: null,
+      iv: null,
+      delta: 0,
+      source: "uw",
+      greeks_source: "none",
+    },
+  ],
+};
+
+beforeEach(() => {
+  h.live = liveSkip;
+  h.preview = previewWithLegs;
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -139,6 +152,32 @@ describe("MacroShortVolEntryGuidance", () => {
     expect(note.textContent).toContain("27.0k");
     expect(note.textContent).toContain("45% of $60k");
     expect(note.textContent).toContain("brp 0.50: 1");
+  });
+
+  it("pre-birth (no cohort): shows the empty state, no fabricated legs/ETD/sizing", () => {
+    // Real signal still resolves, but no cohort exists yet → the preview serves
+    // empty legs + null ETD. The card must NOT invent strikes/mids or a sizing
+    // line (a fake number is worse than none).
+    h.preview = {
+      name: "SPX",
+      as_of: null,
+      spot: 7500,
+      expiry: null,
+      hold_days: 30,
+      action: "SKIP",
+      vrp_z: -1.95,
+      weight: 0,
+      modeled_credit: null,
+      legs: [],
+    };
+    render(<MacroShortVolEntryGuidance />);
+    expect(screen.getByText("No entry preview yet.")).toBeTruthy();
+    expect(screen.getByText(/ETD\s+—/)).toBeTruthy();
+    // no fabricated leg rows (the guidance backtest table still renders, so
+    // assert on the entry-leg rows specifically, not "any table")
+    expect(screen.queryByTestId("entry-leg-short_above")).toBeNull();
+    expect(screen.queryByTestId("entry-leg-wing_below")).toBeNull();
+    expect(screen.queryByTestId("macro-shortvol-unit-sizing")).toBeNull();
   });
 
   it("POSTs to capture on click and shows the captured badge", async () => {


### PR DESCRIPTION
## Summary

- Removes `_bs_indicative_legs` — the pre-birth fallback that fabricated a synthetic 5-pt SPX strike grid (e.g. 7095/7090, which aren't UW-listed strikes) priced with flat-vol Black-Scholes, then rendered them in the card as if they were real market quotes
- Drops `"modeled"` from `LegSource` — it was never a valid persisted source and its presence in the type was misleading
- Pre-birth preview now returns **empty legs** with no fabricated ETD; the card shows "No entry preview yet" / "ETD —" until a real cohort exists (born by the nightly grid-cache job from #184)
- Cleans up ~50 lines of dead code from `regime.py` (`_bs_indicative_legs`, stale BS imports, `resolve_entry_contracts` import)
- `scripts/option_surface_backfill.py`: adds `--max-dates N` flag to cap how many dates the backfill fills in one run (mirrors the nightly per-run budget)

## Why

A synthetic strike/mid is worse than none. The pre-birth fallback was showing strikes that don't exist in the listed chain and prices that don't reflect actual market quotes — actively misleading when evaluating whether to capture an entry. Pairs with #184 (grid-cache fix) which is what ensures a real cohort actually gets born during RTH.

## Test plan

- [ ] `uv run pytest tests/integration/api/test_regime_entry_api.py -v` — snapshot + pre-birth no-legs behaviour
- [ ] `cd web && npm run test` — `MacroShortVolEntryGuidance.test.tsx` updated for no-preview-legs case
- [ ] CI green (lint + unit + integration + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)