### PR TITLE
docs(research): unified candidate master menu + resolution audit

### DIFF
--- a/docs/research/2026-07-04-next-work-shortlist.md
+++ b/docs/research/2026-07-04-next-work-shortlist.md
@@ -1,0 +1,92 @@
+# Next-Work Shortlist & In-Flight Inventory — 2026-07-04
+
+A revisitable menu of what to build next in argon, merging two sources:
+
+1. **argon-native backlog** — existing GitHub issues.
+2. **radon → argon adoption candidates** — from the radon feature probe
+   (`docs/research/2026-07-03-radon-feature-probe.md`), which ranked 5 radon
+   capabilities worth porting into argon.
+
+Plus a full inventory of the **in-flight / parked worktrees** so nothing gets
+lost again.
+
+> **Key fact that reframes the plan:** the radon-adoption list's item #2 — the
+> reusable walk-forward backtest harness — was **shipped this session as PR #210**
+> (`src/uw_scan/backtest/`). So the adoption plan is already **1-of-5 done**. The
+> highest-leverage next move is therefore either *cashing in* that harness (#163)
+> or taking the next-lowest-lift adoption item (SVI surface).
+
+---
+
+## The choice menu
+
+### Group A — argon-native backlog (GitHub issues)
+
+| # | Item | Value | Effort | Readiness |
+|---|---|---|---|---|
+| **A1** | **#163 — VRP kill-switch backtest** | ★★★★★ Tests tail-risk on the *only* validated edge (SPX bull-put spread, Sharpe ~1.65) using the harness just merged (#210). Fully spec'd: 3 gate designs (high-VIX cap / drawdown breaker / vol-floor) + a size-down control + fixed benchmarks (iter-3 base 1.68, SPY B&H 0.62). | M | ✅ ready |
+| A2 | #180 — mega-cap TAPE coverage bug | ★★ 6 highest-traffic names (TSLA/NVDA/MSFT/GOOGL/META/AVGO) have permanently-blank TAPE column. Cosmetic, no analytical dependency. | S–M | ⚠️ runtime-gated — needs a live instrumented single-ticker run after the UW daily-429 reset to root-cause |
+| A3 | #190 — market-tide history backfill | ★★ Enabling infra: unlocks regime/sentiment backtests. | M | ✅ ready |
+| A4 | #167 — unify VRP harvest + surface + regime read | ★★ Research consolidation follow-ups. | M | ✅ ready (research) |
+
+**Do NOT build (issue text itself says so):**
+- **#202** (build `vrp_leg_nbbo` recorder) — feeds the single-name condor, which is **PARKED, no edge**. The issue says confirm a reason before investing. Skip.
+- **#207** (rr_25d 30d-CM tenor fix) — the issue says "**do NOT build expecting better P&L** … ~0 rank-IC." Data-quality cosmetics only.
+
+### Group B — radon → argon adoption (from the 2026-07-03 probe)
+
+| # | Item | Value | Effort | Readiness |
+|---|---|---|---|---|
+| ~~R2~~ | ~~Reusable backtest / walk-forward harness~~ | — | — | ✅ **DONE — shipped as PR #210** (`src/uw_scan/backtest/`) |
+| **R1** | **SVI no-arb surface fit → mispricing signal** | ★★★★ The probe's own #1. argon already banks the full-chain IV grid nightly (`worker/jobs/option_surface_capture.py` → `option_surface_grid_daily`) but uses it *only* as an IB freshness canary. SVI (Gatheral raw-SVI per expiry, butterfly/calendar constraints) turns the dead table into a rich/cheap edge. **No new data source.** radon ref: `scripts/vol_surface.py`. | M | ✅ ready |
+| R3 | Alert rules engine + push notifications | ★★★ Turns pull-only signals (scanner, VRP-z, GEX/CRI/VCG flips) into push (Pushover/Discord). No new upstream data — a rule-eval job + notification sink on existing signals. radon ref: `scripts/alerts/evaluate.py`. | M | ✅ ready |
+| R4 | Polymarket odds vs options-implied-prob divergence | ★★★ Net-new cross-market edge; same fetcher→storage→router shape as Gold Compass's FRED/GPR/CFTC blend. radon ref: `scripts/clients/polymarket_client.py`. | M–L | ⚠️ net-new data source |
+| R5 | Order-book imbalance / microprice strip | ★★★ radon's most differentiated capability, but argon has **no L2 depth feed** — xenon's bridge only gives single-contract greeks + top-of-book spot. Needs new xenon-side plumbing first. radon ref: `scripts/microstructure.py`. | L+ | ❌ blocked on xenon |
+
+**Explicitly skipped in the probe** (assume argon executes trades / holds a portfolio, which it deliberately does not): paper-trading/shadow-fill, IB whatIf margin preview, portfolio correlation risk-budget, node-graph workflow composer.
+
+### Other raw radon candidates (surfaced, not carried into the top 5)
+- X/Twitter sentiment via xAI live-search (`scripts/fetch_x_xai.py`) → could feed Trade Insights AI / scanner.
+- LLM Token Expenditure Index (`scripts/llm_token_index.py`) → AI-cost trend as a macro-regime input; cheap, novel.
+- OAuth-against-consumer-LLM-subscription auth — idea-stage in radon, no code.
+- VPIN / toxic-flow — deferred inside radon too (needs its own T&S tape).
+
+---
+
+## Recommendation
+
+Two genuinely good leads:
+
+- **Compound what you just built → A1 (#163).** Tightest value/effort ratio on the
+  board. You paid for the harness; #163 is the payoff, and it interrogates the tail
+  risk of the one strategy with real capital behind it. argon-native, spec'd, ready.
+- **Keep executing the radon-adoption plan → R1 (SVI surface).** Your own top-ranked
+  adoption item, lowest-lift, no new data, activates a table you already fill nightly.
+
+Everything else is infra/ops (A3, R3), blocked (A2, R5), or a bigger new-data lift (R4).
+
+---
+
+## In-flight / parked worktree inventory
+
+State as of 2026-07-04. All work is now committed (loose-file rescue done this
+session — 2 worktrees were entirely uncommitted and are now on branches + draft PRs).
+
+| Worktree / branch | Commit | Pushed? | PR | Status & revisit trigger |
+|---|---|---|---|---|
+| `fix/skew-tab-demote` | `9cf5e12a` | ✅ | **#208 OPEN, CI green** | **Ready to merge.** Demotes non-tradable Skew verdict to a positioning descriptor + research trace. Free win. |
+| `misc/alpha191-short-swing-scan` | `40e1dcef` | ✅ | **#212 draft** | Preserved short-swing equity research sweep (scripts + persisted traces under `docs/research/alpha191-short-swing/`). Research, not merge-bound. |
+| `misc/uw-historical-alpha-scan` | `cda87173` | ✅ | **#213 draft** | WIP UW historical-alpha backfill feature (today-dated). **Pre-merge blocker:** migrations numbered 095/096 collide with main's `095_backtest_harness.sql` → renumber to **096/097** before merge. |
+| `feat/darkpool-points` | `bc9190ea` | ❌ local only | — | PARKED. "Buy-pressure leads price ~4d" is mostly market beta; OOS persistence n.s. after market-neutralization. Narrow alpha core survives in ANET/NVDA/COIN/PLTR/TSM. **Revisit trigger: re-run `darkpool_oos_markout.py` on ≥90 fresh live days (~late Aug 2026)** — don't re-slice current data. |
+| `misc/momentum-moments` | `30287f75` | ❌ local only | — | PARKED. Barroso–Santa-Clara risk-managed momentum. Scaler validated (Sharpe 0.42→0.83, kurt 12.9→3.0) but **no ready-to-trade strategy yet** — needs more constituent history argon doesn't have. Resume options in memory `project_momentum_moments`. |
+| `chore/strategic-master-plan` | `73b8d3b5` | ❌ (empty) | — | Empty scaffold, no work. Remove if not needed. |
+
+**Stale open argon PRs (cleanup candidates):** #93 (`vcg-positioning-docs`, May 27, docs) and #97 (`canary-wf5-fwd-return-probe`, May 28, research) — both green but likely superseded (canary v2-A was STOP'd). Decide merge-or-close.
+
+---
+
+## Source pointers
+- radon feature probe: `docs/research/2026-07-03-radon-feature-probe.md`
+- radon repo: `~/projects/radon` (feature catalog `docs/features.md`; tracker is `tasks/*.md`, no gh issues)
+- argon backtest harness (shipped R2): `src/uw_scan/backtest/` + `docs/superpowers/plans/2026-07-03-backtest-walkforward-harness.md`
+- #163 spec detail: the issue body (3 gate designs + reproduce via `scripts/research/vrp_robustness_run.py` → `iter5-killswitch.csv`)

--- a/docs/research/2026-07-07-brandnew-improvement-candidates.md
+++ b/docs/research/2026-07-07-brandnew-improvement-candidates.md
@@ -1,0 +1,96 @@
+# Brand-New Improvement Candidates — 2026-07-07 system scan
+
+Five-probe scan (data-assets, alpha ideation, code health, perf/ops, product/UX)
+looking for candidates **not** already on the backlog / shortlist / worktrees.
+Exclusions honored: all open issues (#163/167/180/190/202/203/207/118/90/89/86),
+SVI fit, alerts engine, Polymarket, L2 book, DeepSeek tab, Docker migration,
+every folded/parked research line.
+
+Filed as GitHub issues: #223 (pick 1), #224 (pick 4), #225 (pick 5), #226 (pick 2), #227 (pick 3).
+
+## The 5 picks (decision)
+
+### 1. Trade-lifecycle layer: positions, P&L attribution, review — close the loop on the live edge
+The system is strong at signal computation + persistence and has **nothing** for
+tracking/review. `vrp_macro_entry` banks a full markout series (8 marks/day × 30d
+per captured entry) and **no router or UI reads it back** — capture-and-forget.
+No "list my entries", no P&L curve, no `/today` briefing, no regime replay.
+- Build: read-only router over `vrp_macro_entry` → Positions panel (open entries,
+  per-entry markout/P&L, expiry status) → then a `/today` briefing page composing
+  regime state + VRP signal + open entries + scanner hits + health warnings.
+- Why it compounds: it's the substrate #163 (kill-switch) needs, the render target
+  the future alerts engine needs, and a reusable entry→marks→P&L pattern for every
+  future signal. Sits directly on the only validated edge (Sharpe ~1.65).
+- Effort M. Pure read-composition of existing tables.
+
+### 2. Implied-correlation / dispersion richness gate on the validated index VRP edge
+Index IV richness = vol premium + **correlation premium**. The macro edge sizes only
+on vrp-z (IV−RV level); implied-corr richness is a second, near-orthogonal axis.
+All data in hand: VIX / `vol_index_daily`, `option_surface_grid_daily` (SPX/QQQ),
+component IVs in `vrp_daily`/`stock_analytics_daily`, pairwise realized corr from
+`daily_ohlc`, backtest via the #210 harness.
+- First falsification (~1 day): rolling implied-corr proxy
+  ρ ≈ (σ²_idx − Σw²σ²)/(Σwᵢwⱼσᵢσⱼ) from VIX vs top-10 component IVs; z-score;
+  test whether index short-vol P&L is monotone in ρ-z buckets. Not monotone → kill.
+- Prior MED. Extension of the one working edge, untouched hypothesis space,
+  literature-backed (Driessen–Maenhout–Vilkov dispersion premium).
+
+### 3. Flow-signal verdict: do UW aggressor/vanna/charm signals beat RV−IV? (systematic residualization)
+Goyal–Saretto: 46 option characteristics collapse to ~1 factor ≈ RV−IV, all dead
+net of 30% quoted spread — but their set contains **no aggressor-tagged flow, no
+GEX/vanna/charm**. Whether UW-native signals survive residualization against RV−IV
+is the one question only argon can answer, and it's unbuilt. Data:
+`matrix_state_snapshots`, `flow_events`, `vrp_daily`, ~12mo × ~100 names.
+- First test: residualize 3-day aggressor premium-imbalance (+ net vanna/charm)
+  against RV−IV cross-sectionally; decile-sort fwd 1/5-day returns; report net of
+  30% spread vs the RV−IV-only spread.
+- Prior LOW–MED that flow survives, but **highest decision value on the board**:
+  a clean negative prunes the entire positioning-signal stack argon is built on;
+  a positive is a new alpha axis. Either way it recalibrates the roadmap cheaply.
+
+### 4. Positioning intelligence: exploit `uw_positioning` (banked daily, read by nothing but an LLM prompt)
+Migration 065; refreshed daily; contains short interest %float, days-to-cover,
+**borrow fee/rebate rates**, analyst counts + targets, institutional counts/value,
+insider buy/sell/net flow, earnings-reaction base rates, next ER date. Sole reader:
+`api/routers/trade_insights.py:351` (prompt stuffing). No endpoint, panel, or signal.
+- Build: stock-page Positioning card + watchlist screener (squeeze-risk:
+  si_pct_float × days_to_cover × fee-rate spike; insider net-flow tilt; analyst
+  implied upside; pre-ER reaction base rate). Optional cross-sectional signal
+  research on top (borrow-fee spikes are a documented return predictor).
+- Value HIGH / effort LOW–MED — the data is already there and fresh. New
+  information axis orthogonal to the dead price-pattern space. Deeper cut: parse
+  the 13F/insider `raw_jsonb` already fetched-then-discarded.
+
+### 5. UW same-day fetch dedupe cache — attack the binding constraint
+Budget is chronically exhausted by 08:00 ET, and 6+ jobs independently re-fetch
+the same slow-moving contract/greek-exposure data per ticker per day
+(`option_surface_capture`, `cockpit_daily_snapshot`, `flow_data_refresh`,
+`skew_swing_greeks`, `vrp_macro_entry`, full_scan `pipeline.py`). The new budget
+governor gates spend but does not dedupe.
+- Build: a `(ticker, endpoint, as_of_date)` memo layer in `sources/uw.py`
+  (DB-backed or in-proc per worker-day) consulted before `fetch_option_contracts`
+  / `fetch_greek_exposure_by_expiry`.
+- Why it compounds: every reclaimed request is research budget — this directly
+  unblocks the parked alpha-probe line and prevents #180-style silent gaps.
+  Effort M.
+
+## Runner-ups (worth doing, not top-5)
+- **config.py → pydantic-settings** (893 lines, 127 manual `os.environ.get` dup of
+  139 declared fields) + a **live test-isolation bug found by the probe**:
+  `tests/unit/test_settings_option_surface.py::test_settings_reads_option_surface_flags`
+  fails in the full suite on this machine (`.env.local` Tailscale URL leaks past the
+  expected default; order-dependent). Fix the bug regardless.
+- **scheduler.py declarative job table** (1842 lines, 63 add_job calls, imperative).
+- **Sector-neutral single-name short-vol basket** (cash in the validated
+  `vrp_harvest_by_sector` finding via the harness; condor died on execution, not premium).
+- **Backtest-sweep browser** (`backtest_sweep_*` tables have zero read surface).
+- **`option_intraday_buckets` retention job** (unbounded append, ~400k rows/day at
+  full coverage); **QueueProgress `document.hidden` guard**; **remove unused `d3` dep**;
+  **`api/routers/regime.py` at 1057 lines** needs a split plan.
+
+## Sequencing view
+#5 (budget dedupe) multiplies all future data-hungry work → do early.
+#1 (lifecycle) and #4 (positioning card) are product wins with zero new data.
+#3 is the cheapest big-information research; #2 is the best new-alpha bet.
+
+Reproduce: 5 parallel probe agents, 2026-07-07 session (this doc is the trace).

--- a/docs/research/2026-07-07-candidate-master-menu.md
+++ b/docs/research/2026-07-07-candidate-master-menu.md
@@ -1,0 +1,103 @@
+# Candidate Master Menu — unified (2026-07-07)
+
+Single ranked menu merging the **2026-07-06 sweep** (`2026-07-06-candidate-index.md`, 6 picks)
+and the **2026-07-07 sweep** (`2026-07-07-brandnew-improvement-candidates.md`, 5 picks →
+issues #223–#227). Supersedes both split indexes as the thing to revisit. Uniform schema
+per row; full detail in the source docs / issue bodies (Anchor column).
+
+**Class:** alpha · product · perf · ops · refactor · new-page
+**Status:** LIVE (open) · PARTIAL · DONE · KILLED · GATED (falsify first)
+
+> **Resolution audit (2026-07-07):** C8.1 deploy-gate = **DONE** (#222, c075d8c — gate now `.ok == true`).
+> C11 GEX = **DONE/killed** (#228 committed the negative-result doc). C2 = **PARTIAL** (per-cohort
+> entry read endpoints exist in `regime.py`; no positions list / P&L / `/today`). All others confirmed
+> unbuilt.
+
+## Master table
+
+| ID | Title | Class | Effort | Value | Status | Anchor |
+|----|-------|-------|--------|-------|--------|--------|
+| C1 | UW same-day fetch dedupe cache | ops | M | ★★★★★ | LIVE | #225 · `sources/uw.py` |
+| C2 | Trade-lifecycle layer (positions/P&L/`/today`) | product | M | ★★★★★ | PARTIAL | #223 · `vrp_macro_entry` |
+| C3 | Exploit `uw_positioning` (card + screener) | product | S–M | ★★★★ | LIVE | #224 · migration 065 |
+| C4 | Flow-vs-RV−IV residualization verdict | alpha | S–M | ★★★★ | LIVE | #227 · `matrix_state_snapshots` |
+| C5 | Implied-corr / dispersion gate on VRP edge | alpha | M | ★★★★ | GATED | #226 · `#210` harness |
+| C6 | Charm/vanna per-strike positioning + term slope | alpha | M | ★★★ | GATED | `2026-07-06-candidate-charm-vanna-positioning.md` |
+| C7 | `/stock/{ticker}` perf (N+1, pool, cache) | perf | S+M+S | ★★★★ | LIVE | `...-stock-page-perf.md` |
+| C8 | Ops-hardening (alert sink, staleness, agg, budget attr) | ops | S→M | ★★★ | PARTIAL | `...-ops-hardening.md` · #222 |
+| C9 | Observability dashboards (backtest/provider/benchmark) | new-page | M | ★★★ | LIVE | `...-observability-dashboards.md` |
+| C10 | Quant Technicals tab | new-page | M–L | ★★★ | LIVE | `...-quant-technicals-page-design.md` |
+| C11 | GEX regime-persistence | alpha | — | — | DONE (killed) | `2026-07-06-gex-regime-persistence-result.md` · #228 |
+
+## Per-candidate detail (uniform)
+
+### C1 — UW same-day fetch dedupe cache · ops · M · ★★★★★ · LIVE
+- **What:** 6+ jobs (surface capture, cockpit, flow refresh, skew greeks, vrp entry, full_scan) independently re-fetch identical per-ticker contract/greek data daily; governor gates spend but doesn't dedupe. Add a `(ticker, endpoint, as_of_date)` memo in `sources/uw.py`.
+- **Why:** budget dies by 08:00 ET; every reclaimed request becomes research budget → unblocks parked alpha-probe, prevents #180 gaps.
+- **Next:** build the memo layer before `fetch_option_contracts`/`fetch_greek_exposure_by_expiry`. Do early — multiplies all data-hungry work.
+
+### C2 — Trade-lifecycle layer · product · M · ★★★★★ · PARTIAL
+- **Already there:** `regime.py:541/586/587` reads the **current cohort's** entry + quotes (`fetch_vrp_macro_entry[_quotes]`) for the MacroShortVol card. That's a single-entry preview, not a portfolio.
+- **Still missing:** a "list ALL my entries" positions router, per-entry markout/P&L curve, expiry status, and the `/today` briefing page (no `web/app/today`).
+- **Why:** substrate #163 needs; render target future alerts need; reusable entry→marks→P&L for every signal.
+- **Next:** generalize the existing per-cohort read into a list+P&L router, then `/today`.
+
+### C3 — Exploit `uw_positioning` · product · S–M · ★★★★ · LIVE
+- **What:** migration 065 (SI %float, days-to-cover, borrow fee/rebate, analyst targets, insider net flow, ER base rates) read only by the LLM prompt (`trade_insights.py:351`). Build Positioning card + squeeze/insider/analyst screener.
+- **Why:** fresh data, zero new fetch; orthogonal to the dead price-pattern space.
+- **Next:** card + screener; deeper cut parses discarded 13F/insider `raw_jsonb`.
+
+### C4 — Flow-vs-RV−IV residualization verdict · alpha · S–M · ★★★★ · LIVE
+- **What:** Goyal–Saretto collapse 46 option chars to ~RV−IV (all dead net of costs) but have NO aggressor flow / vanna / charm. Residualize argon's flow signals against RV−IV cross-sectionally, net of 30% spread.
+- **Why:** highest decision value on the board — a clean negative prunes the whole positioning stack; a positive is a new axis.
+- **Next:** residualize 3-day aggressor imbalance (+ net vanna/charm) vs RV−IV; decile-sort fwd 1/5d returns. Cheapest big-information research.
+
+### C5 — Implied-corr / dispersion gate · alpha · M · ★★★★ · GATED
+- **What:** index IV richness = vol premium + correlation premium; the edge sizes only on vrp-z. Add implied-corr richness as a second orthogonal axis. All data in hand.
+- **Why:** best new-alpha bet — extends the one working edge; literature-backed (dispersion premium).
+- **Next:** ~1-day falsification — implied-corr proxy z-score, is short-vol P&L monotone in its buckets? Not monotone → kill.
+
+### C6 — Charm/vanna per-strike positioning + term slope · alpha · M · ★★★ · GATED
+- **What:** `option_surface_grid_daily` banks per-strike vanna/charm nightly, read by nothing. Net charm → expiry-week delta drift; net vanna → hedging direction on IV moves. Bundle durable ATM term-structure slope.
+- **Why / caveat:** per-strike history unrecoverable — urgency to start banking. BUT **C4 gates this** — don't accrue the derivation job until flow-beats-RV−IV survives; C11's result already leans skeptical on the whole family. NOT SVI, NOT skew (both closed-negative).
+- **Next:** run C4 first; if it survives, C6 becomes the build.
+
+### C7 — `/stock/{ticker}` perf · perf · S+M+S · ★★★★ · LIVE
+- **What:** (1) N+1 — `_build_intraday_profiles` calls `fetch_buckets` 10× per load → batch `WHERE (option_symbol, trade_date) = ANY(...)`. (2) No conn pool (`api/deps.py`) → `psycopg_pool`. (3) Report cache per `(ticker, run_id)`.
+- **Why:** busiest read path; `/watchlist/spots` polled every 2.5s per tab.
+- **Next:** N+1 batch is the standalone win; conn pool rides the Docker cutover.
+
+### C8 — Ops-hardening · ops · S→M · ★★★ · PARTIAL
+- **DONE:** (1) deploy health-gate now checks `.ok == true` — shipped #222 / c075d8c (`macmini-prod.sh:128,148`). Confirmed.
+- **Still open:** (2) alert sink (Pushover/Discord), (3) R2 lake-staleness on `/api/health`, (4) job-failure aggregation via `EVENT_JOB_ERROR`, (5) per-job UW budget attribution (data exists, API hides it).
+- **Next:** parts 2–5; all survive Docker.
+
+### C9 — Observability dashboards · new-page · M · ★★★ · LIVE
+- **What:** 3 built-but-unwired backends — Backtest Sweep Explorer (`backtest_sweep_*`, no router/page), Provider-Usage/budget gauge (`provider_usage.py`, 4 endpoints no UI), Pipeline-Benchmark scorecard (`benchmark.py`, no page).
+- **Why:** one web sprint surfaces finished work; natural home for #163 results.
+- **Next:** thin routers + pages. Backtest explorer first (pairs with C2).
+
+### C10 — Quant Technicals tab · new-page · M–L · ★★★ · LIVE
+- **What:** new `/stock/[ticker]` tab, all dimensionless. 5 panels: sigmoid trend-maturity (must beat linear R²), MA kinematics (ATR-norm t-stat), return-distribution, RSI/MACD enhanced. Composite z. Data via apex `/bars` over Tailscale; persists `technical_daily` → graduates to a testable signal after ~60 sessions.
+- **Next:** confirm apex bar-history depth across watchlist; your idea, already designed.
+
+### C11 — GEX regime-persistence · alpha · KILLED
+- **Verdict (tested 2026-07-07):** SPY n=31, short-gamma |fwd ret| 0.82% vs 0.50% but boot95 CI kisses 0 (p=0.41) AND vol-clustering confounded; trend-vs-reversal refuted (0.53 vs 0.55).
+- **Next:** keep banking the label; re-test at n≈90 (~2026-09-01) vol-normalized. Do NOT build now.
+
+## Sequencing (unchanged from the two source docs)
+1. **C1** (dedupe) — multiplies everything downstream, do first.
+2. **C4** (flow verdict) — cheapest big-information research; **gates C6**.
+3. **C2 / C3** — product wins, zero new data, sit on the validated edge.
+4. **C5** — best new-alpha bet (1-day falsify).
+5. **C7** — biggest latency win; conn-pool rides Docker.
+6. **C8** — verify #222 first; then ops parts 2–5.
+7. **C9 / C10** — web sprints once backends/data are proven.
+- **C11** parked. **C6** blocked on C4.
+
+## Overlap notes
+- **C4 gates C6** — same signal family (does flow/vanna/charm beat RV−IV?). Run C4's residualization before accruing C6's derivation job.
+- **C8 part 1 likely == #222** — verify before rebuilding.
+- **C9 backtest explorer + C2 lifecycle** share the `/backtest`+positions surface; build adjacent.
+
+Reproduce: this doc consolidates the two source sweep docs; no new probing.


### PR DESCRIPTION
## What

Consolidates the two candidate sweeps (2026-07-06 and 2026-07-07) into a single **uniform master menu** — `docs/research/2026-07-07-candidate-master-menu.md`. Every candidate (C1–C11) uses the same schema: `ID · Class · Effort · Value · Status · Anchor · Next action`. Supersedes the two split sweep indexes as the thing to revisit.

## Resolution audit (against current code)

| ID | Candidate | Status |
|----|-----------|--------|
| C8.1 | Deploy health-gate | **DONE** — #222 (`macmini-prod.sh` gates `.ok == true`) |
| C11 | GEX regime-persistence | **DONE/killed** — #228 committed the negative-result doc |
| C2 | Trade-lifecycle layer | **PARTIAL** — `regime.py` reads current-cohort entry+quotes; positions-list/P&L/`/today` still missing |
| C8.2–5, C1, C3, C4, C5, C6, C7, C9, C10 | — | confirmed unbuilt |

Board shrinks from 11 to ~9 actionable. Sequencing head unchanged: C1 dedupe first (multiplies all), C4 gates C6, C2/C3 zero-new-data product wins.

Also lands two prior untracked research traces (next-work shortlist, brand-new candidates) that back this menu.

Docs only — no code paths touched.