### PR TITLE
feat(technicals): replace SMA·σ price band with ATR band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
-## [0.10.13] — 2026-07-25
+### Changed
 
+- **Technicals price pane, SMA mode:** the `±1.5σ around SMA200` envelope is
+  replaced by a Keltner-style **ATR band** (`SMA20 ± 2·ATR14`, Wilder ATR
+  computed client-side from OHLC). The old band was a slow-moving cloud price
+  rarely interacted with; the ATR band tracks the tradable range. Toggle relabeled
+  `SMA·σ` → `SMA·ATR`. EMA·BB mode is unchanged.
+
+## [0.10.13] — 2026-07-25
 
 ### Added
 
@@ -22,14 +29,14 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   (`scripts/backfill/uw_alpha_catchup.py`) plus a one-shot runner
   (`scripts/backfill/uw_alpha_capture_once.py`). Migration 108. The four
   gex/volatility endpoints (`gex-levels`, `volatility/{anomaly,character,
-  variance-risk-premium}`) are real but were absent from the curated UW docs;
+variance-risk-premium}`) are real but were absent from the curated UW docs;
   their `?date=` as-of behaviour was verified empirically before wiring.
 - The event logs key each print on `(source, tracking_id, executed_at, price,
-  size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
+size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
   fills, so a `tracking_id`-only key silently collapsed ~95% of lit prints and
   ~7% of darkpool prints. `volume` (cumulative session volume) is the discriminator.
-## [0.10.12] — 2026-07-22
 
+## [0.10.12] — 2026-07-22
 
 ### Fixed
 
@@ -43,8 +50,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   vol/spot both come from `vol_index_daily`, not this code path). Now reads
   the explicit `1d.parquet`, matching the already-correct sibling pattern in
   `_volatility_lake_close`.
-## [0.10.11] — 2026-07-22
 
+## [0.10.11] — 2026-07-22
 
 ### Fixed
 
@@ -94,8 +101,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 - `REGIME_RECOVERY_LOOKBACK_DAYS` 7 → 30 (calendar days). A recovery window must
   exceed time-to-detect, not typical outage length.
-## [0.10.10] — 2026-07-20
 
+## [0.10.10] — 2026-07-20
 
 ### Added
 
@@ -162,6 +169,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   edge. An arrow labelled BUY that moves tomorrow and predicts nothing implies a
   signal the data does not support. The profile, POC, value area and zones stay
   as descriptive structure.
+
 ## [0.10.9] — 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   computed client-side from OHLC). The old band was a slow-moving cloud price
   rarely interacted with; the ATR band tracks the tradable range. Toggle relabeled
   `SMA·σ` → `SMA·ATR`. EMA·BB mode is unchanged.
+- **Price-band rendering now breaks on real data gaps** (`web/lib/lwc/bandsIndicator.ts`)
+  instead of drawing a straight line across a warm-up window or a bar with
+  missing OHLC — the custom canvas primitive previously connected every point
+  in its array unconditionally. Applies to both SMA·ATR and EMA·BB bands.
 
 ## [0.10.13] — 2026-07-25
-
 
 ### Added
 
@@ -30,14 +33,14 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   (`scripts/backfill/uw_alpha_catchup.py`) plus a one-shot runner
   (`scripts/backfill/uw_alpha_capture_once.py`). Migration 108. The four
   gex/volatility endpoints (`gex-levels`, `volatility/{anomaly,character,
-  variance-risk-premium}`) are real but were absent from the curated UW docs;
+variance-risk-premium}`) are real but were absent from the curated UW docs;
   their `?date=` as-of behaviour was verified empirically before wiring.
 - The event logs key each print on `(source, tracking_id, executed_at, price,
-  size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
+size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
   fills, so a `tracking_id`-only key silently collapsed ~95% of lit prints and
   ~7% of darkpool prints. `volume` (cumulative session volume) is the discriminator.
-## [0.10.12] — 2026-07-22
 
+## [0.10.12] — 2026-07-22
 
 ### Fixed
 
@@ -51,8 +54,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   vol/spot both come from `vol_index_daily`, not this code path). Now reads
   the explicit `1d.parquet`, matching the already-correct sibling pattern in
   `_volatility_lake_close`.
-## [0.10.11] — 2026-07-22
 
+## [0.10.11] — 2026-07-22
 
 ### Fixed
 
@@ -102,8 +105,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 - `REGIME_RECOVERY_LOOKBACK_DAYS` 7 → 30 (calendar days). A recovery window must
   exceed time-to-detect, not typical outage length.
-## [0.10.10] — 2026-07-20
 
+## [0.10.10] — 2026-07-20
 
 ### Added
 
