### PR TITLE
feat(vcg): z-score history chart, full-history backfill, and the as_of SQL cap across vcg/cri/canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **VCG z-score history chart** on `/regime` → VCG — signed bars plus a monotone
+  curve over the trailing window, with 1M/3M/6M/1Y range buttons and the
+  ±2.0 / ±2.5 arming thresholds drawn as rules. It plots `vcg` directly, which
+  *is already* the trailing 63-session z-score of the model residual, so the
+  panel labels that definition rather than re-normalising an already-normalised
+  series.
+- **`pathFromPointsSmooth`** (`web/lib/svgChart.ts`) — Fritsch–Carlson monotone
+  cubic interpolation. Deliberately not Catmull–Rom: on `[0, 0, 2, 0, 0]` a
+  Catmull–Rom spline dips below zero either side of the spike, drawing a sign
+  flip that is not in the data. On a signed regime chart that is a fabricated
+  reading; the monotone limiter clamps tangents to the neighbouring samples'
+  range at no visual cost.
+- **`scripts/backfill/vcg_snapshot_backfill.py`** — scores `vcg_snapshots`
+  (`basis='eod'`) across the full aligned lake history. VCG needs no external
+  API (VIX/VVIX/credit-proxy all come from `vol_index_daily`), so the whole
+  history backfills at zero UW cost. Depth is bounded by the shortest input:
+  HYG starts 2007-04-11 and scoring needs 94 aligned bars of warmup.
+
+### Fixed
+
+- **`VolIndexRepository.fetch_history` now caps `as_of` in SQL** instead of
+  filtering after the fact. Fetching the most-recent `days` rows and *then*
+  dropping everything after `as_of` returns an empty series whenever `as_of` is
+  more than `days` bars back — so historical VCG scans silently reported "thin
+  data" and skipped, and a deep backfill looked like it ran while filling
+  nothing. This is what capped backfills at ~600 sessions.
+
 ## [0.10.15] — 2026-07-28
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,17 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 ### Fixed
 
 - **`VolIndexRepository.fetch_history` now caps `as_of` in SQL** instead of
-  filtering after the fact. Fetching the most-recent `days` rows and *then*
-  dropping everything after `as_of` returns an empty series whenever `as_of` is
-  more than `days` bars back — so historical VCG scans silently reported "thin
-  data" and skipped, and a deep backfill looked like it ran while filling
-  nothing. This is what capped backfills at ~600 sessions.
+  filtering after the fact, and **all three scanners that consume it — VCG, CRI,
+  and canary — are fixed together.** Each selected the most-recent `days` (or
+  `days * 2`) rows and only then dropped everything after `as_of`, which anchors
+  the fetch window to *today* while anchoring the filter to *`as_of`*. Once
+  `as_of` is further back than the window, every row is filtered out and the
+  caller gets an empty series rather than an error: the scan reports "thin data"
+  and skips, so a deep historical backfill runs to completion and writes
+  nothing. This is what capped VCG backfills at ~600 sessions. CRI and canary
+  had the identical copy-pasted bug — dormant only because their sole `as_of`
+  caller (`recover_recent_gaps`) stays inside the `days * 2` fudge buffer.
+  Regression tests cover all three and fail against the old code.
 
 ## [0.10.15] — 2026-07-28
 

--- a/scripts/backfill/vcg_snapshot_backfill.py
+++ b/scripts/backfill/vcg_snapshot_backfill.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+"""Backfill `vcg_snapshots` (basis='eod') across the full aligned lake history.
+
+VCG needs no external API — `scanners/vcg.run(as_of=...)` reads VIX/VVIX and the
+credit proxy straight out of `vol_index_daily`. So every session for which those
+three series align can be scored offline, at zero UW/API cost.
+
+Depth is bounded by the shortest input series: HYG starts 2007-04-11 (VVIX 2006,
+VIX 1990), and scoring needs MIN_BARS = OLS_WINDOW + Z_WINDOW + 10 = 94 aligned
+bars of warmup, so the first scoreable date lands ~94 sessions after the proxy's
+first bar.
+
+**Chunked by year on purpose.** `scanners/vcg.recover_recent_gaps` rolls back on
+a per-date exception but `run()` never commits, so across thousands of dates one
+late failure would silently discard every earlier insert while still reporting
+them as filled. Committing per year bounds that blast radius to one year and
+makes the per-chunk counts an honest progress record.
+
+Idempotent: `recover_recent_gaps` skips dates that already have a snapshot, so
+re-running only fills genuine holes.
+
+Reproduce:
+    uv run python scripts/backfill/vcg_snapshot_backfill.py                # all proxies present in the lake
+    uv run python scripts/backfill/vcg_snapshot_backfill.py --proxy HYG
+    uv run python scripts/backfill/vcg_snapshot_backfill.py --since 2020-01-01 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.scanners import vcg
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+log = logging.getLogger("vcg_backfill")
+
+
+def aligned_span(
+    conn: psycopg.Connection, proxy: str, schema: str
+) -> tuple[date, date, int] | None:
+    """(first, last, count) of dates where VIX, VVIX and `proxy` all have a bar."""
+    repo = VolIndexRepository(conn, schema=schema)
+    common = (
+        repo.fetch_dates_for("VIX")
+        & repo.fetch_dates_for("VVIX")
+        & repo.fetch_dates_for(proxy)
+    )
+    if not common:
+        return None
+    days = sorted(common)
+    return days[0], days[-1], len(days)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--proxy", default="HYG", help="credit proxy (default HYG)")
+    ap.add_argument("--since", help="earliest date to fill, YYYY-MM-DD")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report the span and existing coverage, write nothing",
+    )
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    settings = Settings.from_env()
+    proxy = args.proxy.upper()
+    schema = settings.db_schema
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        span = aligned_span(conn, proxy, schema)
+        if span is None:
+            log.error("no aligned VIX/VVIX/%s dates in vol_index_daily", proxy)
+            return 1
+        first, last, n = span
+        log.info("aligned span for %s: %s -> %s (%d sessions)", proxy, first, last, n)
+
+        floor = date.fromisoformat(args.since) if args.since else first
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT count(DISTINCT data_date) FROM {schema}.vcg_snapshots "
+                "WHERE basis = 'eod' AND credit_proxy = %s",
+                (proxy,),
+            )
+            have = cur.fetchone()[0]
+        log.info("existing eod snapshot dates for %s: %d", proxy, have)
+
+        if args.dry_run:
+            log.info("dry-run: would fill from %s to %s", floor, last)
+            return 0
+
+        total_filled = total_skipped = 0
+        # One chunk per calendar year, committed independently.
+        for year in range(floor.year, last.year + 1):
+            # lookback_days is measured back from the LATEST aligned date, so
+            # widen the window to this year's start and let the already-have
+            # filter drop everything newer that is already done.
+            lookback = (last - max(floor, date(year, 1, 1))).days
+            if lookback <= 0:
+                continue
+            try:
+                res = vcg.recover_recent_gaps(
+                    conn, schema=schema, proxy=proxy, lookback_days=lookback
+                )
+                conn.commit()
+            except Exception as exc:  # noqa: BLE001
+                conn.rollback()
+                log.error("chunk %d failed, rolled back: %r", year, exc)
+                continue
+            total_filled += res["filled"]
+            total_skipped += res["skipped"]
+            log.info(
+                "chunk %d: checked=%d filled=%d skipped=%d",
+                year,
+                res["checked"],
+                res["filled"],
+                res["skipped"],
+            )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT count(DISTINCT data_date), min(data_date), max(data_date) "
+                f"FROM {schema}.vcg_snapshots "
+                "WHERE basis = 'eod' AND credit_proxy = %s",
+                (proxy,),
+            )
+            dates, lo, hi = cur.fetchone()
+        log.info(
+            "done proxy=%s filled=%d skipped=%d | now %d dates %s -> %s",
+            proxy,
+            total_filled,
+            total_skipped,
+            dates,
+            lo,
+            hi,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/uw_scan/scanners/canary.py
+++ b/src/uw_scan/scanners/canary.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import logging
 import math
-from datetime import date as _date, timedelta
+from datetime import date as _date
+from datetime import timedelta
 from decimal import Decimal
 from typing import Iterable
 
@@ -44,12 +45,14 @@ def _load(
 
     When ``as_of`` is set the lookback caps at ``trade_date <= as_of`` so
     ``recover_recent_gaps`` can re-aim the scanner at a previous day.
+
+    The cap is pushed into SQL — see VolIndexRepository.fetch_history. Selecting
+    the most-recent rows and filtering to ``<= as_of`` afterwards anchors the
+    fetch window to today while anchoring the filter to ``as_of``; once ``as_of``
+    is further back than the window, every row is filtered out and the caller
+    sees an empty series rather than an error.
     """
