### PR TITLE
chore(docker): complete phase-3 launchd retire + fix web healthcheck HEAD error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+
+- **Docker migration — cutover complete (Phase 2) + launchd retired (Phase 3).**
+  argon now runs in Docker on the mini (`/opt/argon/compose.yml`); the 14 launchd
+  app plists are moved to `/opt/argon/retired-launchd-plists/` (only
+  `com.argon.backup` stays host-native), and deploys flow through the engine-wide
+  Watchtower instead of the launchd `deploy-poller`/`macmini-prod.sh` path. Updated
+  `docs/runbooks/docker-deploy.md` (status → complete, rollback path) and the
+  CLAUDE.md release procedure. Rollback restores the plists from the retired dir.
+
+### Fixed
+
+- **Docker web healthcheck triggered a recurring `transformAlgorithm` error.**
+  The compose web healthcheck used `wget --spider` (a HEAD request); a HEAD against
+  the streaming SSR landing page makes Next.js 16 on Node 22 wire a response
+  `TransformStream` with no body, logging a caught, non-fatal
+  `controller[kState].transformAlgorithm is not a function` every 30s. Switched the
+  healthcheck to a full GET (`wget -qO /dev/null`), which drains the body → zero
+  such errors (verified live). Real user GETs were never affected. Also corrected
+  the compose header container count (12 → 10).
+
 ## [0.9.1] — 2026-07-08
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,17 @@ cd web && npm run gen:types       # regenerate types.ts after API change
 
 ## Release procedure
 
-Tag-driven, launchd-native (no Docker). Cut a release with
+Tag-driven, Docker on the mini (launchd retired 2026-07-08). Cut a release with
 `scripts/release/cut.sh prepare [patch|minor|major]` (opens a release PR) → merge
 → `scripts/release/cut.sh tag` (pushes `vX.Y.Z`). The tag fires
-`.github/workflows/release.yml` (verify → publish GitHub Release). The mini's
-`com.argon.deploy-poller` (every 120s) deploys the latest **published,
-non-prerelease** Release via `scripts/deploy/macmini-prod.sh`. Prereleases
-(`vX.Y.Z-rc1`) verify + publish but never auto-deploy. See
-`docs/runbooks/release.md`.
+`.github/workflows/release.yml` (verify → publish GitHub Release + `ghcr-push`
+builds/pushes the `argon-app`/`argon-web` images; `:latest` floats only for final,
+non-prerelease tags). The mini runs argon from `/opt/argon/compose.yml`; the
+engine-wide Watchtower in `/opt/xenon/compose.yml` auto-deploys the new `:latest`
+images. Prereleases (`vX.Y.Z-rc1`) never float `:latest`, so Watchtower never
+auto-deploys an rc. Schema changes apply out-of-band via the profile-gated
+migrator. Current path: `docs/runbooks/docker-deploy.md`; the superseded launchd
+`deploy-poller`/`macmini-prod.sh` path stays documented in `docs/runbooks/release.md`.
 
 ## Live spot WS feed (xenon primary / massive fallback)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@
 #   docker-compose --profile migrate run --rm migrator   # one-shot schema apply
 #   docker-compose up -d
 #
-# 12 containers: migrator (profile-gated) + api + web + ws-consumer + 2×uw +
-# 2×massive + 2×ai-deepseek. AI Codex/Claude are OFF in phase 1 (kill switches
-# in /opt/argon/.env; retired to issue #248).
+# 10 containers: 9 long-running (api + web + ws-consumer + 2×uw + 2×massive +
+# 2×ai-deepseek) plus a profile-gated one-shot migrator. AI Codex/Claude are OFF
+# in phase 1 (kill switches in /opt/argon/.env; retired to issue #248).
 #
 # host.docker.internal reaches host-native services (set the remapped URLs in
 # /opt/argon/.env): Postgres :5432, xenon WS :8765, xenon query API :8321,
@@ -82,7 +82,12 @@ services:
         condition: service_healthy
     healthcheck:
       # Explicit IPv4 — alpine busybox resolves `localhost` to ::1 first.
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3001/"]
+      # Full GET (-qO /dev/null), NOT --spider: --spider sends HEAD, and a HEAD
+      # against the streaming SSR landing page makes Next.js 16 on Node 22 wire a
+      # response TransformStream with no body → recurring (caught, non-fatal)
+      # `controller[kState].transformAlgorithm is not a function` logs every 30s.
+      # A real GET drains the body and produces zero such errors (verified).
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:3001/"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/docs/runbooks/docker-deploy.md
+++ b/docs/runbooks/docker-deploy.md
@@ -1,9 +1,10 @@
 # Docker deploy runbook (Mac mini)
 
