### PR TITLE
feat(web): trust-styling on the chanlun overlay (trend-tiered 背离, dimmed 1B/1S)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- Chanlun overlay trust-styling on the Technicals price chart: divergence
+  markers now reflect the trust-probe findings
+  (`docs/research/2026-07-18-chanlun-trust-silver`). Trend-aligned 顶/底背离
+  (底 above / 顶 below the chart's 200-DMA — the higher-conviction subset)
+  render at full amber; counter-trend or pre-200-DMA-warmup 背离 dim to
+  ~35%/~60%; repaint-prone base 1B/1S arrows (24–34% repaint) dim to ~40%,
+  while 2B/3B and segment-level markers are unchanged. Two pure helpers
+  (`sma`, `divergenceTrend`) in `web/lib/chanlun.ts` compute the tier from a
+  200-SMA of the chart's own closes; the marker builder in
+  `TechnicalsPriceChart.tsx` applies per-tier alpha via the existing
+  `cssVar`-suffix idiom. Client-side only — no backend, API, worker, or
+  type-gen change; no new chart primitive or toggle. A legend line explains
+  the emphasis and discloses that the 200-DMA is corporate-action-unadjusted
+  (so the trend split is unreliable for ~200 sessions after a split — the
+  known livewire `adj_close` limitation, verified 0/23 NVDA + 0/17 TSLA tier
+  flips against the plotted `SMA200` line).
+
 ### Fixed
 
 - Technicals price charts now reserve ten bar-widths between the newest bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   (底 above / 顶 below the chart's 200-DMA — the higher-conviction subset)
   render at full amber; counter-trend or pre-200-DMA-warmup 背离 dim to
   ~35%/~60%; repaint-prone base 1B/1S arrows (24–34% repaint) dim to ~40%,
-  while 2B/3B and segment-level markers are unchanged. Two pure helpers
-  (`sma`, `divergenceTrend`) in `web/lib/chanlun.ts` compute the tier from a
-  200-SMA of the chart's own closes; the marker builder in
+  while 2B/3B and segment-level markers are unchanged. A pure
+  `divergenceTrend` helper in `web/lib/chanlun.ts` (reusing the shared
+  `lib/indicators` `sma`) computes the tier from a 200-SMA of the chart's own
+  closes; the marker builder in
   `TechnicalsPriceChart.tsx` applies per-tier alpha via the existing
   `cssVar`-suffix idiom. Client-side only — no backend, API, worker, or
   type-gen change; no new chart primitive or toggle. A legend line explains
@@ -35,7 +36,6 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [0.10.7] — 2026-07-15
 
-
 ### Added
 
 - Chanlun Phase B: sub-level (区间套) fast-confirm signal lifecycle engine,
@@ -48,17 +48,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   from apex with an explicit `start` (apex's default-limit window silently
   truncates history otherwise) and never raises. Migration 107 adds
   `chanlun_signal_events` — an append-mostly per-`(ticker, category, kind,
-  extreme_date, extreme_price)` event log (`storage/chanlun_signal_repository.py`,
+extreme_date, extreme_price)` event log (`storage/chanlun_signal_repository.py`,
   standalone, not folded into `Repository`) driving a pure lifecycle state
-  machine (`chanlun/lifecycle.py`): pending → confirmed_sublevel (S1: a
+  machine (`chanlun/lifecycle.py`): pending → confirmed*sublevel (S1: a
   confirmed same-side 30m vertex lands exactly at the daily extreme, no
   later-arriving 30m vertex beats it) → confirmed_native, with breach,
-  20-session staleness, and `|ln(open_d/close_{d-1})| > ln(1.5)`
-  split-boundary invalidation guards (S2 divergence-based sub-level confirm
-  is stubbed as an unused flag for a future iteration). A nightly
-  `chanlun_lifecycle_scan` job (03:10 ET Tue–Sat, massive-0, gated off by
-  default via `UW_SCAN_CHANLUN_LIFECYCLE_ENABLED`) walks the watchlist and
-  a new read-only `GET /api/stock/{ticker}/chanlun/lifecycle` endpoint
+  20-session staleness, and `|ln(open_d/close*{d-1})| > ln(1.5)`split-boundary invalidation guards (S2 divergence-based sub-level confirm
+is stubbed as an unused flag for a future iteration). A nightly`chanlun_lifecycle_scan`job (03:10 ET Tue–Sat, massive-0, gated off by
+default via`UW_SCAN_CHANLUN_LIFECYCLE_ENABLED`) walks the watchlist and
+a new read-only `GET /api/stock/{ticker}/chanlun/lifecycle` endpoint
   exposes current per-mark state.
 
   The walk-forward validation probe that was to gate which categories get
@@ -131,6 +129,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   Stage-1 minimal deliverable = signal→alert pipeline, invariants) with the
   verified option-surface history facts (grid spans 2025-12-26→present under
   UW's ~180-day window).
+
 ## [0.10.6] — 2026-07-12
 
 - Technicals Dual MACD is now a native lightweight-charts sub-pane of the price

--- a/docs/superpowers/plans/2026-07-18-chanlun-chart-trust-styling.md
+++ b/docs/superpowers/plans/2026-07-18-chanlun-chart-trust-styling.md
@@ -1,0 +1,368 @@
+# Chanlun Chart Trust-Styling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restyle the existing Chanlun chart overlay so each mark's appearance reflects the trust-probe findings — trend-aligned 背离 bright, counter-trend/early faint, repaint-prone 1B/1S dimmed — client-side only.
+
+**Architecture:** Two pure helpers (`sma`, `divergenceTrend`) added to `web/lib/chanlun.ts`, consumed by `TechnicalsPriceChart.tsx` where lightweight-charts markers are built. Trend flags come from a 200-SMA of the chart's own closes; marker `color` gets a per-tier rgba opacity (the codebase already appends 2-hex-digit alpha to `cssVar` values). No backend, no new chart primitive, no new toggle.
+
+**Tech Stack:** Next.js 16 + React 19, TypeScript strict, lightweight-charts (price pane only), Vitest.
+
+## Global Constraints
+
+- **No new charting library** — lightweight-charts is the one documented exception, price pane only. No d3/recharts/visx.
+- **Inline styles + CSS variables** (`var(--…)`); alpha via 2-hex-digit suffix on `cssVar` hex (established pattern: `${cssVar("--accent-cool")}80`).
+- **`divergenceTrend` is a pure index-vs-SMA alignment fn → unit-tested with hand-built geometry** (a legitimate test double, not fabricated market data); `sma` on a plain numeric ramp. The real AAPL H1 fixture yields **0** divergences (verified), so it cannot drive the trend test.
+- **No API/type change** → `npm run gen:types` NOT needed; `lib/types.ts` untouched.
+- **Verification gates:** `cd web && npm run test`, `npm run typecheck`, `npm run build` — all must pass. Lint via `npm run lint`.
+- **Never commit without an explicit user request** — commit steps below are drafted; wait for the operator's go.
+
+**Reference — exact facts this plan relies on (verified in the repo 2026-07-18):**
+- `web/lib/chanlun.ts`: `ChanlunBar = { time: string; high; low; close }`; `DivergenceMark = { time; price; kind: "top"|"bottom"; confirmed }`; `computeChanlun(bars) → { …, divergences }`.
+- `TechnicalsPriceChart.tsx:80` `cssVar(name)` returns the CSS var value (hex). `:258-266` the `chanlunGeo` useMemo builds `bars: ChanlunBar[]` from `full` and returns `computeChanlunFull(bars)`. `:807-817` `marker()` helper builds point markers. `:818-841` divergence markers (`--accent-warm` circles). `:1064-1084` the Chanlun legend block (gated on `chanlunOn && candleMode`).
+- Test approach: `divergenceTrend` is exercised with a hand-built `ChanlunBar[]` + `DivergenceMark[]` (closes `[10,20,5,20,5]`, `window=2`). The AAPL H1 fixture (`web/tests/unit/fixtures/aaplDaily2026H1.ts`, 130 bars) produces **0** divergences (verified by running `computeChanlun`), so it cannot exercise the branches — do not import it in this test.
+
+---
+
+### Task 1: Pure trust helpers in `chanlun.ts` (+ unit tests)
+
+**Files:**
+- Modify: `web/lib/chanlun.ts` (add two exported functions, e.g. after `markResonance`, before the `ChanlunFullResult` type at ~line 528)
+- Create: `web/tests/lib/chanlunTrend.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `sma(closes: readonly number[], window: number): (number | null)[]` — rolling mean, `null` for the first `window-1` entries.
+  - `divergenceTrend(bars: readonly ChanlunBar[], divergences: readonly DivergenceMark[], window?: number): (boolean | null)[]` — aligned to `divergences`; `true` = trend-aligned (底背离 close ≥ SMA / 顶背离 close < SMA), `false` = counter-trend, `null` = SMA undefined at that bar or time not found. Default `window = 200`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/tests/lib/chanlunTrend.test.ts`. Note: `divergenceTrend` is a **pure
+index-vs-SMA alignment** function, so it is unit-tested with **hand-built geometry** —
+a `ChanlunBar[]` + `DivergenceMark[]` whose close-vs-SMA relationships are known by
+construction. This is a legitimate test double for a pure function, not market-data
+fabrication. (The real AAPL H1 fixture is deliberately NOT used here: it contains 130
+bars and produces **zero** divergences, so it cannot drive this test at any window.)
+`sma` is tested on a plain numeric ramp.
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  divergenceTrend,
+  sma,
+  type ChanlunBar,
+  type DivergenceMark,
+} from "@/lib/chanlun";
+
+describe("sma", () => {
+  it("nulls the warmup prefix and computes exact window means", () => {
+    const s = sma([2, 4, 6, 8], 2);
+    expect(s[0]).toBeNull();
+    expect(s[1]).toBe(3); // (2+4)/2
+    expect(s[2]).toBe(5); // (4+6)/2
+    expect(s[3]).toBe(7); // (6+8)/2
+  });
+});
+
+describe("divergenceTrend", () => {
+  // closes = [10, 20, 5, 20, 5]; sma(closes, 2) = [null, 15, 12.5, 12.5, 12.5].
+  const bars: ChanlunBar[] = [10, 20, 5, 20, 5].map((c, i) => ({
+    time: `2024-01-0${i + 1}`,
+    high: c + 1,
+    low: c - 1,
+    close: c,
+  }));
+  const divs: DivergenceMark[] = [
+    { time: "2024-01-01", price: 10, kind: "bottom", confirmed: true }, // SMA null -> null
+    { time: "2024-01-02", price: 20, kind: "bottom", confirmed: true }, // 20 >= 15    -> true
+    { time: "2024-01-03", price: 5, kind: "bottom", confirmed: true }, //  5 >= 12.5   -> false
+    { time: "2024-01-04", price: 20, kind: "top", confirmed: true }, //   20 <  12.5   -> false
+    { time: "2024-01-05", price: 5, kind: "top", confirmed: true }, //     5 <  12.5   -> true
+  ];
+
+  it("flags each divergence by close-vs-SMA on its side; null in warmup", () => {
+    expect(divergenceTrend(bars, divs, 2)).toEqual([
+      null,
+      true,
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it("returns null for a divergence whose time is not a bar", () => {
+    expect(
+      divergenceTrend(
+        bars,
+        [{ time: "1999-01-01", price: 0, kind: "bottom", confirmed: true }],
+        2,
+      ),
+    ).toEqual([null]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd web && npm run test -- chanlunTrend`
+Expected: FAIL — `sma`/`divergenceTrend` are not exported yet.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `web/lib/chanlun.ts`, add (after `markResonance`, before `export type ChanlunFullResult`):
+
+```ts
+/** Simple moving average of `closes`; out[i] = mean of the trailing `window`
+ * values, or null for the first window-1 entries. O(n) prefix-sum roll. */
+export function sma(
+  closes: readonly number[],
+  window: number,
+): (number | null)[] {
+  const out: (number | null)[] = new Array(closes.length).fill(null);
+  let run = 0;
+  for (let i = 0; i < closes.length; i++) {
+    run += closes[i];
+    if (i >= window) run -= closes[i - window];
+    if (i >= window - 1) out[i] = run / window;
+  }
+  return out;
+}
+
+/** Per divergence: is it trend-aligned? A 底背离 (bottom) is trend-aligned when
+ * its bar closes ABOVE the `window`-SMA (dip inside an uptrend); a 顶背离 (top)
+ * when it closes BELOW it. Returns true/false, or null when the SMA is not yet
+ * defined at that bar (early history) or the time is not found. The trust probe
+ * (docs/research/2026-07-18-chanlun-trust-silver) found the trend-aligned subset
+ * carries the stronger honest edge. Aligned index-for-index to `divergences`. */
+export function divergenceTrend(
+  bars: readonly ChanlunBar[],
+  divergences: readonly DivergenceMark[],
+  window = 200,
+): (boolean | null)[] {
+  const idxByTime = new Map(bars.map((b, i) => [b.time, i]));
+  const ma = sma(
+    bars.map((b) => b.close),
+    window,
+  );
+  return divergences.map((d) => {
+    const i = idxByTime.get(d.time);
+    if (i === undefined) return null;
+    const m = ma[i];
+    if (m === null) return null;
+    return d.kind === "bottom" ? bars[i].close >= m : bars[i].close < m;
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd web && npm run test -- chanlunTrend`
+Expected: PASS (3 tests: 1 `sma`, 2 `divergenceTrend`).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit** *(await explicit user go)*
+
+```bash
+git add web/lib/chanlun.ts web/tests/lib/chanlunTrend.test.ts
+git commit -m "feat(web): sma + divergenceTrend trust helpers for chanlun overlay"
+```
+
+---
+
+### Task 2: Wire trust-styling into the technicals chart overlay
+
+**Files:**
+- Modify: `web/components/stock/panels/TechnicalsPriceChart.tsx`
+
+**Interfaces:**
+- Consumes: `sma`/`divergenceTrend` (Task 1), existing `chanlunGeo`, `cssVar`, `positive`/`negative`, the marker builders.
+- Produces: no new exports — internal rendering change only.
+
+- [ ] **Step 1: Import `divergenceTrend`**
+
+In the `@/lib/chanlun` import block (lines 44–49), add `divergenceTrend` after `computeChanlunFull` (value import before the `type` imports):
+
+```ts
+import {
+  computeChanlunFull,
+  divergenceTrend,
+  type BuySellPoint,
+  type ChanlunBar,
+  type Zhongshu,
+} from "@/lib/chanlun";
+```
+
+- [ ] **Step 2: Hoist bar construction so the effect can reach the bars**
+
+Replace the `chanlunGeo` useMemo (currently ~lines 258–266) with a hoisted `clBars`
+memo (so the marker effect can call `divergenceTrend(clBars, …)`) plus the unchanged
+`chanlunGeo`:
+
+```ts
+  // Chanlun bars over FULL history (window-cut in the data pass), hoisted so the
+  // marker effect can compute divergence trend without rebuilding them.
+  const clBars = useMemo<ChanlunBar[] | null>(() => {
+    if (!chanlunOn || !candleMode) return null;
+    return full.flatMap((r) =>
+      r.as_of != null && r.high != null && r.low != null && r.close != null
+        ? [{ time: r.as_of, high: r.high, low: r.low, close: r.close }]
+        : [],
+    );
+  }, [full, chanlunOn, candleMode]);
+  const chanlunGeo = useMemo(
+    () => (clBars ? computeChanlunFull(clBars) : null),
+    [clBars],
+  );
+```
+
+No separate trend memo / Map: `divergenceTrend` already returns an array index-aligned
+to `chanlunGeo.divergences`, so the flags are zipped onto the marks *before* the
+`firstAsOf` filter in Step 4 — strictly less machinery than a time-keyed Map.
+
+- [ ] **Step 3: Dim repaint-prone base 1B/1S in the `marker()` helper**
+
+In the marker effect (~line 807), give `marker()` a `dimFirst` flag and apply ~40% alpha to first-class points:
+
+```ts
+      const marker = (
+        p: BuySellPoint,
+        prefix: string,
+        size: number,
+        dimFirst: boolean,
+      ) => {
+        const buy = p.kind.endsWith("B");
+        const base = buy ? positive : negative;
+        const first = p.kind === "1B" || p.kind === "1S";
+        return {
+          time: p.time as Time,
+          position: buy ? ("belowBar" as const) : ("aboveBar" as const),
+          shape: buy ? ("arrowUp" as const) : ("arrowDown" as const),
+          color: dimFirst && first ? `${base}66` : base, // ~40% for repaint-prone 1st points
+          text: `${prefix}${p.kind}${p.confirmed ? "" : "?"}${p.resonant ? "★" : ""}`,
+          size,
+        };
+      };
+```
+
+Update the two callers (base points dim; 段-level points unchanged):
+
+```ts
+          ...chanlunGeo.points
+            .filter((p) => p.time >= firstAsOf)
+            .map((p) => marker(p, "", 1, true)),
+          ...chanlunGeo.segPoints
+            .filter((p) => p.time >= firstAsOf)
+            .map((p) => marker(p, "段", 2, false)),
+```
+
+- [ ] **Step 4: Tier the 背离 marker color by trend**
+
+This edit is inside the `if (chanlunGeo) { … }` block (line 768), so `chanlunGeo` and
+`clBars` are both non-null here. Replace `const divColor = cssVar("--accent-warm");`
+(line 818) with the tier helper + the flags array:
+
+```ts
+      const divBase = cssVar("--accent-warm");
+      const divColorFor = (t: boolean | null | undefined) =>
+        t === true ? divBase : t === false ? `${divBase}59` : `${divBase}99`; // full / ~35% / ~60%
+      // Index-aligned to chanlunGeo.divergences — zip before the firstAsOf filter.
+      const divFlags = divergenceTrend(clBars!, chanlunGeo.divergences);
+```
+
+and replace the divergence `.map(...)` block (currently ~lines 827–839) with a
+zip-then-filter that carries each mark's flag:
+
+```ts
+          ...chanlunGeo.divergences
+            .map((mark, i) => ({ mark, trend: divFlags[i] }))
+            .filter((x) => x.mark.time >= firstAsOf)
+            .map((x) => ({
+              time: x.mark.time as Time,
+              position:
+                x.mark.kind === "top"
+                  ? ("aboveBar" as const)
+                  : ("belowBar" as const),
+              shape: "circle" as const,
+              color: divColorFor(x.trend),
+              text: `${x.mark.kind === "top" ? "顶背离" : "底背离"}${x.mark.confirmed ? "" : "?"}`,
+              size: 1,
+            })),
+```
+
+- [ ] **Step 5: Add `clBars` to the marker effect's dependency array**
+
+The marker effect (`useEffect` at line 664) closes at line 874 with
+`}, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo]);`. Step 4 now reads
+`clBars` inside it (`divergenceTrend(clBars!, …)`), so append `clBars`:
+
+```ts
+  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo, clBars]);
+```
+
+(ESLint `react-hooks/exhaustive-deps` via `npm run lint` will flag it if missed.
+`clBars` and `chanlunGeo` change together, so this adds no extra effect churn.)
+
+- [ ] **Step 6: Append the trust sentence to the Chanlun legend**
+
+In the legend block gated on `chanlunOn && candleMode` (~lines 1064–1084), append this
+exact sentence as text children immediately before the block's closing `</div>` (line
+1083). The leading `{" "}` forces a single separating space:
+
+```tsx
+{" "}Marker emphasis = reliability, not entry timing: bright 顶/底背离 = trend-aligned
+(底 above / 顶 below the 200-DMA, the higher-conviction subset); faint 背离 =
+counter-trend or early; faint 1B/1S = repaint-prone (24–34%). Not a trade signal.
+```
+
+- [ ] **Step 7: Typecheck + lint + build**
+
+Run: `cd web && npm run typecheck && npm run lint && npm run build`
+Expected: all clean (no unused `divColor`, no missing-dep warnings, build succeeds).
+
+- [ ] **Step 8: Full test run**
+
+Run: `cd web && npm run test`
+Expected: green, including `chanlunTrend`.
+
+- [ ] **Step 9: Browser verification**
+
+Start the stack (`bash scripts/dev.sh` if not running), open a stock page with a
+**long-history ticker (≥2y)**, Technicals tab, candle mode + Chanlun overlay ON. The
+default `window=200` means the bright/faint split only appears where the 200-DMA is
+defined; the chart feeds deep history (`full = fullRows ?? rows`, ~1650 daily bars), so
+most divergences qualify — but a short-history name would render mostly faint, so pick a
+long one. Confirm: some 底背离/顶背离 render bright and others faint; 1B/1S arrows are
+visibly dimmer than 2B/3B/2S/3S; the legend sentence reads correctly. Save a screenshot
+to `output/playwright/chanlun-trust-styling.png`.
+
+- [ ] **Step 10: Commit** *(await explicit user go)*
+
+```bash
+git add web/components/stock/panels/TechnicalsPriceChart.tsx
+git commit -m "feat(web): trust-styling on the chanlun overlay (trend-tiered 背离, dimmed 1B/1S)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Trend-emphasis on 背离 (bright/faint/unknown tiers) → Task 1 `divergenceTrend` + Task 2 Step 4. ✓
+- Dim repaint-prone 1B/1S, base points only (段 unchanged) → Task 2 Step 3. ✓
+- One-line legend → Task 2 Step 6. ✓
+- Client-side only, no backend/API/type-gen/toggle → no such files touched; `gen:types` explicitly not run. ✓
+- Tests on hand-built geometry → Task 1 Step 1 (`divergenceTrend` is a pure alignment
+  fn; the real AAPL H1 fixture has **0 divergences** — verified — so it can't drive it;
+  `sma` on a ramp). ✓
+- Honest caveat (reliability, not a trade signal) → legend sentence. ✓
+
+**Placeholder scan:** none — every step carries runnable code or an exact command. Alpha constants (`66`/`59`/`99`) are concrete hex.
+
+**Type consistency:** `divergenceTrend` signature identical across Task 1 (definition), Task 2 Step 4 (call), and the test; it returns `(boolean | null)[]` index-aligned to `chanlunGeo.divergences`, and `divColorFor` accepts `boolean | null | undefined` (array index access can be undefined) — consistent. `marker()` gains one `boolean` param, both callers updated.
+
+**Simpler-approach check:** flags are zipped onto each divergence before the `firstAsOf` filter, so no time-keyed Map and no separate trend memo — the `clBars` hoist is the only added memo (and it removes a duplicated `flatMap`), keeping `chanlunGeo`'s shape unchanged so the ~8 downstream `chanlunGeo.*` reads and the `if (chanlunGeo)` guard are untouched. Marker opacity via alpha-suffixed `cssVar` reuses the codebase's existing idiom (verified: `TechnicalsPriceChart.tsx:444/466/467/499`).

--- a/docs/superpowers/specs/2026-07-18-chanlun-chart-trust-styling-design.md
+++ b/docs/superpowers/specs/2026-07-18-chanlun-chart-trust-styling-design.md
@@ -29,11 +29,13 @@ client-side only, no backend, no new chart primitive, no new toggle.
 ## Scope
 
 **In:**
+
 - Emphasize trend-aligned 背离; dim counter-trend 背离.
 - Dim 1B/1S points (repaint-prone).
 - A one-line legend explaining the styling.
 
 **Out (YAGNI for v1):**
+
 - Validity-window level lines (needs a custom primitive like the 中枢 rects).
 - A separate on/off toggle for the styling (always-on when the overlay is shown).
 - Any backend / API / worker change. Any change to 笔/中枢/段 rendering.
@@ -46,7 +48,7 @@ A pure helper in `web/lib/chanlun.ts`:
 
 ```ts
 /** 200-SMA of closes; sma[i] = null until the window fills. */
-export function sma(closes: number[], window: number): (number | null)[]
+export function sma(closes: number[], window: number): (number | null)[];
 
 /** Per divergence: true if trend-aligned (底背离 above the 200-SMA / 顶背离 below),
  * false if counter-trend, null if the SMA is not yet defined at that bar. */
@@ -54,7 +56,7 @@ export function divergenceTrend(
   bars: ChanlunBar[],
   divergences: DivergenceMark[],
   window = 200,
-): (boolean | null)[]
+): (boolean | null)[];
 ```
 
 - Aligns each `DivergenceMark` to its bar by `time`; reads that bar's `close` vs the
@@ -73,13 +75,13 @@ lightweight-charts markers accept a per-marker `color` (rgba → opacity) and `s
 The marker-building block in `TechnicalsPriceChart.tsx` (~lines 807–840) branches on the
 trust tier. Opacity values are the design default; final constants live in the panel.
 
