### PR TITLE
feat(docker): migration prep — Dockerfiles, compose, GHCR push job (artifacts only)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Keep the build context lean and secret-free. Both images build from the repo
+# root, so one .dockerignore covers app + web.
+.git
+.gitignore
+.worktrees
+.venv
+**/.venv
+**/node_modules
+**/.next
+**/__pycache__
+**/*.pyc
+.pytest_cache
+.ruff_cache
+.mypy_cache
+# Never bake secrets or local env into an image.
+.env
+.env.*
+!.env.example
+# Not needed at runtime.
+docs
+tests
+output
+logs
+*.log
+*.md
+!README.md
+# Local Docker artifacts.
+docker-compose.override.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,3 +166,62 @@ jobs:
           draft: false
           prerelease: ${{ steps.rel.outputs.prerelease }}
           make_latest: ${{ steps.rel.outputs.prerelease == 'false' }}
+
+  ghcr-push:
+    # Build + push the two argon images (app, web) to GHCR. Native arm64 runner
+    # — free on this PUBLIC repo, and deploys target the Apple Silicon mini, so
+    # build natively (no QEMU). The mini's single engine-wide Watchtower (in
+    # /opt/xenon/compose.yml, WATCHTOWER_LABEL_ENABLE=true) auto-deploys whatever
+    # :latest points at; a prerelease tag (hyphen) must never float :latest.
+    needs: verify
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: argon-app
+            dockerfile: docker/app.Dockerfile
+          - image: argon-web
+            dockerfile: docker/web.Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve image tags
+        id: meta
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          REPO_OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          IMAGE="ghcr.io/${REPO_OWNER}/${{ matrix.image }}"
+          # Always publish the immutable version tag. Float :latest ONLY for
+          # final releases — a prerelease (hyphen, e.g. v0.9.0-rc1) must never
+          # become :latest, or the mini's Watchtower would auto-deploy it.
+          TAGS="${IMAGE}:${VERSION}"
+          if [[ "$VERSION" != *-* ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:latest"
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "tags<<TAGS_EOF"
+            echo "${TAGS}"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **Docker migration — prep (artifacts only; no cutover yet).** Ships the pieces
+  to move the mini prod stack off launchd into Docker (xenon/apex house pattern:
+  Colima, `host.docker.internal`, host-native Postgres, GHCR images, the shared
+  engine-wide Watchtower): `docker/app.Dockerfile` + `docker/web.Dockerfile`,
+  root `docker-compose.yml` (10 services), `.dockerignore`, and a `ghcr-push`
+  matrix job in `release.yml` (builds/pushes `argon-app` + `argon-web` to GHCR on
+  every tag; `:latest` floats only for final releases). `config._HOST_DB_RULES`
+  gains a `host.docker.internal` rule so containers pass the DB-isolation
+  tripwire without the blanket override. Web SSR fetch sites now read the runtime
+  `NEXT_INTERNAL_API_BASE` (not the build-inlined `NEXT_PUBLIC_API_BASE*`) so a
+  containerized web renders against the `api` service, not itself; `next.config`
+  emits `output: 'standalone'` with `outputFileTracingRoot` pinned to `web/`.
+  **The launchd stack remains the live prod path** — cutover is phased and
+  user-driven (`docs/runbooks/docker-deploy.md`,
+  `docs/superpowers/specs/2026-07-06-docker-migration-design.md`). AI Codex/Claude
+  workers are retired in phase 1 (issue #248); DeepSeek survives.
+
 ## [0.8.1] — 2026-07-08
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,145 @@
+# docker-compose.yml — argon prod topology (dev/build template).
+#
+# The mini's live file is /opt/argon/compose.yml (mirrored, like apex). This
+# committed copy is the source of truth for that mirror and for local smoke:
+#   docker-compose build
+#   docker-compose --profile migrate run --rm migrator   # one-shot schema apply
+#   docker-compose up -d
+#
+# 12 containers: migrator (profile-gated) + api + web + ws-consumer + 2×uw +
+# 2×massive + 2×ai-deepseek. AI Codex/Claude are OFF in phase 1 (kill switches
+# in /opt/argon/.env; retired to issue #248).
+#
+# host.docker.internal reaches host-native services (set the remapped URLs in
+# /opt/argon/.env): Postgres :5432, xenon WS :8765, xenon query API :8321,
+# apex :8322. Never 127.0.0.1 from inside a container — that is the container
+# itself.
+#
+# The single engine-wide Watchtower in /opt/xenon/compose.yml
+# (WATCHTOWER_LABEL_ENABLE=true) auto-deploys any container carrying the enable
+# label below. Do NOT add a second Watchtower here.
+
+name: argon
+
+# GHCR image + local build context, shared by every Python service.
+x-app-image: &app-image
+  image: ghcr.io/moremeds/argon-app:latest
+  build:
+    context: .
+    dockerfile: docker/app.Dockerfile
+
+x-common: &common
+  env_file: [/opt/argon/.env]
+  restart: unless-stopped
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  labels:
+    com.centurylinklabs.watchtower.enable: "true"
+
+services:
+  # One-shot schema apply. profiles:["migrate"] + restart:"no" → never runs on
+  # `up -d`; invoke explicitly. Runs the module directly (.venv on PATH), not
+  # the scripts/migrate.sh wrapper (which shells out to `uv run`).
+  migrator:
+    <<: [*app-image, *common]
+    profiles: ["migrate"]
+    restart: "no"
+    command: ["python", "-m", "uw_scan.storage.migrate_runner"]
+
+  api:
+    <<: [*app-image, *common]
+    command:
+      ["uvicorn", "uw_scan.api.server:app", "--host", "0.0.0.0", "--port", "8400"]
+    ports:
+      - "127.0.0.1:8400:8400"   # loopback-only publish for host health checks
+    healthcheck:
+      # HTTP-200-only — deliberately does NOT parse `.ok` (folds in
+      # budget-throttled skipped scans → routinely false during RTH). Stays
+      # green through throttle so it won't false-fail web's depends_on. The
+      # #247 serving-liveness lesson, applied to the container layer.
+      test: ["CMD", "curl", "-f", "http://localhost:8400/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 40s   # generous cold-start budget (launchd's 30×1s was too tight)
+
+  web:
+    image: ghcr.io/moremeds/argon-web:latest
+    build:
+      context: .
+      dockerfile: docker/web.Dockerfile
+    <<: *common
+    command: ["node", "server.js"]
+    environment:
+      # One runtime var drives BOTH the next.config rewrite (client /api/*) and
+      # the SSR fetch base (code change #7). Points at the api service, never
+      # 127.0.0.1 (= the web container itself).
+      NEXT_INTERNAL_API_BASE: http://api:8400
+    ports:
+      - "3001:3001"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      # Explicit IPv4 — alpine busybox resolves `localhost` to ::1 first.
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3001/"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # Spot WS consumer (xenon primary / massive fallback). Different module from
+  # the scheduler, so no worker role/index validation applies.
+  ws-consumer:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.massive_ws_consumer"]
+
+  # APScheduler workers. Each role shards its work by (INDEX, COUNT); COUNT must
+  # equal the number of instances of that role or index-1 fails validation on
+  # boot. ponytail: no healthcheck — restart:unless-stopped + in-app
+  # job_failures/heartbeats are the worker liveness layer (no HTTP surface to probe).
+  worker-uw-0:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: uw
+      UW_SCAN_WORKER_INDEX: "0"
+      UW_SCAN_WORKER_COUNT: "2"
+  worker-uw-1:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: uw
+      UW_SCAN_WORKER_INDEX: "1"
+      UW_SCAN_WORKER_COUNT: "2"
+
+  worker-massive-0:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: massive
+      UW_SCAN_WORKER_INDEX: "0"
+      UW_SCAN_WORKER_COUNT: "2"
+  worker-massive-1:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: massive
+      UW_SCAN_WORKER_INDEX: "1"
+      UW_SCAN_WORKER_COUNT: "2"
+
+  # DeepSeek AI survives phase 1 (HTTP + DEEPSEEK_API_KEY, container-safe).
+  worker-ai-deepseek-0:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: ai-deepseek
+      UW_SCAN_WORKER_INDEX: "0"
+      UW_SCAN_WORKER_COUNT: "2"
+  worker-ai-deepseek-1:
+    <<: [*app-image, *common]
+    command: ["python", "-m", "uw_scan.worker.scheduler"]
+    environment:
+      UW_SCAN_WORKER_ROLE: ai-deepseek
+      UW_SCAN_WORKER_INDEX: "1"
+      UW_SCAN_WORKER_COUNT: "2"

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+# argon-app — one Python image for api / workers / ws-consumer / migrator.
+# The api/workers/ws-consumer/migrator all run the same uw_scan package, so
+# each compose service just overrides `command:` (see docker-compose.yml).
+# Built natively on ubuntu-24.04-arm in release.yml for the arm64 mini.
+# Reaches host Postgres + xenon/apex via host.docker.internal (set in the
+# container .env, NOT baked here).
+#
+# Local smoke (arm64 Docker host):
+#   docker build -f docker/app.Dockerfile -t argon-app:dev .
+#   docker run --rm --env-file .env argon-app:dev \
+#     python -m uw_scan.storage.migrate_runner
+
+FROM python:3.13-slim AS builder
+
+# uv pinned to a lock-compatible release. argon's uv.lock is `revision = 3`
+# (produced by uv 0.11.x) — older uv (e.g. 0.5.x) cannot parse it, so pin to a
+# 0.11 line. uv is a BUILD-only tool; it is not shipped to the runtime image.
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+# Lock + manifest + README (setuptools reads `readme`) + source, then a frozen,
+# no-dev install with the postgres extra (psycopg). uv builds .venv with an
+# editable install of uw_scan pointing at /app/src (migrations included, they
+# live under src/uw_scan/storage/migrations/).
+COPY pyproject.toml uv.lock README.md ./
+COPY src/ ./src/
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1
+RUN uv sync --frozen --no-dev --extra postgres
+
+# ---- runtime ----
+FROM python:3.13-slim AS runtime
+
+# libpq5: psycopg runtime. curl: api compose healthcheck. tini: PID 1 for clean
+# SIGTERM on `docker stop` / Watchtower recreate.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq5 ca-certificates curl tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
+# scripts/ is the ops escape hatch — backfills, gap-healer CLI, and the
+# market-tide seed, run on demand via `docker-compose run --rm migrator …`.
+COPY scripts/ ./scripts/
+COPY pyproject.toml uv.lock README.md VERSION ./
+
+# .venv on PATH → `uvicorn`, `python`, and the uw_scan package resolve directly,
+# no `uv run` prefix (uv is absent from this stage by design).
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+# Sane default; every compose service overrides `command:`. No HEALTHCHECK here
+# — the same image runs HTTP-less workers; the api/web healthchecks live in
+# compose where they apply to the right service.
+CMD ["uvicorn", "uw_scan.api.server:app", "--host", "0.0.0.0", "--port", "8400"]
+
+LABEL org.opencontainers.image.source="https://github.com/moremeds/argon" \
+      org.opencontainers.image.title="argon-app" \
+      org.opencontainers.image.description="Argon FastAPI + APScheduler workers + spot-WS consumer"

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.7
+# argon-web — Next.js 16 standalone. The client bundle calls relative /api/*,
+# proxied to the api service by the next.config.mjs rewrite. SSR fetches read
+# the same runtime NEXT_INTERNAL_API_BASE. argon web inlines NO NEXT_PUBLIC_*
+# values, so this image needs zero build args.
+# Built natively on ubuntu-24.04-arm in release.yml for the arm64 mini.
+#
+# Local smoke (arm64 Docker host):
+#   docker build -f docker/web.Dockerfile -t argon-web:dev .
+#   docker run --rm -p 3001:3001 \
+#     -e NEXT_INTERNAL_API_BASE=http://host.docker.internal:8400 argon-web:dev
+
+FROM node:22-alpine AS builder
+# next/font + sharp need libc6-compat on alpine.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app/web
+
+# Deps first for layer cache. web/ is a standalone project with its own lockfile
+# (no repo-root package.json), so this is a single npm ci. legacy-peer-deps
+# mirrors ci.yml / release.yml.
+COPY web/package.json web/package-lock.json ./
+RUN npm ci --no-audit --no-fund --legacy-peer-deps
+
+# Build inputs. next.config.mjs pins outputFileTracingRoot to web/, so the
+# standalone bundle emits at /app/web/.next/standalone/server.js (server.js +
+# node_modules at the standalone root).
+COPY web/ ./
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npx next build
+
+# ---- runtime ----
+FROM node:22-alpine AS runtime
+RUN apk add --no-cache libc6-compat tini
+WORKDIR /app
+
+# Next standalone does NOT bundle static/ or public/ — copy them alongside
+# server.js (it resolves ./.next/static and ./public relative to itself).
+COPY --from=builder /app/web/.next/standalone ./
+COPY --from=builder /app/web/.next/static ./.next/static
+COPY --from=builder /app/web/public ./public
+
+ENV NODE_ENV=production \
+    PORT=3001 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+
+EXPOSE 3001
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "server.js"]
+
+LABEL org.opencontainers.image.source="https://github.com/moremeds/argon" \
+      org.opencontainers.image.title="argon-web" \
+      org.opencontainers.image.description="Argon Next.js terminal"

--- a/docs/runbooks/docker-deploy.md
+++ b/docs/runbooks/docker-deploy.md
@@ -1,0 +1,127 @@
+# Docker deploy runbook (Mac mini)
+
+**Status:** artifacts shipped, cutover **not yet performed**. The live prod path
+is still the launchd stack (`docs/runbooks/release.md`). This runbook is the
+procedure for the phased cutover and for operating argon once it runs in Docker.
+Design + rationale: `docs/superpowers/specs/2026-07-06-docker-migration-design.md`.
+
+## What this migration does
+
+Moves the argon prod stack off launchd into Docker on the mini, matching the
+xenon/apex house pattern: Colima VM, bridge network + `host.docker.internal`,
+host-native Postgres (unchanged), GHCR images built by `release.yml`, and the
+**single engine-wide Watchtower** in `/opt/xenon/compose.yml` for auto-deploy.
+AI Codex/Claude workers are dropped in phase 1 (issue #248); DeepSeek survives.
+
+## Images
+
+Two images, built + pushed by the `ghcr-push` job in `release.yml` on every tag
+(native `ubuntu-24.04-arm`, no QEMU):
+
+- `ghcr.io/moremeds/argon-app` — api / workers / ws-consumer / migrator (one
+  Python image; each service overrides `command:`). `.venv` on PATH → no
+  `uv run` in-container.
+- `ghcr.io/moremeds/argon-web` — Next.js 16 standalone.
+
+`:X.Y.Z` is always published; `:latest` floats only for final releases
+(prerelease tags with a hyphen are excluded, so Watchtower never auto-deploys an
+rc). Local build smoke: `docker-compose build` (or per-image
+`docker build -f docker/app.Dockerfile -t argon-app:dev .`).
+
+## Compose topology
+
+`docker-compose.yml` at the repo root is the source of truth, mirrored to the
+mini's `/opt/argon/compose.yml`. 10 services (9 long-running + a profile-gated
+one-shot `migrator`). Every app service carries
+`com.centurylinklabs.watchtower.enable: "true"`, `extra_hosts:
+["host.docker.internal:host-gateway"]`, and `env_file: [/opt/argon/.env]`.
+
+## `/opt/argon/.env` — key remaps from the launchd `.env`
+
+| Var | container value |
+|---|---|
+| `UW_SCAN_DB_HOST` | `host.docker.internal` |
+| `UW_SCAN_DB_NAME` | `option_wizard` |
+| `XENON_WS_URL` | `ws://host.docker.internal:8765` |
+| `XENON_WS_PORT_FILE` | `""` (empty — host-local file, invisible in-container) |
+| `XENON_QUERY_API_URL` | `http://host.docker.internal:8321` |
+| `APEX_API_URL` | `http://host.docker.internal:8322` |
+| `TRADE_INSIGHTS_AI_ENABLED` / `..._CLAUDE_ENABLED` | `false` (Codex/Claude off) |
+| `TRADE_INSIGHTS_AI_DEEPSEEK_ENABLED` | `true` |
+
+**Do NOT set `UW_SCAN_ALLOW_DB_MISMATCH=1`** in the container `.env` — it bypasses
+ALL DB-isolation checks. The clean container path is the legal
+`host.docker.internal` + `option_wizard` pair (allowed by `_HOST_DB_RULES`), no
+override. `NEXT_INTERNAL_API_BASE=http://api:8400` is set in compose, not `.env`
+(it drives both the client `/api/*` rewrite and SSR fetches).
+
+## Cutover — phased, reversible
+
+### Phase 0 — prep (done in this PR)
+Code + Dockerfiles + compose + `ghcr-push` merged; images published on the first
+tag after merge. Local smoke on the MacBook against `option_wizard_local`.
+
+### Phase 1 — mini setup (no cutover yet)
+
+> **⚠ The Colima resize bounces the WHOLE mini, not just argon.** One shared
+> Colima VM hosts xenon (live IB feed), apex, and the trading-observability
+> stack. Schedule this in a **market-closed window**. After restart, verify all
+> three return healthy before touching argon.
+
+```bash
+ssh macmini
+export PATH=/opt/homebrew/bin:$PATH
+colima stop && colima start --cpu 6 --memory 8      # required headroom (~2 GiB for argon)
+# verify neighbours are back:
+docker ps                                            # xenon-*, apex-*, trading-* all Up
+docker login ghcr.io                                 # same PAT as xenon
+# create /opt/argon/{compose.yml,.env}  (mirror repo compose.yml; author .env per table above)
+docker-compose --profile migrate run --rm migrator   # idempotent; safe against the live DB
+# do NOT start app services yet
+```
+
+### Phase 2 — cutover (the double-writer moment)
+
+```bash
+# 1. Fully stop the launchd app stack FIRST (running both double-writes + double-burns UW budget):
+for l in api web massive-ws worker-uw-0 worker-uw-1 worker-massive-0 worker-massive-1 \
+         worker-ai-deepseek-0 worker-ai-deepseek-1 deploy-poller; do
+  launchctl bootout "gui/$(id -u)/com.argon.$l" 2>/dev/null || true
+done
+# 2. Start compose:
+cd /opt/argon && docker-compose up -d
+# 3. Verify SERVING LIVENESS (not .ok — it's routinely false under budget throttle):
+curl -s http://127.0.0.1:8400/api/health | jq '{version, db, active: .ws_consumer.active_source}'
+#   want: version == deployed tag, db == "up", active_source == "xenon_ws"
+# 4. Verify SSR renders data (catches the NEXT_INTERNAL_API_BASE regression):
+for p in / /gold /regime /stock/AAPL; do curl -sfo /dev/null -w "%{http_code} $p\n" http://127.0.0.1:3001$p; done
+```
+
+### Phase 3 — retire
+After ~3 clean days, remove the app plists from `~/Library/LaunchAgents` (keep
+the two `com.argon.backup*` plists — they stay host-native). Mark release.md
+launchd sections superseded then.
+
+## Rollback (any point)
+
+```bash
+cd /opt/argon && docker-compose down
+for l in api web massive-ws worker-uw-0 ...; do launchctl bootstrap "gui/$(id -u)" \
+  ~/Library/LaunchAgents/com.argon.$l.plist; done
+```
+The plists stay on disk through phase 2, and Postgres never moved, so the launchd
+stack resumes from the same DB. Watchtower has **no** rollback for a bad image —
+pin the previous tag: `sed -i '' 's#:latest#:X.Y.Z#' /opt/argon/compose.yml &&
+docker-compose up -d`.
+
+## Operating notes
+
+- **Watchtower alerts route to xenon's ntfy topic** (`ntfy.sh/xenon-deploy-…`,
+  titled "Xenon auto-deploy") — argon container updates show up there, branded as
+  xenon. One shared deploy channel for the mini; expected, not a bug.
+- **Env rotation** still needs a recreate: `docker-compose up -d --force-recreate
+  <svc>` (same freeze-at-fork semantics as the launchd workers).
+- **Schema changes**: `docker-compose --profile migrate run --rm migrator`. App
+  services never self-migrate, so `up -d` is safe against the live schema.
+- **Backups** (`com.argon.backup*`) remain host-native launchd — untouched by
+  this migration.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -2,6 +2,14 @@
 
 Argon ships to the Mac mini via a tag-driven pipeline (no Docker; launchd stack).
 
+> **Docker migration in progress.** A Docker deploy path (Colima + GHCR +
+> Watchtower, matching xenon/apex) has landed as artifacts — Dockerfiles,
+> `docker-compose.yml`, and the `ghcr-push` job in `release.yml`. **The launchd
+> stack below is still the live prod path** until the phased cutover runs; see
+> `docs/runbooks/docker-deploy.md` and
+> `docs/superpowers/specs/2026-07-06-docker-migration-design.md`. Once cutover
+> completes (Phase 3), the launchd sections here are superseded.
+
 ## Cut a release
 
 1. Land your feature PRs to `main` with CHANGELOG entries under `## [Unreleased]`.

--- a/docs/superpowers/specs/2026-07-06-docker-migration-design.md
+++ b/docs/superpowers/specs/2026-07-06-docker-migration-design.md
@@ -1,6 +1,6 @@
 # Argon Docker migration — design
 
-**Date:** 2026-07-06 · **Status:** DRAFT (design approved pending review)
+**Date:** 2026-07-06 · **Status:** PREP-PR IN FLIGHT 2026-07-08 (branch `feat/docker-migration-prep`; all load-bearing claims re-verified against source + the mini's live Watchtower — engine-wide `WATCHTOWER_LABEL_ENABLE=true`, 60s poll, GHCR creds present. Two cutover gaps folded: Colima resize = cross-project VM bounce; Watchtower alerts route to xenon's ntfy topic. `uv run` dropped from container commands — `.venv` on PATH.)
 **Goal:** move the argon prod stack off launchd into Docker on the Mac mini, matching the xenon/apex house pattern (Colima, bridge network + `host.docker.internal`, host-native Postgres, GHCR images from `release.yml`, Watchtower auto-deploy). AI analysis (Codex/Claude CLI) is knowingly sacrificed in phase 1 and rewritten later; DeepSeek survives.
 
 ## House pattern adopted (verified from xenon/apex)
@@ -9,7 +9,7 @@
 - **Networking:** bridge, published ports, `extra_hosts: ["host.docker.internal:host-gateway"]` on every service. Never `127.0.0.1` for host resources ("127.0.0.1 is the container itself" — xenon runbook).
 - **Postgres:** stays host-native Homebrew. Containers reach it at `host.docker.internal:5432`, DB `option_wizard`, role `argon_app`. No data moves.
 - **Images:** built/pushed by `.github/workflows/release.yml` on `ubuntu-24.04-arm` (native arm64, no QEMU — apex pattern) to GHCR, tags `:X.Y.Z` + `:latest` (prereleases excluded from `:latest`).
-- **Deploy:** apex-style — compose file mirrored at `/opt/argon/compose.yml`, app services carry `com.centurylinklabs.watchtower.enable: "true"`. The single engine-wide Watchtower already in `/opt/xenon/compose.yml` polls GHCR every 60s and recreates on new `:latest`. **Do not add a second Watchtower.** This preserves argon's current auto-deploy UX (deploy-poller retires).
+- **Deploy:** apex-style — compose file mirrored at `/opt/argon/compose.yml`, app services carry `com.centurylinklabs.watchtower.enable: "true"`. The single engine-wide Watchtower already in `/opt/xenon/compose.yml` polls GHCR every 60s and recreates on new `:latest`. **Verified on the mini (2026-07-08):** `WATCHTOWER_LABEL_ENABLE=true`, no `WATCHTOWER_SCOPE`, docker.sock mounted, GHCR `REPO_USER/PASS` present → it watches *any* labelled container engine-wide, so argon's labelled services are picked up with no second Watchtower. **Do not add a second Watchtower.** This preserves argon's current auto-deploy UX (deploy-poller retires). **Caveat:** that Watchtower's `WATCHTOWER_NOTIFICATION_URL` posts to `ntfy://ntfy.sh/xenon-deploy-…` titled "Xenon auto-deploy" — so argon container updates will alert on **xenon's** ntfy topic, branded as xenon. Cosmetic (one shared deploy channel for the mini); accept it, or split topics later — not worth a second Watchtower.
 - **Mini quirks:** hyphenated `docker-compose` (brew v5.1.3); SSH needs `PATH=/opt/homebrew/bin:$PATH`; Colima starts at user login only (auto-login tradeoff already accepted for xenon).
 
 ## Images (2, not 4 — deliberate simplification vs xenon)
@@ -23,13 +23,15 @@ xenon ships 4 near-identical Dockerfiles. Argon's api/workers/ws-consumer/migrat
 
 | Service | command | ports | notes |
 |---|---|---|---|
-| `migrator` | `uv run bash scripts/migrate.sh` (in-process psycopg, no psql needed) | — | `profiles: ["migrate"]`, `restart: "no"` — never auto-runs on `up -d` (xenon pattern) |
-| `api` | `uv run uvicorn uw_scan.api.server:app --host 0.0.0.0 --port 8400` | `127.0.0.1:8400:8400` | bind 0.0.0.0 inside container (drop the launchd `--host 127.0.0.1`); publish loopback-only for host health checks |
-| `web` | node standalone | `3001:3001` | `NEXT_INTERNAL_API_BASE=http://api:8400`; `depends_on: api: service_healthy` |
-| `ws-consumer` | `uv run python -m uw_scan.worker.massive_ws_consumer` | — | see xenon-feed env below |
-| `worker-uw-0/1` | `uv run python -m uw_scan.worker.scheduler` | — | `UW_SCAN_WORKER_ROLE=uw`, `WORKER_INDEX=0/1` — explicit services, not replicas (per-instance INDEX) |
+| `migrator` | `python -m uw_scan.storage.migrate_runner` (in-process psycopg, no psql needed) | — | `profiles: ["migrate"]`, `restart: "no"` — never auto-runs on `up -d` (xenon pattern) |
+| `api` | `uvicorn uw_scan.api.server:app --host 0.0.0.0 --port 8400` | `127.0.0.1:8400:8400` | bind 0.0.0.0 inside container (drop the launchd `--host 127.0.0.1`); publish loopback-only for host health checks |
+| `web` | node standalone | `3001:3001` | `NEXT_INTERNAL_API_BASE=http://api:8400` (runtime rewrite proxy for client `/api/*`); `depends_on: api: service_healthy`. **Also needs the SSR base — see code change #7 + env table** |
+| `ws-consumer` | `python -m uw_scan.worker.massive_ws_consumer` | — | see xenon-feed env below |
+| `worker-uw-0/1` | `python -m uw_scan.worker.scheduler` | — | `UW_SCAN_WORKER_ROLE=uw`, `WORKER_INDEX=0/1` — explicit services, not replicas (per-instance INDEX) |
 | `worker-massive-0/1` | same | — | `ROLE=massive` |
 | `worker-ai-deepseek-0/1` | same | — | `ROLE=ai-deepseek` — HTTP + `DEEPSEEK_API_KEY`, container-safe |
+
+> **No `uv run` prefix in-container.** The app image installs the project into `.venv` (`uv sync --frozen`) and puts `/app/.venv/bin` on `PATH` (xenon-migrator pattern), so `uvicorn`/`python`/the `uw_scan` package resolve directly. `uv` is a build-stage-only tool — it is **not** shipped in the runtime image, and the migrator runs the module directly rather than the `scripts/migrate.sh` wrapper (which is a host convenience that shells out to `uv run`).
 
 All: `restart: unless-stopped`, `env_file: [/opt/argon/.env]`, `extra_hosts`, watchtower label.
 
@@ -46,6 +48,8 @@ Healthchecks: api = `curl -f http://localhost:8400/api/health`; web = `wget --sp
 | `XENON_WS_PORT_FILE` | `/tmp/xenon-ib-realtime.json` | `""` (empty disables — the port file is host-local and invisible in-container; xenon publishes 8765 fixed from its own compose, so discovery is unnecessary) |
 | `XENON_QUERY_API_URL` | `http://127.0.0.1:8321` | `http://host.docker.internal:8321` |
 | `APEX_API_URL` | Tailscale IP | `http://host.docker.internal:8322` (apex publishes 8322) |
+| `NEXT_INTERNAL_API_BASE` | (unset → `localhost:8400`) | `http://api:8400` — **runtime** (next.config.mjs rewrite); works via `/opt/argon/.env` |
+| `NEXT_PUBLIC_API_BASE_URL` / `NEXT_PUBLIC_API_BASE` | `""` (build) → SSR falls back to `127.0.0.1:8400` | **DO NOT set at runtime** — `NEXT_PUBLIC_*` is build-inlined; a runtime value in `.env` is a no-op. Fixed in code change #7 (SSR reads a non-public var instead) |
 | `TRADE_INSIGHTS_AI_ENABLED` | true | **`false`** (Codex off) |
 | `TRADE_INSIGHTS_AI_CLAUDE_ENABLED` | true | **`false`** (Claude off) |
 | `TRADE_INSIGHTS_AI_DEEPSEEK_ENABLED` | true | true |
@@ -54,27 +58,51 @@ Massive WS already passes `proxy=None` explicitly — container-safe, preserve. 
 
 ## Code changes required (one prep PR)
 
-1. **`_enforce_db_isolation`** (`config.py:71-73`): add `host.docker.internal` as a legal host for `option_wizard` (prod container) and `option_wizard_local` (local compose testing). Without this the tripwire refuses startup — hard blocker.
+1. **`_enforce_db_isolation`** (`config.py:70-74`, `_HOST_DB_RULES`): add
+   `"host.docker.internal": frozenset({"option_wizard", "option_wizard_local", "option_wizard_test"})`.
+   Without this the tripwire refuses container startup. **And keep the tripwire
+   meaningful:** do NOT carry `UW_SCAN_ALLOW_DB_MISMATCH=1` into `/opt/argon/.env`.
+   (The mini's *launchd* `.env` sets that override for its `127.0.0.1`+`option_wizard`
+   route — PR #246 — but the override bypasses ALL isolation checks. If the container
+   `.env` inherited it, this code change would be redundant and the container would run
+   with isolation silently disabled. The clean container path is: legal `host.docker.internal`
+   pair + no override.)
 2. **`web/next.config.mjs`**: `output: 'standalone'`.
 3. **Dockerfiles** (`docker/app.Dockerfile`, `docker/web.Dockerfile`) + repo-committed `docker-compose.yml` (dev/build template; the mini's real file is `/opt/argon/compose.yml`, mirrored like apex).
-4. **`release.yml`**: add `ghcr-push` job (matrix × 2 images, `ubuntu-24.04-arm`, after `publish`; prerelease tags excluded from `:latest`).
+4. **`release.yml`**: add `ghcr-push` job (matrix × 2 images, `ubuntu-24.04-arm` — free on this PUBLIC repo, no self-hosted runner needed; `needs: verify`, runs alongside/after `publish`; prerelease tags excluded from `:latest`). The job needs `permissions: packages: write` and a `docker/login-action` step against `ghcr.io` with `GITHUB_TOKEN` — neither exists in the current workflow.
 5. **Docs**: new runbook `docs/runbooks/docker-deploy.md`; mark launchd sections of `docs/runbooks/release.md` superseded (xenon precedent: keep old scripts, mark runbook superseded).
 6. CHANGELOG entry — same PR.
+7. **Web SSR API base** — the server-render fetch path currently reads
+   `process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8400"`
+   (`web/lib/api.ts:22`, `web/lib/regime/api.ts:9`, `web/app/admin/page.tsx:9`) and
+   `NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:8400"` (`web/app/gold/page.tsx:7`,
+   `web/app/gold/replay/[date]/page.tsx:7`). `NEXT_PUBLIC_*` is inlined at **build**
+   time, so `/opt/argon/.env` cannot override it — inside the `web` container the SSR
+   base falls back to `127.0.0.1:8400` = the container itself → every server-rendered
+   page fails its data fetch (including `/`). Change the server-side branch of these
+   files to read a **non-public runtime var** — reuse `NEXT_INTERNAL_API_BASE`
+   (`?? "http://127.0.0.1:8400"` for host/launchd compat) — so one runtime env drives
+   both the client rewrite and the SSR base. Do this in code, not via a build ARG, to
+   avoid baking the compose service name into the image. Hard cutover-blocker if missed.
 
 ## What stays on the host
 
 - **Postgres 16/17 (Homebrew)** — untouched.
 - **`com.argon.backup` / `com.argon.backup-r2`** launchd agents — they pg_dump the host DB with host `pg_dump`; containerizing them buys nothing. Keep. (Requires keeping a repo checkout on the mini for the backup scripts, or inlining the R2 script path — keep the checkout; it's also the rollback escape hatch.)
-- **AI Codex/Claude workers** — retired in phase 1 (kill switches off, so no orphan queued rows: the API only enqueues rows for *enabled* providers). Interim fallback if Claude analyses are missed: their two launchd agents can keep running from the host checkout against the same DB — they're just Postgres pollers. Decision: **off by default**, hybrid only on request. Rewrite (API-based, e.g. Anthropic API runner like the DeepSeek shape) is a separate later project.
+- **AI Codex/Claude workers** — retired in phase 1 (kill switches off, so no orphan queued rows: the API only enqueues rows for *enabled* providers). Interim fallback if Claude analyses are missed: their two launchd agents can keep running from the host checkout against the same DB — they're just Postgres pollers. Decision: **off by default**, hybrid only on request. Rewrite (API-based, e.g. Anthropic API runner like the DeepSeek shape) is a separate later project — tracked in **issue #248**.
 - **`com.argon.deploy-poller`** — retired, replaced by Watchtower.
 
 ## Deploy-semantics tradeoff (eyes open)
 
-Today's `macmini-prod.sh` has health-gated rollback (currently broken — it accepts HTTP 200 with `ok=false`; see ops-hardening candidate). Watchtower has **no rollback**: a bad release runs until someone pins the previous tag (`sed` image tag in `/opt/argon/compose.yml` + `docker-compose up -d`). Mitigations:
+Today's `macmini-prod.sh` gates on **serving liveness** (`.db == "up"` + deployed
+`.version`), NOT `.ok` — PR #247 corrected the earlier `.ok`-based gate that deadlocked
+under budget throttling. Watchtower has **no rollback**: a bad release runs until someone
+pins the previous tag (`sed` image tag in `/opt/argon/compose.yml` + `docker-compose up -d`).
+Mitigations:
 
 - `release.yml` already gates publishing on the full verify suite (ruff, pytest incl. integration vs postgres:15, web build) — the class of "doesn't even boot" releases mostly can't publish.
-- Compose `depends_on: service_healthy` + `restart: unless-stopped` keeps a crash-looping api from taking web down silently; `docker ps` shows unhealthy state.
-- The ops-hardening candidate (webhook alert on `/api/health` `ok=false`) becomes the detection layer — recommend shipping it in the same window.
+- Compose `depends_on: service_healthy` + `restart: unless-stopped` keeps a crash-looping api from taking web down silently; `docker ps` shows unhealthy state. **The container HEALTHCHECK (`curl -f …/api/health`, HTTP-200-only — see topology table) deliberately does NOT parse `.ok`, so it stays green during budget throttle and won't false-fail `depends_on` — the same #247 lesson, applied to the container layer.**
+- The C12 ops-hardening alert (webhook on job-failure streak / budget wall — already shipped, v0.8.0) is the detection layer for runtime-broken-but-published releases, since Watchtower can't roll back.
 
 ## Cutover plan (phased, reversible)
 
@@ -83,10 +111,19 @@ Today's `macmini-prod.sh` has health-gated rollback (currently broken — it acc
 **Phase 1 — mini side-by-side setup** (no cutover yet):
 `colima stop && colima start --cpu 6 --memory 8` → GHCR `docker login` (same PAT approach as xenon) → create `/opt/argon/{compose.yml,.env}` → `docker-compose --profile migrate run --rm migrator` (idempotent, safe against live DB) → do **not** start app services yet.
 
+> **⚠ The Colima resize is NOT argon-local — it bounces the whole mini.** There is one shared Colima VM (verified 2026-07-08: 4 CPU / ~5.77 GiB) hosting **xenon (live IB feed), apex, and the trading-observability stack** (alloy/prometheus/grafana/loki/cadvisor). `colima stop` kills all of them simultaneously; `colima start` must bring all three back. So: **schedule this in a market-closed window** (xenon's IB feed and any live positions go dark during the bounce), and after `colima start` verify **all three stacks return healthy** (`docker ps` all `Up`/`healthy`, xenon `/api/health`, apex `:8322/health`, Grafana reachable) *before* touching argon. Current VM use is ~2.2 GiB; argon's 12 containers add ~2 GiB, so the resize to 8 GiB is required headroom, not optional — do not skip it and try to fit argon into the current 5.77 GiB.
+
 **Phase 2 — cutover (the double-writer moment):**
 1. `launchctl bootout gui/$UID` all `com.argon.*` app agents (api, web, massive-ws, 10 workers, deploy-poller) — **fully stopped before compose starts**; running both stacks double-writes and double-burns the UW budget (known gotcha from the xenon-WS migration).
 2. `docker-compose up -d` at `/opt/argon`.
-3. Verify: `/api/health` `ok=true` + `ws_consumer.active_source=xenon_ws` (proves host.docker.internal:8765 works) + one full scan cycle lands + freshness monitor green next morning + spot updates visible on `:3001`.
+3. Verify **serving liveness, NOT `.ok`** (post-#247: `.ok` folds in budget-throttled
+   skipped full scans and is routinely `false` during RTH — gating cutover on it would
+   read a healthy stack as a failed deploy): `/api/health` `.db == "up"` + `.version`
+   matches the deployed tag + `ws_consumer.active_source=xenon_ws` (proves
+   host.docker.internal:8765 works) + one full scan cycle lands + **server-rendered pages
+   render data — load `/`, `/gold`, and a `/stock/<ticker>` page, not just `/api/health`
+   (catches the SSR-base regression, code change #7)** + freshness monitor green next
+   morning + spot updates visible on `:3001`.
 
 **Phase 3 — retire:** after ~3 clean days, remove app plists from `~/Library/LaunchAgents` (keep backup plists). Update `config/services.list` docs.
 
@@ -102,9 +139,11 @@ Today's `macmini-prod.sh` has health-gated rollback (currently broken — it acc
 - [ ] massive WS connects with no proxy env leakage
 - [ ] Watchtower recreates on a test prerelease→release publish
 - [ ] nightly backup still runs (host launchd, untouched)
+- [ ] **web SSR renders data from inside the container** — `/`, `/gold`, `/stock/<ticker>`, `/regime` all fetch (not just `/` + `/api/health`); confirms code change #7 landed and the SSR base is `api:8400`, not `127.0.0.1:8400`
+- [ ] tripwire is still ACTIVE in-container (no `UW_SCAN_ALLOW_DB_MISMATCH=1` in `/opt/argon/.env`); illegal `(host, db)` still refuses
 
 ## Open items
 
 - Colima VM sizing is shared with xenon/apex containers — watch memory after cutover; workers are idle-poll APScheduler processes (~100-150 MB RSS each expected).
-- Postgres version drift: argon backup plist pins `postgresql@16`, xenon/apex docs say host runs `@17` — confirm which instance actually serves `option_wizard` on the mini before phase 1 (affects only the backup plist's pg_dump path, not the containers).
+- ~~Postgres version drift: argon backup plist pins `postgresql@16`…~~ **RESOLVED by PR #246** — backup plist now uses `postgresql@17`, matching the host cluster. No longer an open item.
 - AI rewrite (Codex/Claude → API-based runners) — separate spec, later.

--- a/docs/superpowers/specs/2026-07-06-docker-migration-design.md
+++ b/docs/superpowers/specs/2026-07-06-docker-migration-design.md
@@ -5,7 +5,7 @@
 
 ## House pattern adopted (verified from xenon/apex)
 
-- **Runtime:** Colima VM on the mini (brew service). xenon default profile is 2 CPU / 2 GiB — argon adds ~12 containers, so resize to `colima start --cpu 6 --memory 8` (xenon docs already flag OOM risk at 2 GiB with 4 containers).
+- **Runtime:** Colima VM on the mini (brew service). xenon default profile is 2 CPU / 2 GiB — argon adds ~10 services (9 long-running + a one-shot migrator), so resize to `colima start --cpu 6 --memory 8` (xenon docs already flag OOM risk at 2 GiB with 4 containers).
 - **Networking:** bridge, published ports, `extra_hosts: ["host.docker.internal:host-gateway"]` on every service. Never `127.0.0.1` for host resources ("127.0.0.1 is the container itself" — xenon runbook).
 - **Postgres:** stays host-native Homebrew. Containers reach it at `host.docker.internal:5432`, DB `option_wizard`, role `argon_app`. No data moves.
 - **Images:** built/pushed by `.github/workflows/release.yml` on `ubuntu-24.04-arm` (native arm64, no QEMU — apex pattern) to GHCR, tags `:X.Y.Z` + `:latest` (prereleases excluded from `:latest`).
@@ -37,7 +37,7 @@ All: `restart: unless-stopped`, `env_file: [/opt/argon/.env]`, `extra_hosts`, wa
 
 Healthchecks: api = `curl -f http://localhost:8400/api/health`; web = `wget --spider -q http://127.0.0.1:3001/` (explicit IPv4 — alpine resolves `localhost` to `::1` first; xenon gotcha). Workers get a lightweight process-liveness check only (no HTTP surface).
 
-**12 containers total.** Phase 1 is a lift-and-shift of the current topology; consolidating 2×uw/2×massive into fewer processes is a later optimization, not now.
+**10 services** (api + web + ws-consumer + 2×uw + 2×massive + 2×ai-deepseek = 9 long-running, plus a profile-gated one-shot migrator). Phase 1 is a lift-and-shift of the current topology; consolidating 2×uw/2×massive into fewer processes is a later optimization, not now.
 
 ## Env remaps (in `/opt/argon/.env`)
 
@@ -111,7 +111,7 @@ Mitigations:
 **Phase 1 — mini side-by-side setup** (no cutover yet):
 `colima stop && colima start --cpu 6 --memory 8` → GHCR `docker login` (same PAT approach as xenon) → create `/opt/argon/{compose.yml,.env}` → `docker-compose --profile migrate run --rm migrator` (idempotent, safe against live DB) → do **not** start app services yet.
 
-> **⚠ The Colima resize is NOT argon-local — it bounces the whole mini.** There is one shared Colima VM (verified 2026-07-08: 4 CPU / ~5.77 GiB) hosting **xenon (live IB feed), apex, and the trading-observability stack** (alloy/prometheus/grafana/loki/cadvisor). `colima stop` kills all of them simultaneously; `colima start` must bring all three back. So: **schedule this in a market-closed window** (xenon's IB feed and any live positions go dark during the bounce), and after `colima start` verify **all three stacks return healthy** (`docker ps` all `Up`/`healthy`, xenon `/api/health`, apex `:8322/health`, Grafana reachable) *before* touching argon. Current VM use is ~2.2 GiB; argon's 12 containers add ~2 GiB, so the resize to 8 GiB is required headroom, not optional — do not skip it and try to fit argon into the current 5.77 GiB.
+> **⚠ The Colima resize is NOT argon-local — it bounces the whole mini.** There is one shared Colima VM (verified 2026-07-08: 4 CPU / ~5.77 GiB) hosting **xenon (live IB feed), apex, and the trading-observability stack** (alloy/prometheus/grafana/loki/cadvisor). `colima stop` kills all of them simultaneously; `colima start` must bring all three back. So: **schedule this in a market-closed window** (xenon's IB feed and any live positions go dark during the bounce), and after `colima start` verify **all three stacks return healthy** (`docker ps` all `Up`/`healthy`, xenon `/api/health`, apex `:8322/health`, Grafana reachable) *before* touching argon. Current VM use is ~2.2 GiB; argon's ~9 long-running containers add ~2 GiB, so the resize to 8 GiB is required headroom, not optional — do not skip it and try to fit argon into the current 5.77 GiB.
 
 **Phase 2 — cutover (the double-writer moment):**
 1. `launchctl bootout gui/$UID` all `com.argon.*` app agents (api, web, massive-ws, 10 workers, deploy-poller) — **fully stopped before compose starts**; running both stacks double-writes and double-burns the UW budget (known gotcha from the xenon-WS migration).

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -71,6 +71,15 @@ _HOST_DB_RULES: dict[str, frozenset[str]] = {
     "100.66.147.98": frozenset({"option_wizard", "option_wizard_test"}),
     "127.0.0.1": frozenset({"option_wizard_local", "option_wizard_test"}),
     "localhost": frozenset({"option_wizard_local", "option_wizard_test"}),
+    # Docker: containers reach host-native Postgres via host.docker.internal.
+    # On the mini that host DB is prodlike `option_wizard`; local/CI Docker
+    # smoke runs target `option_wizard_local`; integration tests use the test
+    # tier. Keeping this rule meaningful means the container `.env` must NOT
+    # carry UW_SCAN_ALLOW_DB_MISMATCH=1 (which bypasses ALL isolation checks) —
+    # the clean container path is a legal pair here, no override.
+    "host.docker.internal": frozenset(
+        {"option_wizard", "option_wizard_local", "option_wizard_test"}
+    ),
 }
 
 

--- a/tests/unit/test_db_isolation_docker.py
+++ b/tests/unit/test_db_isolation_docker.py
@@ -1,0 +1,39 @@
+"""DB-isolation tripwire: the Docker `host.docker.internal` route.
+
+Containers reach host-native Postgres via `host.docker.internal`; the tripwire
+must allow the prodlike/local/test DB names on that host and still refuse an
+illegal pairing (unless the explicit one-off override is set). See the Docker
+migration design spec and `config._HOST_DB_RULES`.
+"""
+
+import pytest
+
+from uw_scan.config import _enforce_db_isolation
+
+
+@pytest.mark.parametrize(
+    "db_name",
+    ["option_wizard", "option_wizard_local", "option_wizard_test"],
+)
+def test_docker_host_allows_legal_db_names(db_name: str) -> None:
+    # Must not raise for any of the three legal names on host.docker.internal.
+    _enforce_db_isolation("host.docker.internal", db_name)
+
+
+def test_docker_host_allows_xdist_test_db_prefix() -> None:
+    # pytest-xdist per-worker test DBs share the isolated test tier.
+    _enforce_db_isolation("host.docker.internal", "option_wizard_test_gw0")
+
+
+def test_docker_host_refuses_illegal_db_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No override → an unlisted DB name on the Docker host is refused.
+    monkeypatch.delenv("UW_SCAN_ALLOW_DB_MISMATCH", raising=False)
+    with pytest.raises(RuntimeError, match="Refusing to start"):
+        _enforce_db_isolation("host.docker.internal", "some_other_db")
+
+
+def test_override_still_bypasses_docker_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The blanket override remains an escape hatch even on the Docker host —
+    # which is exactly why the container `.env` must NOT set it (see spec #1).
+    monkeypatch.setenv("UW_SCAN_ALLOW_DB_MISMATCH", "1")
+    _enforce_db_isolation("host.docker.internal", "some_other_db")

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -3,10 +3,10 @@ import type { components } from "@/lib/types";
 type HealthResponse = components["schemas"]["HealthResponse"];
 
 async function fetchHealth(): Promise<HealthResponse> {
-  // RSC fetch — needs an absolute URL. Use `||` so an empty
-  // NEXT_PUBLIC_API_BASE_URL (set when the bundle should call relative
-  // paths in the browser) still resolves server-side.
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8400";
+  // RSC fetch — needs an absolute URL. Read the runtime NEXT_INTERNAL_API_BASE
+  // (non-public, not build-inlined; `http://api:8400` in Docker, unset →
+  // localhost under launchd). See docker spec code change #7.
+  const base = process.env.NEXT_INTERNAL_API_BASE ?? "http://127.0.0.1:8400";
   const r = await fetch(`${base}/api/health`, { cache: "no-store" });
   return r.json();
 }

--- a/web/app/gold/page.tsx
+++ b/web/app/gold/page.tsx
@@ -4,7 +4,9 @@ import type { components } from "@/lib/types";
 type State = components["schemas"]["GoldStateResponse"];
 
 async function fetchGoldState(): Promise<State | null> {
-  const base = process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:8400";
+  // Runtime NEXT_INTERNAL_API_BASE (not build-inlined): `http://api:8400` in
+  // Docker, unset → localhost under launchd. See docker spec code change #7.
+  const base = process.env.NEXT_INTERNAL_API_BASE ?? "http://127.0.0.1:8400";
   try {
     const res = await fetch(`${base}/api/gold/state`, {
       cache: "no-store",

--- a/web/app/gold/replay/[date]/page.tsx
+++ b/web/app/gold/replay/[date]/page.tsx
@@ -4,7 +4,9 @@ import type { components } from "@/lib/types";
 type State = components["schemas"]["GoldStateResponse"];
 
 async function fetchReplay(date: string): Promise<State | null> {
-  const base = process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:8400";
+  // Runtime NEXT_INTERNAL_API_BASE (not build-inlined): `http://api:8400` in
+  // Docker, unset → localhost under launchd. See docker spec code change #7.
+  const base = process.env.NEXT_INTERNAL_API_BASE ?? "http://127.0.0.1:8400";
   try {
     const res = await fetch(`${base}/api/gold/replay?as_of=${date}`, {
       cache: "no-store",

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -12,14 +12,16 @@ type VrpMacroPositionDetail = components["schemas"]["VrpMacroPositionDetail"];
 // Tunnel, etc.) and get proxied to FastAPI by the Next.js rewrite at
 // `/api/:path*`. On the server (RSC fetches), hit FastAPI directly because
 // relative URLs have no base in a Node fetch context.
-// `||` (not `??`) so an empty NEXT_PUBLIC_API_BASE_URL — used in deploys
-// where the browser bundle should call relative paths — still falls back
-// to the server-side absolute URL during RSC rendering (Node fetch needs
-// an absolute URL).
+// Browser: "" → relative `/api/*`, routed through the next.config.mjs rewrite.
+// Server (RSC): needs an absolute URL. Read NEXT_INTERNAL_API_BASE — a *runtime*
+// (non-NEXT_PUBLIC, so not build-inlined) env, the SAME var the rewrite proxy
+// uses. Under launchd it's unset → localhost fallback; in Docker it's
+// `http://api:8400` (the compose service), never `127.0.0.1` = the container
+// itself. See docker-migration spec code change #7.
 const API =
   typeof window !== "undefined"
     ? ""
-    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8400";
+    : process.env.NEXT_INTERNAL_API_BASE ?? "http://127.0.0.1:8400";
 
 type Json<
   P extends keyof paths,

--- a/web/lib/regime/api.ts
+++ b/web/lib/regime/api.ts
@@ -1,12 +1,11 @@
 // URL-agnostic base. See web/lib/api.ts for rationale: browser uses a
 // relative URL routed through the Next.js `/api/:path*` rewrite; server-side
-// (RSC) hits FastAPI directly.
-// `||` (not `??`) so an empty NEXT_PUBLIC_API_BASE_URL still falls back to
-// the absolute server-side URL during RSC rendering. See web/lib/api.ts.
+// (RSC) hits FastAPI directly via the runtime NEXT_INTERNAL_API_BASE (the same
+// var the rewrite proxy reads). See web/lib/api.ts + docker spec code change #7.
 const API =
   typeof window !== "undefined"
     ? ""
-    : process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8400";
+    : process.env.NEXT_INTERNAL_API_BASE ?? "http://127.0.0.1:8400";
 
 export const regimeApi = {
   cri: () => `${API}/api/regime`,

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,6 +1,21 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// web/ is a standalone Next project (no repo-root package.json). Next otherwise
+// infers the workspace root from the nearest *ancestor* lockfile — on this Mac
+// that's ~/projects/package-lock.json, which nests the standalone output under
+// the full path. Pin the trace root to web/ so `output: 'standalone'` always
+// emits `.next/standalone/server.js` regardless of build host / worktree depth.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Emit a self-contained server bundle (web/.next/standalone/server.js) so the
+  // prod Docker image ships only the traced node_modules — no full `npm install`
+  // in the runtime layer. Required by docker/web.Dockerfile.
+  output: "standalone",
+  outputFileTracingRoot: resolve(__dirname),
   // Next 16 blocks cross-origin requests to dev resources (incl. the HMR
   // WebSocket) by default. Without this, hydration silently fails and the
   // page renders as static HTML. Add the hosts dev.sh actually serves on.


### PR DESCRIPTION
## What

Docker migration **prep** — artifacts only, no cutover. Moves the mini prod stack toward Docker on the xenon/apex house pattern (Colima, `host.docker.internal`, host-native Postgres unchanged, GHCR images, shared engine-wide Watchtower). **The launchd stack stays the live prod path** until the phased, user-driven cutover runs.

## Contents

- `docker/app.Dockerfile` (python:3.13-slim, uv 0.11.17 pinned to match `uv.lock` revision 3, `.venv` on PATH → no `uv run` in-container) + `docker/web.Dockerfile` (node:22-alpine, Next 16 standalone).
- Root `docker-compose.yml` — 10 services (9 long-running + profile-gated one-shot `migrator`), YAML anchors, `host.docker.internal` extra_hosts, Watchtower label, worker sharding (`ROLE`/`INDEX`/`COUNT=2` per 2-instance role).
- `.dockerignore` (secret-free build context).
- `ghcr-push` matrix job in `release.yml` — native arm64 runner, builds + pushes `argon-app` + `argon-web` on every tag; `:X.Y.Z` always, `:latest` only for final releases (prerelease hyphen excluded so Watchtower never auto-deploys an rc).
- `config._HOST_DB_RULES` gains `host.docker.internal` → containers pass the DB-isolation tripwire on the legal `host.docker.internal`+`option_wizard` pair, **without** the blanket `UW_SCAN_ALLOW_DB_MISMATCH` override.
- Web SSR fetch sites read runtime `NEXT_INTERNAL_API_BASE` (not build-inlined `NEXT_PUBLIC_API_BASE*`) so a containerized web renders against the `api` service; `next.config` emits `output: 'standalone'` with `outputFileTracingRoot` pinned to `web/`.
- Runbook `docs/runbooks/docker-deploy.md` (phased cutover) + `release.md` forward-pointer + CHANGELOG.

## Known caveat (tracked)

AI Codex/Claude workers are retired in Docker phase 1 (subprocess CLI + keychain auth don't containerize) — issue #248. DeepSeek (in-process HTTP) survives.

## Verification (local, pre-merge)

- Full `ci.yml` lint+unit reproduced green — 1323 unit tests pass, ruff/guardrails/version-sync/migration-prefix all clean; 6 new `test_db_isolation_docker.py` asserts pass.
- Web: typecheck + lint clean; `next build` exit 0 with pinned standalone layout.
- Both images build (app 1.1 GB arm64, web exit 0); app imports OK, `.venv` on PATH, `uv` absent.
- `docker compose config` valid through Docker's parser.
- web container → HTTP 200 in 2 s (Next 16.2.6 standalone, 0.0.0.0:3001).
- migrator container → real `host.docker.internal:5432/option_wizard_local` → "All migrations applied" exit 0.
- Tripwire negative test in-container: illegal `option_wizard_prod` → "Refusing to start" as designed.

The `ghcr-push` job itself only fires on a tag, so this PR's CI does not build images — the first release tag after merge does.
