### PR TITLE
fix(docker): api self-migrates on boot so schema-bearing releases auto-apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
+- **Schema-bearing releases now auto-migrate on deploy.** The engine-wide
+  Watchtower deploys new *images* but never ran the profile-gated `migrator`, so
+  a release that added a table shipped code against an un-migrated DB until a
+  human remembered to apply migrations (v0.10.0's `technical_daily` was missing
+  for ~7h — api stayed green while the Technicals tab 500'd). The `api` service
+  now self-migrates (`migrate_runner && exec uvicorn`) before serving: it is the
+  single migration owner (no racing DDL across the sharded workers), never serves
+  against an un-migrated schema, and crash-loops loudly on a bad migration instead
+  of silently partial-serving. Idempotent + ~1s, so re-running every boot is free.
+  Activation is a one-time `/opt/argon/compose.yml` mirror + `up -d api` (Watchtower
+  does not deploy compose changes); future image-only releases self-migrate.
 - **VRP macro entry-capture legs now snap to real Δ0.25/Δ0.125, not flat-vol
   strikes.** `resolve_entry_contracts` selected strikes off a single ATM/VIX vol,
   so SPX put skew made the recorded legs systematically too shallow (Δ~0.28 short

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
   # One-shot schema apply. profiles:["migrate"] + restart:"no" → never runs on
   # `up -d`; invoke explicitly. Runs the module directly (.venv on PATH), not
   # the scripts/migrate.sh wrapper (which shells out to `uv run`).
+  # NOTE: the api service now self-migrates on boot (see its command), so routine
+  # schema-bearing deploys apply automatically. This profile stays for first-boot
+  # bootstrap (before api exists) and for explicit out-of-band applies.
   migrator:
     <<: [*app-image, *common]
     profiles: ["migrate"]
@@ -48,8 +51,25 @@ services:
 
   api:
     <<: [*app-image, *common]
+    # Self-migrate before serving. Watchtower deploys the new image but never runs
+    # the one-shot `migrator`, so a schema-bearing release used to ship code against
+    # an un-migrated DB (v0.10.0: api green for 7h while a feature 500'd on a missing
+    # table). `migrate && exec uvicorn` makes api the single migration owner — it
+    # never serves against an un-migrated schema, and a bad migration crash-loops the
+    # container (healthcheck red → web down) instead of silently partial-serving.
+    # Idempotent + ~1s, so re-running every boot is free. `exec` gives uvicorn PID 1
+    # for clean SIGTERM shutdown.
+    # ponytail: only api self-migrates (single non-sharded container = no racing DDL);
+    # the 2× workers get new code from the same deploy and could touch a new table in
+    # the seconds before api finishes — tolerable (worker jobs are cron-scheduled and
+    # exception-safe), and gating workers on api-healthy is false safety because
+    # Watchtower recreate ignores depends_on ordering.
     command:
-      ["uvicorn", "uw_scan.api.server:app", "--host", "0.0.0.0", "--port", "8400"]
+      - sh
+      - -c
+      - >-
+        python -m uw_scan.storage.migrate_runner &&
+        exec uvicorn uw_scan.api.server:app --host 0.0.0.0 --port 8400
     ports:
       - "127.0.0.1:8400:8400"   # loopback-only publish for host health checks
     healthcheck:

--- a/docs/runbooks/docker-deploy.md
+++ b/docs/runbooks/docker-deploy.md
@@ -136,7 +136,19 @@ docker-compose up -d`.
   xenon. One shared deploy channel for the mini; expected, not a bug.
 - **Env rotation** still needs a recreate: `docker-compose up -d --force-recreate
   <svc>` (same freeze-at-fork semantics as the launchd workers).
-- **Schema changes**: `docker-compose --profile migrate run --rm migrator`. App
-  services never self-migrate, so `up -d` is safe against the live schema.
+- **Schema changes auto-apply on deploy.** The `api` service self-migrates
+  (`migrate_runner && exec uvicorn` in its `command`) before serving, so a
+  Watchtower image update applies pending migrations automatically — closing the
+  gap where Watchtower deploys new *code* but never runs the one-shot `migrator`
+  (v0.10.0 shipped code against an un-migrated DB for ~7h). A bad migration
+  crash-loops api (healthcheck red → `web` down), which is intentional: loud
+  beats the silent partial-serving that hid the v0.10.0 gap. The `migrator`
+  profile is still valid for **first-boot bootstrap** (before api exists) and
+  explicit out-of-band applies: `docker-compose --profile migrate run --rm migrator`.
+- **`compose.yml` changes are NOT auto-deployed** — Watchtower updates images
+  only. After merging a change to the committed `docker-compose.yml` (e.g. this
+  self-migrate command), mirror it to `/opt/argon/compose.yml` on the mini and
+  `docker-compose up -d api` once to activate. Future image-only releases then
+  self-migrate through the updated command.
 - **Backups** (`com.argon.backup*`) remain host-native launchd — untouched by
   this migration.


### PR DESCRIPTION
## Problem

The engine-wide Watchtower deploys new **images** but never runs the profile-gated `migrator`, and it doesn't deploy `compose.yml` changes either. So a release that adds a table ships new **code** against an **un-migrated DB** until a human remembers to apply migrations.

Concrete: **v0.10.0's `technical_daily` table was missing on the mini for ~7h** — api stayed green (the `/api/health` check is HTTP-200-only by design) while the new Technicals tab silently 500'd on the missing table. The partial-serving *hid* the gap.

## Fix

Make the **api** service self-migrate before serving:

```yaml
command:
  - sh
  - -c
  - >-
    python -m uw_scan.storage.migrate_runner &&
    exec uvicorn uw_scan.api.server:app --host 0.0.0.0 --port 8400
```

- **api is the single migration owner** — it's the only non-sharded container, so no racing DDL across the 2× workers.
- **Never serves against an un-migrated schema** (`migrate && exec uvicorn`).
- **Fail-loud on a bad migration**: api crash-loops → healthcheck red → `web` (depends_on api-healthy) goes down. This deliberately reverses the original *decouple-migrations-from-deploy* choice — for a **required** migration, loud beats the silent partial-serving that hid the v0.10.0 gap. Migrations are CI-replayed-twice + idempotent, so prod failures are rare and almost always env/permission.
- **Idempotent + ~1s**, so re-running on every boot is free. `exec` gives uvicorn PID 1 for clean SIGTERM shutdown.
- The `migrator` profile stays for first-boot bootstrap and explicit out-of-band applies.

## Scope

- No new migration; no image/code change (migrate_runner + SQL already ship in the image).
- Touches `docker-compose.yml` (committed source-of-truth mirror) + the deploy runbook + CHANGELOG.

## Activation (post-merge, one-time)

Watchtower does **not** deploy compose changes, so this needs a one-time mirror of `docker-compose.yml` → `/opt/argon/compose.yml` on the mini + `docker-compose up -d api`. **After that, every future schema release self-migrates through the image with zero compose changes** — deliberately kept as a one-time step rather than adding a second (launchd) deploy path alongside Watchtower.

## Verification

- `docker-compose config` on the mini renders the intended `sh -c "migrate && exec uvicorn"` command ✅
- `sh -n` on the rendered command string → valid ✅
- No test/guardrail pins the old api command ✅
- `migrate_runner.main()` propagates exceptions → non-zero exit → crash-loop on bad migration ✅
- api shares `env_file` (→ same `argon_app` role that owns schema `uw_scan`) with the migrator, so it has DDL privilege ✅

> Note: xenon has the identical latent gap (same manual-migrator design). Out of scope here (one change, one PR) — can port as a follow-up if wanted.