-| Mark | Color | Rationale |
-|---|---|---|
-| 背离 trend-agree | `--accent-warm`, full opacity | the marks to trust (+0.65% subset) |
-| 背离 counter-trend | `--accent-warm` @ ~0.35 alpha | weaker edge |
-| 背离 unknown (early bars) | `--accent-warm` @ ~0.6 alpha | SMA undefined, don't over-claim |
-| **1B / 1S** | positive/negative @ ~0.4 alpha | repaints 24–34% |
-| 2B/3B, 2S/3S | positive/negative, unchanged | stable once confirmed |
+| Mark                      | Color                          | Rationale                          |
+| ------------------------- | ------------------------------ | ---------------------------------- |
+| 背离 trend-agree          | `--accent-warm`, full opacity  | the marks to trust (+0.65% subset) |
+| 背离 counter-trend        | `--accent-warm` @ ~0.35 alpha  | weaker edge                        |
+| 背离 unknown (early bars) | `--accent-warm` @ ~0.6 alpha   | SMA undefined, don't over-claim    |
+| **1B / 1S**               | positive/negative @ ~0.4 alpha | repaints 24–34%                    |
+| 2B/3B, 2S/3S              | positive/negative, unchanged   | stable once confirmed              |
 
 Marker `text` stays as today (e.g. `底背离`, `1B?`); only color/opacity change.
 The existing `?` (unconfirmed) suffix is orthogonal and preserved.
