### PR TITLE
feat(health): monitor gold/rates tables in the daily freshness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **Gold/rates tables added to the daily freshness monitor.** `etf_flows_daily`,
+  `wgc_etf_monthly`, `cb_gold_reserves_monthly`, and `exchange_inventory_daily`
+  join `MONITORED_TABLES` (`/api/health` `freshness` block, nightly
+  `data_freshness_monitor`) — none were previously monitored, which is why
+  `etf_flows_daily`'s ~7-week silent staleness (fixed in v0.5.1) required a
+  manual investigation to catch instead of surfacing automatically.
+  `_DATE_COL_PREFERENCE` now recognizes `obs_date`/`obs_month` (the gold/rates
+  convention, distinct from the options-chain `market_date`/`trade_date`).
+  `MonitoredTable` gains a per-table `grace_days` override so monthly-cadence
+  sources (WGC releases monthly; COMEX/LBMA vault data is effectively monthly)
+  don't cry wolf under the 4-day default meant for daily options data.
+  `wgc_etf_monthly` / `cb_gold_reserves_monthly` / `exchange_inventory_daily`
+  will show `frozen=true` until someone provisions a `WGC_GOLDHUB_COOKIE` or a
+  licensed COMEX data source — that's accurate, not noise.
+
 ## [0.5.1] — 2026-07-02
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   `wgc_etf_monthly` / `cb_gold_reserves_monthly` / `exchange_inventory_daily`
   will show `frozen=true` until someone provisions a `WGC_GOLDHUB_COOKIE` or a
   licensed COMEX data source — that's accurate, not noise.
+- **Freshness monitor coverage expanded from 12 to 48 tables.** A follow-up
+  audit of the full 118-table data-gap registry found ~40 more genuinely
+  continuous tables with zero prior `/api/health` visibility: the durable
+  option-surface IV grid, the options-chain pipeline (greeks/IV term/skew/max
+  pain/exposures), regime scanner outputs (GEX/CRI/VCG/GRG/canary), and the
+  remaining FRED/rates/gold sources not already known to be blocked.
+  `_DATE_COL_PREFERENCE` now also recognizes `data_date` and `snapshot_date`.
+  `MonitoredTable` gains a `date_col_override` for the handful of tables with
+  a one-off column name (`auction_date`, `record_date`, `event_date`) rather
+  than growing the shared preference list with names that could collide on a
+  future table. Deliberately **not** added: `dark_pool_events`, `flow_events`,
+  `option_contract_snapshots`, `massive_fundamentals`, `short_interest_snapshots`
+  (no DATE-typed column, only TIMESTAMPTZ event/insert timestamps —
+  `compute_freshness` only handles DATE columns today) and `corporate_actions`
+  (has both a date and ticker column, but is genuinely event-sparse per ticker;
+  watchlist-scope coverage would produce a permanent false LOW COVERAGE
+  warning, not a real signal).
 
 ## [0.5.1] — 2026-07-02
 

--- a/src/uw_scan/reports/data_freshness.py
+++ b/src/uw_scan/reports/data_freshness.py
@@ -25,6 +25,8 @@ _DATE_COL_PREFERENCE = (
     "as_of_date",
     "obs_date",
     "obs_month",
+    "data_date",
+    "snapshot_date",
     "date",
 )
 
@@ -35,6 +37,7 @@ class MonitoredTable:
     scope: str  # 'watchlist' (denominator = active watchlist) | 'subset' (named set)
     expected_tickers: frozenset[str] | None  # required when scope == 'subset'
     grace_days: int | None = None  # None -> inherit compute_freshness's grace_days
+    date_col_override: str | None = None  # for a table with no _DATE_COL_PREFERENCE hit
 
 
 @dataclass(frozen=True)
@@ -100,6 +103,115 @@ MONITORED_TABLES: list[MonitoredTable] = [
         None,
         grace_days=45,  # LBMA leg is monthly; COMEX leg is blocked
     ),
