### PR TITLE
feat(watchlist): many-to-many industry-chain membership + chain-driven filter rail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ ohlc_cache.pkl
 
 # setuptools build tree (uv build / python -m build)
 build/
+
+# graphify knowledge-graph output — generated, machine-local
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **Many-to-many industry-chain membership for the watchlist.** New table
+  `uw_scan.watchlist_chain` (migration `113`) plus
+  `src/uw_scan/watchlist_taxonomy.py` as the single source of truth for the
+  9-layer / 38-chain taxonomy. `watchlist.sector` is unchanged and keeps its
+  job — it is still the ticker's one PRIMARY tag and decides which section a
+  card renders under; the join table carries the full membership set that
+  FILTERING selects on. Both exist because a single column cannot express the
+  taxonomy: NVDA is genuinely in `Computer/GPU`, `M7` *and*
+  `Foundation-Model-Proxy`, ARM is in three L1 chains, IBM is in both
+  `Cloud/Hyperscaler` and `Quantum`. The visible symptom was
+  `Foundation-Model-Proxy` reading as **empty** on the dashboard while all five
+  of its members sat on the page tagged `M7` — the whole Model & Tooling layer
+  was unreachable. Keeping `sector` as the display tag is what stops a naive
+  many-to-many render from drawing NVDA's card three times and ARM's three
+  times (~114 tickers becoming ~150 cards for the same names).
+- **`GET /api/watchlist/chains`** — every chain with its layer and live member
+  count. `GET /api/watchlist` gains a `chain=` filter that selects on
+  membership, so a ticker in several chains matches each of them, and
+  `WatchlistCard` gains a `chains: list[str]` field.
+- **59 tickers added to the watchlist**, screened market-wide by option
+  liquidity rather than hand-listed. This is what surfaced `FRMI` (968k OI) and
+  `KEEL` (1,076k OI) for `DC-REIT/Colo`, a chain that had read as empty only
+  because the hand-authored list was EQIX/DLR/IRM/AMT.
+
+### Changed
+
+- **The watchlist filter rail is served, not hardcoded.** `sectorGroups.ts` now
+  holds only rail ordering and short labels and builds itself from
+  `/api/watchlist/chains`; copying 38 chain names into TypeScript would have
+  recreated exactly the drift the taxonomy module exists to remove. Chains with
+  zero members are dropped — a rail button that filters to an empty grid is
+  worse than one that is not there. Filtering moved from `?sector=` to
+  `?chain=`.
+- **UW pool ceilings rebalanced** (mini `.env`): live `80000` → `60000`,
+  research `30000` → `45000`. The two now sum to `UW_TOTAL_DAILY_GUARD`
+  (105000), so the account-wide guard stays the binding constraint instead of
+  the pools being able to over-allocate against it. Measured weekday burn
+  before the adds was live ~38.4k / research ~24.9k, i.e. research sat at 83% of
+  its ceiling while live used 48% of its own.
+
 ## [0.11.3] — 2026-08-09
 
 