@@ -170,6 +173,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   edge. An arrow labelled BUY that moves tomorrow and predicts nothing implies a
   signal the data does not support. The profile, POC, value area and zones stay
   as descriptive structure.
+
 ## [0.10.9] — 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [0.10.13] — 2026-07-25
 
+
 ### Added
 
 - **UW historical-alpha datasets** (`uw_gex_levels_daily`,
@@ -29,14 +30,14 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   (`scripts/backfill/uw_alpha_catchup.py`) plus a one-shot runner
   (`scripts/backfill/uw_alpha_capture_once.py`). Migration 108. The four
   gex/volatility endpoints (`gex-levels`, `volatility/{anomaly,character,
-variance-risk-premium}`) are real but were absent from the curated UW docs;
+  variance-risk-premium}`) are real but were absent from the curated UW docs;
   their `?date=` as-of behaviour was verified empirically before wiring.
 - The event logs key each print on `(source, tracking_id, executed_at, price,
-size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
+  size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
   fills, so a `tracking_id`-only key silently collapsed ~95% of lit prints and
   ~7% of darkpool prints. `volume` (cumulative session volume) is the discriminator.
-
 ## [0.10.12] — 2026-07-22
+
 
 ### Fixed
 
@@ -50,8 +51,8 @@ size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
   vol/spot both come from `vol_index_daily`, not this code path). Now reads
   the explicit `1d.parquet`, matching the already-correct sibling pattern in
   `_volatility_lake_close`.
-
 ## [0.10.11] — 2026-07-22
+
 
 ### Fixed
 
@@ -101,8 +102,8 @@ size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
 
 - `REGIME_RECOVERY_LOOKBACK_DAYS` 7 → 30 (calendar days). A recovery window must
   exceed time-to-detect, not typical outage length.
-
 ## [0.10.10] — 2026-07-20
+
 
 ### Added
 