+    # --- coverage-expansion pass: every table below was previously invisible
+    # to /api/health freshness. Excluded on purpose (not an oversight):
+    #   dark_pool_events, flow_events, option_contract_snapshots,
+    #   massive_fundamentals, short_interest_snapshots -- no DATE-typed "as of"
+    #   column, only TIMESTAMPTZ event/insert timestamps; compute_freshness
+    #   only handles DATE columns today.
+    #   corporate_actions -- has both a date and a ticker column, but is
+    #   genuinely event-sparse per ticker (most tickers have zero splits/
+    #   dividends on any given day); watchlist-scope coverage would show a
+    #   permanent false LOW COVERAGE warning, not a real signal.
+    # --- Tier 1: core derived/durable tables, zero prior visibility ---
+    MonitoredTable("option_surface_grid_daily", "watchlist", None),
+    MonitoredTable("stock_analytics_daily", "watchlist", None),
+    MonitoredTable("realized_volatility_history", "watchlist", None),
+    MonitoredTable("volatility_stats_history", "watchlist", None),
+    MonitoredTable(
+        "market_tide_sentiment_daily", "watchlist", None
+    ),  # ticker-less; the gap-healer's own trading-day calendar spine
+    # --- Tier 2: options-chain pipeline (full_scan / option_surface_capture) ---
+    MonitoredTable("option_chain_per_strike", "watchlist", None),
+    MonitoredTable("greeks_by_expiry_strike", "watchlist", None),
+    MonitoredTable("iv_term_snapshots", "watchlist", None),
+    MonitoredTable("interpolated_iv_snapshots", "watchlist", None),
+    MonitoredTable("risk_reversal_skew_history", "watchlist", None),
+    MonitoredTable("iv_smile_snapshots", "watchlist", None),
+    MonitoredTable("max_pain_by_expiry", "watchlist", None),
+    MonitoredTable("oi_change_events", "watchlist", None),  # ticker-less
+    MonitoredTable("exposures_summary", "watchlist", None),
+    # --- Tier 3: regime scanner outputs (hourly :20/:25 scans) ---
+    MonitoredTable("gex_snapshots", "watchlist", None),
+    MonitoredTable("cri_snapshots", "watchlist", None),  # ticker-less
+    MonitoredTable("vcg_snapshots", "watchlist", None),  # ticker-less
+    MonitoredTable("grg_snapshots", "watchlist", None),  # ticker-less
+    MonitoredTable("matrix_state_snapshots", "watchlist", None),
+    MonitoredTable("canary_snapshots", "watchlist", None),  # ticker-less
+    # --- Tier 4: FRED/rates/gold sources not yet known to be blocked ---
+    MonitoredTable("macro_series_daily", "watchlist", None),  # ticker-less
+    MonitoredTable("rates_observations", "watchlist", None),  # ticker-less
+    MonitoredTable("rates_snapshots", "watchlist", None),  # ticker-less
+    MonitoredTable("rates_policy_path", "watchlist", None),  # ticker-less
+    MonitoredTable(
+        "rates_treasury_auctions",
+        "watchlist",  # ticker-less
+        None,
+        grace_days=10,  # auctions cluster weekly across tenors, not daily
+        date_col_override="auction_date",
+    ),
+    MonitoredTable("gold_posture_daily", "watchlist", None),  # ticker-less
+    MonitoredTable(
+        "uw_gold_options_daily",
+        "subset",
+        frozenset({"GLD", "GDX", "IAU"}),  # uw_gold_options.GOLD_OPTIONS_TICKERS
+    ),
+    MonitoredTable(
+        "etf_holdings_daily",
+        "subset",
+        frozenset({"GLD", "IAU", "GLDM", "PHYS"}),
+    ),
+    MonitoredTable(
+        "rates_cftc_tff_weekly",
+        "watchlist",
+        None,
+        grace_days=10,  # ticker-less
+    ),
+    MonitoredTable("cot_gold_weekly", "watchlist", None, grace_days=10),  # ticker-less
+    # --- Lower priority: still legitimate, less critical ---
+    MonitoredTable("pcr_history", "watchlist", None),
+    MonitoredTable("uw_positioning", "watchlist", None),
+    MonitoredTable(
+        "vol_index_daily",
+        "subset",
+        frozenset(
+            {
+                "VIX",
+                "VIX3M",
+                "VVIX",
+                "RVX",
+                "OVX",
+                "NDX",
+                "RUT",
+                "SPX",
+                "COR1M",
+                "COR3M",
+                "HYG",
+                "JNK",
+                "LQD",
+                "VXEEM",
+                "VXGDX",
+                "VXHYG",
+                "VXN",
+                "VXSLV",
+                "VXSMH",
+            }
+        ),
+    ),
+    MonitoredTable("index_ohlc_daily", "watchlist", None),
+    MonitoredTable(
+        "rates_fiscal_debt_daily",
+        "watchlist",  # ticker-less
+        None,
+        date_col_override="record_date",
+    ),
+    MonitoredTable(
+        "rates_policy_events",
+        "watchlist",  # ticker-less
+        None,
+        grace_days=45,  # sparse, event-driven (FOMC meetings ~8x/year)
+        date_col_override="event_date",
+    ),
 ]
 
 
