### PR TITLE
fix(test): drop ad-hoc table so it can't leak into the data-gap discovery gate

### DIFF
--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -384,16 +384,28 @@ def test_health_record_check_discovers_new_ticker_timestamp_tables(
         )
     repo.conn.commit()
 
-    r = client.get(
-        "/api/health?record_window_hours=8&record_tables=synthetic_endpoint_snapshots"
-    )
+    try:
+        r = client.get(
+            "/api/health?record_window_hours=8&record_tables=synthetic_endpoint_snapshots"
+        )
 
-    assert r.status_code == 200
-    body = r.json()
-    synthetic = body["record_health"][0]
-    assert synthetic["table"] == "synthetic_endpoint_snapshots"
-    assert synthetic["ok"] is True
-    assert synthetic["actual_tickers"] == repo.count_active_watchlist()
+        assert r.status_code == 200
+        body = r.json()
+        synthetic = body["record_health"][0]
+        assert synthetic["table"] == "synthetic_endpoint_snapshots"
+        assert synthetic["ok"] is True
+        assert synthetic["actual_tickers"] == repo.count_active_watchlist()
+    finally:
+        # Ad-hoc, non-migration table: the per-test baseline restore is
+        # TRUNCATE+COPY, which never DROPs it. Leaving it leaks into other tests
+        # on the same xdist worker and trips the data-gap discovery gate
+        # (test_zero_unregistered_after_full_registry, which sees an
+        # unregistered temporal table). Drop it here so the test is self-contained.
+        with repo.conn.cursor() as cur:
+            cur.execute(
+                f"DROP TABLE IF EXISTS {repo._schema}.synthetic_endpoint_snapshots"
+            )
+        repo.conn.commit()
 
 
 def test_health_daily_window_passes_nightly_table_aged_under_26h(


### PR DESCRIPTION
## Why
The `v0.5.0` release **verify** job failed on `test_data_gap_full_coverage.py::test_zero_unregistered_after_full_registry`:
```
AssertionError: unregistered temporal tables remain: ['synthetic_endpoint_snapshots']
```

`test_health_record_check_discovers_new_ticker_timestamp_tables` `CREATE`s a non-migration table (`synthetic_endpoint_snapshots`) in the shared test schema. The per-test baseline restore is `TRUNCATE + COPY` (per `tests/CLAUDE.md`), which never **drops** it — so it leaks into later tests on the same xdist worker and trips the data-gap discovery gate (which correctly flags any unregistered temporal table).

The 4-way sharded PR CI hid this (polluter and gate landed in different shards / DBs); the **unsharded** release `verify` job ran them in one DB and surfaced it, blocking v0.5.0 publish.

## Fix
Drop the ad-hoc table in a `finally` so the test is self-contained. It's the only ad-hoc `CREATE TABLE` in the whole suite. The discovery gate is correct and unchanged.

## Verify
`uv run pytest tests/integration/api/test_health.py tests/integration/worker/test_data_gap_full_coverage.py -p no:randomly` → **23 passed** (polluter + gate now green in one process).