### PR TITLE
fix(vrp): skew-aware delta selection for macro entry legs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **VRP macro entry-capture legs now snap to real Δ0.25/Δ0.125, not flat-vol
+  strikes.** `resolve_entry_contracts` selected strikes off a single ATM/VIX vol,
+  so SPX put skew made the recorded legs systematically too shallow (Δ~0.28 short
+  / ~0.17 wing instead of 0.25 / 0.125) — the tracked strikes sat well above the
+  legs you'd actually trade. Selection is now skew-aware: it brackets each target
+  in delta-space using each strike's *own* IV. The nightly
+  `vrp_macro_entry_grid_refresh` caches the per-strike IV map alongside the strike
+  grid (`vrp_macro_entry_grid.strike_ivs` JSONB, migration 103) so both the RTH
+  auto-birth and the Capture button stay zero-extra-UW; a legacy grid without the
+  IV map falls back to the old flat-vol path. To re-capture today on the corrected
+  strikes, refresh the grid first (populates the IV map), then click Capture.
+
 ## [0.10.0] — 2026-07-09
 
 

--- a/src/uw_scan/reports/vrp_macro_entry.py
+++ b/src/uw_scan/reports/vrp_macro_entry.py
@@ -1,10 +1,11 @@
 """Forward entry-capture: resolve the SPX bull-put-spread the Macro Short-Vol
 signal would place onto *listed* strikes, then quote each leg.
 
-`resolve_entry_contracts` is pure (no I/O): it maps the BS target strike for the
-0.25Δ short and 0.125Δ wing onto the nearest listed strikes that bracket each
-target. `quote_leg` (Task 4) quotes a resolved leg IB-primary / UW-fallback with
-BS-computed greeks.
+`resolve_entry_contracts` is pure (no I/O): it snaps the 0.25Δ short and 0.125Δ
+wing onto the listed strikes that bracket each target — skew-aware (bracket by
+each strike's real per-strike-IV delta) when a `strike_ivs` map is supplied, else
+the flat-vol BS target strike. `quote_leg` quotes a resolved leg IB-primary /
+UW-fallback with IB-native-or-BS greeks.
 """
 
 from __future__ import annotations
@@ -53,6 +54,43 @@ def _bracket(target: float, strikes_sorted: list[float]) -> tuple[float, float]:
     return below, above
 
 