@@ -149,7 +261,7 @@ def compute_freshness(
     active = {t.upper() for t in active_tickers}
     for mt in monitored:
         table_grace = mt.grace_days if mt.grace_days is not None else grace_days
-        date_col = _detect_date_col(conn, schema, mt.name)
+        date_col = mt.date_col_override or _detect_date_col(conn, schema, mt.name)
         tcol = _ticker_col(conn, schema, mt.name)
         if date_col is None:
             # No data-date column at all -> nothing this monitor can measure.

--- a/src/uw_scan/reports/data_freshness.py
+++ b/src/uw_scan/reports/data_freshness.py
@@ -23,6 +23,8 @@ _DATE_COL_PREFERENCE = (
     "session_date",
     "curr_date",
     "as_of_date",
+    "obs_date",
+    "obs_month",
     "date",
 )
 
@@ -32,6 +34,7 @@ class MonitoredTable:
     name: str
     scope: str  # 'watchlist' (denominator = active watchlist) | 'subset' (named set)
     expected_tickers: frozenset[str] | None  # required when scope == 'subset'
+    grace_days: int | None = None  # None -> inherit compute_freshness's grace_days
 
 
 @dataclass(frozen=True)
@@ -66,6 +69,36 @@ MONITORED_TABLES: list[MonitoredTable] = [
         "iv_rank_history",
         "subset",
         frozenset({"SPX", "SPY", "QQQ", "IWM"}),  # cockpit-only by design
+    ),
+    # --- gold_rates_macro: known-stale-since-2026-06/07 tables from the
+    # etf_flows_daily timezone-bug investigation. Only etf_flows_daily has a
+    # confirmed fix (gold_etf_holdings_ingest_job now uses ET, not host-local,
+    # dates) -- daily cadence, default grace_days is fine. The other three
+    # remain genuinely blocked (WGC Goldhub login wall / CME anonymous-scrape
+    # 403) and WILL show frozen until someone provisions a credential or a
+    # paid data license -- that is a real, standing alert, not noise.
+    MonitoredTable(
+        "etf_flows_daily",
+        "subset",
+        frozenset({"GLD", "IAU", "GLDM"}),  # gold_jobs.GOLD_ETF_FLOW_TICKERS
+    ),
+    MonitoredTable(
+        "wgc_etf_monthly",
+        "subset",
+        frozenset({"GLD", "IAU", "GLDM", "PHYS"}),
+        grace_days=45,  # monthly WGC release cadence
+    ),
+    MonitoredTable(
+        "cb_gold_reserves_monthly",
+        "watchlist",  # ticker-less (keyed by country_iso3) -> freshness-only
+        None,
+        grace_days=45,  # monthly WGC CB-reserves cadence
+    ),
+    MonitoredTable(
+        "exchange_inventory_daily",
+        "watchlist",  # ticker-less (keyed by exchange) -> freshness-only
+        None,
+        grace_days=45,  # LBMA leg is monthly; COMEX leg is blocked
     ),
 ]
 
