### PR TITLE
fix(deploy): gate on serving-liveness, not data-freshness ok (unblocks v0.8.x deploy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   cannot write removable volumes without it) plus a shape-test probe to verify it
   after OS upgrades. Config/ops only — no application code paths change.
 
+### Fixed
+
+- **Deploy health-gate no longer deadlocks on benign budget-throttled scans.**
+  The v0.7.2 change gated deploy success (and rollback verify) on `/api/health`
+  `.ok == true`. But `.ok` folds in "expected full scans missed", which is
+  routinely false for a *benign* reason — UW daily-budget exhaustion legitimately
+  **skips** full scans for most of the trading day, so the whole health reports
+  `ok=false`. With `.ok == true` required on *both* the forward gate and the
+  rollback verify, a deploy launched during a budget-throttled window can pass
+  neither: it burns its retry budget, rolls back, the rollback verify also fails,
+  and the outer `gtimeout` kills `macmini-prod.sh` (rc=124). This is exactly how
+  the v0.8.0 deploy failed and stranded the mini on v0.7.2. The gate now asserts
+  **serving liveness** — `.db == "up" and .version == "<VERSION>"` (DB reachable +
+  the newly-deployed code is the process actually answering) — and the rollback
+  verify asserts `.db == "up"`. Worker/scan health stays monitored separately
+  (C12 job-failure streaks + heartbeats); it is no longer conflated with whether a
+  build deployed correctly.
+
+## [0.8.0] — 2026-07-08
+
 
 ### Added
 

--- a/scripts/deploy/macmini-prod.sh
+++ b/scripts/deploy/macmini-prod.sh
@@ -103,8 +103,17 @@ step "Health checks"
 sleep 5
 # check_url URL NAME [JQ_FILTER]
 # Reachability check by default. With JQ_FILTER, the body must also satisfy it —
-# needed because /api/health returns HTTP 200 even when ok=false (db down, missed
-# scans, record-coverage collapse), so a plain -fsS gate can never trip rollback.
+# needed because /api/health returns HTTP 200 even when the stack is broken, so a
+# plain -fsS gate can never trip rollback.
+#
+# The gate asserts SERVING LIVENESS (what a deploy controls), NOT data freshness.
+# It does NOT gate on `.ok`: `.ok` folds in `missed full scans`, which is routinely
+# false for a benign reason — UW daily-budget exhaustion legitimately SKIPS full
+# scans (see the budget governor), so the whole health goes ok=false most of the
+# trading day. Gating deploy success on `.ok` deadlocks: neither the forward gate
+# nor the rollback verify can pass, the script burns its retry budget and gtimeout
+# kills it (rc=124). Worker/scan health is monitored separately (job_failures +
+# heartbeats). So the gate checks db-up + the new VERSION actually serving.
 check_url() {
   local url="$1" name="$2" filter="${3:-}"
   for _ in {1..30}; do
@@ -125,7 +134,7 @@ check_url() {
   return 1
 }
 
-if check_url "http://127.0.0.1:8400/api/health" "api" '.ok == true' \
+if check_url "http://127.0.0.1:8400/api/health" "api" ".db == \"up\" and .version == \"$FILE_VERSION\"" \
    && check_url "http://127.0.0.1:3001"      "web"; then
   step "Deploy OK: $TAG ($COMMIT)"
   printf '%s  %s  %s  OK\n' "$(date -u +%FT%TZ)" "$TAG" "$COMMIT" >> "$REPO_ROOT/logs/deploy.log"
@@ -145,7 +154,7 @@ while IFS= read -r label; do
   launchctl kickstart -k "gui/$UID/${label}"
 done < config/services.list
 sleep 5
-check_url "http://127.0.0.1:8400/api/health" "api(rollback)" '.ok == true' || die "rollback ALSO failed — manual intervention required"
+check_url "http://127.0.0.1:8400/api/health" "api(rollback)" '.db == "up"' || die "rollback ALSO failed — manual intervention required"
 check_url "http://127.0.0.1:3001"        "web(rollback)" || die "rollback ALSO failed — manual intervention required"
 printf '%s  %s  %s  ROLLBACK→%s\n' "$(date -u +%FT%TZ)" "$TAG" "$COMMIT" "$PREV_TAG" >> "$REPO_ROOT/logs/deploy.log"
 die "deploy of $TAG failed; rolled back to $PREV_TAG"


### PR DESCRIPTION
## The bug (why the mini is stranded on v0.7.2)

The v0.7.2 release tightened the deploy gate to require `/api/health` `.ok == true` on **both** the forward check and the rollback verify. But `.ok` folds in **"expected full scans missed"**, which is routinely `false` for a *benign* reason: UW daily-budget exhaustion legitimately **skips** full scans for most of the trading day, so the whole health reports `ok=false`.

With `.ok == true` required on both paths, a deploy launched in a budget-throttled window can pass **neither**:
1. forward gate loops ~90s on `ok=false`, never passes
2. rolls back to prev tag
3. rollback verify *also* requires `ok=true` → also can't pass
4. the outer `gtimeout` in the poller kills `macmini-prod.sh` → **rc=124**

**This is exactly how the v0.8.0 deploy failed** at 06:50 UTC and stranded the mini on v0.7.2 (poller marked v0.8.0 FAILED). The C12 Track A ops-hardening in v0.8.0 is therefore **not running in prod**.

## The fix

Gate on **serving liveness** (what a deploy actually controls), not upstream data freshness:

- **forward:** `.db == "up" and .version == "$FILE_VERSION"` — DB reachable **and** the newly-deployed code is the process actually answering (catches a build that broke DB access, and a stale process that survived the kickstart — both real deploy failures the old plain-`curl` gate missed)
- **rollback verify:** `.db == "up"`

Worker/scan health stays monitored **separately** — that is precisely what the C12 `job_failures` streaks + heartbeats are for. It's just no longer conflated with "did the build deploy correctly."

## Testing

Shell/jq — not unit-tested in CI. jq predicates validated by hand against representative payloads:

| payload | forward gate | expected |
|---|---|---|
| `ok=false, db=up, version=0.8.1` (current budget-throttled state) | PASS | ✓ deploy proceeds |
| `ok=true, db=up, version=0.8.0` (stale process survived kickstart) | FAIL | ✓ rollback |
| `ok=false, db=down, version=0.8.1` (broken build) | FAIL | ✓ rollback |

`bash -n` clean.

## Deploy note

Ships as **v0.8.1** (tags are immutable — can't fix v0.8.0's gate in place; v0.8.1 carries the same Track A). Will be deployed to the mini with a **pre-checkout** so the fixed gate runs deterministically (`macmini-prod.sh` checks out the tag mid-script at line 44; self-modifying a small buffered shell script via the poller is unreliable).