### PR TITLE
fix(worker): anchor autoheal frozen-streak count on the job's injected today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+- Fix: the data-freshness autoheal circuit breaker now counts frozen-night
+  streaks anchored on the job's injected `today` instead of the DB wall clock
+  (`consecutive_frozen_counts(as_of=...)`). The `CURRENT_DATE` anchor silently
+  shrank the counted streak whenever the caller's day differed from the wall
+  clock — surfaced as a date-rolling CI time bomb in
+  `test_autoheal_circuit_breaker_stops_retriggering` (green until 2026-07-13,
+  deterministic failure after). `/api/health`'s streak enrichment keeps the
+  wall-clock default.
+
 - Docs: `docs/masterplan/` — cross-stack vision & blockers review plus the
   per-component master plan (goal ladder Stage 1–4, gaps, open decisions
   D-A..D-E, Stage-1 attack order) for the livewire/signal-lab/apex/argon/xenon

--- a/src/uw_scan/storage/data_freshness_repository.py
+++ b/src/uw_scan/storage/data_freshness_repository.py
@@ -58,22 +58,30 @@ class DataFreshnessRepository:
         self._conn.commit()
         return len(params)
 
-    def consecutive_frozen_counts(self, lookback: int = 14) -> dict[str, int]:
+    def consecutive_frozen_counts(
+        self, lookback: int = 14, as_of: date | None = None
+    ) -> dict[str, int]:
         """For every table with at least one snapshot in the last `lookback`
         days, count how many of the most recent consecutive nights were
         frozen=True (stops at the first non-frozen or missing night). Feeds
         the autoheal circuit breaker -- a table stuck frozen for N nights
         running despite repeated heal attempts is a real, unfixable block
         (missing credential, licensed source), not something worth retrying
-        forever."""
+        forever.
+
+        `as_of` anchors the lookback window; None means the DB clock. The
+        monitor job passes its injected `today` -- anchoring on CURRENT_DATE
+        there silently shrank the counted streak whenever the caller's day
+        differed from the wall clock (which is exactly what pinned-date tests
+        do), so the breaker under-counted and retriggered."""
         sql = """
             SELECT table_name, run_date, frozen
               FROM data_freshness_snapshots
-             WHERE run_date > CURRENT_DATE - %s::int
+             WHERE run_date > COALESCE(%s, CURRENT_DATE) - %s::int
              ORDER BY table_name, run_date DESC
         """
         with self._conn.cursor() as cur:
-            cur.execute(sql, (lookback,))
+            cur.execute(sql, (as_of, lookback))
             rows = cur.fetchall()
         counts: dict[str, int] = {}
         current_table: str | None = None

--- a/src/uw_scan/worker/jobs/data_freshness_monitor.py
+++ b/src/uw_scan/worker/jobs/data_freshness_monitor.py
@@ -59,7 +59,7 @@ def _autoheal_frozen_tables(
     scoped heal or trip the circuit breaker. Returns what happened per table
     so it can be logged and surfaced on /api/health."""
     fresh_repo = DataFreshnessRepository(repo.conn, schema=settings.db_schema)
-    streaks = fresh_repo.consecutive_frozen_counts()
+    streaks = fresh_repo.consecutive_frozen_counts(as_of=today)
     gap = DataGapHealerRepository(repo.conn, schema=settings.db_schema)
 
     healed: list[str] = []


### PR DESCRIPTION
## Summary

`consecutive_frozen_counts()` filtered its lookback window on `CURRENT_DATE` while `data_freshness_monitor` threads a pinned `today` through everything else. The counted streak therefore silently shrank whenever the caller's day differed from the wall clock. In production the two coincide, but the pinned-date integration test (`today=2026-07-02`, frozen nights seeded relative to it) rolled out of the 14-day `CURRENT_DATE` window on 2026-07-13 — `test_autoheal_circuit_breaker_stops_retriggering` now fails deterministically on **every** branch (verified on `main` locally), blocking all merges including #277.

- `DataFreshnessRepository.consecutive_frozen_counts(lookback, as_of=None)` — window anchored on `COALESCE(%s, CURRENT_DATE)`
- `data_freshness_monitor._autoheal_frozen_tables` passes `as_of=today`
- `/api/health`'s streak enrichment (`latest_snapshot` path) keeps the wall-clock default — correct there
- CHANGELOG `[Unreleased]` entry

This is an independent prerequisite for merging #277 (and anything else), hence its own PR.

## Testing

- `uv run pytest tests/integration/worker/test_data_freshness_autoheal.py tests/integration/worker/test_data_freshness_monitor_job.py` → 9 passed (was 1 failed on main)
- `uv run pytest tests/integration/storage/test_data_freshness_repository.py` → 6 passed
- `ruff check` clean on both touched files