### PR TITLE
fix(reports): read explicit 1d.parquet for lake equity spot reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **QQQ/IWM macro short-vol signal no longer skips every run.**
+  `vrp_macro_drawdown._lake_spot` pointed pyarrow's directory-dataset reader
+  at the whole `symbol=<TICKER>` lake directory instead of the explicit
+  `1d.parquet` file. Sibling files in that directory (`1d.parquet.lock` and
+  the 30m/5m timeframe parquets + their own `.lock` markers) made pyarrow
+  choke on a zero-byte lock file with `ArrowInvalid`, silently starving
+  QQQ since 2026-06-24 and IWM since 2026-07-08 (SPX was unaffected — its
+  vol/spot both come from `vol_index_daily`, not this code path). Now reads
+  the explicit `1d.parquet`, matching the already-correct sibling pattern in
+  `_volatility_lake_close`.
+
 ## [0.10.11] — 2026-07-22
 
 

--- a/src/uw_scan/reports/vrp_macro_drawdown.py
+++ b/src/uw_scan/reports/vrp_macro_drawdown.py
@@ -92,10 +92,16 @@ def _vol_index_close(repo, symbol: str, start: _date) -> dict[_date, float]:
 def _lake_spot(
     symbol: str, lake_root: pathlib.Path, start: _date
 ) -> dict[_date, float]:
-    import pyarrow.dataset as ds
+    """Reads the explicit 1d.parquet — pointing pyarrow at the symbol
+    directory instead picks up sibling files (1d.parquet.lock, 30m/5m
+    parquet + their .lock markers) and breaks on the zero-byte lock file
+    (same class of bug as _volatility_lake_close below)."""
+    import pyarrow.parquet as pq
 
-    path = lake_root / "bronze" / "asset_class=equity" / f"symbol={symbol}"
-    table = ds.dataset(str(path)).to_table(columns=["trade_date", "close"])
+    path = (
+        lake_root / "bronze" / "asset_class=equity" / f"symbol={symbol}" / "1d.parquet"
+    )
+    table = pq.read_table(str(path), columns=["trade_date", "close"])
     dts = table.column("trade_date").to_pylist()
     cls = table.column("close").to_pylist()
     # SPY's lake parquet carries ~73% null-trade_date rows (an alternate-schema

--- a/tests/unit/reports/test_vrp_macro_drawdown.py
+++ b/tests/unit/reports/test_vrp_macro_drawdown.py
@@ -1,0 +1,40 @@
+"""Regression: _lake_spot must read the explicit 1d.parquet file, not the
+whole symbol directory — a sibling .lock marker (or 30m/5m parquet) in that
+directory breaks pyarrow's directory-dataset reader with a zero-byte-file
+ArrowInvalid, which is exactly what silently starved QQQ/IWM's macro
+short-vol signal for weeks (2026-07-22).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from uw_scan.reports.vrp_macro_drawdown import _lake_spot
+
+
+def test_lake_spot_ignores_lock_and_other_timeframe_files(tmp_path):
+    symbol_dir = tmp_path / "bronze" / "asset_class=equity" / "symbol=QQQ"
+    symbol_dir.mkdir(parents=True)
+
+    table = pa.table(
+        {
+            "trade_date": [date(2026, 7, 20), date(2026, 7, 21)],
+            "close": [500.0, 501.5],
+        }
+    )
+    pq.write_table(table, symbol_dir / "1d.parquet")
+
+    # Zero-byte lock marker + an unrelated-timeframe parquet, exactly like the
+    # real lake layout — must not be picked up by the reader.
+    (symbol_dir / "1d.parquet.lock").touch()
+    pq.write_table(
+        pa.table({"trade_date": [date(2026, 7, 21)], "close": [500.9]}),
+        symbol_dir / "30m.parquet",
+    )
+
+    result = _lake_spot("QQQ", tmp_path, date(2026, 7, 1))
+
+    assert result == {date(2026, 7, 20): 500.0, date(2026, 7, 21): 501.5}


### PR DESCRIPTION
## Summary
- `_lake_spot` (used by QQQ/IWM's macro short-vol signal via `vrp_macro_drawdown.py`) pointed pyarrow's directory-dataset reader at the whole `symbol=<TICKER>` lake directory instead of the explicit `1d.parquet` file.
- Sibling files in that directory (`1d.parquet.lock` and the 30m/5m timeframe parquets + their own `.lock` markers) made pyarrow choke on a zero-byte lock file with `ArrowInvalid`.
- This silently starved QQQ since 2026-06-24 and IWM since 2026-07-08 (confirmed via direct DB query — `vrp_macro_signal_daily` had 1 QQQ row total, 10 IWM rows, both stopped dead on those dates). SPX was unaffected — its vol/spot both come from `vol_index_daily`, not this code path.
- Fix: read the explicit `1d.parquet`, matching the already-correct sibling pattern already in place in `_volatility_lake_close` two functions below (which has a comment describing the identical class of bug for the volatility-lake path).

## Test plan
- [x] New regression test `tests/unit/reports/test_vrp_macro_drawdown.py` — writes a real parquet fixture plus a zero-byte `.lock` sibling and an unrelated-timeframe parquet, reproducing the exact lake layout; asserts `_lake_spot` reads correctly.
- [x] Verified the test fails against the pre-fix code with the exact production `ArrowInvalid` error, and passes with the fix.
- [x] Existing `tests/integration/reports/test_vrp_macro_drawdown.py` (SPX/VIX path) still passes — no regression to the unaffected path.