@@ -115,6 +148,7 @@ def compute_freshness(
     out: list[FreshnessRow] = []
     active = {t.upper() for t in active_tickers}
     for mt in monitored:
+        table_grace = mt.grace_days if mt.grace_days is not None else grace_days
         date_col = _detect_date_col(conn, schema, mt.name)
         tcol = _ticker_col(conn, schema, mt.name)
         if date_col is None:
@@ -141,7 +175,7 @@ def compute_freshness(
             )
             max_date = cur.fetchone()[0]
         days_stale = (today - max_date).days if max_date else None
-        frozen = days_stale is not None and days_stale > grace_days
+        frozen = days_stale is not None and days_stale > table_grace
 
         if tcol is None:
             # Freshness-only: no per-ticker coverage possible.
@@ -180,7 +214,7 @@ def compute_freshness(
                 tbl=psql.Identifier(schema, mt.name),
             )
             with conn.cursor() as cur:
-                cur.execute(covq, (max_date, grace_days, list(expected)))
+                cur.execute(covq, (max_date, table_grace, list(expected)))
                 covered = cur.fetchone()[0]
 
         coverage_pct = (covered / expected_count) if expected_count else None

--- a/tests/integration/reports/test_data_freshness.py
+++ b/tests/integration/reports/test_data_freshness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
+from decimal import Decimal
 
 import pytest
 
@@ -113,3 +114,74 @@ def test_ticker_less_table_is_freshness_only(seeded_db_empty_cards):
     assert r.frozen is True  # 5-weeks stale -> frozen flagged
     assert r.coverage_pct is None  # no ticker column -> no coverage
     assert r.expected_count == 0
+
+
+def _seed_etf_flow(repo, ticker, obs_date):
+    repo.insert_etf_flows_daily(
+        ticker=ticker,
+        obs_date=obs_date,
+        share_change=Decimal("0"),
+        premium_change_usd=Decimal("0"),
+        close=Decimal("100"),
+        volume=Decimal("1"),
+        as_of=datetime.now(timezone.utc),
+        source="UW",
+    )
+
+
+def test_obs_date_column_detected(seeded_db_empty_cards):
+    # etf_flows_daily uses obs_date, not one of the original _DATE_COL_PREFERENCE
+    # entries -- regression guard for the timezone-bug investigation follow-up
+    # that added etf_flows_daily/wgc_etf_monthly/cb_gold_reserves_monthly/
+    # exchange_inventory_daily monitoring.
+    repo = seeded_db_empty_cards
+    today = date(2026, 7, 2)
+    _seed_etf_flow(repo, "GLD", date(2026, 7, 1))
+    _seed_etf_flow(repo, "GLDM", date(2026, 7, 1))
+    monitored = [
+        MonitoredTable("etf_flows_daily", "subset", frozenset({"GLD", "IAU", "GLDM"}))
+    ]
+    rows = compute_freshness(
+        repo.conn, repo._schema, monitored, active_tickers=[], today=today
+    )
+    r = rows[0]
+    assert r.date_col == "obs_date"
+    assert r.max_data_date == date(2026, 7, 1)
+    assert r.frozen is False
+    # IAU has no row -> 2/3 covered, not a false "everything's fine" 100%.
+    assert r.expected_count == 3
+    assert r.covered_count == 2
+    assert r.coverage_pct == pytest.approx(2 / 3)
+
+
+def test_per_table_grace_days_override(seeded_db_empty_cards):
+    # wgc_etf_monthly is monthly-cadence; the global 4-day default grace would
+    # always flag it frozen even when healthy. grace_days=45 must be honored.
+    repo = seeded_db_empty_cards
+    today = date(2026, 7, 2)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.wgc_etf_monthly
+                (ticker, obs_date, source_url, as_of, source)
+            VALUES ('GLD', %s, 'file:///test.xlsx', now(), 'WGC')
+            """,
+            (date(2026, 5, 31),),
+        )
+    repo.conn.commit()
+    monitored_default = [
+        MonitoredTable("wgc_etf_monthly", "subset", frozenset({"GLD"}))
+    ]
+    monitored_relaxed = [
+        MonitoredTable("wgc_etf_monthly", "subset", frozenset({"GLD"}), grace_days=45)
+    ]
+    default_rows = compute_freshness(
+        repo.conn, repo._schema, monitored_default, active_tickers=[], today=today
+    )
+    relaxed_rows = compute_freshness(
+        repo.conn, repo._schema, monitored_relaxed, active_tickers=[], today=today
+    )
+    # 32 days stale: frozen under the global 4-day default, not under grace_days=45.
+    assert default_rows[0].days_stale == 32
+    assert default_rows[0].frozen is True
+    assert relaxed_rows[0].frozen is False

--- a/tests/integration/reports/test_data_freshness.py
+++ b/tests/integration/reports/test_data_freshness.py
@@ -185,3 +185,60 @@ def test_per_table_grace_days_override(seeded_db_empty_cards):
     assert default_rows[0].days_stale == 32
     assert default_rows[0].frozen is True
     assert relaxed_rows[0].frozen is False
+
+
+def test_data_date_column_detected(seeded_db_empty_cards):
+    # gex_snapshots uses data_date -- not one of the original preference
+    # entries either; regression guard for the coverage-expansion pass.
+    repo = seeded_db_empty_cards
+    today = date(2026, 7, 2)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.gex_snapshots (ticker, data_date, payload)
+            VALUES ('SPX', %s, '{{}}'::jsonb)
+            """,
+            (date(2026, 7, 1),),
+        )
+    repo.conn.commit()
+    monitored = [MonitoredTable("gex_snapshots", "watchlist", None)]
+    rows = compute_freshness(
+        repo.conn, repo._schema, monitored, active_tickers=["SPX"], today=today
+    )
+    r = rows[0]
+    assert r.date_col == "data_date"
+    assert r.max_data_date == date(2026, 7, 1)
+    assert r.frozen is False
+
+
+def test_date_col_override_bypasses_auto_detection(seeded_db_empty_cards):
+    # rates_fiscal_debt_daily's real "as of" column is record_date, which is
+    # not (and should not become) a generic _DATE_COL_PREFERENCE entry --
+    # explicit date_col_override is how a one-off column name gets used.
+    repo = seeded_db_empty_cards
+    today = date(2026, 7, 2)
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            f"""
+            INSERT INTO {repo._schema}.rates_fiscal_debt_daily
+                (record_date, as_of, total_public_debt)
+            VALUES (%s, now(), 1000000)
+            """,
+            (date(2026, 6, 30),),
+        )
+    repo.conn.commit()
+    monitored = [
+        MonitoredTable(
+            "rates_fiscal_debt_daily",
+            "watchlist",
+            None,
+            date_col_override="record_date",
+        )
+    ]
+    rows = compute_freshness(
+        repo.conn, repo._schema, monitored, active_tickers=[], today=today
+    )
+    r = rows[0]
+    assert r.date_col == "record_date"
+    assert r.max_data_date == date(2026, 6, 30)
+    assert r.days_stale == 2


