### PR TITLE
fix(web): preserve technicals chart right gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- Technicals price charts now reserve ten bar-widths between the newest bar
+  and the right price axis on initial load and after Reset. The chart's
+  `fixRightEdge` setting had silently clamped the configured offset back to
+  zero; regression coverage now protects both short- and long-history views.
+
 ## [0.10.7] — 2026-07-15
 
 

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -187,6 +187,13 @@ type ChartHandles = {
 };
 
 const READABLE_BAR_PX = 6; // min bar width before we scroll instead of squish
+const RIGHT_GAP_BARS = 10; // gap (in bar-widths) between the last bar and the price axis
+export const TECHNICALS_TIME_SCALE_OPTIONS = {
+  rightOffset: RIGHT_GAP_BARS,
+  fixLeftEdge: true,
+  fixRightEdge: false,
+  minBarSpacing: 4,
+} as const;
 
 // Hover-only below-bar labels must not participate in autoscaling. The default
 // marker behavior reserves bottom margin as soon as a label appears, which
@@ -197,14 +204,15 @@ export const VOLUME_MARKER_OPTIONS = { autoScale: false } as const;
 // readable bar width, fit it edge-to-edge. Otherwise (e.g. FULL = 5y) fitContent
 // would squish bars to ~1px — instead pin a readable bar width and scroll to the
 // newest bars, leaving the rest to scroll left.
-function resetView(h: ChartHandles, barCount: number) {
+export function resetView(h: ChartHandles, barCount: number) {
   const ts = h.chart.timeScale();
   const width = ts.width();
   if (width > 0 && barCount * READABLE_BAR_PX > width) {
     ts.applyOptions({ barSpacing: READABLE_BAR_PX });
-    ts.scrollToPosition(0, false); // newest bar at the right edge
+    ts.scrollToPosition(RIGHT_GAP_BARS, false);
   } else {
-    ts.fitContent();
+    // Fit the full short window while explicitly reserving the same right gap.
+    ts.setVisibleLogicalRange({ from: 0, to: barCount - 1 + RIGHT_GAP_BARS });
   }
 }
 
@@ -325,14 +333,11 @@ export function TechnicalsPriceChart({
       timeScale: {
         borderColor: borderDim,
         timeVisible: false,
-        // Last bar pinned to the right edge (no right-side slack). Bars keep a
-        // readable minimum width: a long window (FULL) overflows and scrolls
-        // horizontally rather than being squished to 1px — the Reset button
-        // snaps back to fit-and-latest.
-        rightOffset: 0,
-        fixLeftEdge: true,
-        fixRightEdge: true,
-        minBarSpacing: 4,
+        // Small right-side gap between the last bar and the price axis (in
+        // bar-widths). Bars keep a readable minimum width: a long window (FULL)
+        // overflows and scrolls horizontally rather than being squished to 1px
+        // — the Reset button snaps back to fit-and-latest.
+        ...TECHNICALS_TIME_SCALE_OPTIONS,
       },
       rightPriceScale: { borderColor: borderDim },
     });

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -207,7 +207,10 @@ export const VOLUME_MARKER_OPTIONS = { autoScale: false } as const;
 export function resetView(h: ChartHandles, barCount: number) {
   const ts = h.chart.timeScale();
   const width = ts.width();
-  if (width > 0 && barCount * READABLE_BAR_PX > width) {
+  if (
+    width > 0 &&
+    (barCount + RIGHT_GAP_BARS) * READABLE_BAR_PX > width
+  ) {
     ts.applyOptions({ barSpacing: READABLE_BAR_PX });
     ts.scrollToPosition(RIGHT_GAP_BARS, false);
   } else {

--- a/web/tests/unit/priceChartData.test.ts
+++ b/web/tests/unit/priceChartData.test.ts
@@ -169,6 +169,16 @@ describe("technicals chart reset view", () => {
     expect(timeScale.scrollToPosition).toHaveBeenCalledWith(10, false);
   });
 
+  it("counts the right gap when enforcing readable bar spacing", () => {
+    const { handles, timeScale } = chartHandles(600);
+
+    resetView(handles, 100);
+
+    expect(timeScale.applyOptions).toHaveBeenCalledWith({ barSpacing: 6 });
+    expect(timeScale.scrollToPosition).toHaveBeenCalledWith(10, false);
+    expect(timeScale.setVisibleLogicalRange).not.toHaveBeenCalled();
+  });
+
   it("leaves ten logical bars after the latest bar for a short history", () => {
     const { handles, timeScale } = chartHandles(800);
 

--- a/web/tests/unit/priceChartData.test.ts
+++ b/web/tests/unit/priceChartData.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   hasOhlcv,
   toBandData,
@@ -8,7 +8,11 @@ import {
   toVolumeData,
   toVolumeMaData,
 } from "@/lib/priceChartData";
-import { VOLUME_MARKER_OPTIONS } from "@/components/stock/panels/TechnicalsPriceChart";
+import {
+  resetView,
+  TECHNICALS_TIME_SCALE_OPTIONS,
+  VOLUME_MARKER_OPTIONS,
+} from "@/components/stock/panels/TechnicalsPriceChart";
 import { SPY_BARS } from "./fixtures/spyBars";
 
 const full = {
@@ -132,6 +136,48 @@ describe("toVolumeData (extreme-highlight shading)", () => {
 describe("volume annotation scaling", () => {
   it("does not let hover labels change the volume scale", () => {
     expect(VOLUME_MARKER_OPTIONS).toEqual({ autoScale: false });
+  });
+});
+
+describe("technicals chart reset view", () => {
+  it("allows the configured right offset to extend beyond the latest bar", () => {
+    expect(TECHNICALS_TIME_SCALE_OPTIONS).toMatchObject({
+      rightOffset: 10,
+      fixRightEdge: false,
+    });
+  });
+
+  function chartHandles(width: number) {
+    const timeScale = {
+      width: vi.fn(() => width),
+      applyOptions: vi.fn(),
+      scrollToPosition: vi.fn(),
+      setVisibleLogicalRange: vi.fn(),
+    };
+    return {
+      handles: { chart: { timeScale: () => timeScale } } as never,
+      timeScale,
+    };
+  }
+
+  it("leaves ten bar-widths after the latest bar for a long history", () => {
+    const { handles, timeScale } = chartHandles(500);
+
+    resetView(handles, 100);
+
+    expect(timeScale.applyOptions).toHaveBeenCalledWith({ barSpacing: 6 });
+    expect(timeScale.scrollToPosition).toHaveBeenCalledWith(10, false);
+  });
+
+  it("leaves ten logical bars after the latest bar for a short history", () => {
+    const { handles, timeScale } = chartHandles(800);
+
+    resetView(handles, 100);
+
+    expect(timeScale.setVisibleLogicalRange).toHaveBeenCalledWith({
+      from: 0,
+      to: 109,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- reserve ten bar-widths between the newest technicals bar and the right price axis
- preserve the same gap on initial load and after Reset for both short and long histories
- add regression coverage and an `[Unreleased]` changelog entry

## Root cause

Lightweight Charts treats `fixRightEdge: true` as a hard clamp: its maximum right offset becomes zero. That silently overrode both the configured `rightOffset: 10` and the Reset position.

## User impact

The latest candle and indicator data no longer sit against the price axis, leaving the intended visual breathing room on the QQQ Technicals chart and other ticker pages.

## Validation

- `cd web && npm test` — 97 files, 591 tests passed
- `cd web && npm run typecheck`
- browser-verified QQQ `/stock/QQQ/technicals` on initial load and after clicking Reset