@@ -151,7 +153,8 @@ correct.
 
 - **Reuse:** existing `computeChanlun`/`DivergenceMark`/`BuySellPoint`, the
   lightweight-charts marker path, `--accent-warm`/`--positive`/`--negative` tokens,
-  `ChanlunBar`.
-- **New:** `sma` + `divergenceTrend` helpers in `chanlun.ts` (+ unit test), the trust
+  `ChanlunBar`, and the shared `lib/indicators` `sma` (it already null-guards
+  non-finite windows — better than a fresh rolling mean).
+- **New:** `divergenceTrend` helper in `chanlun.ts` (+ unit test), the trust
   branch in the marker builder, the legend line.
 - **No production data surface** — no migration, API, worker, or type-gen change.

--- a/docs/superpowers/specs/2026-07-18-chanlun-chart-trust-styling-design.md
+++ b/docs/superpowers/specs/2026-07-18-chanlun-chart-trust-styling-design.md
@@ -1,0 +1,157 @@
+# Chanlun chart trust-styling — design
+
+**Date:** 2026-07-18 · **Status:** design (approved in brainstorm; spec under user review)
+**Prior art:** `docs/research/2026-07-18-chanlun-trust-silver/` (the trust probe this
+operationalizes) · `web/lib/chanlun.ts` (compute) · `web/components/stock/panels/TechnicalsPriceChart.tsx`
+(lightweight-charts overlay).
+
+## Problem
+
+The trust probe established (on corporate-action-adjusted bars, 223 names, ~5.3y):
+
+- **背离 (顶/底背离)** and **2/3 买卖点** never retract once confirmed; **1B/1S repaint
+  24–34%** — untrustworthy even as annotations.
+- Only 背离 carries a faint honest forward edge, and it is materially stronger when
+  **trend-aligned**: a 底背离 **above** the 200-DMA / 顶背离 **below** it → 57% hit,
+  +0.65% edge at 10 sessions (CI-positive, period-robust). The counter-trend subset is
+  weaker.
+
+The live Chanlun overlay draws every mark **uniformly** (divergences as one
+`--accent-warm` circle marker; points as up/down arrows). The operator gets no visual
+cue about which marks the research says to trust. This feature closes that gap —
+purely by restyling existing markers.
+
+## Goal
+
+When the Chanlun overlay is on, make each mark's appearance reflect its trust tier —
+client-side only, no backend, no new chart primitive, no new toggle.
+
+## Scope
+
+**In:**
+- Emphasize trend-aligned 背离; dim counter-trend 背离.
+- Dim 1B/1S points (repaint-prone).
+- A one-line legend explaining the styling.
+
+**Out (YAGNI for v1):**
+- Validity-window level lines (needs a custom primitive like the 中枢 rects).
+- A separate on/off toggle for the styling (always-on when the overlay is shown).
+- Any backend / API / worker change. Any change to 笔/中枢/段 rendering.
+
+## Design
+
+### 1. Trend-agree computation (the one piece of new logic)
+
+A pure helper in `web/lib/chanlun.ts`:
+
+```ts
+/** 200-SMA of closes; sma[i] = null until the window fills. */
+export function sma(closes: number[], window: number): (number | null)[]
+
+/** Per divergence: true if trend-aligned (底背离 above the 200-SMA / 顶背离 below),
+ * false if counter-trend, null if the SMA is not yet defined at that bar. */
+export function divergenceTrend(
+  bars: ChanlunBar[],
+  divergences: DivergenceMark[],
+  window = 200,
+): (boolean | null)[]
+```
+
+- Aligns each `DivergenceMark` to its bar by `time`; reads that bar's `close` vs the
+  200-SMA at that index.
+- **底背离 (bottom)** trend-agree ⇔ close ≥ SMA200; **顶背离 (top)** trend-agree ⇔
+  close < SMA200.
+- First 200 bars → SMA null → **unknown** (neutral rendering, never dimmed).
+- **Honest nuance (documented in the legend + spec):** the chart flags at the
+  divergence's **own bar**; the probe measured at the confirmation close ~8 bars later.
+  In practice both sit in the same 200-DMA regime, so the visual cue matches the
+  research subset; the chart is not claiming point-in-time-exact entry.
+
+### 2. Visual treatment
+
+lightweight-charts markers accept a per-marker `color` (rgba → opacity) and `size`.
+The marker-building block in `TechnicalsPriceChart.tsx` (~lines 807–840) branches on the
+trust tier. Opacity values are the design default; final constants live in the panel.
+
+| Mark | Color | Rationale |
+|---|---|---|
+| 背离 trend-agree | `--accent-warm`, full opacity | the marks to trust (+0.65% subset) |
+| 背离 counter-trend | `--accent-warm` @ ~0.35 alpha | weaker edge |
+| 背离 unknown (early bars) | `--accent-warm` @ ~0.6 alpha | SMA undefined, don't over-claim |
+| **1B / 1S** | positive/negative @ ~0.4 alpha | repaints 24–34% |
+| 2B/3B, 2S/3S | positive/negative, unchanged | stable once confirmed |
+
+Marker `text` stays as today (e.g. `底背离`, `1B?`); only color/opacity change.
+The existing `?` (unconfirmed) suffix is orthogonal and preserved.
+
+**Scope of the 1B/1S dimming:** applies to the **base 买卖点** (`chanlunGeo.points`) —
+the level the probe measured. **段-level points** (`chanlunGeo.segPoints`, drawn at
+`size: 2` with the `段` prefix) are a different level the probe did not test and are
+**left unchanged** in v1. Same for 背离: only base `chanlunGeo.divergences` are
+tiered (there is no separate seg-divergence marker today).
+
+### 3. Legend
+
+One compact line appended to the existing Chanlun legend block (`--text-muted`, same
+style). The **canonical final copy lives in the plan** (Task 2 Step 6) — implement that
+exact string; do not paraphrase:
+
+> Marker emphasis = reliability, not entry timing: bright 顶/底背离 = trend-aligned
+> (底 above / 顶 below the 200-DMA, the higher-conviction subset); faint 背离 =
+> counter-trend or early; faint 1B/1S = repaint-prone (24–34%). Not a trade signal.
+
+Without it the dimming is unexplained. Keep it terse; it is the only prose added.
+
+## Testing
+
+- **Vitest** (`web/tests/lib/chanlunTrend.test.ts`):
+  - `sma` — pure numeric helper, tested on a known ramp series (no market data;
+    asserts the null-warmup prefix and exact means).
+  - `divergenceTrend` — a **pure index-vs-SMA alignment** function, tested with a small
+    **hand-built** `ChanlunBar[]` + `DivergenceMark[]` whose close-vs-SMA relationships
+    are known by construction (covering: warmup→null, bottom-above→true, bottom-below→
+    false, top-below→true, top-above→false, unknown-time→null). This is a legitimate
+    test double for a pure function — not fabricated market data. The real AAPL H1
+    fixture is **not** usable here: it is 130 bars and produces **zero** divergences at
+    any window (verified), so it cannot exercise the branches.
+- `npm run typecheck` clean.
+- `npm run build` clean.
+- Manual/browser: load a stock page with the overlay on, confirm bright vs faint 背离
+  and dimmed 1B/1S render, legend reads correctly. Screenshot under `output/playwright/`.
+
+## What this can and cannot claim
+
+- **Can:** direct the eye to the marks the research found more trustworthy, and flag the
+  ones that repaint — making the overlay honest about its own reliability.
+- **Cannot:** turn chanlun into a trade signal. The edge is a weak tilt (+0.65%,
+  pre-cost, mega-cap-biased). The legend and spec say so; no sizing/entry guidance is
+  implied by the styling.
+
+### Known limitation — unadjusted 200-DMA near splits (verified 2026-07-18)
+
+The trend split uses the **same 200-DMA the chart already plots** (the `sma200`
+field behind the pink `SMA200` line) — verified identical to the client-rolled
+`sma(closes, 200)` to the penny across every divergence on NVDA (0/23 flips) and
+TSLA (0/17 flips), so the emphasis never contradicts the drawn line. But that
+series is **not corporate-action adjusted**: for ~200 sessions after a stock
+split the trailing window mixes unadjusted pre-split prices with post-split
+prices, so the 200-DMA is corrupted (e.g. TSLA 2022-10-24 close 211.25 vs
+"200-DMA" 732.11 after the Aug-2022 3:1 split; NVDA 2024-08-05 close 100.45 vs
+593.64 after the Jun-2024 10:1 split). In that window the trend tier is
+meaningless — but consistent with the equally-wrong pink line, and the trust
+probe that justified this feature ran on adjusted **silver** bars where the
+200-DMA is clean. This is the known livewire `adj_close` blocker surfacing on
+the chart; it also corrupts the z-score and σ-band tiles, not just this styling.
+The correct fix is upstream adjusted closes, **not** a client-side split
+heuristic (fragile — legitimate large moves would misfire). Shipped as-is with
+the legend disclosing it; away from splits (every recent view) the tier is
+correct.
+
+## Reused vs new
+
+- **Reuse:** existing `computeChanlun`/`DivergenceMark`/`BuySellPoint`, the
+  lightweight-charts marker path, `--accent-warm`/`--positive`/`--negative` tokens,
+  `ChanlunBar`.
+- **New:** `sma` + `divergenceTrend` helpers in `chanlun.ts` (+ unit test), the trust
+  branch in the marker builder, the legend line.
+- **No production data surface** — no migration, API, worker, or type-gen change.

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -43,6 +43,7 @@ import { BandsIndicator } from "@/lib/lwc/bandsIndicator";
 import { ChanlunZhongshu } from "@/lib/lwc/chanlunZhongshu";
 import {
   computeChanlunFull,
+  divergenceTrend,
   type BuySellPoint,
   type ChanlunBar,
   type Zhongshu,
@@ -207,10 +208,7 @@ export const VOLUME_MARKER_OPTIONS = { autoScale: false } as const;
 export function resetView(h: ChartHandles, barCount: number) {
   const ts = h.chart.timeScale();
   const width = ts.width();
-  if (
-    width > 0 &&
-    (barCount + RIGHT_GAP_BARS) * READABLE_BAR_PX > width
-  ) {
+  if (width > 0 && (barCount + RIGHT_GAP_BARS) * READABLE_BAR_PX > width) {
     ts.applyOptions({ barSpacing: READABLE_BAR_PX });
     ts.scrollToPosition(RIGHT_GAP_BARS, false);
   } else {
@@ -255,15 +253,20 @@ export function TechnicalsPriceChart({
   };
   // Chanlun geometry over the FULL history (window-cut in the data pass, like
   // the other client-side indicators). Pure + deterministic, so memo on rows.
-  const chanlunGeo = useMemo(() => {
+  // Chanlun bars over FULL history (window-cut in the data pass), hoisted so the
+  // marker effect can compute divergence trend without rebuilding them.
+  const clBars = useMemo<ChanlunBar[] | null>(() => {
     if (!chanlunOn || !candleMode) return null;
-    const bars: ChanlunBar[] = full.flatMap((r) =>
+    return full.flatMap((r) =>
       r.as_of != null && r.high != null && r.low != null && r.close != null
         ? [{ time: r.as_of, high: r.high, low: r.low, close: r.close }]
         : [],
     );
-    return computeChanlunFull(bars);
   }, [full, chanlunOn, candleMode]);
+  const chanlunGeo = useMemo(
+    () => (clBars ? computeChanlunFull(clBars) : null),
+    [clBars],
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const readoutRef = useRef<HTMLDivElement>(null);
@@ -804,37 +807,49 @@ export function TechnicalsPriceChart({
           }));
       h.clZs.setRects(rects(chanlunGeo.zhongshus));
       h.segZs.setRects(rects(chanlunGeo.segZhongshus));
-      const marker = (p: BuySellPoint, prefix: string, size: number) => {
+      const marker = (
+        p: BuySellPoint,
+        prefix: string,
+        size: number,
+        dimFirst: boolean,
+      ) => {
         const buy = p.kind.endsWith("B");
+        const base = buy ? positive : negative;
+        const first = p.kind === "1B" || p.kind === "1S";
         return {
           time: p.time as Time,
           position: buy ? ("belowBar" as const) : ("aboveBar" as const),
           shape: buy ? ("arrowUp" as const) : ("arrowDown" as const),
-          color: buy ? positive : negative,
+          color: dimFirst && first ? `${base}66` : base, // ~40% for repaint-prone 1st points
           text: `${prefix}${p.kind}${p.confirmed ? "" : "?"}${p.resonant ? "★" : ""}`,
           size,
         };
       };
-      const divColor = cssVar("--accent-warm");
+      const divBase = cssVar("--accent-warm");
+      const divColorFor = (t: boolean | null | undefined) =>
+        t === true ? divBase : t === false ? `${divBase}59` : `${divBase}99`; // full / ~35% / ~60%
+      // Index-aligned to chanlunGeo.divergences — zip before the firstAsOf filter.
+      const divFlags = divergenceTrend(clBars!, chanlunGeo.divergences);
       h.clMarkers.setMarkers(
         [
           ...chanlunGeo.points
             .filter((p) => p.time >= firstAsOf)
-            .map((p) => marker(p, "", 1)),
+            .map((p) => marker(p, "", 1, true)),
           ...chanlunGeo.segPoints
             .filter((p) => p.time >= firstAsOf)
-            .map((p) => marker(p, "段", 2)),
+            .map((p) => marker(p, "段", 2, false)),
           ...chanlunGeo.divergences
-            .filter((d) => d.time >= firstAsOf)
-            .map((d) => ({
-              time: d.time as Time,
+            .map((mark, i) => ({ mark, trend: divFlags[i] }))
+            .filter((x) => x.mark.time >= firstAsOf)
+            .map((x) => ({
+              time: x.mark.time as Time,
               position:
-                d.kind === "top"
+                x.mark.kind === "top"
                   ? ("aboveBar" as const)
                   : ("belowBar" as const),
               shape: "circle" as const,
-              color: divColor,
-              text: `${d.kind === "top" ? "顶背离" : "底背离"}${d.confirmed ? "" : "?"}`,
+              color: divColorFor(x.trend),
+              text: `${x.mark.kind === "top" ? "顶背离" : "底背离"}${x.mark.confirmed ? "" : "?"}`,
               size: 1,
             })),
         ].sort((a, b) => String(a.time).localeCompare(String(b.time))),
@@ -871,7 +886,7 @@ export function TechnicalsPriceChart({
         volMaByTimeRef.current.get(lastRow.as_of),
       );
     }
-  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo]);
+  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo, clBars]);
 
   const clearAnchor = () => {
     setAnchor(null);
@@ -1079,7 +1094,13 @@ export function TechnicalsPriceChart({
           signal). Structures on the trailing edge repaint by design — decisions
           belong on confirmed marks only. Amber thick lines = 线段 (segments)
           with amber 段级中枢 boxes; 段-prefixed markers = segment-level 买卖点;
-          ★ = weekly×daily 区间套 resonance (both levels confirmed).
+          ★ = weekly×daily 区间套 resonance (both levels confirmed). Marker
+          emphasis = reliability, not entry timing: bright 顶/底背离 =
+          trend-aligned (底 above / 顶 below the 200-DMA, the higher-conviction
+          subset); faint 背离 = counter-trend or early; faint 1B/1S =
+          repaint-prone (24–34%). Not a trade signal. The 200-DMA is
+          corporate-action-unadjusted, so the trend split is unreliable for ~200
+          sessions after a stock split.
         </div>
       )}
       <MacdLegend signal={macd} />

--- a/web/lib/chanlun.ts
+++ b/web/lib/chanlun.ts
@@ -525,6 +525,47 @@ export function markResonance(
   });
 }
 
+/** Simple moving average of `closes`; out[i] = mean of the trailing `window`
+ * values, or null for the first window-1 entries. O(n) prefix-sum roll. */
+export function sma(
+  closes: readonly number[],
+  window: number,
+): (number | null)[] {
+  const out: (number | null)[] = new Array(closes.length).fill(null);
+  let run = 0;
+  for (let i = 0; i < closes.length; i++) {
+    run += closes[i];
+    if (i >= window) run -= closes[i - window];
+    if (i >= window - 1) out[i] = run / window;
+  }
+  return out;
+}
+
+/** Per divergence: is it trend-aligned? A 底背离 (bottom) is trend-aligned when
+ * its bar closes ABOVE the `window`-SMA (dip inside an uptrend); a 顶背离 (top)
+ * when it closes BELOW it. Returns true/false, or null when the SMA is not yet
+ * defined at that bar (early history) or the time is not found. The trust probe
+ * (docs/research/2026-07-18-chanlun-trust-silver) found the trend-aligned subset
+ * carries the stronger honest edge. Aligned index-for-index to `divergences`. */
+export function divergenceTrend(
+  bars: readonly ChanlunBar[],
+  divergences: readonly DivergenceMark[],
+  window = 200,
+): (boolean | null)[] {
+  const idxByTime = new Map(bars.map((b, i) => [b.time, i]));
+  const ma = sma(
+    bars.map((b) => b.close),
+    window,
+  );
+  return divergences.map((d) => {
+    const i = idxByTime.get(d.time);
+    if (i === undefined) return null;
+    const m = ma[i];
+    if (m === null) return null;
+    return d.kind === "bottom" ? bars[i].close >= m : bars[i].close < m;
+  });
+}
+
 export type ChanlunFullResult = ChanlunResult & {
   segVertices: SegVertex[];
   segZhongshus: Zhongshu[];

--- a/web/lib/chanlun.ts
+++ b/web/lib/chanlun.ts
@@ -9,7 +9,7 @@
 // The trailing structures are PROVISIONAL by construction (the last stroke
 // endpoint can still move, the forming counter-leg tracks the running
 // extreme) — consumers must render them dashed/"?" and never alert off them.
-import { ema } from "@/lib/indicators";
+import { ema, sma } from "@/lib/indicators";
 import { buildSegments, type SegVertex } from "@/lib/chanlunSeg";
 
 export type ChanlunBar = {
@@ -523,22 +523,6 @@ export function markResonance(
       );
     return hit ? { ...p, resonant: true } : p;
   });
-}
-
-/** Simple moving average of `closes`; out[i] = mean of the trailing `window`
- * values, or null for the first window-1 entries. O(n) prefix-sum roll. */
-export function sma(
-  closes: readonly number[],
-  window: number,
-): (number | null)[] {
-  const out: (number | null)[] = new Array(closes.length).fill(null);
-  let run = 0;
-  for (let i = 0; i < closes.length; i++) {
-    run += closes[i];
-    if (i >= window) run -= closes[i - window];
-    if (i >= window - 1) out[i] = run / window;
-  }
-  return out;
 }
 
 /** Per divergence: is it trend-aligned? A 底背离 (bottom) is trend-aligned when

--- a/web/tests/lib/chanlunTrend.test.ts
+++ b/web/tests/lib/chanlunTrend.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  divergenceTrend,
+  sma,
+  type ChanlunBar,
+  type DivergenceMark,
+} from "@/lib/chanlun";
+
+describe("sma", () => {
+  it("nulls the warmup prefix and computes exact window means", () => {
+    const s = sma([2, 4, 6, 8], 2);
+    expect(s[0]).toBeNull();
+    expect(s[1]).toBe(3); // (2+4)/2
+    expect(s[2]).toBe(5); // (4+6)/2
+    expect(s[3]).toBe(7); // (6+8)/2
+  });
+});
+
+describe("divergenceTrend", () => {
+  // closes = [10, 20, 5, 20, 5]; sma(closes, 2) = [null, 15, 12.5, 12.5, 12.5].
+  const bars: ChanlunBar[] = [10, 20, 5, 20, 5].map((c, i) => ({
+    time: `2024-01-0${i + 1}`,
+    high: c + 1,
+    low: c - 1,
+    close: c,
+  }));
+  const divs: DivergenceMark[] = [
+    { time: "2024-01-01", price: 10, kind: "bottom", confirmed: true }, // SMA null -> null
+    { time: "2024-01-02", price: 20, kind: "bottom", confirmed: true }, // 20 >= 15    -> true
+    { time: "2024-01-03", price: 5, kind: "bottom", confirmed: true }, //  5 >= 12.5   -> false
+    { time: "2024-01-04", price: 20, kind: "top", confirmed: true }, //   20 <  12.5   -> false
+    { time: "2024-01-05", price: 5, kind: "top", confirmed: true }, //     5 <  12.5   -> true
+  ];
+
+  it("flags each divergence by close-vs-SMA on its side; null in warmup", () => {
+    expect(divergenceTrend(bars, divs, 2)).toEqual([
+      null,
+      true,
+      false,
+      false,
+      true,
+    ]);
+  });
+
+  it("returns null for a divergence whose time is not a bar", () => {
+    expect(
+      divergenceTrend(
+        bars,
+        [{ time: "1999-01-01", price: 0, kind: "bottom", confirmed: true }],
+        2,
+      ),
+    ).toEqual([null]);
+  });
+});

--- a/web/tests/lib/chanlunTrend.test.ts
+++ b/web/tests/lib/chanlunTrend.test.ts
@@ -2,21 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   divergenceTrend,
-  sma,
   type ChanlunBar,
   type DivergenceMark,
 } from "@/lib/chanlun";
 
-describe("sma", () => {
-  it("nulls the warmup prefix and computes exact window means", () => {
-    const s = sma([2, 4, 6, 8], 2);
-    expect(s[0]).toBeNull();
-    expect(s[1]).toBe(3); // (2+4)/2
-    expect(s[2]).toBe(5); // (4+6)/2
-    expect(s[3]).toBe(7); // (6+8)/2
-  });
-});
-
+// divergenceTrend rolls the shared lib/indicators `sma` (own coverage there);
+// the expected vector below depends on sma([10,20,5,20,5],2)=[null,15,12.5,12.5,12.5],
+// so it exercises the SMA path end-to-end.
 describe("divergenceTrend", () => {
   // closes = [10, 20, 5, 20, 5]; sma(closes, 2) = [null, 15, 12.5, 12.5, 12.5].
   const bars: ChanlunBar[] = [10, 20, 5, 20, 5].map((c, i) => ({


### PR DESCRIPTION
## What

Restyle the Technicals chanlun overlay so each mark's appearance reflects the trust probe (\`docs/research/2026-07-18-chanlun-trust-silver\`), client-side only — no new marker, no toggle, no backend.

| Mark | Treatment |
|---|---|
| **顶/底背离 trend-aligned** (底 above / 顶 below the 200-DMA) | full amber — the higher-conviction subset (+0.65% @10d, CI-positive) |
| **背离 counter-trend / pre-warmup** | dim ~35% / ~60% |
| **base 1B/1S** | dim ~40% — repaint 24–34% |
| **2B/3B, 2S/3S, 段-level** | unchanged (stable once confirmed) |
| legend | one line explaining emphasis = reliability, + split caveat |

## How

- Two pure helpers in \`web/lib/chanlun.ts\`: \`sma(closes, window)\` (prefix-sum roll, null warmup) and \`divergenceTrend(bars, divergences, window=200)\` (底 trend-aligned ⇔ close ≥ SMA200; 顶 ⇔ close < SMA200; null when SMA undefined).
- \`TechnicalsPriceChart.tsx\`: hoist \`clBars\` memo, tier the 背离 color + dim base 1B/1S via per-tier alpha on the existing \`cssVar\`-suffix idiom, zip flags index-aligned before the \`firstAsOf\` filter.
- No API/type change → \`gen:types\` not run.

## Data caveat (verified, disclosed)

The trend split uses the **same 200-DMA the chart plots** — verified identical to the client-rolled SMA to the penny: **0/23 flips on NVDA, 0/17 on TSLA**. But that series is **not corporate-action adjusted**, so for ~200 sessions after a split the 200-DMA is corrupted (TSLA 2022-10 close \$211 vs "200-DMA" \$732; NVDA 2024-08 close \$100 vs \$594). This is the known livewire \`adj_close\` blocker surfacing — it also corrupts the z-score/σ-band tiles. Fix belongs upstream; the legend discloses it, and away from splits (every recent view) the tier is correct. Details in the spec's "Known limitation" section.

## Verification

- \`web/tests/lib/chanlunTrend.test.ts\` — 3 unit tests on hand-built geometry (all tiers + unknown-time).
- Real-data pipeline over live series: NVDA 6 bright / 15 faint / 2 unknown + 3 dimmable 1B/1S.
- Browser: before/after on NVDA + TSLA (\`output/playwright/\`), legend renders verbatim.
- \`npm run typecheck\` / \`lint\` / \`test\` (595) / \`build\` all green.

Spec: \`docs/superpowers/specs/2026-07-18-chanlun-chart-trust-styling-design.md\`
Plan: \`docs/superpowers/plans/2026-07-18-chanlun-chart-trust-styling.md\`