--- a/docs/runbooks/data-gap-dataset-policy.md
+++ b/docs/runbooks/data-gap-dataset-policy.md
@@ -6,7 +6,7 @@ Generated from `REGISTRY` in `src/uw_scan/reports/data_gap_healer.py` (one sourc
 uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_policy_markdown as r; open('docs/runbooks/data-gap-dataset-policy.md','w').write(r())"
 ```
 
-**131 datasets** across 9 groups.
+**132 datasets** across 9 groups.
 
 ## core_watchlist
 
@@ -69,6 +69,7 @@ uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_pol
 | scan_runs | provenance | none | none |  | none |  |
 | uw_fetch_memo | excluded | none | none |  | none | ephemeral same-day fetch dedupe cache; pruned daily, nothing to backfill/heal |
 | volatility_backfill_status | provenance | none | none |  | none |  |
+| watchlist_chain | excluded | none | none |  | none | chain membership, not a time series; added_at is a seed stamp, not a cadence |
 | watchlist_ticker_events | provenance | none | none |  | none |  |
 | worker_heartbeat | provenance | none | none |  | none |  |
 | ws_consumer_state | operational_state | none | none |  | liveness |  |

--- a/scripts/backfill/watchlist_chain_seed.py
+++ b/scripts/backfill/watchlist_chain_seed.py
@@ -1,0 +1,125 @@
+"""Seed `uw_scan.watchlist_chain` and optionally add the approved tickers.
+
+Two separable jobs behind one script, because they must happen in this order:
+
+1. `--add-tickers` inserts `SELECTED_ADDS` into the watchlist. Each gets a
+   primary `sector` = its first chain, since `sector` still decides which single
+   section a card renders under.
+2. Membership seeding always runs: taxonomy rows from the module, then
+   `sector`-inherited rows so nothing is left unreachable by the filter.
+
+Adding a ticker is NOT free — it enlists the name in every per-ticker scheduled
+job at roughly 240 UW calls/day. Against the mini that is a budget decision, so
+`--add-tickers` is opt-in and the script prints the cost before doing it.
+
+Idempotent and safe to re-run. Re-seeding replaces taxonomy rows wholesale (see
+WatchlistChainRepository.replace_taxonomy_memberships for why) and leaves
+inherited rows alone.
+
+Reproduce (local):
+    uv run python scripts/backfill/watchlist_chain_seed.py --dry-run
+    uv run python scripts/backfill/watchlist_chain_seed.py --add-tickers
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import psycopg
+
+from uw_scan.storage.watchlist_chain import WatchlistChainRepository
+from uw_scan.watchlist_taxonomy import LAYERS, SELECTED_ADDS, chains_for, memberships
+
+CALLS_PER_TICKER_DAY = 240  # measured 2026-08-03..07 on the mini
+
+
+def layer_for_chain() -> dict[str, str]:
+    return {chain: layer.key for layer in LAYERS for chain in layer.chains}
+
+
+def primary_sector(ticker: str) -> str:
+    """The single tag a card renders under. First chain in declared layer order.
+
+    Deliberately not "most specific" or "highest layer" — any rule here is a
+    judgement call, and a stable, explainable one beats a clever one.
+    """
+    chains = chains_for(ticker)
+    return chains[0] if chains else "Unassigned"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--dsn", default="host=127.0.0.1 dbname=option_wizard_local user=chenxi"
+    )
+    ap.add_argument("--schema", default="uw_scan")
+    ap.add_argument("--add-tickers", action="store_true", help="insert SELECTED_ADDS")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    with psycopg.connect(args.dsn) as conn:
+        repo = WatchlistChainRepository(conn, schema=args.schema)
+        with conn.cursor() as cur:
+            cur.execute(
+                f"SELECT ticker FROM {args.schema}.watchlist WHERE removed_at IS NULL"
+            )
+            existing = {r[0] for r in cur.fetchall()}
+
+        to_add = sorted(SELECTED_ADDS - existing)
+        already = sorted(SELECTED_ADDS & existing)
+        print(f"watchlist: {len(existing)} active")
+        print(
+            f"approved adds: {len(SELECTED_ADDS)}  new: {len(to_add)}  already held: {len(already)}"
+        )
+        if to_add:
+            print(
+                f"UW cost of adding {len(to_add)}: "
+                f"~{len(to_add) * CALLS_PER_TICKER_DAY / 1000:.1f}k calls/day"
+            )
+
+        if args.dry_run:
+            for t in to_add:
+                print(f"  + {t:<6} sector={primary_sector(t)}  chains={chains_for(t)}")
+            return 0
+
+        if args.add_tickers and to_add:
+            with conn.cursor() as cur:
+                cur.executemany(
+                    f"""
+                    INSERT INTO {args.schema}.watchlist (ticker, sector, sort_rank)
+                    VALUES (%s, %s, 0)
+                    ON CONFLICT (ticker) DO UPDATE
+                       SET sector = EXCLUDED.sector, removed_at = NULL
+                    """,
+                    [(t, primary_sector(t)) for t in to_add],
+                )
+            print(f"added {len(to_add)} tickers")
+
+        n_tax = repo.replace_taxonomy_memberships(memberships())
+        n_sec = repo.inherit_sector_memberships(layer_for_chain())
+        conn.commit()
+        print(f"memberships: {n_tax} taxonomy, {n_sec} inherited")
+
+        counts = repo.counts_by_chain()
+        empty = [c for c in layer_for_chain() if c not in counts]
+        print(f"chains with active members: {len(counts)}/{len(layer_for_chain())}")
+        if empty:
+            # Named, not hidden: an empty chain is a rail button that filters to
+            # nothing, and the UI needs to decide whether to render it.
+            print(f"empty chains: {' '.join(sorted(empty))}")
+
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT count(*) FROM {args.schema}.watchlist w
+                 WHERE w.removed_at IS NULL
+                   AND NOT EXISTS (SELECT 1 FROM {args.schema}.watchlist_chain c
+                                    WHERE c.ticker = w.ticker)
+                """
+            )
+            print(f"active tickers with NO chain: {cur.fetchone()[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/sync_local_from_mini.py
+++ b/scripts/dev/sync_local_from_mini.py
@@ -1,0 +1,280 @@
+"""Refresh option_wizard_local with a recent slice of the mini's option_wizard.
+
+Local dev DBs go stale (11 days, when this was written) and stale data hides
+bugs that only appear against real shapes. This pulls the most recent N market
+days from the mini so development runs against something realistic.
+
+READ-ONLY against the mini. The source connection is opened in a read-only
+transaction and the script never issues a write against it — the mini is the
+prodlike writer and nothing here may touch it.
+
+Destination is guarded: the script refuses to run unless the destination is a
+local host AND the database name ends in `_local`. That guard is the whole
+reason this is a standalone script rather than something wired through
+`uw_scan.config` — a typo here would write into the prodlike DB.
+
+Idempotent: each table's synced window is deleted locally and re-copied, so
+re-running converges rather than duplicating. Tables without a usable date
+column are full-replaced when small and skipped when large.
+
+Credentials come from ~/.pgpass (or PG* env vars) — this script deliberately
+takes no password argument so secrets stay out of shell history.
+
+Reproduce:
+    uv run python scripts/dev/sync_local_from_mini.py --days 20
+    uv run python scripts/dev/sync_local_from_mini.py --days 20 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+import psycopg
+
+SCHEMA = "uw_scan"
+
+SRC = {
+    "host": "100.66.147.98",
+    "port": 5432,
+    "dbname": "option_wizard",
+    "user": "argon_app",
+}
+DST = {
+    "host": "127.0.0.1",
+    "port": 5432,
+    "dbname": "option_wizard_local",
+    "user": "chenxi",
+}
+
+# raw_payloads is 61% of a 30-day slice (5.1 GB of 8.4 GB) and nothing in the
+# dashboard reads it — it is the raw UW response archive kept for replay/audit.
+# Excluding it by default is the single biggest win in this script.
+DEFAULT_EXCLUDE = {"raw_payloads"}
+
+# Preference order matters: market_date is the analytic partition key and gives
+# a clean per-day slice, while inserted_at is a write-time fallback that can
+# drag in rows whose market_date is far older (backfills). Prefer real business
+# dates; fall back to write time only when there is nothing better.
+DATE_COL_PREFERENCE = (
+    "market_date",
+    "trade_date",
+    "snapshot_date",
+    "data_date",
+    "as_of",
+    "as_of_date",
+    "obs_date",
+    "curr_date",
+    "executed_at",
+    "scanned_at",
+    "computed_at",
+    "created_at",
+    "requested_at",
+    "fetched_at",
+    "started_at",
+    "inserted_at",
+)
+
+# A dateless table this size is a fact table we cannot slice; copying it whole
+# would defeat the point of a windowed sync, so it is skipped and reported.
+FULL_COPY_MAX_ROWS = 200_000
+
+
+@dataclass
+class Plan:
+    table: str
+    date_col: str | None
+    est_rows: int
+
+
+def guard_destination() -> None:
+    host = DST["host"]
+    name = DST["dbname"]
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        sys.exit(f"REFUSING: destination host {host!r} is not local")
+    if not name.endswith("_local"):
+        sys.exit(f"REFUSING: destination db {name!r} does not end in '_local'")
+
+
+def tables_with_columns(conn: psycopg.Connection) -> dict[str, set[str]]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT c.relname, a.attname
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+            WHERE n.nspname = %s AND c.relkind = 'r'
+            """,
+            (SCHEMA,),
+        )
+        out: dict[str, set[str]] = {}
+        for table, col in cur.fetchall():
+            out.setdefault(table, set()).add(col)
+        return out
+
+
+def est_rows(conn: psycopg.Connection, table: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COALESCE(c.reltuples, 0)::bigint FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = %s AND c.relname = %s",
+            (SCHEMA, table),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+
+
+def cutoff_date(conn: psycopg.Connection, days: int) -> str:
+    """The Nth most recent distinct market_date — real trading days, not calendar.
+
+    Counting calendar days would silently under-deliver across holidays; asking
+    the data which days exist is exact and costs one indexed scan.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT DISTINCT market_date FROM {SCHEMA}.option_surface_grid_daily "
+            "ORDER BY market_date DESC LIMIT %s",
+            (days,),
+        )
+        rows = cur.fetchall()
+    if not rows:
+        sys.exit(
+            "could not determine cutoff: option_surface_grid_daily is empty on the source"
+        )
+    return rows[-1][0].isoformat()
+
+
+def build_plans(src_cols, dst_cols, exclude: set[str]) -> tuple[list[Plan], list[str]]:
+    plans: list[Plan] = []
+    skipped: list[str] = []
+    shared = sorted(set(src_cols) & set(dst_cols))
+    for table in shared:
+        if table in exclude:
+            skipped.append(f"{table} (excluded)")
+            continue
+        cols = src_cols[table] & dst_cols[table]
+        date_col = next((c for c in DATE_COL_PREFERENCE if c in cols), None)
+        plans.append(Plan(table=table, date_col=date_col, est_rows=0))
+    only_src = sorted(set(src_cols) - set(dst_cols))
+    only_dst = sorted(set(dst_cols) - set(src_cols))
+    for t in only_src:
+        skipped.append(f"{t} (source only — local schema is behind)")
+    for t in only_dst:
+        skipped.append(f"{t} (local only — not on the mini yet)")
+    return plans, skipped
+
+
+def sync_table(
+    src: psycopg.Connection,
+    dst: psycopg.Connection,
+    plan: Plan,
+    cutoff: str,
+    src_cols,
+    dst_cols,
+) -> tuple[int, str]:
+    """Copy one table's window. Returns (rows, mode)."""
+    # Only columns present on BOTH sides, so a schema drift in either direction
+    # degrades to a narrower copy instead of blowing up mid-transfer.
+    cols = sorted(src_cols[plan.table] & dst_cols[plan.table])
+    collist = ", ".join(f'"{c}"' for c in cols)
+
+    if plan.date_col:
+        where = f'WHERE "{plan.date_col}" >= %(cutoff)s'
+        mode = f"window({plan.date_col})"
+    else:
+        n = est_rows(src, plan.table)
+        if n > FULL_COPY_MAX_ROWS:
+            return (0, f"SKIPPED (no date column, ~{n:,} rows)")
+        where = ""
+        mode = "full"
+
+    with dst.cursor() as dcur:
+        if plan.date_col:
+            dcur.execute(
+                f'DELETE FROM {SCHEMA}.{plan.table} WHERE "{plan.date_col}" >= %s',
+                (cutoff,),
+            )
+        else:
+            dcur.execute(f"TRUNCATE {SCHEMA}.{plan.table}")
+
+    src_sql = f"COPY (SELECT {collist} FROM {SCHEMA}.{plan.table} {where}) TO STDOUT (FORMAT binary)"
+    dst_sql = f"COPY {SCHEMA}.{plan.table} ({collist}) FROM STDIN (FORMAT binary)"
+
+    rows = 0
+    with src.cursor() as scur, dst.cursor() as dcur:
+        with scur.copy(
+            src_sql, {"cutoff": cutoff} if plan.date_col else None
+        ) as reader:
+            with dcur.copy(dst_sql) as writer:
+                for block in reader:
+                    writer.write(block)
+        rows = dcur.rowcount if dcur.rowcount and dcur.rowcount > 0 else 0
+    return (rows, mode)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--days", type=int, default=20, help="most recent N market days (default 20)"
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="print the plan, copy nothing"
+    )
+    ap.add_argument("--tables", default="", help="comma-separated subset")
+    ap.add_argument(
+        "--include-raw-payloads",
+        action="store_true",
+        help="do not exclude raw_payloads",
+    )
+    args = ap.parse_args()
+
+    guard_destination()
+    exclude = set() if args.include_raw_payloads else set(DEFAULT_EXCLUDE)
+
+    print(f"source: {SRC['user']}@{SRC['host']}/{SRC['dbname']} (read-only)")
+    print(f"dest:   {DST['user']}@{DST['host']}/{DST['dbname']}")
+
+    with psycopg.connect(**SRC) as src, psycopg.connect(**DST) as dst:
+        src.read_only = True  # belt-and-braces: the mini must never be written
+        cutoff = cutoff_date(src, args.days)
+        print(f"cutoff: {cutoff}  ({args.days} most recent market days)\n")
+
+        src_cols = tables_with_columns(src)
+        dst_cols = tables_with_columns(dst)
+        plans, skipped = build_plans(src_cols, dst_cols, exclude)
+        if args.tables:
+            wanted = {t.strip() for t in args.tables.split(",") if t.strip()}
+            plans = [p for p in plans if p.table in wanted]
+
+        if args.dry_run:
+            for p in plans:
+                print(f"  {p.table:<40} {p.date_col or '(no date column)'}")
+            for s in skipped:
+                print(f"  SKIP {s}")
+            return 0
+
+        total = 0
+        for p in plans:
+            t0 = time.time()
+            try:
+                rows, mode = sync_table(src, dst, p, cutoff, src_cols, dst_cols)
+            except Exception as exc:  # noqa: BLE001 — one bad table must not abort the sync
+                dst.rollback()
+                print(f"  {p.table:<40} FAILED: {exc!r}")
+                continue
+            dst.commit()
+            total += rows
+            print(f"  {p.table:<40} {rows:>10,}  {mode}  {time.time() - t0:.1f}s")
+
+        print(f"\ndone: {total:,} rows")
+        for s in skipped:
+            print(f"  skipped: {s}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/sync_local_from_mini.py
+++ b/scripts/dev/sync_local_from_mini.py
@@ -28,6 +28,9 @@ Reproduce:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import socket
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -36,9 +39,15 @@ import psycopg
 
 SCHEMA = "uw_scan"
 
+# The mini's Postgres requires a password over the network but trusts local
+# connections, so we forward a port over SSH and connect through it. The
+# credential never leaves the mini and nothing lands in ~/.pgpass here.
+SSH_HOST = "macmini"  # ~/.ssh/config: moremeds@100.66.147.98
+TUNNEL_PORT = 15432
+
 SRC = {
-    "host": "100.66.147.98",
-    "port": 5432,
+    "host": "127.0.0.1",
+    "port": TUNNEL_PORT,
     "dbname": "option_wizard",
     "user": "argon_app",
 }
@@ -47,7 +56,63 @@ DST = {
     "port": 5432,
     "dbname": "option_wizard_local",
     "user": "chenxi",
+    # Startup option, not a SET: a SET inside a transaction is reverted by
+    # the per-table rollback, silently re-enabling FK checks mid-run.
+    "options": "-c session_replication_role=replica",
 }
+
+
+@contextlib.contextmanager
+def ssh_tunnel():
+    """Forward the mini's Postgres to TUNNEL_PORT for the life of the sync.
+
+    ExitOnForwardFailure matters: without it ssh reports success while the
+    forward silently failed, and the sync would then connect to whatever else
+    happens to be on that port.
+    """
+    # Pre-flight: if something already listens here, ssh fails to bind but the
+    # connect-poll below would happily succeed against THAT tunnel — pointing the
+    # sync at an unknown database. Refuse instead of silently inheriting it.
+    with socket.socket() as probe:
+        if probe.connect_ex(("127.0.0.1", TUNNEL_PORT)) == 0:
+            sys.exit(
+                f"port {TUNNEL_PORT} is already in use — a stale tunnel is likely "
+                f"still running. Kill it, then re-run:\n"
+                f"  lsof -ti :{TUNNEL_PORT} | xargs kill"
+            )
+
+    proc = subprocess.Popen(
+        [
+            "ssh",
+            "-N",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "BatchMode=yes",
+            "-L",
+            f"{TUNNEL_PORT}:localhost:5432",
+            SSH_HOST,
+        ]
+    )
+    try:
+        for _ in range(40):  # ~10s for the forward to come up
+            if proc.poll() is not None:
+                sys.exit(
+                    f"ssh tunnel to {SSH_HOST} exited early (rc={proc.returncode})"
+                )
+            try:
+                psycopg.connect(**SRC, connect_timeout=2).close()
+                break
+            except psycopg.OperationalError:
+                time.sleep(0.25)
+        else:
+            sys.exit(f"ssh tunnel to {SSH_HOST} never became usable")
+        yield
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
 
 # raw_payloads is 61% of a 30-day slice (5.1 GB of 8.4 GB) and nothing in the
 # dashboard reads it — it is the raw UW response archive kept for replay/audit.
@@ -60,6 +125,7 @@ DEFAULT_EXCLUDE = {"raw_payloads"}
 # dates; fall back to write time only when there is nothing better.
 DATE_COL_PREFERENCE = (
     "market_date",
+    "date",
     "trade_date",
     "snapshot_date",
     "data_date",
@@ -129,23 +195,26 @@ def est_rows(conn: psycopg.Connection, table: str) -> int:
 
 
 def cutoff_date(conn: psycopg.Connection, days: int) -> str:
-    """The Nth most recent distinct market_date — real trading days, not calendar.
+    """The Nth most recent distinct trading day.
 
-    Counting calendar days would silently under-deliver across holidays; asking
-    the data which days exist is exact and costs one indexed scan.
+    Counting calendar days would silently under-deliver across holidays, so we
+    ask the data which days exist. The source is vol_index_daily rather than
+    option_surface_grid_daily: the grid has ~17.8M rows and no index that
+    serves DISTINCT, so `SELECT DISTINCT market_date ... LIMIT 20` full-scans
+    and sorts it — measured 29.8s for a bare max() and worse for the DISTINCT.
+    vol_index_daily carries the same trading calendar in 0.5s and returns an
+    identical cutoff.
     """
     with conn.cursor() as cur:
         cur.execute(
-            f"SELECT DISTINCT market_date FROM {SCHEMA}.option_surface_grid_daily "
-            "ORDER BY market_date DESC LIMIT %s",
+            f"SELECT min(d) FROM (SELECT DISTINCT trade_date AS d "
+            f"FROM {SCHEMA}.vol_index_daily ORDER BY trade_date DESC LIMIT %s) x",
             (days,),
         )
-        rows = cur.fetchall()
-    if not rows:
-        sys.exit(
-            "could not determine cutoff: option_surface_grid_daily is empty on the source"
-        )
-    return rows[-1][0].isoformat()
+        row = cur.fetchone()
+    if not row or row[0] is None:
+        sys.exit("could not determine cutoff: vol_index_daily is empty on the source")
+    return row[0].isoformat()
 
 
 def build_plans(src_cols, dst_cols, exclude: set[str]) -> tuple[list[Plan], list[str]]:
@@ -192,6 +261,38 @@ def sync_table(
         where = ""
         mode = "full"
 
+    # Stage into a temp table, then INSERT ... ON CONFLICT DO NOTHING.
+    #
+    # Copying straight into the target looks cheaper but is wrong: tables with a
+    # surrogate `id` primary key (backtest_sweep_results, jobs, scan_runs) hold
+    # LOCAL rows whose ids collide with the mini's, and the window-DELETE cannot
+    # clear them because they sit outside the window. That is a UniqueViolation
+    # mid-COPY, which then aborts the shared source transaction and takes every
+    # remaining table down with it. Staging costs one extra local write and makes
+    # the whole run insensitive to id collisions.
+    tmp = f"sync_stage_{plan.table}"[:63]
+    src_sql = f"COPY (SELECT {collist} FROM {SCHEMA}.{plan.table} {where}) TO STDOUT (FORMAT binary)"
+
+    with dst.cursor() as dcur:
+        dcur.execute(f'DROP TABLE IF EXISTS pg_temp."{tmp}"')
+        # `AS SELECT ... WITH NO DATA` clones the column types without dragging
+        # NOT NULL/defaults across — a staging table must accept exactly the
+        # subset of columns we copy, nothing more.
+        dcur.execute(
+            f'CREATE TEMP TABLE "{tmp}" AS '
+            f"SELECT {collist} FROM {SCHEMA}.{plan.table} WITH NO DATA"
+        )
+
+    with src.cursor() as scur, dst.cursor() as dcur:
+        with scur.copy(
+            src_sql, {"cutoff": cutoff} if plan.date_col else None
+        ) as reader:
+            with dcur.copy(
+                f'COPY "{tmp}" ({collist}) FROM STDIN (FORMAT binary)'
+            ) as writer:
+                for block in reader:
+                    writer.write(block)
+
     with dst.cursor() as dcur:
         if plan.date_col:
             dcur.execute(
@@ -199,20 +300,13 @@ def sync_table(
                 (cutoff,),
             )
         else:
-            dcur.execute(f"TRUNCATE {SCHEMA}.{plan.table}")
-
-    src_sql = f"COPY (SELECT {collist} FROM {SCHEMA}.{plan.table} {where}) TO STDOUT (FORMAT binary)"
-    dst_sql = f"COPY {SCHEMA}.{plan.table} ({collist}) FROM STDIN (FORMAT binary)"
-
-    rows = 0
-    with src.cursor() as scur, dst.cursor() as dcur:
-        with scur.copy(
-            src_sql, {"cutoff": cutoff} if plan.date_col else None
-        ) as reader:
-            with dcur.copy(dst_sql) as writer:
-                for block in reader:
-                    writer.write(block)
+            dcur.execute(f"DELETE FROM {SCHEMA}.{plan.table}")
+        dcur.execute(
+            f"INSERT INTO {SCHEMA}.{plan.table} ({collist}) "
+            f'SELECT {collist} FROM "{tmp}" ON CONFLICT DO NOTHING'
+        )
         rows = dcur.rowcount if dcur.rowcount and dcur.rowcount > 0 else 0
+        dcur.execute(f'DROP TABLE IF EXISTS pg_temp."{tmp}"')
     return (rows, mode)
 
 
@@ -235,10 +329,12 @@ def main() -> int:
     guard_destination()
     exclude = set() if args.include_raw_payloads else set(DEFAULT_EXCLUDE)
 
-    print(f"source: {SRC['user']}@{SRC['host']}/{SRC['dbname']} (read-only)")
+    print(
+        f"source: {SRC['user']}@{SSH_HOST}/{SRC['dbname']} via ssh tunnel (read-only)"
+    )
     print(f"dest:   {DST['user']}@{DST['host']}/{DST['dbname']}")
 
-    with psycopg.connect(**SRC) as src, psycopg.connect(**DST) as dst:
+    with ssh_tunnel(), psycopg.connect(**SRC) as src, psycopg.connect(**DST) as dst:
         src.read_only = True  # belt-and-braces: the mini must never be written
         cutoff = cutoff_date(src, args.days)
         print(f"cutoff: {cutoff}  ({args.days} most recent market days)\n")
@@ -264,6 +360,8 @@ def main() -> int:
                 rows, mode = sync_table(src, dst, p, cutoff, src_cols, dst_cols)
             except Exception as exc:  # noqa: BLE001 — one bad table must not abort the sync
                 dst.rollback()
+                src.rollback()  # the failed COPY aborted the SOURCE txn too;
+                # without this, every remaining table dies with InFailedSqlTransaction
                 print(f"  {p.table:<40} FAILED: {exc!r}")
                 continue
             dst.commit()

--- a/scripts/research/watchlist_chain_candidates.py
+++ b/scripts/research/watchlist_chain_candidates.py
@@ -30,229 +30,25 @@ from pathlib import Path
 from uw_scan.api.client import UwClient
 from uw_scan.api.endpoints import EndpointSlug
 from uw_scan.config import Settings
+from uw_scan.watchlist_taxonomy import AI, LAYERS
 
-# layer_id -> (chinese, english, {chain: [tickers]})
+# TAXONOMY moved to uw_scan.watchlist_taxonomy when the chain join table needed
+# it — app code must not import from scripts/. Rebuilt here in this script's
+# legacy (id, name, chains) shape so the renderers below stay untouched. One
+# definition, three consumers: this screener, the membership seeder, the API.
 TAXONOMY: dict[str, tuple[str, str, dict[str, list[str]]]] = {
-    "L1": (
-        "芯片与系统层",
-        "Chip & System",
-        {
-            # ARM is here, in Semi-Logic/ASIC, and in Semi-Cap/EDA: its driver is
-            # AI compute architecture, it licenses design IP like SNPS/CDNS, and
-            # it still trades with the merchant-chip cohort. Three chains, one
-            # ticker, one scan cost.
-            "Computer/GPU": ["NVDA", "AMD", "ARM", "SMCI", "DELL", "HPE", "HPQ"],
-            "Semi-Logic/ASIC": [
-                "AVGO",
-                "MRVL",
-                "ARM",
-                "QCOM",
-                "TXN",
-                "NXPI",
-                "MCHP",
-                "SWKS",
-                "QRVO",
-                "LSCC",
-                "RMBS",
-                "ALGM",
-                "SLAB",
-            ],
-            "Foundry": ["TSM", "INTC", "TSEM", "GFS", "UMC", "ASX"],
-            "Semi-Cap/EDA": [
-                "ARM",
-                "ASML",
-                "AMAT",
-                "LRCX",
-                "KLAC",
-                "TER",
-                "SNPS",
-                "CDNS",
-                "ONTO",
-                "ACLS",
-                "AEIS",
-                "ICHR",
-                "UCTT",
-                "COHU",
-                "FORM",
-                "NVMI",
-                "CAMT",
-                "VECO",
-                "AMKR",
-            ],
-            "Memory/Storage": ["MU", "SNDK", "WDC", "STX", "NTAP", "PSTG"],
-            "Analog/Power-Semi": ["ADI", "MPWR", "ON", "VSH", "DIOD", "POWI"],
-        },
-    ),
-    "L2": (
-        "云与数据平台层",
-        "Cloud & Data Platform",
-        {
-            "Cloud/Hyperscaler": ["MSFT", "AMZN", "GOOGL", "ORCL", "IBM", "BABA"],
-            "AI-Cloud/NeoCloud": [
-                "CRWV",
-                "NBIS",
-                "IREN",
-                "HUT",
-                "CIFR",
-                "APLD",
-                "WULF",
-                "CORZ",
-                "GLXY",
-                "BTDR",
-                "CLSK",
-            ],
-            "Data-Platform": [
-                "SNOW",
-                "PLTR",
-                "MDB",
-                "CFLT",
-                "ESTC",
-                "DDOG",
-                "TDC",
-                "DOCN",
-            ],
-            "Cybersecurity": [
-                "CRWD",
-                "PANW",
-                "NET",
-                "ZS",
-                "S",
-                "FTNT",
-                "OKTA",
-                "CYBR",
-                "TENB",
-                "QLYS",
-                "RPD",
-                "VRNS",
-                "CHKP",
-            ],
-        },
-    ),
-    "L3": (
-        "数据中心基础设施层",
-        "Datacenter Infrastructure",
-        {
-            "Networking/Optical": [
-                "ANET",
-                "CRDO",
-                "ALAB",
-                "COHR",
-                "LITE",
-                "FN",
-                "AAOI",
-                "GLW",
-                "NOK",
-                "CIEN",
-                "CSCO",
-                "JNPR",
-                "EXTR",
-                "APH",
-                "TEL",
-            ],
-            "Power/Electrical": [
-                "VRT",
-                "ETN",
-                "PWR",
-                "GEV",
-                "POWL",
-                "HUBB",
-                "NVT",
-                "ATKR",
-                "AYI",
-            ],
-            "Generation/Nuclear": [
-                "OKLO",
-                "BE",
-                "CEG",
-                "VST",
-                "TLN",
-                "NRG",
-                "SMR",
-                "LEU",
-                "NNE",
-                "CCJ",
-                "UEC",
-                "PEG",
-                "SO",
-                "D",
-            ],
-            "Cooling/Thermal": ["MOD", "SPXC", "AAON", "CARR", "JCI", "TT", "LII"],
-            "DC-REIT/Colo": ["EQIX", "DLR", "IRM", "AMT"],
-            "EPC/Construction": ["MTZ", "DY", "EME", "FIX", "IESC", "STRL", "ACM", "J"],
-        },
-    ),
-    "L4": (
-        "应用与终端层",
-        "Application & Endpoint",
-        {
-            "Software/SaaS": [
-                "CRM",
-                "NOW",
-                "ADBE",
-                "INTU",
-                "WDAY",
-                "TEAM",
-                "HUBS",
-                "VEEV",
-                "ZM",
-                "DOCU",
-                "TWLO",
-                "SHOP",
-            ],
-            "AI-App/Consumer-Net": [
-                "APP",
-                "TTD",
-                "RDDT",
-                "SPOT",
-                "DASH",
-                "ABNB",
-                "U",
-                "RBLX",
-                "PINS",
-                "SNAP",
-            ],
-            "Robotics/Automation": ["SYM", "ROK", "EMR", "HON", "ISRG", "OSIS", "ZBRA"],
-            "Healthcare-AI/LS-Tools": ["TEM", "RXRX", "DNA", "ILMN", "TMO", "A", "DHR"],
-            "Devices/Endpoint": ["AAPL", "TSLA", "SONY", "GRMN", "LOGI"],
-        },
-    ),
-    # Cross-cutting lenses. Membership deliberately overlaps the layers — NVDA is
-    # in L1 Computer/GPU AND here. A ticker costs UW budget once no matter how
-    # many chains list it, so lenses are free; only distinct tickers are billed.
-    "X": (
-        "跨层标签",
-        "Cross-cutting",
-        {
-            "M7": ["AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA", "TSLA"],
-        },
-    ),
-    "L5": (
-        "模型与工具层",
-        "Model & Tooling",
-        {
-            "Foundation-Model-Proxy": ["MSFT", "GOOGL", "META", "AMZN", "NVDA"],
-            "AI-Native-Software": ["AI", "SOUN", "BBAI", "INOD", "PATH", "CXAI"],
-            "DevTools/Observability": ["GTLB", "DDOG", "FROG", "PD", "DT"],
-            "IT-Services/Integration": [
-                "ACN",
-                "EPAM",
-                "GLOB",
-                "CTSH",
-                "INFY",
-                "WIT",
-                "DXC",
-            ],
-        },
-    ),
+    layer.key: (layer.name, layer.name, {c: list(t) for c, t in layer.chains.items()})
+    for layer in LAYERS
+    if layer.focus == AI
 }
 
-# The watchlist covers four focus areas. The 5-layer 五层蛋糕 model is the shape of
-# ONE of them (AI 产业链) — it is not the whole watchlist and the other three are
-# not leftovers. Mirrors the existing rows in web/components/watchlist/sectorGroups.ts.
+# The watchlist covers four focus areas. The 5-layer model is the shape of ONE
+# of them (the AI industrial chain) — not the whole watchlist, and the other
+# three are not leftovers.
 OTHER_FOCUS: dict[str, tuple[str, list[str]]] = {
-    "大盘与宏观": ("Index & Macro", ["Beta", "Sector-ETF", "Credit", "Macro"]),
-    "主题": ("Thematic", ["Crypto", "Fintech", "Space"]),
-    "防御": ("Defensive", ["Healthcare", "Energy", "Banks", "Consumer"]),
+    layer.name: (layer.name, list(layer.chains))
+    for layer in LAYERS
+    if layer.focus != AI
 }
 
 FIELDS = (
@@ -578,8 +374,8 @@ def render_doc(
     out: list[str] = [
         "# Watchlist extension — 五层蛋糕 industry-chain candidates",
         "",
-        "Generated, do not hand-edit the tables — edit `TAXONOMY` in",
-        "`scripts/research/watchlist_chain_candidates.py` and re-run:",
+        "Generated, do not hand-edit the tables — edit `LAYERS` in",
+        "`src/uw_scan/watchlist_taxonomy.py` and re-run:",
         "",
         "```",
         "UW_SCAN_ALLOW_DB_MISMATCH=1 uv run python \\",

--- a/src/uw_scan/api/models/watchlist.py
+++ b/src/uw_scan/api/models/watchlist.py
@@ -57,7 +57,14 @@ class QueueStatus(BaseModel):
 
 class WatchlistCard(BaseModel):
     ticker: str
+    # The single PRIMARY tag. Still decides which one section a card renders
+    # under, which is why it survives alongside `chains` — grouping the grid by a
+    # multi-valued field would draw NVDA's card once per chain.
     sector: str
+    # Every chain this ticker belongs to (uw_scan.watchlist_chain). Filtering
+    # selects on this; grouping does not. Defaults to [] so a response built
+    # before the join table is seeded stays valid.
+    chains: list[str] = Field(default_factory=list)
     pinned: bool
     hot: bool = False
     sort_rank: int
@@ -81,6 +88,26 @@ class WatchlistCard(BaseModel):
     skew: SkewBlock
     positioning: PositioningBlock
     queue: QueueStatus | None = None
+
+
+class WatchlistChainInfo(BaseModel):
+    """One row of the filter rail, served rather than duplicated in TypeScript.
+
+    The taxonomy lives in `uw_scan.watchlist_taxonomy`; hand-copying 38 chains
+    into the frontend would reintroduce exactly the drift that module exists to
+    prevent. `count` is live membership, so the UI can hide a chain that would
+    filter to an empty grid instead of guessing.
+    """
+
+    layer: str
+    layer_name: str
+    focus: str
+    chain: str
+    count: int = 0
+
+
+class WatchlistChainsResponse(BaseModel):
+    chains: list[WatchlistChainInfo] = Field(default_factory=list)
 
 
 class QueueSummary(BaseModel):
@@ -165,6 +192,8 @@ _preserve_api_module(
     PositioningBlock,
     QueueStatus,
     WatchlistCard,
+    WatchlistChainInfo,
+    WatchlistChainsResponse,
     QueueSummary,
     WatchlistResponse,
     WatchlistMutation,

--- a/src/uw_scan/api/routers/watchlist.py
+++ b/src/uw_scan/api/routers/watchlist.py
@@ -16,6 +16,8 @@ from uw_scan.api.schemas import (
     SetupBlock,
     SkewBlock,
     WatchlistCard,
+    WatchlistChainInfo,
+    WatchlistChainsResponse,
     WatchlistMutation,
     WatchlistPatch,
     WatchlistResponse,
@@ -24,11 +26,15 @@ from uw_scan.api.schemas import (
 )
 from uw_scan.config import Settings
 from uw_scan.storage.repository import Repository, WatchlistCardRow
+from uw_scan.storage.watchlist_chain import WatchlistChainRepository
+from uw_scan.watchlist_taxonomy import LAYERS
 
 router = APIRouter()
 
 
-def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
+def _card_to_response(
+    row: WatchlistCardRow, chains: list[str] | None = None
+) -> WatchlistCard:
     """Map a joined watchlist_card + watchlist row to the API shape."""
     queue = None
     if row.active_job_id is not None:
@@ -42,6 +48,7 @@ def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
     return WatchlistCard(
         ticker=row.ticker,
         sector=row.sector,
+        chains=chains or [],
         pinned=row.pinned,
         hot=bool(row.hot),
         sort_rank=row.sort_rank,
@@ -83,6 +90,11 @@ def _card_to_response(row: WatchlistCardRow) -> WatchlistCard:
 @router.get("/watchlist", response_model=WatchlistResponse)
 def get_watchlist(
     sector: str | None = Query(None),
+    chain: str | None = Query(
+        None,
+        description="Industry chain (uw_scan.watchlist_chain). Selects on "
+        "many-to-many membership, so a ticker in several chains matches each.",
+    ),
     setup: str | None = Query(
         None,
         description="e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'",
@@ -92,6 +104,11 @@ def get_watchlist(
     settings: Settings = Depends(get_settings),
 ) -> WatchlistResponse:
     rows, queue = repo.list_watchlist_cards_with_queue_summary()
+    # One query for the whole payload; per-card lookups would be ~170 round
+    # trips to render a single dashboard.
+    chains_by_ticker = WatchlistChainRepository(
+        repo.conn, schema=repo._schema
+    ).chains_by_ticker()
     cutoff = (
         datetime.now(timezone.utc) - timedelta(minutes=fresh_within_minutes)
         if fresh_within_minutes
@@ -112,6 +129,8 @@ def get_watchlist(
     for r in rows:
         if sector and r.sector != sector:
             continue
+        if chain and chain not in chains_by_ticker.get(r.ticker, ()):
+            continue
         # `scanned_at` is None for tickers that haven't been scanned yet
         # (LEFT JOIN from watchlist). A fresh-within filter naturally
         # excludes them; an unfiltered request keeps them as placeholders.
@@ -126,7 +145,7 @@ def get_watchlist(
                     continue
                 if setup_dir and r.setup_direction != setup_dir:
                     continue
-        out.append(_card_to_response(r))
+        out.append(_card_to_response(r, chains_by_ticker.get(r.ticker)))
 
     scanned_times = [c.scanned_at for c in out if c.scanned_at is not None]
     # Hot-slots meter reflects ALL flagged tickers (pre sector/setup filter) so
@@ -185,6 +204,34 @@ def get_watchlist_spots(
                 spot_source=source,
             )
             for (ticker, spot, quoted_at, source) in repo.list_watchlist_spots()
+        ]
+    )
+
+
+@router.get("/watchlist/chains", response_model=WatchlistChainsResponse)
+def get_watchlist_chains(
+    repo: Repository = Depends(get_repo),
+) -> WatchlistChainsResponse:
+    """The filter rail: every chain, its layer, and live member count.
+
+    Declared order is preserved from the taxonomy module — the rail leads with
+    Index & Macro and M7 deliberately, so alphabetising here would silently
+    undo that.
+    """
+    counts = WatchlistChainRepository(
+        repo.conn, schema=repo._schema
+    ).counts_by_chain()
+    return WatchlistChainsResponse(
+        chains=[
+            WatchlistChainInfo(
+                layer=layer.key,
+                layer_name=layer.name,
+                focus=layer.focus,
+                chain=chain,
+                count=counts.get(chain, 0),
+            )
+            for layer in LAYERS
+            for chain in layer.chains
         ]
     )
 

--- a/src/uw_scan/api/schemas.py
+++ b/src/uw_scan/api/schemas.py
@@ -42,6 +42,8 @@ from .models.watchlist import (
 )
 from .models.watchlist import (
     WatchlistCard as WatchlistCard,
+    WatchlistChainInfo as WatchlistChainInfo,
+    WatchlistChainsResponse as WatchlistChainsResponse,
 )
 from .models.watchlist import (
     WatchlistMutation as WatchlistMutation,

--- a/src/uw_scan/reports/data_gap_healer.py
+++ b/src/uw_scan/reports/data_gap_healer.py
@@ -453,6 +453,21 @@ REGISTRY: list[DatasetRegistryEntry] = [
         expected_frequency="none",
         reason="cohort membership, not a time series; selected_on is a point-in-time tag, not a cadence",
     ),
+    # Industry-chain membership (migration 113). Same shape as research_universe
+    # above: a dimension, not a series. One row per (ticker, chain); `added_at`
+    # is an audit stamp of when the membership was seeded, not an observation
+    # date, so there is no cadence to be late for and no date to backfill. It is
+    # caught by the temporal-table heuristic purely on the `%_at` column-name
+    # match. The chains' actual time series are the per-ticker tables the
+    # members already appear in, each registered on its own terms.
+    DatasetRegistryEntry(
+        "watchlist_chain",
+        "operational_provenance",
+        "excluded",
+        ticker_col="ticker",
+        expected_frequency="none",
+        reason="chain membership, not a time series; added_at is a seed stamp, not a cadence",
+    ),
 ]
 
 

--- a/src/uw_scan/storage/migrations/113_watchlist_chain.sql
+++ b/src/uw_scan/storage/migrations/113_watchlist_chain.sql
@@ -1,0 +1,57 @@
+-- 113_watchlist_chain.sql — many-to-many industry-chain membership. Idempotent.
+--
+-- `uw_scan.watchlist.sector` is a single TEXT column, so a ticker can hold exactly
+-- one tag. The taxonomy it is being asked to express is not one-to-one: NVDA is
+-- genuinely in Computer/GPU, M7 AND Foundation-Model-Proxy; ARM is in three L1
+-- chains; IBM is both Cloud/Hyperscaler and Quantum. Under one column those are
+-- mutually exclusive, and the consequence is visible on the dashboard today —
+-- the Foundation-Model-Proxy chain reads as EMPTY while all five of its members
+-- sit on the page tagged `M7`.
+--
+-- ADDITIVE, not a replacement. `watchlist.sector` stays and keeps its job: it is
+-- the ticker's single PRIMARY tag and decides which one section a card renders
+-- under. This table carries the full membership set that FILTERING selects on.
+-- Filtering Computer/GPU shows NVDA; the unfiltered grid still shows NVDA exactly
+-- once, under its sector. Without that split, a naive many-to-many render draws
+-- NVDA's card three times and ARM's three times — ~114 tickers becoming ~150
+-- cards for the same names.
+--
+-- No date column, deliberately. This is a dimension, not a temporal fact table,
+-- so it is not a data-gap-healer dataset and needs no DatasetRegistryEntry.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.watchlist_chain (
+    ticker     TEXT NOT NULL,
+    -- Layer key from uw_scan.watchlist_taxonomy (L1..L5, X, IDX, THM, DEF).
+    -- Stored rather than derived from `chain` so a chain can be re-parented
+    -- between layers without rewriting every row's meaning.
+    layer      TEXT NOT NULL,
+    chain      TEXT NOT NULL,
+    -- Where the row came from: 'taxonomy' (enumerated in the module) or
+    -- 'sector' (inherited from the legacy watchlist.sector value). Kept because
+    -- a re-seed must be able to replace taxonomy rows without destroying the
+    -- inherited ones, and because it answers "why is this ticker here?".
+    source     TEXT NOT NULL DEFAULT 'taxonomy',
+    added_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- (ticker, chain) not (ticker, layer, chain): chain names are unique across
+    -- layers by construction, and this PK is what makes re-seeding idempotent.
+    PRIMARY KEY (ticker, chain)
+);
+
+COMMENT ON TABLE uw_scan.watchlist_chain IS
+    'Many-to-many ticker -> industry chain membership. Additive to '
+    'watchlist.sector, which remains the single primary/display tag. See '
+    '113_watchlist_chain.sql for why both exist.';
+
+-- The filter reads "which tickers are in this chain", so lead with chain.
+CREATE INDEX IF NOT EXISTS ix_watchlist_chain_chain
+    ON uw_scan.watchlist_chain (chain, ticker);
+
+-- The card payload reads "which chains is this ticker in" for every row of the
+-- watchlist response, so that direction needs to be indexed too.
+CREATE INDEX IF NOT EXISTS ix_watchlist_chain_ticker
+    ON uw_scan.watchlist_chain (ticker);
+
+CREATE INDEX IF NOT EXISTS ix_watchlist_chain_layer
+    ON uw_scan.watchlist_chain (layer, chain);

--- a/src/uw_scan/storage/watchlist_chain.py
+++ b/src/uw_scan/storage/watchlist_chain.py
@@ -1,0 +1,134 @@
+"""Many-to-many watchlist chain membership (`uw_scan.watchlist_chain`, migration 113).
+
+Standalone repository rather than a Repository mixin — new persistence domains get
+their own module from method one (storage split rule in CLAUDE.md).
+
+Two membership sources share the table and must not clobber each other:
+
+- `taxonomy` — enumerated in `uw_scan.watchlist_taxonomy`. Re-seeding replaces
+  these wholesale, because the module is the source of truth for them.
+- `sector` — inherited from the legacy `watchlist.sector` value so that every
+  ticker is reachable by at least one chain even if the taxonomy never names it.
+  A ticker on the watchlist that no chain lists would be scanned (costing UW
+  budget) while being invisible to every filter, which is the worst of both.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+import psycopg
+
+
+class WatchlistChainRepository:
+    def __init__(self, conn: psycopg.Connection, schema: str = "uw_scan") -> None:
+        self.conn = conn
+        self._schema = schema
+
+    # ------------------------------------------------------------------
+    # Seeding
+    # ------------------------------------------------------------------
+    def replace_taxonomy_memberships(self, rows: Sequence[tuple[str, str, str]]) -> int:
+        """Replace all source='taxonomy' rows with `rows` — (ticker, layer, chain).
+
+        Delete-then-insert scoped to source='taxonomy' so inherited sector rows
+        survive. A plain upsert would leave orphans behind when a ticker is
+        removed from a chain in the module, and those orphans are invisible —
+        the filter would keep returning a ticker the taxonomy no longer lists.
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {self._schema}.watchlist_chain WHERE source = 'taxonomy'"
+            )
+            if not rows:
+                return 0
+            cur.executemany(
+                f"""
+                INSERT INTO {self._schema}.watchlist_chain (ticker, layer, chain, source)
+                VALUES (%s, %s, %s, 'taxonomy')
+                ON CONFLICT (ticker, chain) DO UPDATE SET layer = EXCLUDED.layer,
+                                                          source = 'taxonomy'
+                """,
+                [(t.upper(), layer, chain) for t, layer, chain in rows],
+            )
+            return cur.rowcount if cur.rowcount and cur.rowcount > 0 else len(rows)
+
+    def inherit_sector_memberships(self, layer_for_chain: dict[str, str]) -> int:
+        """Give every active ticker a membership for its own `watchlist.sector`.
+
+        Only fills gaps: `ON CONFLICT DO NOTHING` means a chain already asserted
+        by the taxonomy keeps source='taxonomy'. Tickers whose sector is not a
+        known chain are skipped rather than inventing a layer for them.
+        """
+        pairs = [(chain, layer) for chain, layer in layer_for_chain.items()]
+        if not pairs:
+            return 0
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.watchlist_chain (ticker, layer, chain, source)
+                SELECT w.ticker, m.layer, w.sector, 'sector'
+                  FROM {self._schema}.watchlist w
+                  JOIN (VALUES %s) AS m(chain, layer) ON m.chain = w.sector
+                 WHERE w.removed_at IS NULL
+                ON CONFLICT (ticker, chain) DO NOTHING
+                """.replace("%s", ", ".join(["(%s, %s)"] * len(pairs))),
+                [v for pair in pairs for v in pair],
+            )
+            return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def chains_by_ticker(
+        self, tickers: Iterable[str] | None = None
+    ) -> dict[str, list[str]]:
+        """ticker -> its chains. One query for the whole watchlist payload.
+
+        Per-ticker lookups would be ~114 round trips to render one dashboard.
+        """
+        sql = f"""
+            SELECT ticker, chain FROM {self._schema}.watchlist_chain
+        """
+        params: list[object] = []
+        tickers = list(tickers) if tickers is not None else None
+        if tickers:
+            sql += " WHERE ticker = ANY(%s)"
+            params.append([t.upper() for t in tickers])
+        sql += " ORDER BY ticker, chain"
+        out: dict[str, list[str]] = {}
+        with self.conn.cursor() as cur:
+            cur.execute(sql, params or None)
+            for ticker, chain in cur.fetchall():
+                out.setdefault(ticker, []).append(chain)
+        return out
+
+    def tickers_in_chain(self, chain: str) -> list[str]:
+        """Active tickers in a chain. Joins watchlist so removed names drop out.
+
+        Membership rows are not deleted when a ticker leaves the watchlist —
+        without this join a removed ticker would still answer the filter.
+        """
+        sql = f"""
+            SELECT c.ticker
+              FROM {self._schema}.watchlist_chain c
+              JOIN {self._schema}.watchlist w ON w.ticker = c.ticker
+             WHERE c.chain = %s AND w.removed_at IS NULL
+             ORDER BY c.ticker
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(sql, (chain,))
+            return [r[0] for r in cur.fetchall()]
+
+    def counts_by_chain(self) -> dict[str, int]:
+        """chain -> active member count, for badges and empty-chain detection."""
+        sql = f"""
+            SELECT c.chain, count(*)
+              FROM {self._schema}.watchlist_chain c
+              JOIN {self._schema}.watchlist w ON w.ticker = c.ticker
+             WHERE w.removed_at IS NULL
+             GROUP BY c.chain
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(sql)
+            return dict(cur.fetchall())

--- a/src/uw_scan/watchlist_taxonomy.py
+++ b/src/uw_scan/watchlist_taxonomy.py
@@ -1,0 +1,352 @@
+"""Watchlist industry-chain taxonomy — the single source of truth.
+
+Lived in `scripts/research/watchlist_chain_candidates.py` until the chain join
+table needed it; app code must not import from `scripts/`, so it moved here and
+the research script now imports it back. One definition, three consumers: the
+candidate screener, the membership seeder, and the API.
+
+Shape: focus area -> layer -> chain -> tickers. The five-layer model (L1..L5)
+describes the AI industrial chain and ONLY that; Index & Macro, Thematic and
+Defensive are equally deliberate coverage with their own chains, not leftovers.
+
+Membership is deliberately many-to-many. NVDA is in Computer/GPU, M7 and
+Foundation-Model-Proxy; ARM is in three chains. UW bills per distinct ticker, so
+extra memberships cost no budget — they cost schema, which is what
+`uw_scan.watchlist_chain` exists to pay. A single `watchlist.sector` column
+cannot express this, which is why Foundation-Model-Proxy looks empty on the
+dashboard while all five of its members sit on the page tagged `M7`.
+
+Names are English-only: these strings are rendered in the filter rail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+AI = "AI"
+INDEX = "Index & Macro"
+THEMATIC = "Thematic"
+DEFENSIVE = "Defensive"
+
+
+@dataclass(frozen=True)
+class Layer:
+    key: str
+    name: str
+    focus: str
+    chains: dict[str, tuple[str, ...]]
+
+
+# Chains whose members are enumerated here. Tickers NOT listed in any chain
+# still get one membership seeded from their existing `watchlist.sector` value,
+# so nothing on the watchlist becomes unreachable by the filter.
+LAYERS: tuple[Layer, ...] = (
+    Layer(
+        key="L1",
+        name="Chip & System",
+        focus=AI,
+        chains={
+            # ARM sits here, in Semi-Logic/ASIC and in Semi-Cap/EDA: its driver
+            # is AI compute architecture, it licenses design IP like SNPS/CDNS,
+            # and it still trades with the merchant-chip cohort.
+            "Computer/GPU": ("NVDA", "AMD", "ARM", "SMCI", "DELL", "HPE", "HPQ"),
+            "Semi-Logic/ASIC": (
+                "AVGO",
+                "MRVL",
+                "ARM",
+                "QCOM",
+                "TXN",
+                "NXPI",
+                "MCHP",
+                "SWKS",
+                "QRVO",
+                "LSCC",
+                "RMBS",
+                "ALGM",
+                "SLAB",
+            ),
+            "Foundry": ("TSM", "INTC", "TSEM", "GFS", "UMC", "ASX"),
+            "Semi-Cap/EDA": (
+                "ARM",
+                "ASML",
+                "AMAT",
+                "LRCX",
+                "KLAC",
+                "TER",
+                "SNPS",
+                "CDNS",
+                "ONTO",
+                "ACLS",
+                "AEIS",
+                "ICHR",
+                "UCTT",
+                "COHU",
+                "FORM",
+                "NVMI",
+                "CAMT",
+                "VECO",
+                "AMKR",
+            ),
+            "Memory/Storage": ("MU", "SNDK", "WDC", "STX", "NTAP", "PSTG"),
+            # NVTS added from the option-hot sweep: 564k OI, 44.6k contracts/day.
+            "Analog/Power-Semi": ("ADI", "MPWR", "ON", "VSH", "DIOD", "POWI", "NVTS"),
+        },
+    ),
+    Layer(
+        key="L2",
+        name="Cloud & Data Platform",
+        focus=AI,
+        chains={
+            "Cloud/Hyperscaler": ("MSFT", "AMZN", "GOOGL", "ORCL", "IBM", "BABA"),
+            "AI-Cloud/NeoCloud": (
+                "CRWV",
+                "NBIS",
+                "IREN",
+                "HUT",
+                "CIFR",
+                "APLD",
+                "WULF",
+                "CORZ",
+                "GLXY",
+                "BTDR",
+                "CLSK",
+            ),
+            "Data-Platform": (
+                "SNOW",
+                "PLTR",
+                "MDB",
+                "CFLT",
+                "ESTC",
+                "DDOG",
+                "TDC",
+                "DOCN",
+            ),
+            "Cybersecurity": (
+                "CRWD",
+                "PANW",
+                "NET",
+                "ZS",
+                "S",
+                "FTNT",
+                "OKTA",
+                "CYBR",
+                "TENB",
+                "QLYS",
+                "RPD",
+                "VRNS",
+                "CHKP",
+            ),
+        },
+    ),
+    Layer(
+        key="L3",
+        name="Datacenter Infrastructure",
+        focus=AI,
+        chains={
+            # POET added from the option-hot sweep: 1,146k OI, 58.9k/day — it
+            # clears both liquidity bars despite a $1.2B cap, which is exactly
+            # the case the cap floor was kept low for.
+            "Networking/Optical": (
+                "ANET",
+                "CRDO",
+                "ALAB",
+                "COHR",
+                "LITE",
+                "FN",
+                "AAOI",
+                "GLW",
+                "NOK",
+                "CIEN",
+                "CSCO",
+                "JNPR",
+                "EXTR",
+                "APH",
+                "TEL",
+                "POET",
+            ),
+            "Power/Electrical": (
+                "VRT",
+                "ETN",
+                "PWR",
+                "GEV",
+                "POWL",
+                "HUBB",
+                "NVT",
+                "ATKR",
+                "AYI",
+            ),
+            "Generation/Nuclear": (
+                "OKLO",
+                "BE",
+                "CEG",
+                "VST",
+                "TLN",
+                "NRG",
+                "SMR",
+                "LEU",
+                "NNE",
+                "CCJ",
+                "UEC",
+                "PEG",
+                "SO",
+                "D",
+            ),
+            "Cooling/Thermal": ("MOD", "SPXC", "AAON", "CARR", "JCI", "TT", "LII"),
+            # FRMI and KEEL rescue this chain: hand-authored it was EQIX/DLR/IRM/AMT
+            # and none cleared the bar. The market-wide sweep found both (968k and
+            # 1,076k OI) — the chain was never illiquid, my ticker list was wrong.
+            "DC-REIT/Colo": ("EQIX", "DLR", "IRM", "AMT", "FRMI", "KEEL"),
+            "EPC/Construction": ("MTZ", "DY", "EME", "FIX", "IESC", "STRL", "ACM", "J"),
+        },
+    ),
+    Layer(
+        key="L4",
+        name="Application & Endpoint",
+        focus=AI,
+        chains={
+            "Software/SaaS": (
+                "CRM",
+                "NOW",
+                "ADBE",
+                "INTU",
+                "WDAY",
+                "TEAM",
+                "HUBS",
+                "VEEV",
+                "ZM",
+                "DOCU",
+                "TWLO",
+                "SHOP",
+                "FIG",
+            ),
+            "AI-App/Consumer-Net": (
+                "APP",
+                "TTD",
+                "RDDT",
+                "SPOT",
+                "DASH",
+                "ABNB",
+                "U",
+                "RBLX",
+                "PINS",
+                "SNAP",
+                "NFLX",
+                "UBER",
+            ),
+            "Robotics/Automation": ("SYM", "ROK", "EMR", "HON", "ISRG", "OSIS", "ZBRA"),
+            "Healthcare-AI/LS-Tools": ("TEM", "RXRX", "DNA", "ILMN", "TMO", "A", "DHR"),
+            "Devices/Endpoint": ("AAPL", "TSLA", "SONY", "GRMN", "LOGI"),
+        },
+    ),
+    Layer(
+        key="L5",
+        name="Model & Tooling",
+        focus=AI,
+        chains={
+            # 5/5 already on the watchlist and tagged M7. This chain is the whole
+            # argument for the join table: without it the layer reads as empty
+            # while every member is on screen under another tag.
+            "Foundation-Model-Proxy": ("MSFT", "GOOGL", "META", "AMZN", "NVDA"),
+            "AI-Native-Software": ("AI", "SOUN", "BBAI", "INOD", "PATH", "CXAI"),
+            "DevTools/Observability": ("GTLB", "DDOG", "FROG", "PD", "DT"),
+            "IT-Services/Integration": (
+                "ACN",
+                "EPAM",
+                "GLOB",
+                "CTSH",
+                "INFY",
+                "WIT",
+                "DXC",
+            ),
+        },
+    ),
+    Layer(
+        key="X",
+        name="Cross-cutting",
+        focus=AI,
+        chains={"M7": ("AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA", "TSLA")},
+    ),
+    # Non-AI focus areas. Their chains match the legacy `watchlist.sector` tags
+    # one-for-one, so membership seeds from the existing column rather than a
+    # ticker list here — except Quantum, which is new and therefore enumerated.
+    Layer(
+        key="IDX",
+        name="Index & Macro",
+        focus=INDEX,
+        chains={"Beta": (), "Sector-ETF": (), "Credit": (), "Macro": ()},
+    ),
+    Layer(
+        key="THM",
+        name="Thematic",
+        focus=THEMATIC,
+        chains={
+            "Crypto": ("BMNR",),
+            "Fintech": ("PYPL",),
+            "Space": (),
+            # IBM is here AND in L2 Cloud/Hyperscaler — the exact many-to-many
+            # case that motivated the join table.
+            "Quantum": ("IONQ", "RGTI", "IBM"),
+        },
+    ),
+    Layer(
+        key="DEF",
+        name="Defensive",
+        focus=DEFENSIVE,
+        chains={"Healthcare": (), "Energy": (), "Banks": (), "Consumer": ()},
+    ),
+)
+
+# The 59 tickers approved for addition. Everything else named above is either
+# already on the watchlist or was screened out — being listed in a chain does
+# NOT mean a ticker gets scanned, only that it is placed if present.
+SELECTED_ADDS: frozenset[str] = frozenset(
+    """
+    ABNB ACN ADBE APLD BABA BTDR CCJ CEG CIFR CLSK CORZ CSCO DASH DDOG DELL
+    GEV GLXY HPE HPQ INFY MCHP MDB NOW ON PATH PINS RBLX RDDT S SHOP SMCI SMR
+    SNAP SOUN STX TEM TTD U UEC UMC VRT VST WULF ZM ZS
+    BBAI BMNR FIG FRMI IONQ KEEL NFLX NVTS POET PYPL RGTI UBER
+    CARR MTZ
+    """.split()
+)
+
+
+def memberships() -> list[tuple[str, str, str]]:
+    """Flatten to (ticker, layer_key, chain) triples for seeding."""
+    return [
+        (ticker, layer.key, chain)
+        for layer in LAYERS
+        for chain, tickers in layer.chains.items()
+        for ticker in tickers
+    ]
+
+
+def chains_for(ticker: str) -> list[str]:
+    """Every chain a ticker belongs to, in layer order."""
+    t = ticker.upper()
+    return [
+        chain
+        for layer in LAYERS
+        for chain, tickers in layer.chains.items()
+        if t in tickers
+    ]
+
+
+def all_chains() -> list[tuple[str, str, str]]:
+    """(layer_key, layer_name, chain) for every chain, in declared order."""
+    return [
+        (layer.key, layer.name, chain) for layer in LAYERS for chain in layer.chains
+    ]
+
+
+def legacy_sector_chains() -> frozenset[str]:
+    """Chains that are also legacy `watchlist.sector` values.
+
+    These seed from the existing column instead of a ticker list, so an empty
+    tuple above means "inherit", not "nobody".
+    """
+    return frozenset(
+        chain
+        for layer in LAYERS
+        for chain, tickers in layer.chains.items()
+        if not tickers or chain in {"M7", "Crypto", "Fintech"}
+    )

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -23728,6 +23728,13 @@
             ],
             "title": "Aum"
           },
+          "chains": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Chains",
+            "type": "array"
+          },
           "gamma": {
             "$ref": "#/components/schemas/GammaBlock"
           },
@@ -23870,6 +23877,53 @@
           "positioning"
         ],
         "title": "WatchlistCard",
+        "type": "object"
+      },
+      "WatchlistChainInfo": {
+        "description": "One row of the filter rail, served rather than duplicated in TypeScript.\n\nThe taxonomy lives in `uw_scan.watchlist_taxonomy`; hand-copying 38 chains\ninto the frontend would reintroduce exactly the drift that module exists to\nprevent. `count` is live membership, so the UI can hide a chain that would\nfilter to an empty grid instead of guessing.",
+        "properties": {
+          "chain": {
+            "title": "Chain",
+            "type": "string"
+          },
+          "count": {
+            "default": 0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "focus": {
+            "title": "Focus",
+            "type": "string"
+          },
+          "layer": {
+            "title": "Layer",
+            "type": "string"
+          },
+          "layer_name": {
+            "title": "Layer Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "layer",
+          "layer_name",
+          "focus",
+          "chain"
+        ],
+        "title": "WatchlistChainInfo",
+        "type": "object"
+      },
+      "WatchlistChainsResponse": {
+        "properties": {
+          "chains": {
+            "items": {
+              "$ref": "#/components/schemas/WatchlistChainInfo"
+            },
+            "title": "Chains",
+            "type": "array"
+          }
+        },
+        "title": "WatchlistChainsResponse",
         "type": "object"
       },
       "WatchlistMutation": {
@@ -24363,7 +24417,7 @@
   },
   "info": {
     "title": "UW Watchlist API",
-    "version": "0.11.1"
+    "version": "0.11.3"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -28133,6 +28187,24 @@
             }
           },
           {
+            "description": "Industry chain (uw_scan.watchlist_chain). Selects on many-to-many membership, so a ticker in several chains matches each.",
+            "in": "query",
+            "name": "chain",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Industry chain (uw_scan.watchlist_chain). Selects on many-to-many membership, so a ticker in several chains matches each.",
+              "title": "Chain"
+            }
+          },
+          {
             "description": "e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL'",
             "in": "query",
             "name": "setup",
@@ -28232,6 +28304,28 @@
           }
         },
         "summary": "Post Watchlist",
