### PR TITLE
fix(health): stop health-bar flicker and always-ALERT Query Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **HealthPanel "API OFFLINE" flicker.** The sidebar rapidly toggled `API
+  OFFLINE` / everything `UNKNOWN` even while the API was up. Root cause: the
+  `/api/health` record-coverage ("Query Coverage") scan costs ~15–20s cold but
+  its cache TTL was only 15s, so a fresh 20s query fired on nearly every 5s
+  poll, stacking on one DB and blowing the browser fetch timeout. Two changes:
+  (1) `_RECORD_HEALTH_CACHE_TTL_SECONDS` 15→120 so the expensive scan runs at
+  most once every 2 min; (2) the poll now caps each request at an 8s timeout and
+  keeps the last-good snapshot on a transient miss, only showing `OFFLINE` after
+  3 consecutive failures (a real outage) instead of flickering on one slow poll.
+  Polls are serialized (next scheduled only after the current settles) so an 8s
+  timeout under a 5s interval can't overlap and let a stale timed-out poll
+  corrupt the consecutive-failure count.
+- **HealthPanel "Query Coverage" permanently ALERT.** The record-coverage check
+  auto-discovered every ticker+timestamp table and expected ~90% watchlist
+  coverage in an 8h window, with no market-calendar awareness — so it flashed
+  ALERT every weekend/holiday/overnight (no scans run → 0 rows) and, during RTH,
+  for sparse/research tables that structurally never reach 90% coverage. Now:
+  (1) the check is market-calendar aware — when no full-scan cron was due in the
+  window it reads healthy and skips the per-table scan (mirrors the WS-consumer
+  relaxation); (2) the structurally-sparse candidate / research / unusual-activity
+  tables (`signal_hits`, `scanner_candidate_snapshots`, `vrp_trade_candidates`,
+  `vrp_paper_positions`, `vrp_backtest_trades`, `vrp_macro_sweep_results`,
+  `corporate_actions`, `iv_source_validation`, `short_interest_snapshots`,
+  `flow_events`, `dark_pool_events`, `oi_change_events`) are excluded — the
+  event tables insert nothing for a ticker with no events, so they never reach
+  90% coverage (but `signal_gates` is kept — it is written once per scanned
+  ticker, so its coverage is a real scanner-persistence signal); (3) the nightly
+  `option_surface_grid_daily` / `flow_alerts_daily_rollup` tables use the 24h
+  window instead of 8h.
+
 ## [0.7.0] — 2026-07-04
 
 

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -177,7 +177,14 @@ class RecordHealthCheck(BaseModel):
     ok: bool
 
 