-**Status:** artifacts shipped, cutover **not yet performed**. The live prod path
-is still the launchd stack (`docs/runbooks/release.md`). This runbook is the
-procedure for the phased cutover and for operating argon once it runs in Docker.
-Design + rationale: `docs/superpowers/specs/2026-07-06-docker-migration-design.md`.
+**Status:** **cutover complete — argon runs in Docker on the mini as of 2026-07-08.**
+The launchd app stack is retired (its 14 plists moved to
+`/opt/argon/retired-launchd-plists/`; only `com.argon.backup` stays host-native).
+This runbook remains the operating procedure and the rollback reference. Design +
+rationale: `docs/superpowers/specs/2026-07-06-docker-migration-design.md`.
 
 ## What this migration does
 
@@ -104,20 +105,27 @@ curl -s http://127.0.0.1:3001/api/health | jq '{via_web_rewrite: .db, version}'
 #   want: db == "up" (NOT a 500 / HTML error page)
 ```
 
-### Phase 3 — retire
-After ~3 clean days, remove the app plists from `~/Library/LaunchAgents` (keep
-the two `com.argon.backup*` plists — they stay host-native). Mark release.md
-launchd sections superseded then.
+### Phase 3 — retire (DONE 2026-07-08)
+The 14 launchd app plists (api, web, massive-ws, the 10 workers, deploy-poller)
+were moved out of `~/Library/LaunchAgents` into `/opt/argon/retired-launchd-plists/`
+— moving them (not just `launchctl bootout`) is what stops `RunAtLoad` from
+resurrecting them on reboot. Only `com.argon.backup` remains host-native (there
+is **one** backup plist, not two). On reboot the containers return via Docker's
+`restart: unless-stopped`, same as xenon/apex. Deploys now flow through the
+engine-wide Watchtower (new `:latest` image → auto-recreate), so the launchd
+`deploy-poller` + `macmini-prod.sh` path in `release.md` is superseded.
 
 ## Rollback (any point)
 
 ```bash
 cd /opt/argon && docker-compose down
+# Post-phase-3: move the retired plists back into the launchd scan dir first.
+mv /opt/argon/retired-launchd-plists/com.argon.*.plist ~/Library/LaunchAgents/
 for l in api web massive-ws worker-uw-0 ...; do launchctl bootstrap "gui/$(id -u)" \
   ~/Library/LaunchAgents/com.argon.$l.plist; done
 ```
-The plists stay on disk through phase 2, and Postgres never moved, so the launchd
-stack resumes from the same DB. Watchtower has **no** rollback for a bad image —
+The retired plists live in `/opt/argon/retired-launchd-plists/`, and Postgres never
+moved, so the launchd stack resumes from the same DB. Watchtower has **no** rollback for a bad image —
 pin the previous tag: `sed -i '' 's#:latest#:X.Y.Z#' /opt/argon/compose.yml &&
 docker-compose up -d`.
 


### PR DESCRIPTION
## Summary
Completes the argon Docker migration — Phase 2 cutover performed on the mini, Phase 3 launchd retire done, plus a web healthcheck fix found during cutover. Backs the live mini state with the committed source of truth.

## Changes
- **docker-compose.yml** — web healthcheck `--spider` (HEAD) → full GET `-qO /dev/null`. A HEAD against the streaming SSR landing page makes Next 16 / Node 22 wire a bodyless response TransformStream, logging a caught, non-fatal `controller[kState].transformAlgorithm is not a function` every 30s (verified: full GET → 0 errors; real user GETs never affected). Header container count 12 → 10.
- **docs/runbooks/docker-deploy.md** — status → cutover complete (2026-07-08); Phase 3 retire documented (14 plists → `/opt/argon/retired-launchd-plists/`; one backup plist, not two); rollback restores from the retired dir.
- **CLAUDE.md** — release procedure → Docker/Watchtower (launchd `deploy-poller`/`macmini-prod.sh` retired).
- **CHANGELOG.md** — [Unreleased] Changed + Fixed.

## Verification (live on the mini)
- argon in Docker: 9 containers up, api+web healthy, `active: xenon_ws`, DB up.
- Healthcheck fix: 0 transformAlgorithm errors over 3+ cycles post-recreate.
- Watchtower deploys argon: Scanned 4→13 when argon's 9 containers joined, Failed=0, GHCR auth OK.
- Launchd retired: only `com.argon.backup` remains loaded.

## Notes
- Docs + compose healthcheck only — no code/runtime change, no migration, no type changes.
- `/opt/argon/compose.yml` on the mini is already re-mirrored from this branch.