+        "tags": [
+          "watchlist"
+        ]
+      }
+    },
+    "/api/watchlist/chains": {
+      "get": {
+        "description": "The filter rail: every chain, its layer, and live member count.\n\nDeclared order is preserved from the taxonomy module \u2014 the rail leads with\nIndex & Macro and M7 deliberately, so alphabetising here would silently\nundo that.",
+        "operationId": "get_watchlist_chains_api_watchlist_chains_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchlistChainsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Watchlist Chains",
         "tags": [
           "watchlist"
         ]

--- a/tests/integration/storage/test_watchlist_chain.py
+++ b/tests/integration/storage/test_watchlist_chain.py
@@ -1,0 +1,110 @@
+"""Chain membership behaviour that the filter and the seeder both rely on."""
+
+from __future__ import annotations
+
+from uw_scan.storage.watchlist_chain import WatchlistChainRepository
+
+
+def _repo(seeded) -> WatchlistChainRepository:
+    return WatchlistChainRepository(seeded.conn, schema=seeded._schema)
+
+
+def _add_ticker(seeded, ticker: str, sector: str) -> None:
+    with seeded.conn.cursor() as cur:
+        cur.execute(
+            f"INSERT INTO {seeded._schema}.watchlist (ticker, sector, sort_rank) "
+            "VALUES (%s, %s, 0) ON CONFLICT (ticker) DO UPDATE SET sector = EXCLUDED.sector, "
+            "removed_at = NULL",
+            (ticker, sector),
+        )
+
+
+def test_one_ticker_holds_several_chains(seeded_db_empty_cards):
+    """The whole point: a single sector column cannot express this."""
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "NVDA", "M7")
+    r.replace_taxonomy_memberships(
+        [
+            ("NVDA", "L1", "Computer/GPU"),
+            ("NVDA", "X", "M7"),
+            ("NVDA", "L5", "Foundation-Model-Proxy"),
+        ]
+    )
+    assert r.chains_by_ticker(["NVDA"])["NVDA"] == [
+        "Computer/GPU",
+        "Foundation-Model-Proxy",
+        "M7",
+    ]
+    # And the chain that reads as empty under a single tag now resolves.
+    assert r.tickers_in_chain("Foundation-Model-Proxy") == ["NVDA"]
+
+
+def test_reseeding_drops_memberships_the_taxonomy_no_longer_lists(
+    seeded_db_empty_cards,
+):
+    """A plain upsert would leave an orphan the filter still returns."""
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "ARM", "Semi-Logic")
+    r.replace_taxonomy_memberships(
+        [("ARM", "L1", "Computer/GPU"), ("ARM", "L1", "Foundry")]
+    )
+    assert r.tickers_in_chain("Foundry") == ["ARM"]
+
+    r.replace_taxonomy_memberships([("ARM", "L1", "Computer/GPU")])
+    assert r.tickers_in_chain("Foundry") == []  # gone, not stranded
+    assert r.tickers_in_chain("Computer/GPU") == ["ARM"]
+
+
+def test_reseed_preserves_inherited_sector_rows(seeded_db_empty_cards):
+    """Re-seeding the taxonomy must not strip a ticker's fallback membership."""
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "JPM", "Banks")
+    r.inherit_sector_memberships({"Banks": "DEF"})
+    # The fixture pre-seeds its own Banks names, so assert membership rather
+    # than an exact list — the point is that inherited rows exist and persist.
+    before = r.tickers_in_chain("Banks")
+    assert "JPM" in before
+
+    r.replace_taxonomy_memberships([("NVDA", "X", "M7")])
+    assert r.tickers_in_chain("Banks") == before  # survived the taxonomy replace
+
+
+def test_inherit_does_not_downgrade_a_taxonomy_row(seeded_db_empty_cards):
+    """Taxonomy wins: ON CONFLICT DO NOTHING must not relabel the source."""
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "NVDA", "M7")
+    r.replace_taxonomy_memberships([("NVDA", "X", "M7")])
+    r.inherit_sector_memberships({"M7": "X"})
+    with seeded_db_empty_cards.conn.cursor() as cur:
+        cur.execute(
+            f"SELECT source FROM {seeded_db_empty_cards._schema}.watchlist_chain "
+            "WHERE ticker = 'NVDA' AND chain = 'M7'"
+        )
+        assert cur.fetchone()[0] == "taxonomy"
+
+
+def test_removed_tickers_drop_out_of_chain_reads(seeded_db_empty_cards):
+    """Membership rows outlive watchlist removal, so reads must join and filter.
+
+    Without the join a removed ticker keeps answering the filter and keeps
+    inflating chain counts.
+    """
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "SPX", "Beta")
+    r.replace_taxonomy_memberships([("SPX", "IDX", "Beta")])
+    assert r.tickers_in_chain("Beta") == ["SPX"]
+
+    with seeded_db_empty_cards.conn.cursor() as cur:
+        cur.execute(
+            f"UPDATE {seeded_db_empty_cards._schema}.watchlist "
+            "SET removed_at = now() WHERE ticker = 'SPX'"
+        )
+    assert r.tickers_in_chain("Beta") == []
+    assert "Beta" not in r.counts_by_chain()
+
+
+def test_ticker_is_upper_cased_on_write(seeded_db_empty_cards):
+    r = _repo(seeded_db_empty_cards)
+    _add_ticker(seeded_db_empty_cards, "AMD", "Semi-Logic")
+    r.replace_taxonomy_memberships([("amd", "L1", "Computer/GPU")])
+    assert r.tickers_in_chain("Computer/GPU") == ["AMD"]