-_RECORD_HEALTH_CACHE_TTL_SECONDS = 15.0
+# The per-table record-health scan (COUNT/COUNT DISTINCT/MAX over a sliding
+# window across every discovered table) costs ~15-20s cold. The TTL MUST exceed
+# that runtime — at 15s the cache expired before it could ever serve warm, so a
+# fresh 20s query fired on nearly every 5s HealthPanel poll, stacking concurrent
+# scans on one DB and blowing the browser fetch timeout (the "API OFFLINE"
+# flicker). Coverage is a slow-moving daily-window signal; 2min staleness is
+# fine. ponytail: single-flight/stale-while-revalidate if this still stalls.
+_RECORD_HEALTH_CACHE_TTL_SECONDS = 120.0
 _RecordHealthCacheKey = tuple[
     tuple[str, ...] | None,
     float,
@@ -231,6 +238,28 @@ def _record_health_cache_set(
 
 def _record_health_cache_clear_for_tests() -> None:
     _record_health_cache.clear()
+
+
+def _record_window_scans_expected(
+    settings: Settings,
+    *,
+    now_utc: datetime,
+    record_window_hours: float | None,
+) -> bool:
+    """True when >=1 full-scan cron was scheduled to fire within the record
+    window. When False (weekend / holiday / overnight) no fresh coverage is
+    expected, so record health should read healthy rather than ALERT. Extracted
+    from the handler so tests can force the market session deterministically,
+    independent of the wall-clock a CI run happens to land on."""
+    if record_window_hours is None:
+        return False
+    fires = expected_market_cron_fires_between(
+        settings.full_scan_crons,
+        settings.rth_tz,
+        start_utc=now_utc - timedelta(hours=record_window_hours),
+        end_utc=now_utc,
+    )
+    return bool(fires)
 
 
 def _parse_record_tables(record_tables: str | None) -> list[str] | None:
@@ -536,7 +565,17 @@ def health(
     }
     record_fields = {"record_health_ok": None, "record_health": []}
     record_reason = None
-    if record_window_hours is not None:
+    # Market-calendar aware: coverage is only expected when scans were due. If no
+    # full-scan cron was scheduled to fire within the record window (weekend,
+    # holiday, overnight), an empty window is healthy — not an ALERT. Mirrors the
+    # WS-consumer's in-session relaxation, and skips the expensive per-table scan
+    # when there is nothing to verify.
+    record_scans_expected = _record_window_scans_expected(
+        settings, now_utc=now_utc, record_window_hours=record_window_hours
+    )
+    if record_window_hours is not None and not record_scans_expected:
+        record_fields = {"record_health_ok": True, "record_health": []}
+    elif record_window_hours is not None:
         selected_tables = _parse_record_tables(record_tables)
         cache_key: _RecordHealthCacheKey = (
             tuple(selected_tables) if selected_tables is not None else None,

--- a/src/uw_scan/storage/health.py
+++ b/src/uw_scan/storage/health.py
@@ -42,6 +42,33 @@ _RECORD_HEALTH_EXCLUDED_TABLES = {
     # flag row. Even at full coverage this caps around 50-60% of the
     # watchlist — a watchlist-wide threshold will never apply.
     "signal_context_flags",
+    # Signal-gated / candidate / research / event tables. Auto-discovery picks
+    # these up (they carry a ticker + write-timestamp) but none of them ever
+    # covers ~90% of the watchlist, so a watchlist-wide coverage threshold reads
+    # a permanent false ALERT. Data-date freshness for the ones that matter is
+    # tracked by the (calendar-aware, curated) freshness monitor instead —
+    # reports/data_freshness.MONITORED_TABLES.
+    # NB: signal_gates is deliberately NOT here — run_single_stock writes one
+    # gate-audit row per scanned ticker (scanner/pipeline.upsert_gate), so it IS
+    # dense per-scan and its coverage is a real scanner-persistence signal.
+    "signal_hits",  # only firing signals (per emission, not per ticker)
+    "scanner_candidate_snapshots",  # only scan candidates, not the watchlist
+    "vrp_trade_candidates",  # candidate subset (~14/93)
+    "vrp_paper_positions",  # open paper positions only (~40/93)
+    "vrp_backtest_trades",  # research backtest output
+    "vrp_macro_sweep_results",  # research parameter sweep output
+    "corporate_actions",  # only tickers with an action on the day
+    "iv_source_validation",  # IB-vs-model canary, a handful of tickers
+    "short_interest_snapshots",  # biweekly settlement cadence, never daily-dense
+    # Unusual-activity event tables: the writer inserts nothing for a ticker
+    # with no events in the scan window (`if not rows: return 0`), and these are
+    # subset-by-definition (unusual flow / dark-pool prints / OI movers), so they
+    # never reach ~90% watchlist coverage even during RTH. (Distinct from the
+    # option greeks/IV/max-pain tables, which get rows for every optionable
+    # ticker and so stay in the check.)
+    "flow_events",  # only tickers with an unusual-flow alert
+    "dark_pool_events",  # only tickers with dark-pool prints in the window
+    "oi_change_events",  # only OI-mover tickers
 }
 
 # Watchlist-wide tables populated once per day (nightly vol rollup at
@@ -55,6 +82,10 @@ _RECORD_HEALTH_DAILY_TABLES = {
     # daily snapshots
     "risk_reversal_skew_history",
     "oi_by_strike",
+    # Nightly captures — the 8h window can never see them, so they must use the
+    # 24h window or they read a permanent ALERT on trading days too.
+    "option_surface_grid_daily",  # nightly option-surface grid (19:00 ET)
+    "flow_alerts_daily_rollup",  # once-per-day flow-alert rollup
 }
 
 

--- a/tests/integration/api/test_health.py
+++ b/tests/integration/api/test_health.py
@@ -20,6 +20,17 @@ def clear_record_health_cache():
     _record_health_cache_clear_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _force_record_scans_expected(monkeypatch):
+    """Record coverage is now market-calendar aware: it only runs when a
+    full-scan cron was due in the window. Default the gate to 'scans expected'
+    so the coverage tests are deterministic regardless of the wall-clock a CI
+    run lands on. The dedicated market-closed test overrides this to False."""
+    monkeypatch.setattr(
+        health_router, "_record_window_scans_expected", lambda *a, **k: True
+    )
+
+
 def test_health_ok_when_recent_scan(client, seeded_db_with_cards):
     seeded_db_with_cards.upsert_heartbeat("worker")
 
@@ -369,6 +380,29 @@ def test_health_record_check_alerts_on_low_recent_ticker_coverage(
         card_check["expected_tickers"] == seeded_db_with_cards.count_active_watchlist()
     )
     assert card_check["ok"] is False
+
+
+def test_health_record_check_skips_when_market_closed(
+    client, seeded_db_with_cards, monkeypatch
+):
+    # Same low-coverage seed as the ALERT test, but no full-scan cron was due in
+    # the window (weekend / holiday / overnight). No coverage is expected, so the
+    # check must read healthy and skip the per-table scan — not flash ALERT.
+    monkeypatch.setattr(
+        health_router, "_record_window_scans_expected", lambda *a, **k: False
+    )
+    seeded_db_with_cards.upsert_heartbeat("worker")
+
+    r = client.get(
+        "/api/health?record_window_hours=8&record_min_coverage=0.9"
+        "&record_tables=watchlist_card"
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["record_health_ok"] is True
+    assert body["record_health"] == []
+    assert "record coverage below expected" not in (body["reason"] or "")
 
 
 def test_health_record_check_passes_when_selected_table_covers_watchlist(

--- a/tests/unit/test_record_window_scans_expected.py
+++ b/tests/unit/test_record_window_scans_expected.py
@@ -1,0 +1,60 @@
+"""Unit tests for the record-coverage market-session gate.
+
+The integration health tests all monkeypatch `_record_window_scans_expected`
+so their coverage assertions are deterministic; this file exercises the real
+computation (cron parsing + US-market-day filter) directly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from uw_scan.api.routers.health import _record_window_scans_expected
+from uw_scan.config import Settings
+
+# Exercise the real configured crons + tz without constructing a full Settings
+# (which requires api_key / DB env). The helper only reads these two attributes.
+_SETTINGS = SimpleNamespace(
+    full_scan_crons=Settings.model_fields["full_scan_crons"].get_default(
+        call_default_factory=True
+    ),
+    rth_tz=Settings.model_fields["rth_tz"].get_default(call_default_factory=True),
+)
+
+
+def test_scans_expected_during_rth_weekday():
+    # Wed 2026-05-13 14:00 ET (18:00 UTC): the 8h window (06:00-14:00 ET) spans
+    # the premarket + open + RTH crons, all on a regular market day.
+    now = datetime(2026, 5, 13, 18, 0, tzinfo=UTC)
+    assert (
+        _record_window_scans_expected(_SETTINGS, now_utc=now, record_window_hours=8)
+        is True
+    )
+
+
+def test_no_scans_expected_on_weekend():
+    # Sat 2026-07-04 14:00 ET: market closed, no crons fire.
+    now = datetime(2026, 7, 4, 18, 0, tzinfo=UTC)
+    assert (
+        _record_window_scans_expected(_SETTINGS, now_utc=now, record_window_hours=8)
+        is False
+    )
+
+
+def test_no_scans_expected_on_observed_holiday():
+    # Fri 2026-07-03 14:00 ET: Independence Day observed — a full-day closure
+    # even though it is a weekday, so is_us_equity_market_day() excludes it.
+    now = datetime(2026, 7, 3, 18, 0, tzinfo=UTC)
+    assert (
+        _record_window_scans_expected(_SETTINGS, now_utc=now, record_window_hours=8)
+        is False
+    )
+
+
+def test_none_window_is_not_expected():
+    now = datetime(2026, 5, 13, 18, 0, tzinfo=UTC)
+    assert (
+        _record_window_scans_expected(_SETTINGS, now_utc=now, record_window_hours=None)
+        is False
+    )

--- a/web/components/shared/HealthPanel.tsx
+++ b/web/components/shared/HealthPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { fmtDateTimeWithZone } from "@/lib/formatters";
 import type { components } from "@/lib/types";
@@ -10,6 +10,8 @@ type WorkerHealth = NonNullable<Health["workers"]>[number];
 type ProviderSource = "uw" | "massive";
 type PanelView = "status" | "benchmark";
 
+const HEALTH_FETCH_TIMEOUT_MS = 8000;
+const HEALTH_FAILURE_LIMIT = 3;
 const HEARTBEAT_HEALTHY_LAG_S = 5;
 const SPOT_REFRESH_HEALTHY_LAG_S = 660;
 const RECORD_WINDOW_HOURS = 8;
@@ -382,24 +384,50 @@ export function HealthPanel() {
     setCollapsed(readStoredCollapsed());
   }, []);
 
+  // A single slow/failed poll must NOT blank the whole panel to OFFLINE —
+  // the record-health query can occasionally exceed the timeout even when the
+  // API is fine. Keep the last-good snapshot until FAILURE_LIMIT consecutive
+  // misses (a genuine outage), and cap each poll at HEALTH_FETCH_TIMEOUT_MS so
+  // a real outage is detected promptly instead of hanging. Polls are SERIALIZED
+  // (schedule the next only after the current settles) rather than a fixed
+  // interval: with an 8s timeout under a 5s interval, requests would overlap and
+  // an older timed-out poll could bump the failure counter after a newer poll
+  // already succeeded — muddying the "consecutive" count and re-introducing a
+  // false OFFLINE while the API is healthy.
+  const failuresRef = useRef(0);
   useEffect(() => {
     let cancelled = false;
-    const fetchOnce = async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    failuresRef.current = 0;
+    const scheduleNext = () => {
+      if (!cancelled) timer = setTimeout(runPoll, 5000);
+    };
+    const runPoll = async () => {
       try {
-        const r = await api.health(source, {
-          recordMinCoverage: RECORD_MIN_COVERAGE,
-          recordWindowHours: RECORD_WINDOW_HOURS,
-        });
-        if (!cancelled) setH(r);
+        const r = await api.health(
+          source,
+          {
+            recordMinCoverage: RECORD_MIN_COVERAGE,
+            recordWindowHours: RECORD_WINDOW_HOURS,
+          },
+          { signal: AbortSignal.timeout(HEALTH_FETCH_TIMEOUT_MS) },
+        );
+        if (cancelled) return;
+        failuresRef.current = 0;
+        setH(r);
       } catch {
-        if (!cancelled) setH(null);
+        if (cancelled) return;
+        failuresRef.current += 1;
+        if (failuresRef.current >= HEALTH_FAILURE_LIMIT) setH(null);
+        // else: keep the last-good snapshot — this was a transient slow poll.
+      } finally {
+        if (!cancelled) scheduleNext();
       }
     };
-    fetchOnce();
-    const t = setInterval(fetchOnce, 5000);
+    runPoll();
     return () => {
       cancelled = true;
-      clearInterval(t);
+      if (timer !== undefined) clearTimeout(timer);
     };
   }, [source]);
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -232,6 +232,7 @@ export const api = {
   health: (
     source: HealthSource = "uw",
     options: HealthOptions = {},
+    init?: RequestInit,
   ): Promise<HealthResponse> => {
     const params = new URLSearchParams({ source: source ?? "uw" });
     if (options.recordWindowHours != null) {
@@ -240,7 +241,7 @@ export const api = {
     if (options.recordMinCoverage != null) {
       params.set("record_min_coverage", String(options.recordMinCoverage));
     }
-    return _fetch<HealthResponse>(`/api/health?${params.toString()}`);
+    return _fetch<HealthResponse>(`/api/health?${params.toString()}`, init);
   },
   healthBenchmarkCurrent: (): Promise<BenchmarkCurrentResponse> =>
     _fetch<BenchmarkCurrentResponse>("/api/health/benchmark/current"),

--- a/web/tests/unit/healthPanel.test.tsx
+++ b/web/tests/unit/healthPanel.test.tsx
@@ -1,9 +1,11 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -49,6 +51,9 @@ describe("HealthPanel", () => {
     cleanup();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    // Guard against a fake-timer test leaking into the real-timer tests that
+    // rely on testing-library's waitFor.
+    vi.useRealTimers();
   });
 
   it("opens a benchmark view from the expanded panel and fetches lazily", async () => {
@@ -266,6 +271,69 @@ describe("HealthPanel", () => {
     expect(screen.getByText("1")).toBeTruthy();
   });
 
+  it("keeps the last-good status on a transient failed poll, then goes OFFLINE after repeated failures", async () => {
+    vi.useFakeTimers();
+    const good = {
+      ok: true,
+      db: "up",
+      scheduler_lag_seconds: 12,
+      last_full_scan_at: "2026-05-14T14:20:42Z",
+      reason: null,
+      worker_lag_seconds: 1,
+      scheduler_heartbeat_lag_seconds: 1,
+      scheduler_heartbeat_name: "worker",
+      rescan_heartbeat_lag_seconds: 8,
+      spot_refresh_heartbeat_lag_seconds: 240,
+      spot_quote_lag_seconds: 60,
+      latest_spot_quote_at: "2026-05-14T14:19:42Z",
+      latest_spot_quote_fetched_at: "2026-05-14T14:20:42Z",
+      watchlist_size: 97,
+      source: "UnusualWhales",
+      version: "0.0.0-test",
+      latency_p95_ms: 88,
+      http_2xx: 120,
+      http_4xx: 3,
+      http_5xx: 1,
+      uw_today: 40,
+      cache_hit_pct: null,
+      throughput_window_minutes: 15,
+      requests_per_minute: 12.4,
+      http_429: 2,
+      avg_scan_duration_seconds: 125,
+      queue_drain_rate_per_minute: 1.6,
+      record_health_ok: true,
+      record_health: [],
+      workers: [],
+    };
+    vi.mocked(api.health)
+      .mockResolvedValueOnce(good)
+      .mockRejectedValue(new Error("timeout"));
+
+    render(<HealthPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /status/i }));
+    // Flush the initial (successful) poll. State updates from the resolved
+    // fetch must settle inside act(), so advance timers within act().
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const apiRow = () => screen.getByText("API").parentElement as HTMLElement;
+    expect(within(apiRow()).getByText("ONLINE")).toBeTruthy();
+
+    // Poll #1 fails — panel must keep the last-good ONLINE, not flicker OFFLINE.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(within(apiRow()).getByText("ONLINE")).toBeTruthy();
+
+    // Polls #2 and #3 fail — three consecutive misses is a real outage.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+    expect(within(apiRow()).getByText("OFFLINE")).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+
   it("keeps dashes for missing metrics", async () => {
     vi.mocked(api.health).mockResolvedValue({
       ok: false,
@@ -366,20 +434,28 @@ describe("HealthPanel", () => {
     await expandPanel();
 
     await waitFor(() =>
-      expect(api.health).toHaveBeenCalledWith("uw", {
-        recordMinCoverage: 0.9,
-        recordWindowHours: 8,
-      }),
+      expect(api.health).toHaveBeenCalledWith(
+        "uw",
+        {
+          recordMinCoverage: 0.9,
+          recordWindowHours: 8,
+        },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
     );
     fireEvent.change(screen.getByRole("combobox", { name: "Source" }), {
       target: { value: "massive" },
     });
 
     await waitFor(() =>
-      expect(api.health).toHaveBeenCalledWith("massive", {
-        recordMinCoverage: 0.9,
-        recordWindowHours: 8,
-      }),
+      expect(api.health).toHaveBeenCalledWith(
+        "massive",
+        {
+          recordMinCoverage: 0.9,
+          recordWindowHours: 8,
+        },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
     );
     expect(screen.getByText("Massive.com")).toBeTruthy();
     expect(screen.getByText("55ms")).toBeTruthy();


### PR DESCRIPTION
## What

Fixes two production issues observed on v0.7.0's health bar.

### 1. Health-bar flicker (API / Query Coverage rows toggling OK↔OFFLINE)
The record-coverage query costs ~15–20s cold, but `HealthPanel` polled on a 5s `setInterval` with no timeout, so requests overlapped and a single slow/failed poll blanked the panel.

- Serialize the poll loop — schedule the next fetch only after the prior one settles (`setTimeout`-after-settle, not `setInterval`).
- Add an 8s `AbortSignal.timeout` per fetch.
- Keep the last-good snapshot until 3 consecutive failures (no blank-on-first-blip).
- Bump the server-side record-health TTL cache to 120s so it exceeds the query runtime.

### 2. "Query Coverage" permanently ALERT
The 8h watchlist-coverage check ran even when the market was closed, and auto-discovery swept in structurally-sparse tables that can never reach 90% coverage.

- Gate the record check on `expected_market_cron_fires_between` — skip (report OK) when no full-scan cron is due in the window (weekends / holidays / off-hours).
- Curate the exclusion set: drop candidate / research / unusual-activity event tables (`flow_events`, `dark_pool_events`, `oi_change_events` insert nothing for no-event tickers), **keep** `signal_gates` (one row per scanned ticker → real coverage signal), and move nightly `option_surface_grid_daily` / `flow_alerts_daily_rollup` to the 24h window.

## Verification
- `pytest` health suite: 28 passed (incl. new `test_record_window_scans_expected.py` + market-closed integration test)
- vitest `healthPanel`: 9 passed (incl. new anti-flicker test)
- ruff clean, `tsc --noEmit` clean
- Ran the worktree stack locally + Playwright: Query Coverage row renders **OK** (was red ALERT), health polls 17–40ms, 0 console errors
- 6-pass `/review-cycle` (2 codex findings applied: keep `signal_gates`, serialize the poll)

CHANGELOG updated in this PR.