### PR TITLE
feat(spot): xenon IB bars primary, Apex fallback for market-tide spot overlay

### DIFF
--- a/src/uw_scan/sources/apex.py
+++ b/src/uw_scan/sources/apex.py
@@ -1,19 +1,19 @@
-"""Apex signal-server read-only client (intraday price bars).
+"""Intraday spot bar client — xenon (IB) primary, Apex REST fallback.
 
-Apex (sibling project) serves EOD-synced intraday OHLC from the market-warehouse
-lake over REST. We use it for ONE thing: the historical SPY 5-min close series
-that overlays as the spot line on the Market Tide chart — UW's market-tide feed
-carries premium + volume but no price, and the live worker only stamps spot for
-the bars it captures in real time, leaving backfilled/historical sessions blank.
+Used for ONE thing: the historical SPY 5-min close series that overlays as the
+spot line on the Market Tide chart. The live worker stamps spot from the WS feed
+for bars it captures in real time; this fills the historical gap.
 
-Live/today spot still comes from the WS feed (`intraday_quote`, stamped by the
-market_tide scanner). Apex has no live bars — it fills the *historical* gap.
+Xenon primary: POST /historical/bars with X-API-Key → IB historical data.
+Apex fallback: GET /bars/{ticker} → EOD-synced lake bars.
 
-Never-raise: any failure returns an empty map so a missing/unreachable Apex
+Never-raise: any failure returns an empty map so a missing/unreachable server
 just leaves the spot column NULL (line absent) rather than breaking the page.
 
-APEX_API_URL default targets the mini over Tailscale (right for MacBook dev);
-on the mini set APEX_API_URL=http://127.0.0.1:8322.
+XENON_QUERY_API_URL  default http://127.0.0.1:8321
+XENON_QUERY_API_KEY  required for xenon path (skip silently if absent)
+APEX_API_URL         default http://100.66.147.98:8322 (Tailscale; set to
+                     http://127.0.0.1:8322 on the mini)
 """
 
 from __future__ import annotations
@@ -26,27 +26,95 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_URL = "http://100.66.147.98:8322"
+_DEFAULT_XENON_URL = "http://127.0.0.1:8321"
+_DEFAULT_APEX_URL = "http://100.66.147.98:8322"
 
 
-def _base_url() -> str:
-    return os.environ.get("APEX_API_URL", _DEFAULT_URL).rstrip("/")
+def _xenon_url() -> str:
+    return os.environ.get("XENON_QUERY_API_URL", _DEFAULT_XENON_URL).rstrip("/")
 
 
-def fetch_intraday_closes(
+def _xenon_key() -> str | None:
+    return os.environ.get("XENON_QUERY_API_KEY") or None
+
+
+def _apex_url() -> str:
+    return os.environ.get("APEX_API_URL", _DEFAULT_APEX_URL).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Xenon path
+# ---------------------------------------------------------------------------
+
+_IB_BAR_SIZE = {"5m": "5 mins", "1m": "1 min", "1d": "1 day"}
+
+
+def _fetch_xenon_closes(
     session_date: date,
-    ticker: str = "SPY",
-    *,
+    ticker: str,
+    timeframe: str = "5m",
+    timeout: float = 30.0,
+) -> dict[datetime, float]:
+    key = _xenon_key()
+    if not key:
+        return {}
+    bar_size = _IB_BAR_SIZE.get(timeframe, "5 mins")
+    end_dt = f"{session_date.strftime('%Y%m%d')} 16:10:00 US/Eastern"
+    try:
+        resp = httpx.post(
+            f"{_xenon_url()}/historical/bars",
+            headers={"X-API-Key": key},
+            json={
+                "contract": {
+                    "symbol": ticker.upper(),
+                    "sec_type": "STK",
+                    "exchange": "SMART",
+                    "currency": "USD",
+                },
+                "end_date_time": end_dt,
+                "duration": "1 D",
+                "bar_size": bar_size,
+                "use_rth": True,
+            },
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        bars = resp.json().get("bars", [])
+    except Exception as exc:
+        logger.warning(
+            "xenon bars fetch failed %s %s: %s", ticker, session_date, repr(exc)
+        )
+        return {}
+    return _parse_xenon_bars(bars)
+
+
+def _parse_xenon_bars(bars: list[dict]) -> dict[datetime, float]:
+    out: dict[datetime, float] = {}
+    for b in bars:
+        t = b.get("date")
+        c = b.get("close")
+        if t is None or c is None:
+            continue
+        try:
+            inst = datetime.fromisoformat(t).astimezone(timezone.utc)
+            out[inst] = float(c)
+        except (ValueError, TypeError) as exc:
+            logger.debug("xenon bar parse skip: %s", repr(exc))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Apex fallback path
+# ---------------------------------------------------------------------------
+
+
+def _fetch_apex_closes(
+    session_date: date,
+    ticker: str,
     timeframe: str = "5m",
     timeout: float = 10.0,
 ) -> dict[datetime, float]:
-    """Return {bar_instant_utc: close} for one session's intraday bars.
-
-    Keys are timezone-aware UTC datetimes at the bar timestamp, so a caller can
-    match them against market_tide ts (also a UTC instant) with an exact lookup.
-    Empty map on any error or no data.
-    """
-    url = f"{_base_url()}/bars/{ticker.upper()}"
+    url = f"{_apex_url()}/bars/{ticker.upper()}"
     params = {
         "timeframe": timeframe,
         "start": session_date.isoformat(),
@@ -56,7 +124,7 @@ def fetch_intraday_closes(
         resp = httpx.get(url, params=params, timeout=timeout)
         resp.raise_for_status()
         bars = resp.json().get("bars", [])
-    except Exception as exc:  # never-raise — fall back to NULL spot
+    except Exception as exc:
         logger.warning(
             "apex bars fetch failed %s %s: %s", ticker, session_date, repr(exc)
         )
@@ -65,9 +133,7 @@ def fetch_intraday_closes(
 
 
 def _parse_bars(bars: list[dict]) -> dict[datetime, float]:
-    """{bar_instant_utc: close} from Apex bar dicts — UTC-normalized so the key
-    matches a market_tide ts at the same wall-clock instant (e.g. an Apex bar at
-    13:30Z and a UW bar at 09:30-04:00 collapse to the same key). Pure (no I/O)."""
+    """{bar_instant_utc: close} from Apex bar dicts."""
     out: dict[datetime, float] = {}
     for b in bars:
         t = b.get("time")
@@ -81,3 +147,40 @@ def _parse_bars(bars: list[dict]) -> dict[datetime, float]:
             logger.debug("apex bar parse skip: %s", repr(exc))
             continue
     return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fetch_intraday_closes(
+    session_date: date,
+    ticker: str = "SPY",
+    *,
+    timeframe: str = "5m",
+    timeout: float = 10.0,
+) -> dict[datetime, float]:
+    """Return {bar_instant_utc: close} for one session's intraday bars.
+
+    Tries xenon (IB historical) first; falls back to Apex if xenon is
+    unavailable or returns no bars.
+    """
+    closes = _fetch_xenon_closes(session_date, ticker, timeframe, timeout=30.0)
+    if closes:
+        logger.debug(
+            "apex.fetch_intraday_closes: xenon hit %s %s (%d bars)",
+            ticker,
+            session_date,
+            len(closes),
+        )
+        return closes
+    closes = _fetch_apex_closes(session_date, ticker, timeframe, timeout=timeout)
+    if closes:
+        logger.debug(
+            "apex.fetch_intraday_closes: apex fallback hit %s %s (%d bars)",
+            ticker,
+            session_date,
+            len(closes),
+        )
+    return closes

--- a/tests/unit/test_apex_source.py
+++ b/tests/unit/test_apex_source.py
@@ -1,10 +1,10 @@
-"""Apex bar-parse + the timestamp-join invariant the spot backfill relies on."""
+"""Apex/xenon bar-parse + the timestamp-join invariant the spot backfill relies on."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from uw_scan.sources.apex import _parse_bars
+from uw_scan.sources.apex import _parse_bars, _parse_xenon_bars
 
 
 def test_parse_bars_keys_by_utc_instant():