--- a/tests/unit/test_watchlist_taxonomy.py
+++ b/tests/unit/test_watchlist_taxonomy.py
@@ -1,0 +1,67 @@
+"""Invariants the chain seeder and the filter rail both depend on."""
+
+from __future__ import annotations
+
+from uw_scan.watchlist_taxonomy import (
+    LAYERS,
+    SELECTED_ADDS,
+    all_chains,
+    chains_for,
+    memberships,
+)
+
+
+def test_every_selected_add_lands_in_at_least_one_chain() -> None:
+    """An add with no chain would be scanned but unreachable by any filter."""
+    placed = {ticker for ticker, _, _ in memberships()}
+    assert not sorted(SELECTED_ADDS - placed)
+
+
+def test_chain_names_are_unique_across_layers() -> None:
+    """`chain` is the filter key and half of the join-table PK.
+
+    Two layers sharing a chain name would make (ticker, chain) ambiguous and
+    silently merge two different chains in the UI.
+    """
+    names = [chain for _, _, chain in all_chains()]
+    assert len(names) == len(set(names))
+
+
+def test_no_duplicate_ticker_within_a_chain() -> None:
+    """A repeat would violate the (ticker, chain) primary key on insert."""
+    for layer in LAYERS:
+        for chain, tickers in layer.chains.items():
+            assert len(tickers) == len(set(tickers)), f"{layer.key}/{chain}"
+
+
+def test_multi_chain_membership_is_expressible() -> None:
+    """The whole reason the join table exists — a single sector column can't."""
+    assert chains_for("NVDA") == [
+        "Computer/GPU",
+        "Foundation-Model-Proxy",
+        "M7",
+    ]
+    assert chains_for("ARM") == ["Computer/GPU", "Semi-Logic/ASIC", "Semi-Cap/EDA"]
+    # IBM in both its layer chain and the new Thematic/Quantum chain.
+    assert chains_for("IBM") == ["Cloud/Hyperscaler", "Quantum"]
+
+
+def test_foundation_model_proxy_is_fully_covered() -> None:
+    """All five are already on the watchlist tagged M7.
+
+    This chain reads as empty under a single-tag schema while every member is
+    on screen — the concrete bug the join table fixes.
+    """
+    proxy = dict(next(layer for layer in LAYERS if layer.key == "L5").chains)
+    assert set(proxy["Foundation-Model-Proxy"]) <= set(
+        dict(next(layer for layer in LAYERS if layer.key == "X").chains)["M7"]
+    )
+
+
+def test_selected_adds_count_is_pinned() -> None:
+    """Budget is computed from this count; a silent change moves the UW spend."""
+    assert len(SELECTED_ADDS) == 59
+
+
+def test_case_insensitive_lookup() -> None:
+    assert chains_for("nvda") == chains_for("NVDA")

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,9 @@
 import { CardGrid } from "@/components/watchlist/CardGrid";
 import { FilterBar } from "@/components/watchlist/FilterBar";