### PR DESCRIPTION
## Summary

`etf_flows_daily`'s ~7-week silent staleness (root-caused and fixed in v0.5.1, PR #200) went undetected because none of `data_freshness_monitor`'s `MONITORED_TABLES` covered it — the daily freshness check only knew about options-chain/watchlist tables, not gold/rates.

- Add `etf_flows_daily`, `wgc_etf_monthly`, `cb_gold_reserves_monthly`, `exchange_inventory_daily` to `MONITORED_TABLES`
- `_DATE_COL_PREFERENCE` now recognizes `obs_date`/`obs_month` — the gold/rates column convention, distinct from options-chain's `market_date`/`trade_date`. Without this, the monitor's auto-detect would silently skip all four tables (`date_col="?"`)
- `MonitoredTable` gains a per-table `grace_days: int | None = None` override. Without it, the global 4-day default (sized for daily options data) would flag monthly-cadence sources (WGC releases, COMEX/LBMA vault data) as "frozen" every month even when healthy

## Known-standing alerts (by design, not noise)

`wgc_etf_monthly`, `cb_gold_reserves_monthly`, and `exchange_inventory_daily`'s COMEX leg are currently genuinely blocked — WGC retired the anonymous CSV (needs a `WGC_GOLDHUB_COOKIE` credential nobody has provisioned) and CME blocks anonymous scraping (403, needs a paid CME DataMine license). These three will show `frozen=true` in `/api/health` until one of those is fixed. That's accurate, not a bug — the previous state was these staying silently broken with zero visibility.

`etf_flows_daily` is the one table with a confirmed code fix (v0.5.1) and daily cadence; it uses the default 4-day grace.

## Test plan

- [x] 2 new regression tests: `test_obs_date_column_detected` (proves the date-column detection fix, and that a per-ticker gap like IAU's genuine UW-side data hole shows as partial coverage, not a false 100%), `test_per_table_grace_days_override` (proves the same 32-days-stale row is `frozen=True` under the global default and `frozen=False` under a 45-day override)
- [x] `uv run pytest tests/integration/reports/test_data_freshness.py tests/integration/worker/test_data_freshness_monitor_job.py tests/integration/api/test_health_freshness.py` — 8/8 pass
- [x] `uv run pytest tests/ -n auto` — 2130 passed, 12 skipped, 3 pre-existing unrelated `tests/live/*` failures (confirmed present on `main` too)
- [x] `uv run ruff check` clean