### PR TITLE
chore(ops): mac mini backups to DATA_LAKE volume, atomic, pg17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
-## [0.8.0] — 2026-07-08
+### Changed
+
+- **Mac mini Postgres backups now target the DATA_LAKE volume, atomically, on
+  pg17.** `com.argon.backup` (and the R2 uploader) write to
+  `${ARGON_BACKUP_DIR:-/Volumes/DATA_LAKE/argon/postgres-backups}` instead of the
+  repo's `data/backups/`, dump via `postgresql@17` (matching the mini's server),
+  and write to a `.part` file renamed into place only on success so a crashed
+  `pg_dump` never leaves a truncated-but-plausible dump. `macmini-bootstrap.sh`
+  now scaffolds the mini `.env` for same-host Postgres (`UW_SCAN_DB_HOST=127.0.0.1`
+  + `UW_SCAN_ALLOW_DB_MISMATCH=1`) rather than routing over Tailscale. Runbook
+  documents the macOS TCC `RemovableVolumes` requirement (background launchd jobs
+  cannot write removable volumes without it) plus a shape-test probe to verify it
+  after OS upgrades. Config/ops only — no application code paths change.
 
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,11 @@ Postgres schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual 
 
 | Host | DB name | Writer | Reset |
 |------|---------|--------|-------|
-| `100.66.147.98` (Mac mini, Tailscale) | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
+| `127.0.0.1` on the Mac mini | `option_wizard` | macmini launchd stack only | persistent (prodlike) |
 | `127.0.0.1` (MacBook / CI) | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned) |
 | either host | `option_wizard_test` | `uv run pytest` | wiped per-fixture (DROP SCHEMA CASCADE) |
 
-MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
+The Mac mini `.env` uses `UW_SCAN_DB_HOST=127.0.0.1`, `UW_SCAN_DB_NAME=option_wizard`, and `UW_SCAN_ALLOW_DB_MISMATCH=1` for the same-host prodlike route. MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
 
 ## Tech stack
 

--- a/config/templates/com.argon.backup.plist.template
+++ b/config/templates/com.argon.backup.plist.template
@@ -9,7 +9,7 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>set -euo pipefail; mkdir -p __PROJECT_DIR__/data/backups; __BREW_PREFIX__/opt/postgresql@16/bin/pg_dump -Fc -h 127.0.0.1 -U argon_app option_wizard | gzip &gt; __PROJECT_DIR__/data/backups/option_wizard-$(date +\%Y\%m\%d).dump.gz; find __PROJECT_DIR__/data/backups -name 'option_wizard-*.dump.gz' -mtime +7 -delete</string>
+        <string>set -euo pipefail; BACKUP_DIR="${ARGON_BACKUP_DIR:-/Volumes/DATA_LAKE/argon/postgres-backups}"; mkdir -p "$BACKUP_DIR"; TMP="$BACKUP_DIR/option_wizard-$(date +\%Y\%m\%d).dump.gz.part"; FINAL="${TMP%.part}"; __BREW_PREFIX__/opt/postgresql@17/bin/pg_dump -Fc -h 127.0.0.1 -U argon_app option_wizard | gzip &gt; "$TMP"; mv "$TMP" "$FINAL"; find "$BACKUP_DIR" -name 'option_wizard-*.dump.gz' -mtime +7 -delete</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/docs/ops/macmini-runbook.md
+++ b/docs/ops/macmini-runbook.md
@@ -4,6 +4,7 @@
 **Repo:** `~/projects/argon` on mini.
 **Services:** 13 launchd jobs (`com.argon.*`) + 2 backup jobs (`com.argon.backup`, `com.argon.backup-r2`).
 **Co-tenant:** xenon shares the mini's Homebrew Postgres cluster (currently `postgresql@17`, port 5432; separate DBs/roles). Bootstrap probes whatever `brew services` reports running, so a future major bump is transparent to argon.
+**DB route:** Same-host Argon launchd services use `127.0.0.1:5432` for `option_wizard`; do not route them through the mini's own Tailscale/LAN address. The mini `.env` sets `UW_SCAN_ALLOW_DB_MISMATCH=1` for this prodlike localhost route.
 **Spec:** `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`
 **Plan:** `docs/superpowers/plans/2026-06-01-mac-mini-stack-migration-plan.md`
 
