### PR TITLE
fix(gold): use ET-aware date for etf_in_outflow ingest, not host clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`gold_etf_holdings_ingest_job` used the host's local clock instead of ET.**
+  `date.today()` picked up the mini's system-local date (ahead of US Eastern by
+  ~12h) to compute the UW `/etfs/{ticker}/in-outflow` date range, so on a host
+  whose local day has already rolled past midnight ET, `end_date` became a
+  "future EST date" and UW rejected every call with HTTP 422 — silently, since
+  the fetch is wrapped in a per-ticker `try/except: logger.warning`. `GLD` /
+  `IAU` / `GLDM` in/outflow data (`etf_flows_daily`) stopped refreshing as a
+  result. Now computes "today" via `datetime.now(ZoneInfo(rth_tz))`, matching
+  the ET-aware pattern already used by `flow_data_refresh`, `regime_live`,
+  `vrp_macro_signal`, and others.
+
 ## [0.5.0] — 2026-06-30
 
 

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -29,11 +29,13 @@ import logging
 from dataclasses import asdict
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import psycopg
 
 from uw_scan.api.client import UwClient
 from uw_scan.reports.gold_posture import compute_and_persist_gold_posture
+from uw_scan.sources import uw as uw_sources
 from uw_scan.sources.cftc_cot import CftcCotProvider
 from uw_scan.sources.comex import ComexProvider
 from uw_scan.sources.etf_holdings import EtfHoldingsProvider
@@ -41,13 +43,12 @@ from uw_scan.sources.fred import FredProvider
 from uw_scan.sources.gpr import GprProvider
 from uw_scan.sources.lbma import LbmaProvider
 from uw_scan.sources.ohlc import MassiveOhlcProvider
-from uw_scan.sources import uw as uw_sources
 from uw_scan.sources.uw_gold_options import (
     GOLD_OPTIONS_TICKERS,
     fetch_gold_options_snapshot,
 )
-from uw_scan.sources.wgc_etf import TROY_OZ_PER_TONNE, WgcEtfProvider
 from uw_scan.sources.wgc_cb import WgcCbProvider
+from uw_scan.sources.wgc_etf import TROY_OZ_PER_TONNE, WgcEtfProvider
 from uw_scan.storage.repository import Repository
 
 logger = logging.getLogger(__name__)
@@ -176,6 +177,7 @@ def gold_etf_holdings_ingest_job(
     wgc_workbook_path: str | None = None,
     lookback_days: int = 45,
     holdings_lookback_days: int = 400,
+    rth_tz: str = "America/New_York",
 ) -> None:
     """Daily ETF refresh (GLD/IAU/GLDM/PHYS). Schedule: 18:30 ET.
 
@@ -185,7 +187,8 @@ def gold_etf_holdings_ingest_job(
     because current entitlement only exposes recent history.
     """
     now = datetime.now(UTC)
