### PR TITLE
fix(changelog): restore missing 0.10.8 version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   high VIX/COR1M" claim directionally sound but statistically underpowered
   (~5yr SPHB/SPLV). No new subtab, no new trading signal.
 
+## [0.10.8] — 2026-07-19
 
 ### Added
 


### PR DESCRIPTION
## Summary
- PR #287's merge accidentally deleted the `## [0.10.8] — 2026-07-19` header, leaving the chanlun trust-styling + fixRightEdge entries (both actually shipped in v0.10.8) stranded under `[Unreleased]`
- Restores the header so only the dispersion-readout entry remains under `[Unreleased]` ahead of cutting v0.10.9

## Test plan
- [x] Visual diff of CHANGELOG.md confirms correct section boundaries