+def _bracket_by_delta(
+    target_delta: float,
+    strikes_sorted: list[float],
+    delta_mag,
+) -> tuple[float, float]:
+    """Two listed strikes whose *real* put-delta magnitude straddles
+    ``target_delta``: (below = highest strike with |Δ| < target,
+    above = lowest strike with |Δ| > target).
+
+    A put's |Δ| rises with strike (deeper ITM ⇒ larger |Δ|); put skew lifts the
+    IV of lower strikes but does not invert that ordering, so the crossing is
+    single. ``delta_mag(k)`` returns |Δ| in [0,1] or None (strike missing an IV —
+    skipped). Same above=higher-strike/below=lower-strike semantics as
+    ``_bracket`` so ``short_above``/``wing_above`` stay the traded legs.
+
+    ponytail: assumes |Δ|(K) monotone in K. A pathological non-monotone smile
+    would bracket a rung off — acceptable; the realized delta is still recorded.
+    """
+    below: float | None = None
+    above: float | None = None
+    for k in strikes_sorted:
+        d = delta_mag(k)
+        if d is None:
+            continue
+        if d < target_delta:
+            below = k
+        elif d > target_delta:
+            above = k
+            break
+    if below is None or above is None:
+        raise ValueError(
+            f"listed strikes do not bracket delta {target_delta:.3f} "
+            f"(range {strikes_sorted[0]}..{strikes_sorted[-1]})"
+        )
+    return below, above
+
+
 def resolve_entry_contracts(
     *,
     spot: float,
@@ -62,17 +100,32 @@ def resolve_entry_contracts(
     listed_strikes: list[float],
     short_delta: float = 0.25,
     wing_delta: float = 0.125,
+    strike_ivs: dict[float, float] | None = None,
 ) -> EntryContracts:
-    """BS target strike per delta, snapped to the listed strikes that bracket it.
+    """Snap each delta target onto the listed strikes that bracket it.
 
-    Flat-vol target (skew ignored — the realized leg delta is recorded at quote
-    time). Both legs are puts (`is_call=False`). Raises ValueError if the grid
-    can't bracket a target."""
+    ``strike_ivs`` (skew-aware, preferred): compute each strike's real put-delta
+    from *its own* IV and bracket in delta-space — the legs then sit at the
+    strikes that actually carry Δ≈0.25/0.125 (SPX put skew makes a flat-vol
+    strike too shallow). Falls back to the flat-vol BS target strike when no
+    per-strike IV is supplied (cold grid / legacy row). Both legs are puts.
+    Raises ValueError if the grid can't bracket a target."""
     strikes_sorted = sorted(set(listed_strikes))
-    short_target = strike_for_delta(spot, T, r, sigma, short_delta, is_call=False)
-    wing_target = strike_for_delta(spot, T, r, sigma, wing_delta, is_call=False)
-    short_below, short_above = _bracket(short_target, strikes_sorted)
-    wing_below, wing_above = _bracket(wing_target, strikes_sorted)
+    if strike_ivs:
+
+        def _dmag(k: float) -> float | None:
+            iv = strike_ivs.get(k)
+            if iv is None or float(iv) <= 0:
+                return None
+            return -bs_delta(spot, k, T, r, float(iv), is_call=False)
+
+        short_below, short_above = _bracket_by_delta(short_delta, strikes_sorted, _dmag)
+        wing_below, wing_above = _bracket_by_delta(wing_delta, strikes_sorted, _dmag)
+    else:
+        short_target = strike_for_delta(spot, T, r, sigma, short_delta, is_call=False)
+        wing_target = strike_for_delta(spot, T, r, sigma, wing_delta, is_call=False)
+        short_below, short_above = _bracket(short_target, strikes_sorted)
+        wing_below, wing_above = _bracket(wing_target, strikes_sorted)
     return EntryContracts(
         short_above=short_above,
         short_below=short_below,

--- a/src/uw_scan/storage/migrations/103_vrp_macro_entry_grid_strike_ivs.sql
+++ b/src/uw_scan/storage/migrations/103_vrp_macro_entry_grid_strike_ivs.sql
@@ -1,0 +1,19 @@
+-- 103_vrp_macro_entry_grid_strike_ivs.sql
+-- Skew-aware entry-capture leg selection: cache each listed strike's own IV
+-- alongside the strike grid, so resolve_entry_contracts can bracket the Δ0.25 /
+-- Δ0.125 targets by *real* per-strike delta instead of a flat-vol strike (which
+-- SPX put skew makes systematically too shallow — the recorded legs came out at
+-- Δ~0.28 / ~0.17 instead of 0.25 / 0.125). Nullable: a legacy row (or a cold
+-- cache) with no IV map falls back to the flat-vol path.
+SET search_path TO uw_scan, public;
+
+BEGIN;
+
+ALTER TABLE uw_scan.vrp_macro_entry_grid
+    ADD COLUMN IF NOT EXISTS strike_ivs JSONB;  -- {"<strike>": <iv>} or NULL
+
+COMMENT ON COLUMN uw_scan.vrp_macro_entry_grid.strike_ivs IS
+    'Per-strike implied vol {strike: iv} from the nightly UW chain; drives '
+    'skew-aware delta bracketing. NULL ⇒ flat-vol fallback.';
+
+COMMIT;

--- a/src/uw_scan/storage/vrp_macro_entry.py
+++ b/src/uw_scan/storage/vrp_macro_entry.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 from typing import Any
 
 import psycopg
+from psycopg.types.json import Jsonb
 
 _QUOTE_COLS = (
     "entry_id",
@@ -162,21 +163,32 @@ class _VrpMacroEntryMixin:
         for_date: _date,
         chosen_expiry: _date,
         strikes: list[float],
+        strike_ivs: dict[float, float] | None = None,
     ) -> None:
         """Cache the day's real UW-listed strike grid for the ~43-DTE expiry.
 
         The RTH birth path reads this instead of calling UW, which 429s once the
         daily budget is spent (reliably before the 10:00 ET birth cron). Idempotent
-        upsert on (name, for_date) — a restart re-fetch overwrites in place."""
+        upsert on (name, for_date) — a restart re-fetch overwrites in place.
+
+        ``strike_ivs`` ({strike: iv}) drives skew-aware delta bracketing; None
+        keeps the legacy flat-vol path. JSON keys are strings — stored as-is and
+        re-floated on fetch."""
+        ivs = (
+            Jsonb({str(k): float(v) for k, v in strike_ivs.items()})
+            if strike_ivs
+            else None
+        )
         sql = (
             f"INSERT INTO {self._schema}.vrp_macro_entry_grid "
-            "(name, for_date, chosen_expiry, strikes) VALUES (%s, %s, %s, %s) "
+            "(name, for_date, chosen_expiry, strikes, strike_ivs) "
+            "VALUES (%s, %s, %s, %s, %s) "
             "ON CONFLICT (name, for_date) DO UPDATE SET "
             "chosen_expiry = EXCLUDED.chosen_expiry, strikes = EXCLUDED.strikes, "
-            "fetched_at = now()"
+            "strike_ivs = EXCLUDED.strike_ivs, fetched_at = now()"
         )
         with self._conn.cursor() as cur:
-            cur.execute(sql, (name, for_date, chosen_expiry, list(strikes)))
+            cur.execute(sql, (name, for_date, chosen_expiry, list(strikes), ivs))
 
     def fetch_vrp_macro_entry_grid(
         self, name: str, for_date: _date, *, max_staleness_days: int = 4
@@ -194,7 +206,7 @@ class _VrpMacroEntryMixin:
         cohort. ``chosen_expiry > for_date`` additionally rejects an already-expired
         cached expiry within the window."""
         sql = (
-            "SELECT for_date, chosen_expiry, strikes, fetched_at "
+            "SELECT for_date, chosen_expiry, strikes, strike_ivs, fetched_at "
             f"FROM {self._schema}.vrp_macro_entry_grid "
             "WHERE name = %s AND for_date BETWEEN %s AND %s AND chosen_expiry > %s "
             "ORDER BY for_date DESC LIMIT 1"

--- a/src/uw_scan/worker/jobs/vrp_macro_entry.py
+++ b/src/uw_scan/worker/jobs/vrp_macro_entry.py
@@ -70,10 +70,12 @@ def _uw_chain_strikes(
     on_date: _date,
     *,
     run_notes: str = "vrp_macro_entry_birth",
-) -> tuple[_date, list[float]]:
-    """(chosen_expiry, sorted listed PUT strikes) for the listed expiry nearest
-    ``on_date + ~43cal``. Enumerates expiries via greek-exposure/expiry, then
-    pulls the chosen expiry's contracts (strikes parsed from each OCC symbol).
+) -> tuple[_date, list[float], dict[float, float]]:
+    """(chosen_expiry, sorted listed PUT strikes, {strike: iv}) for the listed
+    expiry nearest ``on_date + ~43cal``. Enumerates expiries via
+    greek-exposure/expiry, then pulls the chosen expiry's contracts (strike +
+    per-strike IV parsed from each OCC row). The IV map drives skew-aware delta
+    bracketing; strikes with no positive IV are simply absent from it.
     Audit-first UW calls under their own scan_run; the run is closed (failed) on
     error so a UW blip can't leave a stuck 'running' row (the original-bug symptom)."""
     client = UwClient(
@@ -92,16 +94,21 @@ def _uw_chain_strikes(
             client, repo, run_id, symbol, chosen.isoformat()
         )
         strikes: set[float] = set()
+        strike_ivs: dict[float, float] = {}
         for c in contracts:
             parsed = _parse_occ(c.option_symbol)
             if parsed is None:
                 continue
             exp, opt_type, strike = parsed
             if opt_type == "P" and exp == chosen:
-                strikes.add(float(strike))
+                k = float(strike)
+                strikes.add(k)
+                iv = c.implied_volatility
+                if iv is not None and float(iv) > 0:
+                    strike_ivs[k] = float(iv)
         repo.finish_scan_run(run_id, status="ok")
         repo.conn.commit()
-        return chosen, sorted(strikes)
+        return chosen, sorted(strikes), strike_ivs
     except Exception as exc:
         # Roll back the aborted tx, then close the (already-committed) run so it
         # can't dangle in 'running'. Re-raise so callers see the original failure.
@@ -129,7 +136,7 @@ def vrp_macro_entry_grid_refresh(
     Idempotent: upserts on (name, for_date)."""
     now = now or datetime.now(_ET)
     on_date = now.astimezone(_ET).date()
-    chosen_expiry, strikes = _uw_chain_strikes(
+    chosen_expiry, strikes, strike_ivs = _uw_chain_strikes(
         repo, settings, "SPX", on_date, run_notes="vrp_macro_entry_grid_refresh"
     )
     if not strikes:
@@ -141,13 +148,18 @@ def vrp_macro_entry_grid_refresh(
         )
         return {"chosen_expiry": chosen_expiry, "strikes": 0}
     repo.upsert_vrp_macro_entry_grid(
-        name="SPX", for_date=on_date, chosen_expiry=chosen_expiry, strikes=strikes
+        name="SPX",
+        for_date=on_date,
+        chosen_expiry=chosen_expiry,
+        strikes=strikes,
+        strike_ivs=strike_ivs,
     )
     repo.conn.commit()
     logger.info(
-        "vrp_macro_entry_grid_refresh name=SPX expiry=%s strikes=%d",
+        "vrp_macro_entry_grid_refresh name=SPX expiry=%s strikes=%d ivs=%d",
         chosen_expiry,
         len(strikes),
+        len(strike_ivs),
     )
     return {"chosen_expiry": chosen_expiry, "strikes": len(strikes)}
 
@@ -201,8 +213,19 @@ def _live_spot(
     return float(hit.price) if hit is not None else None
 
 
-def _resolve_legs(sig, *, on_date, chosen_expiry, strikes, rfr):
-    """resolve_entry_contracts wrapper: T from expiry vs on_date (calendar)."""
+def _grid_strike_ivs(grid: dict) -> dict[float, float] | None:
+    """Re-float the grid's JSON {str strike: iv} map (psycopg returns str keys),
+    or None for a legacy/cold grid without the column."""
+    raw = grid.get("strike_ivs")
+    if not raw:
+        return None
+    return {float(k): float(v) for k, v in raw.items()}
+
+
+def _resolve_legs(sig, *, on_date, chosen_expiry, strikes, rfr, strike_ivs=None):
+    """resolve_entry_contracts wrapper: T from expiry vs on_date (calendar).
+    ``strike_ivs`` ({strike: iv}) enables skew-aware delta bracketing; None
+    (legacy/cold grid) falls back to the flat-vol strike target."""
     T = max((chosen_expiry - on_date).days, 1) / 365.0
     return resolve_entry_contracts(
         spot=sig.spot,
@@ -212,6 +235,7 @@ def _resolve_legs(sig, *, on_date, chosen_expiry, strikes, rfr):
         listed_strikes=strikes,
         short_delta=sig.short_delta,
         wing_delta=sig.wing_delta,
+        strike_ivs=strike_ivs,
     )
 
 
@@ -268,7 +292,12 @@ def _birth_auto(repo: Repository, settings: Settings, *, on_date, now, rfr) -> i
     chosen_expiry = grid["chosen_expiry"]
     strikes = [float(s) for s in grid["strikes"]]
     ec = _resolve_legs(
-        sig, on_date=on_date, chosen_expiry=chosen_expiry, strikes=strikes, rfr=rfr
+        sig,
+        on_date=on_date,
+        chosen_expiry=chosen_expiry,
+        strikes=strikes,
+        rfr=rfr,
+        strike_ivs=_grid_strike_ivs(grid),
     )
     _insert_cohort(
         repo,
@@ -472,14 +501,28 @@ def capture_entry_now(
         und = sig.spot
     grid = repo.fetch_vrp_macro_entry_grid("SPX", on_date)
     if grid is not None:
+        # Warm cache: never hit UW (the grid exists precisely because inline-UW
+        # births 429'd daily). Skew-aware when the cached grid carries per-strike
+        # IV; a legacy grid without it falls back to flat-vol (strike_ivs=None).
+        # To force a skew-aware re-capture today, refresh the grid first so its
+        # IV map is populated, then click Capture.
         chosen_expiry = grid["chosen_expiry"]
         strikes = [float(s) for s in grid["strikes"]]
+        strike_ivs = _grid_strike_ivs(grid)
     else:
         # cold cache (e.g. day-1 post-deploy) — button is a user action, so a live
-        # UW enumeration here is acceptable (unlike the unattended auto birth).
-        chosen_expiry, strikes = _uw_chain_strikes(repo, settings, "SPX", on_date)
+        # UW enumeration here is acceptable (unlike the unattended auto birth); it
+        # also yields the IV map for skew-aware bracketing.
+        chosen_expiry, strikes, strike_ivs = _uw_chain_strikes(
+            repo, settings, "SPX", on_date
+        )
     ec = _resolve_legs(
-        sig, on_date=on_date, chosen_expiry=chosen_expiry, strikes=strikes, rfr=rfr
+        sig,
+        on_date=on_date,
+        chosen_expiry=chosen_expiry,
+        strikes=strikes,
+        rfr=rfr,
+        strike_ivs=strike_ivs,
     )
     entry_id = _insert_cohort(
         repo,

--- a/tests/integration/api/test_regime_entry_api.py
+++ b/tests/integration/api/test_regime_entry_api.py
@@ -178,7 +178,7 @@ def test_capture_persists_button_cohort(
     monkeypatch.setattr(
         job,
         "_uw_chain_strikes",
-        lambda *a, **k: (date(2026, 8, 7), [500.0 + 5 * i for i in range(2000)]),
+        lambda *a, **k: (date(2026, 8, 7), [500.0 + 5 * i for i in range(2000)], {}),
     )
     monkeypatch.setattr(job, "quote_leg", _fake_quote_leg)
 

--- a/tests/integration/test_vrp_macro_entry_job.py
+++ b/tests/integration/test_vrp_macro_entry_job.py
@@ -30,7 +30,9 @@ def _settings() -> Settings:
 
 
 def _fake_chain(repo, settings, symbol, on_date, **_kw):
-    return _EXPIRY, _STRIKES
+    # empty IV map ⇒ flat-vol fallback in resolve_entry_contracts (keeps the
+    # existing strike assertions stable; the skew-aware path is unit-tested).
+    return _EXPIRY, _STRIKES, {}
 
 
 def _fake_quote_leg(

--- a/tests/integration/test_vrp_macro_entry_storage.py
+++ b/tests/integration/test_vrp_macro_entry_storage.py
@@ -104,6 +104,26 @@ def test_grid_cache_upsert_and_fetch(seeded_db_empty_cards: Repository):
         7090.0,
         7095.0,
     ]
+    # no strike_ivs passed → column is NULL (flat-vol fallback)
+    assert got["strike_ivs"] is None
+
+
+def test_grid_cache_strike_ivs_roundtrip(seeded_db_empty_cards: Repository):
+    repo = seeded_db_empty_cards
+    repo.upsert_vrp_macro_entry_grid(
+        name="SPX",
+        for_date=date(2026, 6, 24),
+        chosen_expiry=date(2026, 8, 6),
+        strikes=[6860.0, 7090.0],
+        strike_ivs={6860.0: 0.184, 7090.0: 0.152},
+    )
+    got = repo.fetch_vrp_macro_entry_grid("SPX", date(2026, 6, 24))
+    assert got is not None
+    # JSON keys come back as strings; values as floats
+    assert {float(k): v for k, v in got["strike_ivs"].items()} == {
+        6860.0: 0.184,
+        7090.0: 0.152,
+    }
 
 
 def test_grid_cache_stale_fallback_and_expiry_guard(seeded_db_empty_cards: Repository):

--- a/tests/unit/test_vrp_macro_entry_finder.py
+++ b/tests/unit/test_vrp_macro_entry_finder.py
@@ -1,5 +1,7 @@
 import pytest
+
 from uw_scan.reports.vrp_macro_entry import resolve_entry_contracts
+from uw_scan.reports.vrp_structure import bs_delta
 
 
 def test_brackets_each_target_above_and_below():
@@ -21,6 +23,37 @@ def test_brackets_each_target_above_and_below():
         k in listed
         for k in (ec.short_above, ec.short_below, ec.wing_above, ec.wing_below)
     )
+
+
+def test_skew_aware_bracket_sits_below_flat_vol_and_straddles_delta():
+    # SPX-shaped: spot 7400, ~43 cal DTE, r 4%, 5-pt grid. Modeled put skew (NOT
+    # observed market data): IV rises ~1 vol per 100 pts below spot off a 13-vol
+    # ATM — a realistic monotone smile used purely as a bracketing-function input.
+    spot, T, r = 7400.0, 43 / 365, 0.04
+    listed = [6600 + 5 * i for i in range(200)]  # 6600..7595
+    atm_iv = 0.13
+    strike_ivs = {k: atm_iv + max(0.0, spot - k) / 100.0 * 0.01 for k in listed}
+
+    flat = resolve_entry_contracts(
+        spot=spot, sigma=atm_iv, T=T, r=r, listed_strikes=listed
+    )
+    skew = resolve_entry_contracts(
+        spot=spot, sigma=atm_iv, T=T, r=r, listed_strikes=listed, strike_ivs=strike_ivs
+    )
+
+    # Put skew lifts OTM IV → the real Δ0.25 / Δ0.125 strikes sit BELOW flat-vol's
+    # (the bug: flat-vol legs came out too shallow, Δ~0.28 / ~0.17).
+    assert skew.short_above < flat.short_above
+    assert skew.wing_above < flat.wing_above
+
+    # And the picked bracket actually straddles the target delta under each
+    # strike's OWN IV — which flat-vol never guarantees.
+    def dmag(k):
+        return -bs_delta(spot, k, T, r, strike_ivs[k], is_call=False)
+
+    assert dmag(skew.short_below) < 0.25 < dmag(skew.short_above)
+    assert dmag(skew.wing_below) < 0.125 < dmag(skew.wing_above)
+    assert skew.wing_above < skew.short_below  # wing strictly deeper OTM than short
 
 
 def test_raises_when_no_bracket():


### PR DESCRIPTION
## Problem

The macro short-vol **entry tracker** (`/regime` Macro Short-Vol card) recorded legs whose realized deltas were nowhere near the Δ0.25 / Δ0.125 targets. The tracked ETD-2026-08-21 cohort landed on 7225/7220 short and 7020/7010 wing at realized Δ −0.279 / −0.177 — above the 7165/6855 the signal would actually place.

## Root cause

`resolve_entry_contracts` inverted delta→strike with a **single ATM/VIX vol**, ignoring SPX put skew. Because OTM-put IV > ATM IV, the true delta at a flat-vol strike is systematically **higher** than target → the picked strikes are too shallow. The miss widens in the wing where skew steepens. Confirmed quantitatively: a flat-vol reproduction (spot 7400, 43 DTE) puts the Δ0.25 target at ~7222, matching the card's recorded strike.

## Fix

- **Skew-aware selection**: bracket each target in **delta-space** using each strike's own IV (`_bracket_by_delta`). Legacy/cold grid → old flat-vol path (backward compatible).
- **Grid carries IV**: the nightly `vrp_macro_entry_grid_refresh` already fetched the full chain with per-strike IV and threw it away — now it caches `{strike: iv}` in `vrp_macro_entry_grid.strike_ivs` (JSONB, **migration 103**), so both auto-birth and the Capture button stay **zero-extra-UW** (the load-bearing "no UW when cache warm" invariant is preserved).
- Leg shape unchanged: still the ↑/↓ 4-leg bracket.

## Verification

- Unit: new skew-aware test asserts picked strikes sit **below** flat-vol and straddle Δ0.25/Δ0.125 under each strike's own IV → 3 passed; full unit suite 1349 passed.
- Integration (storage/job/api, local DB): 20 passed — incl. the "button must not hit UW when warm" guard and a `strike_ivs` round-trip.
- ruff, Guardrail-2, migration-prefix clean; migration 103 verified idempotent.

## Deploy note

"Re-capture today corrected" is post-deploy: after merge + tag (Watchtower deploys, migrator applies 103), refresh the grid (populates the IV map for the target expiry) → click **Capture** → the new record lands on real ~Δ0.25/Δ0.125 strikes; the existing 8×/day mark job snapshots NBBO.