### PR TITLE
perf(stock): kill N+1 + response cache + conn pool on /stock hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Changed
 
+- **`/stock/{ticker}` performance package — three compounding fixes on the app's
+  busiest read path.** (1) Killed an N+1: `_build_intraday_profiles` issued one
+  `option_intraday_buckets` query per top-10 OI mover (10 serial round-trips per
+  page load); new `OptionIntradayBucketRepository.fetch_buckets_batch` collapses
+  them to a single `unnest`-join query. (2) Added a per-`(ticker, run_id)` TTL
+  response cache in front of `assemble_single_stock_report` (default 20s, set
+  `SINGLE_STOCK_REPORT_CACHE_TTL_S=0` to disable) so revisits and the 2.5s
+  watchlist-spot poll don't re-derive the whole report; callers get a deep copy so
+  the header's live-spot mutation can't corrupt the cache. (3) Replaced the
+  connect-per-request path in `api/deps.py` with a process-wide
+  `psycopg_pool.ConnectionPool` (`UW_SCAN_DB_POOL_MIN`/`_MAX`, default 2/10) —
+  removes per-request TCP+auth+`SET search_path`, which matters more now that the
+  api container reaches Postgres across the Docker VM boundary. Added `psycopg`'s
+  `pool` extra.
+- **Request-timing monitor for our own endpoints.** New log-only ASGI middleware
+  tags every response with `X-Response-Time-ms` and logs a WARN when a request
+  exceeds `API_SLOW_REQUEST_MS` (default 500; 0 silences). Distinct from the
+  existing outbound-UW `latency_p95_ms`. Cache hit/miss counters exposed via
+  `report_cache_stats()`.
+
 - **Docker migration — cutover complete (Phase 2) + launchd retired (Phase 3).**
   argon now runs in Docker on the mini (`/opt/argon/compose.yml`); the 14 launchd
   app plists are moved to `/opt/argon/retired-launchd-plists/` (only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 postgres = [
-  "psycopg[binary]>=3.2",
+  "psycopg[binary,pool]>=3.2",
 ]
 
 [dependency-groups]

--- a/src/uw_scan/api/deps.py
+++ b/src/uw_scan/api/deps.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Generator
 from functools import lru_cache
 
-import psycopg
+from psycopg_pool import ConnectionPool
 
 from uw_scan.api.client import UwClient
 from uw_scan.config import Settings
@@ -18,13 +19,32 @@ def get_settings() -> Settings:
     return Settings.from_env()
 
 
-def get_repo() -> Generator[Repository, None, None]:
+@lru_cache(maxsize=1)
+def get_pool() -> ConnectionPool:
+    """Process-wide connection pool, opened once on first request.
+
+    Replaces the old connect-per-request path: TCP + auth + ``SET search_path``
+    were paid on every hit (including the 2.5s watchlist-spot poll). Under the
+    Docker cutover this matters more — connection setup now crosses the VM
+    boundary to host.docker.internal.
+    """
     settings = get_settings()
-    conn = psycopg.connect(settings.db_dsn())
-    try:
-        yield Repository(conn, schema=settings.db_schema)
-    finally:
-        conn.close()
+    return ConnectionPool(
+        settings.db_dsn(),
+        min_size=int(os.getenv("UW_SCAN_DB_POOL_MIN", "2")),
+        max_size=int(os.getenv("UW_SCAN_DB_POOL_MAX", "10")),
+        open=True,
+    )
+
+
+def get_repo() -> Generator[Repository, None, None]:
+    """Borrow a pooled connection for the request; return it on exit.
+
+    ``pool.connection()`` commits on clean exit / rolls back on exception, then
+    hands the connection back — Repository's own write commits are unaffected.
+    """
+    with get_pool().connection() as conn:
+        yield Repository(conn, schema=get_settings().db_schema)
 
 
 def get_uw_client() -> Generator[UwClient, None, None]:

--- a/src/uw_scan/api/routers/stock.py
+++ b/src/uw_scan/api/routers/stock.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import threading
+import time
+from collections import OrderedDict
 from datetime import date as _date
 from decimal import Decimal
 
@@ -19,6 +23,78 @@ from uw_scan.reports.single_stock import assemble_single_stock_report
 from uw_scan.storage.repository import Repository
 
 router = APIRouter()
+
+# Response cache for the two polled stock-page endpoints. Keyed on
+# (ticker, run_id); a new scan mints a new run_id so old keys age out on their
+# own (TTL/LRU) — no explicit invalidation. Short TTL so intraday-bucket
+# refreshes (worker cadence) surface within a poll cycle. Set the TTL to 0 to
+# disable (incident escape hatch).
+# ponytail: naive TTL+LRU dict guarded by one lock — ~20 lines beats a
+# cachetools dep. Swap in cachetools.TTLCache only if we need per-key TTLs.
+_REPORT_CACHE_TTL_S = float(os.getenv("SINGLE_STOCK_REPORT_CACHE_TTL_S", "20"))
+_REPORT_CACHE_MAXSIZE = 256
+_report_cache: OrderedDict[tuple[str, int], tuple[float, SingleStockReport]] = (
+    OrderedDict()
+)
+_report_cache_lock = threading.Lock()
+
+# Cheap hit/miss counters so we can see the cache actually earning its keep.
+_report_cache_hits = 0
+_report_cache_misses = 0
+
+
+def report_cache_stats() -> dict[str, int | float]:
+    """Cumulative cache hit/miss counts + hit rate (for logging / debugging)."""
+    with _report_cache_lock:
+        hits, misses = _report_cache_hits, _report_cache_misses
+    total = hits + misses
+    return {
+        "hits": hits,
+        "misses": misses,
+        "hit_rate": round(hits / total, 3) if total else 0.0,
+    }
+
+
+def _report_cache_clear() -> None:
+    """Drop all cached reports and reset counters (used by tests for isolation)."""
+    global _report_cache_hits, _report_cache_misses
+    with _report_cache_lock:
+        _report_cache.clear()
+        _report_cache_hits = 0
+        _report_cache_misses = 0
+
+
+def _assemble_cached(ticker: str, run_id: int, repo: Repository) -> SingleStockReport:
+    """assemble_single_stock_report with a per-(ticker, run_id) TTL cache.
+
+    Always returns a deep copy so the caller (``_with_latest_spot``) can mutate
+    the report in place without corrupting the shared cache entry.
+    """
+    global _report_cache_hits, _report_cache_misses
+
+    if _REPORT_CACHE_TTL_S <= 0:
+        return assemble_single_stock_report(ticker, run_id, repo)
+
+    key = (ticker, run_id)
+    now = time.monotonic()
+    with _report_cache_lock:
+        hit = _report_cache.get(key)
+        if hit is not None:
+            expires_at, cached = hit
+            if expires_at > now:
+                _report_cache.move_to_end(key)
+                _report_cache_hits += 1
+                return cached.model_copy(deep=True)
+            _report_cache.pop(key, None)
+        _report_cache_misses += 1
+
+    report = assemble_single_stock_report(ticker, run_id, repo)
+    with _report_cache_lock:
+        _report_cache[key] = (now + _REPORT_CACHE_TTL_S, report)
+        _report_cache.move_to_end(key)
+        while len(_report_cache) > _REPORT_CACHE_MAXSIZE:
+            _report_cache.popitem(last=False)
+    return report.model_copy(deep=True)
 
 
 def _dec(v: object) -> Decimal | None:
@@ -46,7 +122,7 @@ def get_stock(ticker: str, repo: Repository = Depends(get_repo)) -> SingleStockR
     run_id = repo.latest_run_id(t)
     if run_id == 0:
         raise HTTPException(status_code=404, detail=f"no runs for {t}")
-    return _with_latest_spot(assemble_single_stock_report(t, run_id, repo), repo)
+    return _with_latest_spot(_assemble_cached(t, run_id, repo), repo)
 
 
 @router.get("/stock/{ticker}/history", response_model=StockHistoryResponse)
@@ -90,7 +166,7 @@ def list_runs(ticker: str, repo: Repository = Depends(get_repo)) -> list[dict]:
 def get_specific_run(
     ticker: str, run_id: int, repo: Repository = Depends(get_repo)
 ) -> SingleStockReport:
-    report = assemble_single_stock_report(ticker.upper(), run_id, repo)
+    report = _assemble_cached(ticker.upper(), run_id, repo)
     return _with_latest_spot(report, repo)
 
 

--- a/src/uw_scan/api/server.py
+++ b/src/uw_scan/api/server.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from uw_scan.api.routers import (
@@ -32,9 +34,30 @@ from uw_scan.version import app_version
 
 logger = logging.getLogger(__name__)
 
+# Request-timing monitor for our own endpoints (distinct from api/client.py's
+# outbound UW latency). Log-only: every response carries X-Response-Time-ms;
+# requests slower than the threshold log a WARN. Set the threshold to 0 to
+# silence the warnings (the header is always added).
+# ponytail: perf_counter + one log line, no deps/tables. Surface a rolling p95
+# on /health only if we actually need dashboards.
+_SLOW_REQUEST_MS = float(os.getenv("API_SLOW_REQUEST_MS", "500"))
+
+
+async def _timing_middleware(request: Request, call_next):
+    start = time.perf_counter()
+    response = await call_next(request)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    response.headers["X-Response-Time-ms"] = str(int(elapsed_ms))
+    if _SLOW_REQUEST_MS > 0 and elapsed_ms >= _SLOW_REQUEST_MS:
+        logger.warning(
+            "slow request %s %s %.0fms", request.method, request.url.path, elapsed_ms
+        )
+    return response
+
 
 def create_app() -> FastAPI:
     app = FastAPI(title="UW Watchlist API", version=app_version())
+    app.middleware("http")(_timing_middleware)
     app.add_middleware(
         CORSMiddleware,
         # CORS is URL-agnostic by design: the real trust boundary is the

--- a/src/uw_scan/reports/single_stock.py
+++ b/src/uw_scan/reports/single_stock.py
@@ -261,18 +261,19 @@ def _build_intraday_profiles(
     if not top_rows:
         return []
     intraday_repo = OptionIntradayBucketRepository(repo.conn, schema=repo._schema)
+    pairs = [
+        (row["option_symbol"], row["curr_date"])
+        for row in top_rows
+        if row.get("option_symbol") and row.get("curr_date") is not None
+    ]
+    buckets_by_key = intraday_repo.fetch_buckets_batch(pairs)
     profiles: list[OptionIntradayProfile] = []
-    for row in top_rows:
-        option_symbol = row.get("option_symbol")
-        trade_date = row.get("curr_date")
-        if not option_symbol or trade_date is None:
-            continue
-        buckets = intraday_repo.fetch_buckets(option_symbol, trade_date)
+    for option_symbol, trade_date in pairs:
         profiles.append(
             derive_intraday_profile(
                 option_symbol=option_symbol,
                 trade_date=trade_date,
-                buckets=buckets,
+                buckets=buckets_by_key.get((option_symbol, trade_date), []),
             )
         )
     return profiles

--- a/src/uw_scan/storage/option_intraday_repository.py
+++ b/src/uw_scan/storage/option_intraday_repository.py
@@ -7,7 +7,7 @@ vcg_snapshot_repository.py. Does not extend Repository (per repo policy on the
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import date as _date
 
 from psycopg import Connection
@@ -122,3 +122,42 @@ class OptionIntradayBucketRepository:
             cur.execute(sql, (option_symbol, trade_date))
             cols = [c.name for c in cur.description]
             return [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
+
+    def fetch_buckets_batch(
+        self,
+        pairs: Sequence[tuple[str, _date]],
+    ) -> dict[tuple[str, _date], list[dict]]:
+        """Buckets for many contracts in ONE round-trip (kills the per-row N+1).
+
+        Returns a dict keyed by (option_symbol, trade_date); missing pairs are
+        simply absent (caller treats that as a zero-volume miss). Rows within
+        each key stay ordered by start_time.
+        """
+        if not pairs:
+            return {}
+        symbols = [p[0] for p in pairs]
+        dates = [p[1] for p in pairs]
+        sql = """
+            SELECT b.option_symbol, b.trade_date, b.start_time,
+                   b.open, b.high, b.low, b.close, b.avg_price,
+                   b.iv_high, b.iv_low,
+                   b.volume_ask_side, b.volume_bid_side,
+                   b.volume_mid_side, b.volume_multi,
+                   b.premium_ask_side, b.premium_bid_side,
+                   b.premium_mid_side, b.premium_no_side
+              FROM option_intraday_buckets b
+              JOIN unnest(%s::text[], %s::date[]) AS k(option_symbol, trade_date)
+                ON b.option_symbol = k.option_symbol
+               AND b.trade_date = k.trade_date
+             ORDER BY b.option_symbol, b.trade_date, b.start_time ASC
+        """
+        out: dict[tuple[str, _date], list[dict]] = {}
+        with self._conn.cursor() as cur:
+            cur.execute(sql, (symbols, dates))
+            cols = [c.name for c in cur.description]
+            for r in cur.fetchall():
+                row = dict(zip(cols, r, strict=True))
+                out.setdefault((row["option_symbol"], row["trade_date"]), []).append(
+                    row
+                )
+        return out

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -30,6 +30,17 @@ def _test_settings() -> Settings:
     return Settings.from_env().model_copy(update={"db_name": test_db})
 
 
+@pytest.fixture(autouse=True)
+def _clear_stock_report_cache():
+    """Isolate the (ticker, run_id) response cache between tests — otherwise a
+    prior test's report could satisfy a later test reusing the same key."""
+    from uw_scan.api.routers.stock import _report_cache_clear
+
+    _report_cache_clear()
+    yield
+    _report_cache_clear()
+
+
 @pytest.fixture
 def client() -> TestClient:
     """TestClient with overrides; works without any DB seeding."""

--- a/tests/integration/api/test_connection_pool.py
+++ b/tests/integration/api/test_connection_pool.py
@@ -1,0 +1,54 @@
+"""get_repo borrows from a shared pool and returns the connection on exit.
+
+Guards the #2 fix: no fresh connect-per-request. Two sequential requests must
+reuse the pool (not open two brand-new backends), and each yields a working
+Repository against the test DB.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from uw_scan.api import deps
+from uw_scan.config import Settings
+
+
+@pytest.fixture
+def _pool_on_test_db(monkeypatch):
+    """Point get_pool()/get_repo() at the isolated test DB, then tear the pool down."""
+    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
+    if not test_db:
+        pytest.fail("UW_SCAN_TEST_DB_NAME not set", pytrace=False)
+    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used-by-db-tests")
+    settings = Settings.from_env().model_copy(update={"db_name": test_db})
+
+    deps.get_settings.cache_clear()
+    deps.get_pool.cache_clear()
+    monkeypatch.setattr(deps, "get_settings", lambda: settings)
+
+    yield
+
+    deps.get_pool().close()
+    deps.get_pool.cache_clear()
+    deps.get_settings.cache_clear()
+
+
+def test_get_repo_reuses_pooled_connection(_pool_on_test_db) -> None:
+    def _one_request() -> int:
+        gen = deps.get_repo()
+        repo = next(gen)
+        with repo.conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            got = cur.fetchone()[0]
+        gen.close()  # returns the connection to the pool
+        return got
+
+    assert _one_request() == 1
+    assert _one_request() == 1
+
+    stats = deps.get_pool().get_stats()
+    # Two requests served, but the pool never grew past one live connection.
+    assert stats["requests_num"] >= 2
+    assert stats["pool_size"] <= deps.get_pool().max_size

--- a/tests/integration/api/test_connection_pool.py
+++ b/tests/integration/api/test_connection_pool.py
@@ -32,7 +32,10 @@ def _pool_on_test_db(monkeypatch):
 
     deps.get_pool().close()
     deps.get_pool.cache_clear()
-    deps.get_settings.cache_clear()
+    # get_settings is monkeypatched to a plain lambda at this point; monkeypatch
+    # restores the real lru_cache function on undo (which runs after this body).
+    # Calling .cache_clear() on the lambda AttributeErrors — the next test's
+    # setup clears the restored real cache, so nothing to do here.
 
 
 def test_get_repo_reuses_pooled_connection(_pool_on_test_db) -> None:

--- a/tests/integration/api/test_timing_middleware.py
+++ b/tests/integration/api/test_timing_middleware.py
@@ -1,0 +1,10 @@
+"""The request-timing monitor tags every response with X-Response-Time-ms."""
+
+from __future__ import annotations
+
+
+def test_response_carries_timing_header(client) -> None:
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert "X-Response-Time-ms" in resp.headers
+    assert int(resp.headers["X-Response-Time-ms"]) >= 0

--- a/tests/integration/storage/test_option_intraday_repository.py
+++ b/tests/integration/storage/test_option_intraday_repository.py
@@ -101,3 +101,42 @@ def test_fetch_scoped_by_symbol_and_date(seeded_db_empty_cards) -> None:
     assert len(rows) == 2
     assert all(r["option_symbol"] == sym_a for r in rows)
     assert all(r["trade_date"] == day for r in rows)
+
+
+def test_fetch_buckets_batch_groups_and_orders(seeded_db_empty_cards) -> None:
+    """One round-trip for many (symbol, date) pairs; grouped by key, each
+    group ordered by start_time. This is the N+1 fix for the stock page."""
+    repo = OptionIntradayBucketRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    sym_a, sym_b = "AAPL260619P00180000", "NVDA260619C00200000"
+    day = date(2026, 5, 14)
+    other_day = date(2026, 5, 15)
+
+    repo.upsert_buckets(sym_a, day, [_bucket(32), _bucket(30), _bucket(31)])
+    repo.upsert_buckets(sym_b, day, [_bucket(30)])
+    repo.upsert_buckets(sym_a, other_day, [_bucket(30)])
+
+    # Missing pair (never written) must simply be absent, not raise.
+    missing = ("TSLA260515C00450000", day)
+    result = repo.fetch_buckets_batch(
+        [(sym_a, day), (sym_b, day), (sym_a, other_day), missing]
+    )
+
+    assert set(result) == {(sym_a, day), (sym_b, day), (sym_a, other_day)}
+    assert missing not in result
+    # Same key isolation as the single-fetch path.
+    assert len(result[(sym_a, day)]) == 3
+    assert len(result[(sym_a, other_day)]) == 1
+    # Within a key, ordered ascending by start_time.
+    minutes = [r["start_time"].minute for r in result[(sym_a, day)]]
+    assert minutes == [30, 31, 32]
+
+
+def test_fetch_buckets_batch_empty_returns_empty(seeded_db_empty_cards) -> None:
+    repo = OptionIntradayBucketRepository(
+        seeded_db_empty_cards.conn,
+        schema=seeded_db_empty_cards._schema,
+    )
+    assert repo.fetch_buckets_batch([]) == {}

--- a/tests/unit/api/test_stock_report_cache.py
+++ b/tests/unit/api/test_stock_report_cache.py
@@ -1,0 +1,87 @@
+"""Unit tests for the /stock response cache helper (_assemble_cached).
+
+Covers the three behaviours that make it safe on the hot path: a hit reuses
+the assembled report (no re-derivation), the returned object is an isolated
+copy (so the router's in-place spot mutation can't corrupt the cache), and a
+zero TTL disables caching entirely.
+"""
+
+from __future__ import annotations
+
+from uw_scan.api.routers import stock as stock_router
+
+
+def _fake_report(spot):
+    from uw_scan.models import SingleStockReport
+
+    # Build via the assembler's model to get a real, mutable instance without a DB.
+    report = SingleStockReport.model_construct(ticker="TSLA")
+    report.market_structure = type("MS", (), {"spot": spot})()
+    return report
+
+
+def test_hit_dedups_and_returns_isolated_copy(monkeypatch):
+    stock_router._report_cache_clear()
+    monkeypatch.setattr(stock_router, "_REPORT_CACHE_TTL_S", 60.0)
+
+    calls = {"n": 0}
+
+    def _fake_assemble(ticker, run_id, repo):
+        calls["n"] += 1
+        return _fake_report(spot=100)
+
+    monkeypatch.setattr(stock_router, "assemble_single_stock_report", _fake_assemble)
+
+    first = stock_router._assemble_cached("TSLA", 1, repo=None)
+    second = stock_router._assemble_cached("TSLA", 1, repo=None)
+
+    assert calls["n"] == 1, "second call must hit the cache, not re-assemble"
+    assert first is not second, "each caller gets its own copy"
+
+    stats = stock_router.report_cache_stats()
+    assert stats["misses"] == 1 and stats["hits"] == 1
+    assert stats["hit_rate"] == 0.5
+
+    # Mutating a returned copy (as _with_latest_spot does) must not leak into
+    # the cache: a fresh call still sees the pristine value.
+    first.market_structure.spot = 999
+    third = stock_router._assemble_cached("TSLA", 1, repo=None)
+    assert third.market_structure.spot == 100
+    stock_router._report_cache_clear()
+
+
+def test_zero_ttl_disables_cache(monkeypatch):
+    stock_router._report_cache_clear()
+    monkeypatch.setattr(stock_router, "_REPORT_CACHE_TTL_S", 0.0)
+
+    calls = {"n": 0}
+
+    def _fake_assemble(ticker, run_id, repo):
+        calls["n"] += 1
+        return _fake_report(spot=100)
+
+    monkeypatch.setattr(stock_router, "assemble_single_stock_report", _fake_assemble)
+
+    stock_router._assemble_cached("TSLA", 1, repo=None)
+    stock_router._assemble_cached("TSLA", 1, repo=None)
+    assert calls["n"] == 2, "TTL<=0 must bypass the cache every call"
+
+
+def test_distinct_run_ids_are_separate_keys(monkeypatch):
+    stock_router._report_cache_clear()
+    monkeypatch.setattr(stock_router, "_REPORT_CACHE_TTL_S", 60.0)
+
+    calls = {"n": 0}
+
+    def _fake_assemble(ticker, run_id, repo):
+        calls["n"] += 1
+        return _fake_report(spot=run_id)
+
+    monkeypatch.setattr(stock_router, "assemble_single_stock_report", _fake_assemble)
+
+    a = stock_router._assemble_cached("TSLA", 1, repo=None)
+    b = stock_router._assemble_cached("TSLA", 2, repo=None)
+    assert calls["n"] == 2
+    assert a.market_structure.spot == 1
+    assert b.market_structure.spot == 2
+    stock_router._report_cache_clear()

--- a/uv.lock
+++ b/uv.lock
@@ -1564,6 +1564,9 @@ wheels = [
 binary = [
     { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
 ]
+pool = [
+    { name = "psycopg-pool" },
+]
 
 [[package]]
 name = "psycopg-binary"
@@ -1614,6 +1617,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -2639,7 +2654,7 @@ dependencies = [
 
 [package.optional-dependencies]
 postgres = [
-    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg", extra = ["binary", "pool"] },
 ]
 
 [package.dev-dependencies]
@@ -2668,7 +2683,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "playwright", specifier = ">=1.44" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2" },
+    { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'postgres'", specifier = ">=3.2" },
     { name = "pyarrow", specifier = ">=18.0" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## What

Three compounding fixes on the app's busiest read path — `/api/stock/{ticker}` (and `/runs/{run_id}`) — from `docs/superpowers/specs/2026-07-06-candidate-stock-page-perf.md`, plus a small log-only request-timing monitor.

| # | Fix | Where |
|---|-----|-------|
| **#1** | **N+1 kill** — `fetch_buckets_batch` collapses the per-top-10-OI-mover query loop (10 serial round-trips/load) into one `unnest`-join query | `storage/option_intraday_repository.py`, `reports/single_stock.py` |
| **#3** | **Response cache** — per-`(ticker, run_id)` TTL cache in front of `assemble_single_stock_report` (default 20s; `SINGLE_STOCK_REPORT_CACHE_TTL_S=0` disables). Callers get a deep copy so the live-spot mutation can't corrupt the entry; `run_id` in the key = free invalidation | `api/routers/stock.py` |
| **#2** | **Connection pool** — process-wide `psycopg_pool.ConnectionPool` replaces connect-per-request (`UW_SCAN_DB_POOL_MIN`/`_MAX` = 2/10). Matters more under Docker (api container → Postgres across the VM boundary). Adds psycopg's `pool` extra | `api/deps.py`, `pyproject.toml` |
| — | **Perf monitor** — log-only ASGI middleware: `X-Response-Time-ms` header + WARN over `API_SLOW_REQUEST_MS` (default 500). Cache hit/miss via `report_cache_stats()` | `api/server.py` |

## Measured impact

- **#3 (biggest, everywhere):** cold 30 ms → warm 6 ms per repeat `/stock` view ≈ **~24 ms/hit saved** (live smoke).
- **#2:** ~2.7 ms/request saved (connect eliminated), all endpoints.
- **#1:** ~0 on localhost (round-trips are ~free there) — the win is the 9 saved hops, which only pays off under **Docker cross-VM / loaded Postgres** (~15–27 ms). Kept as insurance for exactly the path the Docker migration makes expensive.

## Tests

- New: batch fetch (grouping/order/missing-pair), cache (hit dedup + copy isolation + TTL=0 bypass + stats), timing header, pool reuse.
- Full local sweep: **1825 passed / 1 skipped**.
- **Live smoke** against `option_wizard_local`: `/api/stock/TSLA` → 200, 10 intraday profiles, cold→warm 30→6 ms, slow-log fired, 0 errors.

## Deploy notes

- `uv.lock` changed (new `psycopg-pool`) — picked up on the next image rebuild, no manual step.
- All new knobs default to safe values; caches/pool are opt-out via env.