### PR TITLE
docs: fable choice — candidate sweep + Docker migration design

### DIFF
--- a/docs/research/2026-07-06-candidate-charm-vanna-positioning.md
+++ b/docs/research/2026-07-06-candidate-charm-vanna-positioning.md
@@ -1,0 +1,30 @@
+# Candidate: dealer charm/vanna per-strike positioning signal
+
+**Date:** 2026-07-06 · **Status:** UNVALIDATED HYPOTHESIS · **Effort:** M
+**Basis:** [INFERRED] from a data-in-hand audit. Confidence MED. Not yet tested.
+
+## The gap (verified)
+
+`uw_scan.option_surface_grid_daily` captures `call_vanna, put_vanna, call_charm, put_charm` (plus gamma/delta) **per strike per expiry, nightly, whole chain, no clip** — written by `worker/jobs/option_surface_capture.py` since ~2026-06-23. Confirmed: `storage/option_surface.py` only ever reads the ATM strike's `call_iv/put_iv` for the IB-vs-UW canary. The vanna and charm columns are **read by nothing** except row-count freshness checks. Every consumer of vanna/charm elsewhere pulls the UW *aggregate* greek-exposure endpoint — never this durable per-strike grid.
+
+## Hypothesis
+
+GEX is gamma-only. Two dealer-hedging channels go unmeasured:
+- **Charm** (∂delta/∂time): aggregate signed dealer charm across the chain predicts mechanical delta-rehedging drift into expiry — strongest OPEX week, high-OI single names.
+- **Vanna** (∂delta/∂vol): net vanna predicts direction/magnitude of dealer hedging when IV moves — the vol-spot feedback that amplifies or dampens moves.
+
+## Cheap validation
+
+For each (ticker, market_date): sum OI-or-gamma-weighted net charm and net vanna per near expiry. Regress next-day and cumulative-into-expiry underlying drift on net charm; regress IV-conditional drift on net vanna. Cross-sectional across the whole watchlist gives N fast even on short history.
+
+## Urgency (why this can't wait)
+
+Only ~9 sessions banked so far, and **per-strike history is unrecoverable from UW** — you cannot backfill it. The derivation/persistence job should start accruing a durable daily rollup **now**, even though statistical power for validation accrues forward over weeks. Design the signal now; test it in a month.
+
+## Bundled second signal (same grid, ~free)
+
+Durable ATM **term-structure slope** — reconstruct ATM-IV(dte) per (ticker, date) from the grid, 30d–90d slope + curvature. The dedicated `iv_term_snapshots`/`interpolated_iv_snapshots` tables are run_id-ephemeral (CASCADE), so this grid is the *only* place term-structure history survives. Explicitly NOT the SVI cross-strike smile fit (parked-negative) and NOT skew direction (closed-negative) — this is the along-expiry slope.
+
+## Reproduce
+
+Derivation script TBD → `scripts/research/charm_vanna_positioning.py` (read `option_surface_grid_daily`, write rollup + markout to a durable artifact under `docs/research/`).

--- a/docs/research/2026-07-06-candidate-gex-regime-persistence.md
+++ b/docs/research/2026-07-06-candidate-gex-regime-persistence.md
@@ -1,0 +1,27 @@
+# Candidate: GEX regime-persistence signal
+
+**Date:** 2026-07-06 · **Status:** UNVALIDATED HYPOTHESIS · **Effort:** S–M
+**Basis:** [INFERRED] from a data-in-hand audit. Confidence MED. **Cheapest real alpha test on the board — has statistical power today.**
+
+## The gap (verified)
+
+`uw_scan.gex_snapshots` is durable, append-only since migration 037, with generated scalar columns: `level_gex_flip_strike, net_gex, spot, level_call_wall_strike, level_put_wall_strike, level_max_magnet_strike, iv_30d, hv_30d, scanned_at, data_date`. Months of it exist. But `scanners/gex.py` `compute_directional_bias` returns `flip_migration: []` and days-above-flip is stubbed to `0` ("v1 — no history"). The history now exists; the time-series signal was never built.
+
+## Hypothesis
+
+- **(a) Regime persistence:** consecutive days of spot-vs-flip sign (short-gamma when spot < flip / net_gex < 0, else long-gamma) predicts next-day realized vol and the reversal-vs-trend character of returns. Short-gamma regimes → higher |return|, more trend; long-gamma → pinning, mean-reversion.
+- **(b) Flip velocity:** the *rate* of flip-strike migration relative to spot is a leading tell for regime flips.
+
+Pure long/short-gamma labeling from already-indexed columns. Distinct from #179 (that's the per-ticker aggregate greek endpoint; this is the index/SPX GEX snapshot series).
+
+## Cheap validation
+
+Label each session short- vs long-gamma from stored columns. Measure next-day |return|, RV, and mean-reversion (sign-flip rate) in each bucket. Test whether flip-migration slope precedes regime change. **All from columns already indexed with months of history** — unlike the charm/vanna candidate, this validates now, not in a month.
+
+## Why do this one first
+
+Same class of idea as charm/vanna (dealer-positioning → forward behavior) but with the data already banked. Run this validation before investing build time in the forward-accruing candidates — if long/short-gamma buckets don't separate forward RV here, it recalibrates confidence in the whole positioning-alpha thesis cheaply.
+
+## Reproduce
+
+`scripts/research/gex_regime_persistence.py` — read `gex_snapshots`, label regimes, bucket forward returns/RV, write full result set to a durable artifact under `docs/research/`.