-    fetch_days = days * 2 if as_of is not None else days
-    rows = vol_repo.fetch_history(symbol, days=fetch_days)
-    if as_of is not None:
-        rows = [r for r in rows if r["trade_date"] <= as_of]
-        rows = rows[-days:]
+    rows = vol_repo.fetch_history(symbol, days=days, as_of=as_of)
     out: dict[_date, float] = {}
     for r in rows:
         c = r.get("close")

--- a/src/uw_scan/scanners/cri.py
+++ b/src/uw_scan/scanners/cri.py
@@ -57,12 +57,14 @@ def _load_vol_series(
     When ``as_of`` is set, the lookback is capped at ``trade_date <= as_of``
     so the historical-recovery path can re-aim the scanner at a previous
     day without changing the rest of the orchestration.
+
+    The cap is pushed into SQL — see VolIndexRepository.fetch_history. Selecting
+    the most-recent rows and filtering to ``<= as_of`` afterwards anchors the
+    fetch window to today while anchoring the filter to ``as_of``; once ``as_of``
+    is further back than the window, every row is filtered out and the caller
+    sees an empty series rather than an error.
     """
-    fetch_days = days * 2 if as_of is not None else days
-    rows = vol_repo.fetch_history(symbol, days=fetch_days)
-    if as_of is not None:
-        rows = [r for r in rows if r["trade_date"] <= as_of]
-        rows = rows[-days:]
+    rows = vol_repo.fetch_history(symbol, days=days, as_of=as_of)
     return {
         r["trade_date"]: float(r["close"]) for r in rows if r.get("close") is not None
     }

--- a/src/uw_scan/scanners/vcg.py
+++ b/src/uw_scan/scanners/vcg.py
@@ -64,11 +64,11 @@ def _load_series(
     When ``as_of`` is set the lookback caps at ``trade_date <= as_of`` so
     the historical-recovery path can re-aim the scanner at a previous day.
     """
-    fetch_days = days * 2 if as_of is not None else days
-    rows = vol_repo.fetch_history(symbol, days=fetch_days)
-    if as_of is not None:
-        rows = [r for r in rows if r["trade_date"] <= as_of]
-        rows = rows[-days:]
+    # The `as_of` cap is pushed into SQL — see VolIndexRepository.fetch_history.
+    # Fetching recent rows and trimming here instead would return an empty
+    # series for any `as_of` more than `days` bars back, capping historical
+    # scans at ~600 sessions with only a "thin data" warning to show for it.
+    rows = vol_repo.fetch_history(symbol, days=days, as_of=as_of)
     out: dict[_date, float] = {}
     for r in rows:
         price = r.get("adj_close") if prefer_adj_close else None

--- a/src/uw_scan/storage/vol_index_repository.py
+++ b/src/uw_scan/storage/vol_index_repository.py
@@ -62,19 +62,32 @@ class VolIndexRepository:
         self._conn.commit()
         return len(rows)
 
-    def fetch_history(self, symbol: str, days: int) -> list[dict]:
-        """Return up to `days` most-recent rows for symbol, ascending."""
+    def fetch_history(
+        self, symbol: str, days: int, *, as_of: date | None = None
+    ) -> list[dict]:
+        """Return up to `days` most-recent rows for symbol, ascending.
+
+        `as_of` caps the window at that trade_date, so the LIMIT applies to the
+        `days` bars ending on `as_of` rather than the `days` bars ending today.
+
+        This cap MUST be pushed into SQL. Fetching the most-recent rows and
+        filtering to `<= as_of` afterwards silently returns nothing once
+        `as_of` is more than `days` bars back — the historical-scan path then
+        reports "thin data" and skips, so a deep backfill looks like it ran
+        while filling nothing. `as_of=None` keeps the original behaviour.
+        """
         sql = """
             SELECT symbol, trade_date,
                    open::float8, high::float8, low::float8,
                    close::float8, adj_close::float8, volume
               FROM vol_index_daily
              WHERE symbol = %s
+               AND (%s::date IS NULL OR trade_date <= %s::date)
              ORDER BY trade_date DESC
              LIMIT %s
         """
         with self._conn.cursor() as cur:
-            cur.execute(sql, (symbol, days))
+            cur.execute(sql, (symbol, as_of, as_of, days))
             cols = [c.name for c in cur.description]
             rows = [dict(zip(cols, r, strict=True)) for r in cur.fetchall()]
         rows.reverse()

--- a/tests/integration/test_canary_scanner.py
+++ b/tests/integration/test_canary_scanner.py
@@ -1,0 +1,63 @@
+"""Integration tests for src/uw_scan/scanners/canary.py series loading."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from uw_scan.scanners import canary as canary_scanner
+from uw_scan.storage.vol_index_repository import VolIndexRepository
+
+
+def _seed_vol(
+    vol_repo: VolIndexRepository,
+    symbol: str,
+    values: list[float],
+    *,
+    start: date,
+) -> None:
+    vol_repo.upsert_rows(
+        [
+            {
+                "symbol": symbol,
+                "trade_date": start + timedelta(days=i),
+                "open": v,
+                "high": v,
+                "low": v,
+                "close": v,
+                "adj_close": v,
+                "volume": 0,
+            }
+            for i, v in enumerate(values)
+        ]
+    )
+
+
+def test_load_honours_an_as_of_far_outside_the_recent_window(
+    seeded_db_empty_cards,
+) -> None:
+    """`as_of` must be pushed into SQL, not applied after a recent-rows LIMIT.
+
+    Regression: `_load` fetched the most-recent `days * 2` rows and only then
+    filtered them to `<= as_of`. That anchors the fetch window to today while
+    anchoring the filter to `as_of` — so any `as_of` further back than the
+    window drops every row and yields an EMPTY series. The caller reads that as
+    thin data and skips, so a deep historical backfill reports success while
+    writing nothing. CRI carried the identical copy-pasted bug.
+    """
+    repo = seeded_db_empty_cards
+    vol_repo = VolIndexRepository(repo.conn, schema=repo._schema)
+
+    start = date(2026, 1, 1)
+    _seed_vol(vol_repo, "VIX", [16.0 + i * 0.01 for i in range(400)], start=start)
+
+    # 200 bars back — comfortably outside the old `days * 2` fudge buffer.
+    as_of = start + timedelta(days=200)
+    series = canary_scanner._load(vol_repo, "VIX", 100, as_of=as_of)
+
+    assert len(series) == 100, "empty/short series is the bug this guards"
+    assert max(series) == as_of
+    assert all(d <= as_of for d in series)
+
+    # The uncapped path is unchanged: still the most-recent rows.
+    latest = canary_scanner._load(vol_repo, "VIX", 100)
+    assert max(latest) == start + timedelta(days=399)

--- a/tests/integration/test_cri_scanner.py
+++ b/tests/integration/test_cri_scanner.py
@@ -322,3 +322,34 @@ def test_run_falls_back_to_spy_when_spx_alignment_too_thin(
     assert row_id is not None
     snap = CriSnapshotRepository(conn, schema=repo._schema).fetch_latest()
     assert snap["spx_source"] == "SPY"
+
+
+def test_load_vol_series_honours_an_as_of_far_outside_the_recent_window(
+    seeded_db_empty_cards,
+) -> None:
+    """`as_of` must be pushed into SQL, not applied after a recent-rows LIMIT.
+
+    Regression: `_load_vol_series` fetched the most-recent `days * 2` rows and
+    only then filtered them to `<= as_of`. That anchors the fetch window to
+    today while anchoring the filter to `as_of` — so any `as_of` further back
+    than the window drops every row and yields an EMPTY series. The caller sees
+    thin data and skips, which makes a deep historical backfill report success
+    while writing nothing. Canary carried the identical copy-pasted bug.
+    """
+    repo = seeded_db_empty_cards
+    vol_repo = VolIndexRepository(repo.conn, schema=repo._schema)
+
+    start = date(2026, 1, 1)
+    _seed_vol(vol_repo, "VIX", [16.0 + i * 0.01 for i in range(400)], start=start)
+
+    # 200 bars back — comfortably outside the old `days * 2` fudge buffer.
+    as_of = start + timedelta(days=200)
+    series = cri_scanner._load_vol_series(vol_repo, "VIX", 100, as_of=as_of)
+
+    assert len(series) == 100, "empty/short series is the bug this guards"
+    assert max(series) == as_of
+    assert all(d <= as_of for d in series)
+
+    # The uncapped path is unchanged: still the most-recent rows.
+    latest = cri_scanner._load_vol_series(vol_repo, "VIX", 100)
+    assert max(latest) == start + timedelta(days=399)

--- a/tests/integration/test_vcg_scanner.py
+++ b/tests/integration/test_vcg_scanner.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 import math
 from datetime import date, timedelta
 
-from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
-
 from uw_scan.scanners import vcg as vcg_scanner
+from uw_scan.storage.vcg_snapshot_repository import VcgSnapshotRepository
 from uw_scan.storage.vol_index_repository import VolIndexRepository
 
 
@@ -113,6 +112,69 @@ def test_run_returns_none_when_data_is_thin(seeded_db_empty_cards) -> None:
 
     snap_repo = VcgSnapshotRepository(conn, schema=repo._schema)
     assert snap_repo.fetch_latest() is None
+
+
+def test_fetch_history_as_of_caps_the_window_not_just_the_tail(
+    seeded_db_empty_cards,
+) -> None:
+    """`as_of` must be pushed into SQL, not applied after a recent-rows LIMIT.
+
+    Regression: fetch_history took the most-recent `days` rows and vcg's
+    _load_series filtered them to `<= as_of` afterwards. Any `as_of` further
+    back than `days` bars then yielded an EMPTY series, so historical scans
+    silently skipped with "thin data" and a deep backfill filled nothing.
+    """
+    repo = seeded_db_empty_cards
+    vol_repo = VolIndexRepository(repo.conn, schema=repo._schema)
+
+    start = date(2026, 1, 1)
+    _seed(vol_repo, "VIX", [16.0 + i * 0.01 for i in range(300)], start=start)
+
+    # Ask for a 50-bar window ending 200 bars back — far outside the most
+    # recent 50 rows, which is exactly what the old code could not express.
+    as_of = start + timedelta(days=100)
+    rows = vol_repo.fetch_history("VIX", days=50, as_of=as_of)
+
+    assert len(rows) == 50
+    assert rows[-1]["trade_date"] == as_of
+    assert all(r["trade_date"] <= as_of for r in rows)
+
+    # …and the uncapped call is unchanged: still the most-recent rows.
+    recent = vol_repo.fetch_history("VIX", days=50)
+    assert recent[-1]["trade_date"] == start + timedelta(days=299)
+
+
+def test_run_scores_a_historical_date_far_outside_the_recent_window(
+    seeded_db_empty_cards,
+) -> None:
+    """A scan anchored well before the latest bar must still persist."""
+    repo = seeded_db_empty_cards
+    conn = repo.conn
+    vol_repo = VolIndexRepository(conn, schema=repo._schema)
+
+    n = 800  # far more than the 300-bar LOOKBACK_DAYS the scanner requests
+    start = date(2024, 1, 1)
+    _seed(vol_repo, "VIX", [16.0 + 0.05 * (i % 7) for i in range(n)], start=start)
+    _seed(vol_repo, "VVIX", [90.0 + 0.3 * (i % 11) for i in range(n)], start=start)
+    _seed(
+        vol_repo,
+        "HYG",
+        [80.0 - 0.002 * i + 0.05 * (i % 5) for i in range(n)],
+        start=start,
+    )
+
+    # 150 bars in — clears MIN_ALIGNED_BARS (94) but sits ~650 bars before the
+    # newest row, so the old recent-rows-then-filter path returned nothing.
+    as_of = start + timedelta(days=150)
+    row_id = vcg_scanner.run(conn, proxy="HYG", schema=repo._schema, as_of=as_of)
+
+    assert row_id is not None
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT data_date FROM {repo._schema}.vcg_snapshots WHERE id = %s",
+            (row_id,),
+        )
+        assert cur.fetchone()[0] == as_of
 
 
 def test_run_returns_none_when_no_overlap(seeded_db_empty_cards) -> None:

--- a/web/components/regime/VcgSubTab.tsx
+++ b/web/components/regime/VcgSubTab.tsx
@@ -16,6 +16,7 @@ import VcgStressHistorySection from "./vcg/VcgStressHistorySection";
 import { type VcgSignal } from "@/lib/regime/useVcg";
 import { useVcgLive, type VcgLiveResponse } from "@/lib/regime/useVcgLive";
 import { useVcgDaily, type VcgDailyEntry } from "@/lib/regime/useVcgSeries";
+import VcgZScoreHistoryChart from "./vcg/VcgZScoreHistoryChart";
 import VcgSeriesGrids from "./vcg/VcgSeriesGrids";
 import CardSparkline from "./primitives/CardSparkline";
 import {
@@ -266,10 +267,13 @@ export function VcgSubTabView({
   const lastSync = data.scan_time;
   const history = data.history ?? [];
 
-  // 90d daily series for in-card sparklines (oldest → newest).
+  // Full fetched window (oldest → newest) — the z-score history chart ranges
+  // over all of it. The in-card sparklines stay at their documented 90d, so
+  // widening the fetch for the chart doesn't silently restyle them.
   const dailyRows = daily ?? [];
+  const sparkRows = dailyRows.slice(-90);
   const dseries = (k: keyof VcgDailyEntry): (number | null)[] =>
-    dailyRows.map((r) => {
+    sparkRows.map((r) => {
       const v = r[k];
       return typeof v === "number" && Number.isFinite(v) ? v : null;
     });
@@ -836,6 +840,12 @@ export function VcgSubTabView({
           </div>
         </div>
 
+        {/* ── Z-score history (bars + monotone curve, range-selectable) ── */}
+        <VcgZScoreHistoryChart
+          rows={dailyRows}
+          interpretation={interpretationLabel(sig.interpretation)}
+        />
+
         {/* ── Intraday small-multiples grid (basis='live' rows) ── */}
         <VcgSeriesGrids />
 
@@ -854,7 +864,9 @@ export function VcgSubTabView({
 
 export default function VcgSubTab() {
   const { data, syncing, syncNow } = useVcgLive();
-  const { data: daily } = useVcgDaily(90);
+  // 365 = the API's `days` ceiling. Feeds the z-score chart's 6M/ALL ranges;
+  // the sparklines slice back to 90 downstream.
+  const { data: daily } = useVcgDaily(365);
   return (
     <VcgSubTabView
       data={data}

--- a/web/components/regime/vcg/VcgZScoreHistoryChart.tsx
+++ b/web/components/regime/vcg/VcgZScoreHistoryChart.tsx
@@ -46,6 +46,12 @@ const PLOT_H = H - PAD.top - PAD.bottom;
 /** The scanner's own trigger levels — the reason the axis is pinned to ±3. */
 const Y_TICKS = [3, 2, 1, 0, -1, -2, -3];
 
+/** The scanner's own trigger levels, drawn as rules (mirrored to ±). */
+const ARM_LEVELS = [
+  { z: 2.0, color: "var(--warning)" },
+  { z: 2.5, color: "var(--fault)" },
+];
+
 export type VcgZPoint = { date: string; z: number };
 
 /**
@@ -265,6 +271,26 @@ export default function VcgZScoreHistoryChart({
               </text>
             </g>
           ))}
+
+          {/* The two levels the scanner actually fires on. Without these the
+              tooltip tells you |z| ≥ 2.0 arms and ≥ 2.5 escalates, and the
+              chart gives you no way to see whether today is near either — the
+              integer gridlines above are axis furniture, and 2.5 isn't among
+              them at all. Warning below RISK_OFF, matching the badge colours. */}
+          {ARM_LEVELS.filter(({ z }) => z <= bound).flatMap(({ z, color }) =>
+            [z, -z].map((v) => (
+              <line
+                key={`arm-${v}`}
+                x1={PAD.left}
+                y1={y(v)}
+                x2={PAD.left + PLOT_W}
+                y2={y(v)}
+                stroke={color}
+                strokeDasharray="2 5"
+                opacity={0.55}
+              />
+            )),
+          )}
 
           {/* Bars: the actual per-session values. The curve is a reading aid. */}
           {series.map((p, i) => (

--- a/web/components/regime/vcg/VcgZScoreHistoryChart.tsx
+++ b/web/components/regime/vcg/VcgZScoreHistoryChart.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+/**
+ * VcgZScoreHistoryChart — the VCG z-score series as bars + a smooth curve.
+ *
+ * IMPORTANT, and a deliberate departure from the reference mock this was
+ * modelled on: the mock's subtitle read `z = (VCG - 20-session mean) / sigma`,
+ * i.e. it re-standardised VCG on the client over a 20-session window. That is
+ * wrong twice over for this codebase.
+ *
+ * `vcg` as served by /api/regime/vcg/history is ALREADY a z-score —
+ * `cards/vcg_scoring.standardise_residuals` takes a trailing z of the
+ * VIX/VVIX→credit OLS residual over `Z_WINDOW = 63` sessions. Re-z-scoring it
+ * would be double standardisation (a z-of-a-z), which rescales the axis so the
+ * ±2 / ±2.5 trigger thresholds the scanner actually fires on no longer land at
+ * ±2 / ±2.5 on the chart. The window is also 63, not 20.
+ *
+ * So this plots `vcg` directly and labels the real definition.
+ */
+
+import { useMemo, useState } from "react";
+import type { VcgDailyEntry } from "@/lib/regime/useVcgSeries";
+import { linearScale, pathFromPointsSmooth, type Point } from "@/lib/svgChart";
+import InfoTooltip from "../InfoTooltip";
+
+/** Trading sessions per range. The widest keeps whatever the fetch returned.
+ *
+ *  It is labelled 1Y, not ALL: `/api/regime/vcg/history` caps `days` at 365,
+ *  so the widest window this can ever show is a year — while the table holds
+ *  ~4.7k sessions back to 2007. "ALL" would promise the whole history and
+ *  quietly deliver the last year of it. Widening it is a backend change
+ *  (the `le=365` Query bound), not a frontend one. */
+const RANGES: { key: string; sessions: number | null }[] = [
+  { key: "1M", sessions: 21 },
+  { key: "3M", sessions: 63 },
+  { key: "6M", sessions: 126 },
+  { key: "1Y", sessions: null },
+];
+
+const W = 1000;
+const H = 300;
+const PAD = { top: 16, right: 24, bottom: 34, left: 52 };
+const PLOT_W = W - PAD.left - PAD.right;
+const PLOT_H = H - PAD.top - PAD.bottom;
+
+/** The scanner's own trigger levels — the reason the axis is pinned to ±3. */
+const Y_TICKS = [3, 2, 1, 0, -1, -2, -3];
+
+export type VcgZPoint = { date: string; z: number };
+
+/**
+ * Keep only rows with a finite `vcg`, oldest→newest, then take the last
+ * `sessions`. Exported for unit testing.
+ *
+ * Null `vcg` rows are dropped rather than gap-rendered: VCG is undefined for
+ * the first Z_WINDOW sessions of any series, so the nulls cluster at the head
+ * where they carry no information.
+ */
+export function selectZSeries(
+  rows: VcgDailyEntry[] | null | undefined,
+  sessions: number | null,
+): VcgZPoint[] {
+  const clean: VcgZPoint[] = [];
+  for (const r of rows ?? []) {
+    if (typeof r.vcg !== "number" || !Number.isFinite(r.vcg)) continue;
+    if (!r.date) continue;
+    clean.push({ date: String(r.date), z: r.vcg });
+  }
+  clean.sort((a, b) => a.date.localeCompare(b.date));
+  return sessions == null ? clean : clean.slice(-sessions);
+}
+
+function fmtDate(iso: string): string {
+  // Parse as UTC parts, not `new Date(iso)` — the latter reads a bare
+  // YYYY-MM-DD as UTC midnight and then renders it in local time, which shows
+  // the previous day for anyone west of Greenwich.
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  const month = new Date(Date.UTC(y, m - 1, d)).toLocaleString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  });
+  return `${month} ${d}`;
+}
+
+function zColor(z: number): string {
+  return z >= 0 ? "var(--signal-core)" : "var(--fault)";
+}
+
+export default function VcgZScoreHistoryChart({
+  rows,
+  interpretation,
+}: {
+  rows: VcgDailyEntry[] | null | undefined;
+  interpretation?: string | null;
+}) {
+  const [range, setRange] = useState("1M");
+
+  const series = useMemo(
+    () =>
+      selectZSeries(
+        rows,
+        RANGES.find((r) => r.key === range)?.sessions ?? null,
+      ),
+    [rows, range],
+  );
+
+  // How much history exists at all — drives which range buttons are offered.
+  const total = useMemo(() => selectZSeries(rows, null).length, [rows]);
+
+  const latest = series.length ? series[series.length - 1] : null;
+  const prior = series.length > 1 ? series[series.length - 2] : null;
+  const delta = latest && prior ? latest.z - prior.z : null;
+
+  if (series.length < 2) {
+    return (
+      <div className="section" data-testid="vcg-zscore-history">
+        <div className="section-header">
+          <div className="section-title">VCG Z-Score History</div>
+        </div>
+        <div
+          style={{
+            padding: 24,
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            color: "var(--text-muted)",
+          }}
+        >
+          Not enough scored sessions yet — VCG is undefined until 63 sessions of
+          history exist.
+        </div>
+      </div>
+    );
+  }
+
+  // Symmetric axis pinned to at least ±3 so the ±2 / ±2.5 trigger lines sit in
+  // a fixed place across ranges; grows only if the data actually exceeds it.
+  const bound = Math.max(3, ...series.map((p) => Math.abs(p.z)));
+  const y = linearScale([-bound, bound], [PAD.top + PLOT_H, PAD.top]);
+  const band = PLOT_W / series.length;
+  const cx = (i: number) => PAD.left + band * (i + 0.5);
+  const barW = Math.max(1, band * 0.7);
+  const zeroY = y(0);
+  const points: Point[] = series.map((p, i) => [cx(i), y(p.z)]);
+
+  // Label roughly every ~6 bands, always including the last.
+  const step = Math.max(1, Math.ceil(series.length / 6));
+  const ticks = series
+    .map((p, i) => ({ p, i }))
+    .filter(({ i }) => i % step === 0 || i === series.length - 1);
+
+  return (
+    <div className="section" data-testid="vcg-zscore-history">
+      <div className="section-header">
+        <div className="section-title">
+          VCG Z-Score History
+          <InfoTooltip text="Trailing 63-session z-score of the VIX/VVIX→credit OLS residual (Z_WINDOW=63). This is the same value the scanner triggers on: |z| ≥ 2.0 arms the signal, ≥ 2.5 escalates to RISK_OFF." />
+        </div>
+        {latest && (
+          <div style={{ textAlign: "right" }}>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 22,
+                fontWeight: 700,
+                color: zColor(latest.z),
+              }}
+              data-testid="vcg-zscore-history-latest"
+            >
+              {latest.z >= 0 ? "+" : ""}
+              {latest.z.toFixed(2)}
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                color: "var(--text-muted)",
+                letterSpacing: "0.08em",
+              }}
+            >
+              {interpretation ?? "—"}
+              {delta != null && (
+                <>
+                  {" · "}
+                  {delta >= 0 ? "+" : ""}
+                  {delta.toFixed(2)}σ vs prior
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="section-body">
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: "var(--text-muted)",
+            letterSpacing: "0.08em",
+          }}
+        >
+          z = trailing 63-session z-score of the model residual
+        </div>
+
+        <div style={{ display: "flex", gap: 6, margin: "10px 0 4px" }}>
+          {RANGES.map((r) => {
+            // Offering a range the data can't fill renders a chart identical to
+            // the one before it, which reads as a broken button.
+            const available = r.sessions == null || total > (r.sessions ?? 0);
+            if (!available && r.key !== "1Y" && r.key !== "1M") return null;
+            return (
+              <button
+                key={r.key}
+                type="button"
+                onClick={() => setRange(r.key)}
+                data-testid={`vcg-z-range-${r.key}`}
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 11,
+                  letterSpacing: "0.08em",
+                  padding: "4px 12px",
+                  cursor: "pointer",
+                  borderRadius: 4,
+                  border: "1px solid var(--border-dim)",
+                  background:
+                    range === r.key ? "var(--signal-core)" : "transparent",
+                  color:
+                    range === r.key ? "var(--bg-panel)" : "var(--text-muted)",
+                }}
+              >
+                {r.key}
+              </button>
+            );
+          })}
+        </div>
+
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          width="100%"
+          role="img"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}
+        >
+          <title>{`VCG z-score, last ${series.length} sessions`}</title>
+
+          {Y_TICKS.filter((t) => Math.abs(t) <= bound).map((t) => (
+            <g key={t}>
+              <line
+                x1={PAD.left}
+                y1={y(t)}
+                x2={PAD.left + PLOT_W}
+                y2={y(t)}
+                stroke="var(--border-dim)"
+                strokeDasharray={t === 0 ? "4 4" : undefined}
+                opacity={t === 0 ? 1 : 0.45}
+              />
+              <text
+                x={PAD.left - 8}
+                y={y(t) + 4}
+                textAnchor="end"
+                fill="var(--text-muted)"
+                fontSize={10}
+              >
+                {t > 0 ? `+${t.toFixed(2)}` : t.toFixed(2)}
+              </text>
+            </g>
+          ))}
+
+          {/* Bars: the actual per-session values. The curve is a reading aid. */}
+          {series.map((p, i) => (
+            <rect
+              key={p.date}
+              x={cx(i) - barW / 2}
+              y={Math.min(zeroY, y(p.z))}
+              width={barW}
+              height={Math.abs(y(p.z) - zeroY)}
+              fill={zColor(p.z)}
+              opacity={0.22}
+            />
+          ))}
+
+          <path
+            d={pathFromPointsSmooth(points)}
+            fill="none"
+            stroke="var(--signal-core)"
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+
+          <circle
+            cx={points[points.length - 1][0]}
+            cy={points[points.length - 1][1]}
+            r={4.5}
+            // Sign-coloured, not fixed teal: it marks the latest value, and a
+            // teal dot beside a red "-0.43" readout contradicts itself.
+            fill={zColor(series[series.length - 1].z)}
+            stroke="var(--bg-panel)"
+            strokeWidth={2}
+          />
+
+          {ticks.map(({ p, i }) => (
+            <text
+              key={p.date}
+              x={cx(i)}
+              y={PAD.top + PLOT_H + 20}
+              textAnchor="middle"
+              fill="var(--text-muted)"
+              fontSize={10}
+            >
+              {fmtDate(p.date)}
+            </text>
+          ))}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/svgChart.ts
+++ b/web/lib/svgChart.ts
@@ -66,6 +66,65 @@ export function pathFromNullablePoints(
   return out.trimEnd();
 }
 
+/**
+ * Smooth path through `points` using a Fritsch–Carlson **monotone** cubic.
+ *
+ * Deliberately NOT Catmull-Rom. A Catmull-Rom spline overshoots: on the series
+ * [0, 0, 2, 0, 0] it swings visibly below zero on both sides of the spike,
+ * drawing a negative excursion that is not in the data. On a signed regime
+ * chart that is a fabricated sign flip — the reader sees the series cross zero
+ * when it never did. The monotone variant clamps tangents so the curve stays
+ * within the range of its neighbouring samples, which costs nothing visually.
+ *
+ * Points must be sorted ascending by x. Fewer than 3 points falls back to a
+ * straight polyline (a spline through 2 points is just the segment anyway).
+ */
+export function pathFromPointsSmooth(points: Point[]): string {
+  const n = points.length;
+  if (n < 3) return pathFromPoints(points);
+
+  // Secant slopes between consecutive points.
+  const dx: number[] = [];
+  const delta: number[] = [];
+  for (let i = 0; i < n - 1; i++) {
+    const h = points[i + 1][0] - points[i][0];
+    dx.push(h);
+    delta.push(h === 0 ? 0 : (points[i + 1][1] - points[i][1]) / h);
+  }
+
+  // Initial tangents: one-sided at the ends, averaged in the interior.
+  const m: number[] = new Array(n);
+  m[0] = delta[0];
+  m[n - 1] = delta[n - 2];
+  for (let i = 1; i < n - 1; i++) m[i] = (delta[i - 1] + delta[i]) / 2;
+
+  // Fritsch–Carlson limiter — this is the step that prevents overshoot.
+  for (let i = 0; i < n - 1; i++) {
+    if (delta[i] === 0) {
+      m[i] = 0;
+      m[i + 1] = 0;
+      continue;
+    }
+    const a = m[i] / delta[i];
+    const b = m[i + 1] / delta[i];
+    const s = a * a + b * b;
+    if (s > 9) {
+      const t = 3 / Math.sqrt(s);
+      m[i] = t * a * delta[i];
+      m[i + 1] = t * b * delta[i];
+    }
+  }
+
+  let d = `M${points[0][0]},${points[0][1]}`;
+  for (let i = 0; i < n - 1; i++) {
+    const h = dx[i] / 3;
+    const [x0, y0] = points[i];
+    const [x1, y1] = points[i + 1];
+    d += ` C${x0 + h},${y0 + m[i] * h} ${x1 - h},${y1 - m[i + 1] * h} ${x1},${y1}`;
+  }
+  return d;
+}
+
 export function niceTicks(min: number, max: number, count = 5): number[] {
   if (!isFinite(min) || !isFinite(max) || min === max) return [min];
   // Heckbert nice-number rounding: snap the raw step to 1/2/5/10 × 10^k.

--- a/web/tests/unit/vcgZScoreHistory.test.ts
+++ b/web/tests/unit/vcgZScoreHistory.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { selectZSeries } from "@/components/regime/vcg/VcgZScoreHistoryChart";
+import { pathFromPointsSmooth, type Point } from "@/lib/svgChart";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const row = (date: string, vcg: number | null) => ({ date, vcg }) as any;
+
+describe("selectZSeries", () => {
+  it("drops null/non-finite vcg, sorts ascending, and takes the tail", () => {
+    const out = selectZSeries(
+      [
+        row("2026-03-03", 1.5),
+        row("2026-03-01", 0.5),
+        row("2026-03-02", null),
+        row("2026-03-04", -2.1),
+      ],
+      2,
+    );
+    expect(out.map((p) => p.date)).toEqual(["2026-03-03", "2026-03-04"]);
+    expect(out[1].z).toBe(-2.1);
+  });
+
+  it("returns everything when sessions is null", () => {
+    const rows = [row("2026-03-01", 1), row("2026-03-02", 2)];
+    expect(selectZSeries(rows, null)).toHaveLength(2);
+  });
+
+  it("tolerates null input", () => {
+    expect(selectZSeries(null, 21)).toEqual([]);
+  });
+});
+
+describe("pathFromPointsSmooth", () => {
+  /** Pull every coordinate pair out of an SVG path's M/C commands. */
+  function ys(d: string): number[] {
+    return Array.from(d.matchAll(/[-\d.]+,([-\d.]+)/g)).map((m) =>
+      Number(m[1]),
+    );
+  }
+
+  it("never overshoots a spike — the reason this is not Catmull-Rom", () => {
+    // Screen coords: y=100 is the zero line, y=0 is the top of the spike.
+    // A Catmull-Rom spline dips BELOW the baseline (y > 100) on both flanks,
+    // drawing a negative excursion that is not in the data.
+    const pts: Point[] = [
+      [0, 100],
+      [10, 100],
+      [20, 0],
+      [30, 100],
+      [40, 100],
+    ];
+    const all = ys(pathFromPointsSmooth(pts));
+    expect(Math.max(...all)).toBeLessThanOrEqual(100 + 1e-9);
+    expect(Math.min(...all)).toBeGreaterThanOrEqual(0 - 1e-9);
+  });
+
+  it("stays within the data range on a monotone series", () => {
+    const pts: Point[] = [
+      [0, 50],
+      [10, 40],
+      [20, 30],
+      [30, 10],
+    ];
+    const all = ys(pathFromPointsSmooth(pts));
+    expect(Math.min(...all)).toBeGreaterThanOrEqual(10 - 1e-9);
+    expect(Math.max(...all)).toBeLessThanOrEqual(50 + 1e-9);
+  });
+
+  it("passes exactly through every input point", () => {
+    const pts: Point[] = [
+      [0, 10],
+      [10, 90],
+      [20, 20],
+      [30, 60],
+    ];
+    const d = pathFromPointsSmooth(pts);
+    for (const [x, yv] of pts) expect(d).toContain(`${x},${yv}`);
+  });
+
+  it("falls back to a polyline below three points", () => {
+    expect(pathFromPointsSmooth([[0, 0]])).toBe("M0,0");
+    expect(
+      pathFromPointsSmooth([
+        [0, 0],
+        [1, 1],
+      ]),
+    ).toBe("M0,0 L1,1");
+  });
+});

--- a/web/tests/unit/vcgZScoreHistory.test.ts
+++ b/web/tests/unit/vcgZScoreHistory.test.ts
@@ -1,6 +1,10 @@
+import { render } from "@testing-library/react";
+import { createElement } from "react";
 import { describe, expect, it } from "vitest";
 
-import { selectZSeries } from "@/components/regime/vcg/VcgZScoreHistoryChart";
+import VcgZScoreHistoryChart, {
+  selectZSeries,
+} from "@/components/regime/vcg/VcgZScoreHistoryChart";
 import { pathFromPointsSmooth, type Point } from "@/lib/svgChart";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,5 +90,31 @@ describe("pathFromPointsSmooth", () => {
         [1, 1],
       ]),
     ).toBe("M0,0 L1,1");
+  });
+});
+
+describe("arming threshold rules", () => {
+  // Regression: the chart's tooltip states that |z| >= 2.0 arms and >= 2.5
+  // escalates, and the y-axis is deliberately pinned to +/-3 so both fit. The
+  // rules themselves were never drawn, so the reader was told about two levels
+  // they couldn't see — and 2.5 isn't one of the integer gridlines at all.
+  const rows = Array.from({ length: 40 }, (_, i) =>
+    row(`2026-01-${String((i % 28) + 1).padStart(2, "0")}`, (i % 7) - 3),
+  );
+
+  it("draws both levels, mirrored above and below zero", () => {
+    const { container } = render(
+      createElement(VcgZScoreHistoryChart, { rows }),
+    );
+    const dashed = Array.from(
+      container.querySelectorAll('line[stroke-dasharray="2 5"]'),
+    );
+    // 2.0 and 2.5, each mirrored to +/- => 4 rules.
+    expect(dashed).toHaveLength(4);
+
+    const ys = dashed.map((n) => Number(n.getAttribute("y1")));
+    // Symmetric about the zero line: every rule has a partner.
+    const mid = ys.reduce((a, b) => a + b, 0) / ys.length;
+    for (const v of ys) expect(ys).toContain(2 * mid - v);
   });
 });


### PR DESCRIPTION
## What

Adds a **z-score history chart** to `/regime` → VCG: signed bars plus a monotone curve, with the ±2.0 / ±2.5 arming thresholds drawn as rules and 1M / 3M / 6M / 1Y range buttons. The sub-tab previously showed the current reading and 90d sparklines but nothing that answered "how unusual is this, historically?"

The chart plots `vcg` **directly**. `vcg` is already the trailing 63-session z-score of the model residual (`Z_WINDOW=63`, `OLS_WINDOW=21`), so the panel labels that definition rather than z-scoring an already-normalised series.

## Three things had to be true first

### 1. There had to be history — and there wasn't

`VolIndexRepository.fetch_history` fetched the most-recent `days` rows and *then* filtered to `trade_date <= as_of`. That anchors the **fetch window to today** while anchoring the **filter to `as_of`**, and nothing reconciles the two. Once `as_of` is further back than the window, every row is filtered away.

The failure was silent in the worst way: an empty series isn't an exception. The historical-scan path read it as thin data, logged a warning, and skipped — so a deep backfill ran to completion, reported success, and filled nothing. This is what capped backfills at ~600 sessions.

The cap is now pushed into SQL (`AND (%s::date IS NULL OR trade_date <= %s::date)`), so the `LIMIT` applies to the `days` bars ending *on `as_of`*. `as_of=None` keeps the original behaviour, so every existing caller is untouched.

**CRI and canary carried the identical copy-pasted loader and are fixed in the same PR.** Both did `fetch_days = days * 2 if as_of else days`, fetched, then filtered in Python. The bug was dormant rather than absent: their only `as_of` caller is `recover_recent_gaps`, which looks back a handful of sessions and stays inside the `days * 2` fudge buffer. It arms the moment either scanner is pointed at deep history — exactly what building CRI/canary history would do.

Regression tests for all three assert a 100-bar window ending 200 bars back, and were **verified to fail against the old code** — CRI and canary each returned 1 row of the 100 requested, the boundary case where the two anchors overlap by a single session.

### 2. The curve had to not lie

A Catmull–Rom spline overshoots. On the series `[0, 0, 2, 0, 0]` it swings visibly **below zero** on both sides of the spike — drawing a negative excursion that is not in the data. On a *signed* regime chart that is a fabricated sign flip: the reader sees the series cross zero when it never did.

`pathFromPointsSmooth` uses a **Fritsch–Carlson monotone cubic** instead. The limiter (`s = a² + b² > 9 → scale tangents by 3/√s`) clamps tangents so the curve stays within the range of its neighbouring samples. Visually it costs nothing.

### 3. The range buttons had to be honest

The widest button is labelled **`1Y`, not `ALL`**. `/api/regime/vcg/history` caps `days` at 365 (`Query(90, ge=5, le=365)`), so the widest window this chart can *ever* show is a year — while the table now holds ~4.7k sessions back to 2007. An `ALL` button would promise the whole history and quietly deliver the last year of it.

Widening it is a backend change (the `le=365` bound) plus an OpenAPI-snapshot and `gen:types` regen, and is deliberately **not** in this PR.

## Verification

- `npm run typecheck` (`tsc --noEmit`) clean
- `npm run lint` clean
- **642/642 vitest pass** across 104 files, including 8 tests in `vcgZScoreHistory.test.ts`
- `uv run ruff check` + `ruff format --check` clean on all touched Python
- `uv run pytest` on the vcg + cri + canary scanner suites — **18 passed**; full unit suite **1501 passed**
- Backfill executed against the mini; audit results above

CHANGELOG `[Unreleased]` entry rides this PR.

## Not in scope

Three untracked items on separate topics stay out: the regime flip-rate probe + research note, the sector-crowding panel plan, and the adaptive-EMA smoother catalog.



## Post-review fixes on this branch

- `80f19e8` — the ±2.0/±2.5 arming rules were *described* by the panel's tooltip and by the axis comment, but never drawn (2.5 isn't even one of the integer gridlines). Now rendered, warning below RISK_OFF, with a test asserting all four appear and are symmetric about zero. The test earned its keep immediately: the first filter compared the level objects against the bound instead of their `z`, so every rule silently failed to render while typecheck, lint and 641 tests stayed green.
- `e8a2dde` — the CRI/canary `as_of` fix described above.
