### PR TITLE
fix(regime): ungate market-tide capture from the UW research budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
+- **Market Tide tab froze mid-session when the shared UW account hit its guard.**
+  `_regime_market_tide_scan` was budget-gated via `_research_budget_ok`, which
+  returns False once the account-wide `official_daily_count` crosses
+  `uw_total_daily_guard` (105k) — a threshold the shared UW key crosses most days
+  by mid-morning (co-tenant + always-on stack). So the 5-min tide capture stopped
+  appending bars (frozen at the prior session) even though it costs just **1 UW
+  call/tick (~78/day)** — spot comes from the WS DB table, not UW. Dropped the gate
+  to match its identical-cost sibling `regime_top_net_impact_scan` (never gated).
+  Expensive intraday research (`regime_gex_scan`, ~4k calls/day) stays gated.
+
 - **Deploy health-gate now checks `ok`, not just reachability.**
   `scripts/deploy/macmini-prod.sh` gated deploy success (and auto-rollback) on
   `curl -fsS` against `/api/health` — but that endpoint returns HTTP 200 in every

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -139,9 +139,12 @@ def _research_budget_ok(settings: Settings, repo) -> bool:
       ``greek_exposure_daily_refresh``, discovery) — they run at 18:30-19:00 ET,
       after the live RTH scans are done and near the 20:00 ET budget reset, so
       they don't contend with live; gating them on the shared research ceiling
-      would risk starving high-value durable data. Only the recurring *intraday*
-      research spenders (``regime_gex_scan``, ``regime_market_tide_scan``) gate
-      here — and gex is the dominant one, so RTH research is effectively bounded.
+      would risk starving high-value durable data. Among the recurring *intraday*
+      research spenders, only ``regime_gex_scan`` (the dominant one, ~4k
+      calls/day) gates here, so RTH research is effectively bounded.
+      ``regime_market_tide_scan`` is deliberately NOT gated: at ~78 calls/day
+      it's too cheap to be worth freezing the whole Market Tide tab when the
+      shared UW key crosses the guard (matches ``regime_top_net_impact_scan``).
     """
     if not settings.uw_budget_governor_enabled:
         return True
@@ -1032,11 +1035,12 @@ def main() -> int:
                 job_name="regime_market_tide_scan",
             ) as uw:
                 with _repo(settings) as repo:
-                    if not _research_budget_ok(settings, repo):
-                        logger.info(
-                            "regime_market_tide_scan skipped: research UW budget exhausted"
-                        )
-                        return
+                    # NOT budget-gated: one UW call per 5-min tick (~78/day) —
+                    # spot comes from the WS DB table, not UW. Matches its
+                    # identical-cost sibling _regime_top_net_impact_scan. Gating
+                    # it behind the account-wide total_guard froze the whole
+                    # Market Tide tab whenever the shared UW key crossed 105k
+                    # mid-session; the ~78 calls it saves aren't worth that.
                     try:
                         n = market_tide_scanner.run(
                             uw, repo, spot_ticker=settings.market_tide_spot_ticker


### PR DESCRIPTION
Market Tide tab was frozen at the prior session on the mini (verified: zero bars captured today while market open, last bar Mon 07-06 14:05 ET).

## Root cause

`_regime_market_tide_scan` was budget-gated via `_research_budget_ok`, which returns False once the **account-wide** `official_daily_count` crosses `uw_total_daily_guard` (105k). On the mini that counter hits 96k–120k **every** UTC day (resets ~00:00 UTC, verified) — dominated by co-tenant usage on the shared UW key plus the always-on `full_scan`/`gex` stack, not market-tide itself. So the gate trips mid-morning and every gated research job halts for the rest of the day.

The capture costs exactly **1 UW call per 5-min tick (~78/day)** — spot comes from the WS-fed `intraday_quote` table, not UW (`scanners/market_tide.py:38`). Its identical-cost sibling `regime_top_net_impact_scan` was never gated, which is why that kept ticking while tide froze.

## Fix

Drop the `_research_budget_ok` gate from `_regime_market_tide_scan` (one branch deletion) so it matches `regime_top_net_impact_scan`. Expensive intraday research (`regime_gex_scan`, ~4k calls/day) stays gated — RTH research is still effectively bounded by that.

## Verified

- `import uw_scan.worker.scheduler` → OK
- `pytest tests/unit/worker/test_market_tide_schedule.py` → 2 passed
- `ruff check src/uw_scan/worker/scheduler.py` → clean; `_research_budget_ok` still used (gex gate)

Live capture only resumes after a release ships (workers do not hot-reload; deploy is tag-driven).

## Not addressed here

The underlying budget leak — the shared UW key hitting ~118k/day, mostly *not* argons own calls — still starves the genuinely-gated `gex_scan`. Separate investigation (who the co-tenant is / cutting that burn).