@@ -124,7 +125,7 @@ done < ~/projects/argon/config/services.list'
 
 From MacBook over Tailscale:
 ```
-curl -fsS http://100.66.147.98:8400/health | jq .
+curl -fsS http://100.66.147.98:8400/api/health | jq .
 curl -fsSI http://100.66.147.98:3001 | head -1
 psql -h 100.66.147.98 -U argon_app -d option_wizard -c "SELECT COUNT(*) FROM uw_scan.scan_runs"
 ```

--- a/docs/ops/macmini-runbook.md
+++ b/docs/ops/macmini-runbook.md
@@ -43,15 +43,25 @@ Refuses if MacBook writers are listening.
 
 ## Backups
 
-- Nightly local: `com.argon.backup` (03:00) writes `data/backups/option_wizard-<date>.dump.gz`, retains 7 days.
+- Nightly local: `com.argon.backup` (03:00) writes `/Volumes/DATA_LAKE/argon/postgres-backups/option_wizard-<date>.dump.gz`, retains 7 days.
 - Weekly R2: `com.argon.backup-r2` (Sundays 04:00) uploads to `s3://${R2_BUCKET}/postgres/`.
+
+**DATA_LAKE launchd access:** macOS TCC protects removable volumes from background jobs. The `com.argon.backup` shell opens the `.part` file, so `/bin/bash` must have `kTCCServiceSystemPolicyRemovableVolumes` access for unattended backups. Verify after OS upgrades or TCC resets:
+```
+launchctl submit -l com.argon.backup-shape-test \
+  -o /tmp/argon-backup-shape.out -e /tmp/argon-backup-shape.err \
+  -- /bin/bash -lc 'set -euo pipefail; d=/Volumes/DATA_LAKE/argon/postgres-backups; t="$d/.probe-$(date +%s).dump.gz.part"; f="${t%.part}"; echo probe | gzip > "$t"; mv "$t" "$f"; gzip -t "$f"; find "$d" -name ".probe-*.dump.gz" -delete; echo ok'
+sleep 3
+cat /tmp/argon-backup-shape.out /tmp/argon-backup-shape.err
+launchctl remove com.argon.backup-shape-test 2>/dev/null || true
+```
 
 **Note on auth:** The mini's `~/.pgpass` (mode 600, populated by `macmini-bootstrap.sh`) supplies the `argon_app` password for `127.0.0.1:5432`. None of the commands below need an inline `PGPASSWORD=...`. If you need to operate from a different host or as a different user, either populate `~/.pgpass` for that user or set `PGPASSWORD` inline (the password is in `${ARGON_HOME}/.env` on the mini as `UW_SCAN_DB_PASSWORD`).
 
 Restore from local dump:
 ```
 ssh moremeds@100.66.147.98 'cd ~/projects/argon
-  latest=$(ls -1t data/backups/option_wizard-*.dump.gz | head -1)
+  latest=$(ls -1t /Volumes/DATA_LAKE/argon/postgres-backups/option_wizard-*.dump.gz | head -1)
   echo "Restoring from $latest"
   gunzip -c "$latest" \
     | pg_restore --clean --if-exists --no-owner --no-acl \

--- a/scripts/deploy/macmini-backup-upload-r2.sh
+++ b/scripts/deploy/macmini-backup-upload-r2.sh
@@ -19,8 +19,9 @@ for var in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET; do
 done
 
 R2_ENDPOINT="${R2_ENDPOINT_OVERRIDE:-https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
+BACKUP_DIR="${ARGON_BACKUP_DIR:-/Volumes/DATA_LAKE/argon/postgres-backups}"
 
-latest="$(ls -1t data/backups/option_wizard-*.dump.gz | head -1)"
+latest="$(ls -1t "${BACKUP_DIR}"/option_wizard-*.dump.gz | head -1)"
 [[ -n "$latest" ]] || { echo "no local backup to upload" >&2; exit 1; }
 
 echo "Uploading $latest to s3://${R2_BUCKET}/postgres/"

--- a/scripts/deploy/macmini-bootstrap.sh
+++ b/scripts/deploy/macmini-bootstrap.sh
@@ -258,18 +258,18 @@ if [[ ! -f "${ARGON_HOME}/.env" ]]; then
   say "Creating .env from .env.example (you must fill secrets before services start)"
   cp "${ARGON_HOME}/.env.example" "${ARGON_HOME}/.env"
   # The .env.example defaults are tuned for MacBook dev (HOST=127.0.0.1,
-  # NAME=option_wizard_local). On the mini, we point HOST at the Tailscale
-  # address so the (host, db_name) tripwire in uw_scan.config recognises
-  # (100.66.147.98, option_wizard) as the prodlike combo, and override
-  # NAME / USER / PASSWORD to the mini-specific values.
+  # NAME=option_wizard_local). On the mini, same-host services use localhost
+  # for Postgres and set the isolation override for the prodlike DB name.
   python3 - <<PY
 from pathlib import Path
 p = Path("${ARGON_HOME}/.env")
 text = p.read_text()
-text = text.replace("UW_SCAN_DB_HOST=127.0.0.1", "UW_SCAN_DB_HOST=100.66.147.98")
+text = text.replace("UW_SCAN_DB_HOST=127.0.0.1", "UW_SCAN_DB_HOST=127.0.0.1")
 text = text.replace("UW_SCAN_DB_NAME=option_wizard_local", "UW_SCAN_DB_NAME=${ARGON_DB_NAME}")
 text = text.replace("UW_SCAN_DB_USER=argon_app", "UW_SCAN_DB_USER=${ARGON_DB_ROLE}")
 text = text.replace("UW_SCAN_DB_PASSWORD=", "UW_SCAN_DB_PASSWORD=${ARGON_DB_PASSWORD}", 1)
+if "UW_SCAN_ALLOW_DB_MISMATCH=" not in text:
+    text += "\nUW_SCAN_ALLOW_DB_MISMATCH=1\n"
 p.write_text(text)
 print("  .env scaffolded")
 PY


### PR DESCRIPTION
## What

Extracts ops-hardening changes that had been living **uncommitted on the mini's working tree** — which blocks the deploy-poller (it refuses to auto-deploy onto a dirty tree). Committing them here so the mini converges on the next deploy and stops going dirty.

These were already running on the mini; this PR just makes them the repo source of truth. No application code paths change — config/ops/docs only.

## Changes

- **`config/templates/com.argon.backup.plist.template`** — nightly `pg_dump` now:
  - writes to `${ARGON_BACKUP_DIR:-/Volumes/DATA_LAKE/argon/postgres-backups}` instead of the repo's `data/backups/`
  - dumps via `postgresql@17` (matching the mini's actual server), was `@16`
  - **atomic write**: dumps to `<name>.dump.gz.part`, `mv`s into place only on success — a crashed `pg_dump` never leaves a truncated-but-plausible dump
- **`scripts/deploy/macmini-backup-upload-r2.sh`** — reads the same `ARGON_BACKUP_DIR` / DATA_LAKE location
- **`scripts/deploy/macmini-bootstrap.sh`** — scaffolds the mini `.env` for **same-host Postgres** (`UW_SCAN_DB_HOST=127.0.0.1` + `UW_SCAN_ALLOW_DB_MISMATCH=1`) instead of routing over Tailscale (`100.66.147.98`). The isolation tripwire in `uw_scan.config` needs the override because `(127.0.0.1, option_wizard)` is otherwise a blocked combo.
- **`docs/ops/macmini-runbook.md`** — DATA_LAKE paths + documents the macOS **TCC `RemovableVolumes`** requirement (background launchd jobs can't write removable volumes without it) plus a shape-test probe to verify it after OS upgrades / TCC resets.

## Why now

The v0.8.0 deploy was blocked by these four files sitting dirty on the mini. They were preserved to a patch, the tree stashed to unblock the deploy, and this PR is that patch made canonical.

## Testing

Config/docs/shell only — no unit-testable code. Backup behavior is exercised live by the mini's nightly `com.argon.backup` job; the runbook now carries the shape-test probe to validate the DATA_LAKE + TCC path on demand.