### PR TITLE
fix(tests): contain dotenv leakage across the test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 - **`vrp_macro_drawdown` reads its lake root from `Settings`** instead of a bare
   `os.environ` lookup with a home-dir fallback, consolidating path defaults into
   `config.py`.
+- **Test isolation: dotenv no longer leaks across tests.**
+  `Settings.from_env()` writes `.env`/`.env.local` keys into `os.environ` with a
+  raw assignment (not `monkeypatch`), so the first test to call it leaked a
+  developer's local dotenv into every later test — e.g. a `.env` pointing
+  `XENON_QUERY_API_URL` at the mini made `test_settings_option_surface` pass in
+  isolation but fail in a full local run. An autouse `tests/conftest.py` fixture
+  now snapshots and restores `os.environ` per test. CI was never affected (no
+  `.env` in CI).
 
 ### Added
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,37 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 
 def pytest_configure() -> None:
     # Local safety default: integration fixtures still point at an isolated DB,
     # but developers do not need to prefix every pytest command.
     os.environ.setdefault("UW_SCAN_TEST_DB_NAME", "option_wizard_test")
+
+
+@pytest.fixture(autouse=True)
+def _restore_os_environ():
+    """Confine os.environ mutations to the test that made them.
+
+    Settings.from_env() calls _load_dotenv, which copies every key from the repo
+    .env / .env.local into os.environ with a *raw* assignment (for keys not
+    already set) — not via monkeypatch, so nothing reverts it. The first test to
+    call bare from_env() therefore leaks the developer's local dotenv into every
+    later test. On a machine whose .env points XENON_QUERY_API_URL at the mini
+    (http://100.66.147.98:8321), that leak makes test_settings_option_surface —
+    which asserts the *default* url — pass in isolation but fail after any leaker
+    runs. CI has no .env, so it never sees this: a purely local false negative.
+
+    Snapshot/restore per test contains any such raw write to its origin.
+    monkeypatch already reverts its own changes; this only adds coverage for the
+    os.environ writes monkeypatch does not manage. Keys set before the first test
+    (e.g. UW_SCAN_TEST_DB_NAME in pytest_configure) are in every snapshot and so
+    are preserved, not stripped.
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(snapshot)

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -1,0 +1,27 @@
+"""Regression: raw os.environ writes must not leak across tests.
+
+Settings.from_env() → _load_dotenv writes dotenv keys straight into os.environ
+(not via monkeypatch), which historically leaked a developer's local .env into
+later tests (see the _restore_os_environ fixture in tests/conftest.py). These
+two tests exercise that fixture directly: test_a plants a raw sentinel the way
+_load_dotenv would; test_b (which runs after it, definition order) asserts the
+fixture cleaned it up. Delete the fixture and test_b fails.
+"""
+
+from __future__ import annotations
+
+import os
+
+_SENTINEL = "ARGON_ENV_ISOLATION_SENTINEL"
+
+
+def test_a_plants_a_raw_env_var() -> None:
+    os.environ[_SENTINEL] = "leaked"  # raw write, exactly like _load_dotenv
+    assert os.environ[_SENTINEL] == "leaked"
+
+
+def test_b_does_not_see_the_leak() -> None:
+    assert _SENTINEL not in os.environ, (
+        "the autouse _restore_os_environ fixture in tests/conftest.py did not "
+        "clean up test_a's raw os.environ write"
+    )


### PR DESCRIPTION
## What

Follow-up to #293. Kills the class of test-isolation bug that made
`test_settings_option_surface` fail in a full local run.

`Settings.from_env()` calls `_load_dotenv`, which copies every key from the repo
`.env` / `.env.local` into `os.environ` with a **raw assignment** (only for keys
not already set) — *not* via `monkeypatch`, so nothing reverts it. The first
test to call bare `from_env()` therefore leaks the developer's local dotenv into
every later test for the rest of the process.

On a machine whose `.env` points `XENON_QUERY_API_URL` at the mini
(`http://100.66.147.98:8321`), that leak makes `test_settings_option_surface` —
which asserts the **default** url `http://127.0.0.1:8321` — pass in isolation but
fail once any leaker has run:

```
AssertionError: assert 'http://100.66.147.98:8321' == 'http://127.0.0.1:8321'
```

CI never saw it (no `.env` in CI) — a purely local false negative.

## Fix

An autouse fixture in the top-level `tests/conftest.py` snapshots `os.environ`
before each test and restores it after (`clear()` + `update(snapshot)` handles
added / changed / deleted keys). It lives at the top level, not `tests/unit/`,
because a full `uv run pytest` runs `tests/integration/` first and an
integration `from_env()` can be the leaker too.

`tests/unit/test_env_isolation.py` is the regression: `test_a` plants a raw
sentinel the way `_load_dotenv` does; `test_b` asserts it did not survive.
Remove the fixture and `test_b` fails.

## Verification

- Reproduced before: victim green alone, red after a leaker (`test_config_edge_quality_weights` → `test_settings_option_surface`).
- After: the leaker→victim pair passes; full **unit suite 1463 passed**.
- Regression test proven genuine: with the fixture removed, `test_b` fails.
- Integration compatibility: **410/410** real tests in `storage/` + `worker/` pass under `-n auto` with the fixture active. (The one `@pytest.mark.live` R2 test that skips normally is the pre-existing retired-R2 case — `skipif` is collection-time, this fixture is runtime, so it is mechanically unaffected.)

## Not in this PR (local-only)

The retired R2 credentials were also removed from the developer `.env`
(gitignored, so not part of the diff). R2's producer died 2026-05-21 and #293's
boot guard now refuses to start a worker that still carries `R2_*`.
