### PR TITLE
fix(deploy): health-gate checks ok=true, not just reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deploy health-gate now checks `ok`, not just reachability.**
+  `scripts/deploy/macmini-prod.sh` gated deploy success (and auto-rollback) on
+  `curl -fsS` against `/api/health` — but that endpoint returns HTTP 200 in every
+  branch, including `ok=false` (db down, missed scans, record-coverage collapse), so
+  a broken release passed the gate clean and rollback never fired. `check_url` now
+  takes an optional jq filter; the api gate and the post-rollback verify both require
+  `.ok == true`. (jq already a deploy dep via `macmini-deploy-poller.sh`.)
+
 ### Added
 
 - **SVI surface-fit feasibility + residual edge test (research spike).**

--- a/scripts/deploy/macmini-prod.sh
+++ b/scripts/deploy/macmini-prod.sh
@@ -101,12 +101,23 @@ done < config/services.list
 # ---------- Health checks ----------
 step "Health checks"
 sleep 5
+# check_url URL NAME [JQ_FILTER]
+# Reachability check by default. With JQ_FILTER, the body must also satisfy it —
+# needed because /api/health returns HTTP 200 even when ok=false (db down, missed
+# scans, record-coverage collapse), so a plain -fsS gate can never trip rollback.
 check_url() {
-  local url="$1" name="$2"
+  local url="$1" name="$2" filter="${3:-}"
   for _ in {1..30}; do
-    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
-      say "✓ $name $url"
-      return 0
+    if [[ -z "$filter" ]]; then
+      if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
+        say "✓ $name $url"
+        return 0
+      fi
+    else
+      if curl -fsS --max-time 2 "$url" 2>/dev/null | jq -e "$filter" >/dev/null 2>&1; then
+        say "✓ $name $url"
+        return 0
+      fi
     fi
     sleep 1
   done
@@ -114,7 +125,7 @@ check_url() {
   return 1
 }
 
-if check_url "http://127.0.0.1:8400/api/health" "api" \
+if check_url "http://127.0.0.1:8400/api/health" "api" '.ok == true' \
    && check_url "http://127.0.0.1:3001"      "web"; then
   step "Deploy OK: $TAG ($COMMIT)"
   printf '%s  %s  %s  OK\n' "$(date -u +%FT%TZ)" "$TAG" "$COMMIT" >> "$REPO_ROOT/logs/deploy.log"
@@ -134,7 +145,7 @@ while IFS= read -r label; do
   launchctl kickstart -k "gui/$UID/${label}"
 done < config/services.list
 sleep 5
-check_url "http://127.0.0.1:8400/api/health" "api(rollback)" || die "rollback ALSO failed — manual intervention required"
+check_url "http://127.0.0.1:8400/api/health" "api(rollback)" '.ok == true' || die "rollback ALSO failed — manual intervention required"
 check_url "http://127.0.0.1:3001"        "web(rollback)" || die "rollback ALSO failed — manual intervention required"
 printf '%s  %s  %s  ROLLBACK→%s\n' "$(date -u +%FT%TZ)" "$TAG" "$COMMIT" "$PREV_TAG" >> "$REPO_ROOT/logs/deploy.log"
 die "deploy of $TAG failed; rolled back to $PREV_TAG"


### PR DESCRIPTION
## Summary

The mini's deploy health-gate could never trip rollback. `scripts/deploy/macmini-prod.sh` gated deploy success (and auto-rollback) on `curl -fsS` reachability against `/api/health` — but that endpoint returns **HTTP 200 in every branch, including `ok=false`** (`api/routers/health.py:359` db-down, `:636` record-coverage collapse, `:659`/`:674` missed scans). A release that broke the DB or collapsed coverage passed the gate clean; the one automated safety net checked the wrong signal.

From candidate #1 in the 2026-07-06 ops-hardening sweep (`docs/superpowers/specs/2026-07-06-candidate-ops-hardening.md`).

## Change

- `check_url` gains an optional third arg — a jq filter. When present, the response body must satisfy it, not just return 2xx.
- The api gate and the post-rollback verify both now require `.ok == true`.
- Web gate (`:3001`) stays a plain reachability check — no health JSON there.
- `jq` is already a deploy dependency (`macmini-deploy-poller.sh` uses it).

## Verification

- Gate logic tested against 4 bodies: `ok:true`→ALLOW; `ok:false`/garbage/empty→BLOCK. All pass.
- `bash -n scripts/deploy/macmini-prod.sh` clean.

## Notes

- Partly overlaps the pending Docker migration (Watchtower would retire the launchd deploy path). Until that lands, this is the only automated deploy safety net — worth fixing now. CHANGELOG entry rides this PR.