### PR TITLE
chore: market-tide deploy seed + option-surface backfill script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   (`sentiment` block) + a banner in the tab. EOD-persisted per session for
   backtesting (`market_tide_sentiment_daily`, migration `091`; nightly
   `market_tide_sentiment_eod` @16:25 ET). `reports/market_tide_sentiment.py`.
+  `macmini-prod.sh` seeds the full stored-bar history once at deploy time
+  (`market_tide_sentiment_backfill.py --if-empty`, best-effort, no UW budget),
+  so the backtest dataset is complete the moment the feature ships; later
+  deploys skip it (seeds only when the table is empty).
   Forward-return probe (`scripts/research/tide_slope_backtest.py`,
   `docs/research/tide-slope/`) finds it **descriptive, not predictive** at the
   daily horizon (n=120 YTD: ~50% hit, |corr| below the significance bar).

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -22,8 +22,14 @@ The tag push fires `.github/workflows/release.yml`:
 `com.argon.deploy-poller` (launchd, every 120s) polls
 `gh api repos/moremeds/argon/releases/latest`. When the latest published,
 non-prerelease Release tag differs from `logs/deployed_tag.txt`, it runs
-`scripts/deploy/macmini-prod.sh <tag>` (checkout → build → migrate → kickstart →
-health-check → auto-rollback). Prereleases (`vX.Y.Z-rc1`) verify + publish a
+`scripts/deploy/macmini-prod.sh <tag>` (checkout → build → migrate → one-off
+data seed → kickstart → health-check → auto-rollback). The seed step runs
+`scripts/backfill/market_tide_sentiment_backfill.py --if-empty` (best-effort, no
+UW budget) so the tide slope→forward-return backtest has full history the moment
+the feature ships. `--if-empty` makes it a true one-off — it seeds only when
+`market_tide_sentiment_daily` is empty, so later deploys are an instant no-op
+(drop the flag to force a full recompute, e.g. after a formula change).
+Prereleases (`vX.Y.Z-rc1`) verify + publish a
 GitHub prerelease but are **never** auto-deployed.
 
 Logs: `logs/deploy-poller.{out,err}.log`, `logs/deploy.log`.

--- a/scripts/backfill/market_tide_sentiment_backfill.py
+++ b/scripts/backfill/market_tide_sentiment_backfill.py
@@ -4,13 +4,17 @@ Pure DB→DB reshape of market_tide_snapshots → market_tide_sentiment_daily (n
 UW calls). Idempotent. Seed history so the EOD slope→forward-return backtest has
 data to chew on.
 
-Reproduce:
+Reproduce (force a full re-seed):
   uv run python scripts/backfill/market_tide_sentiment_backfill.py