+import {
+  buildSectorGroups,
+  chainCounts,
+} from "@/components/watchlist/sectorGroups";
 import { AddTickerDialog } from "@/components/watchlist/AddTickerDialog";
 import { QueueProgress } from "@/components/shared/QueueProgress";
 import { ScanAllButton } from "@/components/shared/ScanAllButton";
@@ -17,9 +21,11 @@ export default async function DashboardPage({
   const sp = await searchParams;
   const qs = new URLSearchParams();
   if (sp.sector) qs.set("sector", sp.sector);
+  if (sp.chain) qs.set("chain", sp.chain);
   if (sp.setup) qs.set("setup", sp.setup);
   if (sp.fresh) qs.set("fresh_within_minutes", sp.fresh);
-  const { data, apiUnavailable } = await loadDashboardData(qs);
+  const { data, chains, apiUnavailable } = await loadDashboardData(qs);
+  const groups = buildSectorGroups(chains);
 
   return (
     <div style={{ padding: 24, maxWidth: 1600, margin: "0 auto" }}>
@@ -43,7 +49,7 @@ export default async function DashboardPage({
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
           <QueueProgress queue={data.queue} />
           <ScanAllButton />
-          <AddTickerDialog />
+          <AddTickerDialog chains={chains} />
         </div>
       </header>
       {apiUnavailable && (
@@ -62,7 +68,7 @@ export default async function DashboardPage({
           ready.
         </div>
       )}
-      <FilterBar current={sp} />
+      <FilterBar current={sp} groups={groups} counts={chainCounts(chains)} />
       <CardGrid data={data} />
     </div>
   );

--- a/web/components/watchlist/AddTickerDialog.tsx
+++ b/web/components/watchlist/AddTickerDialog.tsx
@@ -3,14 +3,17 @@ import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, ChevronDown } from "lucide-react";
 import { api } from "@/lib/api";
-import { SECTOR_ROWS, WATCHLIST_SECTORS } from "./sectorGroups";
+import { sectorRowsFromChains } from "./sectorGroups";
+import type { WatchlistChainInfo } from "@/lib/api";
 
 function SectorMenu({
   value,
   onChange,
+  rows,
 }: {
   value: string;
   onChange: (sector: string) => void;
+  rows: { label: string; items: string[] }[];
 }) {
   const [open, setOpen] = useState(false);
 
@@ -65,7 +68,7 @@ function SectorMenu({
             boxShadow: "0 18px 40px rgba(0, 0, 0, 0.45)",
           }}
         >
-          {SECTOR_ROWS.map((row) => {
+          {rows.map((row) => {
             const sectors = row.items.filter((item) => item !== "All");
             if (sectors.length === 0) return null;
 
@@ -131,11 +134,19 @@ function SectorMenu({
   );
 }
 
-export function AddTickerDialog() {
+export function AddTickerDialog({
+  chains = [],
+}: {
+  // The dialog still writes the single `watchlist.sector` column, so it needs
+  // the chain list as a flat picker. Passed in rather than fetched so the
+  // header does not fire a second request on every dashboard render.
+  chains?: WatchlistChainInfo[];
+}) {
+  const rows = sectorRowsFromChains(chains);
   const ref = useRef<HTMLDialogElement>(null);
   const router = useRouter();
   const [ticker, setTicker] = useState("");
-  const [sector, setSector] = useState(WATCHLIST_SECTORS[0]);
+  const [sector, setSector] = useState("");
   const [notes, setNotes] = useState("");
 
   const submit = async (e: React.FormEvent) => {
@@ -187,7 +198,7 @@ export function AddTickerDialog() {
             onChange={(e) => setTicker(e.target.value)}
             className="uw-dialog-field"
           />
-          <SectorMenu value={sector} onChange={setSector} />
+          <SectorMenu rows={rows} value={sector} onChange={setSector} />
           <input
             placeholder="notes (optional)"
             value={notes}

--- a/web/components/watchlist/FilterBar.tsx
+++ b/web/components/watchlist/FilterBar.tsx
@@ -1,11 +1,7 @@
 "use client";
 import { useState, type CSSProperties } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import {
-  SECTOR_GROUPS,
-  groupForSector,
-  type SectorGroup,
-} from "./sectorGroups";
+import { groupForChain, type SectorGroup } from "./sectorGroups";
 
 const SETUPS = ["All", "C-bull", "C-bear", "F-MULTI", "NEUTRAL"];
 
@@ -95,22 +91,26 @@ function SetupFormulaPopover() {
 
 export function FilterBar({
   current,
+  groups,
+  counts,
 }: {
   current: Record<string, string | undefined>;
+  // Built server-side from /api/watchlist/chains — the rail is data, not a
+  // hardcoded list, so it cannot drift from uw_scan.watchlist_taxonomy.
+  groups: SectorGroup[];
+  counts?: Record<string, number>;
 }) {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
 
-  const sector = current.sector;
-  const filteredGroup = groupForSector(sector);
+  const chain = current.chain;
+  const filteredGroup = groupForChain(groups, chain);
   // `null` means "follow the URL". A rail click pins the row open so you can
   // browse a layer's chains without filtering to one of them first.
   const [pinnedKey, setPinnedKey] = useState<string | null>(null);
   const openGroup =
-    SECTOR_GROUPS.find((g) => g.key === pinnedKey) ??
-    filteredGroup ??
-    SECTOR_GROUPS[0];
+    groups.find((g) => g.key === pinnedKey) ?? filteredGroup ?? groups[0];
 
   const setParam = (key: string, value: string | null) => {
     const q = new URLSearchParams(params.toString());
@@ -119,9 +119,14 @@ export function FilterBar({
     router.push(`${pathname}?${q.toString()}`);
   };
 
-  const chip = (label: string, active: boolean, onClick: () => void) => (
+  const chip = (
+    label: string,
+    active: boolean,
+    onClick: () => void,
+    key?: string,
+  ) => (
     <button
-      key={label}
+      key={key ?? label}
       className="wl-chip"
       data-active={active}
       onClick={onClick}
@@ -134,6 +139,10 @@ export function FilterBar({
         border: `1px solid ${active ? "var(--accent-bg)" : "var(--border-dim)"}`,
         borderRadius: 3,
         cursor: "pointer",
+        // Chain names plus a count are long enough to wrap inside the chip,
+        // which doubles the chip height and defeats the fixed-height row.
+        whiteSpace: "nowrap",
+        flexShrink: 0,
       }}
     >
       {label}
@@ -179,11 +188,13 @@ export function FilterBar({
   const onRailClick = (g: SectorGroup) => {
     if (g.leaf) {
       setPinnedKey(g.key);
-      setParam("sector", sector === g.items[0] ? null : g.items[0]);
+      setParam("chain", chain === g.items[0] ? null : g.items[0]);
       return;
     }
     setPinnedKey(g.key);
   };
+
+  if (!openGroup) return null;
 
   return (
     <div
@@ -194,11 +205,11 @@ export function FilterBar({
     >
       {/* Row 1 — group rail. Fixed height regardless of how many chains exist. */}
       <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap" }}>
-        {railButton("all", "All", "No sector filter", !sector, false, () =>
-          setParam("sector", null),
+        {railButton("all", "All", "No chain filter", !chain, false, () =>
+          setParam("chain", null),
         )}
-        {SECTOR_GROUPS.map((g, i) => {
-          const prev = SECTOR_GROUPS[i - 1];
+        {groups.map((g, i) => {
+          const prev = groups[i - 1];
           const newCluster = i === 0 || prev.cluster !== g.cluster;
           return [
             newCluster ? (
@@ -233,7 +244,11 @@ export function FilterBar({
           alignItems: "center",
           justifyContent: "space-between",
           gap: 16,
-          flexWrap: "wrap",
+          // nowrap, not wrap: chain names are long (Foundation-Model-Proxy,
+          // IT-Services/Integration) and wrapping pushed Setup onto a third
+          // row, which is exactly the fixed-height property this layout exists
+          // to guarantee. The chain strip scrolls instead.
+          flexWrap: "nowrap",
           padding: "8px 0 10px",
         }}
       >
@@ -242,13 +257,21 @@ export function FilterBar({
             display: "flex",
             alignItems: "center",
             gap: 8,
-            flexWrap: "wrap",
+            flexWrap: "nowrap",
+            overflowX: "auto",
+            // Without minWidth:0 a flex item refuses to shrink below its
+            // content width, so overflowX never engages.
+            minWidth: 0,
+            scrollbarWidth: "thin",
           }}
         >
           <span style={monoLabelStyle}>{openGroup.full}</span>
           {openGroup.items.map((s) =>
-            chip(s, sector === s, () =>
-              setParam("sector", sector === s ? null : s),
+            chip(
+              counts?.[s] ? `${s} ${counts[s]}` : s,
+              chain === s,
+              () => setParam("chain", chain === s ? null : s),
+              s,
             ),
           )}
         </div>
@@ -258,6 +281,9 @@ export function FilterBar({
             alignItems: "center",
             gap: 8,
             flexWrap: "wrap",
+            // Setup never shrinks or scrolls away — the chain strip absorbs the
+            // overflow instead, so this stays reachable at any width.
+            flexShrink: 0,
           }}
         >
           <span

--- a/web/components/watchlist/sectorGroups.ts
+++ b/web/components/watchlist/sectorGroups.ts
@@ -1,107 +1,136 @@
+import type { WatchlistChainInfo } from "@/lib/api";
+
 export type SectorCluster = "core" | "ai" | "other";
 
 export type SectorGroup = {
-  /** Stable id for rail state. Not persisted — the URL still carries `sector`. */
+  /** Stable id for rail state. Not persisted — the URL carries `chain`. */
   key: string;
   /** Rail text. Uppercased at render. */
   label: string;
-  /** Full layer name. Shown as the chain-row caption, and as the rail tooltip. */
+  /** Full layer name. Shown as the chain-row caption and the rail tooltip. */
   full: string;
   cluster: SectorCluster;
-  /** Chain tags. These are the values that reach `?sector=`. */
+  /** Chain names. These are the values that reach `?chain=`. */
   items: string[];
   /**
    * Rail click filters straight to `items[0]` instead of opening a chain row.
-   * For groups whose name IS the tag (M7), a chain row holding one chip that
-   * repeats the group name is pure noise.
+   * For a layer whose name IS its only chain (M7), a chain row holding one chip
+   * that repeats the group name is pure noise.
    */
   leaf?: boolean;
 };
 
 /**
- * Rail order is deliberate: Index/Macro and M7 lead because that is the
- * top-of-session read — what beta is doing, what the megacaps are doing —
- * before drilling into any chain. The five AI layers stay contiguous so
- * they read as one cluster rather than five unrelated groups.
+ * Rail order, and which layers lead. Index & Macro and M7 come first because
+ * that is the top-of-session read — what beta is doing, what the megacaps are
+ * doing — before drilling into a chain.
  *
- * `items` lists tags that exist in `uw_scan.watchlist.sector` TODAY. The
- * Model & Tooling layer and the wider chain set from
- * docs/research/2026-08-09-watchlist-industry-chains/ arrive with the chain
- * migration; a rail button that filters to an empty grid is worse than one
- * that isn't there yet, so layers land here as their tags land in the DB.
+ * Everything else is DERIVED from `/api/watchlist/chains`, not hardcoded. The
+ * taxonomy lives in `uw_scan.watchlist_taxonomy`; duplicating 38 chain names
+ * here would reintroduce exactly the drift that module exists to prevent.
  */
-export const SECTOR_GROUPS: SectorGroup[] = [
-  {
-    key: "index",
-    label: "Index",
-    full: "Index & Macro",
-    cluster: "core",
-    items: ["Beta", "Sector-ETF", "Credit", "Macro"],
-  },
-  {
-    key: "m7",
-    label: "M7",
-    full: "Cross-cutting",
-    cluster: "core",
-    items: ["M7"],
-    leaf: true,
-  },
-  {
-    key: "chip",
-    label: "Chip",
-    full: "Chip & System",
-    cluster: "ai",
-    items: ["Foundry", "Semi-Logic", "Semi-Cap", "Memory"],
-  },
-  {
-    key: "cloud",
-    label: "Cloud",
-    full: "Cloud & Data Platform",
-    cluster: "ai",
-    items: ["NeoCloud"],
-  },
-  {
-    key: "dc",
-    label: "DC",
-    full: "Datacenter Infrastructure",
-    cluster: "ai",
-    items: ["DC-Connect", "Power"],
-  },
-  {
-    key: "app",
-    label: "App",
-    full: "Application & Endpoint",
-    cluster: "ai",
-    items: ["SaaS"],
-  },
-  {
-    key: "thematic",
-    label: "Thematic",
-    full: "Thematic",
-    cluster: "other",
-    items: ["Crypto", "Fintech", "Space"],
-  },
-  {
-    key: "defensive",
-    label: "Defensive",
-    full: "Defensive",
-    cluster: "other",
-    items: ["Healthcare", "Energy", "Banks", "Consumer"],
-  },
-];
+const LAYER_ORDER = ["IDX", "X", "L1", "L2", "L3", "L4", "L5", "THM", "DEF"];
 
-/** The group whose chain row should be open for a given `?sector=` value. */
-export function groupForSector(
-  sector: string | undefined,
-): SectorGroup | undefined {
-  if (!sector || sector === "All") return undefined;
-  return SECTOR_GROUPS.find((g) => g.items.includes(sector));
+const LAYER_LABEL: Record<string, string> = {
+  IDX: "Index",
+  X: "M7",
+  L1: "Chip",
+  L2: "Cloud",
+  L3: "DC",
+  L4: "App",
+  L5: "Model",
+  THM: "Thematic",
+  DEF: "Defensive",
+};
+
+const LAYER_CLUSTER: Record<string, SectorCluster> = {
+  IDX: "core",
+  X: "core",
+  L1: "ai",
+  L2: "ai",
+  L3: "ai",
+  L4: "ai",
+  L5: "ai",
+  THM: "other",
+  DEF: "other",
+};
+
+/**
+ * Build the rail from live chain rows.
+ *
+ * Chains with zero members are dropped: a rail button that filters to an empty
+ * grid is worse than one that isn't there. That is what previously forced the
+ * Model & Tooling layer out of the UI entirely — its members existed but were
+ * unreachable under a single-tag schema, so the layer looked empty.
+ */
+export function buildSectorGroups(chains: WatchlistChainInfo[]): SectorGroup[] {
+  const byLayer = new Map<string, WatchlistChainInfo[]>();
+  for (const c of chains) {
+    if (c.count <= 0) continue;
+    const arr = byLayer.get(c.layer) ?? [];
+    arr.push(c);
+    byLayer.set(c.layer, arr);
+  }
+
+  const groups: SectorGroup[] = [];
+  for (const layer of LAYER_ORDER) {
+    const rows = byLayer.get(layer);
+    if (!rows || rows.length === 0) continue;
+    groups.push({
+      key: layer.toLowerCase(),
+      label: LAYER_LABEL[layer] ?? layer,
+      full: rows[0].layer_name,
+      cluster: LAYER_CLUSTER[layer] ?? "other",
+      items: rows.map((r) => r.chain),
+      leaf: rows.length === 1 && rows[0].chain === LAYER_LABEL[layer],
+    });
+  }
+  // Any layer the server knows about that we have no order entry for still
+  // renders, rather than silently vanishing when the taxonomy grows.
+  for (const [layer, rows] of byLayer) {
+    if (LAYER_ORDER.includes(layer)) continue;
+    groups.push({
+      key: layer.toLowerCase(),
+      label: rows[0].layer_name,
+      full: rows[0].layer_name,
+      cluster: "other",
+      items: rows.map((r) => r.chain),
+    });
+  }
+  return groups;
 }
 
-/** Grouped label/items pairs — consumed by AddTickerDialog's sector picker. */
-export const SECTOR_ROWS: { label: string; items: string[] }[] =
-  SECTOR_GROUPS.map((g) => ({ label: g.label, items: g.items }));
+/** The group whose chain row should be open for a given `?chain=` value. */
+export function groupForChain(
+  groups: SectorGroup[],
+  chain: string | undefined,
+): SectorGroup | undefined {
+  if (!chain || chain === "All") return undefined;
+  return groups.find((g) => g.items.includes(chain));
+}
 
-export const WATCHLIST_SECTORS = SECTOR_GROUPS.flatMap((g) => g.items);
+/** Member counts keyed by chain, for the rail's count badges. */
+export function chainCounts(
+  chains: WatchlistChainInfo[],
+): Record<string, number> {
+  return Object.fromEntries(chains.map((c) => [c.chain, c.count]));
+}
+
+/**
+ * Legacy sector list for the Add Ticker dialog, which still writes the single
+ * `watchlist.sector` column. Grouped by layer name so the picker keeps its
+ * headings.
+ */
+export function sectorRowsFromChains(
+  chains: WatchlistChainInfo[],
+): { label: string; items: string[] }[] {
+  const out = new Map<string, string[]>();
+  for (const c of chains) {
+    const arr = out.get(c.layer_name) ?? [];
+    arr.push(c.chain);
+    out.set(c.layer_name, arr);
+  }
+  return [...out.entries()].map(([label, items]) => ({ label, items }));
+}
 
 export const PRIORITY_SECTORS = ["Beta", "M7", "Semi-Logic"] as const;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -39,6 +39,11 @@ type Json<
 type WatchlistResponse = Json<"/api/watchlist", "get">;
 type QueueSummaryResponse = Json<"/api/watchlist/queue", "get">;
 type WatchlistSpotsResponse = Json<"/api/watchlist/spots", "get">;
+type WatchlistChainsResponse = Json<"/api/watchlist/chains", "get">;
+// One rail row. Derived from the response rather than the component schema so
+// it cannot drift from what the endpoint actually returns.
+// NonNullable: `chains` has a server-side default so OpenAPI marks it optional.
+type WatchlistChainInfo = NonNullable<WatchlistChainsResponse["chains"]>[number];
 type SingleStockReport = Json<"/api/stock/{ticker}", "get">;
 type StockHistoryResponse = Json<"/api/stock/{ticker}/history", "get">;
 type JobStatus = Json<"/api/jobs/{job_id}", "get">;
@@ -141,6 +146,8 @@ export const api = {
     _fetch<QueueSummaryResponse>(`/api/watchlist/queue`),
   watchlistSpots: (): Promise<WatchlistSpotsResponse> =>
     _fetch<WatchlistSpotsResponse>(`/api/watchlist/spots`),
+  watchlistChains: (): Promise<WatchlistChainsResponse> =>
+    _fetch<WatchlistChainsResponse>(`/api/watchlist/chains`),
   stock: (ticker: string): Promise<SingleStockReport> =>
     _fetch<SingleStockReport>(`/api/stock/${ticker}`),
   stockHistory: (ticker: string): Promise<StockHistoryResponse> =>
@@ -389,5 +396,7 @@ export type {
   TechnicalsResponse,
   TradeInsightsResponse,
   VolatilitySeriesResponse,
+  WatchlistChainInfo,
+  WatchlistChainsResponse,
   WatchlistResponse,
 };

--- a/web/lib/dashboardData.ts
+++ b/web/lib/dashboardData.ts
@@ -1,4 +1,4 @@
-import { api, type WatchlistResponse } from "./api";
+import { api, type WatchlistChainInfo, type WatchlistResponse } from "./api";
 
 const emptyWatchlist: WatchlistResponse = {
   scanned_at_min: null,
@@ -15,13 +15,35 @@ const emptyWatchlist: WatchlistResponse = {
   tickers: [],
 };
 
-export async function loadDashboardData(
-  qs: URLSearchParams,
-): Promise<{ data: WatchlistResponse; apiUnavailable: boolean }> {
+export async function loadDashboardData(qs: URLSearchParams): Promise<{
+  data: WatchlistResponse;
+  chains: WatchlistChainInfo[];
+  apiUnavailable: boolean;
+}> {
+  // The rail is chrome; the grid is the page. A failing /watchlist/chains must
+  // degrade to an unfiltered grid, never blank the dashboard — so its failure
+  // is swallowed independently rather than sharing the outer try.
+  const chainsPromise = (async () => {
+    try {
+      return (await api.watchlistChains())?.chains ?? [];
+    } catch {
+      return [];
+    }
+  })();
+
   try {
-    const data = await api.watchlist(qs);
-    return { data, apiUnavailable: false };
+    // Both in one pass: fetching the rail client-side would flash an empty
+    // filter bar on every navigation.
+    const [data, chains] = await Promise.all([
+      api.watchlist(qs),
+      chainsPromise,
+    ]);
+    return { data, chains, apiUnavailable: false };
   } catch {
-    return { data: emptyWatchlist, apiUnavailable: true };
+    return {
+      data: emptyWatchlist,
+      chains: await chainsPromise,
+      apiUnavailable: true,
+    };
   }
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -122,6 +122,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/watchlist/chains": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Watchlist Chains
+         * @description The filter rail: every chain, its layer, and live member count.
+         *
+         *     Declared order is preserved from the taxonomy module — the rail leads with
+         *     Index & Macro and M7 deliberately, so alphabetising here would silently
+         *     undo that.
+         */
+        get: operations["get_watchlist_chains_api_watchlist_chains_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/watchlist/{ticker}": {
         parameters: {
             query?: never;
@@ -9757,6 +9781,8 @@ export interface components {
             ticker: string;
             /** Sector */
             sector: string;
+            /** Chains */
+            chains?: string[];
             /** Pinned */
             pinned: boolean;
             /**
@@ -9790,6 +9816,35 @@ export interface components {
             skew: components["schemas"]["SkewBlock"];
             positioning: components["schemas"]["PositioningBlock"];
             queue?: components["schemas"]["QueueStatus"] | null;
+        };
+        /**
+         * WatchlistChainInfo
+         * @description One row of the filter rail, served rather than duplicated in TypeScript.
+         *
+         *     The taxonomy lives in `uw_scan.watchlist_taxonomy`; hand-copying 38 chains
+         *     into the frontend would reintroduce exactly the drift that module exists to
+         *     prevent. `count` is live membership, so the UI can hide a chain that would
+         *     filter to an empty grid instead of guessing.
+         */
+        WatchlistChainInfo: {
+            /** Layer */
+            layer: string;
+            /** Layer Name */
+            layer_name: string;
+            /** Focus */
+            focus: string;
+            /** Chain */
+            chain: string;
+            /**
+             * Count
+             * @default 0
+             */
+            count: number;
+        };
+        /** WatchlistChainsResponse */
+        WatchlistChainsResponse: {
+            /** Chains */
+            chains?: components["schemas"]["WatchlistChainInfo"][];
         };
         /** WatchlistMutation */
         WatchlistMutation: {
@@ -10051,6 +10106,8 @@ export interface operations {
         parameters: {
             query?: {
                 sector?: string | null;
+                /** @description Industry chain (uw_scan.watchlist_chain). Selects on many-to-many membership, so a ticker in several chains matches each. */
+                chain?: string | null;
                 /** @description e.g. 'C-bull', 'C-bear', 'F-MULTI', 'NEUTRAL' */
                 setup?: string | null;
                 fresh_within_minutes?: number | null;
@@ -10152,6 +10209,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WatchlistSpotsResponse"];
+                };
+            };
+        };
+    };
+    get_watchlist_chains_api_watchlist_chains_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistChainsResponse"];
                 };
             };
         };

--- a/web/tests/unit/dashboardData.test.ts
+++ b/web/tests/unit/dashboardData.test.ts
@@ -6,6 +6,7 @@ import { api } from "@/lib/api";
 vi.mock("@/lib/api", () => ({
   api: {
     watchlist: vi.fn(),
+    watchlistChains: vi.fn(),
   },
 }));
 

--- a/web/tests/unit/filterBar.test.tsx
+++ b/web/tests/unit/filterBar.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FilterBar } from "@/components/watchlist/FilterBar";
-import { groupForSector } from "@/components/watchlist/sectorGroups";
+import {
+  buildSectorGroups,
+  groupForChain,
+} from "@/components/watchlist/sectorGroups";
+import type { WatchlistChainInfo } from "@/lib/api";
 
 const push = vi.fn();
 
@@ -16,9 +20,101 @@ beforeEach(() => {
   push.mockClear();
 });
 
+/** Shaped like a real /api/watchlist/chains payload, counts included. */
+const CHAINS: WatchlistChainInfo[] = [
+  {
+    layer: "IDX",
+    layer_name: "Index & Macro",
+    focus: "Index & Macro",
+    chain: "Beta",
+    count: 4,
+  },
+  {
+    layer: "IDX",
+    layer_name: "Index & Macro",
+    focus: "Index & Macro",
+    chain: "Macro",
+    count: 3,
+  },
+  {
+    layer: "X",
+    layer_name: "Cross-cutting",
+    focus: "AI",
+    chain: "M7",
+    count: 7,
+  },
+  {
+    layer: "L1",
+    layer_name: "Chip & System",
+    focus: "AI",
+    chain: "Computer/GPU",
+    count: 7,
+  },
+  {
+    layer: "L1",
+    layer_name: "Chip & System",
+    focus: "AI",
+    chain: "Foundry",
+    count: 4,
+  },
+  {
+    layer: "L5",
+    layer_name: "Model & Tooling",
+    focus: "AI",
+    chain: "Foundation-Model-Proxy",
+    count: 5,
+  },
+  // Zero members — must not render a button that filters to an empty grid.
+  {
+    layer: "L3",
+    layer_name: "Datacenter Infrastructure",
+    focus: "AI",
+    chain: "EPC/Construction",
+    count: 0,
+  },
+];
+
+const groups = buildSectorGroups(CHAINS);
+
+describe("buildSectorGroups", () => {
+  it("drops chains with no members", () => {
+    const all = groups.flatMap((g) => g.items);
+    expect(all).toContain("Computer/GPU");
+    expect(all).not.toContain("EPC/Construction");
+  });
+
+  it("leads with Index and M7 regardless of payload order", () => {
+    expect(groups.map((g) => g.label).slice(0, 2)).toEqual(["Index", "M7"]);
+  });
+
+  it("surfaces the Model layer once its chain has members", () => {
+    const model = groups.find((g) => g.label === "Model");
+    expect(model?.items).toEqual(["Foundation-Model-Proxy"]);
+  });
+
+  it("treats a single self-named chain as a leaf", () => {
+    expect(groups.find((g) => g.label === "M7")?.leaf).toBe(true);
+    expect(groups.find((g) => g.label === "Chip")?.leaf).toBe(false);
+  });
+});
+
+describe("groupForChain", () => {
+  it("maps a chain back to its layer", () => {
+    expect(groupForChain(groups, "Computer/GPU")?.label).toBe("Chip");
+    expect(groupForChain(groups, "Foundation-Model-Proxy")?.label).toBe(
+      "Model",
+    );
+  });
+
+  it("treats absent and All as unfiltered", () => {
+    expect(groupForChain(groups, undefined)).toBeUndefined();
+    expect(groupForChain(groups, "All")).toBeUndefined();
+  });
+});
+
 describe("FilterBar", () => {
   it("shows setup formula explanation in a compact popover", () => {
-    render(<FilterBar current={{}} />);
+    render(<FilterBar current={{}} groups={groups} />);
 
     expect(screen.getByText("Setup")).toBeDefined();
     expect(screen.queryByText(/Flow direction/)).toBeNull();
@@ -28,69 +124,61 @@ describe("FilterBar", () => {
     fireEvent.mouseEnter(hoverRegion);
 
     expect(screen.getByText(/Flow direction/)).toBeDefined();
-    expect(screen.getByText(/net premium = net call premium/)).toBeDefined();
-    expect(screen.getByText(/abs\(net premium\) >= \$5M/)).toBeDefined();
-    expect(screen.getByText(/flow imbalance = abs\(net premium\)/)).toBeDefined();
     expect(screen.getByText(/F-MULTI = Type C base/)).toBeDefined();
-    expect(screen.getByText(/IV rank is context/)).toBeDefined();
 
     fireEvent.mouseLeave(hoverRegion);
-
     expect(screen.queryByText(/Flow direction/)).toBeNull();
   });
 
   it("opens a layer's chain row without applying a filter", () => {
-    render(<FilterBar current={{}} />);
+    render(<FilterBar current={{}} groups={groups} />);
 
-    // Index is open by default, so its chains are the ones on screen.
     expect(screen.getByText("Beta")).toBeDefined();
-    expect(screen.queryByText("Semi-Logic")).toBeNull();
+    expect(screen.queryByText("Computer/GPU")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Chip" }));
 
-    expect(screen.getByText("Semi-Logic")).toBeDefined();
+    expect(screen.getByText("Computer/GPU")).toBeDefined();
     expect(screen.queryByText("Beta")).toBeNull();
-    // Browsing a layer is not filtering by it.
-    expect(push).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled(); // browsing is not filtering
+  });
+
+  it("filters on ?chain= not ?sector=", () => {
+    render(<FilterBar current={{}} groups={groups} />);
+    fireEvent.click(screen.getByText("Beta"));
+    expect(push).toHaveBeenCalledWith("/?chain=Beta");
   });
 
   it("filters directly from the rail for leaf groups", () => {
-    render(<FilterBar current={{}} />);
-
+    render(<FilterBar current={{}} groups={groups} />);
     fireEvent.click(screen.getByRole("button", { name: "M7" }));
-
-    expect(push).toHaveBeenCalledWith("/?sector=M7");
+    expect(push).toHaveBeenCalledWith("/?chain=M7");
   });
 
-  it("opens the group holding the active sector on load", () => {
-    render(<FilterBar current={{ sector: "Semi-Cap" }} />);
+  it("opens the group holding the active chain on load", () => {
+    render(
+      <FilterBar
+        current={{ chain: "Foundation-Model-Proxy" }}
+        groups={groups}
+      />,
+    );
 
-    // Chip's chains are visible even though nothing was clicked...
-    expect(screen.getByText("Semi-Logic")).toBeDefined();
-    // ...and the rail marks Chip as holding the filter.
     expect(
-      screen.getByRole("button", { name: "Chip" }).getAttribute("aria-pressed"),
+      screen
+        .getByRole("button", { name: "Model" })
+        .getAttribute("aria-pressed"),
     ).toBe("true");
   });
 
-  it("toggles a chain off when it is already the active filter", () => {
-    render(<FilterBar current={{ sector: "Beta" }} />);
-
-    fireEvent.click(screen.getByText("Beta"));
-
-    expect(push).toHaveBeenCalledWith("/?");
-  });
-});
-
-describe("groupForSector", () => {
-  it("maps a chain tag back to its layer", () => {
-    expect(groupForSector("Semi-Cap")?.key).toBe("chip");
-    expect(groupForSector("NeoCloud")?.key).toBe("cloud");
-    expect(groupForSector("Healthcare")?.key).toBe("defensive");
+  it("renders member counts when supplied", () => {
+    render(
+      <FilterBar current={{}} groups={groups} counts={{ Beta: 4, Macro: 3 }} />,
+    );
+    expect(screen.getByText("Beta 4")).toBeDefined();
   });
 
-  it("treats absent and All as unfiltered", () => {
-    expect(groupForSector(undefined)).toBeUndefined();
-    expect(groupForSector("All")).toBeUndefined();
+  it("renders nothing when the rail is empty rather than crashing", () => {
+    const { container } = render(<FilterBar current={{}} groups={[]} />);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/web/tests/unit/watchlistUi.test.tsx
+++ b/web/tests/unit/watchlistUi.test.tsx
@@ -250,38 +250,35 @@ describe("QueueProgress", () => {
 });
 
 describe("AddTickerDialog", () => {
-  it("uses the current dashboard sector grouping in the sector menu", () => {
+  // The dialog is now prop-driven: the chain list comes from
+  // /api/watchlist/chains via the page, not from a hardcoded module.
+  const CHAINS = [
+    { layer: "IDX", layer_name: "Index & Macro", focus: "Index & Macro", chain: "Beta", count: 4 },
+    { layer: "X", layer_name: "Cross-cutting", focus: "AI", chain: "M7", count: 7 },
+    { layer: "L2", layer_name: "Cloud & Data Platform", focus: "AI", chain: "AI-Cloud/NeoCloud", count: 11 },
+    { layer: "L3", layer_name: "Datacenter Infrastructure", focus: "AI", chain: "Power/Electrical", count: 2 },
+    { layer: "DEF", layer_name: "Defensive", focus: "Defensive", chain: "Healthcare", count: 7 },
+  ];
+
+  it("groups the sector menu by layer from the served chain list", () => {
     installDialogPolyfill();
-    render(<AddTickerDialog />);
+    render(<AddTickerDialog chains={CHAINS} />);
 
     fireEvent.click(screen.getByRole("button", { name: /\+ ticker/i }));
-
     expect(screen.queryByRole("combobox")).toBeNull();
-    expect(screen.getByRole("button", { name: /sector beta/i })).not.toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /sector beta/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sector/i }));
 
-    expect(screen.getByText("Index")).not.toBeNull();
-    // The old single "AI/Tech" bucket is now the five AI layers, so the
-    // dialog inherits the finer grouping for free.
-    expect(screen.getByText("Chip")).not.toBeNull();
-    expect(screen.getByText("Cloud")).not.toBeNull();
-    expect(screen.getByText("DC")).not.toBeNull();
-    expect(screen.getByText("App")).not.toBeNull();
-    expect(screen.getByText("Thematic")).not.toBeNull();
-    expect(screen.getByText("Defensive")).not.toBeNull();
+    // Headings are layer names, and options are chain names.
+    expect(screen.getByText("Index & Macro")).not.toBeNull();
+    expect(screen.getByText("Cloud & Data Platform")).not.toBeNull();
     expect(screen.getByRole("option", { name: "Beta" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "M7" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "NeoCloud" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "Power" })).not.toBeNull();
-    expect(screen.getByRole("option", { name: "Healthcare" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "AI-Cloud/NeoCloud" })).not.toBeNull();
     expect(screen.queryByRole("option", { name: "Technology" })).toBeNull();
-    expect(screen.queryByRole("option", { name: "All" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("option", { name: "Power" }));
-
+    fireEvent.click(screen.getByRole("option", { name: "Power/Electrical" }));
     expect(
-      screen.getByRole("button", { name: /sector power/i }),
+      screen.getByRole("button", { name: /power\/electrical/i }),
     ).not.toBeNull();
     expect(screen.queryByRole("listbox")).toBeNull();
   });


### PR DESCRIPTION
## Why

The watchlist filter had a defect that no amount of restyling could fix: the
**Foundation-Model-Proxy chain read as empty** while all five of its members
(AMZN, GOOGL, META, MSFT, NVDA) sat on the dashboard tagged `M7`. The entire
Model & Tooling layer was unreachable.

The cause is schema, not UI. `uw_scan.watchlist.sector` is a single `TEXT`
column, so a ticker holds exactly one tag — but the taxonomy is genuinely
many-to-many. NVDA is in `Computer/GPU`, `M7` **and** `Foundation-Model-Proxy`;
ARM is in three L1 chains; IBM is in both `Cloud/Hyperscaler` and `Quantum`.

## What

**`uw_scan.watchlist_chain`** (migration `113`) — additive join table carrying
full membership. `watchlist.sector` is untouched and keeps its job as the single
PRIMARY/display tag that decides which section a card renders under.

That split is load-bearing. Filtering `Computer/GPU` shows NVDA; the unfiltered
grid still shows NVDA exactly **once**. Without it, a naive many-to-many render
draws NVDA's card three times and ARM's three times — ~114 tickers becoming
~150 cards for the same names.

**`src/uw_scan/watchlist_taxonomy.py`** — single source of truth for 9 layers /
38 chains. It previously lived in `scripts/research/`, which app code must not
import from; the research screener now imports it back.

**`GET /api/watchlist/chains`** + a `chain=` filter on `GET /api/watchlist`.
`WatchlistCard` gains `chains: list[str]`.

**The rail is served, not hardcoded.** `sectorGroups.ts` keeps only ordering and
short labels. Copying 38 chain names into TypeScript would have recreated
exactly the drift the taxonomy module exists to remove. Chains with zero members
are dropped — a rail button that filters to an empty grid is worse than absent.

**59 tickers added**, screened market-wide by option liquidity rather than
hand-listed. That is what surfaced `FRMI` (968k OI) and `KEEL` (1,076k OI) for
`DC-REIT/Colo` — a chain that read as empty only because my hand-authored list
was EQIX/DLR/IRM/AMT.

## UW budget

Measured on the mini, weekdays 2026-08-03..07, not estimated:

| pool | spend | ceiling | used |
|---|---|---|---|
| live | ~38.4k | 80k | 48% |
| research | ~24.9k | 30k | **83%** |

Marginal cost of the 59 adds is ~263 calls/ticker/day, but it splits **~85/15
live/research** (`full_scan` is 224.6 of it and is a live job). Projected after
adds: live ~51.6k, research ~27.2k. Live is fine; research at 91% of ceiling is
not.

So the ceilings move to live `60000` / research `45000` — summing to
`UW_TOTAL_DAILY_GUARD` (105000), so the account-wide guard stays the binding
constraint rather than the pools over-allocating against it. `.env` change on
the mini, applied at deploy.

Worth noting `full_scan` self-limits: `_live_max_tickers` converts remaining live
budget into a per-pass ticker cap, so more tickers degrade into **staleness**,
never overspend.

## Verification

703/703 vitest · 1709 pytest · typecheck · eslint · ruff · OpenAPI snapshot ·
model-exports gate.

Exercised end-to-end in a browser against `option_wizard_local` synced from the
mini (114 mini tickers + 59 adds = 173):

```
38/38 chains have active members; active tickers with NO chain: 0
Foundation-Model-Proxy -> AMZN GOOGL META MSFT NVDA
Quantum                -> IBM IONQ RGTI
NVDA -> Computer/GPU, Foundation-Model-Proxy, M7
IBM  -> Cloud/Hyperscaler, Quantum
```

Two layout bugs were found only by looking, not by tests: long chain names
pushed `Setup` onto a third row, and `Foundation-Model-Proxy 5` wrapped inside
its chip. Both broke the fixed-height property the two-row design exists for.
Fixed with `nowrap` + `overflow-x` on the chain strip.