### PR TITLE
fix(regime): source SPX dealer levels from UW, guard the gamma flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,53 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
-## [0.11.0] — 2026-08-02
+### Fixed
 
+- **Gamma flip is now distance-guarded, not drawn unconditionally** — `gamma_levels.py`
+  exempted `gamma_flip` from the side-guard on purpose (it legitimately sits either side
+  of spot), which left it with _no_ guard. Probing UW's `/gex-levels` for SPX over eight
+  sessions on 2026-08-02 returned `gamma_flip` null on six and 8109.8 / 8156.26 on the
+  other two — both ~8–9% above a ~7450–7490 spot, both non-round where every sibling
+  field is a listed strike, and both contradicting UW's own positive-gamma ("dampening")
+  regime badge on the same screen. `apply_flip_guard` now drops a flip further than
+  `FLIP_MAX_DISTANCE_PCT` (5%, a judgement call — see the constant) from spot and names
+  it in `dropped`. A flip that was never offered is not reported as dropped. The chart's
+  disclosure note changes from "wrong side of spot" to the cause-agnostic "implausible vs
+  spot", since two different guards now feed `dropped`.
+
+- **SPX dealer levels on the density cone were fabricated by argon, not sourced from
+  UW** — `gex_levels_capture` swept only the active watchlist, and SPX is deliberately
+  _not_ a watchlist ticker (a slot there costs a full per-ticker UW burn). So
+  `uw_gex_levels_daily` held 114 tickers / 79k rows / **zero SPX**, `fetch_uw_gamma_levels`
+  returned None, and `resolve_levels` fell through to the `gex_snapshots` fallback —
+  argon's own unconstrained argmax, which `reports/gamma_levels.py` documents as
+  untrustworthy. Measured 2026-08-02 at spot 7489.72: the chart drew put wall **7000**
+  and γ flip **7475** where UW reports **7485** and **8156.26**. Two of the three overlay
+  lines were wrong. The capture now sweeps the watchlist ∪ `settings.gex_scan_tickers`
+  (the index scope the intraday GEX scanner already maintains), which adds exactly one
+  name — SPX — for +1 UW call/night. The other four alpha captures stay watchlist-only.
+  Nothing flagged this because `/api/health` freshness scopes coverage to the _active_
+  watchlist, so an off-watchlist ticker reads as 100% covered; that blind spot is
+  unchanged and is worth a separate look.
+
+### Changed
+
+- **SPX density cone readability pass (Regime → Market Compass)** — six display-only
+  tweaks, no change to the model, the API, or any persisted value:
+  - the recon strip now sits in a `.section` container with its own header, matching
+    the Gamma Exposure panel chrome instead of floating on the page background;
+  - the next-session density silhouette is anchored flush to the right price axis and
+    grows leftward (volume-profile idiom) rather than hanging off the h=1 date;
+  - the 1–5 day fan renders at the same price-range-per-pixel as the next-session
+    view by growing its pane (capped at 620 px), so the shared candles are the same
+    size in both — previously the fan squashed them into the same 360 px;
+  - the fan's `rightOffset` drops 2 → 0, closing the dead gap at the right axis;
+  - the next-session view gains dashed PROJ HIGH / PROJ LOW levels with axis labels
+    and a dot on the anchor close;
+  - the cone bands move off `--accent-vol` purple onto `--positive` teal (chart,
+    legend swatches, and mini-cone strip).
+
+## [0.11.0] — 2026-08-02
 
 ### Added
 
@@ -108,7 +153,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   `gamma_levels` and per-horizon `density`.
 - **Four bounds the review pass added, each closing a way the panel could state
   something it had not checked.** (1) `vol_index_daily.close` is nullable, and a
-  NULL arrives as NaN — which would sail straight *through* the alignment rail,
+  NULL arrives as NaN — which would sail straight _through_ the alignment rail,
   because the max disagreement becomes NaN and `NaN > 0` is `False`. A series
   with a hole in it would have passed the "exact agreement" check that a
   one-cent error fails, then been fitted under the same index and seed as a
@@ -117,7 +162,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   measures against the price the chart is actually drawn at, not the level row's
   own spot — an unbounded `market_date <= as_of` lookback would happily draw
   walls from a session months old, and the guard would not catch them because
-  they are consistent with *that* session's spot. (3) The backfill refuses to
+  they are consistent with _that_ session's spot. (3) The backfill refuses to
   touch any session the nightly job issued prospectively, even under `--force`:
   `upsert_rows` updates `origin` on conflict, so a recompute would relabel a
   genuinely out-of-sample cone as reconstructed and quietly inflate the only
@@ -125,7 +170,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   real bar are dropped rather than drawn over sessions whose outcome is already
   known, which also removes the duplicate `target_date` the settle pass can
   produce when a holiday falls inside the window — lightweight-charts asserts
-  strictly ascending times only in its *development* bundle, so in production a
+  strictly ascending times only in its _development_ bundle, so in production a
   duplicate renders a degenerate series instead of failing loudly.
 
 ### Changed