@@ -19,6 +19,20 @@ def test_parse_bars_keys_by_utc_instant():
     assert len(closes) == 2
     assert closes[datetime(2026, 6, 26, 13, 30, tzinfo=timezone.utc)] == 727.86
     assert closes[datetime(2026, 6, 26, 13, 35, tzinfo=timezone.utc)] == 728.13
+
+
+def test_parse_xenon_bars_keys_by_utc_instant():
+    """Xenon bars come back with full ISO timestamps (after the _bar_date_to_iso fix)."""
+    closes = _parse_xenon_bars(
+        [
+            {"date": "2026-06-29T09:30:00-04:00", "close": 545.10},
+            {"date": "2026-06-29T09:35:00-04:00", "close": "545.50"},  # str close
+            {"date": "2026-06-29T09:40:00-04:00"},  # missing close → skipped
+        ]
+    )
+    assert len(closes) == 2
+    assert closes[datetime(2026, 6, 29, 13, 30, tzinfo=timezone.utc)] == 545.10
+    assert closes[datetime(2026, 6, 29, 13, 35, tzinfo=timezone.utc)] == 545.50
 
 
 def test_join_invariant_apex_utc_matches_uw_et():


### PR DESCRIPTION
## Summary

- `sources/apex.py` rewritten as a two-source client: xenon `POST /historical/bars` (IB historical data, X-API-Key auth) is tried first; Apex REST `GET /bars/{ticker}` is the fallback. Both produce `{utc_instant: close}` consumed by the spot backfill and market-tide scanner unchanged.
- Adds `_parse_xenon_bars` (parses xenon's full ISO timestamps) alongside the existing `_parse_bars` (Apex format).
- Xenon fix required: `_bar_date_to_iso` in xenon was truncating datetime to `YYYY-MM-DD` (separate xenon PR), losing the time component for intraday bars.

## Test plan

- [ ] CI green
- [ ] `uv run pytest tests/unit/test_apex_source.py` — 3 tests pass (2 existing + 1 new xenon parse test)
- [ ] With xenon running: `market_tide_spot_backfill.py --sessions 1` fills the gold line from IB bars
- [ ] With xenon down: same script falls back to Apex silently