+
+One-off deploy seed (skip if already populated — used by macmini-prod.sh):
+  uv run python scripts/backfill/market_tide_sentiment_backfill.py --if-empty
 """
 
 from __future__ import annotations
 
 import logging
+import sys
 
 import psycopg
 
@@ -22,11 +26,25 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("market_tide_sentiment_backfill")
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    # --if-empty: one-off guard for the deploy hook — seed only when the table
+    # has no rows yet, so re-running on every release is a no-op. Omit it (the
+    # default) to force a full recompute, e.g. after a sentiment-formula change.
+    if_empty = "--if-empty" in (sys.argv[1:] if argv is None else argv)
+
     settings = Settings.from_env()
     conn = psycopg.connect(settings.db_dsn())
     try:
         repo = Repository(conn, schema=settings.db_schema)
+        if if_empty:
+            existing = conn.execute(
+                f"SELECT count(*) FROM {settings.db_schema}.market_tide_sentiment_daily"
+            ).fetchone()[0]
+            if existing:
+                logger.info(
+                    "--if-empty: %d row(s) already present — skip seed", existing
+                )
+                return 0
         # Cover the full stored corpus (YTD ≈ 121 sessions); sessions with no
         # bars are skipped inside the job.
         n = refresh_eod_sentiment(repo, sessions=300)

--- a/scripts/backfill/option_surface_backfill.py
+++ b/scripts/backfill/option_surface_backfill.py
@@ -1,0 +1,110 @@
+"""One-shot backfill for option_surface_grid_daily recent gaps. UW-bound, gated
+behind --confirm and a self-spend cap. Sibling of intraday_buckets_backfill.py.
+
+option_surface_backfill() walks the last --days-back weekdays ending yesterday,
+oldest-first, and fills any market_date not already fully captured (idempotent,
+per-ticker). A full day costs ~1.9k UW calls (1 + N_expiries per ticker).
+
+--quota caps how many calls THIS run adds. The job's quota_limit compares against
+the UW *server-side* daily counter (x-uw-daily-req-count), shared with the live
+stack — so we pre-flight one probe call, read the current count, and pass
+quota_limit = current + --quota. The run stops when the server total reaches that.
+
+Reproduce (fill June gaps oldest-first, add at most 20k UW calls):
+  uv run python scripts/backfill/option_surface_backfill.py --confirm --quota 20000 --days-back 17
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import psycopg
+
+from uw_scan.api.client import UwClient
+from uw_scan.config import Settings
+from uw_scan.sources.uw import fetch_greek_exposure_by_expiry
+from uw_scan.storage.repository import Repository
+from uw_scan.worker.jobs.option_surface_capture import option_surface_backfill
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("surface_backfill")
+
+
+def _client(s: Settings) -> UwClient:
+    return UwClient(
+        api_key=s.api_key.get_secret_value(),
+        base_url=s.base_url,
+        timeout=s.request_timeout_seconds,
+        job_name="option_surface_backfill",
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--confirm", action="store_true", help="actually call UW")
+    ap.add_argument(
+        "--quota", type=int, default=20000, help="max UW calls THIS run adds"
+    )
+    ap.add_argument("--days-back", type=int, default=17, help="weekdays back to scan")
+    ap.add_argument(
+        "--min-remaining",
+        type=int,
+        default=2000,
+        help="abort if UW daily budget left is below this floor",
+    )
+    args = ap.parse_args()
+
+    s = Settings.from_env()
+    repo = Repository(psycopg.connect(s.db_dsn()), schema=s.db_schema)
+    client = _client(s)
+    try:
+        # Pre-flight: one probe call to read the server-side daily budget.
+        cards = repo.list_watchlist_cards()
+        if not cards:
+            log.error("no watchlist cards")
+            return 2
+        probe = cards[0].ticker
+        run_id = repo.insert_scan_run(probe, notes="option_surface_backfill_probe")
+        fetch_greek_exposure_by_expiry(client, repo, run_id, probe, date=None)
+        repo.finish_scan_run(run_id, status="ok")
+        repo.conn.commit()
+
+        used = client.rate_limit.daily_count
+        limit = client.rate_limit.daily_limit
+        remaining = (limit - used) if (limit is not None and used is not None) else None
+        log.info("UW budget: used=%s limit=%s remaining=%s", used, limit, remaining)
+
+        if remaining is not None and remaining < args.min_remaining:
+            log.error(
+                "only %s UW calls left (< %s floor) — aborting",
+                remaining,
+                args.min_remaining,
+            )
+            return 1
+
+        # Cap THIS run at ~--quota added calls, never past the server hard limit.
+        stop_at = (used or 0) + args.quota
+        if limit is not None:
+            stop_at = min(stop_at, limit)
+        log.info("will stop when server daily count reaches %s", stop_at)
+
+        if not args.confirm:
+            log.info(
+                "DRY RUN — would backfill days_back=%d, adding up to %d calls. Re-run with --confirm.",
+                args.days_back,
+                args.quota,
+            )
+            return 0
+
+        written = option_surface_backfill(
+            repo=repo, client=client, days_back=args.days_back, quota_limit=stop_at
+        )
+        log.info("DONE — wrote %d surface-grid rows", written)
+        return 0
+    finally:
+        repo.conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/macmini-prod.sh
+++ b/scripts/deploy/macmini-prod.sh
@@ -9,6 +9,7 @@
 #   - Fetches and checks out the new tag
 #   - Syncs Python deps, installs web deps, builds web
 #   - Runs SQL migrations (forward-only, idempotent)
+#   - Seeds idempotent DB→DB datasets (market-tide sentiment) — no UW budget
 #   - Kickstarts all com.argon.* launchd services from config/services.list
 #   - Health-checks; if any fail, rolls back to the previous tag and re-kickstarts
 
@@ -73,6 +74,21 @@ build_release() {
   (cd web && npm run build)
 }
 build_release
+
+# ---------- One-off data seed (post-migration) ----------
+# Seed EOD market-tide sentiment for the full stored bar history so the
+# slope→forward-return backtest has data the moment the feature ships. Pure
+# DB→DB reshape of market_tide_snapshots (no UW budget spent). --if-empty makes
+# it a true one-off: it seeds only when market_tide_sentiment_daily is empty, so
+# re-running on every later release is an instant no-op; the nightly
+# _market_tide_sentiment_eod job maintains it from then on. Best-effort: a
+# failure here must NOT fail the deploy (the `if` keeps it exempt from set -e).
+step "Seed market-tide sentiment (one-off)"
+if uv run python scripts/backfill/market_tide_sentiment_backfill.py --if-empty; then
+  say "✓ sentiment seed checked"
+else
+  warn "✗ sentiment seed failed (non-fatal — nightly job will recompute)"
+fi
 
 # ---------- Kickstart services ----------
 step "Kickstart launchd services"


### PR DESCRIPTION
Pre-release cleanup — these changes were left uncommitted after PR #189 merged.

## Changes

- **`market_tide_sentiment_backfill.py`** — adds `--if-empty` flag; one-off guard for the deploy hook so re-running on every later release is a no-op
- **`macmini-prod.sh`** — calls `backfill --if-empty` as a best-effort post-migration seed step (failure is non-fatal; nightly job maintains the table after first run)
- **`docs/runbooks/release.md`** — documents the seed step
- **`CHANGELOG.md`** — fills in the missing deploy-seed prose for the Unreleased entry
- **`scripts/backfill/option_surface_backfill.py`** — new UW-gated backfill for `option_surface_grid_daily` recent gaps (`--confirm` + `--quota` cap)

## Test plan

- [ ] CI green
- [ ] `uv run python scripts/backfill/market_tide_sentiment_backfill.py --if-empty` dry-runs cleanly (exits 0 if table populated, runs backfill if empty)
- [ ] `uv run python scripts/backfill/option_surface_backfill.py` (no `--confirm`) prints a dry-run summary and exits 0