### PR TITLE
fix(storage): drop dead mixin method, dedupe stock-history builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -615,6 +615,29 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   That is UW reporting equity parent-only, excluding non-controlling interest.
   A check there would mark half the universe broken while its data is fine.
 
+### Fixed
+
+- **Dead duplicate method on `Repository`.** `_VrpTradingMixin` carried its own
+  copy of `fetch_distinct_vrp_tickers`, but `_CorporateActionsMixin` sits at MRO
+  position 3 versus 31, so all 11 callers resolved to the corporate-actions
+  version and the trading copy never ran. Both bodies issued identical SQL, so
+  nothing was broken — but any future edit to the losing copy would have been a
+  silent no-op. Removed the dead copy and added
+  `tests/unit/storage/test_repository_mixin_collisions.py`, which fails if any
+  two of the ~34 mixins ever define the same name again.
+
+### Changed
+
+- **Stock-history rollup builder deduplicated** into
+  `src/uw_scan/reports/stock_history.py`. `api/routers/stock.py` and
+  `api/routers/trade_insights.py` each carried a byte-identical `_build_curve`
+  plus history-row loop, which meant the `net_dex=None` placeholder had to be
+  fixed in two places. Both routers now call one
+  `build_stock_history_response()`; responses are unchanged. Also corrects the
+  stale `stock.py:75` file/line citation in
+  `docs/research/six-dimension-matrix/08-implementation-gaps.md` (that line has
+  been the report cache since well before this change).
+
 ## [0.11.4] — 2026-08-10
 
 

--- a/docs/research/six-dimension-matrix/08-implementation-gaps.md
+++ b/docs/research/six-dimension-matrix/08-implementation-gaps.md
@@ -35,7 +35,7 @@ Legend: ✅ = production-ready; ⚠️ = partial / proxy / missing classifier; �
 | Persistence | `uw_scan.greeks_by_expiry_strike.call_vanna/put_vanna` (per-contract), `uw_scan.exposures_by_expiry_strike.call_vanna/put_vanna` (aggregated) | ✅ |
 | Repository read | None — `fetch_vanna_*_for_ticker` does not exist | ❌ |
 | Report assembler | No assembler reads vanna | ❌ |
-| API router | No router exposes vanna; `net_dex`/`net_dex_*` hardcoded `None` at `src/uw_scan/api/routers/stock.py:75` (DEX is also unsurfaced) | ❌ |
+| API router | No router exposes vanna; `net_dex` hardcoded `None` in `src/uw_scan/reports/stock_history.py::build_stock_history_response` — the single builder behind both `/api/stock/{T}/history` and the Trade Insights payload (DEX is also unsurfaced) | ❌ |
 | UI | No component | ❌ |
 | Conditional reading classifier | None — the 4 conditional readings from [`01-vanna.md`](01-vanna.md) §2 require joining vanna with flow color + dealer net-gamma + IV direction | ❌ |
 | AI blacklist | `src/uw_scan/reports/trade_insights_ai.py:965` rejects `"vanna"` in source paths | (block) |

--- a/src/uw_scan/api/routers/stock.py
+++ b/src/uw_scan/api/routers/stock.py
@@ -6,13 +6,10 @@ import os
 import threading
 import time
 from collections import OrderedDict
