### PR TITLE
feat(technicals): volume profile overlay + fast MACD lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   edge on either side** (resistance correct in 2–3 of 6 names at every window
   tested; support's apparent edge did not survive a distance-matched placebo).
 
+- Fair value gaps behind a separate `FVG` toggle (default off): unfilled
+  three-bar imbalances drawn as amber boxes extending to the right edge, via
+  `web/lib/fvg.ts` (O(n) back-to-front fill test). Deliberately stricter than
+  the Pine original — a gap closes as soon as any later bar _enters_ the band,
+  not only when price traverses it completely, since a partially-traded band is
+  no longer untraded. Painting reuses the existing zhongshu rectangle primitive
+  rather than cloning it.
+- The fast pair's own MACD and signal lines in the dual-MACD sub-pane, drawn
+  over its histogram on the same ATR-normalized scale (the histogram is exactly
+  their difference, asserted in `tests/unit/cards/test_dual_macd.py`). The
+  histogram alone shows how wide the gap between the lines is but not where the
+  crossing sits relative to zero — the difference between a momentum turn inside
+  a trend and an outright trend flip. Two new series fields,
+  `fast_macd_line_atr` / `fast_macd_signal_atr`, computed in
+  `dual_macd_series` and carried in the `technical_daily` metrics JSONB. The
+  slow 55/89/34 pair stays histogram-only: it is structural background, and four
+  lines in a 150px pane is noise. **Existing rows need a technicals recompute**
+  before the lines appear — the new keys are absent from already-stored JSONB.
+
 ### Removed
 
 - VP BUY/SELL/touch/reject marks, before they ever shipped in a release. They
@@ -53,13 +72,6 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   edge. An arrow labelled BUY that moves tomorrow and predicts nothing implies a
   signal the data does not support. The profile, POC, value area and zones stay
   as descriptive structure.
-- Fair value gaps behind a separate `FVG` toggle (default off): unfilled
-  three-bar imbalances drawn as amber boxes extending to the right edge, via
-  `web/lib/fvg.ts` (O(n) back-to-front fill test). Deliberately stricter than
-  the Pine original — a gap closes as soon as any later bar _enters_ the band,
-  not only when price traverses it completely, since a partially-traded band is
-  no longer untraded. Painting reuses the existing zhongshu rectangle primitive
-  rather than cloning it.
 
 ## [0.10.9] — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,25 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   candles. Each bar spreads its volume evenly across its own high–low (daily
   OHLCV is all we have) — this is where-it-traded context, not an order book,
   and it is explicitly not a signal.
-
+- Volume-profile S/R matrix on the same `VP` toggle: high-volume nodes become
+  support/resistance bands (greedy peak-picking with proportional separation,
+  per-side caps and a strength floor), labelled with strength as a % of the POC
+  and a distinct-retest count; low-volume nodes render as gray dashed lines.
+  BUY/SELL arrows mark closes crossing the nearest zone on above-average
+  volume, with faint dots for touches and rejections that held. A stats readout
+  (`VolumeProfileStatsPanel`) shows POC/VAH/VAL, nearest S/R with zone counts,
+  and value-area bias; its numbers are pushed up from the chart primitive
+  rather than recomputed, so they always describe the bars actually drawn.
+  **The marks are annotation, not a backtest** — the levels derive from the
+  whole visible window including bars later than each mark, which the on-chart
+  copy states plainly.
+- Fair value gaps behind a separate `FVG` toggle (default off): unfilled
+  three-bar imbalances drawn as amber boxes extending to the right edge, via
+  `web/lib/fvg.ts` (O(n) back-to-front fill test). Deliberately stricter than
+  the Pine original — a gap closes as soon as any later bar _enters_ the band,
+  not only when price traverses it completely, since a partially-traded band is
+  no longer untraded. Painting reuses the existing zhongshu rectangle primitive
+  rather than cloning it.
 
 ### Added
 
@@ -45,6 +63,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   marker already in the CRI trigger) and found the "deleverage high-beta on
   high VIX/COR1M" claim directionally sound but statistically underpowered
   (~5yr SPHB/SPLV). No new subtab, no new trading signal.
+
 ## [0.10.8] — 2026-07-19
 
 ### Added
@@ -73,6 +92,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   and the right price axis on initial load and after Reset. The chart's
   `fixRightEdge` setting had silently clamped the configured offset back to
   zero; regression coverage now protects both short- and long-history views.
+
 ## [0.10.7] — 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
-## [0.10.9] — 2026-07-20
+### Added
+
+- Visible-range volume profile (VRVP) on the Technicals price chart, behind a
+  `VP` toggle beside `Zen` (localStorage-persisted, candle-mode only). Renders
+  against the right edge of the price pane: horizontal bars per price bin, buy
+  volume (bars that closed up) hugging the axis and sell volume stacked
+  outside, length scaled to the busiest bin. Value-area bins (70%) draw at full
+  opacity, tails dim; an amber line marks the POC. Binning math is pure and
+  unit-tested (`web/lib/volumeProfile.ts` — volume conservation, contiguous
+  bins, minimal value area, determinism, against the frozen real SPY OHLCV
+  fixture); painting is a lightweight-charts series primitive
+  (`web/lib/lwc/volumeProfile.ts`) in the mold of `chanlunZhongshu.ts`. The
+  profile re-bins to whatever range is on screen, memoized on the visible
+  range, and draws in the **background** layer so it never buries the newest
+  candles. Each bar spreads its volume evenly across its own high–low (daily
+  OHLCV is all we have) — this is where-it-traded context, not an order book,
+  and it is explicitly not a signal.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,48 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
-- Visible-range volume profile (VRVP) on the Technicals price chart, behind a
-  `VP` toggle beside `Zen` (localStorage-persisted, candle-mode only). Renders
-  against the right edge of the price pane: horizontal bars per price bin, buy
-  volume (bars that closed up) hugging the axis and sell volume stacked
-  outside, length scaled to the busiest bin. Value-area bins (70%) draw at full
-  opacity, tails dim; an amber line marks the POC. Binning math is pure and
-  unit-tested (`web/lib/volumeProfile.ts` — volume conservation, contiguous
-  bins, minimal value area, determinism, against the frozen real SPY OHLCV
-  fixture); painting is a lightweight-charts series primitive
-  (`web/lib/lwc/volumeProfile.ts`) in the mold of `chanlunZhongshu.ts`. The
-  profile re-bins to whatever range is on screen, memoized on the visible
-  range, and draws in the **background** layer so it never buries the newest
-  candles. Each bar spreads its volume evenly across its own high–low (daily
-  OHLCV is all we have) — this is where-it-traded context, not an order book,
-  and it is explicitly not a signal.
+- Volume profile on the Technicals price chart, behind a `VP` toggle beside
+  `Zen` (localStorage-persisted, candle-mode only). Renders against the right
+  edge of the price pane: horizontal bars per price bin, buy volume (bars that
+  closed up) hugging the axis and sell volume stacked outside, length scaled to
+  the busiest bin. Value-area bins (70%) draw at full opacity, tails dim; an
+  amber line marks the POC. Binning math is pure and unit-tested
+  (`web/lib/volumeProfile.ts` — volume conservation, contiguous bins, minimal
+  value area, determinism, against the frozen real SPY OHLCV fixture); painting
+  is a lightweight-charts series primitive (`web/lib/lwc/volumeProfile.ts`) in
+  the mold of `chanlunZhongshu.ts`, drawn in the **background** layer so it
+  never buries the newest candles. Each bar spreads its volume evenly across its
+  own high–low (daily OHLCV is all we have) — where-it-traded context, not an
+  order book, and explicitly not a signal.
+- **Fixed 360-session profile window**, not the visible range. Shipped as VRVP
+  first and that was wrong: panning between ~150 and ~600 visible bars moved the
+  POC by a median of **11.6 ATR** across six names, so the levels were largely a
+  function of the viewport. The window is now counted back from the newest bar
+  and fed from the unwindowed series, so pan, zoom and the 3M/1Y/FULL selector
+  all leave the levels untouched. 360 is measured, not inherited: stability keeps
+  improving out to 5 years, but by then the POC sits 35–92% below spot — steady
+  because it describes a market that no longer exists. Study:
+  `docs/research/2026-07-20-volume-profile-window-study.md`, reproduce with
+  `npx tsx scripts/research/volume_profile_window_study.mts`.
 - Volume-profile S/R matrix on the same `VP` toggle: high-volume nodes become
   support/resistance bands (greedy peak-picking with proportional separation,
   per-side caps and a strength floor), labelled with strength as a % of the POC
