### PR TITLE
fix(storage): anchor /api/health freshness streaks on the snapshot's newest run_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+- Fix: `/api/health`'s freshness block now anchors `consecutive_frozen_nights`
+  on the snapshot's own newest `run_date` instead of the DB wall clock —
+  `latest_snapshot()` was the last bare `consecutive_frozen_counts()` caller
+  left behind by the autoheal-circuit-breaker fix, and its `CURRENT_DATE`
+  anchor made the reported streak (and `autoheal_circuit_broken`) shrink as
+  the clock advanced past the seeded nights (surfaced as the
+  `test_health_autoheal_circuit_broken_includes_eligible_tripped_table`
+  date-bomb in CI).
+
 - Technicals price chart gains a 缠论 (Chanlun) overlay behind a header toggle
   (next to the SMA·σ/EMA·BB segmented control, localStorage-persisted):
   笔 stroke polylines (solid confirmed / dashed provisional tail), 中枢 pivot

--- a/src/uw_scan/storage/data_freshness_repository.py
+++ b/src/uw_scan/storage/data_freshness_repository.py
@@ -120,7 +120,15 @@ class DataFreshnessRepository:
             cur.execute(sql)
             cols = [c.name for c in cur.description]
             rows = [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
-        streaks = self.consecutive_frozen_counts()
+            # Anchor the streak lookback on the snapshot's own newest night,
+            # not the wall clock: /api/health reports the streak AS OF the
+            # data it shows, and a CURRENT_DATE anchor silently shrinks the
+            # counted streak whenever the newest snapshot lags the clock
+            # (pinned-date tests, a paused monitor) — same date-bomb class
+            # the monitor job's call site already fixed by passing `today`.
+            cur.execute("SELECT MAX(run_date) FROM data_freshness_snapshots")
+            max_run_date = cur.fetchone()[0]
+        streaks = self.consecutive_frozen_counts(as_of=max_run_date)
         for row in rows:
             row["consecutive_frozen_nights"] = streaks.get(row["table_name"], 0)
         return rows


### PR DESCRIPTION
## Summary

`integration (1/4)` went red on main on 2026-07-14: `test_health_autoheal_circuit_broken_includes_eligible_tripped_table` asserts `'daily_ohlc' in []`. Second instance of the date-bomb class fixed in #278 — that PR added the injectable `as_of` anchor to `consecutive_frozen_counts()` and fixed the autoheal monitor's call site, but `latest_snapshot()` (the `/api/health` freshness path) still called it bare. Its `CURRENT_DATE`-anchored 14-day window drifted past the test's pinned snapshot nights (2026-06-29→07-02), shrinking the counted streak below the breaker threshold.

Beyond the test, the production behavior was also subtly wrong: `/api/health` reports rows as-of `MAX(run_date)` but counted streaks as-of the wall clock — if the monitor pauses for a few days, the reported streak shrinks while the data stays frozen. The fix anchors the streak on the snapshot's own newest `run_date`, so the streak is as-of the data the endpoint actually shows.

This blocks every open PR's CI (including #279), hence the standalone fix — same justification as #278.

## Test plan

- [x] Reproduced the failure on clean `origin/main` locally (forced-local test DB env)
- [x] With the fix: `tests/integration/api/test_health.py` + `tests/integration/storage/test_data_freshness_repository.py` + `tests/integration/worker/test_data_freshness_autoheal.py` — 38/38 pass
- [x] `ruff check` + `ruff format --check` clean on the touched file
- [x] Repository-level streak tests already anchor on `date.today()` (`_night()` helper) — unaffected