--- a/docs/research/2026-07-06-candidate-index.md
+++ b/docs/research/2026-07-06-candidate-index.md
@@ -1,0 +1,22 @@
+# 2026-07-06 candidate sweep — index
+
+A probe sweep (4 agents: code-health, underused-data/alpha, web-gaps, ops/reliability) produced these brand-new candidates (excluding everything already in issues/worktrees/the next-work shortlist). Each is saved as its own doc.
+
+| # | Candidate | Type | Effort | Doc | Status |
+|---|---|---|---|---|---|
+| 0 | Quant Technicals tab (sigmoid fit, MA kinematics, return-dist, enhanced RSI/MACD) | new page | M–L | `../superpowers/specs/2026-07-06-quant-technicals-page-design.md` | user's idea, designed |
+| 1 | Deploy-gate fix + ops-hardening (alerting, R2 staleness, job-failure agg, per-job budget) | ops/reliability | S→M | `../superpowers/specs/2026-07-06-candidate-ops-hardening.md` | **do #1 first** |
+| 2 | Dealer charm/vanna per-strike positioning + term-structure slope | alpha | M | `2026-07-06-candidate-charm-vanna-positioning.md` | unvalidated; start banking history now |
+| 3 | GEX regime-persistence (long/short-gamma buckets, flip velocity) | alpha | S–M | `2026-07-06-candidate-gex-regime-persistence.md` | unvalidated; **has power today — test first** |
+| 4 | /stock/{ticker} perf (N+1 batch, conn pool, report cache) | perf | S+M+S | `../superpowers/specs/2026-07-06-candidate-stock-page-perf.md` | biggest latency win |
+| 5 | Backtest explorer + provider-usage + benchmark dashboards | new pages | M | `../superpowers/specs/2026-07-06-candidate-observability-dashboards.md` | 3 built-but-unwired backends |
+
+Plus the separately-requested, now-in-progress **Docker migration** design: `../superpowers/specs/2026-07-06-docker-migration-design.md`.
+
+## Mastermind sequence recommendation
+
+Ops #1 deploy-gate one-liner (today) → alpha #3 (cheap validation, data ready) → alpha #2 derivation job (start accruing unrecoverable per-strike history) → perf #4 → Technicals tab #0 → dashboards #5. Perf #2 (conn pool) should ride with the Docker cutover.
+
+## Not carried forward (real but weaker)
+
+scheduler god-file split (1,842 lines — fold into next touch); per-strike OI-build velocity + aggressor-ratio z-score (adjacent to parked flow signals — validate #3 first); cross-ticker comparison page; table retention policy (bundle disk gauge into ops #1).

--- a/docs/superpowers/specs/2026-07-06-candidate-observability-dashboards.md
+++ b/docs/superpowers/specs/2026-07-06-candidate-observability-dashboards.md
@@ -1,0 +1,31 @@
+# Candidate: backtest explorer + provider-usage + benchmark dashboards
+
+**Date:** 2026-07-06 · **Status:** DRAFT (candidate) · **Basis:** [COMPUTED] from web-gaps probe. Confidence HIGH.
+**Effort:** M total. One web sprint surfacing three fully-built-but-unwired backends.
+
+## 1. Backtest Sweep Explorer (highest value×buildability)
+
+`backtest_sweep_runs` / `backtest_sweep_results` (migration 095) are fully populated by `src/uw_scan/backtest/sweep.py` + `BacktestRepository` (id, created_at, config, metrics, gates, n_trades, status, error) — but there is **no API router and no web page**. Sweep results are readable only via SQL/scripts today.
+
+Build: a thin FastAPI router wrapping `BacktestRepository` read methods (no router exists yet) → `/backtest` page: sortable runs table, drill into per-config metrics/gates JSON, diff two runs. This is the direct payoff of the walk-forward harness (PR #210) and the natural home for future kill-switch (#163) sweep results.
+
+## 2. Provider-Usage / UW-budget dashboard (Effort: S — endpoints already shipped)
+
+`api/routers/provider_usage.py` has 4 working endpoints (summary, breakdown by endpoint/ticker, raw request log, incl. `uw_latest_daily_count/limit`, latency p95, per-endpoint/ticker error rates). **Zero** web page consumes any of them.
+
+Build: `/admin/provider-usage` (or promote off `/admin`) — daily request-count/latency/error-rate charts + a UW daily-limit gauge. Directly answers "are we about to hit the UW rate limit." Pairs with ops-hardening #5 (add `job_name` breakdown → per-job budget attribution on the same page).
+
+## 3. Pipeline-Benchmark dashboard (Effort: S — shipped, never wired)
+
+`api/routers/benchmark.py` `/health/benchmark/current` and `/history` (composite score, subscores, snapshot history, reasons) are fully implemented, have generated TS types, and even a unit test (`healthBenchmarkApi.test.ts`) — but **no page renders them**. Looks shipped-then-abandoned.
+
+Build: a scorecard page — current score + subscore breakdown + benchmark-history sparkline. Wire-up only.
+
+## Also-noted (not in this bundle)
+
+- **Ops/Admin rebuild** (health + jobs currently a raw `JSON.stringify` blob at `/admin`) — S–M, more UI surface; fold in if doing #2/#3 anyway.
+- **Cross-ticker comparison** (`/compare?tickers=A,B,C` matrix of GEX/skew/VRP/IV-pctile) — M, all per-ticker endpoints exist; deferred as lower-priority.
+
+## Order
+
+#2 + #3 first (pure frontend, backends done) → #1 (needs a small new router) → optional admin rebuild.

--- a/docs/superpowers/specs/2026-07-06-candidate-ops-hardening.md
+++ b/docs/superpowers/specs/2026-07-06-candidate-ops-hardening.md
@@ -1,0 +1,42 @@
+# Candidate: deploy-gate fix + ops-hardening package
+
+**Date:** 2026-07-06 · **Status:** DRAFT (candidate) · **Basis:** [COMPUTED] from ops probe, file:line-verified. Confidence HIGH.
+**Note:** partly overlaps the Docker migration (Watchtower removes the launchd deploy path). The *alerting* and *health-surface* pieces survive that migration and become the primary detection layer once Watchtower's no-rollback tradeoff is accepted. Sequence with `2026-07-06-docker-migration-design.md`.
+
+## 1. Deploy health-gate bug — DO FIRST (Effort: S)
+
+`scripts/deploy/macmini-prod.sh:104-118` gates deploy success (and auto-rollback) on `check_url` = `curl -fsS --max-time 2 "$url"` — any 2xx passes. But `/api/health` returns **HTTP 200 in every branch, including `ok=false`** (`api/routers/health.py:358` db-down, `:635`, `:658`, `:673`). So a release that breaks the DB, misses 2 full scans, or collapses record-coverage passes the gate clean and the rollback never fires — the one automated safety net checks the wrong signal.
+
+Fix: swap the `curl -fsS` reachability check for a body check — `curl -fsS "$url" | jq -e '.ok == true'` — on both the forward gate and the post-rollback verify.
+
+**Caveat given the Docker migration:** if launchd deploy retires in favour of Watchtower, this script fix is moot for prod — but the *reason* it matters (no health-aware gate at all under Watchtower) makes the alerting piece below mandatory, not optional.
+
+## 2. Ops alerting channel (Effort: M)
+
+`grep -rli "pushover|telegram|discord|slack|webhook" src/uw_scan` → zero real hits. Every failure path (scheduler job exceptions, R2 lake-staleness fallback, frozen `data_freshness` tables, gap-healer circuit-breaker trips, budget wall) ends in a `logger.warning`/DB row — never pushed. The whole stack runs unattended on one Mac mini; no operator is in the loop unless they open the health panel.
+
+Distinct from shortlist R3 (which pushes *trading signals*). This is purely operational: "the worker died" / "UW budget hit the wall at 08:03 ET" has zero notification path.
+
+Build: one notification sink (Pushover or Discord webhook) wired to 3-4 existing conditions — `/api/health` `ok=false`, `autoheal_circuit_broken`, deploy/Watchtower recreate failure, budget `total_guard` breach.
+
+## 3. R2 lake-staleness on /api/health (Effort: S)
+
+`sources/lake_resolver.py:93-124` silently falls back to the local mirror and only `logger.warning(...)`s (line 122) when R2 is behind. `sources/CLAUDE.md` documents this defense was added 2026-06-07 after a **16-day silent stall** when the producer→R2 push died — yet the fix is still just a log line, not wired into `HealthResponse` or `data_freshness`. The exact failure it was built for can recur silently for another 16 days.
+
+Fix: emit a heartbeat/counter row when the WARN fires; surface `lake_resolver_stale: bool` on `/api/health` (same pattern as `ws_consumer`/`gap_healer`).
+
+## 4. Job-failure aggregation (Effort: M)
+
+No `add_listener(EVENT_JOB_ERROR, ...)` anywhere in `worker/scheduler.py` (~40 jobs). Failure handling is per-job local try/except → `logger.warning` and move on (e.g. `:1014-1017`, `:1045-1047`). Nothing aggregates "N consecutive failures for job X" — a job dead 3 days looks identical to a single transient blip in the logs.
+
+Fix: one `EVENT_JOB_ERROR` listener → small `job_failures` table + a failure-streak field on `/api/health` (feeds #2's alerting).
+
+## 5. Per-job UW budget attribution (Effort: S — cheapest, answers the stated pain)
+
+`sources/uw_budget.py:102-119` `read_snapshot` already groups `external_api_requests` by `job_name` internally but folds it into just `live`/`research` buckets. The breakdown API (`storage/external_api.py:223-238`) whitelists only `endpoint_key`/`ticker` — `job_name` is deliberately excluded, and `provider_usage.py` has no `/provider-usage/jobs` route. The exact per-job attribution needed to explain "why is the 40k budget gone by 08:00 ET" is sitting in the DB, unused.
+
+Fix: add `"job_name"` to the allowed column set + one router endpoint, reusing existing plumbing. Unlocks smarter per-job ceilings vs the flat live/research split. (Pairs with the provider-usage dashboard candidate.)
+
+## Recommended order
+
+#1 (today, one-liner) → #5 (cheap, answers a live pain point) → #3 → #2 (needs #4's streak signal to be most useful) → #4.

--- a/docs/superpowers/specs/2026-07-06-candidate-stock-page-perf.md
+++ b/docs/superpowers/specs/2026-07-06-candidate-stock-page-perf.md
@@ -1,0 +1,28 @@
+# Candidate: /stock/{ticker} performance package
+
+**Date:** 2026-07-06 · **Status:** DRAFT (candidate) · **Basis:** [COMPUTED] from code-health probe, file:line-verified. Confidence HIGH.
+**Effort:** S + M + S. Three compounding fixes on the highest-traffic read path.
+
+## 1. N+1 in the hottest report (Effort: S — biggest single latency win)
+
+`reports/single_stock.py:250-274` (`_build_intraday_profiles`) loops over `OI_MOVERS_INTRADAY_TOP_N` (10) rows and calls `intraday_repo.fetch_buckets(option_symbol, trade_date)` **once per row** — 10 sequential DB round-trips to `option_intraday_buckets` on every `/api/stock/{ticker}` and `/api/stock/{ticker}/runs/{run_id}` request (`api/routers/stock.py:44,90`). This backs the busiest page in the app.
+
+Fix: rewrite `fetch_buckets` to accept a batch of `(option_symbol, trade_date)` pairs → one `WHERE (option_symbol, trade_date) = ANY(...)` query. Cuts ~10 round-trips to 1 per stock-page load.
+
+## 2. No API connection pool (Effort: M)
+
+`api/deps.py:21-27` — `get_repo()` calls `psycopg.connect(settings.db_dsn())` fresh per request, closes in `finally`. Documented as intentional ("one conn per request") but that convention predates load: it pays full TCP + auth + `SET search_path` on every hit, including `/api/watchlist/spots` polled every 2.5s per open tab (`web/components/watchlist/LiveSpotsProvider.tsx:25`). Compounds with #1 across many tabs.
+
+Fix: `psycopg_pool.ConnectionPool` created once at app startup; `get_repo()` borrows/returns. Removes per-request connection setup; lowers Postgres connection churn.
+
+**Docker interaction:** under the container migration the api runs as its own service against `host.docker.internal:5432` — a pool matters *more* there (connection setup crosses the VM boundary). Do this before or with the Docker cutover.
+
+## 3. Report response cache (Effort: S)
+
+Compounding with #1: every `/api/stock/{ticker}` call rebuilds 10 intraday profiles from raw buckets even though `option_intraday_buckets` only changes on its own worker cadence (`worker/jobs/option_intraday_jobs.py`) — no caching keyed on `run_id`/last-write, so page revisits and adjacent polling redo full derivation each time.
+
+Fix: cache `assemble_single_stock_report` per `(ticker, run_id)` with short TTL / eviction, invalidated when `latest_run_id` changes. Pairs with #1 to make repeat views near-O(1) DB work within a scan cycle.
+
+## Order
+
+#1 (standalone win) → #3 (rides on #1's batched read) → #2 (broader, do with the Docker cutover).

--- a/docs/superpowers/specs/2026-07-06-docker-migration-design.md
+++ b/docs/superpowers/specs/2026-07-06-docker-migration-design.md
@@ -1,0 +1,110 @@
+# Argon Docker migration — design
+
+**Date:** 2026-07-06 · **Status:** DRAFT (design approved pending review)
+**Goal:** move the argon prod stack off launchd into Docker on the Mac mini, matching the xenon/apex house pattern (Colima, bridge network + `host.docker.internal`, host-native Postgres, GHCR images from `release.yml`, Watchtower auto-deploy). AI analysis (Codex/Claude CLI) is knowingly sacrificed in phase 1 and rewritten later; DeepSeek survives.
+
+## House pattern adopted (verified from xenon/apex)
+
+- **Runtime:** Colima VM on the mini (brew service). xenon default profile is 2 CPU / 2 GiB — argon adds ~12 containers, so resize to `colima start --cpu 6 --memory 8` (xenon docs already flag OOM risk at 2 GiB with 4 containers).
+- **Networking:** bridge, published ports, `extra_hosts: ["host.docker.internal:host-gateway"]` on every service. Never `127.0.0.1` for host resources ("127.0.0.1 is the container itself" — xenon runbook).
+- **Postgres:** stays host-native Homebrew. Containers reach it at `host.docker.internal:5432`, DB `option_wizard`, role `argon_app`. No data moves.
+- **Images:** built/pushed by `.github/workflows/release.yml` on `ubuntu-24.04-arm` (native arm64, no QEMU — apex pattern) to GHCR, tags `:X.Y.Z` + `:latest` (prereleases excluded from `:latest`).
+- **Deploy:** apex-style — compose file mirrored at `/opt/argon/compose.yml`, app services carry `com.centurylinklabs.watchtower.enable: "true"`. The single engine-wide Watchtower already in `/opt/xenon/compose.yml` polls GHCR every 60s and recreates on new `:latest`. **Do not add a second Watchtower.** This preserves argon's current auto-deploy UX (deploy-poller retires).
+- **Mini quirks:** hyphenated `docker-compose` (brew v5.1.3); SSH needs `PATH=/opt/homebrew/bin:$PATH`; Colima starts at user login only (auto-login tradeoff already accepted for xenon).
+
+## Images (2, not 4 — deliberate simplification vs xenon)
+
+xenon ships 4 near-identical Dockerfiles. Argon's api/workers/ws-consumer/migrator all run the same Python package, so:
+
+1. **`ghcr.io/moremeds/argon-app`** — multi-stage `python:3.13-slim`; uv static binary (`COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/`), `uv sync --frozen --no-dev --extra postgres` in builder, runtime copies `.venv` + `src` + `scripts/` + `db` migrations, installs `libpq5 ca-certificates curl tini`; tini is PID 1. No default CMD dependence — each compose service sets `command:`.
+2. **`ghcr.io/moremeds/argon-web`** — `node:22-alpine` multi-stage, Next.js **standalone output** (requires `output: 'standalone'` in `web/next.config.mjs`), `CMD ["node", "server.js"]`.
+
+## Compose topology (`/opt/argon/compose.yml`)
+
+| Service | command | ports | notes |
+|---|---|---|---|
+| `migrator` | `uv run bash scripts/migrate.sh` (in-process psycopg, no psql needed) | — | `profiles: ["migrate"]`, `restart: "no"` — never auto-runs on `up -d` (xenon pattern) |
+| `api` | `uv run uvicorn uw_scan.api.server:app --host 0.0.0.0 --port 8400` | `127.0.0.1:8400:8400` | bind 0.0.0.0 inside container (drop the launchd `--host 127.0.0.1`); publish loopback-only for host health checks |
+| `web` | node standalone | `3001:3001` | `NEXT_INTERNAL_API_BASE=http://api:8400`; `depends_on: api: service_healthy` |
+| `ws-consumer` | `uv run python -m uw_scan.worker.massive_ws_consumer` | — | see xenon-feed env below |
+| `worker-uw-0/1` | `uv run python -m uw_scan.worker.scheduler` | — | `UW_SCAN_WORKER_ROLE=uw`, `WORKER_INDEX=0/1` — explicit services, not replicas (per-instance INDEX) |
+| `worker-massive-0/1` | same | — | `ROLE=massive` |
+| `worker-ai-deepseek-0/1` | same | — | `ROLE=ai-deepseek` — HTTP + `DEEPSEEK_API_KEY`, container-safe |
+
+All: `restart: unless-stopped`, `env_file: [/opt/argon/.env]`, `extra_hosts`, watchtower label.
+
+Healthchecks: api = `curl -f http://localhost:8400/api/health`; web = `wget --spider -q http://127.0.0.1:3001/` (explicit IPv4 — alpine resolves `localhost` to `::1` first; xenon gotcha). Workers get a lightweight process-liveness check only (no HTTP surface).
+
+**12 containers total.** Phase 1 is a lift-and-shift of the current topology; consolidating 2×uw/2×massive into fewer processes is a later optimization, not now.
+
+## Env remaps (in `/opt/argon/.env`)
+
+| Var | launchd value | container value |
+|---|---|---|
+| `UW_SCAN_DB_HOST` | `127.0.0.1` / `100.66.147.98` | `host.docker.internal` |
+| `XENON_WS_URL` | `ws://127.0.0.1:8765` | `ws://host.docker.internal:8765` |
+| `XENON_WS_PORT_FILE` | `/tmp/xenon-ib-realtime.json` | `""` (empty disables — the port file is host-local and invisible in-container; xenon publishes 8765 fixed from its own compose, so discovery is unnecessary) |
+| `XENON_QUERY_API_URL` | `http://127.0.0.1:8321` | `http://host.docker.internal:8321` |
+| `APEX_API_URL` | Tailscale IP | `http://host.docker.internal:8322` (apex publishes 8322) |
+| `TRADE_INSIGHTS_AI_ENABLED` | true | **`false`** (Codex off) |
+| `TRADE_INSIGHTS_AI_CLAUDE_ENABLED` | true | **`false`** (Claude off) |
+| `TRADE_INSIGHTS_AI_DEEPSEEK_ENABLED` | true | true |
+
+Massive WS already passes `proxy=None` explicitly — container-safe, preserve. Env rotation still requires container recreate (`docker-compose up -d --force-recreate <svc>`) — same freeze-at-fork semantics as today.
+
+## Code changes required (one prep PR)
+
+1. **`_enforce_db_isolation`** (`config.py:71-73`): add `host.docker.internal` as a legal host for `option_wizard` (prod container) and `option_wizard_local` (local compose testing). Without this the tripwire refuses startup — hard blocker.
+2. **`web/next.config.mjs`**: `output: 'standalone'`.
+3. **Dockerfiles** (`docker/app.Dockerfile`, `docker/web.Dockerfile`) + repo-committed `docker-compose.yml` (dev/build template; the mini's real file is `/opt/argon/compose.yml`, mirrored like apex).
+4. **`release.yml`**: add `ghcr-push` job (matrix × 2 images, `ubuntu-24.04-arm`, after `publish`; prerelease tags excluded from `:latest`).
+5. **Docs**: new runbook `docs/runbooks/docker-deploy.md`; mark launchd sections of `docs/runbooks/release.md` superseded (xenon precedent: keep old scripts, mark runbook superseded).
+6. CHANGELOG entry — same PR.
+
+## What stays on the host
+
+- **Postgres 16/17 (Homebrew)** — untouched.
+- **`com.argon.backup` / `com.argon.backup-r2`** launchd agents — they pg_dump the host DB with host `pg_dump`; containerizing them buys nothing. Keep. (Requires keeping a repo checkout on the mini for the backup scripts, or inlining the R2 script path — keep the checkout; it's also the rollback escape hatch.)
+- **AI Codex/Claude workers** — retired in phase 1 (kill switches off, so no orphan queued rows: the API only enqueues rows for *enabled* providers). Interim fallback if Claude analyses are missed: their two launchd agents can keep running from the host checkout against the same DB — they're just Postgres pollers. Decision: **off by default**, hybrid only on request. Rewrite (API-based, e.g. Anthropic API runner like the DeepSeek shape) is a separate later project.
+- **`com.argon.deploy-poller`** — retired, replaced by Watchtower.
+
+## Deploy-semantics tradeoff (eyes open)
+
+Today's `macmini-prod.sh` has health-gated rollback (currently broken — it accepts HTTP 200 with `ok=false`; see ops-hardening candidate). Watchtower has **no rollback**: a bad release runs until someone pins the previous tag (`sed` image tag in `/opt/argon/compose.yml` + `docker-compose up -d`). Mitigations:
+
+- `release.yml` already gates publishing on the full verify suite (ruff, pytest incl. integration vs postgres:15, web build) — the class of "doesn't even boot" releases mostly can't publish.
+- Compose `depends_on: service_healthy` + `restart: unless-stopped` keeps a crash-looping api from taking web down silently; `docker ps` shows unhealthy state.
+- The ops-hardening candidate (webhook alert on `/api/health` `ok=false`) becomes the detection layer — recommend shipping it in the same window.
+
+## Cutover plan (phased, reversible)
+
+**Phase 0 — prep PR** (code changes above), CI green, merged. Local smoke: `docker-compose up` on the MacBook against `option_wizard_local` via `host.docker.internal`, run migrator, load `/`, `/api/health`.
+
+**Phase 1 — mini side-by-side setup** (no cutover yet):
+`colima stop && colima start --cpu 6 --memory 8` → GHCR `docker login` (same PAT approach as xenon) → create `/opt/argon/{compose.yml,.env}` → `docker-compose --profile migrate run --rm migrator` (idempotent, safe against live DB) → do **not** start app services yet.
+
+**Phase 2 — cutover (the double-writer moment):**
+1. `launchctl bootout gui/$UID` all `com.argon.*` app agents (api, web, massive-ws, 10 workers, deploy-poller) — **fully stopped before compose starts**; running both stacks double-writes and double-burns the UW budget (known gotcha from the xenon-WS migration).
+2. `docker-compose up -d` at `/opt/argon`.
+3. Verify: `/api/health` `ok=true` + `ws_consumer.active_source=xenon_ws` (proves host.docker.internal:8765 works) + one full scan cycle lands + freshness monitor green next morning + spot updates visible on `:3001`.
+
+**Phase 3 — retire:** after ~3 clean days, remove app plists from `~/Library/LaunchAgents` (keep backup plists). Update `config/services.list` docs.
+
+**Rollback at any point:** `docker-compose down` → `launchctl bootstrap` the plists back (they stay on disk through phase 2) → old stack resumes from the same DB. No data migration in either direction — DB never moved.
+
+## Verification checklist
+
+- [ ] tripwire: container boots against `host.docker.internal`/`option_wizard`; still refuses illegal pairs (unit test)
+- [ ] xenon WS primary connects from container; failover to massive still works (kill xenon relay, watch `active_source` flip)
+- [ ] xenon query API reachable (surface IV canary writes `iv_source_validation` rows with `source='ib'`)
+- [ ] UW scan cycle completes; budget governor counters sane (no double burn)
+- [ ] DeepSeek analysis end-to-end (enqueue via web → worker claims → result renders)
+- [ ] massive WS connects with no proxy env leakage
+- [ ] Watchtower recreates on a test prerelease→release publish
+- [ ] nightly backup still runs (host launchd, untouched)
+
+## Open items
+
+- Colima VM sizing is shared with xenon/apex containers — watch memory after cutover; workers are idle-poll APScheduler processes (~100-150 MB RSS each expected).
+- Postgres version drift: argon backup plist pins `postgresql@16`, xenon/apex docs say host runs `@17` — confirm which instance actually serves `option_wizard` on the mini before phase 1 (affects only the backup plist's pg_dump path, not the containers).
+- AI rewrite (Codex/Claude → API-based runners) — separate spec, later.

--- a/docs/superpowers/specs/2026-07-06-quant-technicals-page-design.md
+++ b/docs/superpowers/specs/2026-07-06-quant-technicals-page-design.md
@@ -1,0 +1,41 @@
+# Quant Technicals tab — design
+
+**Date:** 2026-07-06 · **Status:** DRAFT (candidate) · **Effort:** M–L
+**Origin:** user idea (sigmoid price model, MA slope/curvature, std of price-change changes), designed out into a full tab.
+
+## What it is
+
+A new `Technicals` tab on `/stock/[ticker]` (fits the existing tab architecture in `web/components/stock/tabs/`), not a standalone page. Enhanced, dimensionless, cross-ticker-comparable takes on RSI/MACD/MA — everything is a z-score or ratio so a reading on NVDA means the same as on KO.
+
+## Data path (no new external plumbing)
+
+- **Bars:** apex `/bars/{ticker}` over Tailscale (`http://100.66.147.98:8322`, verified live 2026-07-06 — daily OHLC deep history, plus baseline `/indicators/{ticker}?indicator=rsi` returning value+zone series). This is the sanctioned price source per the standing apex-REST memory — no direct lake reads.
+- **Compute:** new `cards/technicals.py` (pure functions on bar arrays, `Decimal` for prices, numpy for the fits).
+- **Persist:** new `technical_daily` table (per the persist-everything rule) — one snapshot row per (ticker, date) with all sub-scores. This is what lets the composite later be marked-out against forward returns in the backtest harness for free.
+- **Serve:** `/api/stock/{ticker}/technicals` → typed model → `gen:types`.
+- **Refresh:** nightly worker job (`worker/jobs/technical_daily_refresh.py`) over the watchlist; on-demand compute for cache misses at request time.
+
+## The five panels
+
+1. **Sigmoid trend-maturity fit** (core idea). Fit logistic `L/(1+e^(-k(t-t0)))` to the price segment since the last swing pivot. Output: S-curve position `s = k(t_now - t0)` → phase (early / accelerating / decelerating / saturated), steepness `k`, and **R² vs a plain linear fit**. The sigmoid read only counts when it beats linear — otherwise the panel says "no S-curve structure." This guard is what keeps it honest (a sigmoid can fit anything if you don't compare).
+2. **MA kinematics.** Slope (velocity) and curvature (acceleration) of EMA20/50/200 via short-window regression, **normalized by ATR(14)** → dimensionless. t-stat of the slope replaces crossover folklore; alignment score across the three EMAs.
+3. **Return-distribution panel** (the "std of price-change changes" idea). 20d realized σ z-scored vs its own 252d history; vol-of-vol (std of Δσ); 60d skewness/kurtosis; second-difference std as a "jerkiness" gauge.
+4. **RSI enhanced.** RSI(14) z-scored against its own 252d distribution; RSI slope; algorithmic pivot-based divergence detector (price HH + RSI LH, scored by the gap).
+5. **MACD enhanced.** Histogram normalized by ATR; its first derivative; cross-sectional percentile across the watchlist.
+
+## Composite
+
+Each panel → one bounded z → a single trend-quality score, with sub-scores always visible (never a black box). Because `technical_daily` snapshots persist, after ~60 sessions the composite graduates from display to a testable signal via the existing walk-forward harness — no extra work to earn that option.
+
+## Build order
+
+1. `cards/technicals.py` + a `demo()` self-check (sigmoid-beats-linear on a synthetic S-curve, flat on noise).
+2. `technical_daily` migration + storage repository (standalone, per storage/CLAUDE.md).
+3. API model + route + `gen:types`.
+4. Nightly worker job.
+5. Web tab (hand-rolled SVG, Argon dark theme; reuse existing chart primitives).
+
+## Open items
+
+- apex bar history depth per ticker (saw AAPL back to 2024-07 in the probe — confirm coverage for the full watchlist; short-history names weaken the 252d z-scores).
+- Swing-pivot detection algorithm for panel 1's segment start (ATR-based zigzag is the lazy default).


### PR DESCRIPTION
## Summary

Seven brand-new improvement candidates from a 4-agent probe sweep (code-health, underused-data/alpha, web-gaps, ops/reliability), each saved as an individually-actionable doc — plus the separately-requested Docker migration design. Docs only; no code touched.

## Candidates

| Type | Doc |
|---|---|
| Docker migration (launchd → Colima, apex-style Watchtower deploy) | `docs/superpowers/specs/2026-07-06-docker-migration-design.md` |
| Quant Technicals tab (sigmoid fit, MA kinematics, enhanced RSI/MACD) | `docs/superpowers/specs/2026-07-06-quant-technicals-page-design.md` |
| Deploy-gate fix + ops-hardening (alerting, R2 staleness, per-job budget) | `docs/superpowers/specs/2026-07-06-candidate-ops-hardening.md` |
| /stock perf (N+1 batch, conn pool, report cache) | `docs/superpowers/specs/2026-07-06-candidate-stock-page-perf.md` |
| Backtest/provider-usage/benchmark dashboards | `docs/superpowers/specs/2026-07-06-candidate-observability-dashboards.md` |
| Alpha: dealer charm/vanna per-strike positioning (unvalidated) | `docs/research/2026-07-06-candidate-charm-vanna-positioning.md` |
| Alpha: GEX regime-persistence (unvalidated, testable today) | `docs/research/2026-07-06-candidate-gex-regime-persistence.md` |

Index with mastermind sequencing: `docs/research/2026-07-06-candidate-index.md`

## Notes

- Excludes everything already in issues/worktrees/the next-work shortlist.
- Engineering candidates are file:line-verified; the two alpha candidates are tagged UNVALIDATED hypotheses needing a validation trace before any build.
- The ops-hardening deploy-gate fix and the Docker migration partly collide (Watchtower removes the launchd deploy path) — flagged inside both docs.