### PR TITLE
feat(technicals): 1Y default, MACD/kinematics reorder, downtrend shading, colored ALIGN badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
-## [0.10.2] — 2026-07-10
+### Changed
 
+- **Technicals tab UI refinements** — the chart timeframe now defaults to **1Y**
+  (was FULL/5Y); the reorderable stack now defaults to **dual MACD first,
+  MA-Kinematics second** (the saved-order localStorage key is bumped to `:v2` so
+  the new default supersedes any order saved under the original key); and the
+  MA-Kinematics chart now tints the **below-zero region as a downtrend zone**
+  (a subtle red band from the y=0 line to the plot floor via a new
+  `shadeBelowZero` prop on `OscillatorChart`) so any moving-average slope dipping
+  under zero reads as falling at a glance — line colors and t-stat weighting
+  unchanged. The MA-Kinematics **alignment badge** now names the direction and
+  colors by sign — `BULL ALIGN n/3` (green), `BEAR ALIGN n/3` (red), or
+  `MIXED ALIGN 0/3` (muted) — instead of a sign-agnostic `ALIGN ±n/3`, so a
+  bearish stack reads red at a glance (`OscillatorChart`'s `headline` widened to
+  `ReactNode` to carry the colored label).
+
+## [0.10.2] — 2026-07-10
 
 ### Added
 
