### PR TITLE
fix(docker): bake web /api rewrite target at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker web image: client-side `/api/*` rewrite baked the wrong target.**
+  `next.config.mjs` `rewrites()` is evaluated at *build* time, so the CI-built
+  `argon-web` image froze the `localhost:8400` fallback into its standalone
+  server — every browser `/api/*` call 500'd in-container (SSR was unaffected,
+  masking it). `docker/web.Dockerfile` now sets `ARG NEXT_INTERNAL_API_BASE=`
+  `http://api:8400` before `next build` so the rewrite bakes the compose
+  service name; the launchd (non-Docker) build still bakes its correct
+  co-located `localhost` default. Runbook Phase 2 gains an explicit
+  web→api rewrite check (SSR page codes pass even when this path is broken).
+
 ## [0.9.0] — 2026-07-08
 
 

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -2,7 +2,10 @@
 # argon-web — Next.js 16 standalone. The client bundle calls relative /api/*,
 # proxied to the api service by the next.config.mjs rewrite. SSR fetches read
 # the same runtime NEXT_INTERNAL_API_BASE. argon web inlines NO NEXT_PUBLIC_*
-# values, so this image needs zero build args.
+# values — but next.config.mjs rewrites() is evaluated at BUILD time and frozen
+# into the standalone server, so the client-side /api/* proxy target is a build
+# arg (below), not runtime. Without it the rewrite bakes the localhost fallback
+# and every browser /api/* call 500s in-container.
 # Built natively on ubuntu-24.04-arm in release.yml for the arm64 mini.
 #
 # Local smoke (arm64 Docker host):
@@ -25,6 +28,12 @@ RUN npm ci --no-audit --no-fund --legacy-peer-deps
 # standalone bundle emits at /app/web/.next/standalone/server.js (server.js +
 # node_modules at the standalone root).
 COPY web/ ./
+# rewrites() bakes at build time — set the compose service-name target for the
+# client-side /api/* proxy. SSR still reads this same value from runtime env.
+# The launchd (non-Docker) build never sets this, keeping its correct localhost
+# co-located default.
+ARG NEXT_INTERNAL_API_BASE=http://api:8400
+ENV NEXT_INTERNAL_API_BASE=$NEXT_INTERNAL_API_BASE
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npx next build
 

--- a/docs/runbooks/docker-deploy.md
+++ b/docs/runbooks/docker-deploy.md
@@ -95,6 +95,13 @@ curl -s http://127.0.0.1:8400/api/health | jq '{version, db, active: .ws_consume
 #   want: version == deployed tag, db == "up", active_source == "xenon_ws"
 # 4. Verify SSR renders data (catches the NEXT_INTERNAL_API_BASE regression):
 for p in / /gold /regime /stock/AAPL; do curl -sfo /dev/null -w "%{http_code} $p\n" http://127.0.0.1:3001$p; done
+# 5. Verify the CLIENT-SIDE /api/* rewrite proxies web -> api. SSR page codes
+#    (step 4) pass even when this is broken, so check it explicitly: the browser
+#    hits web:3001/api/*, which next.config rewrites to the api service. The
+#    rewrite target is BAKED at image build (ARG NEXT_INTERNAL_API_BASE in
+#    web.Dockerfile); a mis-baked image 500s here while step 4 stays green.
+curl -s http://127.0.0.1:3001/api/health | jq '{via_web_rewrite: .db, version}'
+#   want: db == "up" (NOT a 500 / HTML error page)
 ```
 
 ### Phase 3 — retire


### PR DESCRIPTION
## Problem

Live-tested the published `argon-web:0.9.0` image (from the v0.9.0 `ghcr-push`) and found the client-side `/api/*` rewrite 500s in-container. Root cause: **`next.config.mjs` `rewrites()` is evaluated at *build* time** and frozen into the standalone server. CI builds web with no `NEXT_INTERNAL_API_BASE`, so the rewrite baked the `localhost:8400` fallback — inside the web container that's the web container itself → ECONNREFUSED → 500. SSR reads the var at *runtime* so it worked, masking the bug (and the runbook's Phase-2 check only curled SSR page codes).

## Fix

- `docker/web.Dockerfile`: `ARG NEXT_INTERNAL_API_BASE=http://api:8400` + `ENV` before `next build` → rewrite bakes the compose service name. The launchd (non-Docker) build never sets it, keeping its correct co-located `localhost` default. SSR still reads the same value from runtime compose env.
- `docs/runbooks/docker-deploy.md`: Phase 2 gains an explicit web→api rewrite check.
- CHANGELOG `[Unreleased]` Fixed entry.

## Verification (locally rebuilt image)

Rebuilt web with the build arg, ran api (`argon-app:0.9.0` from GHCR) + web on a shared network with the api aliased `api`:

- Client rewrite `curl web:3001/api/health` → `REWRITE OK — version 0.9.0 | db up | ok True` (was 500).
- SSR routes `/ /gold /regime /stock/AAPL` → all 200.
- web logs: **0** ECONNREFUSED (was 4× per request).

Ships as v0.9.1 → `ghcr-push` rebuilds the corrected image.