@@ -169,7 +170,6 @@ size, volume)`: UW's `tracking_id` is an **order** id shared by distinct child
   edge. An arrow labelled BUY that moves tomorrow and predicts nothing implies a
   signal the data does not support. The profile, POC, value area and zones stay
   as descriptive structure.
-
 ## [0.10.9] — 2026-07-20
 
 ### Added

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -86,12 +86,19 @@ COUNTS="UW_SCAN_UW_WORKER_COUNT=2 UW_SCAN_MASSIVE_WORKER_COUNT=2 $AI_COUNTS"
 # remote xenon (e.g. the mini) via XENON_WS_URL in .env.local.
 WS="MASSIVE_WS_ENABLED=true XENON_WS_ENABLED=${XENON_WS_ENABLED:-true}"
 
+# Ports are overridable so a second stack can run beside an already-bound one
+# (e.g. WEB_PORT=3002 API_PORT=8402 bash scripts/dev.sh). The web process reaches
+# FastAPI through NEXT_INTERNAL_API_BASE, so it has to move with API_PORT.
+WEB_PORT="${WEB_PORT:-3001}"
+API_PORT="${API_PORT:-8400}"
+API_BASE="${NEXT_INTERNAL_API_BASE:-http://127.0.0.1:$API_PORT}"
+
 # Base stack (always): web, API, 2x uw, 2x massive.
 names=(next api uw-0 uw-1 massive-0 massive-1)
 colors=(cyan green yellow magenta blue white)
 cmds=(
-  "cd web && npx next dev --port 3001 --webpack"
-  "sleep 15 && $COUNTS $WS uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src"
+  "cd web && NEXT_INTERNAL_API_BASE=$API_BASE npx next dev --port $WEB_PORT --webpack"
+  "sleep 15 && $COUNTS $WS uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port $API_PORT --reload --reload-dir src"
   "sleep 20 && $COUNTS $WS UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"
   "sleep 22 && $COUNTS $WS UW_SCAN_WORKER_ROLE=uw UW_SCAN_WORKER_INDEX=1 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"
   "sleep 24 && $COUNTS $WS UW_SCAN_WORKER_ROLE=massive UW_SCAN_WORKER_INDEX=0 UW_SCAN_WORKER_COUNT=2 uv run python -m uw_scan.worker.scheduler"

--- a/web/components/stock/panels/TechnicalsPriceChart.tsx
+++ b/web/components/stock/panels/TechnicalsPriceChart.tsx
@@ -23,7 +23,7 @@ import { fmtDecimal } from "@/lib/formatters";
 import { anchoredVwap } from "@/lib/vwap";
 import {
   hasOhlcv,
-  toBandData,
+  toAtrBandData,
   toBollingerBandData,
   toCandleData,
   toCloseLineData,
@@ -843,7 +843,8 @@ export function TechnicalsPriceChart({
       h.mas.fast.setData(toSmaLineData(rows, "sma20"));
       h.mas.mid.setData(toSmaLineData(rows, "sma50"));
       h.mas.slow.setData(toSmaLineData(rows, "sma200"));
-      h.bands.setBandData(toBandData(rows));
+      // ATR needs a 14-bar warm-up, so compute on full history and cut.
+      h.bands.setBandData(cut(toAtrBandData(full)));
     } else {
       h.mas.fast.setData(cut(toEmaLineData(full, 5)));
       h.mas.mid.setData(cut(toEmaLineData(full, 20)));
@@ -1124,7 +1125,7 @@ export function TechnicalsPriceChart({
       >
         {(
           [
-            ["sma", "SMA·σ"],
+            ["sma", "SMA·ATR"],
             ["ema", "EMA·BB"],
           ] as const
         ).map(([m, label]) => (
@@ -1247,7 +1248,7 @@ export function TechnicalsPriceChart({
 
   const title =
     mode === "sma"
-      ? "Price, Moving Averages & ±1.5σ Band"
+      ? "Price, Moving Averages & ATR Band (SMA20 ±2·ATR14)"
       : "Price, EMAs & Bollinger Bands";
 
   if (rows.length < 2) {

--- a/web/lib/indicators.ts
+++ b/web/lib/indicators.ts
@@ -111,7 +111,8 @@ export function atr(
   period = 14,
 ): (number | null)[] {
   const out: (number | null)[] = new Array(closes.length).fill(null);
-  let seed: number[] = [];
+  let seedSum = 0;
+  let seedCount = 0;
   let prev: number | null = null;
   for (let i = 0; i < closes.length; i++) {
     const h = highs[i];
@@ -119,7 +120,8 @@ export function atr(
     const c = closes[i];
     const pc = closes[i - 1];
     if (!fin(h) || !fin(l) || !fin(c)) {
-      seed = [];
+      seedSum = 0;
+      seedCount = 0;
       prev = null;
       continue;
     }
@@ -127,9 +129,10 @@ export function atr(
       ? Math.max(h - l, Math.abs(h - pc), Math.abs(l - pc))
       : h - l;
     if (prev == null) {
-      seed.push(tr);
-      if (seed.length === period) {
-        prev = seed.reduce((a, b) => a + b, 0) / period;
+      seedSum += tr;
+      seedCount++;
+      if (seedCount === period) {
+        prev = seedSum / period;
         out[i] = prev;
       }
     } else {

--- a/web/lib/indicators.ts
+++ b/web/lib/indicators.ts
@@ -100,11 +100,49 @@ export function bollinger(
   return { upper, lower };
 }
 
+/** Wilder ATR: seeded with the SMA of the first `period` true ranges, then
+ * smoothed by ((prev·(n−1)) + tr)/n. A bar with missing H/L/C breaks the chain —
+ * output is null there and the seed restarts.
+ * ponytail: chain restart, not interpolation; a data hole should show as a gap. */
+export function atr(
+  highs: readonly (number | null | undefined)[],
+  lows: readonly (number | null | undefined)[],
+  closes: readonly (number | null | undefined)[],
+  period = 14,
+): (number | null)[] {
+  const out: (number | null)[] = new Array(closes.length).fill(null);
+  let seed: number[] = [];
+  let prev: number | null = null;
+  for (let i = 0; i < closes.length; i++) {
+    const h = highs[i];
+    const l = lows[i];
+    const c = closes[i];
+    const pc = closes[i - 1];
+    if (!fin(h) || !fin(l) || !fin(c)) {
+      seed = [];
+      prev = null;
+      continue;
+    }
+    const tr = fin(pc)
+      ? Math.max(h - l, Math.abs(h - pc), Math.abs(l - pc))
+      : h - l;
+    if (prev == null) {
+      seed.push(tr);
+      if (seed.length === period) {
+        prev = seed.reduce((a, b) => a + b, 0) / period;
+        out[i] = prev;
+      }
+    } else {
+      prev = (prev * (period - 1) + tr) / period;
+      out[i] = prev;
+    }
+  }
+  return out;
+}
+
 /** MarketSmith prevC coloring: up = close >= previous close; the first bar
  * (or a null prev close) falls back to close >= open; null close → null. */
-export function prevCloseUp(
-  rows: readonly IndicatorBar[],
-): (boolean | null)[] {
+export function prevCloseUp(rows: readonly IndicatorBar[]): (boolean | null)[] {
   return rows.map((r, i) => {
     if (!fin(r.close)) return null;
     const prev = i > 0 ? rows[i - 1].close : null;

--- a/web/lib/lwc/bandsIndicator.ts
+++ b/web/lib/lwc/bandsIndicator.ts
@@ -10,6 +10,10 @@
  * - Times converted to epoch seconds for the autoscale binary search
  *   (upstream assumed numeric times; ours are 'yyyy-mm-dd' strings).
  * - Empty-data guards added (upstream crashed on points[0]).
+ * - Gap-aware rendering: upstream always connected every point in the array.
+ *   A `BandPoint` with upper/lower omitted now breaks the polyline into a new
+ *   segment instead of drawing a straight line across a hole in the data
+ *   (warm-up, or a bar with missing OHLC) — see `contiguousValidRuns`.
  */
 import { CanvasRenderingTarget2D } from "fancy-canvas";
 import type {
@@ -26,11 +30,12 @@ import type {
   Time,
 } from "lightweight-charts";
 
-export interface BandPoint {
-  time: Time; // same representation as the attached series' data ('yyyy-mm-dd')
-  upper: number;
-  lower: number;
-}
+// A point with upper/lower omitted is a gap (mirrors lightweight-charts'
+// LineData | WhitespaceData convention) — it breaks the polyline instead of
+// connecting straight across a hole in the underlying data.
+export type BandPoint =
+  | { time: Time; upper: number; lower: number }
+  | { time: Time; upper?: undefined; lower?: undefined };
 
 export interface BandsIndicatorOptions {
   lineColor?: string;
@@ -105,7 +110,9 @@ interface UpperLowerData {
   lower: number;
 }
 
-class UpperLowerInRange<T extends UpperLowerData> {
+// Gap points (upper/lower undefined) are skipped, not treated as 0 — a gap
+// contributes nothing to the visible price range.
+class UpperLowerInRange<T extends { upper?: number; lower?: number }> {
   private _arr: T[];
   private _chunkSize: number;
   private _cache: Map<string, UpperLowerData>;
@@ -154,7 +161,11 @@ class UpperLowerInRange<T extends UpperLowerData> {
     return result;
   }
 
-  private _check(item: UpperLowerData, state: UpperLowerData) {
+  private _check(
+    item: { upper?: number; lower?: number },
+    state: UpperLowerData,
+  ) {
+    if (item.lower == null || item.upper == null) return;
     if (item.lower < state.lower) state.lower = item.lower;
     if (item.upper > state.upper) state.upper = item.upper;
   }
@@ -197,13 +208,36 @@ abstract class PluginBase implements ISeriesPrimitive<Time> {
 
 interface BandRendererData {
   x: Coordinate | number;
-  upper: Coordinate | number;
-  lower: Coordinate | number;
+  upper: Coordinate | number | null;
+  lower: Coordinate | number | null;
 }
 
 interface BandViewData {
   data: BandRendererData[];
   options: Required<BandsIndicatorOptions>;
+}
+
+// Maximal [start, end] index ranges (inclusive) where upper is non-null.
+// A run needs >= 2 points to draw a region; isolated single-point runs are
+// dropped by callers, same as the original whole-array `length < 2` guard.
+// Pulled out of drawBackground so the gap-segmentation logic is unit-testable
+// without a canvas.
+export function contiguousValidRuns(
+  points: readonly { upper: unknown }[],
+): Array<[number, number]> {
+  const runs: Array<[number, number]> = [];
+  let i = 0;
+  while (i < points.length) {
+    if (points[i].upper == null) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j + 1 < points.length && points[j + 1].upper != null) j++;
+    if (j > i) runs.push([i, j]);
+    i = j + 1;
+  }
+  return runs;
 }
 
 class BandsIndicatorPaneRenderer implements IPrimitivePaneRenderer {
@@ -214,7 +248,10 @@ class BandsIndicatorPaneRenderer implements IPrimitivePaneRenderer {
   draw() {}
   drawBackground(target: CanvasRenderingTarget2D) {
     const points: BandRendererData[] = this._viewData.data;
-    if (points.length < 2) return; // adaptation: upstream crashed on empty data
+    // A gap point (null upper/lower) breaks the polyline into segments
+    // instead of connecting straight across a hole in the underlying data.
+    const runs = contiguousValidRuns(points);
+    if (runs.length === 0) return; // adaptation: upstream crashed on empty data
     target.useBitmapCoordinateSpace((scope) => {
       const ctx = scope.context;
       ctx.scale(scope.horizontalPixelRatio, scope.verticalPixelRatio);
@@ -224,21 +261,24 @@ class BandsIndicatorPaneRenderer implements IPrimitivePaneRenderer {
       ctx.beginPath();
       const region = new Path2D();
       const lines = new Path2D();
-      region.moveTo(points[0].x, points[0].upper);
-      lines.moveTo(points[0].x, points[0].upper);
-      for (const point of points) {
-        region.lineTo(point.x, point.upper);
-        lines.lineTo(point.x, point.upper);
+      for (const [i, j] of runs) {
+        const upperAt = (k: number) => points[k].upper as number;
+        const lowerAt = (k: number) => points[k].lower as number;
+        region.moveTo(points[i].x, upperAt(i));
+        lines.moveTo(points[i].x, upperAt(i));
+        for (let k = i; k <= j; k++) {
+          region.lineTo(points[k].x, upperAt(k));
+          lines.lineTo(points[k].x, upperAt(k));
+        }
+        region.lineTo(points[j].x, lowerAt(j));
+        lines.moveTo(points[j].x, lowerAt(j));
+        for (let k = j - 1; k >= i; k--) {
+          region.lineTo(points[k].x, lowerAt(k));
+          lines.lineTo(points[k].x, lowerAt(k));
+        }
+        region.lineTo(points[i].x, upperAt(i));
+        region.closePath();
       }
-      const end = points.length - 1;
-      region.lineTo(points[end].x, points[end].lower);
-      lines.moveTo(points[end].x, points[end].lower);
-      for (let i = points.length - 2; i >= 0; i--) {
-        region.lineTo(points[i].x, points[i].lower);
-        lines.lineTo(points[i].x, points[i].lower);
-      }
-      region.lineTo(points[0].x, points[0].upper);
-      region.closePath();
       ctx.stroke(lines);
       ctx.fillStyle = this._viewData.options.fillColor;
       ctx.fill(region);
@@ -260,8 +300,10 @@ class BandsIndicatorPaneView implements IPrimitivePaneView {
     const timeScale = this._source.chart.timeScale();
     this._data.data = this._source._bandsData.map((d) => ({
       x: timeScale.timeToCoordinate(d.time) ?? -100,
-      upper: series.priceToCoordinate(d.upper) ?? -100,
-      lower: series.priceToCoordinate(d.lower) ?? -100,
+      upper:
+        d.upper != null ? (series.priceToCoordinate(d.upper) ?? -100) : null,
+      lower:
+        d.lower != null ? (series.priceToCoordinate(d.lower) ?? -100) : null,
     }));
   }
 

--- a/web/lib/lwc/bandsIndicator.ts
+++ b/web/lib/lwc/bandsIndicator.ts
@@ -6,7 +6,7 @@
  * Adaptations for argon:
  * - Upstream computed a demo ±10% envelope from the attached series' own
  *   data; this version renders EXPLICIT band values fed via setBandData()
- *   (the ±1.5σ envelope recovered from the stored z-score).
+ *   (an ATR or Bollinger envelope, depending on overlay mode).
  * - Times converted to epoch seconds for the autoscale binary search
  *   (upstream assumed numeric times; ours are 'yyyy-mm-dd' strings).
  * - Empty-data guards added (upstream crashed on points[0]).

--- a/web/lib/priceChartData.ts
+++ b/web/lib/priceChartData.ts
@@ -158,19 +158,18 @@ export function toAtrBandData(
     rows.map((r) => r.close),
     period,
   );
-  const out: BandPoint[] = [];
-  rows.forEach((r, i) => {
+  // One entry per row, always — a gap (warm-up or a broken bar) is an
+  // explicit whitespace point, not an omission, so the renderer can break
+  // the polyline there instead of connecting straight across the hole.
+  return rows.map((r, i) => {
     const m = r.sma20;
     const v = a[i];
+    const t = r.as_of as Time;
     if (m != null && v != null && v > 0) {
-      out.push({
-        time: r.as_of as Time,
-        upper: m + mult * v,
-        lower: m - mult * v,
-      });
+      return { time: t, upper: m + mult * v, lower: m - mult * v };
     }
+    return { time: t };
   });
-  return out;
 }
 
 export function toEmaLineData(
@@ -198,15 +197,15 @@ export function toBollingerBandData(
     period,
     mult,
   );
-  const out: BandPoint[] = [];
-  rows.forEach((r, i) => {
+  // One entry per row, always — see toAtrBandData's gap-point rationale.
+  return rows.map((r, i) => {
     const u = bb.upper[i];
     const l = bb.lower[i];
-    if (u != null && l != null && u > l) {
-      out.push({ time: r.as_of as Time, upper: u, lower: l });
-    }
+    const t = r.as_of as Time;
+    return u != null && l != null && u > l
+      ? { time: t, upper: u, lower: l }
+      : { time: t };
   });
-  return out;
 }
 
 export function toVolumeMaData(

--- a/web/lib/priceChartData.ts
+++ b/web/lib/priceChartData.ts
@@ -8,6 +8,7 @@ import type {
 import type { TechnicalsResponse } from "@/lib/api";
 import type { BandPoint } from "@/lib/lwc/bandsIndicator";
 import {
+  atr,
   bollinger,
   ema,
   lowestInWindow,
@@ -144,19 +145,31 @@ export function toVolumeData(
   });
 }
 
-// ±1.5σ envelope recovered from stored z exactly as the retired SVG pane did:
-// half = 1.5 * (close - sma200) / z, where z = (close - sma200) / sigma.
-export function toBandData(rows: readonly SeriesRow[]): BandPoint[] {
+// Keltner-style ATR envelope: sma20 ± mult · ATR(period). Replaces the old
+// ±1.5σ-around-sma200 band, which was a slow-moving cloud price rarely touched.
+export function toAtrBandData(
+  rows: readonly SeriesRow[],
+  period = 14,
+  mult = 2,
+): BandPoint[] {
+  const a = atr(
+    rows.map((r) => r.high),
+    rows.map((r) => r.low),
+    rows.map((r) => r.close),
+    period,
+  );
   const out: BandPoint[] = [];
-  for (const r of rows) {
-    const c = r.close;
-    const m = r.sma200;
-    const z = r.z;
-    if (c != null && m != null && z != null && z !== 0 && Number.isFinite(z)) {
-      const half = 1.5 * ((c - m) / z);
-      out.push({ time: r.as_of as Time, upper: m + half, lower: m - half });
+  rows.forEach((r, i) => {
+    const m = r.sma20;
+    const v = a[i];
+    if (m != null && v != null && v > 0) {
+      out.push({
+        time: r.as_of as Time,
+        upper: m + mult * v,
+        lower: m - mult * v,
+      });
     }
-  }
+  });
   return out;
 }
 

--- a/web/tests/e2e/technicals-tab.spec.ts
+++ b/web/tests/e2e/technicals-tab.spec.ts
@@ -33,7 +33,7 @@ test("overlay toggle flips SMA/EMA legend without console errors", async ({
   await expect(toggle).toBeVisible();
   await toggle.click();
   await expect(page.getByText("EMA5", { exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "SMA·σ" }).click();
+  await page.getByRole("button", { name: "SMA·ATR" }).click();
   await expect(page.getByText("EMA5", { exact: true })).not.toBeVisible();
   expect(consoleErrors.get(page)).toHaveLength(0);
 });

--- a/web/tests/unit/bandsIndicator.test.ts
+++ b/web/tests/unit/bandsIndicator.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { contiguousValidRuns } from "@/lib/lwc/bandsIndicator";
+
+describe("contiguousValidRuns", () => {
+  it("finds no runs in an all-gap array", () => {
+    expect(contiguousValidRuns([{ upper: null }, { upper: null }])).toEqual([]);
+  });
+
+  it("drops an isolated single valid point (can't draw a region from one)", () => {
+    expect(
+      contiguousValidRuns([{ upper: null }, { upper: 1 }, { upper: null }]),
+    ).toEqual([]);
+  });
+
+  it("returns the whole array as one run when nothing is a gap", () => {
+    expect(
+      contiguousValidRuns([{ upper: 1 }, { upper: 2 }, { upper: 3 }]),
+    ).toEqual([[0, 2]]);
+  });
+
+  it("splits into separate runs around a mid-series gap", () => {
+    const points = [
+      { upper: 1 },
+      { upper: 2 },
+      { upper: null }, // the gap
+      { upper: 3 },
+      { upper: 4 },
+      { upper: 5 },
+    ];
+    expect(contiguousValidRuns(points)).toEqual([
+      [0, 1],
+      [3, 5],
+    ]);
+  });
+
+  it("drops leading/trailing warm-up gaps but keeps the middle run", () => {
+    const points = [
+      { upper: null },
+      { upper: null },
+      { upper: 1 },
+      { upper: 2 },
+      { upper: null },
+    ];
+    expect(contiguousValidRuns(points)).toEqual([[2, 3]]);
+  });
+});

--- a/web/tests/unit/indicators.test.ts
+++ b/web/tests/unit/indicators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  atr,
   bollinger,
   ema,
   fmtVolCompact,
@@ -72,6 +73,38 @@ describe("bollinger", () => {
   });
 });
 
+describe("atr", () => {
+  it("seeds with the SMA of the first N true ranges, then Wilder-smooths varying TRs", () => {
+    // period=3, hand-computed true ranges (see PR review notes):
+    // tr = [2, 3, 1, 4] -> seed avg at i2 = (2+3+1)/3 = 2
+    // i3: prev = (2*2 + 4)/3 = 8/3 -- only a varying TR can catch a smoothing bug;
+    // a constant-TR fixture can't distinguish the seed average from the recursion.
+    const highs = [10, 12, 11, 14];
+    const lows = [8, 9, 10, 10];
+    const closesLocal = [9, 11, 10, 13];
+    const out = atr(highs, lows, closesLocal, 3);
+    expect(out[0]).toBeNull();
+    expect(out[1]).toBeNull();
+    expect(out[2]).toBeCloseTo(2, 10);
+    expect(out[3]).toBeCloseTo(8 / 3, 10);
+  });
+
+  it("breaks the chain on a missing bar and reseeds from scratch after it", () => {
+    // bar 4 is fully missing (H/L/C null) -> breaks the chain AND leaves bar 5
+    // with no valid prior close, so its TR is a plain h-l, not a true range.
+    const highs = [10, 12, 11, 14, null, 10, 10, 13];
+    const lows = [8, 9, 10, 10, null, 9, 8, 10];
+    const closesLocal = [9, 11, 10, 13, null, 9.5, 9, 12];
+    const out = atr(highs, lows, closesLocal, 3);
+    expect(out[3]).toBeCloseTo(8 / 3, 10); // seeded chain before the gap
+    expect(out[4]).toBeNull(); // the gap itself
+    expect(out[5]).toBeNull(); // reseeding, 1/3 TRs collected post-gap
+    expect(out[6]).toBeNull(); // reseeding, 2/3 TRs collected post-gap
+    // reseeded TRs post-gap: i5 tr=h-l=1 (no valid prior close), i6 tr=2, i7 tr=4
+    expect(out[7]).toBeCloseTo((1 + 2 + 4) / 3, 10);
+  });
+});
+
 describe("prevCloseUp", () => {
   it("colors by previous close, falling back to open on the first bar", () => {
     const up = prevCloseUp(SPY_BARS);
@@ -134,7 +167,9 @@ describe("lowVolMarkers", () => {
     50,
   );
   it("no bar is 25% below MA50 on this fixture", () => {
-    expect(lowVolMarkers(SPY_BARS, ma, { thresholdPct: -25, color: "#888" })).toEqual([]);
+    expect(
+      lowVolMarkers(SPY_BARS, ma, { thresholdPct: -25, color: "#888" }),
+    ).toEqual([]);
   });
   it("fires at -20% and labels the rounded deficit", () => {
     const m = lowVolMarkers(SPY_BARS, ma, { thresholdPct: -20, color: "#888" });

--- a/web/tests/unit/priceChartData.test.ts
+++ b/web/tests/unit/priceChartData.test.ts
@@ -70,7 +70,7 @@ describe("priceChartData", () => {
     expect(c).toEqual({ time: "2026-07-07" }); // no volume -> whitespace
   });
 
-  it("toAtrBandData: sma20 ±2·ATR14, nothing before the 14-bar warm-up", () => {
+  it("toAtrBandData: sma20 ±2·ATR14, one entry per row, warm-up as gap points", () => {
     // constant H/L/C -> every true range is 2, so ATR14 = 2 from bar 13 on.
     const bars = Array.from({ length: 15 }, (_, i) => ({
       as_of: `d${i}`,
@@ -80,12 +80,16 @@ describe("priceChartData", () => {
       sma20: 100,
     }));
     const out = toAtrBandData(bars as never[]);
-    expect(out).toEqual([
-      { time: "d13", upper: 104, lower: 96 },
-      { time: "d14", upper: 104, lower: 96 },
-    ]);
-    // missing H/L breaks the chain -> no band at all in a short window
-    expect(toAtrBandData(bars.slice(0, 13) as never[])).toEqual([]);
+    expect(out).toHaveLength(15); // never omits a row, even during warm-up
+    expect(out.slice(0, 13)).toEqual(
+      Array.from({ length: 13 }, (_, i) => ({ time: `d${i}` })),
+    );
+    expect(out[13]).toEqual({ time: "d13", upper: 104, lower: 96 });
+    expect(out[14]).toEqual({ time: "d14", upper: 104, lower: 96 });
+    // too short to ever finish warm-up -> every entry is a gap point
+    expect(toAtrBandData(bars.slice(0, 13) as never[])).toEqual(
+      Array.from({ length: 13 }, (_, i) => ({ time: `d${i}` })),
+    );
   });
 });
 
@@ -205,18 +209,23 @@ describe("toEmaLineData / toBollingerBandData / toVolumeMaData", () => {
     const last = out[out.length - 1] as { value?: number };
     expect(last.value).toBeCloseTo(750.2677023210776, 8);
   });
-  it("bollinger emits only converged points with frozen bounds at the tail", () => {
+  it("bollinger emits a gap point per warm-up bar, converged bounds at the tail", () => {
     const bb = toBollingerBandData(rows);
-    expect(bb.length).toBe(SPY_BARS.length - 19); // first 19 bars warmup
-    expect(bb[bb.length - 1].upper).toBeCloseTo(758.1623930384142, 6);
-    expect(bb[bb.length - 1].lower).toBeCloseTo(729.4606069615859, 6);
+    expect(bb).toHaveLength(SPY_BARS.length); // one entry per row, never omitted
+    const warmup = bb.slice(0, 19); // first 19 bars warmup
+    expect(warmup.every((p) => !("upper" in p))).toBe(true);
+    const last = bb[bb.length - 1] as { upper: number; lower: number };
+    expect(last.upper).toBeCloseTo(758.1623930384142, 6);
+    expect(last.lower).toBeCloseTo(729.4606069615859, 6);
   });
-  it("skips degenerate zero-width Bollinger points", () => {
+  it("degenerate zero-width Bollinger points render as gaps, not omitted rows", () => {
     const rows = Array.from({ length: 20 }, (_, i) => ({
       as_of: `2026-01-${String(i + 1).padStart(2, "0")}`,
       close: 100,
     }));
-    expect(toBollingerBandData(rows)).toEqual([]);
+    const out = toBollingerBandData(rows);
+    expect(out).toHaveLength(20);
+    expect(out.every((p) => !("upper" in p))).toBe(true);
   });
   it("volume MA50 last point matches the frozen pandas value", () => {
     const out = toVolumeMaData(rows, 50);

--- a/web/tests/unit/priceChartData.test.ts
+++ b/web/tests/unit/priceChartData.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   hasOhlcv,
-  toBandData,
+  toAtrBandData,
   toBollingerBandData,
   toCandleData,
   toEmaLineData,
@@ -70,15 +70,22 @@ describe("priceChartData", () => {
     expect(c).toEqual({ time: "2026-07-07" }); // no volume -> whitespace
   });
 
-  it("toBandData recovers the ±1.5σ envelope from stored z (half = 1.5·(c−m)/z)", () => {
-    const r = { as_of: "2026-07-06", close: 110, sma200: 100, z: 2 };
-    // sigma = (c-m)/z = 5 -> half = 7.5
-    expect(toBandData([r] as never[])).toEqual([
-      { time: "2026-07-06", upper: 107.5, lower: 92.5 },
+  it("toAtrBandData: sma20 ±2·ATR14, nothing before the 14-bar warm-up", () => {
+    // constant H/L/C -> every true range is 2, so ATR14 = 2 from bar 13 on.
+    const bars = Array.from({ length: 15 }, (_, i) => ({
+      as_of: `d${i}`,
+      high: 10,
+      low: 8,
+      close: 9,
+      sma20: 100,
+    }));
+    const out = toAtrBandData(bars as never[]);
+    expect(out).toEqual([
+      { time: "d13", upper: 104, lower: 96 },
+      { time: "d14", upper: 104, lower: 96 },
     ]);
-    expect(
-      toBandData([{ as_of: "x", close: 110, sma200: 100, z: 0 }] as never[]),
-    ).toEqual([]);
+    // missing H/L breaks the chain -> no band at all in a short window
+    expect(toAtrBandData(bars.slice(0, 13) as never[])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace the Technicals price-pane `±1.5σ around SMA200` band (backed out from the stored z-score) with a Keltner-style ATR band: `SMA20 ± 2·ATR14`, Wilder ATR computed client-side from OHLC. The old band was a slow-moving valuation cloud that price rarely touched; the ATR band tracks the tradable range. Toggle relabeled `SMA·σ` → `SMA·ATR`. EMA·BB mode unchanged.
- `scripts/dev.sh` gains `WEB_PORT`/`API_PORT` overrides so a second local stack can run without colliding with an already-bound 3001/8400.

## Test plan
- [x] `npx vitest run tests/unit/priceChartData.test.ts` — new ATR-band assertions pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Manually verified web+API stack on 3002/8402 against local Postgres, hit `/stock/QQQ/technicals` (200) and toggled SMA·ATR / EMA·BB
- [ ] `npm run test:e2e -- technicals-tab` (button-name rename only, not re-run in CI here)