-    holdings_start = date.today() - timedelta(days=holdings_lookback_days)
+    today_et = datetime.now(ZoneInfo(rth_tz)).date()
+    holdings_start = today_et - timedelta(days=holdings_lookback_days)
     with psycopg.connect(dsn) as conn, EtfHoldingsProvider() as etf:
         repo = Repository(conn, schema="uw_scan")
         for ticker, fetch_fn, source in [
@@ -266,8 +269,8 @@ def gold_etf_holdings_ingest_job(
         else:
             logger.info("WGC Goldhub auth/export not provided; skipping WGC ETF ingest")
         if uw_api_key:
-            start = (date.today() - timedelta(days=lookback_days)).isoformat()
-            end = date.today().isoformat()
+            start = (today_et - timedelta(days=lookback_days)).isoformat()
+            end = today_et.isoformat()
             with UwClient(
                 api_key=uw_api_key,
                 timeout=30.0,
@@ -533,13 +536,18 @@ def gold_wgc_cb_ingest_job(
         return
 
     now = datetime.now(UTC)
-    with psycopg.connect(dsn) as conn, WgcCbProvider(
-        cookie_header=wgc_goldhub_cookie,
-        workbook_path=wgc_workbook_path,
-    ) as wgc:
+    with (
+        psycopg.connect(dsn) as conn,
+        WgcCbProvider(
+            cookie_header=wgc_goldhub_cookie,
+            workbook_path=wgc_workbook_path,
+        ) as wgc,
+    ):
         repo = Repository(conn, schema="uw_scan")
         try:
-            start = date.today() - timedelta(days=lookback_days) if lookback_days else None
+            start = (
+                date.today() - timedelta(days=lookback_days) if lookback_days else None
+            )
             for row in wgc.fetch_monthly(start=start):
                 repo.insert_cb_gold_reserves_monthly(
                     country_iso3=row.country_iso3,

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -1023,6 +1023,7 @@ def main() -> int:
                 else None
             ),
             wgc_workbook_path=settings.wgc_etf_flows_workbook_path or None,
+            rth_tz=settings.rth_tz,
         )
 
     def _gold_comex_vault_ingest() -> None:

--- a/tests/integration/worker/test_gold_daily_jobs.py
+++ b/tests/integration/worker/test_gold_daily_jobs.py
@@ -27,6 +27,7 @@ from uw_scan.worker.jobs.gold_jobs import (
     gold_gpr_ingest_job,
 )
 
+
 class _FixedDatetime(datetime):
     @classmethod
     def now(cls, tz=None):
@@ -50,7 +51,9 @@ def _write_wgc_etf_workbook(path: Path) -> None:
             "phys us equity",
         ]
     )
-    ws.append(["Active", None, None, None, None, "Active", "Active", "Active", "Active"])
+    ws.append(
+        ["Active", None, None, None, None, "Active", "Active", "Active", "Active"]
+    )
     ws.append(
         ["Fund Type", None, None, None, None, "ETF", "ETF", "ETF", "Closed-End Fund"]
     )
@@ -292,6 +295,59 @@ def test_gold_etf_holdings_ingest_writes_uw_etf_flows(
     assert len(rows) == 1
     assert rows[0]["share_change"] == Decimal("-900000")
     assert rows[0]["premium_change_usd"] == Decimal("-375300000")
+
+
+class _TzAwareDatetime(datetime):
+    """Returns a date that depends on the tz argument, to prove the job
+    computes "today" from the ET zone it's given rather than from a naive
+    host-local clock. America/New_York -> 2026-05-19; anything else
+    (simulating a host clock already past midnight ET, e.g. HKT) -> 2026-05-20.
+    """
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is not None and getattr(tz, "key", None) == "America/New_York":
+            return cls(2026, 5, 19, 23, 0, tzinfo=tz)
+        return cls(2026, 5, 20, 11, 0, tzinfo=tz or UTC)
+
+
+def test_gold_etf_holdings_ingest_uses_et_date_not_host_clock(
+    fresh_db: Settings,
+) -> None:
+    sample = [
+        EtfInOutflowRow(
+            ticker="GLD",
+            date=date(2026, 5, 15),
+            change=Decimal("-900000"),
+            change_prem=Decimal("-375300000"),
+            close=Decimal("417.29"),
+            volume=Decimal("8801181"),
+        )
+    ]
+    with (
+        patch("uw_scan.worker.jobs.gold_jobs.EtfHoldingsProvider") as MockProvider,
+        patch("uw_scan.worker.jobs.gold_jobs.UwClient"),
+        patch(
+            "uw_scan.worker.jobs.gold_jobs.uw_sources.fetch_etf_in_outflow",
+            return_value=sample,
+        ) as mock_fetch,
+    ):
+        instance = MockProvider.return_value.__enter__.return_value
+        instance.fetch_gld.return_value = []
+        instance.fetch_iau.return_value = []
+        instance.fetch_gldm.return_value = []
+        instance.fetch_phys.return_value = []
+
+        with patch("uw_scan.worker.jobs.gold_jobs.datetime", _TzAwareDatetime):
+            gold_etf_holdings_ingest_job(
+                dsn=fresh_db.db_dsn(),
+                uw_api_key="test-key",
+                lookback_days=45,
+                rth_tz="America/New_York",
+            )
+
+    assert mock_fetch.call_args.kwargs["end_date"] == "2026-05-19"
+    assert mock_fetch.call_args.kwargs["start_date"] == "2026-04-04"
 
 
 def test_gold_comex_vault_ingest_writes_inventory(fresh_db: Settings) -> None:


### PR DESCRIPTION
## Summary

- `gold_etf_holdings_ingest_job` computed the UW `/etfs/{ticker}/in-outflow` date range with `date.today()`, which reads the mini's system-local clock (~12h ahead of US Eastern). Once the host's local day rolls past midnight ET, `end_date` becomes a "future EST date" and UW rejects every call with HTTP 422 — silently, since the fetch is wrapped in a per-ticker `try/except: logger.warning`.
- Confirmed via live worker logs on the mini: `etf_flows_daily` (GLD/IAU/GLDM in/outflow) stopped refreshing on 2026-05-15 and has been silently failing every day since (422 on 2026-07-02, transient 429 on 2026-07-01).
- Fix: compute "today" via `datetime.now(ZoneInfo(rth_tz))`, matching the ET-aware pattern already used by `flow_data_refresh`, `regime_live`, `vrp_macro_signal`, and others in this codebase.

## Test plan

- [x] New regression test `test_gold_etf_holdings_ingest_uses_et_date_not_host_clock` proves the date is computed from the ET zone, not a naive host clock
- [x] `uv run pytest tests/integration/worker/test_gold_daily_jobs.py tests/unit/worker/test_gold_warmup.py` — 9/9 pass
- [x] `uv run ruff check` clean on all changed files