-  and a distinct-retest count; low-volume nodes render as gray dashed lines.
-  BUY/SELL arrows mark closes crossing the nearest zone on above-average
-  volume, with faint dots for touches and rejections that held. A stats readout
-  (`VolumeProfileStatsPanel`) shows POC/VAH/VAL, nearest S/R with zone counts,
-  and value-area bias; its numbers are pushed up from the chart primitive
-  rather than recomputed, so they always describe the bars actually drawn.
-  **The marks are annotation, not a backtest** — the levels derive from the
-  whole visible window including bars later than each mark, which the on-chart
-  copy states plainly.
+  and a distinct-retest count; low-volume nodes render as gray dashed lines. A
+  stats readout (`VolumeProfileStatsPanel`) shows POC/VAH/VAL, nearest S/R with
+  zone counts, and value-area bias; its numbers are pushed up from the chart
+  primitive rather than recomputed, so they always describe the bars actually
+  binned. Zones are descriptive only — the same study found **no forward-return
+  edge on either side** (resistance correct in 2–3 of 6 names at every window
+  tested; support's apparent edge did not survive a distance-matched placebo).
+
+### Removed
+
+- VP BUY/SELL/touch/reject marks, before they ever shipped in a release. They
+  redrew 21% of mark history per day at a 360-bar window and essentially all of
+  it on the worst 10% of days, and the levels underneath them carry no measured
+  edge. An arrow labelled BUY that moves tomorrow and predicts nothing implies a
+  signal the data does not support. The profile, POC, value area and zones stay
+  as descriptive structure.
 - Fair value gaps behind a separate `FVG` toggle (default off): unfilled
   three-bar imbalances drawn as amber boxes extending to the right edge, via
   `web/lib/fvg.ts` (O(n) back-to-front fill test). Deliberately stricter than
@@ -43,6 +58,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   not only when price traverses it completely, since a partially-traded band is
   no longer untraded. Painting reuses the existing zhongshu rectangle primitive
   rather than cloning it.
+
+## [0.10.9] — 2026-07-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 - Volume-profile S/R matrix on the same `VP` toggle: high-volume nodes become
   support/resistance bands (greedy peak-picking with proportional separation,
   per-side caps and a strength floor), labelled with strength as a % of the POC
-  and a distinct-retest count; low-volume nodes render as gray dashed lines. A
+  and a distinct-retest count; low-volume nodes render as labelled
+  (`LVN <price>`) long-dashed lines, styled to read distinctly from the chart's
+  own dotted grid rather than as furniture. A
   stats readout (`VolumeProfileStatsPanel`) shows POC/VAH/VAL, nearest S/R with
   zone counts, and value-area bias; its numbers are pushed up from the chart
   primitive rather than recomputed, so they always describe the bars actually

--- a/docs/research/2026-07-20-volume-profile-window-study.json
+++ b/docs/research/2026-07-20-volume-profile-window-study.json
@@ -1,0 +1,1128 @@
+{
+  "meta": {
+    "generated_for": "volume-profile window choice",
+    "source": "http://100.66.147.98:8322/bars/{ticker}?timeframe=1d&limit=5000",
+    "tickers": [
+      "SPY",
+      "QQQ",
+      "IWM",
+      "AAPL",
+      "NVDA",
+      "MSFT"
+    ],
+    "bins": 60,
+    "valuePct": 70,
+    "windows": [
+      60,
+      120,
+      250,
+      360,
+      500,
+      750,
+      1000,
+      1260,
+      2000
+    ],
+    "stride": 5,
+    "fwdSessions": 5,
+    "reproduce": "cd web && npx tsx ../scripts/research/volume_profile_window_study.mts",
+    "note": "Imports the shipped web/lib/volumeProfile.ts. All levels strictly point-in-time (bars <= t)."
+  },
+  "perTicker": {
+    "SPY": {
+      "bars": 5000,
+      "range": [
+        "2006-08-29",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 11.443190997425429,
+        "pocSpreadAtrP90": 31.171279734562233,
+        "nearestSupSpreadAtrMedian": 4.874728513700785,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.41706525347280043,
+            "markChurnMean": 0.4393152263160198,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 33.98833050978816,
+            "supportPlaceboMeanBp": 29.17662288246739,
+            "supportN": 476,
+            "resistanceRealMeanBp": 38.358784966344984,
+            "resistancePlaceboMeanBp": 39.65931397587564,
+            "resistanceN": 337
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.26106788521668833,
+            "markChurnMean": 0.3495202009285586,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 59.107245492524655,
+            "supportPlaceboMeanBp": 35.495296823814606,
+            "supportN": 414,
+            "resistanceRealMeanBp": 26.798953278579194,
+            "resistancePlaceboMeanBp": 28.53418355205606,
+            "resistanceN": 311
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.27990883041067094,
+            "markChurnMean": 0.2769590012782928,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 44.15110481641977,
+            "supportPlaceboMeanBp": 30.511857433304044,
+            "supportN": 302,
+            "resistanceRealMeanBp": 11.475516335369647,
+            "resistancePlaceboMeanBp": 17.125394343529376,
+            "resistanceN": 230
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.2783786088153843,
+            "markChurnMean": 0.24529921994204126,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 57.71441505977113,
+            "supportPlaceboMeanBp": 13.130798263014112,
+            "supportN": 247,
+            "resistanceRealMeanBp": 17.62148606569864,
+            "resistancePlaceboMeanBp": 25.48244821144217,
+            "resistanceN": 190
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.21734716882274568,
+            "markChurnMean": 0.22386638097636918,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 86.63990345082617,
+            "supportPlaceboMeanBp": 33.34679406672691,
+            "supportN": 206,
+            "resistanceRealMeanBp": 6.037841831406776,
+            "resistancePlaceboMeanBp": 5.328364347336424,
+            "resistanceN": 173
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.15528058134854306,
+            "markChurnMean": 0.15901417608088553,
+            "markChurnP90": 0.8804705882352948,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 40.20298384974531,
+            "supportPlaceboMeanBp": 52.31260898039081,
+            "supportN": 138,
+            "resistanceRealMeanBp": 43.8623301932958,
+            "resistancePlaceboMeanBp": 32.20547763866417,
+            "resistanceN": 99
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1402479707456412,
+            "markChurnMean": 0.10073636491029683,
+            "markChurnP90": 0.4774703557312256,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": -4.345518237013398,
+            "supportPlaceboMeanBp": -37.34439520430737,
+            "supportN": 92,
+            "resistanceRealMeanBp": 12.471976993932858,
+            "resistancePlaceboMeanBp": -30.28559653944116,
+            "resistanceN": 77
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.17420795424421617,
+            "markChurnMean": 0.05837718000518439,
+            "markChurnP90": 0.02702702702702703,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": 44.88936181972737,
+            "supportPlaceboMeanBp": 103.03134242622183,
+            "supportN": 44,
+            "resistanceRealMeanBp": 47.3447268004692,
+            "resistancePlaceboMeanBp": 17.91248506385116,
+            "resistanceN": 35
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.08127883381254374,
+            "markChurnMean": 0.035891174927510046,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 279.4237553780122,
+            "supportPlaceboMeanBp": 323.3651555259928,
+            "supportN": 3,
+            "resistanceRealMeanBp": 231.043326297633,
+            "resistancePlaceboMeanBp": 166.1088759493872,
+            "resistanceN": 4
+          }
+        }
+      }
+    },
+    "QQQ": {
+      "bars": 5000,
+      "range": [
+        "2006-08-30",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 13.47931677228567,
+        "pocSpreadAtrP90": 27.033727061481844,
+        "nearestSupSpreadAtrMedian": 4.311598154013139,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.38975139527030783,
+            "markChurnMean": 0.4414814612825343,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 40.9828827153787,
+            "supportPlaceboMeanBp": 35.59577466220494,
+            "supportN": 486,
+            "resistanceRealMeanBp": 43.887702885123154,
+            "resistancePlaceboMeanBp": 31.010248549001332,
+            "resistanceN": 346
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.31109359485498933,
+            "markChurnMean": 0.35477398809159766,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 62.082873938094274,
+            "supportPlaceboMeanBp": 56.798228165908384,
+            "supportN": 404,
+            "resistanceRealMeanBp": 42.450214361556945,
+            "resistancePlaceboMeanBp": 40.15873589727862,
+            "resistanceN": 316
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.23107228844669225,
+            "markChurnMean": 0.26873499284546276,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 52.66020176178873,
+            "supportPlaceboMeanBp": 47.288037176801275,
+            "supportN": 289,
+            "resistanceRealMeanBp": 61.19811331843511,
+            "resistancePlaceboMeanBp": 45.66218238509427,
+            "resistanceN": 241
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.2796808505308376,
+            "markChurnMean": 0.2311148755615455,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 75.44876684581438,
+            "supportPlaceboMeanBp": 83.82991875132683,
+            "supportN": 241,
+            "resistanceRealMeanBp": 75.49317925570689,
+            "resistancePlaceboMeanBp": 74.12511083330484,
+            "resistanceN": 188
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.20266187648643963,
+            "markChurnMean": 0.19816592919624063,
+            "markChurnP90": 0.9773737373737376,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 23.52510469453361,
+            "supportPlaceboMeanBp": 42.570559710001326,
+            "supportN": 180,
+            "resistanceRealMeanBp": 69.79497751349331,
+            "resistancePlaceboMeanBp": 54.01281626861084,
+            "resistanceN": 169
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.20128092068467132,
+            "markChurnMean": 0.1655281134267911,
+            "markChurnP90": 0.875,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 49.502941636858196,
+            "supportPlaceboMeanBp": 43.589990624928866,
+            "supportN": 131,
+            "resistanceRealMeanBp": 59.490949038622865,
+            "resistancePlaceboMeanBp": 49.11699560058536,
+            "resistanceN": 107
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1836703868583192,
+            "markChurnMean": 0.09993792711698408,
+            "markChurnP90": 0.45454545454545453,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 56.05161826723527,
+            "supportPlaceboMeanBp": -58.66924682599973,
+            "supportN": 61,
+            "resistanceRealMeanBp": 98.71865205650892,
+            "resistancePlaceboMeanBp": 77.90695540187346,
+            "resistanceN": 61
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.12473080146589816,
+            "markChurnMean": 0.06834377669028821,
+            "markChurnP90": 0.08333333333333333,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": 208.73526934873263,
+            "supportPlaceboMeanBp": -6.384856491153111,
+            "supportN": 34,
+            "resistanceRealMeanBp": 119.31920156373825,
+            "resistancePlaceboMeanBp": 119.24603127601999,
+            "resistanceN": 39
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.06219624954470387,
+            "markChurnMean": 0.03454615276526597,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 74.06131103207014,
+            "supportPlaceboMeanBp": -104.83547889141373,
+            "supportN": 12,
+            "resistanceRealMeanBp": 254.42882155484128,
+            "resistancePlaceboMeanBp": 187.78064168635808,
+            "resistanceN": 15
+          }
+        }
+      }
+    },
+    "IWM": {
+      "bars": 5000,
+      "range": [
+        "2006-08-29",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 6.676255708059354,
+        "pocSpreadAtrP90": 18.866620481990996,
+        "nearestSupSpreadAtrMedian": 2.6198121048672025,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.2637198881941732,
+            "markChurnMean": 0.4408997428466036,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 50.27212450492724,
+            "supportPlaceboMeanBp": 38.20963969115528,
+            "supportN": 504,
+            "resistanceRealMeanBp": 46.384356953917404,
+            "resistancePlaceboMeanBp": 46.46417550863986,
+            "resistanceN": 389
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1899138539988464,
+            "markChurnMean": 0.34198450844447303,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 56.40349914198525,
+            "supportPlaceboMeanBp": 62.49213583859959,
+            "supportN": 418,
+            "resistanceRealMeanBp": 56.95549451191686,
+            "resistancePlaceboMeanBp": 49.35039331302985,
+            "resistanceN": 346
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.14499139934578795,
+            "markChurnMean": 0.25218871127533155,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 49.364511911059076,
+            "supportPlaceboMeanBp": 33.12586373478405,
+            "supportN": 362,
+            "resistanceRealMeanBp": 42.85322161892849,
+            "resistancePlaceboMeanBp": 42.49711772030867,
+            "resistanceN": 292
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.07271843610327108,
+            "markChurnMean": 0.19768499558725733,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 43.0946544854798,
+            "supportPlaceboMeanBp": 27.50121092034392,
+            "supportN": 314,
+            "resistanceRealMeanBp": 33.97815436612787,
+            "resistancePlaceboMeanBp": 27.891946574985337,
+            "resistanceN": 244
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.06647169013462152,
+            "markChurnMean": 0.17888785346646627,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 49.52440065821433,
+            "supportPlaceboMeanBp": 44.9799826408574,
+            "supportN": 278,
+            "resistanceRealMeanBp": 27.208705011111217,
+            "resistancePlaceboMeanBp": 48.74686700007309,
+            "resistanceN": 213
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.024079586414043553,
+            "markChurnMean": 0.13609690384433118,
+            "markChurnP90": 0.8381884944920455,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 12.9165338220001,
+            "supportPlaceboMeanBp": 74.71775682282018,
+            "supportN": 194,
+            "resistanceRealMeanBp": -1.6839431984963715,
+            "resistancePlaceboMeanBp": 25.133507199494804,
+            "resistanceN": 168
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0,
+            "markChurnMean": 0.10724699603992587,
+            "markChurnP90": 0.5827633378932987,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 5.914800722950458,
+            "supportPlaceboMeanBp": 6.765996074354859,
+            "supportN": 139,
+            "resistanceRealMeanBp": 14.96271036312917,
+            "resistancePlaceboMeanBp": 38.44874962656299,
+            "resistanceN": 128
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0,
+            "markChurnMean": 0.08884976614559244,
+            "markChurnP90": 0.2,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": -54.173762166479946,
+            "supportPlaceboMeanBp": -68.33207031228329,
+            "supportN": 100,
+            "resistanceRealMeanBp": -6.0479296489625405,
+            "resistancePlaceboMeanBp": -1.8747150499961507,
+            "resistanceN": 87
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0,
+            "markChurnMean": 0.048047520127761555,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 15.885767487662788,
+            "supportPlaceboMeanBp": 133.96596838697826,
+            "supportN": 47,
+            "resistanceRealMeanBp": 145.95220629040244,
+            "resistancePlaceboMeanBp": 68.67812004818276,
+            "resistanceN": 36
+          }
+        }
+      }
+    },
+    "AAPL": {
+      "bars": 5000,
+      "range": [
+        "2006-08-30",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 13.579106051854167,
+        "pocSpreadAtrP90": 28.01912073289541,
+        "nearestSupSpreadAtrMedian": 4.666611659161212,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.363867986421647,
+            "markChurnMean": 0.42834715329795964,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 25.90087576921063,
+            "supportPlaceboMeanBp": 16.962626264761603,
+            "supportN": 418,
+            "resistanceRealMeanBp": 52.905257707410584,
+            "resistancePlaceboMeanBp": 47.23065433175287,
+            "resistanceN": 398
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.23856080886525063,
+            "markChurnMean": 0.33284188209315857,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 42.63346030107537,
+            "supportPlaceboMeanBp": 16.145267230924368,
+            "supportN": 361,
+            "resistanceRealMeanBp": 90.00207026336119,
+            "resistancePlaceboMeanBp": 71.88498219779288,
+            "resistanceN": 343
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.20796259581916263,
+            "markChurnMean": 0.23998768281613475,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 44.68564759160224,
+            "supportPlaceboMeanBp": 14.15187375955514,
+            "supportN": 265,
+            "resistanceRealMeanBp": 75.22164299785008,
+            "resistancePlaceboMeanBp": 51.083511884101874,
+            "resistanceN": 254
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.20652292728482669,
+            "markChurnMean": 0.20931678016996114,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 60.5724545175458,
+            "supportPlaceboMeanBp": 36.345002543488626,
+            "supportN": 222,
+            "resistanceRealMeanBp": 56.02721079751115,
+            "resistancePlaceboMeanBp": 30.233639454334455,
+            "resistanceN": 230
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.15006793292355203,
+            "markChurnMean": 0.1722114651962925,
+            "markChurnP90": 0.9528138528138533,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 83.0484182706618,
+            "supportPlaceboMeanBp": 63.26852971404739,
+            "supportN": 170,
+            "resistanceRealMeanBp": 33.55163202860679,
+            "resistancePlaceboMeanBp": 21.311884621808623,
+            "resistanceN": 169
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1084115277939762,
+            "markChurnMean": 0.11710783845813834,
+            "markChurnP90": 0.6325358851674654,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 116.5420688584414,
+            "supportPlaceboMeanBp": 130.19254349233753,
+            "supportN": 87,
+            "resistanceRealMeanBp": 130.24274043605539,
+            "resistancePlaceboMeanBp": 81.62004843393939,
+            "resistanceN": 96
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.059951138170304556,
+            "markChurnMean": 0.06438113652619537,
+            "markChurnP90": 0.07692307692307693,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 329.1715524664636,
+            "supportPlaceboMeanBp": 234.79555618857225,
+            "supportN": 40,
+            "resistanceRealMeanBp": 116.3457290699455,
+            "resistancePlaceboMeanBp": 71.32289265067374,
+            "resistanceN": 29
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.05969615786167759,
+            "markChurnMean": 0.04054569118361711,
+            "markChurnP90": 0,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": 513.7284818621023,
+            "supportPlaceboMeanBp": 290.0882571174455,
+            "supportN": 17,
+            "resistanceRealMeanBp": 228.44391798686252,
+            "resistancePlaceboMeanBp": 127.35033974417826,
+            "resistanceN": 15
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.028374712128323615,
+            "markChurnMean": 0.0008336112037345782,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": null,
+            "supportPlaceboMeanBp": null,
+            "supportN": 0,
+            "resistanceRealMeanBp": null,
+            "resistancePlaceboMeanBp": null,
+            "resistanceN": 0
+          }
+        }
+      }
+    },
+    "NVDA": {
+      "bars": 5000,
+      "range": [
+        "2006-08-30",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 10.697751469212694,
+        "pocSpreadAtrP90": 22.436814060209297,
+        "nearestSupSpreadAtrMedian": 5.515999999999999,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1897857181157938,
+            "markChurnMean": 0.37880927324099023,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 114.43151615074738,
+            "supportPlaceboMeanBp": 136.59440249050942,
+            "supportN": 429,
+            "resistanceRealMeanBp": 81.40022211561273,
+            "resistancePlaceboMeanBp": 9.067998196840907,
+            "resistanceN": 388
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.15848916957092926,
+            "markChurnMean": 0.28986152762738254,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 185.6891399055484,
+            "supportPlaceboMeanBp": 172.89806385871793,
+            "supportN": 363,
+            "resistanceRealMeanBp": 120.88398148846274,
+            "resistancePlaceboMeanBp": 66.88647307979535,
+            "resistanceN": 302
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.15930085087053603,
+            "markChurnMean": 0.2043008314531974,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 188.03616677101078,
+            "supportPlaceboMeanBp": 132.21857810849417,
+            "supportN": 234,
+            "resistanceRealMeanBp": 84.20753402258745,
+            "resistancePlaceboMeanBp": 97.63110180606482,
+            "resistanceN": 210
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.09599356367135753,
+            "markChurnMean": 0.17340905137656,
+            "markChurnP90": 0.993043478260872,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 112.9815962287546,
+            "supportPlaceboMeanBp": 123.11427041898389,
+            "supportN": 211,
+            "resistanceRealMeanBp": 118.01487199442298,
+            "resistancePlaceboMeanBp": 145.67418938244626,
+            "resistanceN": 164
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.05629089970393947,
+            "markChurnMean": 0.12801658095044868,
+            "markChurnP90": 0.7647058823529411,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 46.91532417728168,
+            "supportPlaceboMeanBp": 106.15462556596395,
+            "supportN": 167,
+            "resistanceRealMeanBp": 160.43784279510712,
+            "resistancePlaceboMeanBp": 49.33765347578372,
+            "resistanceN": 146
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.023577151729395163,
+            "markChurnMean": 0.08789034016219276,
+            "markChurnP90": 0.25,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 29.918933352726505,
+            "supportPlaceboMeanBp": 67.27891944331378,
+            "supportN": 106,
+            "resistanceRealMeanBp": -58.49354987690547,
+            "resistancePlaceboMeanBp": -29.936499907809328,
+            "resistanceN": 72
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.010941022472586576,
+            "markChurnMean": 0.04933541566352548,
+            "markChurnP90": 0,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 80.79726197348249,
+            "supportPlaceboMeanBp": 144.365358228792,
+            "supportN": 72,
+            "resistanceRealMeanBp": 172.2843620390788,
+            "resistancePlaceboMeanBp": 283.72995341924934,
+            "resistanceN": 49
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.007622020298049573,
+            "markChurnMean": 0.035936296925930845,
+            "markChurnP90": 0,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": 110.01866648538892,
+            "supportPlaceboMeanBp": 65.1589507942725,
+            "supportN": 28,
+            "resistanceRealMeanBp": -26.396389488598324,
+            "resistancePlaceboMeanBp": -97.30948710532464,
+            "resistanceN": 47
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.0035120600498976073,
+            "markChurnMean": 0.00434627634498856,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 72.46376811594193,
+            "supportPlaceboMeanBp": 108.69565217391289,
+            "supportN": 3,
+            "resistanceRealMeanBp": 217.39130434782578,
+            "resistancePlaceboMeanBp": 217.39130434782578,
+            "resistanceN": 2
+          }
+        }
+      }
+    },
+    "MSFT": {
+      "bars": 5000,
+      "range": [
+        "2006-08-30",
+        "2026-07-17"
+      ],
+      "panSensitivity": {
+        "pocSpreadAtrMedian": 11.839349691050039,
+        "pocSpreadAtrP90": 23.722522041391777,
+        "nearestSupSpreadAtrMedian": 4.45894667664272,
+        "n": 210
+      },
+      "byWindow": {
+        "60": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.217742683061332,
+            "markChurnMean": 0.41506318001943443,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 62.877513429541274,
+            "supportPlaceboMeanBp": 54.7740045397262,
+            "supportN": 451,
+            "resistanceRealMeanBp": 21.709592948700656,
+            "resistancePlaceboMeanBp": 12.329933027101893,
+            "resistanceN": 396
+          }
+        },
+        "120": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.1530987086691761,
+            "markChurnMean": 0.33125248565344184,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 55.87427353724632,
+            "supportPlaceboMeanBp": 84.64244477029023,
+            "supportN": 384,
+            "resistanceRealMeanBp": 25.716304035781473,
+            "resistancePlaceboMeanBp": 26.550830718445177,
+            "resistanceN": 328
+          }
+        },
+        "250": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.14160428766337155,
+            "markChurnMean": 0.24165391304980166,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 68.33487282902605,
+            "supportPlaceboMeanBp": 73.7917316491046,
+            "supportN": 315,
+            "resistanceRealMeanBp": -14.059111079228254,
+            "resistancePlaceboMeanBp": 43.08757957602772,
+            "resistanceN": 258
+          }
+        },
+        "360": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.11013007635617743,
+            "markChurnMean": 0.2069923561892264,
+            "markChurnP90": 1,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 53.71527622133358,
+            "supportPlaceboMeanBp": 81.47931058741759,
+            "supportN": 245,
+            "resistanceRealMeanBp": 26.336588634845924,
+            "resistancePlaceboMeanBp": 37.03535899942343,
+            "resistanceN": 196
+          }
+        },
+        "500": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.10560304563401694,
+            "markChurnMean": 0.17043767170703358,
+            "markChurnP90": 0.9757259001161441,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 61.94506200478674,
+            "supportPlaceboMeanBp": 107.84408412475072,
+            "supportN": 209,
+            "resistanceRealMeanBp": 44.75552939873383,
+            "resistancePlaceboMeanBp": 81.85846005680985,
+            "resistanceN": 179
+          }
+        },
+        "750": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.10404606640322721,
+            "markChurnMean": 0.12139514876408007,
+            "markChurnP90": 0.6470588235294118,
+            "n": 4199
+          },
+          "efficacy": {
+            "supportRealMeanBp": 91.19219561928327,
+            "supportPlaceboMeanBp": 147.22616866773916,
+            "supportN": 152,
+            "resistanceRealMeanBp": 62.94693667388834,
+            "resistancePlaceboMeanBp": 67.25591154113734,
+            "resistanceN": 132
+          }
+        },
+        "1000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.08528609580863715,
+            "markChurnMean": 0.0947485286227772,
+            "markChurnP90": 0.42857142857142855,
+            "n": 3999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 86.97272113767373,
+            "supportPlaceboMeanBp": 130.5355499494466,
+            "supportN": 93,
+            "resistanceRealMeanBp": 40.740640041382086,
+            "resistancePlaceboMeanBp": 20.863193781879705,
+            "resistanceN": 83
+          }
+        },
+        "1260": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.05249986454118865,
+            "markChurnMean": 0.05708737890568047,
+            "markChurnP90": 0.037037037037037035,
+            "n": 3739
+          },
+          "efficacy": {
+            "supportRealMeanBp": 115.94156368180303,
+            "supportPlaceboMeanBp": 114.56682770023555,
+            "supportN": 53,
+            "resistanceRealMeanBp": 84.91805191425753,
+            "resistancePlaceboMeanBp": 94.84654743832374,
+            "resistanceN": 40
+          }
+        },
+        "2000": {
+          "churn": {
+            "pocMoveAtrMedian": 0,
+            "pocMoveAtrP90": 0.020871273736042407,
+            "markChurnMean": 0.018313376641229655,
+            "markChurnP90": 0,
+            "n": 2999
+          },
+          "efficacy": {
+            "supportRealMeanBp": 64.29775861577319,
+            "supportPlaceboMeanBp": 113.07398305912523,
+            "supportN": 11,
+            "resistanceRealMeanBp": 143.460920787995,
+            "resistancePlaceboMeanBp": 34.00730019770064,
+            "resistanceN": 8
+          }
+        }
+      }
+    }
+  },
+  "aggregate": {
+    "60": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.42398600616725707,
+      "supportEdgeBpMedian": 6.745308471494418,
+      "supportEdgeTickersPositive": 5,
+      "resistanceEdgeBpMedian": 7.527131648628237,
+      "resistanceEdgeTickersNegative": 2,
+      "tickers": 6
+    },
+    "120": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.3333724321397687,
+      "supportEdgeBpMedian": 9.037860909508172,
+      "supportEdgeTickersPositive": 4,
+      "resistanceEdgeBpMedian": 4.94828983158267,
+      "resistanceEdgeTickersNegative": 2,
+      "tickers": 6
+    },
+    "250": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.24730418878637014,
+      "supportEdgeBpMedian": 14.938947779695376,
+      "supportEdgeTickersPositive": 5,
+      "resistanceEdgeBpMedian": -2.646887054769957,
+      "resistanceEdgeTickersNegative": 3,
+      "tickers": 6
+    },
+    "360": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.21063621313776526,
+      "supportEdgeBpMedian": 3.606145829811714,
+      "supportEdgeTickersPositive": 3,
+      "resistanceEdgeBpMedian": -3.2464468616707407,
+      "resistanceEdgeTickersNegative": 3,
+      "tickers": 6
+    },
+    "500": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.1785976469154751,
+      "supportEdgeBpMedian": -7.250518499055392,
+      "supportEdgeTickersPositive": 3,
+      "resistanceEdgeBpMedian": 6.474612445434259,
+      "resistanceEdgeTickersNegative": 2,
+      "tickers": 6
+    },
+    "750": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.13117208678940315,
+      "supportEdgeBpMedian": -25.505230362241708,
+      "supportEdgeTickersPositive": 1,
+      "resistanceEdgeBpMedian": 3.032489285394252,
+      "resistanceEdgeTickersNegative": 3,
+      "tickers": 6
+    },
+    "1000": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.08606439481328414,
+      "supportEdgeBpMedian": 16.073840807944784,
+      "supportEdgeTickersPositive": 3,
+      "resistanceEdgeBpMedian": 20.344571457068916,
+      "resistanceEdgeTickersNegative": 2,
+      "tickers": 6
+    },
+    "1260": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.05819001497604892,
+      "supportEdgeBpMedian": 29.509011918459883,
+      "supportEdgeTickersPositive": 5,
+      "resistanceEdgeBpMedian": 14.752706012168149,
+      "resistanceEdgeTickersNegative": 2,
+      "tickers": 6
+    },
+    "2000": {
+      "pocMoveAtrMedian": 0,
+      "markChurnMean": 0.023663018668415064,
+      "supportEdgeBpMedian": -40.086642102975794,
+      "supportEdgeTickersPositive": 1,
+      "resistanceEdgeBpMedian": 71.96113305535144,
+      "resistanceEdgeTickersNegative": 0,
+      "tickers": 6
+    }
+  },
+  "panSensitivityAggregate": {
+    "pocSpreadAtrMedian": 11.641270344237734,
+    "nearestSupSpreadAtrMedian": 4.562779167901966
+  }
+}