@@ -139,6 +184,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   `.section` / `.section-header` / `.section-body` chrome, matching the Gamma
   Exposure tab — the body padding is repeated on the panel rather than inherited
   because `.section-body` ships `padding: 0` and each panel opts in.
+
 ## [0.10.18] — 2026-07-29
 
 ### Added

--- a/src/uw_scan/models/spx_density.py
+++ b/src/uw_scan/models/spx_density.py
@@ -84,8 +84,8 @@ class SpxDensityPathPoint(_UwBase):
 
 class SpxGammaLevels(_UwBase):
     """Dealer levels for the chart overlay. Any field may be None — a level that failed
-    the side-guard is omitted and named in `dropped`, never drawn on the wrong side of
-    spot. See reports/gamma_levels.py for why the guard exists."""
+    a guard is omitted and named in `dropped`: walls on the wrong side of spot, a gamma
+    flip too far from spot to be a credible crossing. See reports/gamma_levels.py."""
 
     as_of: date | None = None
     spot: float | None = None

--- a/src/uw_scan/reports/gamma_levels.py
+++ b/src/uw_scan/reports/gamma_levels.py
@@ -19,8 +19,11 @@ signal, it is a false one. So:
   * Either way a side-guard runs: a call wall at or below spot, or a put wall at or above
     spot, is DROPPED and named in `dropped`. A missing line is honest; a wrong one is not.
 
-Gamma flip is exempt from the guard — it legitimately sits on either side of spot (that is
-what makes it the flip), and its observed values track spot closely.
+Gamma flip is exempt from the SIDE guard — it legitimately sits on either side of spot,
+that is what makes it the flip. That left it with no guard at all, which turned out to
+matter: UW's `/gex-levels` returns `gamma_flip` null on most SPX sessions and, when it
+does resolve, a value 8-9% above spot. So it gets a DISTANCE guard instead — see
+`apply_flip_guard`.
 
 Not fixing cards/gex.py here on purpose: it feeds the GEX tab, the cockpit, dealer_regime
 and the AI prompt payloads, so changing its numbers is a far wider blast radius than a
@@ -39,6 +42,21 @@ from decimal import Decimal
 # would happily draw levels from a session months old, and the side-guard would not catch
 # it because those walls are consistent with THAT session's spot, not today's.
 LEVELS_MAX_AGE_DAYS = 7
+
+# How far from spot a gamma flip may sit and still be drawn, as a fraction of spot.
+#
+# 5% is a JUDGEMENT CALL, not a derived threshold. It was picked to keep everything that
+# behaves like a near-spot zero-gamma crossing (argon's own snapshots sit well inside 2%)
+# while rejecting what UW returns for SPX. Probed 2026-08-02 over eight sessions,
+# `/api/stock/SPX/gex-levels` gave gamma_flip null on six and 8109.8 / 8156.26 on the
+# other two — both ~8-9% above a ~7450-7490 spot, both non-round where every other field
+# in the same payload is a listed strike (7500 / 7300 / 6910). A fractional value that
+# far out is a root-find extrapolating past the traded strike range, not a crossing; it
+# also contradicts UW's own regime badge on the same screen, which read positive gamma
+# ("dampening") and so implies a flip at or below spot.
+#
+# Widen it if a legitimate flip is ever observed outside — but require the evidence.
+FLIP_MAX_DISTANCE_PCT = 0.05
 
 
 @dataclass(frozen=True)
@@ -83,6 +101,26 @@ def apply_side_guard(
     return call_wall, put_wall, dropped
 
 
+def apply_flip_guard(
+    *,
+    spot: float | None,
+    gamma_flip: float | None,
+) -> tuple[float | None, list[str]]:
+    """Drop a gamma flip too far from spot to be a credible zero-gamma crossing.
+
+    Distance, not side, is the discriminator here — see FLIP_MAX_DISTANCE_PCT for the
+    observations that set the threshold. With no spot there is nothing to measure
+    against, so the flip goes, same as the walls do.
+    """
+    if gamma_flip is None:
+        return None, []
+    if spot is None or spot <= 0:
+        return None, ["gamma_flip"]
+    if abs(gamma_flip - spot) / spot > FLIP_MAX_DISTANCE_PCT:
+        return None, ["gamma_flip"]
+    return gamma_flip, []
+
+
 def resolve_levels(
     *,
     uw_row: dict | None,
@@ -110,14 +148,17 @@ def resolve_levels(
         call_wall=_f(row.get("call_wall")),
         put_wall=_f(row.get("put_wall")),
     )
+    gamma_flip, flip_dropped = apply_flip_guard(
+        spot=spot, gamma_flip=_f(row.get("gamma_flip"))
+    )
     return GammaLevels(
         as_of=row.get("market_date") or row.get("data_date"),
         spot=spot,
         call_wall=call_wall,
         put_wall=put_wall,
-        gamma_flip=_f(row.get("gamma_flip")),
+        gamma_flip=gamma_flip,
         source=source,
-        dropped=dropped,
+        dropped=dropped + flip_dropped,
     )
 
 

--- a/src/uw_scan/worker/jobs/uw_alpha_capture.py
+++ b/src/uw_scan/worker/jobs/uw_alpha_capture.py
@@ -308,6 +308,34 @@ _CaptureFn = Callable[
 ]
 
 
+def _sweep_tickers(repo: Repository, extra: Sequence[str]) -> list[str]:
+    """Active watchlist first, then any `extra` names not already on it.
+
+    The watchlist is the default scope for every capture, but it is NOT the whole
+    universe argon tracks. Index symbols — SPX above all — are swept every couple of
+    minutes by the GEX scanner from `settings.gex_scan_tickers` and never appear on the
+    watchlist at all. A watchlist-only sweep therefore left `uw_gex_levels_daily` with
+    zero SPX rows (verified on the mini: 114 tickers, 79k rows, no SPX), which made
+    `SpxDensityRepository.fetch_uw_gamma_levels` return None and silently dropped the
+    density cone's dealer overlay onto the `gex_snapshots` fallback — argon's own
+    unconstrained argmax, which reports/gamma_levels.py documents as untrustworthy.
+
+    Nothing flagged it: `/api/health` freshness scopes coverage to the ACTIVE watchlist,
+    so a ticker that is off the list reads as 100% covered.
+
+    Dedup is order-preserving so the watchlist keeps priority if the UW budget governor
+    cuts the sweep short.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in [c.ticker for c in repo.list_watchlist_cards()] + list(extra):
+        t = name.upper()
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
 def _run_capture(
     name: str,
     capture_fn: _CaptureFn,
@@ -318,6 +346,7 @@ def _run_capture(
     settings: Settings,
     ticker_filter: Callable[[str], bool] | None,
     market_date: date | None = None,
+    extra_tickers: Sequence[str] = (),
 ) -> dict[str, int]:
     if not repo.try_advisory_lock(lock_key):
         logger.info("%s: lock held; skipping this tick", name)
@@ -327,8 +356,7 @@ def _run_capture(
         market_date = datetime.now(ZoneInfo(settings.rth_tz)).date()
     tickers_done = rows_written = errors = 0
     try:
-        for card in repo.list_watchlist_cards():
-            ticker = card.ticker.upper()
+        for ticker in _sweep_tickers(repo, extra_tickers):
             if ticker_filter is not None and not ticker_filter(ticker):
                 continue
             run_id = repo.insert_scan_run(ticker, notes=name)
@@ -358,6 +386,13 @@ def gex_levels_capture(
     lock_key: int = GEX_LEVELS_CAPTURE_LOCK,
     market_date: date | None = None,
 ) -> dict[str, int]:
+    # Only this capture widens past the watchlist. UW's precomputed dealer levels are
+    # the density cone's primary wall source, and the cone is drawn on SPX — an index
+    # that is deliberately NOT a watchlist ticker (a slot there costs a full per-ticker
+    # UW burn). `gex_scan_tickers` is the index scope argon already maintains for the
+    # intraday GEX scanner; reusing it adds exactly one name (SPX) to this sweep, i.e.
+    # +1 UW call/night. The other four alpha captures stay watchlist-only on purpose —
+    # nothing reads them for an off-watchlist symbol.
     return _run_capture(
         "uw_alpha_gex_capture",
         capture_gex_levels_for,
@@ -367,6 +402,7 @@ def gex_levels_capture(
         settings=settings,
         ticker_filter=ticker_filter,
         market_date=market_date,
+        extra_tickers=settings.gex_scan_tickers,
     )
 
 

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -15630,7 +15630,7 @@
         "type": "object"
       },
       "SpxGammaLevels": {
-        "description": "Dealer levels for the chart overlay. Any field may be None \u2014 a level that failed\nthe side-guard is omitted and named in `dropped`, never drawn on the wrong side of\nspot. See reports/gamma_levels.py for why the guard exists.",
+        "description": "Dealer levels for the chart overlay. Any field may be None \u2014 a level that failed\na guard is omitted and named in `dropped`: walls on the wrong side of spot, a gamma\nflip too far from spot to be a credible crossing. See reports/gamma_levels.py.",
         "properties": {
           "as_of": {
             "anyOf": [

--- a/tests/integration/worker/test_uw_alpha_capture.py
+++ b/tests/integration/worker/test_uw_alpha_capture.py
@@ -163,3 +163,31 @@ def test_gex_levels_capture_wrapper_real_path(
             (target,),
         )
         assert cur.fetchone()[0] == 1
+
+
+def test_gex_levels_capture_covers_offwatchlist_index(
+    seeded_db_empty_cards, _migrated_settings
+):
+    """SPX is swept even though it is not a watchlist ticker.
+
+    This is the whole point of `extra_tickers`: the density cone reads UW's precomputed
+    dealer levels for SPX, and a watchlist-only sweep left that table with zero SPX rows
+    while /api/health still reported 100% coverage (coverage is scoped to the watchlist).
+    """
+    repo = seeded_db_empty_cards
+    active = {c.ticker.upper() for c in repo.list_watchlist_cards()}
+    assert "SPX" not in active, "fixture regressed — SPX must be off-watchlist here"
+    assert "SPX" in _migrated_settings.gex_scan_tickers
+
+    summary = gex_levels_capture(
+        repo=repo,
+        client=_FakeUwClient(),
+        settings=_migrated_settings,
+        ticker_filter=lambda t: t == "SPX",
+    )
+    assert summary == {"tickers": 1, "rows": 1, "errors": 0}
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM uw_scan.uw_gex_levels_daily WHERE ticker='SPX'"
+        )
+        assert cur.fetchone()[0] == 1

--- a/tests/unit/reports/test_gamma_levels.py
+++ b/tests/unit/reports/test_gamma_levels.py
@@ -9,7 +9,13 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from uw_scan.reports.gamma_levels import apply_side_guard, resolve_levels
+import pytest
+
+from uw_scan.reports.gamma_levels import (
+    apply_flip_guard,
+    apply_side_guard,
+    resolve_levels,
+)
 
 
 def test_wall_below_spot_is_dropped_not_drawn() -> None:
@@ -84,8 +90,66 @@ def test_falls_back_to_snapshot_and_still_guards() -> None:
     assert levels.source == "gex_snapshots"
     assert levels.call_wall is None
     assert levels.dropped == ["call_wall"]
-    # gamma flip is exempt from the guard and survives above spot
+    # gamma flip is exempt from the SIDE guard: 7525 is above spot 7383 and survives,
+    # because 1.9% away is a credible crossing. Distance is the only thing that kills it.
     assert levels.gamma_flip == 7525.0
+    assert levels.empty is False
+
+
+# --------------------------------------------------------------------------- #
+# Distance guard on the gamma flip.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("flip", [8109.8, 8156.26])
+def test_real_uw_far_flip_is_dropped(flip: float) -> None:
+    """The two values UW's /gex-levels actually returned for SPX (2026-07-20 and
+    2026-07-31, probed 2026-08-02) against that week's ~7490 spot. Both land ~8-9% out —
+    a root-find past the traded strike range, not a zero-gamma crossing."""
+    kept, dropped = apply_flip_guard(spot=7489.72, gamma_flip=flip)
+    assert kept is None
+    assert dropped == ["gamma_flip"]
+
+
+def test_near_spot_flip_on_either_side_survives() -> None:
+    """Side is NOT the discriminator — a flip above spot is still a legitimate flip."""
+    assert apply_flip_guard(spot=7489.72, gamma_flip=7475.0) == (7475.0, [])
+    assert apply_flip_guard(spot=7489.72, gamma_flip=7600.0) == (7600.0, [])
+
+
+def test_flip_guard_boundary_is_inclusive() -> None:
+    """Exactly at the threshold is kept; a hair beyond is dropped."""
+    spot = 1000.0
+    assert apply_flip_guard(spot=spot, gamma_flip=1050.0) == (1050.0, [])
+    assert apply_flip_guard(spot=spot, gamma_flip=1050.01) == (None, ["gamma_flip"])
+
+
+def test_absent_flip_is_not_reported_as_dropped() -> None:
+    """UW returns null on most SPX sessions. Nothing was suppressed, so `dropped` must
+    stay empty — otherwise the chart prints a 'not drawn' note about a level that was
+    never offered."""
+    assert apply_flip_guard(spot=7489.72, gamma_flip=None) == (None, [])
+
+
+def test_no_spot_means_no_flip() -> None:
+    assert apply_flip_guard(spot=None, gamma_flip=7475.0) == (None, ["gamma_flip"])
+
+
+def test_far_flip_is_dropped_end_to_end_and_walls_survive() -> None:
+    """The exact shape of the SPX row once the capture fix lands: UW's walls are good,
+    its flip is not. The overlay must keep the walls and lose only the flip."""
+    levels = resolve_levels(
+        uw_row={
+            "market_date": date(2026, 7, 31),
+            "call_wall": 7500.0,
+            "put_wall": 7485.0,
+            "gamma_flip": 8156.26,
+            "spot": None,
+        },
+        gex_row=None,
+        chart_spot=7489.72,
+    )
+    assert (levels.call_wall, levels.put_wall) == (7500.0, 7485.0)
+    assert levels.gamma_flip is None
+    assert levels.dropped == ["gamma_flip"]
     assert levels.empty is False
 
 

--- a/web/components/regime/DensityConeChart.tsx
+++ b/web/components/regime/DensityConeChart.tsx
@@ -22,7 +22,12 @@ import type {
 
 export type ConeView = "fan" | "focused";
 
-const HEIGHT = 360;
+// Height of the next-session view. The fan scales OFF this — see paneHeight.
+const BASE_HEIGHT = 360;
+// Ceiling for the fan. A cone whose h=5 tails blow out (a vol shock) would otherwise
+// demand a pane taller than the viewport; past this the fan does compress, which is
+// the right failure — an unscrollable chart is worse than an uneven candle scale.
+const MAX_HEIGHT = 620;
 
 // Outermost first so the inner, denser bands paint on top.
 const BANDS: Array<[keyof SpxDensityHorizon, keyof SpxDensityHorizon, number]> =
@@ -44,6 +49,46 @@ function cssVar(name: string, fallback: string): string {
  *  a correct chronological compare, which the whitespace filter below relies on. */
 const asTime = (d: string) => d as unknown as Time;
 
+/**
+ * Both views must render at the same price-range-per-pixel, or the fan's wider span
+ * squashes the identical candles it shares with the next-session view and the two
+ * pictures stop being comparable. The pane height is the only free variable that does
+ * not cost information: locking the fan to the near range would crop the h=5 90% band,
+ * which is the one thing the fan exists to show.
+ *
+ * scaleMargins is identical across views, so the ratio of DATA spans is the ratio of
+ * visible spans — no need to ask lightweight-charts what it autoscaled to.
+ */
+function paneHeight(
+  view: ConeView,
+  forecast: SpxDensityForecast,
+  recentPath: SpxPathPoint[],
+): number {
+  if (view === "focused") return BASE_HEIGHT;
+  const anchor = forecast.anchor_close;
+  const candles: number[] = [anchor];
+  for (const p of recentPath) {
+    candles.push(p.close);
+    if (p.high != null) candles.push(p.high);
+    if (p.low != null) candles.push(p.low);
+  }
+  // Price lines (dealer levels) are excluded on purpose: lightweight-charts does not
+  // autoscale to them either, so counting them here would overstate the span.
+  const span = (rows: SpxDensityHorizon[], withBaseline: boolean) => {
+    const v = [...candles];
+    for (const r of rows) {
+      v.push(anchor * (1 + r.q05), anchor * (1 + r.q95));
+      if (withBaseline)
+        v.push(anchor * (1 + r.baseline_q10), anchor * (1 + r.baseline_q90));
+    }
+    return Math.max(...v) - Math.min(...v);
+  };
+  const near = span(forecast.rows.slice(0, 1), false);
+  const full = span(forecast.rows, true);
+  if (!(near > 0) || !(full > near)) return BASE_HEIGHT;
+  return Math.min(MAX_HEIGHT, Math.round(BASE_HEIGHT * (full / near)));
+}
+
 function DensityConeChart({
   forecast,
   recentPath,
@@ -56,6 +101,7 @@ function DensityConeChart({
   view: ConeView;
 }) {
   const hostRef = useRef<HTMLDivElement>(null);
+  const height = paneHeight(view, forecast, recentPath);
 
   useEffect(() => {
     const el = hostRef.current;
@@ -65,11 +111,11 @@ function DensityConeChart({
     const borderDim = cssVar("--border-dim", "rgba(148,163,184,0.18)");
     const positive = cssVar("--positive", "#26a69a");
     const negative = cssVar("--negative", "#ef5350");
-    const bandBase = cssVar("--accent-vol", "#7c6cf0");
+    const bandBase = cssVar("--positive", "#05ad98");
 
     const chart = createChart(el, {
       autoSize: true,
-      height: HEIGHT,
+      height,
       layout: {
         background: { type: ColorType.Solid, color: "transparent" },
         textColor: muted,
@@ -89,13 +135,13 @@ function DensityConeChart({
       timeScale: {
         borderColor: borderDim,
         timeVisible: false,
-        // Blank bar-widths reserved right of the last point. Focused needs enough to
-        // hold the density silhouette; the fan just ungluess the h=5 edge from the
-        // price axis. NOT combined with fixRightEdge — that pins the last bar to the
-        // frame and silently cancels this offset, which left the profile with zero
-        // room and nothing drawn. Scroll/scale are already disabled, so no pinning
-        // is needed to keep the content in place.
-        rightOffset: view === "focused" ? 3 : 2,
+        // Blank bar-widths reserved right of the last point. Focused reserves the strip
+        // the density silhouette occupies; the fan reserves nothing — its h=5 edge IS
+        // the subject and any gap there just reads as dead space. NOT combined with
+        // fixRightEdge — that pins the last bar to the frame and silently cancels this
+        // offset, which left the profile with zero room and nothing drawn. Scroll/scale
+        // are already disabled, so no pinning is needed to keep the content in place.
+        rightOffset: view === "focused" ? 3 : 0,
       },
       rightPriceScale: {
         borderColor: borderDim,
@@ -155,10 +201,6 @@ function DensityConeChart({
     // for why a stale or duplicated target date must not reach the axis.
     const drawRows = drawableRows(coneRows, lastBarDate);
     const futureDates = drawRows.map((r) => r.target_date);
-    // The density silhouette hangs off the h=1 target date and grows into the blank
-    // space `rightOffset` reserves — so it is anchored to the date it describes, and
-    // no fictitious sessions are added to the axis to make room for it.
-    const profileAnchor = futureDates[futureDates.length - 1];
 
     const bars = recentPath.map((p) =>
       useCandles && p.open != null && p.high != null && p.low != null
@@ -233,23 +275,68 @@ function DensityConeChart({
           ]);
           primitives.push(block);
         }
-      }
 
-      if (head?.density && profileAnchor) {
-        const profile = new DensityProfile({
-          upColor: withAlpha(negative, 0.45),
-          downColor: withAlpha(positive, 0.45),
-          lineColor: withAlpha(muted, 0.7),
-          maxWidthPx: 115,
-          style: "curve",
+        // Flat baseline flush against the price axis, silhouette bulging LEFT into the
+        // pane — the volume-profile idiom. Hanging it off the h=1 date and growing
+        // right instead put the fat part of the distribution in the corner and left a
+        // dead gap against the axis.
+        if (head.density) {
+          const profile = new DensityProfile({
+            upColor: withAlpha(negative, 0.45),
+            downColor: withAlpha(positive, 0.45),
+            lineColor: withAlpha(muted, 0.7),
+            maxWidthPx: 115,
+            style: "curve",
+            anchor: "pane-right",
+            direction: "left",
+          });
+          series.attachPrimitive(profile);
+          profile.setProfile({
+            time: asTime(head.target_date), // ignored under anchor: "pane-right"
+            bars: densityBarsFromBins(head.density, anchor),
+            splitPrice: anchor,
+          });
+          primitives.push(profile);
+        }
+
+        // The two numbers the next-session view is read for, drawn as levels rather
+        // than left to the caption underneath. Deliberately not the median: the dotted
+        // p50 series already crosses the pane, and a third axis label collides with
+        // CALL WALL / γ FLIP, which are the levels that actually constrain a trade.
+        for (const [ret, color, title] of [
+          [head.q95, negative, "PROJ HIGH"],
+          [head.q05, positive, "PROJ LOW"],
+        ] as Array<[number, string, string]>) {
+          series.createPriceLine({
+            price: price(ret),
+            color,
+            lineWidth: 1,
+            lineStyle: LineStyle.Dashed,
+            axisLabelVisible: true,
+            title,
+          });
+        }
+
+        // Marks where the cone is issued FROM. Light, not black as in the reference
+        // shot: on this theme a black dot disappears whenever the close sits on a wick
+        // instead of a candle body.
+        const closeDot = chart.addSeries(LineSeries, {
+          color: cssVar("--text-primary", "#e2e8f0"),
+          lineVisible: false,
+          pointMarkersVisible: true,
+          pointMarkersRadius: 4,
+          priceLineVisible: false,
+          lastValueVisible: false,
+          crosshairMarkerVisible: false,
         });
-        series.attachPrimitive(profile);
-        profile.setProfile({
-          time: asTime(profileAnchor),
-          bars: densityBarsFromBins(head.density, anchor),
-          splitPrice: anchor,
-        });
-        primitives.push(profile);
+        closeDot.setData([
+          {
+            time: asTime(lastBarDate),
+            value: recentPath.length
+              ? recentPath[recentPath.length - 1].close
+              : anchor,
+          },
+        ] as never);
       }
     }
 
@@ -320,13 +407,13 @@ function DensityConeChart({
       for (const p of primitives) series.detachPrimitive(p);
       chart.remove();
     };
-  }, [forecast, recentPath, gammaLevels, view]);
+  }, [forecast, recentPath, gammaLevels, view, height]);
 
   return (
     <div
       ref={hostRef}
       data-testid="spx-density-chart"
-      style={{ width: "100%", height: HEIGHT }}
+      style={{ width: "100%", height }}
     />
   );
 }

--- a/web/components/regime/DensityConePanel.tsx
+++ b/web/components/regime/DensityConePanel.tsx
@@ -209,7 +209,7 @@ export default function DensityConePanel() {
               style={{
                 width: 16,
                 height: 9,
-                background: "var(--accent-vol, #7c6cf0)",
+                background: "var(--positive, #05ad98)",
                 opacity,
                 border: "1px solid var(--border-dim)",
               }}
@@ -261,7 +261,9 @@ export default function DensityConePanel() {
         )}
         {levels && levels.dropped.length > 0 && (
           <span data-testid="cone-levels-note">
-            {levels.dropped.join("/")} not drawn — wrong side of spot
+            {/* Two guards feed `dropped` now (wrong-side walls, far-from-spot gamma
+                flip), so the note states the outcome rather than naming one cause. */}
+            {levels.dropped.join("/")} not drawn — implausible vs spot
           </span>
         )}
       </div>

--- a/web/components/regime/DensityConeStrip.tsx
+++ b/web/components/regime/DensityConeStrip.tsx
@@ -16,7 +16,7 @@ const H = 110;
 const PAD = { top: 8, right: 8, bottom: 16, left: 8 };
 
 const COLORS = {
-  band: "var(--accent-vol, #7c6cf0)",
+  band: "var(--positive, #05ad98)",
   realised: "var(--accent-warm, #F5A623)",
   muted: "var(--text-muted)",
   good: "var(--positive, #22c55e)",
@@ -135,10 +135,27 @@ export default function DensityConeStrip() {
     return r ? `${r.inside}/${r.total}` : "0/0";
   };
 
+  // Same `.section` chrome as the GEX panel and the cone above it — the strip used to
+  // sit bare on the page background, which read as chart debris rather than a panel.
   return (
-    <div data-testid="spx-density-strip">
+    <div className="section" data-testid="spx-density-strip">
+      <div className="section-header">
+        <div className="section-title">Recent Cones vs Realised</div>
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: COLORS.muted,
+          }}
+        >
+          80%-band hit rate (scored horizons) · prospective {fmt("prospective")}{" "}
+          · reconstructed {fmt("reconstructed")} (in-sample)
+        </span>
+      </div>
       <div
+        className="section-body"
         style={{
+          padding: 16,
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
           gap: 10,
@@ -147,17 +164,6 @@ export default function DensityConeStrip() {
         {forecasts.map((f) => (
           <MiniCone key={f.as_of} f={f} />
         ))}
-      </div>
-      <div
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: 10,
-          color: COLORS.muted,
-          marginTop: 6,
-        }}
-      >
-        80%-band hit rate (scored horizons) · prospective {fmt("prospective")} ·
-        reconstructed {fmt("reconstructed")} (in-sample)
       </div>
     </div>
   );

--- a/web/lib/lwc/densityProfile.ts
+++ b/web/lib/lwc/densityProfile.ts
@@ -41,6 +41,11 @@ export interface DensityProfileOptions {
   maxWidthPx?: number;
   /** Grow to the right of the anchor date (default) or to the left. */
   direction?: "right" | "left";
+  /** Where the flat baseline sits: on the profile's own `time` (default), or flush
+   *  against the right price axis regardless of date — the TradingView volume-profile
+   *  idiom, which reads as "this is the distribution", not "this happens on that bar".
+   *  With "pane-right" the `time` field is ignored. */
+  anchor?: "time" | "pane-right";
   /** "curve" draws one filled silhouette through the bin tops (the reference look);
    *  "bars" draws each bin as a discrete rectangle. */
   style?: "curve" | "bars";
@@ -52,6 +57,7 @@ const defaults: Required<DensityProfileOptions> = {
   downColor: "rgba(38, 166, 154, 0.55)",
   maxWidthPx: 90,
   direction: "right",
+  anchor: "time",
   style: "curve",
   lineColor: "rgba(226, 232, 240, 0.55)",
 };
@@ -142,12 +148,17 @@ class DensityProfilePaneView implements IPrimitivePaneView {
     const data = this._source._data;
     if (!chart || !series || !data || data.bars.length === 0) return;
 
-    const x0 = chart.timeScale().timeToCoordinate(data.time);
+    const opts = this._source._options;
+    // timeScale().width() is the drawing area in media coords — i.e. exactly where the
+    // price axis starts — so "pane-right" needs no ResizeObserver of its own.
+    const x0 =
+      opts.anchor === "pane-right"
+        ? chart.timeScale().width()
+        : chart.timeScale().timeToCoordinate(data.time);
     if (x0 == null) return; // profile date scrolled off-screen
 
     const peak = Math.max(...data.bars.map((b) => b.weight));
     if (!(peak > 0)) return;
-    const opts = this._source._options;
 
     for (const b of data.bars) {
       const yTop = series.priceToCoordinate(b.upper);

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6784,8 +6784,8 @@ export interface components {
         /**
          * SpxGammaLevels
          * @description Dealer levels for the chart overlay. Any field may be None — a level that failed
-         *     the side-guard is omitted and named in `dropped`, never drawn on the wrong side of
-         *     spot. See reports/gamma_levels.py for why the guard exists.
+         *     a guard is omitted and named in `dropped`: walls on the wrong side of spot, a gamma
+         *     flip too far from spot to be a credible crossing. See reports/gamma_levels.py.
          */
         SpxGammaLevels: {
             /** As Of */

--- a/web/tests/unit/density-cone.test.tsx
+++ b/web/tests/unit/density-cone.test.tsx
@@ -156,7 +156,30 @@ describe("DensityConePanel", () => {
     render(<DensityConePanel />);
     const note = await screen.findByTestId("cone-levels-note");
     expect(note.textContent).toContain("call_wall");
-    expect(note.textContent).toContain("wrong side of spot");
+    // Wording is deliberately cause-agnostic: `dropped` is fed by two different guards
+    // (wrong-side walls, far-from-spot gamma flip), so it states the outcome only.
+    expect(note.textContent).toContain("implausible vs spot");
+  });
+
+  it("discloses a gamma flip dropped for distance, not just walls", async () => {
+    // UW returned gamma_flip 8156.26 against a ~7490 spot — ~9% out. The API-side
+    // distance guard nulls it and names it; the panel must say so rather than simply
+    // rendering one fewer line.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...LATEST,
+        gamma_levels: {
+          ...LATEST.gamma_levels,
+          gamma_flip: null,
+          dropped: ["gamma_flip"],
+        },
+      }),
+    });
+    render(<DensityConePanel />);
+    const note = await screen.findByTestId("cone-levels-note");
+    expect(note.textContent).toContain("gamma_flip");
+    expect(note.textContent).toContain("implausible vs spot");
   });
 
   it("counts close-only sessions instead of drawing invented candles", async () => {


### PR DESCRIPTION
## Why

Two of the three dealer lines on the SPX density cone overlay were computed by argon rather than sourced from UW, and one was plainly wrong. Measured on the mini at spot **7489.72**:

| line | argon drew | UW `/gex-levels` |
|---|---|---|
| call wall | 7500 | 7500 (coincidence) |
| put wall | **7000** | **7485** |
| γ flip | **7475** | **8156.26** |

A put wall 490 points under spot is a false statement, not a weak signal.

## Root cause

`gex_levels_capture` swept only the **active watchlist**, and SPX is deliberately not a watchlist ticker (a slot costs a full per-ticker UW burn). So:

- `uw_gex_levels_daily`: 79,051 rows / **114 tickers** / 2023-08-03 → 2026-07-31 — **zero SPX**
- `scan_runs WHERE notes='uw_alpha_gex_capture'`: 570 rows = 114 × 5 nights — **zero SPX**
- `fetch_uw_gamma_levels` → `None` → `resolve_levels` falls through to the `gex_snapshots` fallback, i.e. `cards/gex.py::_market_structure_levels`'s unconstrained argmax, which `reports/gamma_levels.py` already documents as untrustworthy.

**Nothing flagged this.** `/api/health` freshness reported `coverage_pct: 1.0`, `days_stale: 0` — because coverage is scoped to the *active* watchlist, so a ticker that is off the list reads as fully covered. That blind spot is **not** fixed here and is worth a separate look.

UW itself is fine: `/api/stock/SPX/gex-levels` returns HTTP 200 with every field, with or without `?date=`.

## Fix 1 — capture scope

`gex_levels_capture` now sweeps **watchlist ∪ `settings.gex_scan_tickers`**, the index scope the intraday GEX scanner already maintains. Of its 12 names, **SPX is the only one not already on the watchlist** — so this is **+1 UW call/night**, not +12. The other four alpha captures stay watchlist-only; nothing reads them off-watchlist.

## Fix 2 — the gamma flip does not survive scrutiny either

Probed `/gex-levels` for SPX over eight sessions on 2026-08-02:

```
2026-07-20  flip 8109.8     2026-07-27  flip null     2026-07-30  flip null
2026-07-23  flip null       2026-07-28  flip null     2026-07-31  flip 8156.26
2026-07-24  flip null       2026-07-29  flip null
```

Null on six of eight. The two that resolve land **+8–9% above spot**, are **non-round** where every sibling field is a listed strike (7500 / 7300 / 6910), and **contradict UW's own regime badge on the same screen** — "Dampening · Γ +0.70" is positive gamma, which implies a flip at or below spot.

`gamma_flip` was exempt from the side-guard for a *correct* reason — it legitimately sits either side of spot. That left it with **no guard at all**. `apply_flip_guard` adds the orthogonal axis:

```python
FLIP_MAX_DISTANCE_PCT = 0.05   # judgement call, evidence documented at the constant
```

A flip that was **never offered** returns `[]`, not `["gamma_flip"]` — UW gives null most days, and absent-as-dropped would print a "not drawn" note daily about a level nobody claimed. Test pins this.

Net effect on SPX once the capture lands: walls from UW, **no flip line**, and a note saying so. Honest — neither source could produce a credible flip.

## Display pass (same panel, no model or persisted value touched)

- recon strip moves into a `.section` container matching the Gamma Exposure chrome
- next-session density silhouette anchors flush to the right price axis, growing **leftward** (volume-profile idiom) instead of hanging off the h=1 date
- the 1–5 day fan renders at the **same price-range-per-pixel** as the next-session view by growing its pane (capped 620 px) rather than squashing the shared candles into 360 px
- fan `rightOffset` 2 → 0, closing the dead gap at the right axis
- next-session gains dashed PROJ HIGH / PROJ LOW levels + a dot on the anchor close
- bands move off `--accent-vol` purple onto `--positive` teal
- disclosure note → "implausible vs spot" (two guards feed `dropped` now, so naming one cause would be a false explanation)

## Verification

- `ruff check src/ tests/` — clean
- **1955 passed, 3 skipped** — `tests/unit/` + `tests/integration/api/` + `tests/integration/worker/`
- `npm run typecheck` clean · **670 web tests passed** (107 files)
- `openapi.snapshot.json` patched surgically with the documented `json.dumps(indent=2, ensure_ascii=True, sort_keys=True)` args — **1-line diff**
- `web/lib/types.ts` regenerated with openapi-typescript 7.13.0 — **2-line diff, no reorder churn**

New tests cover both real UW flip values (8109.8, 8156.26), the threshold boundary, null-is-not-dropped, no-spot, end-to-end walls-survive-flip-drops, and an off-watchlist SPX capture.

## Not verified

The capture fix **has not run on the mini** — that needs a deploy. Proof will be an SPX row in `uw_gex_levels_daily` after the 18:35 ET cron and `gamma_levels.source` flipping to `uw_gex_levels_daily`.

The 5% threshold is a judgement call, not derived. Documented as such at the constant.