-from datetime import date as _date
-from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from uw_scan.api.deps import get_repo, get_settings
-from uw_scan.cards.gex import classify_bias, find_flip_strike
 from uw_scan.cards.magnets import (
     CONE_HORIZONS,
     all_pivots,
@@ -29,8 +26,6 @@ from uw_scan.models import (
     MagnetsResponse,
     SingleStockReport,
     StockHistoryResponse,
-    StockHistoryRow,
-    StrikeGexBucket,
     TechnicalsLiveResponse,
     TechnicalsResponse,
     TechnicalsVwapAnchor,
@@ -45,6 +40,7 @@ from uw_scan.reports.magnet_data import (
     trim_to_clean_segment,
 )
 from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.reports.stock_history import build_stock_history_response
 from uw_scan.reports.technicals import assemble_technicals
 from uw_scan.storage.repository import Repository
 
@@ -123,25 +119,6 @@ def _assemble_cached(ticker: str, run_id: int, repo: Repository) -> SingleStockR
     return report.model_copy(deep=True)
 
 
-def _dec(v: object) -> Decimal | None:
-    if v is None:
-        return None
-    return Decimal(str(v))
-
-
-def _build_curve(raw: list[dict]) -> list[StrikeGexBucket]:
-    return [
-        StrikeGexBucket(
-            strike=Decimal(str(row["strike"])),
-            expiry=_date.fromisoformat(row["expiry"]),
-            net_gex=_dec(row.get("net_gex")),
-            call_gex=_dec(row.get("call_gex")),
-            put_gex=_dec(row.get("put_gex")),
-        )
-        for row in raw
-    ]
-
-
 @router.get("/stock/{ticker}", response_model=SingleStockReport)
 def get_stock(ticker: str, repo: Repository = Depends(get_repo)) -> SingleStockReport:
     t = ticker.upper()
@@ -160,27 +137,7 @@ def get_stock_history(
     One row per trading day, sorted newest-first. Today's row may have
     spot=None if the post-close OHLC pull hasn't fired yet.
     """
-    t = ticker.upper()
-    raw_rows = repo.fetch_stock_history_rollup(t, limit=30)
-    rows: list[StockHistoryRow] = []
-    for r in raw_rows:
-        curve = _build_curve(r["strike_gex_curve"] or [])
-        net_gex = sum((b.net_gex for b in curve if b.net_gex is not None), Decimal("0"))
-        flip = find_flip_strike(curve)
-        spot = _dec(r.get("spot"))
-        rows.append(
-            StockHistoryRow(
-                market_date=r["market_date"],
-                spot=spot,
-                gex_flip=flip,
-                net_gex=net_gex if curve else None,
-                net_dex=None,
-                iv30d=_dec(r.get("iv30d")),
-                pcr_vol=_dec(r.get("pcr_vol")),
-                bias=classify_bias(spot, flip, net_gex if curve else None),
-            )
-        )
-    return StockHistoryResponse(ticker=t, rows=rows)
+    return build_stock_history_response(ticker.upper(), repo)
 
 
 @router.get("/stock/{ticker}/runs")

--- a/src/uw_scan/api/routers/trade_insights.py
+++ b/src/uw_scan/api/routers/trade_insights.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import date as _date
 from datetime import datetime
-from decimal import Decimal
 from typing import Any, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from uw_scan.api.deps import get_repo, get_settings
-from uw_scan.cards.gex import classify_bias, find_flip_strike
 from uw_scan.config import Settings
 from uw_scan.models import (
-    StockHistoryResponse,
-    StockHistoryRow,
-    StrikeGexBucket,
     TradeInsightAiAnalysisEnqueueResponse,
     TradeInsightAiAnalysisRequest,
     TradeInsightAiAnalysisResponse,
@@ -28,6 +22,7 @@ from uw_scan.models import (
     TradeInsightsResponse,
 )
 from uw_scan.reports.single_stock import assemble_single_stock_report
+from uw_scan.reports.stock_history import build_stock_history_response
 from uw_scan.reports.trade_blast import (
     PROMPT_VERSION as BLAST_PROMPT_VERSION,
 )
@@ -51,49 +46,6 @@ from uw_scan.reports.volatility_series import assemble_volatility_series
 from uw_scan.storage.repository import Repository
 
 router = APIRouter()
-
-
-def _dec(v: object) -> Decimal | None:
-    if v is None:
-        return None
-    return Decimal(str(v))
-
-
-def _build_curve(raw: list[dict]) -> list[StrikeGexBucket]:
-    return [
-        StrikeGexBucket(
-            strike=Decimal(str(row["strike"])),
-            expiry=_date.fromisoformat(str(row["expiry"])),
-            net_gex=_dec(row.get("net_gex")),
-            call_gex=_dec(row.get("call_gex")),
-            put_gex=_dec(row.get("put_gex")),
-        )
-        for row in raw
-    ]
-
-
-def _build_stock_history_response(
-    ticker: str, repo: Repository
-) -> StockHistoryResponse:
-    rows: list[StockHistoryRow] = []
-    for r in repo.fetch_stock_history_rollup(ticker, limit=30):
-        curve = _build_curve(r["strike_gex_curve"] or [])
-        net_gex = sum((b.net_gex for b in curve if b.net_gex is not None), Decimal("0"))
-        flip = find_flip_strike(curve)
-        spot = _dec(r.get("spot"))
-        rows.append(
-            StockHistoryRow(
-                market_date=r["market_date"],
-                spot=spot,
-                gex_flip=flip,
-                net_gex=net_gex if curve else None,
-                net_dex=None,
-                iv30d=_dec(r.get("iv30d")),
-                pcr_vol=_dec(r.get("pcr_vol")),
-                bias=classify_bias(spot, flip, net_gex if curve else None),
-            )
-        )
-    return StockHistoryResponse(ticker=ticker, rows=rows)
 
 
 _BLAST_MACRO_SERIES: tuple[str, ...] = (
@@ -334,7 +286,7 @@ def post_trade_insights_ai_analysis(
         repo,
     )
     stock_report = assemble_single_stock_report(t, run_id, repo)
-    stock_history = _build_stock_history_response(t, repo)
+    stock_history = build_stock_history_response(t, repo)
     backfill_status = (repo.get_volatility_backfill_status(t) or {}).get(
         "status"
     ) or "ready"

--- a/src/uw_scan/reports/stock_history.py
+++ b/src/uw_scan/reports/stock_history.py
@@ -1,0 +1,65 @@
+"""Daily stock-history rollup → `StockHistoryResponse`.
+
+Shared by `/api/stock/{ticker}/history` and the Trade Insights assembler. Both
+routers previously carried byte-identical copies of this loop, so the
+`net_dex=None` placeholder had to be fixed in two places.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from decimal import Decimal
+
+from uw_scan.cards.gex import classify_bias, find_flip_strike
+from uw_scan.models import StockHistoryResponse, StockHistoryRow, StrikeGexBucket
+from uw_scan.storage.repository import Repository
+
+
+def _dec(v: object) -> Decimal | None:
+    if v is None:
+        return None
+    return Decimal(str(v))
+
+
+def build_curve(raw: list[dict]) -> list[StrikeGexBucket]:
+    return [
+        StrikeGexBucket(
+            strike=Decimal(str(row["strike"])),
+            expiry=_date.fromisoformat(str(row["expiry"])),
+            net_gex=_dec(row.get("net_gex")),
+            call_gex=_dec(row.get("call_gex")),
+            put_gex=_dec(row.get("put_gex")),
+        )
+        for row in raw
+    ]
+
+
+def build_stock_history_response(
+    ticker: str, repo: Repository, *, limit: int = 30
+) -> StockHistoryResponse:
+    """One row per trading day, newest-first.
+
+    Today's row may have spot=None if the post-close OHLC pull hasn't fired yet.
+    `net_dex` is always None — the daily rollup carries no DEX column, and no
+    router surfaces one (docs/research/six-dimension-matrix/08-implementation-gaps.md).
+    Callers normalise the ticker; this passes it through verbatim.
+    """
+    rows: list[StockHistoryRow] = []
+    for r in repo.fetch_stock_history_rollup(ticker, limit=limit):
+        curve = build_curve(r["strike_gex_curve"] or [])
+        net_gex = sum((b.net_gex for b in curve if b.net_gex is not None), Decimal("0"))
+        flip = find_flip_strike(curve)
+        spot = _dec(r.get("spot"))
+        rows.append(
+            StockHistoryRow(
+                market_date=r["market_date"],
+                spot=spot,
+                gex_flip=flip,
+                net_gex=net_gex if curve else None,
+                net_dex=None,
+                iv30d=_dec(r.get("iv30d")),
+                pcr_vol=_dec(r.get("pcr_vol")),
+                bias=classify_bias(spot, flip, net_gex if curve else None),
+            )
+        )
+    return StockHistoryResponse(ticker=ticker, rows=rows)

--- a/src/uw_scan/storage/vrp_trading.py
+++ b/src/uw_scan/storage/vrp_trading.py
@@ -59,13 +59,8 @@ class _VrpTradingMixin:
             (as_of,),
         )
 
-    def fetch_distinct_vrp_tickers(self) -> list[str]:
-        # convenience mirror of vrp_markout._all_vrp_tickers for the trading layer
-        with self._conn.cursor() as cur:
-            cur.execute(
-                f"SELECT DISTINCT ticker FROM {self._schema}.vrp_daily ORDER BY ticker"
-            )
-            return [r[0] for r in cur.fetchall()]
+    # fetch_distinct_vrp_tickers lives on _CorporateActionsMixin — it sits
+    # earlier in Repository's MRO, so the copy that used to live here was dead.
 
     # ── backtest ─────────────────────────────────────────────────────────────
     def clear_vrp_backtest_results(self) -> None:

--- a/tests/unit/storage/test_repository_mixin_collisions.py
+++ b/tests/unit/storage/test_repository_mixin_collisions.py
@@ -1,0 +1,31 @@
+"""Guard: no two `Repository` mixins may define the same member name.
+
+`Repository` composes ~34 domain mixins. Python's MRO silently keeps the
+leftmost definition, so a duplicated method name is dead code that still looks
+live — and a future edit to the losing copy is a silent no-op. This is how
+`_VrpTradingMixin`'s mirror of `fetch_distinct_vrp_tickers` went unnoticed.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from uw_scan.storage.repository import Repository
+
+
+def test_no_duplicate_member_names_across_mixins() -> None:
+    owners: dict[str, list[str]] = defaultdict(list)
+    for base in Repository.__bases__:
+        for name, value in vars(base).items():
+            if name.startswith("__"):
+                continue
+            if not (callable(value) or isinstance(value, property)):
+                continue
+            owners[name].append(base.__name__)
+
+    collisions = {name: mixins for name, mixins in owners.items() if len(mixins) > 1}
+    assert not collisions, (
+        "Repository mixins define the same name more than once; every mixin "
+        "after the first in the MRO is dead code. Keep one definition: "
+        f"{collisions}"
+    )


### PR DESCRIPTION
Found by interrogating the `graphify` knowledge graph built over this repo — specifically the `Repository` god node (719 edges, betweenness 0.218) and an AMBIGUOUS doc→code edge the extractor flagged because the cited symbol didn't exist at the cited line.

## 1. Dead duplicate method on `Repository`

`Repository` composes 34 domain mixins. `_VrpTradingMixin` carried its own `fetch_distinct_vrp_tickers`, but `_CorporateActionsMixin` sits at **MRO position 3 vs 31**, so all 11 callers resolved to the corporate-actions version and the trading copy never ran.

Both bodies issued identical SQL, so nothing was broken. The risk was forward-looking: any future edit to the losing copy would have been a silent no-op.

Removes the dead copy and adds `tests/unit/storage/test_repository_mixin_collisions.py`, which fails if any two mixins ever define the same name again. This is a *global* invariant across 34 independently-edited files — no single-file diff can surface it, so it only survives as an executable check.

## 2. Deduplicated stock-history builder

`api/routers/stock.py` and `api/routers/trade_insights.py` each carried a byte-identical `_build_curve` plus history-row loop, which meant the `net_dex=None` placeholder had to be fixed in two places. Both now call one `build_stock_history_response()` in `reports/stock_history.py` — which is also where `src/uw_scan/api/CLAUDE.md` says this logic belongs ("no business logic in routers — call into `reports/*` or `cards/*`").

**One tiny behavior widening:** the two copies weren't quite identical — `stock.py` called `_date.fromisoformat(row["expiry"])`, `trade_insights.py` called `_date.fromisoformat(str(row["expiry"]))`. The shared version keeps the `str()` coercion, so `/stock/{ticker}/history` now tolerates a `date` object in `expiry` where it previously raised `TypeError`. The DB returns strings today, so no live path changes.

## 3. Stale doc citation

`docs/research/six-dimension-matrix/08-implementation-gaps.md:38` cited `src/uw_scan/api/routers/stock.py:75` for the hardcoded `net_dex`. That line has been the report cache since well before this change; the real sites were `stock.py:175` and `trade_insights.py:90`, now consolidated into one. Doc untouched since 2026-05-26 (`d97bdef`).

The gap the doc describes is still open — `net_dex` remains unsurfaced. This PR only makes it fixable in one place.

## Verification

| Gate | Result |
|---|---|
| `uv run pytest` (full suite) | **2744 passed, 14 skipped** |
| All 8 CI `lint + unit` steps reproduced locally | green |
| OpenAPI snapshot | **unchanged** — no contract drift |
| New MRO guard | passes |

No migration, no config, no API contract change.