--- a/docs/research/2026-07-20-volume-profile-window-study.md
+++ b/docs/research/2026-07-20-volume-profile-window-study.md
@@ -1,0 +1,221 @@
+# Volume-profile window choice — stability vs. edge
+
+**Date:** 2026-07-20
+**Status:** complete; conclusions acted on in the VP overlay
+**Trace:** `docs/research/2026-07-20-volume-profile-window-study.json`
+**Reproduce:** `npx tsx scripts/research/volume_profile_window_study.mts`
+
+## Question
+
+The VP overlay shipped as true VRVP — the profile recomputes from whatever bars
+are on screen. Panning therefore moves the POC, the value area, the S/R zones,
+and redraws the BUY/SELL marks. Which window definition best represents the
+profile, and what does the instability cost?
+
+"True" needs restating: a volume profile is a *description of a chosen window*,
+so every window is faithful to itself. There is no ground truth to be near. The
+answerable version is a trade-off between two measurable properties:
+
+- **Stability** — how far do the derived levels move when the window shifts?
+- **Adaptivity** — do the levels still say anything about future price?
+
+Stability alone is maximised by an infinite window, which would be perfectly
+steady and possibly worthless. Both are required.
+
+## Method
+
+Imports the **shipped** compute (`web/lib/volumeProfile.ts`) rather than a
+re-implementation, so the numbers describe what the chart actually draws.
+
+- **Data:** apex REST `GET /bars/{t}?timeframe=1d&limit=5000` — real daily
+  OHLCV, zero null volumes. SPY, QQQ, IWM, AAPL, NVDA, MSFT; 5000 sessions each
+  (2006-08-29 → 2026-07-17).
+- **Profile settings:** 60 bins, 70% value area — the shipped defaults.
+- **Windows tested:** W ∈ {60, 120, 250, 360, 500, 750} bars.
+- **Point-in-time throughout:** levels at bar *t* use only bars ≤ *t*. Forward
+  returns come from bars strictly after the touch.
+
+Three experiments:
+
+**A. Pan sensitivity.** At a *fixed* date, recompute with W ∈ {150…600} and
+measure the spread of the resulting POC, in ATR14 units. This is the panning
+complaint measured directly: scrolling changes W.
+
+**B. Time churn.** At a *fixed* W, advance one bar and measure (i) POC movement
+in ATR units, and (ii) the fraction of the trailing-250-session BUY/SELL/touch/
+reject mark set that flips. The mark rule mirrors `TechnicalsPriceChart.tsx`.
+Marks on the newly-arrived bar are excluded so only genuine *redraws of history*
+count.
+
+**C. Efficacy.** From point-in-time zones, find the first touch of the nearest
+support/resistance within 20 sessions, then measure the 5-session forward return
+from the touch close. Compared against a **placebo** level at 1.4× the same
+signed distance from spot — without it this measures equity drift, not the level.
+
+## Results
+
+### A. Pan sensitivity — the direct answer
+
+POC spread across a plausible scroll range (W 150→600), in ATR14:
+
+| Ticker | median | P90 | nearest-support spread (median) |
+|---|---|---|---|
+| SPY | 11.44 | 31.17 | 4.87 |
+| QQQ | 13.48 | 27.03 | 4.31 |
+| IWM | 6.68 | 18.87 | 2.62 |
+| AAPL | 13.58 | 28.02 | 4.67 |
+| NVDA | 10.70 | 22.44 | 5.52 |
+| MSFT | 11.84 | 23.72 | 4.46 |
+
+**Median ≈ 11.6 ATR, tail to 31 ATR.** Scrolling relocates the POC by roughly
+ten average daily ranges, every ticker, no exceptions. For SPY at ~750 with
+ATR ≈ 8 that is ~90 points of POC movement purely from how far you zoomed.
+
+This is not a subtle artifact. Visible-range is disqualified as a *reference*
+tool: the level is substantially a function of the viewport.
+
+### B. Time churn — repaint, by window
+
+| W | POC move/bar (median) | POC move/bar (P90) | mark churn (mean) | mark churn (P90) |
+|---|---|---|---|---|
+| 60 | 0.000 | 0.364 | **42.4%** | 1.000 |
+| 120 | 0.000 | 0.239 | **33.3%** | 1.000 |
+| 250 | 0.000 | 0.208 | **24.7%** | 1.000 |
+| 360 | 0.000 | 0.207 | **21.1%** | 0.999 |
+| 500 | 0.000 | 0.150 | **17.9%** | 0.945 |
+| 750 | 0.000 | 0.108 | **13.1%** | 0.687 |
+
+Median POC move is exactly 0 — the POC is a bin midpoint and the argmax bin
+usually survives one new bar. The action is in the tail: occasional jumps to a
+different shelf.
+
+Mark churn falls monotonically with W but **never becomes small**. At the Pine
+default (360) one mark in five is redrawn *every day*, and the P90 of 0.999 says
+that on the worst 10% of days essentially the entire historical mark set is
+rewritten — the nearest level hopped to another shelf and every arrow moved.
+Even at W=750, 13% churn daily.
+
+Longer windows help. No window fixes this.
+
+### C. Efficacy — no reliable edge
+
+Edge = (real level forward return) − (placebo level forward return), 5 sessions,
+basis points. Support should be positive, resistance negative.
+
+| W | support edge (bp) | tickers positive /6 | resistance edge (bp) | tickers negative /6 |
+|---|---|---|---|---|
+| 60 | +6.7 | 5 | +7.5 | 2 |
+| 120 | +9.0 | 4 | +4.9 | 2 |
+| 250 | +14.9 | 5 | −2.6 | 3 |
+| 360 | +3.6 | 3 | −3.2 | 3 |
+| 500 | −7.3 | 3 | +6.5 | 2 |
+| 750 | −25.5 | 1 | +3.0 | 3 |
+
+**Resistance is a coin flip** — 2–3 of 6 tickers show the correct sign at every
+window. No effect.
+
+**Support is not robust.** Per-ticker at the best-looking W=250, raw support
+returns are +44 to +188bp — but the *placebo* returns are +14 to +132bp over the
+same events. Nearly all of the apparent effect is 20 years of equity drift plus
+the fact that touching a level below spot means buying a dip in a bull market.
+
+Read as a whole: **the zones carry no measured predictive information.**
+
+> **Analyst note on how this was misread twice.** With six windows the support
+> column (+6.7, +9.0, +14.9, +3.6, −7.3, −25.5) looks like a single-peaked curve
+> — the shape a real effect would make if short windows are noisy and long ones
+> stale. That reading was wrong. Extending to nine windows (below) gives
+> +6.7, +9.0, +14.9, +3.6, −7.3, −25.5, +16.1, +29.5, −40.1, which oscillates.
+> Six points were not enough to distinguish a peak from noise, and confident
+> claims in *either* direction were unsupported at that sample size.
+
+### D. Extended windows — does "longer is always better" hold?
+
+| W | ~years | mark churn (mean) | mark churn (P90) | support edge | sup ✓/6 | resistance edge | res ✓/6 |
+|---|---|---|---|---|---|---|---|
+| 60 | 0.2 | 0.424 | 1.000 | +6.7 | 5 | +7.5 | 2 |
+| 120 | 0.5 | 0.333 | 1.000 | +9.0 | 4 | +4.9 | 2 |
+| 250 | 1.0 | 0.247 | 1.000 | +14.9 | 5 | −2.6 | 3 |
+| 360 | 1.4 | 0.211 | 0.999 | +3.6 | 3 | −3.2 | 3 |
+| 500 | 2.0 | 0.179 | 0.945 | −7.3 | 3 | +6.5 | 2 |
+| 750 | 3.0 | 0.131 | 0.687 | −25.5 | 1 | +3.0 | 3 |
+| 1000 | 4.0 | 0.086 | 0.337 | +16.1 | 3 | +20.3 | 2 |
+| 1260 | 5.0 | **0.058** | **0.058** | +29.5 | 5 | +14.8 | 2 |
+| 2000 | 7.9 | 0.024 | 0.000 | −40.1 | 1 | +72.0 | 0 |
+
+Stability keeps improving all the way out, and the P90 collapse is dramatic:
+the "entire mark history rewrites at once" event (P90 ≈ 1.0 at W ≤ 360) is
+essentially gone by 5 years (P90 = 0.058).
+
+The efficacy columns past W≈750 must be discarded — touch events become rare:
+
+| touch events (sup/res) | 250 | 500 | 1000 | 1260 | 2000 |
+|---|---|---|---|---|---|
+| SPY | 302/230 | 206/173 | 92/77 | 44/35 | 3/4 |
+| AAPL | 265/254 | 170/169 | 40/29 | 17/15 | **0/0** |
+| NVDA | 234/210 | 167/146 | 72/49 | 28/47 | 3/2 |
+
+### E. Relevance — where do long-window levels actually sit?
+
+Distance from the latest close to the POC (%), and to the nearest support zone:
+
+| | W=250 POC | W=1260 POC | W=250 nearest sup | W=1260 nearest sup |
+|---|---|---|---|---|
+| SPY | −8.9% | −43.5% | −9% | −9% |
+| QQQ | −13.2% | −49.3% | −10% | −13% |
+| IWM | −17.2% | −35.2% | −11% | −24% |
+| AAPL | −18.7% | −56.5% | −19% | −49% |
+| NVDA | −10.0% | −91.9% | −6% | −92% |
+| MSFT | +1.1% | +4.2% | −5% | −7% |
+
+**This is the mechanism behind the stability.** A 5-year profile is steady
+because it is anchored to prices the market has left behind — NVDA's 5-year POC
+sits 92% below spot, and its nearest 5-year "support" is a 2021 price that will
+realistically never trade again. The levels stop moving because they stopped
+being about the present.
+
+A stable level that price cannot reach is not a better level. It is a worse one
+that fails to advertise the fact.
+
+## Conclusions
+
+1. **Fixed window, not visible-range.** 11.6 ATR of POC movement from scrolling
+   alone makes viewport-dependent levels unusable as a reference. This confirms
+   the Pine original's default (`useFixed = true`, 360 bars), which the argon
+   implementation had inverted.
+2. **Longer is better for stability, but it is NOT free.** Churn falls
+   monotonically all the way to 7.9 years (42% → 2%), so on stability alone the
+   answer would be "use everything". Section E shows what that buys: by 5 years
+   the POC sits 35–92% below spot for five of six names. Stability is purchased
+   by describing a market that no longer exists. **Do not use 5 years.**
+   The usable band is roughly 250–360 sessions (1–1.4 years), where levels stay
+   within ~10–20% of spot and can still be reached.
+3. **The BUY/SELL marks should be removed.** They redraw 21% of history per day
+   at W=360, rewrite essentially all of it on the worst 10% of days, and the
+   underlying levels show no edge. An arrow labelled BUY that moves tomorrow and
+   predicts nothing is worse than no arrow — it implies a signal the data does
+   not support. The profile, POC and value area are honest descriptive
+   structure and should stay.
+4. **Removing the marks dissolves the trade-off.** Churn is almost entirely a
+   *mark* phenomenon — the histogram itself barely moves (median POC move per
+   bar is 0.000 ATR at every window). With the arrows gone there is no longer
+   any pressure to lengthen the window for stability's sake, so the choice
+   collapses to relevance alone, and relevance says 250–360. The two findings
+   are complementary, not competing.
+
+## Limitations
+
+- Daily bars only. Intraday profiles may behave differently; volume distribution
+  within a daily bar is approximated as uniform across its high–low.
+- Single forward horizon (5 sessions) and a single touch definition (first touch
+  within 20 sessions). A different horizon could change the efficacy read,
+  though the absence of cross-window coherence argues against a hidden effect.
+- The placebo at 1.4× distance is imperfectly matched: it is touched less often
+  and later than the real level. This biases toward *false positives*, and none
+  were found for resistance — so the main risk is that the weak positive support
+  numbers are placebo mismatch rather than signal.
+- Six large-cap US names over one predominantly rising 20-year sample.
+  Cross-sectionally correlated; the "tickers with correct sign" count is a
+  robustness check, not an independent-sample p-value.
+- Zone parameters (60 bins, 45% strength floor, per-side caps) held fixed. The
+  study varies the window, not the zone-detection knobs.