@@ -61,6 +76,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   every date-axis chart below at once (a pure client-side slice of the series
   already in the payload — no extra fetch). The return-distribution panel keeps
   its own fixed 60d sample (it's a shape, not a date-axis graph the window pans).
+
 ## [0.10.1] — 2026-07-09
 
 ### Fixed

--- a/web/components/stock/panels/OscillatorChart.tsx
+++ b/web/components/stock/panels/OscillatorChart.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   finiteDomain,
   linearScale,
@@ -48,10 +49,11 @@ export function OscillatorChart({
   unit = "",
   refLines = [],
   zones = [],
+  shadeBelowZero = false,
 }: {
   title: string;
   subtitle?: string;
-  headline?: string;
+  headline?: ReactNode;
   explanation?: string;
   dates: Array<string | null | undefined>;
   lines?: ChartLine[];
@@ -66,6 +68,9 @@ export function OscillatorChart({
   unit?: string;
   refLines?: RefLine[];
   zones?: Zone[];
+  // Tint everything below the y=0 line (a "downtrend zone"): where a slope
+  // dips under zero it's falling. Domain-independent — clamps to the plot.
+  shadeBelowZero?: boolean;
 }) {
   const H = height;
   const n = dates.length;
@@ -91,6 +96,8 @@ export function OscillatorChart({
   const y = linearScale([dom.lo - pad, dom.hi + pad], [H - CPAD.b, CPAD.t]);
   const ticks = niceTicks(dom.lo, dom.hi, 4);
   const barW = Math.max(1, ((CW - CPAD.l - CPAD.r) / Math.max(1, n)) * 0.85);
+  const floorY = H - CPAD.b;
+  const zeroY = Math.max(CPAD.t, Math.min(floorY, y(0)));
 
   return (
     <AnalyticalSeriesPanel
@@ -105,6 +112,16 @@ export function OscillatorChart({
         style={{ display: "block" }}
       >
         <title>{title}</title>
+        {shadeBelowZero && floorY > zeroY && (
+          <rect
+            x={CPAD.l}
+            y={zeroY}
+            width={CW - CPAD.r - CPAD.l}
+            height={floorY - zeroY}
+            fill="var(--negative)"
+            opacity={0.08}
+          />
+        )}
         {zones.map((z, i) => (
           <rect
             key={`z${i}`}

--- a/web/components/stock/panels/TechnicalsOscillators.tsx
+++ b/web/components/stock/panels/TechnicalsOscillators.tsx
@@ -168,8 +168,25 @@ export function TechnicalsKinematicsChart({
     t == null
       ? name
       : `${name} · t ${Math.abs(t) >= 10 ? t.toFixed(0) : t.toFixed(1)}`;
+  // Alignment badge: label the direction (BULL/BEAR/MIXED) and color it by sign
+  // so a bearish stack reads red at a glance — |a| shows how many of the 3 MAs
+  // are stacked that way.
   const a = kin.alignment;
-  const badge = a == null ? undefined : `ALIGN ${a > 0 ? "+" : ""}${a}/3`;
+  const badge =
+    a == null ? undefined : (
+      <span
+        style={{
+          color:
+            a > 0
+              ? "var(--positive)"
+              : a < 0
+                ? "var(--negative)"
+                : "var(--text-muted)",
+        }}
+      >
+        {a > 0 ? "BULL" : a < 0 ? "BEAR" : "MIXED"} ALIGN {Math.abs(a)}/3
+      </span>
+    );
   return (
     <OscillatorChart
       title="MA Kinematics — slope of each average"
@@ -197,7 +214,8 @@ export function TechnicalsKinematicsChart({
         },
       ]}
       refLines={[{ y: 0, solid: true }]}
-      explanation={`${reading ? reading + " " : ""}Slope (per-day rise/fall) of each moving average, divided by ATR so it reads as 'ATRs per day'. Each line is weighted by its slope t-stat: bold/solid = statistically reliable (|t| ≥ 2), faded = likely noise. The ALIGN badge counts how many of the three MAs are stacked in bullish order (−3…+3). Read direction + reliability + stack in one glance.`}
+      shadeBelowZero
+      explanation={`${reading ? reading + " " : ""}Slope (per-day rise/fall) of each moving average, divided by ATR so it reads as 'ATRs per day'. Each line is weighted by its slope t-stat: bold/solid = statistically reliable (|t| ≥ 2), faded = likely noise. The red band below the zero line is the downtrend zone — wherever a slope dips into it, that average is falling. The ALIGN badge counts how many of the three MAs are stacked in bullish order (−3…+3). Read direction + reliability + stack in one glance.`}
     />
   );
 }

--- a/web/components/stock/tabs/TechnicalsTab.tsx
+++ b/web/components/stock/tabs/TechnicalsTab.tsx
@@ -278,7 +278,7 @@ export function TechnicalsTab({ ticker }: { ticker: string }) {
     error: null,
   });
   const [live, setLive] = useState<TechnicalsLiveResponse | null>(null);
-  const [timeframe, setTimeframe] = useState<Timeframe>("full");
+  const [timeframe, setTimeframe] = useState<Timeframe>("1y");
 
   useEffect(() => {
     let cancelled = false;
@@ -359,14 +359,14 @@ export function TechnicalsTab({ ticker }: { ticker: string }) {
   // selector and its date axis is the alignment reference, so it never moves.
   // The oscillator/detail stack below stays reorderable (persisted per-browser).
   const chartItems: ReorderItem[] = [
+    { id: "macd", node: <TechnicalsMacdChart data={view} /> },
+    { id: "kinematics", node: <TechnicalsKinematicsChart data={view} /> },
     { id: "z", node: <TechnicalsZChart data={view} /> },
     { id: "rsi", node: <TechnicalsRsiChart data={view} /> },
-    { id: "macd", node: <TechnicalsMacdChart data={view} /> },
     { id: "vol", node: <TechnicalsVolChart data={view} /> },
     // The return distribution is a shape over its own fixed 60d sample, not a
     // date-axis graph the timeframe should pan — keep it on full data.
     { id: "return-hist", node: <ReturnHistogram data={data} /> },
-    { id: "kinematics", node: <TechnicalsKinematicsChart data={view} /> },
     { id: "rs", node: <TechnicalsRsChart data={view} /> },
     { id: "forward-returns", node: <ForwardReturnTable data={view} /> },
     { id: "detail", node: <TechnicalsDetailPanels data={view} /> },
@@ -389,7 +389,13 @@ export function TechnicalsTab({ ticker }: { ticker: string }) {
       />
       {/* Aligned stack: oscillators share the anchor's date axis. Drag any row
           to reorder. */}
-      <ReorderableList items={chartItems} storageKey="technicals:chartOrder" />
+      {/* key bumped to :v2 so the new macd-first / kinematics-second default
+          supersedes any order saved under the original key (the reorder
+          feature is <1 day old — no meaningful saved arrangements to preserve). */}
+      <ReorderableList
+        items={chartItems}
+        storageKey="technicals:chartOrder:v2"
+      />
     </div>
   );
 }

--- a/web/tests/unit/technicals-kinematics.test.tsx
+++ b/web/tests/unit/technicals-kinematics.test.tsx
@@ -1,7 +1,10 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { TechnicalsResponse } from "@/lib/api";
-import { TechnicalsKinematicsChart } from "@/components/stock/panels/TechnicalsOscillators";
+import {
+  TechnicalsKinematicsChart,
+  TechnicalsRsChart,
+} from "@/components/stock/panels/TechnicalsOscillators";
 
 const data = {
   series: [
@@ -29,9 +32,29 @@ const data = {
 } as unknown as TechnicalsResponse;
 
 describe("TechnicalsKinematicsChart (blended trend)", () => {
-  it("shows the current alignment badge", () => {
+  it("labels + reddens a bearish alignment badge", () => {
+    // data has alignment: -1 -> a bearish lean, shown as BEAR + red.
     const { getByText } = render(<TechnicalsKinematicsChart data={data} />);
-    expect(getByText(/ALIGN.*-1\/3/i)).toBeTruthy();
+    const badge = getByText(/BEAR ALIGN 1\/3/i);
+    expect(badge).toBeTruthy();
+    expect(badge.style.color).toBe("var(--negative)");
+  });
+
+  it("labels + greens a bullish alignment badge", () => {
+    const bull = {
+      series: data.series,
+      detail: {
+        kinematics: {
+          sma20: { tstat: 14.2 },
+          sma50: { tstat: 1.1 },
+          sma200: { tstat: 275.6 },
+          alignment: 3,
+        },
+      },
+    } as unknown as TechnicalsResponse;
+    const { getByText } = render(<TechnicalsKinematicsChart data={bull} />);
+    const badge = getByText(/BULL ALIGN 3\/3/i);
+    expect(badge.style.color).toBe("var(--positive)");
   });
 
   it("surfaces each MA's t-stat so significance is legible", () => {
@@ -44,5 +67,54 @@ describe("TechnicalsKinematicsChart (blended trend)", () => {
     // sma20 +14.2 & sma200 +275.6 are significant & rising; sma50 weak.
     const { getByText } = render(<TechnicalsKinematicsChart data={data} />);
     expect(getByText(/Reading:.*rising.*uptrend/i)).toBeTruthy();
+  });
+
+  it("shades the below-zero region so falling slopes read as a downtrend zone", () => {
+    // slopes that dip below 0 -> the negative band must have real height.
+    const down = {
+      series: [
+        {
+          as_of: "2026-07-08",
+          kin_slope20: -0.1,
+          kin_slope50: -0.05,
+          kin_slope200: 0.02,
+        },
+        {
+          as_of: "2026-07-09",
+          kin_slope20: -0.12,
+          kin_slope50: -0.06,
+          kin_slope200: 0.01,
+        },
+      ],
+      detail: {
+        kinematics: {
+          sma20: { tstat: -14.2 },
+          sma50: { tstat: -1.1 },
+          sma200: { tstat: 3.0 },
+          alignment: -1,
+        },
+      },
+    } as unknown as TechnicalsResponse;
+    const { container } = render(<TechnicalsKinematicsChart data={down} />);
+    const shade = Array.from(container.querySelectorAll("rect")).find(
+      (r) => r.getAttribute("fill") === "var(--negative)",
+    );
+    expect(shade).toBeTruthy();
+    expect(Number(shade!.getAttribute("height"))).toBeGreaterThan(0);
+  });
+
+  it("does not shade other oscillators (the band is opt-in to kinematics)", () => {
+    const rs = {
+      series: [
+        { as_of: "2026-07-08", rs_ratio: -0.2 },
+        { as_of: "2026-07-09", rs_ratio: -0.3 },
+      ],
+      detail: { rs: { ratio: -0.3, trend: "LAGGING" } },
+    } as unknown as TechnicalsResponse;
+    const { container } = render(<TechnicalsRsChart data={rs} />);
+    const shade = Array.from(container.querySelectorAll("rect")).find(
+      (r) => r.getAttribute("fill") === "var(--negative)",
+    );
+    expect(shade).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Default Technicals timeframe to 1Y (was full history)
- Reorder movable charts: dual MACD first, MA-Kinematics second (storage key bumped to `:v2` so saved orderings don't mask the new default)
- Shade the below-zero region on MA-kinematics slopes as a downtrend zone (`shadeBelowZero` prop on `OscillatorChart`)
- Color the ALIGN badge red/green by sign and label it BULL/BEAR/MIXED (`OscillatorChart.headline` widened to `ReactNode`)

## Test plan
- [x] `npm run test` — 494 passing (new: badge color + label, downtrend shading, opt-in scoping to kinematics only)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Verified live in browser: NVDA → `BULL ALIGN 1/3` green, MSFT → `BEAR ALIGN 1/3` red