### PR TITLE
chore: harden xdist test isolation and npm ci deploy step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **xdist sharding blind spot** — `_reset_to_baseline` in `tests/integration/conftest.py`
+  now drops any tables the test under execution created that are not in the
+  post-migration baseline snapshot, before the `TRUNCATE … CASCADE` restore.
+  Previously, an ad-hoc `CREATE TABLE` inside a test survived across tests within
+  the same xdist worker and was only exposed by the unsharded release-verify gate
+  (which runs the full suite serially in a single DB). The fix kills the whole
+  class: drop extras → truncate baseline → copy baseline back.
+- **`macmini-prod.sh` npm ci flakiness** — `rm -rf web/node_modules` is now run
+  before `npm ci` so a partially-written `node_modules` (e.g. the `ENOTEMPTY:
+  rmdir lucide-react/dist/esm` error that blocked the first v0.5.0 deploy attempt)
+  cannot stall the build step and leave the deploy script mid-way through
+  `set -euo pipefail`.
+
 ## [0.5.0] — 2026-06-30
 
 

--- a/docs/runbooks/data-gap-healer-macmini-evidence.md
+++ b/docs/runbooks/data-gap-healer-macmini-evidence.md
@@ -74,34 +74,65 @@ row's own date refused to mark anything healed that a provider could not serve.
 Massive (uncapped) backfilled `daily_ohlc`: **3,764 healed, 101 free massive
 calls, 0 UW spend**; re-audit `missing=0`.
 
-### `volatility_stats_history` — YTD backfill (UW, in progress)
+### `volatility_stats_history` — YTD backfill (final)
 
 `volatility_stats_history` only accumulated forward from its 2026-05-11
 inception (the fetcher was current-snapshot-only). The new `volatility_stats`
 adapter + `fetch_volatility_stats(market_date=…)` backfills it from UW, one call
 per (ticker, date).
 
