### PR TITLE
docs(ops): fix mini DB route + backup path + health endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,11 @@ Postgres schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual 
 
 | Host | DB name | Writer | Reset |
 |------|---------|--------|-------|
-| `100.66.147.98` (Mac mini, Tailscale) | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
+| `127.0.0.1` on the Mac mini | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
 | `127.0.0.1` (MacBook / CI) | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned) |
 | either host | `option_wizard_test` | `uv run pytest` | wiped per-fixture (DROP SCHEMA CASCADE) |
 
-MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
+The Mac mini `.env` uses `UW_SCAN_DB_HOST=127.0.0.1`, `UW_SCAN_DB_NAME=option_wizard`, and `UW_SCAN_ALLOW_DB_MISMATCH=1` for the same-host prodlike route. MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
 
 ## Tech stack
 

--- a/docs/ops/macmini-runbook.md
+++ b/docs/ops/macmini-runbook.md
@@ -4,6 +4,7 @@
 **Repo:** `~/projects/argon` on mini.
 **Services:** 13 launchd jobs (`com.argon.*`) + 2 backup jobs (`com.argon.backup`, `com.argon.backup-r2`).
 **Co-tenant:** xenon shares the mini's Homebrew Postgres cluster (currently `postgresql@17`, port 5432; separate DBs/roles). Bootstrap probes whatever `brew services` reports running, so a future major bump is transparent to argon.
+**DB route:** Same-host Argon launchd services use `127.0.0.1:5432` for `option_wizard`; do not route them through the mini's own Tailscale/LAN address. The mini `.env` sets `UW_SCAN_ALLOW_DB_MISMATCH=1` for this prodlike localhost route.
 **Spec:** `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`
 **Plan:** `docs/superpowers/plans/2026-06-01-mac-mini-stack-migration-plan.md`
 
@@ -43,7 +44,7 @@ Refuses if MacBook writers are listening.
 
 ## Backups
 
-- Nightly local: `com.argon.backup` (03:00) writes `data/backups/option_wizard-<date>.dump.gz`, retains 7 days.
+- Nightly local: `com.argon.backup` (03:00) writes `/Volumes/DATA_LAKE/argon/postgres-backups/option_wizard-<date>.dump.gz`, retains 7 days.
 - Weekly R2: `com.argon.backup-r2` (Sundays 04:00) uploads to `s3://${R2_BUCKET}/postgres/`.
 
 **Note on auth:** The mini's `~/.pgpass` (mode 600, populated by `macmini-bootstrap.sh`) supplies the `argon_app` password for `127.0.0.1:5432`. None of the commands below need an inline `PGPASSWORD=...`. If you need to operate from a different host or as a different user, either populate `~/.pgpass` for that user or set `PGPASSWORD` inline (the password is in `${ARGON_HOME}/.env` on the mini as `UW_SCAN_DB_PASSWORD`).
@@ -114,7 +115,7 @@ done < ~/projects/argon/config/services.list'
 
 From MacBook over Tailscale:
 ```
-curl -fsS http://100.66.147.98:8400/health | jq .
+curl -fsS http://100.66.147.98:8400/api/health | jq .
 curl -fsSI http://100.66.147.98:3001 | head -1
 psql -h 100.66.147.98 -U argon_app -d option_wizard -c "SELECT COUNT(*) FROM uw_scan.scan_runs"
 ```


### PR DESCRIPTION
Recovers two doc corrections that were made directly on the mini (uncommitted, sitting at HEAD `be37de8` / v0.7.1) while investigating why the v0.7.2 deploy-poller refused to auto-deploy — its dirty-tree guard was correctly blocking on these.

## What this fixes

- **`CLAUDE.md`**: same-host argon services on the mini route to `option_wizard` via `127.0.0.1`, not the Tailscale IP (`100.66.147.98`) — that address is only for cross-machine browse from the MacBook. Mini `.env` sets `UW_SCAN_ALLOW_DB_MISMATCH=1` for this localhost route.
- **`docs/ops/macmini-runbook.md`**: nightly backup now lands on `/Volumes/DATA_LAKE/argon/postgres-backups/`, not `data/backups/`; cross-machine health curl needs `/api/health`, not the stale `/health`.

No code changes — docs only, correcting drift between the runbook and actual mini config. Original diff preserved verbatim from `git diff` on the mini before stashing to unblock deploy.