--- a/scripts/research/volume_profile_window_study.mts
+++ b/scripts/research/volume_profile_window_study.mts
@@ -1,0 +1,382 @@
+/**
+ * Volume-profile window study — how should the VP overlay choose its bar window?
+ *
+ * Reproduce:
+ *   cd web && npx tsx ../scripts/research/volume_profile_window_study.mts
+ *
+ * Imports the SHIPPED compute (web/lib/volumeProfile.ts) so the numbers describe
+ * what the chart actually draws, not a re-implementation. Bars come from the
+ * apex REST API (real daily OHLCV, cached to the scratchpad after first fetch).
+ *
+ * Three questions, in the order they matter for the decision:
+ *
+ *   A. PAN SENSITIVITY — at a FIXED date, how much do the levels move as the
+ *      window length changes? This is the "why does it change when I scroll"
+ *      complaint measured directly: panning a visible-range profile changes W.
+ *
+ *   B. TIME CHURN — at a FIXED window length, how much do levels and the
+ *      BUY/SELL mark set move as one new bar arrives? This is repaint.
+ *
+ *   C. EFFICACY — are the levels worth anything? Point-in-time zones only
+ *      (bars <= t), forward returns from the touch bar, against a distance- and
+ *      direction-matched placebo level. Without the placebo this measures the
+ *      market's drift, not the level.
+ *
+ * All three are needed: A and B alone are minimised by an infinite window, which
+ * would be perfectly stable and perfectly useless.
+ */
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  computeVolumeProfile,
+  findSrZones,
+  type SrZone,
+  type VpBar,
+} from "../../web/lib/volumeProfile.ts";
+
+const APEX = "http://100.66.147.98:8322";
+const TICKERS = ["SPY", "QQQ", "IWM", "AAPL", "NVDA", "MSFT"];
+const CACHE = "/private/tmp/claude-501/-Users-chenxi-projects-argon/2035550c-04d2-4b00-a4d7-8f56c85c7b72/scratchpad/vp_bars.json";
+const OUT_JSON = "docs/research/2026-07-20-volume-profile-window-study.json";
+
+const BINS = 60;
+const VALUE_PCT = 70;
+// Through 5y (1260 sessions) and beyond, to test "longer is always better".
+const WINDOWS = [60, 120, 250, 360, 500, 750, 1000, 1260, 2000];
+const STRIDE = 5; // subsample evaluation dates; 20y of dailies is plenty
+const FWD = 5; // forward horizon (sessions) for the efficacy test
+const VOL_MA = 20;
+
+type Bar = VpBar & { time: string };
+
+// ---------------------------------------------------------------- data
+
+async function loadBars(): Promise<Record<string, Bar[]>> {
+  if (existsSync(CACHE)) return JSON.parse(readFileSync(CACHE, "utf8"));
+  const out: Record<string, Bar[]> = {};
+  for (const t of TICKERS) {
+    const r = await fetch(`${APEX}/bars/${t}?timeframe=1d&limit=5000`);
+    if (!r.ok) throw new Error(`apex ${t}: ${r.status}`);
+    const j = (await r.json()) as { bars: Record<string, number | string>[] };
+    out[t] = j.bars
+      .filter((b) => b.volume != null && b.open != null)
+      .map((b) => ({
+        time: String(b.time).slice(0, 10),
+        open: Number(b.open),
+        high: Number(b.high),
+        low: Number(b.low),
+        close: Number(b.close),
+        volume: Number(b.volume),
+      }));
+    process.stderr.write(`fetched ${t}: ${out[t].length} bars\n`);
+  }
+  mkdirSync(dirname(CACHE), { recursive: true });
+  writeFileSync(CACHE, JSON.stringify(out));
+  return out;
+}
+
+// ---------------------------------------------------------------- helpers
+
+/** Wilder-free ATR14: plain mean of true range, enough for a scale denominator. */
+function atrAt(bars: Bar[], t: number, n = 14): number {
+  let sum = 0;
+  let k = 0;
+  for (let i = Math.max(1, t - n + 1); i <= t; i += 1) {
+    const tr = Math.max(
+      bars[i].high - bars[i].low,
+      Math.abs(bars[i].high - bars[i - 1].close),
+      Math.abs(bars[i].low - bars[i - 1].close),
+    );
+    sum += tr;
+    k += 1;
+  }
+  return k ? sum / k : NaN;
+}
+
+function quantile(xs: number[], q: number): number {
+  if (xs.length === 0) return NaN;
+  const s = [...xs].sort((a, b) => a - b);
+  const i = (s.length - 1) * q;
+  const lo = Math.floor(i);
+  const hi = Math.ceil(i);
+  return lo === hi ? s[lo] : s[lo] + (s[hi] - s[lo]) * (i - lo);
+}
+
+const mean = (xs: number[]) =>
+  xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : NaN;
+
+/** Profile + zones from bars[a..t] inclusive — strictly point-in-time. */
+function levelsAt(bars: Bar[], t: number, w: number) {
+  const a = Math.max(0, t - w + 1);
+  const slice = bars.slice(a, t + 1);
+  const p = computeVolumeProfile(slice, BINS, VALUE_PCT);
+  if (!p) return null;
+  const zones = findSrZones(p, slice, bars[t].close);
+  const sup = zones.filter((z) => z.side === "support").map((z) => z.price);
+  const res = zones.filter((z) => z.side === "resistance").map((z) => z.price);
+  return {
+    poc: p.pocPrice,
+    vah: p.bins[p.vahIdx].high,
+    val: p.bins[p.valIdx].low,
+    nearestSup: sup.length ? Math.max(...sup) : null,
+    nearestRes: res.length ? Math.min(...res) : null,
+    zones,
+  };
+}
+
+/**
+ * BUY/SELL/touch/reject marks over a trailing span, using ONE pair of levels.
+ * Mirrors the rule in TechnicalsPriceChart.tsx (that component is the source of
+ * truth); duplicated here rather than imported because the component pulls in
+ * React. Encoded as a string set so two recomputes can be diffed.
+ */
+function markSet(
+  bars: Bar[],
+  from: number,
+  to: number,
+  sup: number | null,
+  res: number | null,
+  volMa: (number | null)[],
+): Set<string> {
+  const out = new Set<string>();
+  for (let i = Math.max(1, from); i <= to; i += 1) {
+    const b = bars[i];
+    const prev = bars[i - 1].close;
+    const ma = volMa[i];
+    const volOk = ma != null && b.volume > ma;
+    if (res != null && volOk && prev <= res && b.close > res) {
+      out.add(`${b.time}:BUY`);
+    } else if (sup != null && volOk && prev >= sup && b.close < sup) {
+      out.add(`${b.time}:SELL`);
+    } else if (sup != null && b.low <= sup && b.close > sup) {
+      out.add(`${b.time}:TOUCH`);
+    } else if (res != null && b.high >= res && b.close < res) {
+      out.add(`${b.time}:REJECT`);
+    }
+  }
+  return out;
+}
+
+function volumeMa(bars: Bar[], n: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  let sum = 0;
+  for (let i = 0; i < bars.length; i += 1) {
+    sum += bars[i].volume;
+    if (i >= n) sum -= bars[i - n].volume;
+    out.push(i >= n - 1 ? sum / n : null);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- experiments
+
+/** A. At a fixed date, how far do levels move as W varies over a pan range? */
+function panSensitivity(bars: Bar[]) {
+  const spreads: number[] = [];
+  const supSpreads: number[] = [];
+  for (let t = 800; t < bars.length; t += STRIDE * 4) {
+    const atr = atrAt(bars, t);
+    if (!(atr > 0)) continue;
+    const pocs: number[] = [];
+    const sups: number[] = [];
+    // A plausible scroll range: the user pans between ~150 and ~600 visible bars.
+    for (const w of [150, 200, 250, 300, 400, 500, 600]) {
+      const L = levelsAt(bars, t, w);
+      if (!L) continue;
+      pocs.push(L.poc);
+      if (L.nearestSup != null) sups.push(L.nearestSup);
+    }
+    if (pocs.length > 1) spreads.push((Math.max(...pocs) - Math.min(...pocs)) / atr);
+    if (sups.length > 1)
+      supSpreads.push((Math.max(...sups) - Math.min(...sups)) / atr);
+  }
+  return {
+    pocSpreadAtrMedian: quantile(spreads, 0.5),
+    pocSpreadAtrP90: quantile(spreads, 0.9),
+    nearestSupSpreadAtrMedian: quantile(supSpreads, 0.5),
+    n: spreads.length,
+  };
+}
+
+/** B. At a fixed W, how much do levels and marks move when one bar arrives? */
+function timeChurn(bars: Bar[], w: number, vma: (number | null)[]) {
+  const pocMove: number[] = [];
+  const markChurn: number[] = [];
+  let prev: ReturnType<typeof levelsAt> = null;
+  let prevMarks: Set<string> | null = null;
+  for (let t = Math.max(w, 800); t < bars.length; t += 1) {
+    const atr = atrAt(bars, t);
+    const L = levelsAt(bars, t, w);
+    if (!L || !(atr > 0)) {
+      prev = null;
+      prevMarks = null;
+      continue;
+    }
+    // Marks the chart would draw today over the trailing 250 sessions.
+    const marks = markSet(
+      bars,
+      t - 250,
+      t,
+      L.nearestSup,
+      L.nearestRes,
+      vma,
+    );
+    if (prev && prevMarks) {
+      pocMove.push(Math.abs(L.poc - prev.poc) / atr);
+      // Churn = symmetric difference over union, restricted to marks whose bar
+      // exists in both recomputes (so the newest bar's arrival isn't counted).
+      const a = new Set([...prevMarks].filter((m) => m.slice(0, 10) < bars[t].time));
+      const b = new Set([...marks].filter((m) => m.slice(0, 10) < bars[t].time));
+      const uni = new Set([...a, ...b]);
+      let diff = 0;
+      for (const m of uni) if (!a.has(m) || !b.has(m)) diff += 1;
+      markChurn.push(uni.size ? diff / uni.size : 0);
+    }
+    prev = L;
+    prevMarks = marks;
+  }
+  return {
+    pocMoveAtrMedian: quantile(pocMove, 0.5),
+    pocMoveAtrP90: quantile(pocMove, 0.9),
+    markChurnMean: mean(markChurn),
+    markChurnP90: quantile(markChurn, 0.9),
+    n: pocMove.length,
+  };
+}
+
+/**
+ * C. Do the zones do anything? Point-in-time zones from bars<=t; find the first
+ * touch within the next 20 sessions; measure FWD-session return from the touch
+ * close. Placebo = a level at the same signed distance from spot but shifted to
+ * a price the profile does NOT call a shelf.
+ */
+function efficacy(bars: Bar[], w: number) {
+  const real: Record<"support" | "resistance", number[]> = {
+    support: [],
+    resistance: [],
+  };
+  const placebo: Record<"support" | "resistance", number[]> = {
+    support: [],
+    resistance: [],
+  };
+
+  const firstTouchFwd = (t: number, level: number) => {
+    for (let i = t + 1; i <= Math.min(t + 20, bars.length - FWD - 1); i += 1) {
+      if (bars[i].low <= level && bars[i].high >= level) {
+        return (bars[i + FWD].close - bars[i].close) / bars[i].close;
+      }
+    }
+    return null;
+  };
+
+  for (let t = Math.max(w, 800); t < bars.length - FWD - 21; t += STRIDE) {
+    const L = levelsAt(bars, t, w);
+    if (!L) continue;
+    const spot = bars[t].close;
+    for (const side of ["support", "resistance"] as const) {
+      const lvl = side === "support" ? L.nearestSup : L.nearestRes;
+      if (lvl == null) continue;
+      const r = firstTouchFwd(t, lvl);
+      if (r != null) real[side].push(r);
+      // Placebo: same distance, nudged 40% further out — a price the profile
+      // did not flag, so any difference is the zone, not the distance.
+      const shifted = spot + (lvl - spot) * 1.4;
+      const rp = firstTouchFwd(t, shifted);
+      if (rp != null) placebo[side].push(rp);
+    }
+  }
+  return {
+    supportRealMeanBp: mean(real.support) * 1e4,
+    supportPlaceboMeanBp: mean(placebo.support) * 1e4,
+    supportN: real.support.length,
+    resistanceRealMeanBp: mean(real.resistance) * 1e4,
+    resistancePlaceboMeanBp: mean(placebo.resistance) * 1e4,
+    resistanceN: real.resistance.length,
+  };
+}
+
+// ---------------------------------------------------------------- main
+
+const bars = await loadBars();
+const results: Record<string, unknown> = {
+  meta: {
+    generated_for: "volume-profile window choice",
+    source: `${APEX}/bars/{ticker}?timeframe=1d&limit=5000`,
+    tickers: TICKERS,
+    bins: BINS,
+    valuePct: VALUE_PCT,
+    windows: WINDOWS,
+    stride: STRIDE,
+    fwdSessions: FWD,
+    reproduce:
+      "cd web && npx tsx ../scripts/research/volume_profile_window_study.mts",
+    note: "Imports the shipped web/lib/volumeProfile.ts. All levels strictly point-in-time (bars <= t).",
+  },
+};
+
+const perTicker: Record<string, unknown> = {};
+for (const tk of TICKERS) {
+  const b = bars[tk];
+  const vma = volumeMa(b, VOL_MA);
+  const entry: Record<string, unknown> = {
+    bars: b.length,
+    range: [b[0].time, b[b.length - 1].time],
+    panSensitivity: panSensitivity(b),
+    byWindow: {} as Record<string, unknown>,
+  };
+  for (const w of WINDOWS) {
+    (entry.byWindow as Record<string, unknown>)[String(w)] = {
+      churn: timeChurn(b, w, vma),
+      efficacy: efficacy(b, w),
+    };
+  }
+  perTicker[tk] = entry;
+  process.stderr.write(`done ${tk}\n`);
+}
+results.perTicker = perTicker;
+
+// Cross-ticker aggregate: median of per-ticker stats, plus a sign-consistency
+// count (how many tickers agree) — more honest than a pooled p-value given
+// heavy autocorrelation and cross-sectional correlation between these names.
+const agg: Record<string, unknown> = {};
+for (const w of WINDOWS) {
+  const ch = TICKERS.map(
+    (t) => (perTicker[t] as any).byWindow[String(w)].churn,
+  );
+  const ef = TICKERS.map(
+    (t) => (perTicker[t] as any).byWindow[String(w)].efficacy,
+  );
+  const supEdge = ef.map(
+    (e: any) => e.supportRealMeanBp - e.supportPlaceboMeanBp,
+  );
+  const resEdge = ef.map(
+    (e: any) => e.resistanceRealMeanBp - e.resistancePlaceboMeanBp,
+  );
+  agg[String(w)] = {
+    pocMoveAtrMedian: quantile(ch.map((c: any) => c.pocMoveAtrMedian), 0.5),
+    markChurnMean: mean(ch.map((c: any) => c.markChurnMean)),
+    supportEdgeBpMedian: quantile(supEdge, 0.5),
+    supportEdgeTickersPositive: supEdge.filter((x) => x > 0).length,
+    resistanceEdgeBpMedian: quantile(resEdge, 0.5),
+    resistanceEdgeTickersNegative: resEdge.filter((x) => x < 0).length,
+    tickers: TICKERS.length,
+  };
+}
+results.aggregate = agg;
+results.panSensitivityAggregate = {
+  pocSpreadAtrMedian: quantile(
+    TICKERS.map((t) => (perTicker[t] as any).panSensitivity.pocSpreadAtrMedian),
+    0.5,
+  ),
+  nearestSupSpreadAtrMedian: quantile(
+    TICKERS.map(
+      (t) => (perTicker[t] as any).panSensitivity.nearestSupSpreadAtrMedian,
+    ),
+    0.5,
+  ),
+};
+
+mkdirSync(dirname(OUT_JSON), { recursive: true });
+writeFileSync(OUT_JSON, JSON.stringify(results, null, 2));
+console.log(JSON.stringify({ aggregate: agg, pan: results.panSensitivityAggregate }, null, 2));
+process.stderr.write(`\nwrote ${OUT_JSON}\n`);

--- a/src/uw_scan/cards/technicals.py
+++ b/src/uw_scan/cards/technicals.py
@@ -81,6 +81,8 @@ SERIES_METRIC_COLS: tuple[str, ...] = (
     "alignment",
     "fast_macd_hist_atr",
     "slow_macd_hist_atr",
+    "fast_macd_line_atr",
+    "fast_macd_signal_atr",
     "fast_macd_delta",
     "slow_macd_delta",
     "fast_macd_delta2",
@@ -310,15 +312,23 @@ def rsi14(close: pd.Series) -> pd.Series:
     return rsi.mask((dn == 0.0) & (up > 0.0), 100.0)
 
 
-def macd_hist(
+def macd_lines(
     close: pd.Series, fast: int = 8, slow: int = 17, signal: int = 9
-) -> pd.Series:
-    """MACD histogram, Shepherd's 8/17/9 default."""
+) -> tuple[pd.Series, pd.Series]:
+    """The two MACD lines: (macd, signal). The histogram is their difference."""
     macd = (
         close.ewm(span=fast, adjust=False).mean()
         - close.ewm(span=slow, adjust=False).mean()
     )
-    return macd - macd.ewm(span=signal, adjust=False).mean()
+    return macd, macd.ewm(span=signal, adjust=False).mean()
+
+
+def macd_hist(
+    close: pd.Series, fast: int = 8, slow: int = 17, signal: int = 9
+) -> pd.Series:
+    """MACD histogram, Shepherd's 8/17/9 default."""
+    macd, sig = macd_lines(close, fast=fast, slow=slow, signal=signal)
+    return macd - sig
 
 
 def _num(v: Any) -> float:
@@ -348,7 +358,12 @@ def dual_macd_series(df: pd.DataFrame, *, slope_lookback: int = 3) -> pd.DataFra
     raw x2 multiplier."""
     close = df["close"]
     atr = atr14(df).replace(0.0, np.nan)
-    fast = macd_hist(close, fast=13, slow=21, signal=9) / atr
+    # The fast pair's own lines are kept (same ATR normalization as the
+    # histogram, so they share its axis): the histogram shows the gap's size but
+    # not where the crossing sits relative to zero, which is the difference
+    # between a momentum turn and an outright trend flip.
+    fast_line, fast_signal = macd_lines(close, fast=13, slow=21, signal=9)
+    fast = (fast_line - fast_signal) / atr
     slow = macd_hist(close, fast=55, slow=89, signal=34) / atr
     fast_delta = fast.diff(slope_lookback)
     slow_delta = slow.diff(slope_lookback)
@@ -356,6 +371,8 @@ def dual_macd_series(df: pd.DataFrame, *, slope_lookback: int = 3) -> pd.DataFra
         {
             "fast_macd_hist_atr": fast,
             "slow_macd_hist_atr": slow,
+            "fast_macd_line_atr": fast_line / atr,
+            "fast_macd_signal_atr": fast_signal / atr,
             "fast_macd_delta": fast_delta,
             "slow_macd_delta": slow_delta,
             "fast_macd_delta2": fast_delta.diff(1),

--- a/src/uw_scan/models/technicals.py
+++ b/src/uw_scan/models/technicals.py
@@ -48,10 +48,13 @@ class TechnicalsSeriesRow(_UwBase):
     kin_slope50: float | None = None
     kin_slope200: float | None = None
     alignment: float | None = None
-    # Dual MACD histograms (13/21/9 fast vs 55/89/34 slow), ATR-normalized.
-    # Only the two charted histograms are typed; deltas/norms stay in JSONB.
+    # Dual MACD histograms (13/21/9 fast vs 55/89/34 slow), ATR-normalized,
+    # plus the fast pair's own MACD/signal lines. Only what the chart draws is
+    # typed; deltas/norms stay in JSONB.
     fast_macd_hist_atr: float | None = None
     slow_macd_hist_atr: float | None = None
+    fast_macd_line_atr: float | None = None
+    fast_macd_signal_atr: float | None = None
 
 
 class ForwardReturnBandRow(_UwBase):

--- a/src/uw_scan/reports/technicals.py
+++ b/src/uw_scan/reports/technicals.py
@@ -36,6 +36,8 @@ _METRIC_FIELDS = frozenset(
         "alignment",
         "fast_macd_hist_atr",
         "slow_macd_hist_atr",
+        "fast_macd_line_atr",
+        "fast_macd_signal_atr",
     }
 )
 

--- a/src/uw_scan/storage/technicals_repository.py
+++ b/src/uw_scan/storage/technicals_repository.py
@@ -45,6 +45,8 @@ _METRIC_COLS = (
     "alignment",
     "fast_macd_hist_atr",
     "slow_macd_hist_atr",
+    "fast_macd_line_atr",
+    "fast_macd_signal_atr",
     "fast_macd_delta",
     "slow_macd_delta",
     "fast_macd_delta2",

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -16099,6 +16099,28 @@
             ],
             "title": "Fast Macd Hist Atr"
           },
+          "fast_macd_line_atr": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fast Macd Line Atr"
+          },
+          "fast_macd_signal_atr": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fast Macd Signal Atr"
+          },
           "high": {
             "anyOf": [
               {

--- a/tests/unit/cards/test_dual_macd.py
+++ b/tests/unit/cards/test_dual_macd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from uw_scan.cards.technicals import dual_macd_series, dual_macd_state
 
@@ -27,6 +28,8 @@ def test_series_has_all_columns_and_is_finite_at_tail():
     assert list(out.columns) == [
         "fast_macd_hist_atr",
         "slow_macd_hist_atr",
+        "fast_macd_line_atr",
+        "fast_macd_signal_atr",
         "fast_macd_delta",
         "slow_macd_delta",
         "fast_macd_delta2",
@@ -35,6 +38,12 @@ def test_series_has_all_columns_and_is_finite_at_tail():
     ]
     assert np.isfinite(out["fast_macd_hist_atr"].iloc[-1])
     assert np.isfinite(out["slow_macd_hist_atr"].iloc[-1])
+    # The charted trio must stay self-consistent: the histogram the pane draws
+    # is exactly the gap between the two lines drawn over it.
+    tail = out.iloc[-1]
+    assert tail["fast_macd_hist_atr"] == pytest.approx(
+        tail["fast_macd_line_atr"] - tail["fast_macd_signal_atr"]
+    )
     # norms are 0..1 percentile ranks
     assert 0.0 <= out["fast_macd_norm"].iloc[-1] <= 1.0
 

--- a/tests/unit/test_technicals.py
+++ b/tests/unit/test_technicals.py
@@ -278,6 +278,8 @@ def test_build_technical_snapshot_full():
         "macd_hist_atr",
         "fast_macd_hist_atr",
         "slow_macd_hist_atr",
+        "fast_macd_line_atr",
+        "fast_macd_signal_atr",
         "fast_macd_delta",
         "slow_macd_delta",
         "fast_macd_delta2",

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -66,8 +66,12 @@ const OVERLAY_MODE_KEY = "technicals:priceOverlayMode";
 const CHANLUN_KEY = "technicals:chanlun";
 const VOLUME_PROFILE_KEY = "technicals:volumeProfile";
 const FVG_KEY = "technicals:fvg";
-// Volume confirm for VP breakout/breakdown marks (Pine `volMaLen`).
-const VP_SIGNAL_VOL_MA = 20;
+// Sessions the volume profile covers, counted back from the newest bar. Fixed,
+// not the visible range — panning a visible-range profile moved the POC by a
+// median of 11.6 ATR. 360 keeps the levels within ~10-20% of spot; longer
+// windows are steadier but anchor to prices the market has left behind.
+// docs/research/2026-07-20-volume-profile-window-study.md
+const VP_LOOKBACK = 360;
 
 // ReorderableList.tsx pattern: lazy init + try/catch; client-only component
 // so no hydration mismatch.
@@ -212,7 +216,6 @@ type ChartHandles = {
   segDashed: ISeriesApi<"Line">;
   segZs: ChanlunZhongshu;
   vp: VolumeProfileIndicator;
-  vpMarkers: ISeriesMarkersPluginApi<Time>;
   fvg: ChanlunZhongshu;
 };
 
@@ -550,12 +553,12 @@ export function TechnicalsPriceChart({
       supportColor: cssVar("--positive"),
       resistanceColor: cssVar("--negative"),
       lvnColor: `${cssVar("--text-muted")}b3`,
+      lookback: VP_LOOKBACK,
       // setVpStats is a stable useState setter, so the once-built primitive can
       // hold it for the life of the chart.
       onStats: setVpStats,
     });
     price.attachPrimitive(vp);
-    const vpMarkers = createSeriesMarkers(price, []);
 
     // Fair value gaps are time-bounded price rectangles — exactly what the
     // zhongshu primitive already draws, so reuse it rather than clone 150 lines.
@@ -630,7 +633,6 @@ export function TechnicalsPriceChart({
       segDashed,
       segZs,
       vp,
-      vpMarkers,
       fvg,
     };
     fitKeyRef.current = ""; // force a fitContent on the first data pass
@@ -945,9 +947,13 @@ export function TechnicalsPriceChart({
     }
     // Volume profile gets the whole window; it re-bins itself to whatever slice
     // is on screen, so panning/zooming updates it without a data pass.
+    // `full`, not `rows`: the profile window is VP_LOOKBACK sessions regardless
+    // of the timeframe selector, so the levels stay put when you switch 3M/1Y/
+    // FULL. Feeding the windowed rows would silently shrink the profile to ~63
+    // bars on 3M — back in the noisy, high-churn regime the study rejected.
     h.vp.setBars(
       vpOn && candleMode
-        ? rows.flatMap((r) =>
+        ? full.flatMap((r) =>
             r.as_of != null &&
             r.open != null &&
             r.high != null &&
@@ -1023,81 +1029,6 @@ export function TechnicalsPriceChart({
     vpOn,
     fvgOn,
   ]);
-
-  // VP breakout / breakdown / touch / reject marks against the nearest zones.
-  // Own effect (not the data pass): the levels move with the visible range, so
-  // this reruns on pan/zoom without re-feeding every other series.
-  useEffect(() => {
-    const h = handlesRef.current;
-    if (!h) return;
-    if (!vpOn || !candleMode || !vpStats) {
-      h.vpMarkers.setMarkers([]);
-      return;
-    }
-    const { nearestResistance: res, nearestSupport: sup } = vpStats;
-    const positive = cssVar("--positive");
-    const negative = cssVar("--negative");
-    const volMa = volumeMa(
-      rows.map((r) => r.volume),
-      VP_SIGNAL_VOL_MA,
-    );
-    const marks: SeriesMarker<Time>[] = [];
-    for (let i = 1; i < rows.length; i += 1) {
-      const r = rows[i];
-      const prevClose = rows[i - 1].close;
-      if (r.as_of == null || r.close == null || prevClose == null) continue;
-      const time = r.as_of as Time;
-      const ma = volMa[i];
-      // Breakouts need volume behind them; touches/rejects are just reactions.
-      const volOk = r.volume != null && ma != null && r.volume > ma;
-      if (res != null && volOk && prevClose <= res && r.close > res) {
-        marks.push({
-          time,
-          position: "belowBar",
-          shape: "arrowUp",
-          color: positive,
-          text: "BUY",
-          size: 1,
-        });
-      } else if (sup != null && volOk && prevClose >= sup && r.close < sup) {
-        marks.push({
-          time,
-          position: "aboveBar",
-          shape: "arrowDown",
-          color: negative,
-          text: "SELL",
-          size: 1,
-        });
-      } else if (
-        sup != null &&
-        r.low != null &&
-        r.low <= sup &&
-        r.close > sup
-      ) {
-        marks.push({
-          time,
-          position: "belowBar",
-          shape: "circle",
-          color: `${positive}99`,
-          size: 0,
-        });
-      } else if (
-        res != null &&
-        r.high != null &&
-        r.high >= res &&
-        r.close < res
-      ) {
-        marks.push({
-          time,
-          position: "aboveBar",
-          shape: "circle",
-          color: `${negative}99`,
-          size: 0,
-        });
-      }
-    }
-    h.vpMarkers.setMarkers(marks);
-  }, [rows, vpOn, candleMode, vpStats]);
 
   const clearAnchor = () => {
     setAnchor(null);
@@ -1368,24 +1299,24 @@ export function TechnicalsPriceChart({
             lineHeight: 1.55,
           }}
         >
-          VP: volume traded at each price over the <em>visible</em> range — pan
-          or zoom and it re-bins. Green hugs the axis (bars that closed up),
-          violet stacks outside it (closed down); bar length is share of the
-          busiest price. Full-opacity rows are the 70% value area, faded rows
-          are the tails. Amber line = POC, the single most-traded price.
-          Green/red bands are high-volume shelves read as support (below spot)
-          or resistance (above), labelled with strength as a % of the POC and ×N
-          retests; gray dashed lines are low-volume nodes — prices the market
-          travelled through rather than accepted. BUY/SELL arrows mark closes
-          crossing the nearest zone on above-average volume; faint dots mark
-          touches and rejections that did not break through. Each bar spreads
-          its volume evenly across its own high–low, so this is where-it-traded,
-          not an order book. Zones are descriptive structure, not a trade
-          signal. Read the marks with care: the levels come from the whole
-          visible window, <em>including bars later than the mark itself</em>, so
-          a past arrow had information that was not available on the day it
-          points at. Change the window and the marks move. This is annotation of
-          structure, not a backtest, and nothing here has been validated.
+          VP: volume traded at each price over the last{" "}
+          <strong>{VP_LOOKBACK} sessions</strong> — a fixed window, so panning
+          and zooming never move these levels. Green hugs the axis (bars that
+          closed up), violet stacks outside it (closed down); bar length is
+          share of the busiest price. Full-opacity rows are the 70% value area,
+          faded rows are the tails. Amber line = POC, the single most-traded
+          price. Green/red bands are high-volume shelves read as support (below
+          spot) or resistance (above), labelled with strength as a % of the POC
+          and ×N retests; gray dashed lines are low-volume nodes — prices the
+          market travelled through rather than accepted. Each bar spreads its
+          volume evenly across its own high–low, so this is where-it-traded, not
+          an order book. Descriptive structure only: a 20-year test across six
+          names found <em>no</em> forward-return edge at these zones on either
+          side, so treat a shelf as context for where price has been accepted,
+          never as a reason to trade. Why 360 and not longer: stability keeps
+          improving out to 5 years, but by then the POC sits 35–92% below spot —
+          steady because it describes a market that no longer exists (
+          <code>docs/research/2026-07-20-volume-profile-window-study.md</code>).
         </div>
       )}
       {fvgOn && candleMode && (

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -552,7 +552,9 @@ export function TechnicalsPriceChart({
       pocColor: cssVar("--warning"),
       supportColor: cssVar("--positive"),
       resistanceColor: cssVar("--negative"),
-      lvnColor: `${cssVar("--text-muted")}b3`,
+      // --text-secondary, not --text-muted: muted sat at the same value as the
+      // dotted grid and the LVN levels read as chart furniture.
+      lvnColor: `${cssVar("--text-secondary")}cc`,
       lookback: VP_LOOKBACK,
       // setVpStats is a stable useState setter, so the once-built primitive can
       // hold it for the life of the chart.

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/lib/indicators";
 import { BandsIndicator } from "@/lib/lwc/bandsIndicator";
 import { ChanlunZhongshu } from "@/lib/lwc/chanlunZhongshu";
+import { VolumeProfileIndicator } from "@/lib/lwc/volumeProfile";
 import {
   computeChanlunFull,
   divergenceTrend,
@@ -58,6 +59,7 @@ const MACD_H = 150;
 type OverlayMode = "sma" | "ema";
 const OVERLAY_MODE_KEY = "technicals:priceOverlayMode";
 const CHANLUN_KEY = "technicals:chanlun";
+const VOLUME_PROFILE_KEY = "technicals:volumeProfile";
 
 // ReorderableList.tsx pattern: lazy init + try/catch; client-only component
 // so no hydration mismatch.
@@ -72,6 +74,14 @@ function loadOverlayMode(): OverlayMode {
 function loadChanlun(): boolean {
   try {
     return localStorage.getItem(CHANLUN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function loadVolumeProfile(): boolean {
+  try {
+    return localStorage.getItem(VOLUME_PROFILE_KEY) === "1";
   } catch {
     return false;
   }
@@ -185,6 +195,7 @@ type ChartHandles = {
   segSolid: ISeriesApi<"Line">;
   segDashed: ISeriesApi<"Line">;
   segZs: ChanlunZhongshu;
+  vp: VolumeProfileIndicator;
 };
 
 const READABLE_BAR_PX = 6; // min bar width before we scroll instead of squish
@@ -247,6 +258,15 @@ export function TechnicalsPriceChart({
     setChanlunOn(on);
     try {
       localStorage.setItem(CHANLUN_KEY, on ? "1" : "0");
+    } catch {
+      /* storage unavailable */
+    }
+  };
+  const [vpOn, setVpOn] = useState<boolean>(loadVolumeProfile);
+  const setVpPersist = (on: boolean) => {
+    setVpOn(on);
+    try {
+      localStorage.setItem(VOLUME_PROFILE_KEY, on ? "1" : "0");
     } catch {
       /* storage unavailable */
     }
@@ -491,6 +511,15 @@ export function TechnicalsPriceChart({
     });
     price.attachPrimitive(segZs);
 
+    // Visible-range volume profile, pinned to the right edge of the price pane.
+    // Same "create always, feed empty while off" contract as the Chanlun layer.
+    const vp = new VolumeProfileIndicator({
+      buyColor: `${cssVar("--positive")}d9`,
+      sellColor: `${cssVar("--accent-vivid")}d9`,
+      pocColor: cssVar("--warning"),
+    });
+    price.attachPrimitive(vp);
+
     // Dual MACD in pane index 1 (below price). Two histograms sharing one price
     // scale: the slow 55/89/34 is the structural background (accent-vol, ~50%
     // alpha) drawn first; the fast 13/21/9 is the sharp tactical bar on top, its
@@ -552,6 +581,7 @@ export function TechnicalsPriceChart({
       segSolid,
       segDashed,
       segZs,
+      vp,
     };
     fitKeyRef.current = ""; // force a fitContent on the first data pass
 
@@ -863,6 +893,31 @@ export function TechnicalsPriceChart({
       h.segZs.setRects([]);
       h.clMarkers.setMarkers([]);
     }
+    // Volume profile gets the whole window; it re-bins itself to whatever slice
+    // is on screen, so panning/zooming updates it without a data pass.
+    h.vp.setBars(
+      vpOn && candleMode
+        ? rows.flatMap((r) =>
+            r.as_of != null &&
+            r.open != null &&
+            r.high != null &&
+            r.low != null &&
+            r.close != null &&
+            r.volume != null
+              ? [
+                  {
+                    time: r.as_of as Time,
+                    open: r.open,
+                    high: r.high,
+                    low: r.low,
+                    close: r.close,
+                    volume: r.volume,
+                  },
+                ]
+              : [],
+          )
+        : [],
+    );
     // Fit on ticker or window-start change only — a live head append (length
     // change, same first bar) must not reset the user's zoom.
     const fitKey = `${ticker}:${candleMode}:${firstAsOf}`;
@@ -886,7 +941,7 @@ export function TechnicalsPriceChart({
         volMaByTimeRef.current.get(lastRow.as_of),
       );
     }
-  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo, clBars]);
+  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo, clBars, vpOn]);
 
   const clearAnchor = () => {
     setAnchor(null);
@@ -987,6 +1042,28 @@ export function TechnicalsPriceChart({
           }}
         >
           Zen
+        </button>
+      )}
+      {candleMode && (
+        <button
+          type="button"
+          onClick={() => setVpPersist(!vpOn)}
+          aria-pressed={vpOn}
+          data-testid="volume-profile-toggle"
+          title="Visible-range volume profile — buy/sell by price, POC"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            letterSpacing: 1,
+            color: vpOn ? "var(--text-primary)" : "var(--text-muted)",
+            background: vpOn ? "var(--bg-panel-raised)" : "transparent",
+            border: "1px solid var(--border-dim)",
+            borderRadius: 4,
+            padding: "2px 7px",
+            cursor: "pointer",
+          }}
+        >
+          VP
         </button>
       )}
       <button
@@ -1101,6 +1178,25 @@ export function TechnicalsPriceChart({
           repaint-prone (24–34%). Not a trade signal. The 200-DMA is
           corporate-action-unadjusted, so the trend split is unreliable for ~200
           sessions after a stock split.
+        </div>
+      )}
+      {vpOn && candleMode && (
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            marginTop: 6,
+            lineHeight: 1.55,
+          }}
+        >
+          VP: volume traded at each price over the <em>visible</em> range — pan
+          or zoom and it re-bins. Green hugs the axis (bars that closed up),
+          violet stacks outside it (closed down); bar length is share of the
+          busiest price. Full-opacity rows are the 70% value area, faded rows
+          are the tails. Amber line = POC, the single most-traded price. Each
+          bar spreads its volume evenly across its own high–low, so this is
+          where-it-traded, not an order book — thick shelves are prior
+          acceptance, thin ones are prices the market moved through quickly.
         </div>
       )}
       <MacdLegend signal={macd} />

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -41,7 +41,12 @@ import {
 } from "@/lib/indicators";
 import { BandsIndicator } from "@/lib/lwc/bandsIndicator";
 import { ChanlunZhongshu } from "@/lib/lwc/chanlunZhongshu";
-import { VolumeProfileIndicator } from "@/lib/lwc/volumeProfile";
+import {
+  VolumeProfileIndicator,
+  type VolumeProfileStats,
+} from "@/lib/lwc/volumeProfile";
+import { findFairValueGaps } from "@/lib/fvg";
+import { VolumeProfileStatsPanel } from "./VolumeProfileStatsPanel";
 import {
   computeChanlunFull,
   divergenceTrend,
@@ -60,6 +65,9 @@ type OverlayMode = "sma" | "ema";
 const OVERLAY_MODE_KEY = "technicals:priceOverlayMode";
 const CHANLUN_KEY = "technicals:chanlun";
 const VOLUME_PROFILE_KEY = "technicals:volumeProfile";
+const FVG_KEY = "technicals:fvg";
+// Volume confirm for VP breakout/breakdown marks (Pine `volMaLen`).
+const VP_SIGNAL_VOL_MA = 20;
 
 // ReorderableList.tsx pattern: lazy init + try/catch; client-only component
 // so no hydration mismatch.
@@ -82,6 +90,14 @@ function loadChanlun(): boolean {
 function loadVolumeProfile(): boolean {
   try {
     return localStorage.getItem(VOLUME_PROFILE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function loadFvg(): boolean {
+  try {
+    return localStorage.getItem(FVG_KEY) === "1";
   } catch {
     return false;
   }
@@ -196,6 +212,8 @@ type ChartHandles = {
   segDashed: ISeriesApi<"Line">;
   segZs: ChanlunZhongshu;
   vp: VolumeProfileIndicator;
+  vpMarkers: ISeriesMarkersPluginApi<Time>;
+  fvg: ChanlunZhongshu;
 };
 
 const READABLE_BAR_PX = 6; // min bar width before we scroll instead of squish
@@ -271,6 +289,18 @@ export function TechnicalsPriceChart({
       /* storage unavailable */
     }
   };
+  const [fvgOn, setFvgOn] = useState<boolean>(loadFvg);
+  const setFvgPersist = (on: boolean) => {
+    setFvgOn(on);
+    try {
+      localStorage.setItem(FVG_KEY, on ? "1" : "0");
+    } catch {
+      /* storage unavailable */
+    }
+  };
+  // Pushed up from the VP primitive whenever the visible range changes, so the
+  // readout and the signal marks always describe the bars actually drawn.
+  const [vpStats, setVpStats] = useState<VolumeProfileStats | null>(null);
   // Chanlun geometry over the FULL history (window-cut in the data pass, like
   // the other client-side indicators). Pure + deterministic, so memo on rows.
   // Chanlun bars over FULL history (window-cut in the data pass), hoisted so the
@@ -517,8 +547,26 @@ export function TechnicalsPriceChart({
       buyColor: `${cssVar("--positive")}d9`,
       sellColor: `${cssVar("--accent-vivid")}d9`,
       pocColor: cssVar("--warning"),
+      supportColor: cssVar("--positive"),
+      resistanceColor: cssVar("--negative"),
+      lvnColor: `${cssVar("--text-muted")}b3`,
+      // setVpStats is a stable useState setter, so the once-built primitive can
+      // hold it for the life of the chart.
+      onStats: setVpStats,
     });
     price.attachPrimitive(vp);
+    const vpMarkers = createSeriesMarkers(price, []);
+
+    // Fair value gaps are time-bounded price rectangles — exactly what the
+    // zhongshu primitive already draws, so reuse it rather than clone 150 lines.
+    // Unrelated to volume: its own toggle, its own data.
+    const fvg = new ChanlunZhongshu({
+      // Faint: gaps overlap and each box runs to the right edge, so the fills
+      // compound where several stack.
+      fillColor: `${cssVar("--warning")}14`,
+      borderColor: `${cssVar("--warning")}66`,
+    });
+    price.attachPrimitive(fvg);
 
     // Dual MACD in pane index 1 (below price). Two histograms sharing one price
     // scale: the slow 55/89/34 is the structural background (accent-vol, ~50%
@@ -582,6 +630,8 @@ export function TechnicalsPriceChart({
       segDashed,
       segZs,
       vp,
+      vpMarkers,
+      fvg,
     };
     fitKeyRef.current = ""; // force a fitContent on the first data pass
 
@@ -918,6 +968,26 @@ export function TechnicalsPriceChart({
           )
         : [],
     );
+    // Unfilled fair value gaps, drawn from the gap bar to the right edge.
+    const lastTime = rows[rows.length - 1]?.as_of;
+    if (fvgOn && candleMode && lastTime) {
+      const fvgBars = rows.flatMap((r) =>
+        r.as_of != null && r.high != null && r.low != null
+          ? [{ time: r.as_of, high: r.high, low: r.low }]
+          : [],
+      );
+      h.fvg.setRects(
+        findFairValueGaps(fvgBars).map((g) => ({
+          start: g.time as Time,
+          end: lastTime as Time,
+          zg: g.top,
+          zd: g.bottom,
+          confirmed: true, // solid border; an unfilled gap is not provisional
+        })),
+      );
+    } else {
+      h.fvg.setRects([]);
+    }
     // Fit on ticker or window-start change only — a live head append (length
     // change, same first bar) must not reset the user's zoom.
     const fitKey = `${ticker}:${candleMode}:${firstAsOf}`;
@@ -941,7 +1011,93 @@ export function TechnicalsPriceChart({
         volMaByTimeRef.current.get(lastRow.as_of),
       );
     }
-  }, [rows, full, ticker, candleMode, anchor, mode, chanlunGeo, clBars, vpOn]);
+  }, [
+    rows,
+    full,
+    ticker,
+    candleMode,
+    anchor,
+    mode,
+    chanlunGeo,
+    clBars,
+    vpOn,
+    fvgOn,
+  ]);
+
+  // VP breakout / breakdown / touch / reject marks against the nearest zones.
+  // Own effect (not the data pass): the levels move with the visible range, so
+  // this reruns on pan/zoom without re-feeding every other series.
+  useEffect(() => {
+    const h = handlesRef.current;
+    if (!h) return;
+    if (!vpOn || !candleMode || !vpStats) {
+      h.vpMarkers.setMarkers([]);
+      return;
+    }
+    const { nearestResistance: res, nearestSupport: sup } = vpStats;
+    const positive = cssVar("--positive");
+    const negative = cssVar("--negative");
+    const volMa = volumeMa(
+      rows.map((r) => r.volume),
+      VP_SIGNAL_VOL_MA,
+    );
+    const marks: SeriesMarker<Time>[] = [];
+    for (let i = 1; i < rows.length; i += 1) {
+      const r = rows[i];
+      const prevClose = rows[i - 1].close;
+      if (r.as_of == null || r.close == null || prevClose == null) continue;
+      const time = r.as_of as Time;
+      const ma = volMa[i];
+      // Breakouts need volume behind them; touches/rejects are just reactions.
+      const volOk = r.volume != null && ma != null && r.volume > ma;
+      if (res != null && volOk && prevClose <= res && r.close > res) {
+        marks.push({
+          time,
+          position: "belowBar",
+          shape: "arrowUp",
+          color: positive,
+          text: "BUY",
+          size: 1,
+        });
+      } else if (sup != null && volOk && prevClose >= sup && r.close < sup) {
+        marks.push({
+          time,
+          position: "aboveBar",
+          shape: "arrowDown",
+          color: negative,
+          text: "SELL",
+          size: 1,
+        });
+      } else if (
+        sup != null &&
+        r.low != null &&
+        r.low <= sup &&
+        r.close > sup
+      ) {
+        marks.push({
+          time,
+          position: "belowBar",
+          shape: "circle",
+          color: `${positive}99`,
+          size: 0,
+        });
+      } else if (
+        res != null &&
+        r.high != null &&
+        r.high >= res &&
+        r.close < res
+      ) {
+        marks.push({
+          time,
+          position: "aboveBar",
+          shape: "circle",
+          color: `${negative}99`,
+          size: 0,
+        });
+      }
+    }
+    h.vpMarkers.setMarkers(marks);
+  }, [rows, vpOn, candleMode, vpStats]);
 
   const clearAnchor = () => {
     setAnchor(null);
@@ -1066,6 +1222,28 @@ export function TechnicalsPriceChart({
           VP
         </button>
       )}
+      {candleMode && (
+        <button
+          type="button"
+          onClick={() => setFvgPersist(!fvgOn)}
+          aria-pressed={fvgOn}
+          data-testid="fvg-toggle"
+          title="Fair value gaps — unfilled 3-bar imbalances"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            letterSpacing: 1,
+            color: fvgOn ? "var(--text-primary)" : "var(--text-muted)",
+            background: fvgOn ? "var(--bg-panel-raised)" : "transparent",
+            border: "1px solid var(--border-dim)",
+            borderRadius: 4,
+            padding: "2px 7px",
+            cursor: "pointer",
+          }}
+        >
+          FVG
+        </button>
+      )}
       <button
         type="button"
         aria-label="Reset zoom and jump to latest bar"
@@ -1180,6 +1358,7 @@ export function TechnicalsPriceChart({
           sessions after a stock split.
         </div>
       )}
+      {vpOn && candleMode && <VolumeProfileStatsPanel stats={vpStats} />}
       {vpOn && candleMode && (
         <div
           style={{
@@ -1193,10 +1372,37 @@ export function TechnicalsPriceChart({
           or zoom and it re-bins. Green hugs the axis (bars that closed up),
           violet stacks outside it (closed down); bar length is share of the
           busiest price. Full-opacity rows are the 70% value area, faded rows
-          are the tails. Amber line = POC, the single most-traded price. Each
-          bar spreads its volume evenly across its own high–low, so this is
-          where-it-traded, not an order book — thick shelves are prior
-          acceptance, thin ones are prices the market moved through quickly.
+          are the tails. Amber line = POC, the single most-traded price.
+          Green/red bands are high-volume shelves read as support (below spot)
+          or resistance (above), labelled with strength as a % of the POC and ×N
+          retests; gray dashed lines are low-volume nodes — prices the market
+          travelled through rather than accepted. BUY/SELL arrows mark closes
+          crossing the nearest zone on above-average volume; faint dots mark
+          touches and rejections that did not break through. Each bar spreads
+          its volume evenly across its own high–low, so this is where-it-traded,
+          not an order book. Zones are descriptive structure, not a trade
+          signal. Read the marks with care: the levels come from the whole
+          visible window, <em>including bars later than the mark itself</em>, so
+          a past arrow had information that was not available on the day it
+          points at. Change the window and the marks move. This is annotation of
+          structure, not a backtest, and nothing here has been validated.
+        </div>
+      )}
+      {fvgOn && candleMode && (
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-muted)",
+            marginTop: 6,
+            lineHeight: 1.55,
+          }}
+        >
+          FVG: amber boxes are unfilled fair value gaps — three-bar imbalances
+          where the middle bar ran far enough that the prior bar&apos;s high sat
+          below the next bar&apos;s low (or the mirror), leaving a price band
+          untraded. Only gaps no later bar has re-entered are drawn; each
+          extends to the right edge. Price action, not volume — independent of
+          the VP toggle.
         </div>
       )}
       <MacdLegend signal={macd} />

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -208,6 +208,8 @@ type ChartHandles = {
   volMarkers: ISeriesMarkersPluginApi<Time> | null;
   macdSlow: ISeriesApi<"Histogram">;
   macdFast: ISeriesApi<"Histogram">;
+  macdFastLine: ISeriesApi<"Line">;
+  macdFastSignal: ISeriesApi<"Line">;
   biSolid: ISeriesApi<"Line">;
   biDashed: ISeriesApi<"Line">;
   clZs: ChanlunZhongshu;
@@ -598,7 +600,33 @@ export function TechnicalsPriceChart({
       },
       1,
     );
-    // Both MACD series share pane 1's right scale — tighten its margins.
+    // The fast pair's own MACD and signal lines, on the same scale as its
+    // histogram (the histogram IS their difference, so they belong together).
+    // The lines say where the crossing sits relative to zero; the histogram
+    // only says how wide the gap is.
+    const macdFastLine = chart.addSeries(
+      LineSeries,
+      {
+        color: cssVar("--accent-vivid"),
+        lineWidth: 2,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      },
+      1,
+    );
+    const macdFastSignal = chart.addSeries(
+      LineSeries,
+      {
+        color: cssVar("--accent-warm"),
+        lineWidth: 1,
+        priceLineVisible: false,
+        lastValueVisible: false,
+        crosshairMarkerVisible: false,
+      },
+      1,
+    );
+    // All four MACD series share pane 1's right scale — tighten its margins.
     macdFast
       .priceScale()
       .applyOptions({ scaleMargins: { top: 0.12, bottom: 0.12 } });
@@ -627,6 +655,8 @@ export function TechnicalsPriceChart({
       volMarkers,
       macdSlow,
       macdFast,
+      macdFastLine,
+      macdFastSignal,
       biSolid,
       biDashed,
       clZs,
@@ -849,6 +879,15 @@ export function TechnicalsPriceChart({
           : [],
       ),
     );
+    const macdLine = (key: "fast_macd_line_atr" | "fast_macd_signal_atr") =>
+      rows.flatMap((r) => {
+        const v = r[key];
+        return r.as_of != null && v != null
+          ? [{ time: r.as_of as Time, value: v }]
+          : [];
+      });
+    h.macdFastLine.setData(macdLine("fast_macd_line_atr"));
+    h.macdFastSignal.setData(macdLine("fast_macd_signal_atr"));
     // Chanlun overlay: geometry precomputed over `full`, cut to the window
     // here. The dashed tail restarts at the last confirmed vertex so the two
     // polylines connect.

--- a/web/components/stock/panels/VolumeProfileStatsPanel.tsx
+++ b/web/components/stock/panels/VolumeProfileStatsPanel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { VolumeProfileStats } from "@/lib/lwc/volumeProfile";
+
+const BIAS_COLOR: Record<VolumeProfileStats["bias"], string> = {
+  bullish: "var(--positive)",
+  bearish: "var(--negative)",
+  balanced: "var(--text-muted)",
+};
+
+const BIAS_NOTE: Record<VolumeProfileStats["bias"], string> = {
+  bullish: "above value",
+  bearish: "below value",
+  balanced: "inside value",
+};
+
+function Tile({
+  label,
+  value,
+  color,
+  note,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+  note?: string;
+}) {
+  return (
+    <div style={{ minWidth: 96 }}>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          letterSpacing: 1.5,
+          textTransform: "uppercase",
+          color: "var(--text-muted)",
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 15,
+          fontWeight: 700,
+          color: color ?? "var(--text-primary)",
+          lineHeight: 1.4,
+        }}
+      >
+        {value}
+      </div>
+      {note && (
+        <div style={{ fontSize: 10, color: "var(--text-muted)" }}>{note}</div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Readout for whatever the volume profile currently covers. Values come from
+ * the chart primitive rather than being recomputed here, so the numbers always
+ * match the bars actually drawn — pan or zoom and these follow.
+ */
+export function VolumeProfileStatsPanel({
+  stats,
+}: {
+  stats: VolumeProfileStats | null;
+}) {
+  if (!stats) return null;
+  const f = (v: number | null) => (v == null ? "–" : v.toFixed(2));
+  return (
+    <div
+      data-testid="volume-profile-stats"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 18,
+        marginTop: 8,
+        padding: "8px 10px",
+        background: "var(--bg-panel-raised)",
+        border: "1px solid var(--border-dim)",
+        borderRadius: 4,
+      }}
+    >
+      <Tile label="POC" value={f(stats.poc)} color="var(--warning)" />
+      <Tile label="VAH" value={f(stats.vah)} />
+      <Tile label="VAL" value={f(stats.val)} />
+      <Tile
+        label="Nearest R"
+        value={f(stats.nearestResistance)}
+        color="var(--negative)"
+        note={`${stats.resistanceCount} zone${stats.resistanceCount === 1 ? "" : "s"}`}
+      />
+      <Tile
+        label="Nearest S"
+        value={f(stats.nearestSupport)}
+        color="var(--positive)"
+        note={`${stats.supportCount} zone${stats.supportCount === 1 ? "" : "s"}`}
+      />
+      <Tile
+        label="Bias"
+        value={stats.bias}
+        color={BIAS_COLOR[stats.bias]}
+        note={BIAS_NOTE[stats.bias]}
+      />
+    </div>
+  );
+}

--- a/web/lib/fvg.ts
+++ b/web/lib/fvg.ts
@@ -1,0 +1,53 @@
+/**
+ * Fair value gaps — three-bar imbalances where the middle bar's move left a
+ * price band untouched (bar i-1's high below bar i+1's low, or the mirror).
+ *
+ * Price action, not volume: this lives apart from lib/volumeProfile.ts on
+ * purpose. Only gaps no later bar has traded back through are returned, since a
+ * filled gap is just history.
+ */
+
+export type FvgBar = { time: string; high: number; low: number };
+
+export type FairValueGap = {
+  time: string; // the middle (gap-creating) bar
+  top: number;
+  bottom: number;
+  bullish: boolean;
+};
+
+export function findFairValueGaps(
+  bars: readonly FvgBar[],
+  maxCount = 6,
+): FairValueGap[] {
+  if (bars.length < 3) return [];
+
+  // Running extremes of everything strictly newer than the gap's third bar,
+  // accumulated back-to-front so the fill test stays O(n).
+  const out: FairValueGap[] = [];
+  let minLowAfter = Infinity;
+  let maxHighAfter = -Infinity;
+
+  for (let i = bars.length - 2; i >= 1; i -= 1) {
+    const prev = bars[i - 1];
+    const next = bars[i + 1];
+    const bullish = prev.high < next.low;
+    const bearish = prev.low > next.high;
+    if (bullish || bearish) {
+      const top = bullish ? next.low : prev.low;
+      const bottom = bullish ? prev.high : next.high;
+      // Unfilled = nothing newer than the third bar entered the band AT ALL.
+      // Deliberately stricter than the Pine original, which only closes a gap
+      // once price traverses it completely — a partially-traded band is no
+      // longer untraded, which is the whole claim the box makes.
+      const open = bullish ? minLowAfter >= top : maxHighAfter <= bottom;
+      if (open && out.length < maxCount) {
+        out.push({ time: bars[i].time, top, bottom, bullish });
+      }
+    }
+    // bars[i+1] is now "after" the next (older) gap we test.
+    minLowAfter = Math.min(minLowAfter, next.low);
+    maxHighAfter = Math.max(maxHighAfter, next.high);
+  }
+  return out.reverse(); // oldest first
+}

--- a/web/lib/lwc/volumeProfile.ts
+++ b/web/lib/lwc/volumeProfile.ts
@@ -1,0 +1,231 @@
+/**
+ * Visible-range volume profile (VRVP) drawn against the right edge of the price
+ * pane — horizontal bars growing leftward, buy volume hugging the axis, sell
+ * volume stacked outside it. Same attach/paneViews lifecycle as
+ * lib/lwc/chanlunZhongshu.ts; the binning math lives in lib/volumeProfile.ts.
+ *
+ * The profile is recomputed from the visible time range on every view update
+ * (that's what makes it "visible range"), memoized on the range so crosshair
+ * moves don't re-bin.
+ */
+import { CanvasRenderingTarget2D } from "fancy-canvas";
+import type {
+  IChartApi,
+  IPrimitivePaneRenderer,
+  IPrimitivePaneView,
+  ISeriesApi,
+  ISeriesPrimitive,
+  SeriesAttachedParameter,
+  SeriesOptionsMap,
+  Time,
+} from "lightweight-charts";
+import {
+  computeVolumeProfile,
+  type VolumeProfile,
+  type VpBar,
+} from "@/lib/volumeProfile";
+
+export type VolumeProfileBar = VpBar & { time: Time };
+
+export interface VolumeProfileOptions {
+  buyColor?: string;
+  sellColor?: string;
+  pocColor?: string;
+  bins?: number;
+  valuePct?: number;
+  /** Profile width as a fraction of pane width, clamped by min/max px. */
+  widthFrac?: number;
+  minWidthPx?: number;
+  maxWidthPx?: number;
+}
+
+const defaults: Required<VolumeProfileOptions> = {
+  buyColor: "rgba(0, 137, 123, 0.85)",
+  sellColor: "rgba(156, 39, 176, 0.85)",
+  pocColor: "rgba(255, 167, 38, 0.9)",
+  bins: 60,
+  valuePct: 70,
+  widthFrac: 0.22,
+  minWidthPx: 70,
+  maxWidthPx: 240,
+};
+
+type RowPx = {
+  yTop: number;
+  yBottom: number;
+  buyFrac: number; // 0..1 of the profile width
+  sellFrac: number;
+  inValueArea: boolean;
+};
+
+type ViewPx = { rows: RowPx[]; pocY: number | null; pocPrice: number };
+
+class VolumeProfileRenderer implements IPrimitivePaneRenderer {
+  constructor(
+    private _view: ViewPx | null,
+    private _options: Required<VolumeProfileOptions>,
+  ) {}
+
+  draw() {}
+
+  // Background: the profile sits behind the candles it summarizes. Our right
+  // gap is only RIGHT_GAP_BARS wide, so a foreground profile would bury the
+  // newest bars — the layer, not alpha, keeps price legible.
+  drawBackground(target: CanvasRenderingTarget2D) {
+    const view = this._view;
+    if (!view || view.rows.length === 0) return;
+    target.useBitmapCoordinateSpace((scope) => {
+      const ctx = scope.context;
+      ctx.save();
+      ctx.scale(scope.horizontalPixelRatio, scope.verticalPixelRatio);
+      const right = scope.mediaSize.width;
+      const width = Math.max(
+        this._options.minWidthPx,
+        Math.min(this._options.maxWidthPx, right * this._options.widthFrac),
+      );
+
+      for (const r of view.rows) {
+        const h = Math.max(1, r.yBottom - r.yTop - 0.5); // hairline gap between rows
+        const buyLen = r.buyFrac * width;
+        const sellLen = r.sellFrac * width;
+        if (buyLen + sellLen < 0.5) continue;
+        // Outside the value area the bins are context, not levels — dim them.
+        ctx.globalAlpha = r.inValueArea ? 1 : 0.4;
+        if (buyLen > 0) {
+          ctx.fillStyle = this._options.buyColor;
+          ctx.fillRect(right - buyLen, r.yTop, buyLen, h);
+        }
+        if (sellLen > 0) {
+          ctx.fillStyle = this._options.sellColor;
+          ctx.fillRect(right - buyLen - sellLen, r.yTop, sellLen, h);
+        }
+      }
+
+      ctx.globalAlpha = 1;
+      if (view.pocY != null) {
+        ctx.strokeStyle = this._options.pocColor;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(right - width, view.pocY);
+        ctx.lineTo(right, view.pocY);
+        ctx.stroke();
+        ctx.fillStyle = this._options.pocColor;
+        ctx.font = "10px monospace";
+        ctx.textBaseline = "bottom";
+        ctx.fillText(
+          `POC ${view.pocPrice.toFixed(2)}`,
+          right - width,
+          view.pocY - 2,
+        );
+      }
+      ctx.restore();
+    });
+  }
+}
+
+class VolumeProfilePaneView implements IPrimitivePaneView {
+  private _view: ViewPx | null = null;
+  private _cacheKey = "";
+  private _profile: VolumeProfile | null = null;
+
+  constructor(private _source: VolumeProfileIndicator) {}
+
+  update() {
+    const chart = this._source.chartApi();
+    const series = this._source.seriesApi();
+    this._view = null;
+    if (!chart || !series) return;
+    const visible = chart.timeScale().getVisibleRange();
+    if (!visible) return;
+
+    const from = String(visible.from);
+    const to = String(visible.to);
+    const key = `${from}|${to}|${this._source._bars.length}`;
+    if (key !== this._cacheKey) {
+      this._cacheKey = key;
+      const slice = this._source._bars.filter((b) => {
+        const t = String(b.time);
+        return t >= from && t <= to;
+      });
+      this._profile = computeVolumeProfile(
+        slice,
+        this._source._options.bins,
+        this._source._options.valuePct,
+      );
+    }
+    const p = this._profile;
+    if (!p) return;
+
+    const rows: RowPx[] = [];
+    for (let i = 0; i < p.bins.length; i += 1) {
+      const b = p.bins[i];
+      const yTop = series.priceToCoordinate(b.high);
+      const yBottom = series.priceToCoordinate(b.low);
+      if (yTop == null || yBottom == null) continue;
+      rows.push({
+        yTop,
+        yBottom,
+        buyFrac: b.buy / p.maxBinVolume,
+        sellFrac: b.sell / p.maxBinVolume,
+        inValueArea: i >= p.valIdx && i <= p.vahIdx,
+      });
+    }
+    this._view = {
+      rows,
+      pocY: series.priceToCoordinate(p.pocPrice),
+      pocPrice: p.pocPrice,
+    };
+  }
+
+  renderer() {
+    return new VolumeProfileRenderer(this._view, this._source._options);
+  }
+}
+
+export class VolumeProfileIndicator implements ISeriesPrimitive<Time> {
+  _bars: VolumeProfileBar[] = [];
+  _options: Required<VolumeProfileOptions>;
+  private _paneViews: VolumeProfilePaneView[];
+  private _chart: IChartApi | undefined;
+  private _series: ISeriesApi<keyof SeriesOptionsMap> | undefined;
+  private _requestUpdate?: () => void;
+
+  constructor(options: VolumeProfileOptions = {}) {
+    this._options = { ...defaults, ...options };
+    this._paneViews = [new VolumeProfilePaneView(this)];
+  }
+
+  attached({ chart, series, requestUpdate }: SeriesAttachedParameter<Time>) {
+    this._chart = chart;
+    this._series = series;
+    this._requestUpdate = requestUpdate;
+    this._requestUpdate?.();
+  }
+
+  detached() {
+    this._chart = undefined;
+    this._series = undefined;
+    this._requestUpdate = undefined;
+  }
+
+  chartApi(): IChartApi | undefined {
+    return this._chart;
+  }
+
+  seriesApi(): ISeriesApi<keyof SeriesOptionsMap> | undefined {
+    return this._series;
+  }
+
+  setBars(bars: VolumeProfileBar[]) {
+    this._bars = bars;
+    this._requestUpdate?.();
+  }
+
+  updateAllViews() {
+    this._paneViews.forEach((v) => v.update());
+  }
+
+  paneViews() {
+    return this._paneViews;
+  }
+}

--- a/web/lib/lwc/volumeProfile.ts
+++ b/web/lib/lwc/volumeProfile.ts
@@ -21,33 +21,62 @@ import type {
 } from "lightweight-charts";
 import {
   computeVolumeProfile,
+  findLvnLevels,
+  findSrZones,
+  type SrZone,
   type VolumeProfile,
   type VpBar,
 } from "@/lib/volumeProfile";
 
 export type VolumeProfileBar = VpBar & { time: Time };
 
+/** What the profile currently says — pushed to React for the stats readout. */
+export type VolumeProfileStats = {
+  poc: number;
+  vah: number;
+  val: number;
+  nearestSupport: number | null;
+  nearestResistance: number | null;
+  bias: "bullish" | "bearish" | "balanced";
+  supportCount: number;
+  resistanceCount: number;
+  lastPrice: number;
+};
+
 export interface VolumeProfileOptions {
   buyColor?: string;
   sellColor?: string;
   pocColor?: string;
+  supportColor?: string;
+  resistanceColor?: string;
+  lvnColor?: string;
+  labelColor?: string;
   bins?: number;
   valuePct?: number;
   /** Profile width as a fraction of pane width, clamped by min/max px. */
   widthFrac?: number;
   minWidthPx?: number;
   maxWidthPx?: number;
+  showZones?: boolean;
+  showLvn?: boolean;
+  onStats?: (stats: VolumeProfileStats | null) => void;
 }
 
-const defaults: Required<VolumeProfileOptions> = {
+const defaults: Required<Omit<VolumeProfileOptions, "onStats">> = {
   buyColor: "rgba(0, 137, 123, 0.85)",
   sellColor: "rgba(156, 39, 176, 0.85)",
   pocColor: "rgba(255, 167, 38, 0.9)",
+  supportColor: "rgba(38, 166, 154, 1)",
+  resistanceColor: "rgba(255, 82, 82, 1)",
+  lvnColor: "rgba(140, 140, 150, 0.75)",
+  labelColor: "rgba(240, 240, 245, 0.95)",
   bins: 60,
   valuePct: 70,
   widthFrac: 0.22,
   minWidthPx: 70,
   maxWidthPx: 240,
+  showZones: true,
+  showLvn: true,
 };
 
 type RowPx = {
@@ -58,12 +87,54 @@ type RowPx = {
   inValueArea: boolean;
 };
 
-type ViewPx = { rows: RowPx[]; pocY: number | null; pocPrice: number };
+type ZonePx = {
+  yTop: number;
+  yBottom: number;
+  support: boolean;
+  label: string;
+};
+
+type ViewPx = {
+  rows: RowPx[];
+  pocY: number | null;
+  pocPrice: number;
+  zones: ZonePx[];
+  lvnYs: number[];
+};
+
+function buildStats(
+  profile: VolumeProfile,
+  zones: readonly SrZone[],
+  lastPrice: number,
+): VolumeProfileStats {
+  const vah = profile.bins[profile.vahIdx].high;
+  const val = profile.bins[profile.valIdx].low;
+  const supports = zones.filter((z) => z.side === "support");
+  const resistances = zones.filter((z) => z.side === "resistance");
+  return {
+    poc: profile.pocPrice,
+    vah,
+    val,
+    // Nearest = the one price would reach first, so highest support / lowest
+    // resistance.
+    nearestSupport: supports.length
+      ? Math.max(...supports.map((z) => z.price))
+      : null,
+    nearestResistance: resistances.length
+      ? Math.min(...resistances.map((z) => z.price))
+      : null,
+    bias:
+      lastPrice > vah ? "bullish" : lastPrice < val ? "bearish" : "balanced",
+    supportCount: supports.length,
+    resistanceCount: resistances.length,
+    lastPrice,
+  };
+}
 
 class VolumeProfileRenderer implements IPrimitivePaneRenderer {
   constructor(
     private _view: ViewPx | null,
-    private _options: Required<VolumeProfileOptions>,
+    private _options: Required<Omit<VolumeProfileOptions, "onStats">>,
   ) {}
 
   draw() {}
@@ -83,6 +154,45 @@ class VolumeProfileRenderer implements IPrimitivePaneRenderer {
         this._options.minWidthPx,
         Math.min(this._options.maxWidthPx, right * this._options.widthFrac),
       );
+      ctx.font = "10px monospace";
+
+      // S/R bands span the full pane — they are levels in price, not in time.
+      for (const z of view.zones) {
+        const hue = z.support
+          ? this._options.supportColor
+          : this._options.resistanceColor;
+        const h = Math.max(1, z.yBottom - z.yTop);
+        ctx.globalAlpha = 0.12;
+        ctx.fillStyle = hue;
+        ctx.fillRect(0, z.yTop, right, h);
+        ctx.globalAlpha = 0.7;
+        ctx.strokeStyle = hue;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(0, z.yTop);
+        ctx.lineTo(right, z.yTop);
+        ctx.moveTo(0, z.yBottom);
+        ctx.lineTo(right, z.yBottom);
+        ctx.stroke();
+        // Label sits just left of the profile band so the two never collide.
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = hue;
+        ctx.textAlign = "right";
+        ctx.textBaseline = "middle";
+        ctx.fillText(z.label, right - width - 6, (z.yTop + z.yBottom) / 2);
+      }
+      ctx.textAlign = "left";
+
+      ctx.globalAlpha = 0.8;
+      ctx.strokeStyle = this._options.lvnColor;
+      ctx.setLineDash([4, 4]);
+      for (const y of view.lvnYs) {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(right, y);
+        ctx.stroke();
+      }
+      ctx.setLineDash([]);
 
       for (const r of view.rows) {
         const h = Math.max(1, r.yBottom - r.yTop - 0.5); // hairline gap between rows
@@ -127,6 +237,8 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
   private _view: ViewPx | null = null;
   private _cacheKey = "";
   private _profile: VolumeProfile | null = null;
+  private _zones: SrZone[] = [];
+  private _lvn: number[] = [];
 
   constructor(private _source: VolumeProfileIndicator) {}
 
@@ -141,17 +253,32 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
     const from = String(visible.from);
     const to = String(visible.to);
     const key = `${from}|${to}|${this._source._bars.length}`;
+    // Re-bin only when the window actually moved: updateAllViews() also fires
+    // on every crosshair move, and the stats callback must not re-fire with it.
     if (key !== this._cacheKey) {
       this._cacheKey = key;
       const slice = this._source._bars.filter((b) => {
         const t = String(b.time);
         return t >= from && t <= to;
       });
-      this._profile = computeVolumeProfile(
-        slice,
-        this._source._options.bins,
-        this._source._options.valuePct,
-      );
+      const opts = this._source._options;
+      this._profile = computeVolumeProfile(slice, opts.bins, opts.valuePct);
+      const last = slice[slice.length - 1];
+      if (this._profile && last) {
+        this._zones = opts.showZones
+          ? findSrZones(this._profile, slice, last.close)
+          : [];
+        this._lvn = opts.showLvn
+          ? findLvnLevels(this._profile, last.close)
+          : [];
+        this._source._emitStats(
+          buildStats(this._profile, this._zones, last.close),
+        );
+      } else {
+        this._zones = [];
+        this._lvn = [];
+        this._source._emitStats(null);
+      }
     }
     const p = this._profile;
     if (!p) return;
@@ -170,10 +297,31 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
         inValueArea: i >= p.valIdx && i <= p.vahIdx,
       });
     }
+    const zones: ZonePx[] = [];
+    for (const z of this._zones) {
+      const yTop = series.priceToCoordinate(z.price + z.halfWidth);
+      const yBottom = series.priceToCoordinate(z.price - z.halfWidth);
+      if (yTop == null || yBottom == null) continue;
+      zones.push({
+        yTop,
+        yBottom,
+        support: z.side === "support",
+        label:
+          `${z.side === "support" ? "S" : "R"} ${z.price.toFixed(2)} · ${z.strength}%` +
+          (z.touches > 1 ? ` ×${z.touches}` : ""),
+      });
+    }
+    const lvnYs = this._lvn.flatMap((price) => {
+      const y = series.priceToCoordinate(price);
+      return y == null ? [] : [y];
+    });
+
     this._view = {
       rows,
       pocY: series.priceToCoordinate(p.pocPrice),
       pocPrice: p.pocPrice,
+      zones,
+      lvnYs,
     };
   }
 
@@ -184,15 +332,28 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
 
 export class VolumeProfileIndicator implements ISeriesPrimitive<Time> {
   _bars: VolumeProfileBar[] = [];
-  _options: Required<VolumeProfileOptions>;
+  _options: Required<Omit<VolumeProfileOptions, "onStats">>;
+  private _onStats?: (stats: VolumeProfileStats | null) => void;
   private _paneViews: VolumeProfilePaneView[];
   private _chart: IChartApi | undefined;
   private _series: ISeriesApi<keyof SeriesOptionsMap> | undefined;
   private _requestUpdate?: () => void;
 
-  constructor(options: VolumeProfileOptions = {}) {
+  constructor({ onStats, ...options }: VolumeProfileOptions = {}) {
     this._options = { ...defaults, ...options };
+    this._onStats = onStats;
     this._paneViews = [new VolumeProfilePaneView(this)];
+  }
+
+  /**
+   * Fired only when the visible range actually changed, so this never loops
+   * back through React on a crosshair move. Deferred a tick because
+   * updateAllViews() runs inside lightweight-charts' render pass — a synchronous
+   * setState there would be a render-phase update.
+   */
+  _emitStats(stats: VolumeProfileStats | null) {
+    const cb = this._onStats;
+    if (cb) queueMicrotask(() => cb(stats));
   }
 
   attached({ chart, series, requestUpdate }: SeriesAttachedParameter<Time>) {

--- a/web/lib/lwc/volumeProfile.ts
+++ b/web/lib/lwc/volumeProfile.ts
@@ -107,7 +107,7 @@ type ViewPx = {
   pocY: number | null;
   pocPrice: number;
   zones: ZonePx[];
-  lvnYs: number[];
+  lvn: { y: number; price: number }[];
 };
 
 function buildStats(
@@ -191,16 +191,23 @@ class VolumeProfileRenderer implements IPrimitivePaneRenderer {
       }
       ctx.textAlign = "left";
 
-      ctx.globalAlpha = 0.8;
+      // Long dashes, not the grid's short dots — a faint 4/4 dash reads as
+      // chart furniture and the level disappears into the background.
+      ctx.globalAlpha = 0.9;
       ctx.strokeStyle = this._options.lvnColor;
-      ctx.setLineDash([4, 4]);
-      for (const y of view.lvnYs) {
+      ctx.setLineDash([10, 5]);
+      ctx.textAlign = "right";
+      ctx.textBaseline = "middle";
+      for (const l of view.lvn) {
         ctx.beginPath();
-        ctx.moveTo(0, y);
-        ctx.lineTo(right, y);
+        ctx.moveTo(0, l.y);
+        ctx.lineTo(right, l.y);
         ctx.stroke();
+        ctx.fillStyle = this._options.lvnColor;
+        ctx.fillText(`LVN ${l.price.toFixed(2)}`, right - width - 6, l.y);
       }
       ctx.setLineDash([]);
+      ctx.textAlign = "left";
 
       for (const r of view.rows) {
         const h = Math.max(1, r.yBottom - r.yTop - 0.5); // hairline gap between rows
@@ -317,9 +324,9 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
           (z.touches > 1 ? ` ×${z.touches}` : ""),
       });
     }
-    const lvnYs = this._lvn.flatMap((price) => {
+    const lvn = this._lvn.flatMap((price) => {
       const y = series.priceToCoordinate(price);
-      return y == null ? [] : [y];
+      return y == null ? [] : [{ y, price }];
     });
 
     this._view = {
@@ -327,7 +334,7 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
       pocY: series.priceToCoordinate(p.pocPrice),
       pocPrice: p.pocPrice,
       zones,
-      lvnYs,
+      lvn,
     };
   }
 

--- a/web/lib/lwc/volumeProfile.ts
+++ b/web/lib/lwc/volumeProfile.ts
@@ -1,12 +1,17 @@
 /**
- * Visible-range volume profile (VRVP) drawn against the right edge of the price
- * pane — horizontal bars growing leftward, buy volume hugging the axis, sell
- * volume stacked outside it. Same attach/paneViews lifecycle as
- * lib/lwc/chanlunZhongshu.ts; the binning math lives in lib/volumeProfile.ts.
+ * Volume profile drawn against the right edge of the price pane — horizontal
+ * bars growing leftward, buy volume hugging the axis, sell volume stacked
+ * outside it. Same attach/paneViews lifecycle as lib/lwc/chanlunZhongshu.ts;
+ * the binning math lives in lib/volumeProfile.ts.
  *
- * The profile is recomputed from the visible time range on every view update
- * (that's what makes it "visible range"), memoized on the range so crosshair
- * moves don't re-bin.
+ * FIXED window (the most recent `lookback` bars), NOT the visible range. This
+ * shipped as visible-range first and that was wrong: panning between ~150 and
+ * ~600 visible bars moves the POC by a median of 11.6 ATR, so the levels were
+ * substantially a function of the viewport. 360 sessions is the measured
+ * compromise — long enough that the histogram is steady, short enough that the
+ * levels stay within ~10–20% of spot instead of anchoring to prices the market
+ * has left behind (a 5-year window puts the POC 35–92% below spot).
+ * Study: docs/research/2026-07-20-volume-profile-window-study.md
  */
 import { CanvasRenderingTarget2D } from "fancy-canvas";
 import type {
@@ -53,6 +58,8 @@ export interface VolumeProfileOptions {
   labelColor?: string;
   bins?: number;
   valuePct?: number;
+  /** Sessions the profile covers, counted back from the newest bar. */
+  lookback?: number;
   /** Profile width as a fraction of pane width, clamped by min/max px. */
   widthFrac?: number;
   minWidthPx?: number;
@@ -72,6 +79,7 @@ const defaults: Required<Omit<VolumeProfileOptions, "onStats">> = {
   labelColor: "rgba(240, 240, 245, 0.95)",
   bins: 60,
   valuePct: 70,
+  lookback: 360,
   widthFrac: 0.22,
   minWidthPx: 70,
   maxWidthPx: 240,
@@ -243,25 +251,23 @@ class VolumeProfilePaneView implements IPrimitivePaneView {
   constructor(private _source: VolumeProfileIndicator) {}
 
   update() {
-    const chart = this._source.chartApi();
     const series = this._source.seriesApi();
     this._view = null;
-    if (!chart || !series) return;
-    const visible = chart.timeScale().getVisibleRange();
-    if (!visible) return;
+    if (!series) return;
 
-    const from = String(visible.from);
-    const to = String(visible.to);
-    const key = `${from}|${to}|${this._source._bars.length}`;
-    // Re-bin only when the window actually moved: updateAllViews() also fires
-    // on every crosshair move, and the stats callback must not re-fire with it.
+    const opts = this._source._options;
+    const all = this._source._bars;
+    // The most recent `lookback` sessions — independent of scroll and zoom, so
+    // panning can no longer move the levels.
+    const slice = all.length > opts.lookback ? all.slice(-opts.lookback) : all;
+    const key = slice.length
+      ? `${slice.length}|${String(slice[0].time)}|${String(slice[slice.length - 1].time)}`
+      : "empty";
+    // Re-bin only when the underlying bars actually changed: updateAllViews()
+    // fires on every crosshair move and every pan, and the stats callback must
+    // not re-fire with them.
     if (key !== this._cacheKey) {
       this._cacheKey = key;
-      const slice = this._source._bars.filter((b) => {
-        const t = String(b.time);
-        return t >= from && t <= to;
-      });
-      const opts = this._source._options;
       this._profile = computeVolumeProfile(slice, opts.bins, opts.valuePct);
       const last = slice[slice.length - 1];
       if (this._profile && last) {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6742,6 +6742,10 @@ export interface components {
             fast_macd_hist_atr?: number | null;
             /** Slow Macd Hist Atr */
             slow_macd_hist_atr?: number | null;
+            /** Fast Macd Line Atr */
+            fast_macd_line_atr?: number | null;
+            /** Fast Macd Signal Atr */
+            fast_macd_signal_atr?: number | null;
         };
         /**
          * TechnicalsVwapAnchor

--- a/web/lib/volumeProfile.ts
+++ b/web/lib/volumeProfile.ts
@@ -104,3 +104,161 @@ export function computeVolumeProfile(
     maxBinVolume: total[pocIdx],
   };
 }
+
+const binTotal = (b: VpBin) => b.buy + b.sell;
+const binMid = (b: VpBin) => (b.low + b.high) / 2;
+
+/** Bars only need a range to be tested for retests. */
+export type RangeBar = { high: number; low: number };
+
+/**
+ * Distinct retests of a band: every time price re-enters it from outside.
+ * A bar that stays inside across several sessions counts once.
+ */
+export function countRetests(
+  bars: readonly RangeBar[],
+  price: number,
+  halfWidth: number,
+): number {
+  let count = 0;
+  let wasInside = false;
+  for (const b of bars) {
+    const inside = b.high >= price - halfWidth && b.low <= price + halfWidth;
+    if (inside && !wasInside) count += 1;
+    wasInside = inside;
+  }
+  return count;
+}
+
+export type SrZone = {
+  price: number; // band centre
+  halfWidth: number;
+  side: "support" | "resistance"; // relative to the reference price
+  strength: number; // 0–100, share of the POC bin's volume
+  touches: number;
+};
+
+export type SrZoneOptions = {
+  maxPeaks?: number; // volume peaks to test before giving up
+  maxPerSide?: number;
+  minStrengthPct?: number; // floor as a % of POC volume
+  minGapBins?: number; // minimum separation between kept zones
+  widthMult?: number; // band thickness as a multiple of a bin
+};
+
+/**
+ * High-volume nodes as support/resistance bands: repeatedly take the richest
+ * remaining bin, blank its neighbourhood so the next pick is a distinct shelf,
+ * and keep it if it clears the strength floor and the per-side cap.
+ *
+ * ponytail: greedy peak-picking, not a clustering algorithm. Volume profiles
+ * are already smoothed by binning — the upgrade path is more bins, not k-means.
+ */
+export function findSrZones(
+  profile: VolumeProfile,
+  bars: readonly RangeBar[],
+  refPrice: number,
+  opts: SrZoneOptions = {},
+): SrZone[] {
+  const {
+    maxPeaks = 16,
+    maxPerSide = 5,
+    minStrengthPct = 45,
+    widthMult = 0.6,
+  } = opts;
+
+  const bins = profile.bins;
+  if (bins.length === 0 || !(profile.maxBinVolume > 0)) return [];
+  // Separation scales with resolution — a fixed bin count would blank a third
+  // of a coarse profile per pick and only ever surface one shelf. ~9% of the
+  // profile, matching the Pine original's 10-of-110 ratio.
+  const minGapBins =
+    opts.minGapBins ?? Math.max(2, Math.round(bins.length / 11));
+  const binSize = bins[0].high - bins[0].low;
+  const halfWidth = (binSize * widthMult) / 2;
+  // Never let two bands overlap: the gap floor is the band thickness itself.
+  const gapDist = Math.max(minGapBins * binSize, halfWidth * 2);
+  const sepBins = Math.max(1, Math.round(gapDist / binSize));
+
+  const remaining = bins.map(binTotal);
+  const floor = (profile.maxBinVolume * minStrengthPct) / 100;
+  const zones: SrZone[] = [];
+  let supports = 0;
+  let resistances = 0;
+
+  for (let attempt = 0; attempt < maxPeaks; attempt += 1) {
+    if (supports >= maxPerSide && resistances >= maxPerSide) break;
+    let peak = 0;
+    for (let i = 1; i < remaining.length; i += 1) {
+      if (remaining[i] > remaining[peak]) peak = i;
+    }
+    const vol = remaining[peak];
+    if (vol < floor) break;
+
+    const price = binMid(bins[peak]);
+    for (
+      let i = Math.max(0, peak - sepBins);
+      i <= Math.min(bins.length - 1, peak + sepBins);
+      i += 1
+    ) {
+      remaining[i] = -1;
+    }
+
+    const tooClose = zones.some((z) => Math.abs(z.price - price) < gapDist);
+    const side = price < refPrice ? "support" : "resistance";
+    const sideFull =
+      side === "support" ? supports >= maxPerSide : resistances >= maxPerSide;
+    if (tooClose || sideFull) continue;
+
+    zones.push({
+      price,
+      halfWidth,
+      side,
+      strength: Math.round((vol / profile.maxBinVolume) * 100),
+      touches: countRetests(bars, price, halfWidth),
+    });
+    if (side === "support") supports += 1;
+    else resistances += 1;
+  }
+  return zones;
+}
+
+/**
+ * Low-volume nodes: thin shelves price tends to travel through rather than sit
+ * in. Local minima under `maxPct` of the POC, walking outward from the
+ * reference price so the nearest ones come first.
+ */
+export function findLvnLevels(
+  profile: VolumeProfile,
+  refPrice: number,
+  opts: { maxPct?: number; floorPct?: number; maxCount?: number } = {},
+): number[] {
+  const { maxPct = 25, floorPct = 3, maxCount = 5 } = opts;
+  const bins = profile.bins;
+  if (bins.length < 3 || !(profile.maxBinVolume > 0)) return [];
+  const ceiling = (profile.maxBinVolume * maxPct) / 100;
+  const floor = (profile.maxBinVolume * floorPct) / 100;
+
+  const isLvn = (i: number) => {
+    if (i <= 0 || i >= bins.length - 1) return false;
+    const v = binTotal(bins[i]);
+    return (
+      v < ceiling &&
+      v > floor &&
+      v <= binTotal(bins[i - 1]) &&
+      v <= binTotal(bins[i + 1])
+    );
+  };
+
+  // Bin holding refPrice; -1 means the price is above the whole profile.
+  const hit = bins.findIndex((b) => b.high > refPrice);
+  const start = hit === -1 ? bins.length - 1 : hit;
+  const found: number[] = [];
+  for (let d = 1; d < bins.length && found.length < maxCount; d += 1) {
+    if (isLvn(start - d)) found.push(binMid(bins[start - d]));
+    if (found.length < maxCount && isLvn(start + d)) {
+      found.push(binMid(bins[start + d]));
+    }
+  }
+  return found;
+}

--- a/web/lib/volumeProfile.ts
+++ b/web/lib/volumeProfile.ts
@@ -1,0 +1,106 @@
+/**
+ * Visible-range volume profile (VRVP) — pure geometry, no canvas.
+ *
+ * Each bar's volume is spread evenly across the price bins its H/L range
+ * touches, split buy (close >= open) vs sell. Yields the POC (highest-volume
+ * bin) and the value area: bins expanded outward from the POC, always taking
+ * the richer neighbour, until they hold `valuePct` of total volume.
+ *
+ * ponytail: even spread across the bar's range, not a per-tick distribution —
+ * we only have daily OHLCV. Upgrade path is intraday bars, not a smarter model.
+ */
+
+export type VpBar = {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+};
+
+export type VpBin = {
+  low: number; // bin price bounds
+  high: number;
+  buy: number;
+  sell: number;
+};
+
+export type VolumeProfile = {
+  bins: VpBin[]; // ascending price, contiguous, always `binCount` long
+  pocIdx: number;
+  valIdx: number; // value-area lower bin (inclusive)
+  vahIdx: number; // value-area upper bin (inclusive)
+  pocPrice: number; // mid price of the POC bin
+  maxBinVolume: number; // buy+sell of the POC bin — the bar-length denominator
+};
+
+export function computeVolumeProfile(
+  bars: readonly VpBar[],
+  binCount = 60,
+  valuePct = 70,
+): VolumeProfile | null {
+  if (bars.length < 2 || binCount < 2) return null;
+
+  let hi = -Infinity;
+  let lo = Infinity;
+  for (const b of bars) {
+    if (b.high > hi) hi = b.high;
+    if (b.low < lo) lo = b.low;
+  }
+  const binSize = (hi - lo) / binCount;
+  if (!(binSize > 0) || !Number.isFinite(binSize)) return null;
+
+  const buy = new Array<number>(binCount).fill(0);
+  const sell = new Array<number>(binCount).fill(0);
+  const clampBin = (p: number) =>
+    Math.max(0, Math.min(binCount - 1, Math.floor((p - lo) / binSize)));
+
+  for (const b of bars) {
+    if (!(b.volume > 0)) continue;
+    const loBin = clampBin(b.low);
+    const hiBin = clampBin(b.high);
+    const share = b.volume / (hiBin - loBin + 1);
+    const target = b.close >= b.open ? buy : sell;
+    for (let i = loBin; i <= hiBin; i += 1) target[i] += share;
+  }
+
+  const total = buy.map((v, i) => v + sell[i]);
+  let pocIdx = 0;
+  for (let i = 1; i < binCount; i += 1) {
+    if (total[i] > total[pocIdx]) pocIdx = i;
+  }
+  const grandTotal = total.reduce((a, b) => a + b, 0);
+  if (!(grandTotal > 0)) return null;
+
+  // Value area: walk outward from the POC, always absorbing the richer side.
+  const target = (grandTotal * valuePct) / 100;
+  let valIdx = pocIdx;
+  let vahIdx = pocIdx;
+  let acc = total[pocIdx];
+  while (acc < target && (valIdx > 0 || vahIdx < binCount - 1)) {
+    const up = vahIdx < binCount - 1 ? total[vahIdx + 1] : -1;
+    const dn = valIdx > 0 ? total[valIdx - 1] : -1;
+    if (up < 0 && dn < 0) break;
+    if (up >= dn) {
+      vahIdx += 1;
+      acc += up;
+    } else {
+      valIdx -= 1;
+      acc += dn;
+    }
+  }
+
+  return {
+    bins: Array.from({ length: binCount }, (_, i) => ({
+      low: lo + i * binSize,
+      high: lo + (i + 1) * binSize,
+      buy: buy[i],
+      sell: sell[i],
+    })),
+    pocIdx,
+    valIdx,
+    vahIdx,
+    pocPrice: lo + (pocIdx + 0.5) * binSize,
+    maxBinVolume: total[pocIdx],
+  };
+}

--- a/web/tests/lib/fvg.test.ts
+++ b/web/tests/lib/fvg.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { findFairValueGaps, type FvgBar } from "@/lib/fvg";
+import { SPY_BARS } from "../unit/fixtures/spyBars";
+
+const bar = (time: string, low: number, high: number): FvgBar => ({
+  time,
+  low,
+  high,
+});
+
+describe("findFairValueGaps", () => {
+  it("finds a bullish gap and reports the untraded band", () => {
+    const gaps = findFairValueGaps([
+      bar("d1", 10, 11),
+      bar("d2", 11, 15),
+      bar("d3", 13, 16), // low 13 > d1 high 11 → gap 11..13
+    ]);
+    expect(gaps).toEqual([{ time: "d2", top: 13, bottom: 11, bullish: true }]);
+  });
+
+  it("finds a bearish gap", () => {
+    const gaps = findFairValueGaps([
+      bar("d1", 20, 21),
+      bar("d2", 15, 20),
+      bar("d3", 14, 17), // high 17 < d1 low 20 → gap 17..20
+    ]);
+    expect(gaps).toEqual([{ time: "d2", top: 20, bottom: 17, bullish: false }]);
+  });
+
+  it("drops a gap once a later bar trades back into it", () => {
+    const withFill = [
+      bar("d1", 10, 11),
+      bar("d2", 11, 15),
+      bar("d3", 13, 16),
+      bar("d4", 11.5, 14), // dips to 11.5, inside the 11..13 band
+    ];
+    expect(findFairValueGaps(withFill)).toEqual([]);
+    // ...but a bar that stops short of the band leaves it open.
+    const noFill = [...withFill.slice(0, 3), bar("d4", 13.5, 16)];
+    expect(findFairValueGaps(noFill)).toHaveLength(1);
+  });
+
+  it("returns oldest first and honours maxCount by keeping the newest", () => {
+    const seq: FvgBar[] = [];
+    // Staircase up: every middle bar leaves an unfilled bullish gap.
+    // Zero-padded: "d10" sorts before "d2" as a string otherwise.
+    for (let i = 0; i < 12; i += 1) {
+      seq.push(bar(`d${String(i).padStart(2, "0")}`, 10 + i * 10, 12 + i * 10));
+    }
+    const all = findFairValueGaps(seq, 100);
+    expect(all.length).toBeGreaterThan(3);
+    for (let i = 1; i < all.length; i += 1) {
+      expect(all[i].time > all[i - 1].time).toBe(true);
+    }
+    const capped = findFairValueGaps(seq, 3);
+    expect(capped).toHaveLength(3);
+    expect(capped).toEqual(all.slice(-3));
+  });
+
+  it("needs three bars", () => {
+    expect(findFairValueGaps([bar("d1", 1, 2), bar("d2", 5, 6)])).toEqual([]);
+  });
+
+  it("returns only unfilled gaps on real SPY bars", () => {
+    const spy: FvgBar[] = SPY_BARS.map((b) => ({
+      time: b.as_of,
+      high: b.high,
+      low: b.low,
+    }));
+    const gaps = findFairValueGaps(spy, 20);
+    for (const g of gaps) {
+      expect(g.top).toBeGreaterThan(g.bottom);
+      const after = spy.slice(spy.findIndex((b) => b.time === g.time) + 2);
+      for (const b of after) {
+        const reentered = b.low < g.top && b.high > g.bottom;
+        expect(reentered, `gap at ${g.time} was filled on ${b.time}`).toBe(
+          false,
+        );
+      }
+    }
+  });
+});

--- a/web/tests/lib/volumeProfile.test.ts
+++ b/web/tests/lib/volumeProfile.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { computeVolumeProfile, type VpBar } from "@/lib/volumeProfile";
+import {
+  computeVolumeProfile,
+  countRetests,
+  findLvnLevels,
+  findSrZones,
+  type VpBar,
+} from "@/lib/volumeProfile";
 import { SPY_BARS } from "../unit/fixtures/spyBars";
 
 const bars: VpBar[] = SPY_BARS.map((b) => ({
@@ -91,5 +97,95 @@ describe("computeVolumeProfile on real SPY daily bars", () => {
       ),
       "no volume anywhere",
     ).toBeNull();
+  });
+});
+
+describe("countRetests", () => {
+  const band = (...ranges: [number, number][]) =>
+    ranges.map(([low, high]) => ({ low, high }));
+
+  it("counts one entry per excursion, not per bar inside", () => {
+    // in, in, out, in  →  two distinct entries
+    const bars = band([99, 101], [99, 101], [90, 92], [99, 101]);
+    expect(countRetests(bars, 100, 1)).toBe(2);
+  });
+
+  it("counts nothing when price never reaches the band", () => {
+    expect(countRetests(band([90, 92], [88, 91]), 100, 1)).toBe(0);
+  });
+
+  it("counts a bar that straddles the band", () => {
+    expect(countRetests(band([80, 120]), 100, 1)).toBe(1);
+  });
+});
+
+describe("findSrZones on real SPY daily bars", () => {
+  const profile = computeVolumeProfile(bars, 60, 70)!;
+  const refPrice = bars[bars.length - 1].close;
+  const zones = findSrZones(profile, bars, refPrice);
+
+  it("classifies side by the reference price", () => {
+    for (const z of zones) {
+      if (z.side === "support") expect(z.price).toBeLessThan(refPrice);
+      else expect(z.price).toBeGreaterThanOrEqual(refPrice);
+    }
+  });
+
+  it("respects the per-side cap", () => {
+    const caps = findSrZones(profile, bars, refPrice, { maxPerSide: 2 });
+    expect(caps.filter((z) => z.side === "support").length).toBeLessThanOrEqual(
+      2,
+    );
+    expect(
+      caps.filter((z) => z.side === "resistance").length,
+    ).toBeLessThanOrEqual(2);
+  });
+
+  it("never returns overlapping bands", () => {
+    const sorted = [...zones].sort((a, b) => a.price - b.price);
+    for (let i = 1; i < sorted.length; i += 1) {
+      const gap = sorted[i].price - sorted[i - 1].price;
+      const thickness = sorted[i].halfWidth + sorted[i - 1].halfWidth;
+      expect(gap, `zones ${i - 1}/${i} overlap`).toBeGreaterThan(thickness);
+    }
+  });
+
+  it("honours the strength floor and reports strength as % of POC", () => {
+    for (const z of zones) {
+      expect(z.strength).toBeGreaterThanOrEqual(45);
+      expect(z.strength).toBeLessThanOrEqual(100);
+    }
+    const strict = findSrZones(profile, bars, refPrice, {
+      minStrengthPct: 95,
+    });
+    expect(strict.length).toBeLessThanOrEqual(zones.length);
+  });
+
+  it("counts at least one retest per zone — a shelf is where price sat", () => {
+    for (const z of zones) expect(z.touches).toBeGreaterThan(0);
+  });
+
+  it("is deterministic", () => {
+    expect(findSrZones(profile, bars, refPrice)).toEqual(zones);
+  });
+});
+
+describe("findLvnLevels", () => {
+  const profile = computeVolumeProfile(bars, 60, 70)!;
+
+  it("returns only thin bins, capped and inside the range", () => {
+    const lvns = findLvnLevels(profile, bars[bars.length - 1].close);
+    expect(lvns.length).toBeLessThanOrEqual(5);
+    for (const price of lvns) {
+      const bin = profile.bins.find((b) => b.low <= price && price <= b.high)!;
+      expect(bin.buy + bin.sell).toBeLessThan(profile.maxBinVolume * 0.25);
+      expect(price).toBeGreaterThanOrEqual(profile.bins[0].low);
+      expect(price).toBeLessThanOrEqual(profile.bins[59].high);
+    }
+  });
+
+  it("does not blow up when the reference price is off the profile", () => {
+    expect(() => findLvnLevels(profile, 1e9)).not.toThrow();
+    expect(() => findLvnLevels(profile, 0)).not.toThrow();
   });
 });

--- a/web/tests/lib/volumeProfile.test.ts
+++ b/web/tests/lib/volumeProfile.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { computeVolumeProfile, type VpBar } from "@/lib/volumeProfile";
+import { SPY_BARS } from "../unit/fixtures/spyBars";
+
+const bars: VpBar[] = SPY_BARS.map((b) => ({
+  open: b.open,
+  high: b.high,
+  low: b.low,
+  close: b.close,
+  volume: b.volume,
+}));
+
+describe("computeVolumeProfile on real SPY daily bars", () => {
+  const p = computeVolumeProfile(bars, 60, 70)!;
+
+  it("returns a profile", () => {
+    expect(p).not.toBeNull();
+    expect(p.bins).toHaveLength(60);
+  });
+
+  it("bins tile the full high/low range contiguously and ascending", () => {
+    const hi = Math.max(...bars.map((b) => b.high));
+    const lo = Math.min(...bars.map((b) => b.low));
+    expect(p.bins[0].low).toBeCloseTo(lo, 6);
+    expect(p.bins[59].high).toBeCloseTo(hi, 6);
+    for (let i = 1; i < p.bins.length; i += 1) {
+      expect(p.bins[i].low, `bin ${i} starts where ${i - 1} ends`).toBeCloseTo(
+        p.bins[i - 1].high,
+        6,
+      );
+    }
+  });
+
+  it("conserves total volume across the bins", () => {
+    const total = p.bins.reduce((a, b) => a + b.buy + b.sell, 0);
+    const expected = bars.reduce((a, b) => a + b.volume, 0);
+    expect(total).toBeCloseTo(expected, 0);
+  });
+
+  it("POC is the richest bin and its price sits inside it", () => {
+    const vol = (i: number) => p.bins[i].buy + p.bins[i].sell;
+    for (let i = 0; i < p.bins.length; i += 1) {
+      expect(vol(i)).toBeLessThanOrEqual(vol(p.pocIdx));
+    }
+    expect(p.maxBinVolume).toBeCloseTo(vol(p.pocIdx), 6);
+    expect(p.pocPrice).toBeGreaterThan(p.bins[p.pocIdx].low);
+    expect(p.pocPrice).toBeLessThan(p.bins[p.pocIdx].high);
+  });
+
+  it("value area brackets the POC and holds >= 70% of volume", () => {
+    expect(p.valIdx).toBeLessThanOrEqual(p.pocIdx);
+    expect(p.vahIdx).toBeGreaterThanOrEqual(p.pocIdx);
+    const total = p.bins.reduce((a, b) => a + b.buy + b.sell, 0);
+    const inVa = p.bins
+      .slice(p.valIdx, p.vahIdx + 1)
+      .reduce((a, b) => a + b.buy + b.sell, 0);
+    expect(inVa / total).toBeGreaterThanOrEqual(0.7);
+    // ...and it is minimal: dropping either edge falls below the target.
+    const withoutEdge =
+      inVa -
+      Math.min(
+        p.bins[p.valIdx].buy + p.bins[p.valIdx].sell,
+        p.bins[p.vahIdx].buy + p.bins[p.vahIdx].sell,
+      );
+    expect(withoutEdge / total).toBeLessThan(0.7);
+  });
+
+  it("splits buy/sell by the bar's own close vs open", () => {
+    const upVol = bars
+      .filter((b) => b.close >= b.open)
+      .reduce((a, b) => a + b.volume, 0);
+    expect(p.bins.reduce((a, b) => a + b.buy, 0)).toBeCloseTo(upVol, 0);
+  });
+
+  it("is deterministic", () => {
+    expect(computeVolumeProfile(bars, 60, 70)).toEqual(p);
+  });
+
+  it("returns null on degenerate input", () => {
+    expect(computeVolumeProfile([], 60)).toBeNull();
+    expect(computeVolumeProfile(bars.slice(0, 1), 60)).toBeNull();
+    const flat = [
+      { open: 5, high: 5, low: 5, close: 5, volume: 100 },
+      { open: 5, high: 5, low: 5, close: 5, volume: 100 },
+    ];
+    expect(computeVolumeProfile(flat, 60), "zero-width range").toBeNull();
+    expect(
+      computeVolumeProfile(
+        bars.map((b) => ({ ...b, volume: 0 })),
+        60,
+      ),
+      "no volume anywhere",
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Five commits across the Technicals price chart. Ported a Pine Script VRVP
indicator, then measured it and cut the half that didn't survive.

## Volume profile (`VP` toggle, candle-mode only)

Horizontal volume-per-price-bin bars against the right edge: buy volume
(bars that closed up) hugging the axis, sell volume stacked outside,
value-area bins (70%) at full opacity with an amber POC line. Each bar
spreads its volume evenly across its own high–low — daily OHLCV is all we
have, so this is where-it-traded context, not an order book.

Compute is pure and unit-tested (`web/lib/volumeProfile.ts` — volume
conservation, contiguous bins, minimal value area, determinism, against the
frozen real SPY fixture); painting is a lightweight-charts primitive in the
mold of `chanlunZhongshu.ts`, in the **background** layer so it never
buries the newest candles.

Plus an S/R matrix from the high-volume nodes, labelled LVN levels, a
stats readout, and fair value gaps behind a separate `FVG` toggle.

## The window study — and what it killed

Shipped as true VRVP first. That was wrong: panning between ~150 and ~600
visible bars moved the POC by a median of **11.6 ATR** across six names,
so the levels were substantially a function of the viewport.

Now a fixed 360-session window fed from the unwindowed series, so pan,
zoom and the 3M/1Y/FULL selector all leave the levels untouched. 360 is
measured, not inherited from the Pine default: stability keeps improving
out to 5 years, but by then the POC sits 35–92% below spot (NVDA −91.9%)
— steady because it describes a market that no longer exists.

**The BUY/SELL marks are removed**, before they ever shipped in a release.
They redrew 21% of mark history per day and essentially all of it on the
worst 10% of days, and the levels underneath carry no measured edge —
resistance was correct in 2–3 of 6 names at *every* window tested, and
support's apparent edge did not survive a distance-matched placebo. An
arrow labelled BUY that moves tomorrow and predicts nothing implies a
signal the data does not support.

Study: `docs/research/2026-07-20-volume-profile-window-study.md`.
Reproduce: `npx tsx scripts/research/volume_profile_window_study.mts`.
It imports the shipped compute, not a re-implementation, so the numbers
describe what the chart actually draws. The doc includes a note on how I
misread my own efficacy table twice before extending the window grid
settled it.

## Fast MACD + signal lines

The dual-MACD pane drew only histograms — how wide the gap was, never
where the crossing sat relative to zero. `macd_hist()` computed both lines
and discarded them; split `macd_lines()` out and emit the fast pair
ATR-normalized onto the same scale. The histogram is exactly their
difference, asserted in `test_dual_macd`. Slow pair stays histogram-only.

## Deploy note

`fast_macd_line_atr` / `fast_macd_signal_atr` are absent from already-stored
`technical_daily` metrics JSONB. Untouched tickers render exactly as before
(verified — histograms only, no errors), but **the lines need a technicals
recompute to appear.**

The recompute is automatic: `technical_daily_refresh` (cron `40 18 * * 0-4`
ET, massive-0, enabled by default and not overridden on the mini) rebuilds
the *full* series per ticker and rewrites every row's metrics JSONB, so the
first nightly run after deploy backfills all 106 tickers. Verified the job
is healthy on the mini — last write 18:40 ET Fri 2026-07-17, on schedule.

I could not exercise that path locally: apex answers 200 on the mini but
502 over Tailscale, which is the route MacBook dev uses. The render was
therefore verified against a local recompute sourcing bars from the warm
store instead of apex — same compute and persistence chain, only the bar
source swapped.

## Verification

1448 python unit tests, 619 vitest, typecheck, ESLint, openapi snapshot,
version_sync_check. Chart verified via Playwright: POC identical (677.19)
across zoom, pan and every timeframe; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