-- **As of 2026-06-30 06:24 ET: 6,091 / 9,397 YTD cells healed (64.8%).** Real UW
-  `iv` / `rv` / `iv_rank` for pre-inception dates (validated against live UW).
-- The remaining **3,306 cells** are deferred to the **20:00 ET nightly** (which
-  runs at the 00:00 UTC UW reset, on a fresh 60k budget, off RTH) rather than
-  spent now — the manual backfill was capped to keep **≥25k UW reserved for
-  regular trading hours** (UW was at `33,505/60,000` at capture).
+- Manual backfill (2026-06-30, runs 6+7): **7,503 / 9,397 YTD cells healed
+  (79.8%)**, capped to keep ≥25k UW reserved for RTH (UW at `33,505/60,000` at
+  cap).
+- Remaining **1,894 cells** deferred to the 20:00 ET nightly on a fresh 60k
+  budget.
+- First nightly (run 9, 2026-07-01): the 20k UW cap was fully consumed by the
+  concurrent `option_surface_grid_daily` backlog (1,735-item historical gap since
+  PR #145 deploy, ~12 UW calls/item). The 788 `volatility_stats_history` cells
+  that remained were claimed but `skipped_budget`. They carry forward to the next
+  nightly automatically (re-audited fresh each run). See "First nightly" section
+  below.
 
-## Macmini operational follow-ups (post-deploy)
+## Part 3 — First prod nightly run (run 9, 2026-07-01)
 
-After the release deploys `092`/`093` to the mini:
+Run 9 fired at 08:00 HKT (20:00 ET June 30) — the correct scheduled slot.
 
-1. **Finalize the manual backfill run** (`data_gap_runs` id=6 is left `running`
-   from the capped session) so the nightly's `_another_run_active` guard does not
-   skip — it skips while any `mode='execute'` run is `running`.
-2. **Enable the nightly:** `DATA_GAP_HEALER_ENABLED=true` in the mini `.env`,
-   then kickstart the `uw-0` worker (env is frozen at fork). The 20:00 ET run
-   then audits + heals under the 20k UW cap, which finishes the vol_stats tail
-   automatically on fresh budget.
-3. **Watch the first nightly run** — the scheduled-job path (cron + advisory lock
-   + refresh adapters + evidence write) is test-covered but had not run in prod
-   before this enable. Flip the flag back off if it misbehaves.
+```
+status:   complete
+started:  2026-07-01T08:00:00+08:00
+finished: 2026-07-01T13:01:33+08:00
+healed:         1,000
+no_data:          125
+skipped_budget: 1,727
+budget_spent.uw: 20,000  (cap hit exactly)
+```
 
-Do **not** run a UW-heavy manual `execute` while another manual UW backfill (e.g.
-the option-surface capture) is active.
+### What was healed
+
+All 1,000 healed items were `option_surface_grid_daily` (the EOD option surface
+grid from PR #145). The 20k cap was exhausted on this dataset alone — each
+(ticker, date) item requires ~12 UW calls (`/greek-exposure/expiry` + one call
+per active expiry).
+
+### Refresh adapters (all re-runnable datasets)
+
+All 15 refresh targets ran after the heal phase. One failure:
+`rates_treasury_auctions` — this is a known fragile FRED/Treasury endpoint (not
+a healer bug). One budget skip: `uw_gold_options_daily` (UW budget was at zero
+when the refresh phase ran). All others: `refreshed`.
+
+### Remaining open gaps (post-run audit)
+
+| Dataset | Missing | Notes |
+|---|---|---|
+| `option_surface_grid_daily` | 1,735 | historical backlog from Apr 20; ~12 UW/item; nightly will reduce by ~1,600/night at 20k cap |
+| `volatility_stats_history` | 788 | 1 UW/item; should close in one nightly once option_surface backlog shrinks |
+| `greek_exposure_daily` | 202 | single-name GEX backlog; a few UW/item |
+| `top_net_impact_snapshots` | 121 | session-scoped; 1 UW/call |
+| `vrp_daily` / `stock_analytics_daily` / `realized_volatility_history` | 2 each | likely genuine unhealable gaps (no source data for those dates) — seed caveats after confirming |
+
+### Watchlist lifecycle baseline
+
+First run logged all 103 active tickers as `added` — correct one-time baseline
+behaviour for a fresh `watchlist_ticker_events` table. Future nightlies log only
+diffs (new additions / removals).

--- a/scripts/deploy/macmini-prod.sh
+++ b/scripts/deploy/macmini-prod.sh
@@ -65,7 +65,7 @@ build_release() {
   # npm ci: reproducible install from the committed lock; never rewrites
   # package-lock.json (npm install does, which self-dirties the tree and
   # blocks the next deploy's dirty-guard). ci.yml already uses npm ci.
-  (cd web && npm ci --no-audit --no-fund --legacy-peer-deps)
+  (cd web && rm -rf node_modules && npm ci --no-audit --no-fund --legacy-peer-deps)
 
   step "scripts/migrate.sh"
   bash scripts/migrate.sh

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -152,7 +152,15 @@ def _reset_to_baseline(
     tables: list[str] = snapshot["tables"]
     dumps: dict[str, bytes] = snapshot["dumps"]
     sequences: dict[str, tuple[int, bool]] = snapshot["sequences"]
+    baseline_set = set(tables)
     with conn.cursor() as cur:
+        # Drop tables a test created that aren't in the baseline — they survive
+        # TRUNCATE CASCADE (which only follows FK chains) and would bleed into
+        # later tests inside the same xdist worker.
+        cur.execute("SELECT tablename FROM pg_tables WHERE schemaname = 'uw_scan'")
+        for (t,) in cur.fetchall():
+            if t not in baseline_set:
+                cur.execute(f'DROP TABLE IF EXISTS uw_scan."{t}" CASCADE')
         if tables:
             quoted = ", ".join(f'uw_scan."{t}"' for t in tables)
             cur.execute(f"TRUNCATE {quoted} CASCADE")


### PR DESCRIPTION
## What

Two hardening fixes surfaced during the v0.5.0 release process.

## Fix 1 — xdist sharding blind spot (`tests/integration/conftest.py`)

`_reset_to_baseline` now drops any tables a test created that are **not** in the post-migration baseline snapshot before the `TRUNCATE … CASCADE` restore.

**Root cause:** `TRUNCATE … CASCADE` only propagates down FK chains — it does not touch tables that have no relation to the baseline set. An ad-hoc `CREATE TABLE` inside a test survived across tests within the same xdist worker. The xdist CI shards 4 ways (each worker gets its own DB), so the leak was hidden from other shards; the unsharded release-verify gate — which runs the full suite serially in a single DB — exposed it. The blocking test was `test_health_record_check_discovers_new_ticker_timestamp_tables` creating `synthetic_endpoint_snapshots` and never dropping it, which tripped `test_zero_unregistered_after_full_registry`.

**Fix:** Before the existing TRUNCATE+COPY restore, query the live `pg_tables` for the schema, diff against the baseline set, and `DROP TABLE IF EXISTS … CASCADE` every extra table. Kills the whole class.

## Fix 2 — `macmini-prod.sh` npm ci flakiness

`rm -rf web/node_modules` is now run before `npm ci`.

**Root cause:** The first v0.5.0 deploy attempt failed with `ENOTEMPTY: directory not empty, rmdir '.../lucide-react/dist/esm'`. `npm ci` is supposed to clean `node_modules` itself, but it fails when a prior partial install leaves directories that cannot be atomically removed. `set -euo pipefail` killed the script before `kickstart`, leaving prod stably on v0.4.1 (safe, but required manual rescue: `rm -rf web/node_modules` + clear the `failed_tag` sentinel + re-arm the deploy poller).

**Fix:** One line — pre-clear `node_modules` so `npm ci` always starts from a clean slate.

## Evidence doc (pending)

`docs/runbooks/data-gap-healer-macmini-evidence.md` still shows the stale "64.8% as of 06:24 ET" snapshot from yesterday's backfill session. The first prod nightly (run 9) is still running as of this PR open — final numbers will be committed to this branch before merge.

## Verification

- 744 integration tests pass serially (mirrors the unsharded release-verify gate exactly) — confirms the conftest fix doesn't break existing tests and would have caught the original leak.
- `macmini-prod.sh` change is a one-liner with no logic; deploy gate catches any breakage.