### PR TITLE
fix(test): anchor data-freshness lookback tests to today, not absolute dates

### DIFF
--- a/tests/integration/storage/test_data_freshness_repository.py
+++ b/tests/integration/storage/test_data_freshness_repository.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 from uw_scan.reports.data_freshness import FreshnessRow
 from uw_scan.storage.data_freshness_repository import DataFreshnessRepository
+
+
+def _night(n: int) -> date:
+    """N calendar days before today. `consecutive_frozen_counts` filters on
+    `run_date > CURRENT_DATE - lookback`, so these tests MUST anchor their
+    snapshot dates to today — hardcoded absolute dates silently drift out of
+    the lookback window as the calendar advances and the streak miscounts."""
+    return date.today() - timedelta(days=n)
 
 
 def test_upsert_and_latest(seeded_db_empty_cards):
@@ -94,11 +102,11 @@ def test_consecutive_frozen_counts_stops_at_first_healthy_night(seeded_db_empty_
     fr = DataFreshnessRepository(repo.conn, schema=repo._schema)
     # frozen, frozen, frozen, HEALTHY, frozen (oldest) -- streak from today
     # backward must stop at the healthy night, not count the older frozen one.
-    fr.upsert_snapshot(date(2026, 6, 25), [_row("vrp_daily", True)])
-    fr.upsert_snapshot(date(2026, 6, 24), [_row("vrp_daily", True)])
-    fr.upsert_snapshot(date(2026, 6, 23), [_row("vrp_daily", True)])
-    fr.upsert_snapshot(date(2026, 6, 22), [_row("vrp_daily", False)])
-    fr.upsert_snapshot(date(2026, 6, 21), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(1), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(2), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(3), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(4), [_row("vrp_daily", False)])
+    fr.upsert_snapshot(_night(5), [_row("vrp_daily", True)])
     counts = fr.consecutive_frozen_counts(lookback=14)
     assert counts["vrp_daily"] == 3
 
@@ -108,8 +116,8 @@ def test_consecutive_frozen_counts_zero_when_most_recent_night_healthy(
 ):
     repo = seeded_db_empty_cards
     fr = DataFreshnessRepository(repo.conn, schema=repo._schema)
-    fr.upsert_snapshot(date(2026, 6, 25), [_row("daily_ohlc", False)])
-    fr.upsert_snapshot(date(2026, 6, 24), [_row("daily_ohlc", True)])
+    fr.upsert_snapshot(_night(1), [_row("daily_ohlc", False)])
+    fr.upsert_snapshot(_night(2), [_row("daily_ohlc", True)])
     counts = fr.consecutive_frozen_counts(lookback=14)
     assert counts["daily_ohlc"] == 0
 
@@ -119,12 +127,12 @@ def test_consecutive_frozen_counts_stops_at_a_missing_monitor_night(
 ):
     repo = seeded_db_empty_cards
     fr = DataFreshnessRepository(repo.conn, schema=repo._schema)
-    # frozen, frozen, [monitor didn't run on 6-23], frozen (older) -- the gap
-    # means the state through 6-23 is unknown, not confirmed frozen, so the
+    # frozen, frozen, [monitor didn't run on night 3], frozen (older) -- the gap
+    # means the state through night 3 is unknown, not confirmed frozen, so the
     # streak must stop there rather than bridging across the missing night.
-    fr.upsert_snapshot(date(2026, 6, 25), [_row("vrp_daily", True)])
-    fr.upsert_snapshot(date(2026, 6, 24), [_row("vrp_daily", True)])
-    fr.upsert_snapshot(date(2026, 6, 22), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(1), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(2), [_row("vrp_daily", True)])
+    fr.upsert_snapshot(_night(4), [_row("vrp_daily", True)])
     counts = fr.consecutive_frozen_counts(lookback=14)
     assert counts["vrp_daily"] == 2
 
@@ -132,7 +140,7 @@ def test_consecutive_frozen_counts_stops_at_a_missing_monitor_night(
 def test_latest_snapshot_includes_consecutive_frozen_nights(seeded_db_empty_cards):
     repo = seeded_db_empty_cards
     fr = DataFreshnessRepository(repo.conn, schema=repo._schema)
-    fr.upsert_snapshot(date(2026, 6, 24), [_row("wgc_etf_monthly", True)])
-    fr.upsert_snapshot(date(2026, 6, 25), [_row("wgc_etf_monthly", True)])
+    fr.upsert_snapshot(_night(2), [_row("wgc_etf_monthly", True)])
+    fr.upsert_snapshot(_night(1), [_row("wgc_etf_monthly", True)])
     latest = fr.latest_snapshot()
     assert latest[0]["consecutive_frozen_nights"] == 2


### PR DESCRIPTION
## Problem

`tests/integration/storage/test_data_freshness_repository.py` reddened **every** open PR's `integration (3/4)` shard starting 2026-07-07 — not flakiness, a **time-bomb**.

`consecutive_frozen_counts` filters on `run_date > CURRENT_DATE - lookback`, but the streak tests hardcoded June 2026 snapshot dates. As the calendar crossed 2026-07-07, the healthy-stopper night (6/22) slid out of the 14-day window and the oldest frozen night landed on the boundary → the streak counted 2 instead of 3 (`assert 2 == 3`). It passed on 2026-07-06 and failed on 2026-07-07 with no code change.

Three sibling tests in the same file were about to break the same way within days.

## Fix

Anchor all four lookback-dependent tests to `date.today()` offsets via a `_night(n)` helper, so they are calendar-invariant and still exercise the intended streak/gap logic. The two `upsert`/`latest` tests don't depend on `CURRENT_DATE` and keep their absolute dates.

Test-only — **no production behavior change** (`consecutive_frozen_counts` is correct; the tests were fragile).

## Verify

```
UW_SCAN_TEST_DB_NAME=option_wizard_test_wtfix UW_SCAN_ALLOW_DB_MISMATCH=1 UW_SCAN_DB_USER=<super> \
  uv run pytest tests/integration/storage/test_data_freshness_repository.py
# 6 passed
```

No CHANGELOG entry (test-hygiene, no user-facing surface). **Unblocks the merge train** — PRs #231/#233/#234 (and any other open PR) fail this shard until this lands.