### PR TITLE
fix(worker): commit fundamentals_refresh + fundamental analysis method spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fundamentals_refresh` has never persisted a row — it silently rolled back
+  every night.** `_repo()` (`worker/scheduler.py`) opens a psycopg connection
+  with the default `autocommit=False` and closes it in `finally` without
+  committing, and neither `worker/jobs/fundamentals_jobs.py` nor
+  `storage/fundamentals.py` called `.commit()` — so every upsert was discarded
+  on close while the job logged `"fundamentals_refresh refreshed %d tickers"`
+  and reported success. The sibling `positioning_refresh_once` survives only
+  because `insert_scan_run` / `finish_scan_run` commit internally on the same
+  connection; fundamentals had no such accident. Live on the mini,
+  `massive_fundamentals` holds 669 rows across 86 tickers with a latest
+  `fetched_at` of **2026-06-01** — those arrived through some other historical
+  path, and the scheduled job has contributed nothing since migration `066`.
+  The job now commits **per successful ticker**, and rolls back on failure:
+  Postgres aborts the entire transaction on any error, so without the rollback
+  one bad ticker made every *subsequent* ticker fail with
+  `InFailedSqlTransaction`. That second bug was latent behind the first — with
+  nothing ever committing, a cascade had nothing to lose.
+- **The integration test could not have caught it.** It asserted on the job's
+  own still-open connection, which sees uncommitted rows, so it passed against
+  a job that persisted nothing. Assertions now read through a **separately
+  opened connection**, and the new coverage is a *freshness delta* rather than
+  a row count — a count gate would have passed on production's pre-existing 669
+  rows without the bug being fixed. Both halves of the fix are verified
+  load-bearing: removing the commit fails the fresh-connection test, and
+  removing the rollback fails the cascade test with `InFailedSqlTransaction`.
+
 ## [0.11.4] — 2026-08-10
 
 

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -91,7 +91,13 @@ Buildable, mostly from parts argon already owns. Two findings gate it.
   open connection**. The test is the second bug.
 
 Nightly since migration 066, logging `"fundamentals_refresh refreshed %d tickers"` while rolling
-everything back. **`massive_fundamentals` is empty or stale in production.**
+everything back.
+
+**The production table is stale, not empty** — corrected 2026-08-10 from a live mini query:
+**669 rows across 86 tickers, latest `fetched_at` 2026-06-01**, latest period 2026-05-03. Those rows
+arrived through some other historical or manual path; the scheduled job has contributed nothing. The
+first draft said "empty or stale", and the distinction turns out to matter enormously — see the P0
+exit criterion in §9, which the row count would have satisfied *without the bug being fixed*.
 
 Blast radius is narrow: `ohlc_pull` writes through `market_data.py` (4 commits, safe).
 `fundamentals_jobs` is the confirmed case. Other `_repo()` consumers were not individually
@@ -115,17 +121,35 @@ traced — worth a follow-up audit, out of scope here.
 stock page. The target column is **`analyst_target_avg`** (`065_uw_positioning.sql:26`), not
 `target_avg`.
 
-**Source roles are now explicit** (reversal of the first draft's A4):
+**Source roles, with a fallback chain — massive is not universal.** Live probe of the core 25
+(2026-08-10) found `/vX` current coverage for **23 of 25**. **TSM and ASML return zero rows from
+`/vX` and `/v2` alike** — independently reconfirmed here.
 
-| Window | Source | Role |
+**The root cause is one this spec already documented elsewhere and failed to connect.** §3.3 records
+that the upstream tier files **20-F, not 10-K** (TSM: 6-K ×741, 20-F ×15, zero 10-Ks). massive's
+financials are derived from domestic SEC XBRL, so foreign private issuers are simply absent. One
+structural fact — foreign-issuer filing status — breaks *both* the named-edge graph and the
+statements backbone. Any name reachable only via 20-F should be assumed thin at every provider until
+probed, not just at EDGAR.
+
+| Precedence | Source | Role |
 |---|---|---|
-| 2009 → present | massive `/vX` | **backbone**; the only source that may back a "current" figure |
-| 1997 → 2008 | massive `/v2` | one-time legacy backfill; frozen, never refreshed |
-| 2009 → 2020 | both | **overlap zone** — reconcile and persist disagreements, never silently prefer one |
-| any | UW statements (94q) | independent cross-check, not the backbone |
+| 1 | massive `/vX` | **backbone** for current figures — 23/25 of the core |
+| 2 | UW statements (94q) | **fallback when `/vX` is absent**, not merely a cross-check (revises A4) |
+| 3 | SEC XBRL `companyconcept` | last resort; reaches 20-F filers massive cannot |
+| — | explicit `na` | when all three fail. A covered-looking card over an uncovered name is the worst outcome |
+| history | massive `/v2` | 1997–2008 tail **where it exists** — availability is ticker-relative, not universal |
+| overlap | `/vX` ∩ `/v2` | reconcile and persist disagreements, never silently prefer one |
+
+Coverage expectations are **per ticker**, never global: "history reaches 1997" is a claim about NVDA,
+not about the core 25, and the card must render each name's real span.
+
+**Quarter identity uses `/vX.end_date` = `/v2.reportPeriod`**, never `calendarDate` — the latter
+diverges for non-calendar fiscal issuers such as NVDA and AMD, which would silently mismatch quarters
+in the overlap zone.
 
 The overlap zone is not incidental: it is the only place field-name parity between the two endpoints
-can be validated, and it is what makes the 1997–2008 tail trustworthy enough to score against.
+can be validated, and it is what makes the pre-2009 tail trustworthy enough to score against.
 
 **Gated (Advanced+/Premium, unavailable):** forward analyst estimates, earnings-call transcripts,
 company profile, IPO calendar, UW dividends/splits, macro series.
@@ -181,7 +205,7 @@ Note the convergence: the blueprint author independently landed on a per-company
 | A1 | **Own queue** `fundamental_narrative_analyses` — stage 5, phase P5. **Not** a lane on `trade_insight_ai_analyses` | The first draft claimed this lane was "verified live" on the strength of `analysis_kind` existing (migration `067`) and per-row dispatch at `trade_insights_ai.py:142`. Both are true and both are irrelevant: `017:9` makes `snapshot_id` `NOT NULL REFERENCES trade_insight_snapshots ON DELETE CASCADE` and `run_id` `NOT NULL`, so a fundamental row has no legal parent; dispatch is binary `is_blast`, so `'fundamental'` would silently run the trade prompt; `TradeInsightAiOutcome` demands scenario cards / VRP / preferred expression; and `fetch_unscored_analyses` filters only `status='succeeded'`, so every fundamental row would enter the trade outcome ledger. **The cost of this reversal is real** — the new queue re-pays the SKIP-LOCKED claim logic, heartbeats, per-provider workers and polling hook that A1 originally existed to avoid. That is the price of domain isolation, not an oversight; do not "simplify" it back |
 | A2 | New pure-compute package **`src/uw_scan/fundamentals/`** | Follows `theta_harvester/` / `chanlun/` precedent. Not `reports/` — those are read-time reshapes; these are nightly persisted computations |
 | A3 | New API router **`api/routers/fundamental.py`** | `routers/trade_insights.py` is already ~600 lines; module-size budget |
-| A4 | **massive `/vX`** for the statements backbone; `/v2` for the 1997–2008 tail only; **UW `fundamental-breakdown`** for segments | Reversed after review. argon's own probe records `/v2` frozen at 2020-Q1 and `/vX` live to 2026 — the first draft picked the dead endpoint for its field count and would have rendered FY2020 as current. The IB→UW→FMP→massive rule is scoped to *live quotes/greeks*; massive remains the fundamentals source. UW's 94q statements are the cross-check, and the 2009–2020 overlap is where field parity is proven |
+| A4 | **massive `/vX` → UW statements → SEC XBRL → explicit `na`**, a fallback chain rather than a single backbone; `/v2` for the pre-2009 tail where it exists; **UW `fundamental-breakdown`** for segments | Reversed twice. First draft picked `/v2` for its field count — argon's probe records it frozen at 2020-Q1, so a "current" card would have shown FY2020. Then a live core-25 probe found `/vX` covers only 23/25: TSM and ASML return zero rows from both endpoints because they are 20-F filers and massive derives from domestic XBRL. UW is therefore a **fallback**, not a cross-check. The IB→UW→FMP→massive priority rule is scoped to *live quotes/greeks* and does not govern here |
 | A10 | **Immutable point-in-time observations** for statements, segments and filings; canonical views derived on top | User ruling. Two sources that disagree by six years (A4) make reconciliation mandatory regardless, and PIT is most of the same work. Retrofitting it after rows exist means rebuilding history that was never captured — restatements overwrite the evidence an old `inputs_hash` was computed from |
 | A11 | **On-demand refresh enqueues a persisted run**, returns `202` — never a synchronous router write | The technicals precedent (`stock.py:285`) is deliberately bounded and says to promote it once work becomes async or batched. This stage calls massive, UW and SEC and writes many tables; a synchronous handler leaves partial state with no retry record. argon's rule is mutations route through `/jobs` |
 | A12 | **Own worker role `ai-fundamental`** for the narrative queue | argon already pins roles per lane (`ai-codex`, `ai-claude`, `ai-deepseek`). A shared worker polling two queues needs fair-polling and independent heartbeats to avoid one lane starving the other; a separate role gets that for free and lets the fundamental lane be scaled or disabled without touching trade insights |
@@ -227,11 +251,17 @@ assume.
 
 Each in its own `storage/<domain>.py`. Never extend `repository.py`.
 
-Three tiers, and the separation is the point: **observations are immutable, canonical views are
-derived, outputs are versioned.** Nothing is ever updated in place.
+Three tiers, and the separation is the point: **observation payloads are immutable, canonical views
+are derived, outputs are versioned.**
 
-**Tier 1 — immutable source observations (A10).** One row per thing a provider actually said, at the
-time it said it. Never updated, never deleted; a restatement is a new row.
+Precise immutability contract, because "nothing is ever updated" was overstated: **the payload and
+its identity columns are immutable; sighting metadata (`last_seen_at`) is mutable.** An unchanged
+refresh updates one timestamp and writes no new fact. If that distinction ever becomes load-bearing
+for audit, sightings move to their own append-only table — but not before, since a row per unchanged
+poll is a lot of rows to prove nothing changed.
+
+**Tier 1 — immutable source observations (A10).** One row per thing a provider actually said. A
+restatement is a new row; the old one is never altered or deleted.
 
 | Table | Key columns | Registry |
 |---|---|---|
@@ -243,9 +273,15 @@ time it said it. Never updated, never deleted; a restatement is a new row.
 **Identity is content, not fetch time.** The previous draft keyed observations on `observed_at`,
 which is when *we* fetched — so every unchanged refresh would have inserted another row, directly
 contradicting P1b's own idempotence gate. Dedupe is on `content_hash` over the normalized payload:
-an unchanged refresh bumps `last_seen_at` and writes nothing; a restatement hashes differently and
-becomes a new immutable observation. `provider_record_id` is stored when the provider supplies one,
-because a stable upstream ID beats a hash we computed.
+an unchanged refresh bumps `last_seen_at` and writes **no new fact row**; a restatement hashes
+differently and becomes a new immutable observation. `provider_record_id` is stored when the provider
+supplies one, because a stable upstream ID beats a hash we computed.
+
+`content_hash` is computed over a **normalized** payload with an explicit exclusion list — provider
+response envelopes carry request IDs and generation timestamps that differ on every call, and hashing
+those would make every refresh look like a restatement. The normalization rule is committed with the
+field map in P1a, and the period key is `end_date` (`/vX`) ≡ `reportPeriod` (`/v2`), never
+`calendarDate`.
 
 `first_observed_at` is when we first saw it; `filing_published_at` is when the world could have known
 it. Point-in-time queries filter on the latter — that is what stops look-ahead in a future sweep.
@@ -271,7 +307,8 @@ collides and the second result is lost.
 
 | Table | Key columns | Registry |
 |---|---|---|
-| `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external_facts, recompute_from_cached_facts}`, per-stage status/timing, `rows_written`, `error`, `attempt` | run ledger — dimension, exempt |
+| `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external_facts, recompute_from_cached_facts}`, `status`, per-stage status/timing, `rows_written`, `error`, `attempt`. **Partial unique index on `(ticker) WHERE status IN ('queued','running')`** | run ledger — dimension, exempt |
+| `fundamental_run_outputs` | PK `(run_id, output_kind)`; `result_id`, `reused BOOLEAN` — the bridge from a run to the rows it produced *or reused* | run ledger — dimension, exempt |
 | `valuation_anchors` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; `company_type`, `method`, 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
 | `fundamental_scores` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; one column per subscore, composite, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
 | `customer_concentration` | PK `(ticker, fiscal_period, filing_form, filing_accession)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
@@ -282,9 +319,16 @@ collides and the second result is lost.
 `source_obs_ids` is what makes I2 real: it records the exact tier-1 rows a computation consumed, so
 an old `inputs_hash` can be reconstructed even after later restatements arrive.
 
-**The current-result view resolves on both axes**: active `engine_version` (from the pointer below)
-*and* the latest successful `run_id` for that ticker and date. Latest engine version alone is not
-enough — it does not disambiguate two same-day input sets.
+**The current-result view resolves through `fundamental_run_outputs`, not through a `run_id` column
+on the result.** An identical rerun is supposed to produce one logical output (T4), which means the
+second run *reuses* the first run's immutable row. If the result carried a single `run_id`, that row
+would still be stamped with run 1, so a view joining "latest successful run" to its outputs would
+find nothing for run 2 and the current result would vanish — while updating the stamp would mutate
+history. The bridge resolves both: run 2 gets its own association row with `reused = true`, pointing
+at the same `result_id`.
+
+Resolution is then: active `engine_version` (from the pointer below) → latest successful run for that
+ticker and date → its associated `result_id`.
 
 **Method versioning — immutable versions plus a singleton pointer.** A `BOOLEAN active` column with
 a partial unique index guarantees *at most* one active version, not exactly one: a failed activation
@@ -295,7 +339,13 @@ foreign key from a one-row table makes zero unrepresentable.
 |---|---|
 | `fundamental_method_versions` | PK `engine_version`; `code_version`, `param_hash`, `created_at`, `note`. **No `active` flag** |
 | `fundamental_method_params` | PK `(engine_version, param_key)`; `param_value NUMERIC`. **Immutable** — retuning inserts a new version, never edits rows |
-| `fundamental_method_state` | `singleton_id INT PRIMARY KEY DEFAULT 1 CHECK (singleton_id = 1)`; `active_engine_version TEXT NOT NULL REFERENCES fundamental_method_versions` |
+| `fundamental_method_state` | `singleton_id INT PRIMARY KEY DEFAULT 1 CHECK (singleton_id = 1)`; `active_engine_version TEXT NOT NULL REFERENCES fundamental_method_versions`. **Seeded by migration; a `BEFORE DELETE` trigger raises** |
+
+`CHECK (singleton_id = 1)` constrains the row's *value*, not its *existence* — it happily permits
+`DELETE`, which would leave zero active versions and every computation silently method-less. The
+NOT NULL FK removes the null case; the delete trigger removes the empty case; and stage 2 raises
+loudly rather than defaulting if the pointer cannot be read. Three mechanisms because "exactly one"
+needs both bounds enforced, and the first draft claimed it with only one.
 
 Activation is one atomic `UPDATE` of the pointer. `engine_version` is derived
 `{code_version}:{param_hash[:8]}` and written once at version creation. An "active version" view
@@ -580,8 +630,34 @@ filing writes duplicates that look like new disclosures. `extractor_version` is 
 deliberately excluded from the uniqueness key: a better extractor finding the same sentence must
 recognise it, not re-file it.
 
+**But hash identity alone cannot retract.** If extractor v1 emits a false META edge and v2 correctly
+emits *nothing*, there is no new row to supersede the false one — absence cannot overwrite presence,
+so a known-wrong edge stays current forever. Fixing duplicate-on-improve created
+cannot-retract-on-improve; both need the same missing concept, **the extraction run**:
+
+```sql
+CREATE TABLE IF NOT EXISTS uw_scan.filing_extraction_runs (
+    extraction_run_id  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    filing_accession   TEXT NOT NULL,
+    extractor_version  TEXT NOT NULL,
+    status             TEXT NOT NULL CHECK (status IN ('running','succeeded','failed')),
+    fact_count         INT,
+    started_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at        TIMESTAMPTZ,
+    UNIQUE (filing_accession, extractor_version)
+);
+```
+
+Each observation carries its `extraction_run_id`. **The current projection reads only the latest
+*succeeded* run per accession**, so a re-extraction that finds nothing retracts by omission while
+every earlier run stays queryable for audit. A failed run never becomes current, so a crashed
+extraction cannot silently empty a filing's facts.
+
+The same rule governs `customer_concentration`. Retraction is a projection concern, never a `DELETE`.
+
 **Current-relationship projection** — a view, not a table:
-`fundamental_edge_current` takes the newest observation per `(src_ticker, dst_ticker, edge_type)` and
+`fundamental_edge_current` reads observations **from the latest succeeded `filing_extraction_run` per
+accession only**, then takes the newest surviving one per `(src_ticker, dst_ticker, edge_type)` and
 derives `status` from filing recency (`active` / `stale` after absence from the newest same-form
 filing / `retired` past 400 days). Nothing is mutated to compute it; the full observation history
 stays queryable, which is what "audit trail" was supposed to mean.
@@ -611,7 +687,7 @@ stays queryable, which is what "audit trail" was supposed to mean.
 | User-Agent | SEC-required contact email, from config; requests without it are refused |
 | rate limit | SEC's published ceiling is 10 req/s; the client throttles below it and is the only path to `sec.gov` |
 | retry | bounded exponential backoff on 429/5xx, capped attempts, failures recorded on the `fundamental_runs` row rather than raised into the UI |
-| cache | filings are immutable once accepted — cache by accession on disk and never re-fetch the same document |
+| cache | filings are immutable once accepted — cache by accession in **`sec_filing_documents`** (§4.4) and never re-fetch the same document. Not container disk: the only compose volume is the lake at `:ro` |
 
 **Discovery gate before build.** P4 starts with a read-only probe over the core 25 that reports
 concentration-row yield and named-edge yield. If the ledger's `trend` arrays come back flat and
@@ -743,11 +819,12 @@ artifact and the renderer was never owed.
 no new persisted table, no second scoring path. One engine, two renderings.
 
 **Every aggregate needs a stated basis.** A cell median is meaningless across mixed engine versions
-or stale `as_of` values, so G2 fixes three rules before it aggregates: a common `as_of` (the latest
+or stale `as_of` values, so G2 fixes four rules before it aggregates: a common `as_of` (the latest
 date on which the cell's members share the active `engine_version`), rows on superseded versions are
-excluded rather than mixed, and the **coverage denominator is the cell's full membership** — not the
-subset that happens to have rows. A cell where 2 of 6 names are analysed shows the 2-name aggregate
-*and* says 2/6.
+excluded rather than mixed, the **coverage denominator is the cell's full membership** — not the
+subset that happens to have rows — and **a cell whose members share no common date/version renders
+`unavailable`**, never a silently mixed number. A cell where 2 of 6 names are analysed shows the
+2-name aggregate *and* says 2/6.
 
 ## 9. Phases
 
@@ -758,7 +835,7 @@ stops moving.
 
 | Phase | Ships | Gate | Verification |
 |---|---|---|---|
-| **P0** | Commit-bug fix + a test asserting through a **freshly opened connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | Mini's `massive_fundamentals` row count > 0 after a real scheduler run; rollback-path regression |
+| **P0** | Commit-bug fix + a test asserting through a **freshly opened connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | **Freshness delta, not row count**: record a ticker's `fetched_at` before the run, invoke the *real scheduled function*, then assert from a **new connection** that its `fetched_at` advanced past the run start. Plus a rollback-path regression |
 | **P1a** | **Data-contract spike** (no schema): reconcile `/vX`, `/v2`, UW statements and the filed 10-K on representative tickers; commit the exact field map | The first draft chose a frozen endpoint for its field count. No ingestion is designed until the sources are measured, not read about | An overlap-zone quarter agrees across `/vX` and `/v2` field-for-field, or the disagreement is documented with a resolution rule |
 | **P1b** | Immutable observation tables + canonical views + backfill/incremental modes; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | `/vX` reaches 2026 and `/v2` fills 1997–2008; re-ingest is idempotent; a simulated restatement adds a row without destroying its predecessor; FY2026 segment revenue matches the filed 10-K to the dollar |
 | **P2** | Method appendix (worked examples) · method version tables · ANCHOR then SCORE · confidence downgrades · `fundamental_runs` + enqueued refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors from the appendix; recompute with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and yields new anchors**; a new method version coexists with the old on the same date; exactly one version is active |
@@ -829,6 +906,14 @@ is a required test, not a suggestion.
 | T11 | Container replaced | cached filings survive (Postgres, not container disk) |
 | T12 | Provider disabled | card renders stages 1–4 fully; narrative block marked absent |
 | T13 | Cell members hold mixed engine versions | aggregate uses the shared active version; coverage fraction shown |
+| T14 | Cell members share **no** common date/version | cell renders **unavailable**, never a silently mixed aggregate |
+| T15 | Extractor v1 emits a false edge, v2 emits nothing for that filing | edge disappears from the current projection; v1's observation still queryable |
+| T16 | Extraction run crashes mid-filing | the failed run never becomes current; the prior succeeded run still projects |
+| T17 | `DELETE` the method state row | **rejected** by trigger; worker startup also fails loudly if the pointer is unreadable |
+| T18 | Identical rerun, then query the current view via the second run | resolves to the same `result_id` through a `reused = true` association |
+| T19 | TSM / ASML (no massive coverage) | falls back to UW, then SEC XBRL, then renders explicit `na` — never a blank that reads as zero |
+| T20 | Non-calendar fiscal issuer (NVDA, AMD) in the overlap zone | quarters match on `end_date` ≡ `reportPeriod`; `calendarDate` is never used as the key |
+| T21 | Provider envelope changes (request id / timestamp) with identical financials | `content_hash` unchanged → no new observation |
 
 Gates before merge: `uv run pytest`, ruff, `scripts/check_no_yahoo.py`, and under `web/`
 `npm run typecheck && npm run test && npm run lint && npm run build`, plus Playwright coverage of the
@@ -881,9 +966,15 @@ the active method is a NOT NULL singleton pointer, not a boolean flag; both run 
 anchors and scores; P5 gates on P4 *resolved*, not shipped; filings cache in Postgres; narrative gets
 its own `ai-fundamental` worker role (A12).
 
+Round 3 (live-probed): P0's gate is a freshness delta, not a row count — production already holds
+669 rows, so the old gate passed without the bug being fixed; massive covers only 23/25 of the core,
+so A4 becomes a fallback chain; the method pointer needs a delete trigger, not just a `CHECK`;
+identical reruns resolve through `fundamental_run_outputs`; active runs are enforced by a partial
+unique index; extraction runs make retraction possible; immutability is payload-scoped.
+
 **One review recommendation was rejected on evidence.** Round 2 proposed R2 for raw filing storage.
-R2 is retired: CHANGELOG records "the worker refuses to boot when retired R2 settings are present",
-added after a dead R2 bucket froze `vol_index_daily` for 13 days. Following it would have prevented
-the worker from starting. `CLAUDE.md` still carries the stale "R2 lake is primary" line, which is the
-likely source of the suggestion — **that line should be corrected in a separate PR**, since it will
-keep misleading readers.
+R2 is retired and configuring it is a **boot failure** — verified in runtime code at
+`worker/scheduler.py:215`, added after a dead R2 bucket froze `vol_index_daily` for 13 days.
+`CLAUDE.md` still carries the stale "R2 lake is primary" line, which is the likely source of the
+suggestion — **that line should be corrected in a separate PR**, since it will keep misleading
+readers and has now done so at least once.

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -122,8 +122,20 @@ stock page. The target column is **`analyst_target_avg`** (`065_uw_positioning.s
 `target_avg`.
 
 **Source roles, with a fallback chain — massive is not universal.** Live probe of the core 25
-(2026-08-10) found `/vX` current coverage for **23 of 25**. **TSM and ASML return zero rows from
-`/vX` and `/v2` alike** — independently reconfirmed here.
+(2026-08-10) found `/vX` current coverage for **23 of 25**:
+
+| Ticker | `/vX` (current) | `/v2` (history) | Gap |
+|---|---|---|---|
+| TSM | **0 rows** (HTTP 200, empty `results`) | 76 rows, 2000-12-31 → 2019-12-31 | **2020 → present** |
+| ASML | **0 rows** (HTTP 200, empty `results`) | 391 rows, 2000-12-31 → 2019-12-31 | **2020 → present** |
+| NVDA (control) | current to 2026-04-26 | 5 rows, ends 2020-01-26 | none |
+
+The gap is **current data, not history**. Two earlier readings of this were wrong in opposite
+directions — one claimed both endpoints were empty for both names, the other that only TSM lacked
+`/v2`. Root cause of the bad measurement, recorded so P1a does not repeat it: **`/v2` takes the
+ticker in the URL path** (`/v2/reference/financials/{ticker}`) while **`/vX` takes it as a query
+parameter**. Querying `/v2` in `/vX` form returns **404**, which a naive row-count probe reads as
+"no coverage". A zero must be distinguished from an error before it becomes evidence.
 
 **The root cause is one this spec already documented elsewhere and failed to connect.** §3.3 records
 that the upstream tier files **20-F, not 10-K** (TSM: 6-K ×741, 20-F ×15, zero 10-Ks). massive's
@@ -138,8 +150,16 @@ probed, not just at EDGAR.
 | 2 | UW statements (94q) | **fallback when `/vX` is absent**, not merely a cross-check (revises A4) |
 | 3 | SEC XBRL `companyconcept` | last resort; reaches 20-F filers massive cannot |
 | — | explicit `na` | when all three fail. A covered-looking card over an uncovered name is the worst outcome |
-| history | massive `/v2` | 1997–2008 tail **where it exists** — availability is ticker-relative, not universal |
+| history | massive `/v2` | pre-2020 tail **where it exists** — availability and span are ticker-relative, not universal |
 | overlap | `/vX` ∩ `/v2` | reconcile and persist disagreements, never silently prefer one |
+
+**Foreign issuers emit `na` for anchors in v1 — units before valuation.** TSM reports in TWD and
+ASML in EUR, and both trade in the US as ADRs whose ratio to ordinary shares is not 1:1. A fallback
+that returns statement values without a currency, XBRL-unit, FX-date and ADR-ratio contract would
+divide a TWD revenue figure by a USD market cap and produce an anchor wrong by an order of
+magnitude — silently, and with full provenance attached, which is worse than no anchor. Until P1a
+proves normalized USD/ADR-equivalent inputs, foreign-issuer names render `na` with the reason
+stated. Their statements and history still ingest; only the valuation stage abstains.
 
 Coverage expectations are **per ticker**, never global: "history reaches 1997" is a claim about NVDA,
 not about the core 25, and the card must render each name's real span.
@@ -296,7 +316,8 @@ infrastructure.
 
 **Tier 2 — canonical views, derived not stored.** `fundamental_statement_current` resolves the
 newest non-superseded observation per `(ticker, period_end, period_type)` under a documented source
-precedence (`/vX` wins inside 2009+; `/v2` supplies 1997–2008; UW breaks ties only as cross-check).
+precedence (the §3.2 chain: `/vX` for current, **UW then SEC XBRL where `/vX` is absent**, `/v2` for
+the pre-2020 tail where it exists, explicit `na` when all fail).
 Overlap-zone disagreements are surfaced, never silently resolved: a materialized
 `fundamental_source_discrepancies` row records both values and the delta.
 
@@ -308,7 +329,7 @@ collides and the second result is lost.
 | Table | Key columns | Registry |
 |---|---|---|
 | `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external_facts, recompute_from_cached_facts}`, `status`, per-stage status/timing, `rows_written`, `error`, `attempt`. **Partial unique index on `(ticker) WHERE status IN ('queued','running')`** | run ledger — dimension, exempt |
-| `fundamental_run_outputs` | PK `(run_id, output_kind)`; `result_id`, `reused BOOLEAN` — the bridge from a run to the rows it produced *or reused* | run ledger — dimension, exempt |
+| `fundamental_run_outputs` | PK `run_id`; **`anchor_result_id REFERENCES valuation_anchors`**, **`score_result_id REFERENCES fundamental_scores`**, `reused BOOLEAN` — one row per run, typed columns so both links are real foreign keys | run ledger — dimension, exempt |
 | `valuation_anchors` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; `company_type`, `method`, 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
 | `fundamental_scores` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; one column per subscore, composite, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
 | `customer_concentration` | PK `(ticker, fiscal_period, filing_form, filing_accession)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
@@ -325,7 +346,9 @@ second run *reuses* the first run's immutable row. If the result carried a singl
 would still be stamped with run 1, so a view joining "latest successful run" to its outputs would
 find nothing for run 2 and the current result would vanish — while updating the stamp would mutate
 history. The bridge resolves both: run 2 gets its own association row with `reused = true`, pointing
-at the same `result_id`.
+at the same `result_id`. The bridge uses **typed columns** (`anchor_result_id`, `score_result_id`)
+rather than one polymorphic `result_id` — a single column pointing at either table can carry no
+enforceable foreign key, which is how dangling references get in.
 
 Resolution is then: active `engine_version` (from the pointer below) → latest successful run for that
 ticker and date → its associated `result_id`.
@@ -648,16 +671,36 @@ CREATE TABLE IF NOT EXISTS uw_scan.filing_extraction_runs (
 );
 ```
 
-Each observation carries its `extraction_run_id`. **The current projection reads only the latest
-*succeeded* run per accession**, so a re-extraction that finds nothing retracts by omission while
-every earlier run stays queryable for audit. A failed run never becomes current, so a crashed
-extraction cannot silently empty a filing's facts.
+**Ownership is not membership** — and getting that wrong retracts valid facts. If each observation
+carried a single `extraction_run_id`, then for v1 emitting `{A, B}` and v2 correctly emitting `{A}`:
+A already exists (deduped by `fact_hash`) still stamped with v1, so v2 owns nothing, and a
+"latest-run's observations" projection drops **both** facts. The valid one dies with the false one.
+
+Facts and sightings are separate relations:
+
+```sql
+CREATE TABLE IF NOT EXISTS uw_scan.filing_extraction_run_facts (
+    extraction_run_id  BIGINT NOT NULL REFERENCES uw_scan.filing_extraction_runs,
+    obs_id             BIGINT NOT NULL REFERENCES uw_scan.fundamental_edge_obs,
+    PRIMARY KEY (extraction_run_id, obs_id)
+);
+```
+
+The fact row stays deduplicated and immutable; each run records **which facts it saw**. **The current
+projection is the latest *succeeded* run's membership set** — so v2 re-asserts A and simply omits B,
+retracting the false edge while the true one survives, and v1's full result stays queryable for
+audit. A failed run never becomes current, so a crashed extraction cannot empty a filing.
 
 The same rule governs `customer_concentration`. Retraction is a projection concern, never a `DELETE`.
 
+This is the third form of one problem. `fact_seq` duplicated facts when the extractor improved;
+`fact_hash` alone could not retract; run *ownership* retracted too much. Each fix was locally correct
+and structurally incomplete because the missing concept was never the key — it was that **"what the
+fact is" and "who saw it" are different relations**, and any single table conflates them.
+
 **Current-relationship projection** — a view, not a table:
-`fundamental_edge_current` reads observations **from the latest succeeded `filing_extraction_run` per
-accession only**, then takes the newest surviving one per `(src_ticker, dst_ticker, edge_type)` and
+`fundamental_edge_current` reads the **membership set of the latest succeeded `filing_extraction_run`
+per accession**, then takes the newest surviving one per `(src_ticker, dst_ticker, edge_type)` and
 derives `status` from filing recency (`active` / `stale` after absence from the newest same-form
 filing / `retired` past 400 days). Nothing is mutated to compute it; the full observation history
 stays queryable, which is what "audit trail" was supposed to mean.
@@ -835,9 +878,9 @@ stops moving.
 
 | Phase | Ships | Gate | Verification |
 |---|---|---|---|
-| **P0** | Commit-bug fix + a test asserting through a **freshly opened connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | **Freshness delta, not row count**: record a ticker's `fetched_at` before the run, invoke the *real scheduled function*, then assert from a **new connection** that its `fetched_at` advanced past the run start. Plus a rollback-path regression |
-| **P1a** | **Data-contract spike** (no schema): reconcile `/vX`, `/v2`, UW statements and the filed 10-K on representative tickers; commit the exact field map | The first draft chose a frozen endpoint for its field count. No ingestion is designed until the sources are measured, not read about | An overlap-zone quarter agrees across `/vX` and `/v2` field-for-field, or the disagreement is documented with a resolution rule |
-| **P1b** | Immutable observation tables + canonical views + backfill/incremental modes; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | `/vX` reaches 2026 and `/v2` fills 1997–2008; re-ingest is idempotent; a simulated restatement adds a row without destroying its predecessor; FY2026 segment revenue matches the filed 10-K to the dollar |
+| **P0** | Commit-bug fix + a test asserting through a **freshly opened connection**. Commit **per successful ticker**, rolling back only the failing ticker's transaction | Own PR — independent prod data-loss bug, deploys ahead of feature work | **Freshness delta, not row count**: record a ticker's `fetched_at` before the run, invoke the *real scheduled function*, then assert from a **new connection** that its `fetched_at` advanced past the run start. Plus a regression proving one ticker's DB error does not discard the tickers already processed |
+| **P1a** | **Data-contract spike** (no schema): a committed **25-ticker coverage matrix** reconciling `/vX`, `/v2`, UW statements and the filed **10-K or 20-F**; the exact field map; the `content_hash` normalization/exclusion rule; and the **currency / XBRL-unit / FX-date / ADR-ratio** contract | The first draft chose a frozen endpoint for its field count; the second mis-probed `/v2` and read 404s as absence. No ingestion is designed until every source is measured per ticker, not read about | An overlap-zone quarter agrees across `/vX` and `/v2` field-for-field (or the disagreement has a resolution rule); every core ticker's real span is recorded; TSM/ASML reported currency and ADR ratio are captured, or foreign-issuer anchors are confirmed `na` |
+| **P1b** | Immutable observation tables + canonical views + backfill/incremental modes; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | Each core ticker reaches **its own** measured span (NVDA current via `/vX`; TSM/ASML history via `/v2` with the 2020→present gap rendered, not hidden); re-ingest is idempotent; a simulated restatement adds a row without destroying its predecessor; segment revenue matches the filed **10-K or 20-F** after unit normalization |
 | **P2** | Method appendix (worked examples) · method version tables · ANCHOR then SCORE · confidence downgrades · `fundamental_runs` + enqueued refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors from the appendix; recompute with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and yields new anchors**; a new method version coexists with the old on the same date; exactly one version is active |
 | **P3** | The card's deterministic blocks (§7) — subscores, anchor band, confidence reasons, coverage, provenance drill-down; API models + `gen:types` + tab/route wiring; loading/stale/error states | — | Every rendered number resolves to a persisted row; the coverage block lists a real `na`; a stale-version row renders as stale rather than current |
 | **P4** | Discovery gate → concentration ledger + sparse edge observations (§6); `edgartools` dependency added | After the card; the concentration block ships empty in P3 | Gate reports real yield before build; NVDA yields a concentration row with a real accession and multi-year trend; ANET→META exists as the reference `asc280_named` edge; TSM yields a 20-F-sourced row; re-processing a filing writes no duplicate |
@@ -908,8 +951,12 @@ is a required test, not a suggestion.
 | T13 | Cell members hold mixed engine versions | aggregate uses the shared active version; coverage fraction shown |
 | T14 | Cell members share **no** common date/version | cell renders **unavailable**, never a silently mixed aggregate |
 | T15 | Extractor v1 emits a false edge, v2 emits nothing for that filing | edge disappears from the current projection; v1's observation still queryable |
+| T15b | **v1 emits `{A, B}`, v2 emits `{A}`** | A **survives**, B retracts. The load-bearing case — a naive latest-run projection drops both |
+| T15c | v2 emits `{A, B}` identically to v1 | no duplicate fact rows; both runs have membership for the same `obs_id`s |
+| T19b | Foreign issuer (TSM/ASML) reaches the anchor stage in v1 | anchors render **`na` with reason**, never a number derived from unnormalized TWD/EUR |
+| T20b | `/v2` queried in `/vX` query-param form | probe treats **HTTP 404 as an error, not as zero coverage** |
 | T16 | Extraction run crashes mid-filing | the failed run never becomes current; the prior succeeded run still projects |
-| T17 | `DELETE` the method state row | **rejected** by trigger; worker startup also fails loudly if the pointer is unreadable |
+| T17 | `DELETE` the method state row | **rejected by the `BEFORE DELETE` trigger**; worker startup also fails loudly if the pointer is unreadable |
 | T18 | Identical rerun, then query the current view via the second run | resolves to the same `result_id` through a `reused = true` association |
 | T19 | TSM / ASML (no massive coverage) | falls back to UW, then SEC XBRL, then renders explicit `na` — never a blank that reads as zero |
 | T20 | Non-calendar fiscal issuer (NVDA, AMD) in the overlap zone | quarters match on `end_date` ≡ `reportPeriod`; `calendarDate` is never used as the key |

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -184,6 +184,7 @@ Note the convergence: the blueprint author independently landed on a per-company
 | A4 | **massive `/vX`** for the statements backbone; `/v2` for the 1997–2008 tail only; **UW `fundamental-breakdown`** for segments | Reversed after review. argon's own probe records `/v2` frozen at 2020-Q1 and `/vX` live to 2026 — the first draft picked the dead endpoint for its field count and would have rendered FY2020 as current. The IB→UW→FMP→massive rule is scoped to *live quotes/greeks*; massive remains the fundamentals source. UW's 94q statements are the cross-check, and the 2009–2020 overlap is where field parity is proven |
 | A10 | **Immutable point-in-time observations** for statements, segments and filings; canonical views derived on top | User ruling. Two sources that disagree by six years (A4) make reconciliation mandatory regardless, and PIT is most of the same work. Retrofitting it after rows exist means rebuilding history that was never captured — restatements overwrite the evidence an old `inputs_hash` was computed from |
 | A11 | **On-demand refresh enqueues a persisted run**, returns `202` — never a synchronous router write | The technicals precedent (`stock.py:285`) is deliberately bounded and says to promote it once work becomes async or batched. This stage calls massive, UW and SEC and writes many tables; a synchronous handler leaves partial state with no retry record. argon's rule is mutations route through `/jobs` |
+| A12 | **Own worker role `ai-fundamental`** for the narrative queue | argon already pins roles per lane (`ai-codex`, `ai-claude`, `ai-deepseek`). A shared worker polling two queues needs fair-polling and independent heartbeats to avoid one lane starving the other; a separate role gets that for free and lets the fundamental lane be scaled or disabled without touching trade insights |
 | A5 | **`fundamental_company_type`** persisted separately, seeded from sector+chain, hand-overridable | `watchlist_chain` is many-to-many — a ticker in 3 chains has no unique layer. Valuation methods must not silently flip when taxonomy is edited |
 | A6 | **DeepSeek only** for stage 5 | `docker-compose.yml:10` — "AI Codex/Claude are OFF"; only `worker-ai-deepseek-0/1` are deployed. Codex/Claude runners are subprocess CLIs reading macOS keychain OAuth; there is no keychain in a container. DeepSeek is in-process `httpx` + bearer token |
 | A7 | **Core 25** universe in v1 (§4.3) | Every valuation anchor stays hand-verifiable while the method is still being fixated |
@@ -234,12 +235,28 @@ time it said it. Never updated, never deleted; a restatement is a new row.
 
 | Table | Key columns | Registry |
 |---|---|---|
-| `fundamental_statement_obs` | PK `(source, ticker, period_end, period_type, observed_at)`; `filing_accession`, `filing_published_at`, `raw_jsonb`, `field_map_version` | event-temporal → **DatasetRegistryEntry** |
-| `fundamental_segment_obs` | PK `(source, ticker, period_end, dimension, segment_name, observed_at)`; revenue, `filing_accession` | event-temporal → **DatasetRegistryEntry** |
-| `fundamental_edge_obs` | see §6 — keyed by `(filing_accession, fact_seq)` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_statement_obs` | PK `obs_id`; **UNIQUE `(source, ticker, period_end, period_type, content_hash)`**; `provider_record_id`, `filing_accession`, `filing_published_at`, `first_observed_at`, `last_seen_at`, `raw_jsonb`, `field_map_version` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_segment_obs` | PK `obs_id`; **UNIQUE `(source, ticker, period_end, dimension, segment_name, content_hash)`**; revenue, `filing_accession`, `first_observed_at`, `last_seen_at` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_edge_obs` | see §6 — PK `obs_id`, UNIQUE on `(filing_accession, fact_hash)` | event-temporal → **DatasetRegistryEntry** |
+| `sec_filing_documents` | PK `filing_accession`; `ticker`, `form`, `filing_date`, `filing_published_at`, `document` (compressed `BYTEA`), `fetched_at` | dimension, exempt |
 
-`observed_at` is when *we* fetched it; `filing_published_at` is when the world could have known it.
-Point-in-time queries filter on the latter — that is what stops look-ahead in a future sweep.
+**Identity is content, not fetch time.** The previous draft keyed observations on `observed_at`,
+which is when *we* fetched — so every unchanged refresh would have inserted another row, directly
+contradicting P1b's own idempotence gate. Dedupe is on `content_hash` over the normalized payload:
+an unchanged refresh bumps `last_seen_at` and writes nothing; a restatement hashes differently and
+becomes a new immutable observation. `provider_record_id` is stored when the provider supplies one,
+because a stable upstream ID beats a hash we computed.
+
+`first_observed_at` is when we first saw it; `filing_published_at` is when the world could have known
+it. Point-in-time queries filter on the latter — that is what stops look-ahead in a future sweep.
+
+**Filing documents live in Postgres, not on disk** (F-6). The pipeline caches by accession because
+filings are immutable once accepted, but the only volume in `docker-compose.yml` is the lake at
+`:ro` — a container-local cache dies on every redeploy. **R2 is not the alternative:** it is retired,
+and per CHANGELOG "the worker refuses to boot when retired R2 settings are present", added after a
+dead R2 bucket silently froze `vol_index_daily` for 13 days. Compressed documents for the core 25 are
+tens of megabytes; Postgres is durable, already the persistence rule here, and needs no new
+infrastructure.
 
 **Tier 2 — canonical views, derived not stored.** `fundamental_statement_current` resolves the
 newest non-superseded observation per `(ticker, period_end, period_type)` under a documented source
@@ -247,15 +264,16 @@ precedence (`/vX` wins inside 2009+; `/v2` supplies 1997–2008; UW breaks ties 
 Overlap-zone disagreements are surfaced, never silently resolved: a materialized
 `fundamental_source_discrepancies` row records both values and the delta.
 
-**Tier 3 — versioned outputs.** Keyed to include the engine version so two versions can coexist on
-one date (F-4 fix — the first draft's `(ticker, as_of)` PK made the promised append-not-mutate
-history physically impossible).
+**Tier 3 — versioned outputs.** `engine_version` identifies the *method*; `inputs_hash` identifies the
+*inputs*. Result identity needs both — a `company_type` flip or a restatement arriving on the same
+date changes the inputs while leaving `engine_version` untouched, so a key without `inputs_hash`
+collides and the second result is lost.
 
 | Table | Key columns | Registry |
 |---|---|---|
-| `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external,recompute}`, per-stage status/timing, `rows_written`, `error`, `attempt` | run ledger — dimension, exempt |
-| `valuation_anchors` | PK `(ticker, as_of, engine_version)`; `company_type`, `method`, 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
-| `fundamental_scores` | PK `(ticker, as_of, engine_version)`; one column per subscore, composite, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
+| `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external_facts, recompute_from_cached_facts}`, per-stage status/timing, `rows_written`, `error`, `attempt` | run ledger — dimension, exempt |
+| `valuation_anchors` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; `company_type`, `method`, 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
+| `fundamental_scores` | PK `result_id`; **UNIQUE `(ticker, as_of, engine_version, inputs_hash)`**; one column per subscore, composite, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
 | `customer_concentration` | PK `(ticker, fiscal_period, filing_form, filing_accession)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
 | `fundamental_narrative_analyses` | own queue (A1) — PK `analysis_id`; `ticker`, `run_id`, `provider`, `prompt_version`, `prompt_text`, `prompt_payload_jsonb`, `output_schema_jsonb`, `status`, `outcome_jsonb`, `markdown`, timings. **No `snapshot_id`** | keyed by analysis — dimension, exempt |
 | `fundamental_audit_results` | PK `(analysis_id, claim_seq)`; `claim_text`, `extracted_value`, `backing_source`, `backing_value`, `verdict ∈ {pass,warn,fail,unverifiable}`, `stage ∈ {deterministic,model}` | dimension, exempt |
@@ -264,17 +282,24 @@ history physically impossible).
 `source_obs_ids` is what makes I2 real: it records the exact tier-1 rows a computation consumed, so
 an old `inputs_hash` can be reconstructed even after later restatements arrive.
 
-**Method versioning — header plus children (F-4).** A row-per-parameter table cannot express
-"exactly one active set" with a partial unique index, because many rows share a set:
+**The current-result view resolves on both axes**: active `engine_version` (from the pointer below)
+*and* the latest successful `run_id` for that ticker and date. Latest engine version alone is not
+enough — it does not disambiguate two same-day input sets.
+
+**Method versioning — immutable versions plus a singleton pointer.** A `BOOLEAN active` column with
+a partial unique index guarantees *at most* one active version, not exactly one: a failed activation
+or a stray manual update leaves zero, and every computation silently has no method. A NOT NULL
+foreign key from a one-row table makes zero unrepresentable.
 
 | Table | Key columns |
 |---|---|
-| `fundamental_method_versions` | PK `engine_version`; `code_version`, `param_hash`, `created_at`, `note`, `active BOOLEAN`. Partial unique index on `(active) WHERE active` → exactly one |
+| `fundamental_method_versions` | PK `engine_version`; `code_version`, `param_hash`, `created_at`, `note`. **No `active` flag** |
 | `fundamental_method_params` | PK `(engine_version, param_key)`; `param_value NUMERIC`. **Immutable** — retuning inserts a new version, never edits rows |
+| `fundamental_method_state` | `singleton_id INT PRIMARY KEY DEFAULT 1 CHECK (singleton_id = 1)`; `active_engine_version TEXT NOT NULL REFERENCES fundamental_method_versions` |
 
-Activation is a single transactional flip on the header. `engine_version` is derived
-`{code_version}:{param_hash[:8]}` and written once at version creation. A "latest valid version"
-view backs S1 and S2 so neither surface has to reimplement the resolution rule.
+Activation is one atomic `UPDATE` of the pointer. `engine_version` is derived
+`{code_version}:{param_hash[:8]}` and written once at version creation. An "active version" view
+backs S1 and S2 so neither surface reimplements the resolution rule.
 
 Registry entries and the regenerated data-gap policy doc ride the **same PR** as each table.
 
@@ -291,15 +316,23 @@ method has been broken.
 
 ### 5.1 Pipeline contract
 
-Five stages. Every ticker, every run, no exceptions:
+Five stages, run as one of two **modes**. A run executes its mode's full stage list — the mode
+selects where the run *starts*, never which stages it may skip in the middle:
 
 ```
-1 INGEST   source observations, immutable   → *_observations tables (§4.4)
+1 INGEST   source observations, immutable   → *_obs tables (§4.4)
 2 DERIVE   TTM, growth, margins, ratios     → pure functions, no I/O
 3 ANCHOR   company-type-routed valuation    → valuation_anchors
 4 SCORE    subscores → composite            → fundamental_scores
 5 NARRATE  DeepSeek prose over 3+4, audited → fundamental_narrative_analyses + fundamental_audit_results
+
+refresh_external_facts        : 1 → 2 → 3 → 4 → (5 if requested)
+recompute_from_cached_facts   :     2 → 3 → 4 → (5 if requested)
 ```
+
+A refresh that stopped at stage 1 would hand the user new facts and stale numbers — the opposite of
+what "refresh" means. Both modes always land on fresh anchors and scores; only NARRATE is optional,
+and it is enqueued rather than run inline.
 
 **ANCHOR precedes SCORE.** The first draft ran SCORE at 3 and ANCHOR at 4 while the
 `valuation_position` subscore consumed the anchors — a cycle that no ordering *within* a stage could
@@ -326,17 +359,22 @@ The technicals "Compute now" precedent is a *shape* precedent, not a licence —
 bounded to one cached-data recompute, and `stock.py:285` says to promote it the moment work becomes
 async or batched. This pipeline calls massive, UW and SEC and writes across a dozen tables.
 
-Two modes, deliberately separate:
+The two modes differ only in whether they pay a provider:
 
-| Mode | Does | Costs |
+| Mode | Starts at | Costs |
 |---|---|---|
-| `refresh_external_facts` | stage 1 — pull and persist new observations | provider quota, latency, rate limits |
-| `recompute_from_cached_facts` | stages 2–4 over existing observations | nothing external; safe to run on every parameter change |
+| `refresh_external_facts` | stage 1 — pull and persist new observations, then recompute | provider quota, latency, rate limits |
+| `recompute_from_cached_facts` | stage 2 — existing observations only | nothing external; safe on every parameter change |
 
-Splitting them is what makes a weight change cheap: retuning re-runs stage 2–4 across the universe
-without touching a provider. Conflating them would put an API bill behind every parameter edit.
+Splitting them is what makes a weight change cheap: retuning re-runs 2→4 across the universe without
+touching a provider. Conflating them would put an API bill behind every parameter edit.
 
-Invariants, in force at every stage:
+Concurrency: one active run per ticker. A second request while a run is `queued` or `running`
+returns the existing `run_id` rather than starting a duplicate. A failed run resumes from its first
+incomplete stage — completed stages are not re-executed, which is the practical payoff of persisting
+stage status rather than only a final state.
+
+Invariants:
 
 | # | Invariant | Enforced by |
 |---|---|---|
@@ -361,7 +399,8 @@ Three reasons, in order of weight:
 2. argon already owns a sweep harness (`backtest/` + `backtest_sweep_runs` / `_results`). Weights as
    rows means a named `param_set` is directly sweepable, with the full trace persisted, the day
    there is enough history to sweep against. Weights as constants means a code branch per trial.
-3. Retuning becomes a row update, not a release.
+3. Retuning becomes a new immutable method version plus a pointer flip — no deploy, and the old
+   version's outputs stay valid and comparable rather than being silently reinterpreted.
 
 | Subscore | Inputs (derived at stage 2) | Direction | seed weight |
 |---|---|---|---:|
@@ -450,7 +489,7 @@ and stay valid as history under §5.6.
 | `chips_cyclical` | through-cycle EV/Sales with peak/trough margin normalization | cycle-normalized, not spot |
 | `platform_scale` | FCF multiple + segment-weighted sum | segment revenue from UW |
 | `software_growth` | EV/Sales banded by Rule-of-40 score | growth+margin composite |
-| `power_infra` | EV/EBITDA + contracted-backlog floor | asset-heavy, dividend-aware |
+| `power_infra` | EV/EBITDA, asset-base anchored | asset-heavy, dividend-aware. **No backlog term** — §3.2 records backlog as unavailable at every tier, so a method requiring it would return `na` for every name it routes |
 | `high_risk_growth` | revenue multiple band, **mandatory confidence downgrade** | wide bands, stated as wide |
 
 Every method emits the same five anchors — `buy_below / observe_low / observe_mid / observe_high /
@@ -510,8 +549,10 @@ excerpt and magnitude that justified the earlier one. One filing fact = one immu
 
 ```sql
 CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edge_obs (
+    obs_id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     filing_accession   TEXT NOT NULL,             -- lock enforced: no accession, no row
-    fact_seq           INT  NOT NULL,             -- nth extracted fact within the filing
+    fact_hash          TEXT NOT NULL,             -- over normalized (dst, type, magnitude, excerpt)
+    extractor_version  TEXT NOT NULL,             -- NOT part of identity; records how it was found
     src_ticker         TEXT NOT NULL,             -- the FILER making the disclosure
     dst_ticker         TEXT NOT NULL,
     edge_type          TEXT NOT NULL CHECK (edge_type IN
@@ -529,9 +570,15 @@ CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edge_obs (
     observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT inferred_needs_basis CHECK
       (trust_tier <> 'asc280_inferred' OR identity_inference IS NOT NULL),
-    PRIMARY KEY (filing_accession, fact_seq)
+    UNIQUE (filing_accession, fact_hash)
 );
 ```
+
+Identity is `fact_hash`, not extraction order. A positional `fact_seq` is stable only while the
+extractor never changes — improve the regex and every fact renumbers, so re-processing the same
+filing writes duplicates that look like new disclosures. `extractor_version` is recorded but
+deliberately excluded from the uniqueness key: a better extractor finding the same sentence must
+recognise it, not re-file it.
 
 **Current-relationship projection** — a view, not a table:
 `fundamental_edge_current` takes the newest observation per `(src_ticker, dst_ticker, edge_type)` and
@@ -552,7 +599,7 @@ stays queryable, which is what "audit trail" was supposed to mean.
    this batch job* to locate ambiguous sentences — that is not the deferred live agent of §10, and
    it never authors a row the gate did not verify. If regex recall proves adequate at P4, the LLM
    step is not built at all.
-4. Re-processing a filing is idempotent by `(filing_accession, fact_seq)`. Nothing expires by
+4. Re-processing a filing is idempotent by `(filing_accession, fact_hash)`. Nothing expires by
    mutation; recency is resolved in the view. **No row is ever updated or deleted.**
 
 **Ops — all mandatory before P4 writes a row:**
@@ -717,7 +764,7 @@ stops moving.
 | **P2** | Method appendix (worked examples) · method version tables · ANCHOR then SCORE · confidence downgrades · `fundamental_runs` + enqueued refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors from the appendix; recompute with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and yields new anchors**; a new method version coexists with the old on the same date; exactly one version is active |
 | **P3** | The card's deterministic blocks (§7) — subscores, anchor band, confidence reasons, coverage, provenance drill-down; API models + `gen:types` + tab/route wiring; loading/stale/error states | — | Every rendered number resolves to a persisted row; the coverage block lists a real `na`; a stale-version row renders as stale rather than current |
 | **P4** | Discovery gate → concentration ledger + sparse edge observations (§6); `edgartools` dependency added | After the card; the concentration block ships empty in P3 | Gate reports real yield before build; NVDA yields a concentration row with a real accession and multi-year trend; ANET→META exists as the reference `asc280_named` edge; TSM yields a 20-F-sourced row; re-processing a filing writes no duplicate |
-| **P5** | Stage 5 narrative — **`fundamental_narrative_analyses`** queue, DeepSeek, evidence ledger, staged numeric audit | Needs P3 (numbers to constrain it) and P4 (concentration facts worth citing) | Real worker-path smoke: enqueue → worker claims → narrative renders with audit verdicts persisted; an audit `fail` suppresses the claim; **disabling the provider leaves the card fully usable**; `fetch_unscored_analyses` returns zero fundamental rows |
+| **P5** | Stage 5 narrative — **`fundamental_narrative_analyses`** queue, own `ai-fundamental` worker role, DeepSeek, evidence ledger, staged numeric audit | Needs P3 (numbers to constrain it) and **P4 *resolved*** — shipped or killed. A killed P4 is a resolution: the payload carries an explicit unsupported `supply_chain` block | Real worker-path smoke: enqueue → worker claims → narrative renders with audit verdicts persisted; an audit `fail` suppresses the claim; **disabling the provider leaves the card fully usable**; `fetch_unscored_analyses` returns zero fundamental rows; **the P4-killed path produces a narrative with a stated coverage absence** |
 
 ### S2 — `/industry_graph`
 
@@ -754,14 +801,40 @@ retune the weights it is also evaluating closes a loop nobody is watching. Param
 human action — consistent with argon's invariant that every mutating agent action routes through a
 gate.
 
-**Entry gate — do not start before all three hold:** S1 P4 and S2 G2 are live; the composite has been
-inspected against outcomes for at least one quarter; and the per-subscore `na` rate is known, so
-coverage can be stated honestly rather than plausibly.
+**Entry gate — do not start before all three hold:** S1 P4 is **resolved** (shipped or killed) and
+S2 G2 is live; the composite has been inspected against outcomes for at least one quarter; and the
+per-subscore `na` rate is known, so coverage can be stated honestly rather than plausibly. A killed
+P4 satisfies the first condition — gates depend on decisions being made, not on features existing.
 
 This is argon goal-ladder **Stage 2** (self-tending desk). Scoping it here would import a stage-2
 problem into stage-1 work.
 
-## 11. Risks
+## 11. Acceptance tests
+
+The identity and idempotence rules above are only real if something fails when they break. Each row
+is a required test, not a suggestion.
+
+| # | Scenario | Expected |
+|---|---|---|
+| T1 | Identical provider payload fetched twice | **one** observation row; `last_seen_at` bumped |
+| T2 | Restated payload for the same period | **two** observation rows; the first is unaltered |
+| T3 | Same ticker/date/engine, different `inputs_hash` (e.g. `company_type` flipped) | **two** output rows, both retrievable |
+| T4 | Identical inputs recomputed | **one** logical output; `inputs_hash` stable |
+| T5 | Delete or null the active method pointer | **rejected** — NOT NULL FK; zero-active is unrepresentable |
+| T6 | Refresh requested twice in quick succession | **one** active run; the second returns the existing `run_id` |
+| T7 | Run fails mid-pipeline, then retried | resumes at the first incomplete stage; completed stages not re-executed |
+| T8 | Same filing re-processed after an extractor change | **no duplicate** edge observations (`fact_hash` identity) |
+| T9 | P4 killed, then P5 run | narrative produced with an explicit unsupported `supply_chain` block |
+| T10 | Fundamental narratives exist, trade outcome backfill runs | `fetch_unscored_analyses` returns **zero** fundamental rows |
+| T11 | Container replaced | cached filings survive (Postgres, not container disk) |
+| T12 | Provider disabled | card renders stages 1–4 fully; narrative block marked absent |
+| T13 | Cell members hold mixed engine versions | aggregate uses the shared active version; coverage fraction shown |
+
+Gates before merge: `uv run pytest`, ruff, `scripts/check_no_yahoo.py`, and under `web/`
+`npm run typecheck && npm run test && npm run lint && npm run build`, plus Playwright coverage of the
+card drill-down and provider-down paths.
+
+## 12. Risks
 
 1. **The method is fixated on unvalidated priors.** The §5.2 weights have no backtest behind them and
    the spec says so. Versioned parameter rows make them sweepable and make a revision auditable;
@@ -783,7 +856,7 @@ problem into stage-1 work.
    The `unknowns` field is mandatory, not optional. If audit `fail` rates stay high after prompt
    iteration, ship the card without the narrative — that was a complete product at P4.
 
-## 12. Open items
+## 13. Open items
 
 All provider claims below are repository snapshots, not live probes. **P1a re-measures every one of
 them before any schema is designed** — the `/v2`-frozen error came from trusting exactly this kind of
@@ -799,8 +872,18 @@ second-hand reading.
   pre-computed ratios.
 - Audit the other `_repo()` consumers for the same no-commit pattern (out of scope here).
 
-**Resolved by the 2026-08-10 review** — recorded so they are not re-opened: narrative queue is
+**Resolved by review — recorded so they are not re-opened.** Round 1: narrative queue is
 domain-isolated, not a lane (A1); `/vX` is the backbone (A4); PIT observations are mandatory (A10);
-refresh enqueues rather than writes synchronously (A11); ANCHOR precedes SCORE (§5.1); outputs are
-keyed by `engine_version` (§4.4); edges are immutable per-filing observations (§6); G1 releases with
-G2 (§9).
+refresh enqueues rather than writes synchronously (A11); ANCHOR precedes SCORE (§5.1); edges are
+immutable per-filing observations (§6); G1 releases with G2 (§9). Round 2: observation identity is
+`content_hash`, not fetch time; output identity is `(ticker, as_of, engine_version, inputs_hash)`;
+the active method is a NOT NULL singleton pointer, not a boolean flag; both run modes end on fresh
+anchors and scores; P5 gates on P4 *resolved*, not shipped; filings cache in Postgres; narrative gets
+its own `ai-fundamental` worker role (A12).
+
+**One review recommendation was rejected on evidence.** Round 2 proposed R2 for raw filing storage.
+R2 is retired: CHANGELOG records "the worker refuses to boot when retired R2 settings are present",
+added after a dead R2 bucket froze `vol_index_daily` for 13 days. Following it would have prevented
+the worker from starting. `CLAUDE.md` still carries the stale "R2 lake is primary" line, which is the
+likely source of the suggestion — **that line should be corrected in a separate PR**, since it will
+keep misleading readers.

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -124,25 +124,38 @@ stock page. The target column is **`analyst_target_avg`** (`065_uw_positioning.s
 **Source roles, with a fallback chain — massive is not universal.** Live probe of the core 25
 (2026-08-10) found `/vX` current coverage for **23 of 25**:
 
-| Ticker | `/vX` (current) | `/v2` (history) | Gap |
-|---|---|---|---|
-| TSM | **0 rows** (HTTP 200, empty `results`) | 76 rows, 2000-12-31 → 2019-12-31 | **2020 → present** |
-| ASML | **0 rows** (HTTP 200, empty `results`) | 391 rows, 2000-12-31 → 2019-12-31 | **2020 → present** |
-| NVDA (control) | current to 2026-04-26 | 5 rows, ends 2020-01-26 | none |
+**The pipeline is quarterly, so quarterly counts are the number that matters.** An unfiltered `/v2`
+row count mixes annual, quarterly and trailing rows and materially overstates usable coverage.
+Probed `limit=1000`, with and without `type=Q`:
 
-The gap is **current data, not history**. Two earlier readings of this were wrong in opposite
-directions — one claimed both endpoints were empty for both names, the other that only TSM lacked
-`/v2`. Root cause of the bad measurement, recorded so P1a does not repeat it: **`/v2` takes the
-ticker in the URL path** (`/v2/reference/financials/{ticker}`) while **`/vX` takes it as a query
-parameter**. Querying `/v2` in `/vX` form returns **404**, which a naive row-count probe reads as
-"no coverage". A zero must be distinguished from an error before it becomes evidence.
+| Ticker | `/vX` current | `/v2` **quarterly** | `/v2` all types | Usable state |
+|---|---|---|---|---|
+| TSM | **0 rows** (200, empty `results`) | **0 rows** | 76 (annual / trailing only) | **no usable massive history at all** |
+| ASML | **0 rows** (200, empty `results`) | 93 · 2002-06-30 → 2019-12-31 | 391 | history only; **no current** |
+| NVDA (control) | current to 2026-04-26 | 88 · 1998-10-25 → 2020-01-26 | 405 | covered |
 
-**The root cause is one this spec already documented elsewhere and failed to connect.** §3.3 records
-that the upstream tier files **20-F, not 10-K** (TSM: 6-K ×741, 20-F ×15, zero 10-Ks). massive's
-financials are derived from domestic SEC XBRL, so foreign private issuers are simply absent. One
-structural fact — foreign-issuer filing status — breaks *both* the named-edge graph and the
-statements backbone. Any name reachable only via 20-F should be assumed thin at every provider until
-probed, not just at EDGAR.
+So the gap is **not uniform**: ASML needs a fallback for 2020→present, while TSM needs one for
+*everything* — its 76 rows are annual/trailing and the quarterly pipeline cannot consume them.
+
+**Three successive readings of this endpoint were wrong**, which is why P1a exists and why its
+output is a committed coverage matrix rather than a claim. The failure modes, recorded so they are
+not repeated: (1) **`/v2` takes the ticker in the URL path** (`/v2/reference/financials/{ticker}`)
+while **`/vX` takes it as a query parameter** — querying `/v2` in `/vX` form returns **404**, which
+a naive row-count probe reads as "no coverage"; (2) an unfiltered count is not a quarterly count;
+(3) probe limits must be identical across tickers or the comparison is meaningless (an earlier run
+reported NVDA at 5 rows against ASML's 391). **A zero must be distinguished from an error, and a
+count from a filtered count, before either becomes evidence.**
+
+**A plausible common cause, flagged as inference.** §3.3 records that the upstream tier files
+**20-F, not 10-K** (TSM: 6-K ×741, 20-F ×15, zero 10-Ks), and the two names missing from `/vX` are
+exactly the two foreign private issuers in the core 25. `[INFERRED, MED]` — the correlation is
+measured; the provider's actual derivation path is **not**, and "massive builds `/vX` from domestic
+XBRL" remains an unverified explanation that P1a must confirm or discard. What is established is
+narrower and sufficient to design against: **these two tickers lack current `/vX` coverage.** If the
+inference does hold, one structural fact — foreign-issuer filing status — breaks both the named-edge
+graph and the statements backbone, and any name reachable only via 20-F should be assumed thin at
+every provider until probed, not just at EDGAR. Treat that as a hypothesis to test in P1a, not a
+rule to design around yet.
 
 | Precedence | Source | Role |
 |---|---|---|
@@ -169,7 +182,7 @@ diverges for non-calendar fiscal issuers such as NVDA and AMD, which would silen
 in the overlap zone.
 
 The overlap zone is not incidental: it is the only place field-name parity between the two endpoints
-can be validated, and it is what makes the pre-2009 tail trustworthy enough to score against.
+can be validated, and it is what makes the pre-2020 tail trustworthy enough to score against.
 
 **Gated (Advanced+/Premium, unavailable):** forward analyst estimates, earnings-call transcripts,
 company profile, IPO calendar, UW dividends/splits, macro series.
@@ -225,7 +238,7 @@ Note the convergence: the blueprint author independently landed on a per-company
 | A1 | **Own queue** `fundamental_narrative_analyses` — stage 5, phase P5. **Not** a lane on `trade_insight_ai_analyses` | The first draft claimed this lane was "verified live" on the strength of `analysis_kind` existing (migration `067`) and per-row dispatch at `trade_insights_ai.py:142`. Both are true and both are irrelevant: `017:9` makes `snapshot_id` `NOT NULL REFERENCES trade_insight_snapshots ON DELETE CASCADE` and `run_id` `NOT NULL`, so a fundamental row has no legal parent; dispatch is binary `is_blast`, so `'fundamental'` would silently run the trade prompt; `TradeInsightAiOutcome` demands scenario cards / VRP / preferred expression; and `fetch_unscored_analyses` filters only `status='succeeded'`, so every fundamental row would enter the trade outcome ledger. **The cost of this reversal is real** — the new queue re-pays the SKIP-LOCKED claim logic, heartbeats, per-provider workers and polling hook that A1 originally existed to avoid. That is the price of domain isolation, not an oversight; do not "simplify" it back |
 | A2 | New pure-compute package **`src/uw_scan/fundamentals/`** | Follows `theta_harvester/` / `chanlun/` precedent. Not `reports/` — those are read-time reshapes; these are nightly persisted computations |
 | A3 | New API router **`api/routers/fundamental.py`** | `routers/trade_insights.py` is already ~600 lines; module-size budget |
-| A4 | **massive `/vX` → UW statements → SEC XBRL → explicit `na`**, a fallback chain rather than a single backbone; `/v2` for the pre-2009 tail where it exists; **UW `fundamental-breakdown`** for segments | Reversed twice. First draft picked `/v2` for its field count — argon's probe records it frozen at 2020-Q1, so a "current" card would have shown FY2020. Then a live core-25 probe found `/vX` covers only 23/25: TSM and ASML return zero rows from both endpoints because they are 20-F filers and massive derives from domestic XBRL. UW is therefore a **fallback**, not a cross-check. The IB→UW→FMP→massive priority rule is scoped to *live quotes/greeks* and does not govern here |
+| A4 | **massive `/vX` → UW statements → SEC XBRL → explicit `na`**, a fallback chain rather than a single backbone; `/v2` for the pre-2020 quarterly tail where it exists; **UW `fundamental-breakdown`** for segments | Reversed twice. First draft picked `/v2` for its field count — argon's probe records it frozen at 2020-Q1, so a "current" card would have shown FY2020. Then a live core-25 probe found `/vX` covers only 23/25: **TSM and ASML have no current `/vX` coverage** — ASML retains quarterly `/v2` history to 2019, TSM has *no quarterly `/v2` rows at all* (its 76 rows are annual/trailing, which the quarterly pipeline cannot consume). Both are foreign private issuers, which is a measured correlation but `[INFERRED]` as a cause — P1a confirms or discards it. UW is therefore a **fallback**, not a cross-check. The IB→UW→FMP→massive priority rule is scoped to *live quotes/greeks* and does not govern here |
 | A10 | **Immutable point-in-time observations** for statements, segments and filings; canonical views derived on top | User ruling. Two sources that disagree by six years (A4) make reconciliation mandatory regardless, and PIT is most of the same work. Retrofitting it after rows exist means rebuilding history that was never captured — restatements overwrite the evidence an old `inputs_hash` was computed from |
 | A11 | **On-demand refresh enqueues a persisted run**, returns `202` — never a synchronous router write | The technicals precedent (`stock.py:285`) is deliberately bounded and says to promote it once work becomes async or batched. This stage calls massive, UW and SEC and writes many tables; a synchronous handler leaves partial state with no retry record. argon's rule is mutations route through `/jobs` |
 | A12 | **Own worker role `ai-fundamental`** for the narrative queue | argon already pins roles per lane (`ai-codex`, `ai-claude`, `ai-deepseek`). A shared worker polling two queues needs fair-polling and independent heartbeats to avoid one lane starving the other; a separate role gets that for free and lets the fundamental lane be scaled or disabled without touching trade insights |
@@ -508,7 +521,7 @@ appendix** carrying, for every subscore and every company type, the exact transf
 worked example reproducible by hand. Until that exists the method is named, not fixated — the
 review's F-1, and it stands.
 
-Field-level mapping onto massive `/vX` (and `/v2` for the pre-2009 tail) is the P1 data-contract
+Field-level mapping onto massive `/vX` (and `/v2` for the pre-2020 quarterly tail) is the P1 data-contract
 spike's job and is deliberately not guessed here.
 
 ### 5.3 Company-type routing — a second axis, and its invalidation cascade
@@ -958,7 +971,8 @@ is a required test, not a suggestion.
 | T16 | Extraction run crashes mid-filing | the failed run never becomes current; the prior succeeded run still projects |
 | T17 | `DELETE` the method state row | **rejected by the `BEFORE DELETE` trigger**; worker startup also fails loudly if the pointer is unreadable |
 | T18 | Identical rerun, then query the current view via the second run | resolves to the same `result_id` through a `reused = true` association |
-| T19 | TSM / ASML (no massive coverage) | falls back to UW, then SEC XBRL, then renders explicit `na` — never a blank that reads as zero |
+| T19 | TSM / ASML (no **current** `/vX` coverage; TSM additionally has no quarterly `/v2` rows) | falls back to UW, then SEC XBRL, then renders explicit `na` — never a blank that reads as zero |
+| T20c | A `/v2` count taken without `type=Q` | the coverage matrix records the **quarterly** count; an unfiltered total never stands in for it |
 | T20 | Non-calendar fiscal issuer (NVDA, AMD) in the overlap zone | quarters match on `end_date` ≡ `reportPeriod`; `calendarDate` is never used as the key |
 | T21 | Provider envelope changes (request id / timestamp) with identical financials | `content_hash` unchanged → no new observation |
 

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -1,6 +1,15 @@
 # Fundamental analysis method — design
 
-*Status: ACCEPTED, awaiting implementation plan · 2026-08-10 · branch `feat/fundamental-pm-agent`*
+*Status: DRAFT — revised after review · 2026-08-10 · branch `feat/fundamental-pm-agent`*
+
+> **Revision note (2026-08-10).** A review found two hard errors in the first draft, both verified
+> against source before acceptance: the narrative lane cannot use `trade_insight_ai_analyses`
+> (`snapshot_id` is `NOT NULL` with a cascade to `trade_insight_snapshots`, so a fundamental row has
+> no legal parent), and massive `/v2` is **frozen at 2020-Q1** per argon's own probe — using it as the
+> backbone would have rendered FY2020 financials as current. Both decisions are reversed below.
+> Point-in-time observation storage is **mandatory in v1** (user ruling), not deferred.
+
+---
 
 ## 1. Goal
 
@@ -60,7 +69,7 @@ over a 188-name universe. argon's `watchlist_taxonomy.py` is already the same sh
 | Technical score inside the fundamental composite | Violates his own display-only principle; argon's technicals are deeper |
 | 4-tier universe, PDF reports, Social Monitor, ClickHouse, FMP subscription | argon has equivalents or better; Postgres is law here |
 | His options module | argon's is materially better |
-| 预期差 as *estimate* gap | Forward estimates are Advanced+-gated. Ship the **price-target** gap (`uw_positioning.target_avg` vs anchors); never fake the estimate gap |
+| 预期差 as *estimate* gap | Forward estimates are Advanced+-gated. Ship the **price-target** gap (`uw_positioning.analyst_target_avg` vs anchors); never fake the estimate gap |
 | 供应链瓶颈分 as a hand-assigned score | Replaced by the **measured** ASC 280 concentration metric — same shape, real provenance |
 
 He has **no backtest, no hit-rate, no P&L**, and says so. This is a research organizer, not
@@ -94,7 +103,8 @@ traced — worth a follow-up audit, out of scope here.
 
 | Source | Content | Integrated? |
 |---|---|---|
-| massive `/v2/reference/financials` | **103 fields, quarters back to 1997** | No — argon uses `/vX` (55 fields), persists ~13, `limit=8` |
+| massive `/vX/reference/financials` | **current production endpoint** — quarters 2009-06-27 → 2026-03-28, live | Partially — argon persists ~13 fields, `limit=8`. The endpoint is right; the depth is not |
+| massive `/v2/reference/financials` | 103 pre-computed fields, quarters 1997-09-30 → **2020-03-31, frozen** | No — and it must never be the current-data backbone |
 | UW `/stock/{t}/income-statements`, `/balance-sheets`, `/cash-flows` | 94 quarters each | No |
 | UW `/stock/{t}/fundamental-breakdown` → `rev_breakdown` | **revenue by product AND geography** | No |
 | UW `/stock/{t}/info` | sector, marketcap, beta, issue_type | No |
@@ -102,7 +112,20 @@ traced — worth a follow-up audit, out of scope here.
 
 **Already shipped and reusable:** `uw_positioning` (analyst targets/ratings, insider net flow,
 13F aggregates, short interest, earnings reactions) — daily, correctly committed, live on the
-stock page.
+stock page. The target column is **`analyst_target_avg`** (`065_uw_positioning.sql:26`), not
+`target_avg`.
+
+**Source roles are now explicit** (reversal of the first draft's A4):
+
+| Window | Source | Role |
+|---|---|---|
+| 2009 → present | massive `/vX` | **backbone**; the only source that may back a "current" figure |
+| 1997 → 2008 | massive `/v2` | one-time legacy backfill; frozen, never refreshed |
+| 2009 → 2020 | both | **overlap zone** — reconcile and persist disagreements, never silently prefer one |
+| any | UW statements (94q) | independent cross-check, not the backbone |
+
+The overlap zone is not incidental: it is the only place field-name parity between the two endpoints
+can be validated, and it is what makes the 1997–2008 tail trustworthy enough to score against.
 
 **Gated (Advanced+/Premium, unavailable):** forward analyst estimates, earnings-call transcripts,
 company profile, IPO calendar, UW dividends/splits, macro series.
@@ -155,10 +178,12 @@ Note the convergence: the blueprint author independently landed on a per-company
 
 | # | Decision | Rationale |
 |---|---|---|
-| A1 | **Third lane** `analysis_kind='fundamental'` on the existing `trade_insights_ai` queue — stage 5, phase P5 | Verified live: migration `067`, per-row dispatch at `trade_insights_ai.py:142`. A separate queue would duplicate SKIP-LOCKED claim logic, heartbeats, per-provider workers and the UI polling hook for no gain |
+| A1 | **Own queue** `fundamental_narrative_analyses` — stage 5, phase P5. **Not** a lane on `trade_insight_ai_analyses` | The first draft claimed this lane was "verified live" on the strength of `analysis_kind` existing (migration `067`) and per-row dispatch at `trade_insights_ai.py:142`. Both are true and both are irrelevant: `017:9` makes `snapshot_id` `NOT NULL REFERENCES trade_insight_snapshots ON DELETE CASCADE` and `run_id` `NOT NULL`, so a fundamental row has no legal parent; dispatch is binary `is_blast`, so `'fundamental'` would silently run the trade prompt; `TradeInsightAiOutcome` demands scenario cards / VRP / preferred expression; and `fetch_unscored_analyses` filters only `status='succeeded'`, so every fundamental row would enter the trade outcome ledger. **The cost of this reversal is real** — the new queue re-pays the SKIP-LOCKED claim logic, heartbeats, per-provider workers and polling hook that A1 originally existed to avoid. That is the price of domain isolation, not an oversight; do not "simplify" it back |
 | A2 | New pure-compute package **`src/uw_scan/fundamentals/`** | Follows `theta_harvester/` / `chanlun/` precedent. Not `reports/` — those are read-time reshapes; these are nightly persisted computations |
 | A3 | New API router **`api/routers/fundamental.py`** | `routers/trade_insights.py` is already ~600 lines; module-size budget |
-| A4 | **massive `/v2`** for the statements backbone, **UW `fundamental-breakdown`** for segments | The IB→UW→FMP→massive rule is scoped to *live quotes/greeks*; massive is already the fundamentals source. Preserves UW headroom. UW 94q statements become the cross-check |
+| A4 | **massive `/vX`** for the statements backbone; `/v2` for the 1997–2008 tail only; **UW `fundamental-breakdown`** for segments | Reversed after review. argon's own probe records `/v2` frozen at 2020-Q1 and `/vX` live to 2026 — the first draft picked the dead endpoint for its field count and would have rendered FY2020 as current. The IB→UW→FMP→massive rule is scoped to *live quotes/greeks*; massive remains the fundamentals source. UW's 94q statements are the cross-check, and the 2009–2020 overlap is where field parity is proven |
+| A10 | **Immutable point-in-time observations** for statements, segments and filings; canonical views derived on top | User ruling. Two sources that disagree by six years (A4) make reconciliation mandatory regardless, and PIT is most of the same work. Retrofitting it after rows exist means rebuilding history that was never captured — restatements overwrite the evidence an old `inputs_hash` was computed from |
+| A11 | **On-demand refresh enqueues a persisted run**, returns `202` — never a synchronous router write | The technicals precedent (`stock.py:285`) is deliberately bounded and says to promote it once work becomes async or batched. This stage calls massive, UW and SEC and writes many tables; a synchronous handler leaves partial state with no retry record. argon's rule is mutations route through `/jobs` |
 | A5 | **`fundamental_company_type`** persisted separately, seeded from sector+chain, hand-overridable | `watchlist_chain` is many-to-many — a ticker in 3 chains has no unique layer. Valuation methods must not silently flip when taxonomy is edited |
 | A6 | **DeepSeek only** for stage 5 | `docker-compose.yml:10` — "AI Codex/Claude are OFF"; only `worker-ai-deepseek-0/1` are deployed. Codex/Claude runners are subprocess CLIs reading macOS keychain OAuth; there is no keychain in a container. DeepSeek is in-process `httpx` + bearer token |
 | A7 | **Core 25** universe in v1 (§4.3) | Every valuation anchor stays hand-verifiable while the method is still being fixated |
@@ -201,21 +226,55 @@ assume.
 
 Each in its own `storage/<domain>.py`. Never extend `repository.py`.
 
+Three tiers, and the separation is the point: **observations are immutable, canonical views are
+derived, outputs are versioned.** Nothing is ever updated in place.
+
+**Tier 1 — immutable source observations (A10).** One row per thing a provider actually said, at the
+time it said it. Never updated, never deleted; a restatement is a new row.
+
 | Table | Key columns | Registry |
 |---|---|---|
-| `fundamental_statements` | PK `(ticker, period_end, period_type)`; ~40 wide columns + `raw_jsonb` (full 103-field payload), `source` | temporal → **DatasetRegistryEntry** |
-| `fundamental_segments` | PK `(ticker, period_end, dimension, segment_name)`; `dimension ∈ {product, geography}`, revenue, `source` | temporal → **DatasetRegistryEntry** |
-| `fundamental_score_daily` | PK `(ticker, as_of)`; one column per subscore, composite, `engine_version`, `inputs_hash` | temporal → **DatasetRegistryEntry** |
-| `valuation_anchors_daily` | PK `(ticker, as_of)`; `company_type`, `method`, the 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `engine_version` | temporal → **DatasetRegistryEntry** |
-| `customer_concentration` | PK `(ticker, fiscal_period, filing_form)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_accession`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
-| `fundamental_edges` | see §6 | event-temporal → **DatasetRegistryEntry** |
-| `fundamental_audit_results` | PK `(analysis_id, claim_seq)`; `claim_text`, `extracted_value`, `backing_source`, `backing_value`, `verdict ∈ {pass,warn,fail,unverifiable}`, `stage ∈ {deterministic,model}` | keyed by analysis — dimension, exempt |
-| `fundamental_company_type` | PK `(ticker)`; `company_type`, `source ∈ {rule,manual}`, `set_at` | dimension, exempt |
-| `fundamental_method_params` | PK `(param_set, param_key)`; `param_value NUMERIC`, `active BOOLEAN`, `note`, `updated_at`. Holds §5.2 weights + §5.4 thresholds. Seeded `param_set='v1_prior'` | dimension, exempt |
+| `fundamental_statement_obs` | PK `(source, ticker, period_end, period_type, observed_at)`; `filing_accession`, `filing_published_at`, `raw_jsonb`, `field_map_version` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_segment_obs` | PK `(source, ticker, period_end, dimension, segment_name, observed_at)`; revenue, `filing_accession` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_edge_obs` | see §6 — keyed by `(filing_accession, fact_seq)` | event-temporal → **DatasetRegistryEntry** |
 
-Exactly one `param_set` carries `active=true` — enforced by a partial unique index, not by
-convention. Two active sets would make `engine_version` ambiguous and every downstream row
-unattributable.
+`observed_at` is when *we* fetched it; `filing_published_at` is when the world could have known it.
+Point-in-time queries filter on the latter — that is what stops look-ahead in a future sweep.
+
+**Tier 2 — canonical views, derived not stored.** `fundamental_statement_current` resolves the
+newest non-superseded observation per `(ticker, period_end, period_type)` under a documented source
+precedence (`/vX` wins inside 2009+; `/v2` supplies 1997–2008; UW breaks ties only as cross-check).
+Overlap-zone disagreements are surfaced, never silently resolved: a materialized
+`fundamental_source_discrepancies` row records both values and the delta.
+
+**Tier 3 — versioned outputs.** Keyed to include the engine version so two versions can coexist on
+one date (F-4 fix — the first draft's `(ticker, as_of)` PK made the promised append-not-mutate
+history physically impossible).
+
+| Table | Key columns | Registry |
+|---|---|---|
+| `fundamental_runs` | PK `run_id`; `ticker`, `mode ∈ {refresh_external,recompute}`, per-stage status/timing, `rows_written`, `error`, `attempt` | run ledger — dimension, exempt |
+| `valuation_anchors` | PK `(ticker, as_of, engine_version)`; `company_type`, `method`, 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
+| `fundamental_scores` | PK `(ticker, as_of, engine_version)`; one column per subscore, composite, `inputs_hash`, `source_obs_ids`, `run_id` | temporal → **DatasetRegistryEntry** |
+| `customer_concentration` | PK `(ticker, fiscal_period, filing_form, filing_accession)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_narrative_analyses` | own queue (A1) — PK `analysis_id`; `ticker`, `run_id`, `provider`, `prompt_version`, `prompt_text`, `prompt_payload_jsonb`, `output_schema_jsonb`, `status`, `outcome_jsonb`, `markdown`, timings. **No `snapshot_id`** | keyed by analysis — dimension, exempt |
+| `fundamental_audit_results` | PK `(analysis_id, claim_seq)`; `claim_text`, `extracted_value`, `backing_source`, `backing_value`, `verdict ∈ {pass,warn,fail,unverifiable}`, `stage ∈ {deterministic,model}` | dimension, exempt |
+| `fundamental_company_type` | PK `(ticker, effective_from)`; `company_type`, `source ∈ {rule,manual}` — historised, because it is an `inputs_hash` input | dimension, exempt |
+
+`source_obs_ids` is what makes I2 real: it records the exact tier-1 rows a computation consumed, so
+an old `inputs_hash` can be reconstructed even after later restatements arrive.
+
+**Method versioning — header plus children (F-4).** A row-per-parameter table cannot express
+"exactly one active set" with a partial unique index, because many rows share a set:
+
+| Table | Key columns |
+|---|---|
+| `fundamental_method_versions` | PK `engine_version`; `code_version`, `param_hash`, `created_at`, `note`, `active BOOLEAN`. Partial unique index on `(active) WHERE active` → exactly one |
+| `fundamental_method_params` | PK `(engine_version, param_key)`; `param_value NUMERIC`. **Immutable** — retuning inserts a new version, never edits rows |
+
+Activation is a single transactional flip on the header. `engine_version` is derived
+`{code_version}:{param_hash[:8]}` and written once at version creation. A "latest valid version"
+view backs S1 and S2 so neither surface has to reimplement the resolution rule.
 
 Registry entries and the regenerated data-gap policy doc ride the **same PR** as each table.
 
@@ -235,12 +294,17 @@ method has been broken.
 Five stages. Every ticker, every run, no exceptions:
 
 ```
-1 INGEST   raw statements + segments        → fundamental_statements, fundamental_segments
+1 INGEST   source observations, immutable   → *_observations tables (§4.4)
 2 DERIVE   TTM, growth, margins, ratios     → pure functions, no I/O
-3 SCORE    subscores → composite            → fundamental_score_daily
-4 ANCHOR   company-type-routed valuation    → valuation_anchors_daily
-5 NARRATE  DeepSeek prose over 3+4, audited → trade_insight_ai_analyses + fundamental_audit_results
+3 ANCHOR   company-type-routed valuation    → valuation_anchors
+4 SCORE    subscores → composite            → fundamental_scores
+5 NARRATE  DeepSeek prose over 3+4, audited → fundamental_narrative_analyses + fundamental_audit_results
 ```
+
+**ANCHOR precedes SCORE.** The first draft ran SCORE at 3 and ANCHOR at 4 while the
+`valuation_position` subscore consumed the anchors — a cycle that no ordering *within* a stage could
+resolve. Anchors are computed from derived fundamentals only and never read the composite back, so
+the dependency is a straight line: `DERIVE → ANCHOR → SCORE`.
 
 Stages 1–4 are deterministic and reproducible from `inputs_hash`. Stage 5 is a **provider call
 inside a job**, not an agent: it is triggered by cron or by request, never by its own judgement, and
@@ -251,13 +315,26 @@ Stage 5 degrades cleanly. If DeepSeek is unavailable, disabled, or its output fa
 card renders stages 1–4 with the narrative block marked absent. **The deterministic surfaces never
 depend on the model.**
 
-**Trigger: ad-hoc first, cron later** (user ruling, 2026-08-10). v1 runs the whole pipeline
-on-demand per ticker from a button on the card, following the shipped
-`POST /stock/{ticker}/technicals/refresh` "Compute now" precedent — an explicit, deliberate write on
-an otherwise read-only router. A nightly job over the whole universe is added only once the method
-has stopped moving; scheduling an unstable method just fills tables with rows carrying dead
-`engine_version`s. The job function takes a `ticker_filter` from day one so the cron, when it comes,
-is a scheduler entry and not a rewrite.
+**Trigger: ad-hoc first, cron later** (user ruling, 2026-08-10). No nightly job until the method
+stops moving — scheduling an unstable method just fills tables with rows carrying dead
+`engine_version`s. Job functions take a `ticker_filter` from day one so the cron, when it comes, is a
+scheduler entry and not a rewrite.
+
+**Ad-hoc means enqueued, not synchronous** (A11). `POST /fundamental/{ticker}/refresh` writes a
+`fundamental_runs` row and returns `202`; a worker executes the stages and updates per-stage status.
+The technicals "Compute now" precedent is a *shape* precedent, not a licence — that handler is
+bounded to one cached-data recompute, and `stock.py:285` says to promote it the moment work becomes
+async or batched. This pipeline calls massive, UW and SEC and writes across a dozen tables.
+
+Two modes, deliberately separate:
+
+| Mode | Does | Costs |
+|---|---|---|
+| `refresh_external_facts` | stage 1 — pull and persist new observations | provider quota, latency, rate limits |
+| `recompute_from_cached_facts` | stages 2–4 over existing observations | nothing external; safe to run on every parameter change |
+
+Splitting them is what makes a weight change cheap: retuning re-runs stage 2–4 across the universe
+without touching a provider. Conflating them would put an API bill behind every parameter edit.
 
 Invariants, in force at every stage:
 
@@ -294,26 +371,33 @@ Three reasons, in order of weight:
 | `balance_sheet` | net debt / EBITDA, interest coverage, current ratio | lower leverage better | 0.15 |
 | `valuation_position` | spot vs `observe_low..observe_high` band from stage 4 | cheaper better | 0.15 |
 | `concentration_risk` | top-customer %, its multi-year trend (§6) | lower better | 0.10 |
-| `expectations_gap` | our 1Y anchor vs `uw_positioning.target_avg`, insider net, short interest | wider positive gap better | 0.05 |
+| `expectations_gap` | our 1Y anchor vs `uw_positioning.analyst_target_avg`, insider net, short interest | wider positive gap better | 0.05 |
 
-Seeded by migration as `param_set='v1_prior'`, `active=true`. The table also holds the §5.4
-downgrade thresholds — anything a future sweep might want to move.
+Seeded as version `v1_prior` (header + child rows, §4.4). Parameter rows are **immutable**: retuning
+creates a new `engine_version` and flips the header pointer. The set also holds the §5.4 downgrade
+thresholds — anything a future sweep might want to move.
 
-**Mutable parameters force `engine_version` to be derived, not hand-written.** It is
-`{code_version}:{param_hash[:8]}`, where `param_hash` covers the active parameter set. A hand-bumped
-version would let someone edit a weight while the version stayed put, silently destroying
-comparability across `fundamental_score_daily` rows — the exact question §5.6 exists to answer.
+**Parameters as data force `engine_version` to be derived, not hand-written.** It is
+`{code_version}:{param_hash[:8]}`, computed once at version creation. A hand-bumped version would let
+someone change a weight while the version stayed put, silently destroying comparability across
+`fundamental_scores` rows — the exact question §5.6 exists to answer.
 
-Ordering constraint: `valuation_position` consumes stage 4, so within stage 3 it is computed
-**last**, and stage 4 must never read the composite back. The dependency is one-directional or the
-score becomes self-referential.
+`valuation_position` consumes stage 3 (ANCHOR) and is computed in stage 4 (SCORE). ANCHOR must never
+read the composite back; the dependency is a straight line or the score becomes self-referential.
 
-`concentration_risk` returns `na` until S2 P4 lands; `na` subscores are dropped and the remaining
+`concentration_risk` returns `na` until S1 P4 lands; `na` subscores are dropped and the remaining
 weights renormalize. Renormalization, not zero-fill — a zero would read as "no concentration risk",
 which is a fabricated fact.
 
-Field-level mapping onto massive `/v2`'s 103 columns is P1's job and is deliberately not guessed
-here.
+**This table is a rubric, not an implementation.** Direction and weight do not determine a score:
+normalization, winsorization, breakpoints, lookback windows and the spot-date rule are all still
+free, and two conforming implementations would disagree. **P2 does not exit without a method
+appendix** carrying, for every subscore and every company type, the exact transformation and a
+worked example reproducible by hand. Until that exists the method is named, not fixated — the
+review's F-1, and it stands.
+
+Field-level mapping onto massive `/vX` (and `/v2` for the pre-2009 tail) is the P1 data-contract
+spike's job and is deliberately not guessed here.
 
 ### 5.3 Company-type routing — a second axis, and its invalidation cascade
 
@@ -406,7 +490,7 @@ The payoff. To add each thing, touch only the listed seam:
 
 ### 5.6 Versioning and comparability
 
-`engine_version` is stamped on `fundamental_score_daily` and `valuation_anchors_daily`, and bumps
+`engine_version` is stamped on `fundamental_scores` and `valuation_anchors`, and bumps
 on **any** change to weights, rubric, routing, or a method. `inputs_hash` covers the derived inputs.
 Together they answer the only question that matters when the method evolves: *did this score move
 because the company changed, or because I changed the method?*
@@ -419,9 +503,15 @@ be charted on the same axis only with the version break marked.
 An anonymous-counterparty disclosure is a **concentration row, not an edge**. `dst_ticker` is
 `NOT NULL` on edges; the `curated` tier does not exist.
 
+**Edges are observations, not relationships** (F-7 fix). The first draft made
+`(src_ticker, dst_ticker, edge_type)` unique *and* promised "never DELETE — audit trail". Those
+contradict: a later filing restating the same relationship would have had to overwrite the accession,
+excerpt and magnitude that justified the earlier one. One filing fact = one immutable row.
+
 ```sql
-CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edges (
-    edge_id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edge_obs (
+    filing_accession   TEXT NOT NULL,             -- lock enforced: no accession, no row
+    fact_seq           INT  NOT NULL,             -- nth extracted fact within the filing
     src_ticker         TEXT NOT NULL,             -- the FILER making the disclosure
     dst_ticker         TEXT NOT NULL,
     edge_type          TEXT NOT NULL CHECK (edge_type IN
@@ -432,21 +522,24 @@ CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edges (
     magnitude_basis    TEXT,
     identity_inference TEXT,
     filing_form        TEXT NOT NULL,             -- '10-K' | '20-F'
-    filing_accession   TEXT NOT NULL,             -- lock enforced: no accession, no row
     filing_date        DATE NOT NULL,
+    filing_published_at TIMESTAMPTZ NOT NULL,     -- PIT boundary (A10)
     fiscal_period      TEXT,
     excerpt            TEXT NOT NULL,
-    first_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    last_confirmed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    status             TEXT NOT NULL DEFAULT 'active'
-                         CHECK (status IN ('active','stale','retired')),
+    observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT inferred_needs_basis CHECK
       (trust_tier <> 'asc280_inferred' OR identity_inference IS NOT NULL),
-    UNIQUE (src_ticker, dst_ticker, edge_type)
+    PRIMARY KEY (filing_accession, fact_seq)
 );
 ```
 
-**Pipeline** — one weekly pass, `edge_graph_refresh`:
+**Current-relationship projection** — a view, not a table:
+`fundamental_edge_current` takes the newest observation per `(src_ticker, dst_ticker, edge_type)` and
+derives `status` from filing recency (`active` / `stale` after absence from the newest same-form
+filing / `retired` past 400 days). Nothing is mutated to compute it; the full observation history
+stays queryable, which is what "audit trail" was supposed to mean.
+
+**Pipeline** — one pass per run, `edge_graph_refresh`:
 
 1. Per core ticker, `edgartools` pulls the newest **10-K or 20-F** (form chosen from
    `data.sec.gov` submissions). Section-scoped scan (Item 1 / 1A / 7 + concentration-of-credit-risk
@@ -459,13 +552,24 @@ CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edges (
    this batch job* to locate ambiguous sentences — that is not the deferred live agent of §10, and
    it never authors a row the gate did not verify. If regex recall proves adequate at P4, the LLM
    step is not built at all.
-4. Refresh/expire: re-found in a newer filing → bump `last_confirmed_at`. Absent from the newest
-   same-form filing → `stale`. Stale > 400 days → `retired`. **Never DELETE** — audit trail.
+4. Re-processing a filing is idempotent by `(filing_accession, fact_seq)`. Nothing expires by
+   mutation; recency is resolved in the view. **No row is ever updated or deleted.**
 
-**Ops (runbook line):** every `sec.gov` / `efts.sec.gov` call **must bypass the local proxy** —
-`httpx(trust_env=False)`. Through `127.0.0.1:7897` the TLS handshake fails outright (curl exit 35,
-HTTP 000); DNS resolves fine. This mirrors the documented massive-WS `proxy=None` rule. The
-SEC-required `User-Agent` header (contact email) is mandatory.
+**Ops — all mandatory before P4 writes a row:**
+
+| Requirement | Detail |
+|---|---|
+| dependency | **`edgartools` is not in `pyproject.toml`** — adding it (with a pinned version) is a P4 task, not an assumption |
+| proxy bypass | every `sec.gov` / `efts.sec.gov` call uses `httpx(trust_env=False)`. Through `127.0.0.1:7897` the TLS handshake fails outright (curl exit 35, HTTP 000) while DNS resolves fine — mirrors the documented massive-WS `proxy=None` rule |
+| User-Agent | SEC-required contact email, from config; requests without it are refused |
+| rate limit | SEC's published ceiling is 10 req/s; the client throttles below it and is the only path to `sec.gov` |
+| retry | bounded exponential backoff on 429/5xx, capped attempts, failures recorded on the `fundamental_runs` row rather than raised into the UI |
+| cache | filings are immutable once accepted — cache by accession on disk and never re-fetch the same document |
+
+**Discovery gate before build.** P4 starts with a read-only probe over the core 25 that reports
+concentration-row yield and named-edge yield. If the ledger's `trend` arrays come back flat and
+uninformative, P4 is cut rather than extended (Risk 2), and the node-link graph question (§8)
+resolves itself.
 
 **Prompt payload block:**
 
@@ -501,14 +605,14 @@ and it renders *below* the numbers, never in place of them.
 
 | Block | Content | Source |
 |---|---|---|
-| composite + subscores | seven bars, each with its inputs on hover | `fundamental_score_daily` |
-| anchor band | spot marked against `buy_below / observe_low / observe_mid / observe_high / risk_above`; base/bear/bull × 1y/3y | `valuation_anchors_daily` |
-| method + confidence | `company_type`, method name, `confidence` and **every reason** | `valuation_anchors_daily.confidence_reasons_jsonb` |
-| target gap | our 1Y anchor vs `uw_positioning.target_avg`, as a number | join on the shipped `uw_positioning` |
+| composite + subscores | seven bars, each with its inputs on hover | `fundamental_scores` |
+| anchor band | spot marked against `buy_below / observe_low / observe_mid / observe_high / risk_above`; base/bear/bull × 1y/3y | `valuation_anchors` |
+| method + confidence | `company_type`, method name, `confidence` and **every reason** | `valuation_anchors.confidence_reasons_jsonb` |
+| target gap | our 1Y anchor vs `uw_positioning.analyst_target_avg`, as a number | join on the shipped `uw_positioning` |
 | concentration | top-customer %, multi-year trend, filing citation | `customer_concentration` (P4) |
 | coverage | what is `na` and why — the explicit absence list | `na` propagation from I4 |
 | provenance | `engine_version`, `inputs_hash`, `as_of` per block | every persisted row |
-| **narrative** | `headline` · `thesis` · `price_view` · `target_gap` · `bear_case` · numeric `invalidation` · `monitorables` · `evidence_ledger` · mandatory `unknowns` | stage 5, DeepSeek — Pydantic → `model_json_schema()` → strict function-calling, matching `TradeInsightAiOutcome` |
+| **narrative** | `headline` · `thesis` · `price_view` · `target_gap` · `bear_case` · numeric `invalidation` · `monitorables` · `evidence_ledger` · mandatory `unknowns` | stage 5 — a **`FundamentalNarrativeOutcome`** Pydantic model → `model_json_schema()` → DeepSeek strict function-calling. Borrows the *mechanism* of `TradeInsightAiOutcome`, never its schema: that model demands scenario cards, VRP assessment and preferred expression, none of which a fundamental analysis has |
 | audit verdicts | per-claim `pass / warn / fail / unverifiable` | `fundamental_audit_results` |
 
 The narrative block carries its audit state visibly. A `fail` verdict suppresses the offending claim
@@ -576,7 +680,7 @@ computed from S1's engines:
 
 | Encoding | Source | Reads as |
 |---|---|---|
-| cell fill | median `fundamental_score_daily.composite` | research priority (§5 I5 — a sort key, not a forecast) |
+| cell fill | median `fundamental_scores.composite` | research priority (§5 I5 — a sort key, not a forecast) |
 | cell texture | share of names rich vs cheap in the band | is this pocket stretched |
 | corner mark | mean `customer_concentration.top_customer_pct` + trend | revenue-concentration risk |
 | hatched | no S1 rows yet, or all `confidence = low` | not analysed / not trustworthy |
@@ -591,31 +695,37 @@ artifact and the renderer was never owed.
 **Aggregation.** All rollups are computed **read-time from S1 rows** (`reports/industry_graph.py`) —
 no new persisted table, no second scoring path. One engine, two renderings.
 
+**Every aggregate needs a stated basis.** A cell median is meaningless across mixed engine versions
+or stale `as_of` values, so G2 fixes three rules before it aggregates: a common `as_of` (the latest
+date on which the cell's members share the active `engine_version`), rows on superseded versions are
+excluded rather than mixed, and the **coverage denominator is the cell's full membership** — not the
+subset that happens to have rows. A cell where 2 of 6 names are analysed shows the 2-name aggregate
+*and* says 2/6.
+
 ## 9. Phases
 
-Two tracks plus a deferred one. S1 P0–P2 gate everything; S2 G1 is independent and can run in
-parallel from day one; the loop harness (§10) starts only after both surfaces are trusted.
-
-Every phase is **ad-hoc triggered** (§5.1). No cron is added until the method stops moving.
+Two tracks plus a deferred one. Every phase is **ad-hoc triggered** (§5.1); no cron until the method
+stops moving.
 
 ### S1 — fundamental card
 
 | Phase | Ships | Gate | Verification |
 |---|---|---|---|
-| **P0** | Commit-bug fix + a test asserting on a **fresh connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | Mini's `massive_fundamentals` row count > 0 after a manual run |
-| **P1** | massive `/v2` migration (103 fields, full history) + UW segment revenue; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | NVDA quarters reach the 1990s; FY2026 segment revenue matches the filed 10-K to the dollar |
-| **P2** | `fundamental_score_daily` + `valuation_anchors_daily`; `fundamental_method_params` seeded; company-type routing; confidence downgrades; on-demand refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors; re-run with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and produces new anchors**; editing a weight row moves `engine_version` for every ticker |
-| **P3** | The card's deterministic blocks (§7) — subscores, anchor band, confidence reasons, coverage, provenance | — | Every rendered number resolves to a persisted row; the coverage block lists a real `na` |
-| **P4** | Concentration ledger + sparse edge overlay (§6) | After the card; the concentration block ships empty in P3 | NVDA yields a concentration row with a real accession and multi-year trend; ANET→META exists as the reference `asc280_named` edge; TSM yields a 20-F-sourced row proving the corpus extension |
-| **P5** | Stage 5 narrative — `analysis_kind='fundamental'`, DeepSeek, evidence ledger, staged numeric audit | Needs P3 (numbers to constrain it) and P4 (concentration facts worth citing) | Real worker-path smoke: enqueue from the card → worker claims → narrative renders with audit verdicts persisted; **disabling the provider leaves the card fully usable** |
+| **P0** | Commit-bug fix + a test asserting through a **freshly opened connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | Mini's `massive_fundamentals` row count > 0 after a real scheduler run; rollback-path regression |
+| **P1a** | **Data-contract spike** (no schema): reconcile `/vX`, `/v2`, UW statements and the filed 10-K on representative tickers; commit the exact field map | The first draft chose a frozen endpoint for its field count. No ingestion is designed until the sources are measured, not read about | An overlap-zone quarter agrees across `/vX` and `/v2` field-for-field, or the disagreement is documented with a resolution rule |
+| **P1b** | Immutable observation tables + canonical views + backfill/incremental modes; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | `/vX` reaches 2026 and `/v2` fills 1997–2008; re-ingest is idempotent; a simulated restatement adds a row without destroying its predecessor; FY2026 segment revenue matches the filed 10-K to the dollar |
+| **P2** | Method appendix (worked examples) · method version tables · ANCHOR then SCORE · confidence downgrades · `fundamental_runs` + enqueued refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors from the appendix; recompute with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and yields new anchors**; a new method version coexists with the old on the same date; exactly one version is active |
+| **P3** | The card's deterministic blocks (§7) — subscores, anchor band, confidence reasons, coverage, provenance drill-down; API models + `gen:types` + tab/route wiring; loading/stale/error states | — | Every rendered number resolves to a persisted row; the coverage block lists a real `na`; a stale-version row renders as stale rather than current |
+| **P4** | Discovery gate → concentration ledger + sparse edge observations (§6); `edgartools` dependency added | After the card; the concentration block ships empty in P3 | Gate reports real yield before build; NVDA yields a concentration row with a real accession and multi-year trend; ANET→META exists as the reference `asc280_named` edge; TSM yields a 20-F-sourced row; re-processing a filing writes no duplicate |
+| **P5** | Stage 5 narrative — **`fundamental_narrative_analyses`** queue, DeepSeek, evidence ledger, staged numeric audit | Needs P3 (numbers to constrain it) and P4 (concentration facts worth citing) | Real worker-path smoke: enqueue → worker claims → narrative renders with audit verdicts persisted; an audit `fail` suppresses the claim; **disabling the provider leaves the card fully usable**; `fetch_unscored_analyses` returns zero fundamental rows |
 
 ### S2 — `/industry_graph`
 
 | Phase | Ships | Gate | Verification |
 |---|---|---|---|
-| **G1** | Layer × chain matrix from `watchlist_chain`, cells empty, drill-down to ticker list → S1 | none — skeleton exists, runs parallel to S1 P0–P2 | Cell membership matches `watchlist_chain ∩ active watchlist`; the 10 multi-chain tickers appear in each of their cells |
-| **G2** | Cell encodings from S1 + read-time rollups | needs S1 P2 | A cell's fill equals the median of its members' `fundamental_score_daily`; uncovered cells hatch, never blank |
-| **G3** | Concentration corner marks | needs S1 P4 | Every mark traces to `customer_concentration` rows with real accessions |
+| **G1** | Layer × chain matrix from `watchlist_chain`, drill-down to ticker list → S1. **Built and tested in parallel from day one; route stays unreleased** | Publishing an empty matrix would ship the "colouring book with no colours" this spec rejects, duplicating the shipped chain filter | Cell membership matches `watchlist_chain ∩ active watchlist`; the 10 multi-chain tickers appear in each of their cells; route is not reachable in the nav |
+| **G2** | Cell encodings from S1 + read-time rollups + the common-version/coverage rules above. **Route released here** | needs S1 P2 | A cell's fill equals the median of its members' `fundamental_scores` at a shared `engine_version`; partial cells show their coverage fraction; uncovered cells hatch, never blank |
+| **G3** | Concentration corner marks + row pivot (layer ⇄ company_type) | needs S1 P4 | Every mark traces to `fundamental_edge_obs` / `customer_concentration` rows with real accessions; trend selection rule is explicit and reproducible |
 
 **Deferred:** ranked long/short book, congress/13F enrichment, true estimate gap (blocked on gated
 tier), cross-chain flow/weight sizing, node-link graph (kill criterion above).
@@ -653,13 +763,12 @@ problem into stage-1 work.
 
 ## 11. Risks
 
-1. **The method is fixated on unvalidated priors.** The §5.2 weights have no backtest behind them
-   and the spec says so. Holding them in `fundamental_method_params` makes them sweepable and
-   `engine_version` makes a revision auditable; neither makes the current values right. Do not let
-   the composite acquire authority it has not earned.
-   Inherited from the blueprint, which also ships no backtest, hit-rate or P&L. The composite is a
-   **sort key** and must be labelled research priority on every surface — argon's own theta-harvester
-   precedent is correct ordering with a losing selection.
+1. **The method is fixated on unvalidated priors.** The §5.2 weights have no backtest behind them and
+   the spec says so. Versioned parameter rows make them sweepable and make a revision auditable;
+   neither makes the current values right. Inherited from the blueprint, which also ships no
+   backtest, hit-rate or P&L. The composite is a **sort key** and must be labelled research priority
+   on every surface — argon's own theta-harvester precedent is correct ordering with a losing
+   selection.
 2. **The concentration ledger is decorative rather than decision-useful.** MED confidence it
    earns its place. The `trend` array is the specific bet; if concentration trends turn out flat
    and uninformative across the core 25, P4 should be cut rather than extended.
@@ -676,9 +785,22 @@ problem into stage-1 work.
 
 ## 12. Open items
 
-- Confirm massive has no segment-revenue endpoint before P1 locks segments to UW
-  (`[INFERRED]` from the capability audit's silence — MED-HIGH, needs a 2-minute live probe).
+All provider claims below are repository snapshots, not live probes. **P1a re-measures every one of
+them before any schema is designed** — the `/v2`-frozen error came from trusting exactly this kind of
+second-hand reading.
+
+- Confirm massive has no segment-revenue endpoint before segments lock to UW (`[INFERRED]` from the
+  capability audit's silence — MED-HIGH).
 - The UW capability audit is dated 2026-05-15 (~3 months stale). The live MCP surface exposes
-  `get_income_statement_screener` / `get_earnings_screener` names absent from local docs —
-  re-probe before assuming either availability or gating.
+  `get_income_statement_screener` / `get_earnings_screener` names absent from local docs — re-probe
+  before assuming either availability or gating.
+- Confirm `/vX`'s actual field set. The 103-field count belongs to the frozen `/v2`; what `/vX`
+  exposes is unmeasured here, and the subscore rubric assumes ordinary statement lines rather than
+  pre-computed ratios.
 - Audit the other `_repo()` consumers for the same no-commit pattern (out of scope here).
+
+**Resolved by the 2026-08-10 review** — recorded so they are not re-opened: narrative queue is
+domain-isolated, not a lane (A1); `/vX` is the backbone (A4); PIT observations are mandatory (A10);
+refresh enqueues rather than writes synchronously (A11); ANCHOR precedes SCORE (§5.1); outputs are
+keyed by `engine_version` (§4.4); edges are immutable per-filing observations (§6); G1 releases with
+G2 (§9).

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -1,0 +1,684 @@
+# Fundamental analysis method — design
+
+*Status: ACCEPTED, awaiting implementation plan · 2026-08-10 · branch `feat/fundamental-pm-agent`*
+
+## 1. Goal
+
+**A fixated, extensible fundamental-analysis method — plus the two surfaces that render it.**
+The method (§5) is the deliverable. The surfaces are how it is read.
+
+| | Shipment | Surface | Question it answers |
+|---|---|---|---|
+| **S1** | Fundamental card | new tab on `/stock/{ticker}` | *Is this one name attractive, and what would prove me wrong?* |
+| **S2** | Chain heatmap | new screen `/industry_graph` | *Where in the AI stack is the value, and where is risk piled up?* |
+
+**Python computes every number. DeepSeek writes prose over those numbers and nothing else.** The
+narrative stage is in v1 (§5.1 stage 5) — it is a provider call inside a deterministic job, not an
+agent. It cannot move a single value produced by stages 3–4 (invariant I1), and a numeric auditor
+diffs its prose against the backing rows before the card renders.
+
+**What is deferred is the loop harness, not the model call** (§10). Nothing in argon decides on its
+own when to recompute, re-analyse or re-plot; every stage stays cron- or request-triggered. The
+autonomous layer arrives later as an external **pi agent** harness driving these jobs, which is
+argon goal-ladder Stage 2 (self-tending desk) and out of scope here. User ruling, 2026-08-10.
+
+S1 → S2 is a real dependency, not a preference: argon already ships a layer-rail chain filter on the
+watchlist (v0.11.4), so a surface that only redraws membership duplicates existing capability. What
+makes `/industry_graph` new is that every cell carries a *computed fundamental attribute*. S2 without
+S1's engines is a colouring book with no colours.
+
+Explicitly **not** in scope: a ranked long/short book — it needs both surfaces as inputs.
+
+Fits argon's Stage-1 lane ("trustworthy foundation"): the deliverable is honest fundamental
+data with per-fact provenance, not more surface area. Keeping the model out of the numbers is what
+makes that true —
+every number on both surfaces is reproducible from an `inputs_hash`.
+
+## 2. Blueprint and what we take from it
+
+Modeled on @sunlc_crypto's "BewinQuant Terminal" AI investment radar (5-part X series,
+part 5 = 2086014788187164904). His taxonomy is 黄仁勋's AI 五层蛋糕理论 — 5 layers × ~20 chains
+over a 188-name universe. argon's `watchlist_taxonomy.py` is already the same shape
+(9 layers, 38 chains, 235 memberships), so the taxonomy is not new work.
+
+**The load-bearing idea is the constraint on the AI, not the AI.** His stated rule:
+*"AI 只能使用系统提供的证据，不能修改系统算出的价格区间，也不能编造新闻或财务数字"* and
+*"产业链结果主要由固定规则计算，不是 AI 自由判断"*.
+
+| Take | Why |
+|---|---|
+| Deterministic fixed score, LLM cannot move it | The whole point. Score = **research priority**, never a return forecast |
+| Multi-anchor valuation (`buy_below / observe_low / observe_mid / observe_high / risk_above`) | Company-type-routed; a defensible price *range*, not a prediction |
+| Evidence ledger — `source · quality · timestamp` per fact | argon already persists prompt/schema/model/hash; this extends it to per-fact |
+| Numeric 失效条件 (invalidation conditions) | The single most useful output field; forces falsifiability |
+| 数字审计 — audit prose against backing data | The only mechanism that makes the arrangement falsifiable |
+
+| Reject | Why |
+|---|---|
+| 增长假设 H0–H5, 买方研究备忘录 | Render **empty** in his own screenshots — claimed, not demonstrated |
+| "Warren Composite" as headline | argon's theta-harvester lesson: a score that *orders* (IC +0.075) can still select a losing set |
+| Technical score inside the fundamental composite | Violates his own display-only principle; argon's technicals are deeper |
+| 4-tier universe, PDF reports, Social Monitor, ClickHouse, FMP subscription | argon has equivalents or better; Postgres is law here |
+| His options module | argon's is materially better |
+| 预期差 as *estimate* gap | Forward estimates are Advanced+-gated. Ship the **price-target** gap (`uw_positioning.target_avg` vs anchors); never fake the estimate gap |
+| 供应链瓶颈分 as a hand-assigned score | Replaced by the **measured** ASC 280 concentration metric — same shape, real provenance |
+
+He has **no backtest, no hit-rate, no P&L**, and says so. This is a research organizer, not
+validated alpha. We inherit that limitation and must not oversell it.
+
+## 3. Feasibility verdict
+
+Buildable, mostly from parts argon already owns. Two findings gate it.
+
+### 3.1 BLOCKER — `fundamentals_refresh` has never persisted a row (verified)
+
+- `_repo()` (`worker/scheduler.py:498`) does `psycopg.connect(...)` with **no `autocommit=True`**,
+  yields a `Repository`, and `finally: conn.close()`.
+- `worker/jobs/fundamentals_jobs.py` and `storage/fundamentals.py` contain **zero `.commit()`**.
+- psycopg 3.3.4 defaults `autocommit=False`; `close()` without commit discards the transaction.
+- The sibling `positioning_refresh_once` survives only because `insert_scan_run` /
+  `finish_scan_run` commit internally on the same connection. Fundamentals has no such rescue.
+- `tests/integration/worker/test_fundamentals_job.py` passes because it asserts on the **same
+  open connection**. The test is the second bug.
+
+Nightly since migration 066, logging `"fundamentals_refresh refreshed %d tickers"` while rolling
+everything back. **`massive_fundamentals` is empty or stale in production.**
+
+Blast radius is narrow: `ohlc_pull` writes through `market_data.py` (4 commits, safe).
+`fundamentals_jobs` is the confirmed case. Other `_repo()` consumers were not individually
+traced — worth a follow-up audit, out of scope here.
+
+### 3.2 Data inventory
+
+**Available and unused (currently costs zero UW calls/day):**
+
+| Source | Content | Integrated? |
+|---|---|---|
+| massive `/v2/reference/financials` | **103 fields, quarters back to 1997** | No — argon uses `/vX` (55 fields), persists ~13, `limit=8` |
+| UW `/stock/{t}/income-statements`, `/balance-sheets`, `/cash-flows` | 94 quarters each | No |
+| UW `/stock/{t}/fundamental-breakdown` → `rev_breakdown` | **revenue by product AND geography** | No |
+| UW `/stock/{t}/info` | sector, marketcap, beta, issue_type | No |
+| SEC EDGAR `data.sec.gov` + `efts.sec.gov` FTS | filings, XBRL, concentration language | No |
+
+**Already shipped and reusable:** `uw_positioning` (analyst targets/ratings, insider net flow,
+13F aggregates, short interest, earnings reactions) — daily, correctly committed, live on the
+stock page.
+
+**Gated (Advanced+/Premium, unavailable):** forward analyst estimates, earnings-call transcripts,
+company profile, IPO calendar, UW dividends/splits, macro series.
+
+**Absent at any tier from every provider:** supply-chain relationship graph, forward guidance,
+backlog/bookings, KPI disclosures, unit economics. Every stage **must be able to emit `na`** for
+these, and both surfaces must render the absence (§5 I4, §7 coverage block). This is a hard ceiling,
+not a backlog item.
+
+**Budget:** live ceiling 80k, research 30k, account guard 105k. Current burn ≈45.5k/day
+(173 × ~263). ≈60k/day headroom; segment pulls for a 25-name core are noise against it.
+
+### 3.3 The edge-graph reality (measured, 2026-08-10)
+
+Live EDGAR full-text probes. Controls pass (`"CoWoS"` → 10 hits, all NVDA 10-Ks).
+
+| Query | Hits | Note |
+|---|---:|---|
+| `"one customer accounted for"` (10-K) | **9,261** | unnamed |
+| `"no customer accounted for more than 10%"` (10-K) | **3,281** | unnamed |
+| `"customer accounted for"` (**20-F**) | **459** | unnamed; reaches TSM/ASML/STM |
+| `"NVIDIA accounted for"` | **0** | |
+| `"Taiwan Semiconductor accounted for"` | **0** | |
+| `"Broadcom accounted for"` / `"Tesla accounted for"` | **0** | |
+| `"Meta Platforms accounted for"` | **1** | Arista Networks 2023 |
+| `"revenue from NVIDIA"` | 2 | Rambus 2018/2019 |
+| `"Amazon accounted for"` | 115 | Emerson Radio etc. — *marketplace sellers*, not AWS |
+
+Two structural causes:
+
+1. **ASC 280-10-50-42 requires the amount, not the identity.** Modern mega-caps uniformly do
+   not name. Boilerplate outnumbers named disclosures ~200:1.
+2. **The upstream tier files 20-F/6-K, not 10-K.** TSM's SEC mix: 6-K ×741, 20-F ×15,
+   **zero 10-Ks** (verified via `data.sec.gov/submissions/CIK0001046179.json`). 20-Fs *are* in
+   the FTS corpus, so this is a corpus-selection fix. Korea (Samsung, SK Hynix) files nothing
+   with the SEC and is **permanently unreachable**.
+
+**Consequence, stated plainly:** a dense EDGAR-anchored *named* edge graph for the AI chain does
+not exist. The filing-citation discipline stays mechanically enforced; only the density
+expectation is revised. The primary artifact becomes a **per-company customer-concentration
+ledger** (dense, citable, trend-bearing), with a **sparse named-edge overlay** where small/mid-cap
+suppliers name their mega-cap customers.
+
+Note the convergence: the blueprint author independently landed on a per-company
+供应链瓶颈分 rather than a graph. Two builders hitting the same wall is evidence about the data.
+
+## 4. Architecture
+
+### 4.1 Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| A1 | **Third lane** `analysis_kind='fundamental'` on the existing `trade_insights_ai` queue — stage 5, phase P5 | Verified live: migration `067`, per-row dispatch at `trade_insights_ai.py:142`. A separate queue would duplicate SKIP-LOCKED claim logic, heartbeats, per-provider workers and the UI polling hook for no gain |
+| A2 | New pure-compute package **`src/uw_scan/fundamentals/`** | Follows `theta_harvester/` / `chanlun/` precedent. Not `reports/` — those are read-time reshapes; these are nightly persisted computations |
+| A3 | New API router **`api/routers/fundamental.py`** | `routers/trade_insights.py` is already ~600 lines; module-size budget |
+| A4 | **massive `/v2`** for the statements backbone, **UW `fundamental-breakdown`** for segments | The IB→UW→FMP→massive rule is scoped to *live quotes/greeks*; massive is already the fundamentals source. Preserves UW headroom. UW 94q statements become the cross-check |
+| A5 | **`fundamental_company_type`** persisted separately, seeded from sector+chain, hand-overridable | `watchlist_chain` is many-to-many — a ticker in 3 chains has no unique layer. Valuation methods must not silently flip when taxonomy is edited |
+| A6 | **DeepSeek only** for stage 5 | `docker-compose.yml:10` — "AI Codex/Claude are OFF"; only `worker-ai-deepseek-0/1` are deployed. Codex/Claude runners are subprocess CLIs reading macOS keychain OAuth; there is no keychain in a container. DeepSeek is in-process `httpx` + bearer token |
+| A7 | **Core 25** universe in v1 (§4.3) | Every valuation anchor stays hand-verifiable while the method is still being fixated |
+| A8 | **Staged numeric audit** — deterministic always, model auditor conditional | Two things get audited, and they arrive at different times. Stages 1–4 are validated from P2 (anchors ordered, percentages in range, `inputs_hash` reproducible). Prose auditing starts at P5; clean narratives cost nothing extra, suspicious ones get the deep check |
+| A9 | `asc280_inferred` identities are **stored and rendered flagged as inference** | The "NVDA's top customer is probably a hyperscaler" fact is the most important fundamental fact about NVDA. In v1 the flag is a UI label; when the agent lands (§10) it also becomes an audit rule that FAILS prose stating an inferred identity as fact |
+
+### 4.2 Module split (`src/uw_scan/fundamentals/`)
+
+| Module | Responsibility | ~lines |
+|---|---|---|
+| `statements.py` | normalize massive/UW rows, derive TTM / growth / margins | 300 |
+| `company_type.py` | routing classification (chips / software / power / high-risk-growth) | 100 |
+| `scoring.py` | subscores + composite | 250 |
+| `valuation.py` | anchor blending, confidence downgrades | 300 |
+| `valuation_methods.py` | per-company-type method implementations | 350 |
+| `concentration.py` | ASC 280 extraction + edge overlay (Phase 4) | 400 |
+
+S2's chain/layer rollups are a **read-time reshape of S1 rows**, so by A2's own seam they live in
+`reports/industry_graph.py` (~150 lines), not in this package. No second scoring path exists.
+
+### 4.3 Core 25 universe (v1)
+
+Spans every taxonomy layer L1–L5 so chain context is meaningful from day one. Stored as a
+`fundamental_universe` flag rather than a new tier scheme — argon already has watchlist + `hot`
++ research cohorts, and a fourth tiering scheme would be pure admin.
+
+| Layer | Tickers |
+|---|---|
+| L1 Chip & System | NVDA AMD AVGO MRVL TSM ASML AMAT MU |
+| L2 Cloud & Data | MSFT GOOGL AMZN META ORCL |
+| L3 Datacenter Infra | ANET VRT ETN GEV CEG VST |
+| L4/L5 App & Model | DELL SMCI PLTR CRWD NOW APP |
+
+**Membership must intersect the active watchlist** (`removed_at IS NULL`) — the SPX precedent
+shows captures silently skip anything off the active list. Any name here that is not on the
+watchlist either gets added or is dropped from the core before P1. Verify at build time; do not
+assume.
+
+### 4.4 Storage
+
+Each in its own `storage/<domain>.py`. Never extend `repository.py`.
+
+| Table | Key columns | Registry |
+|---|---|---|
+| `fundamental_statements` | PK `(ticker, period_end, period_type)`; ~40 wide columns + `raw_jsonb` (full 103-field payload), `source` | temporal → **DatasetRegistryEntry** |
+| `fundamental_segments` | PK `(ticker, period_end, dimension, segment_name)`; `dimension ∈ {product, geography}`, revenue, `source` | temporal → **DatasetRegistryEntry** |
+| `fundamental_score_daily` | PK `(ticker, as_of)`; one column per subscore, composite, `engine_version`, `inputs_hash` | temporal → **DatasetRegistryEntry** |
+| `valuation_anchors_daily` | PK `(ticker, as_of)`; `company_type`, `method`, the 5 anchors, base/bear/bull × 1y/3y, `confidence`, `confidence_reasons_jsonb`, `inputs_jsonb`, `engine_version` | temporal → **DatasetRegistryEntry** |
+| `customer_concentration` | PK `(ticker, fiscal_period, filing_form)`; `top_customer_pct`, `customers_over_10pct`, `none_over_10pct`, `magnitude_basis`, `filing_accession`, `filing_date`, `excerpt` | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_edges` | see §6 | event-temporal → **DatasetRegistryEntry** |
+| `fundamental_audit_results` | PK `(analysis_id, claim_seq)`; `claim_text`, `extracted_value`, `backing_source`, `backing_value`, `verdict ∈ {pass,warn,fail,unverifiable}`, `stage ∈ {deterministic,model}` | keyed by analysis — dimension, exempt |
+| `fundamental_company_type` | PK `(ticker)`; `company_type`, `source ∈ {rule,manual}`, `set_at` | dimension, exempt |
+| `fundamental_method_params` | PK `(param_set, param_key)`; `param_value NUMERIC`, `active BOOLEAN`, `note`, `updated_at`. Holds §5.2 weights + §5.4 thresholds. Seeded `param_set='v1_prior'` | dimension, exempt |
+
+Exactly one `param_set` carries `active=true` — enforced by a partial unique index, not by
+convention. Two active sets would make `engine_version` ambiguous and every downstream row
+unattributable.
+
+Registry entries and the regenerated data-gap policy doc ride the **same PR** as each table.
+
+## 5. The method (fixated)
+
+What is being shipped is a **method**. The two screens are how it is viewed; the method is what has
+to survive the universe going 25 → 220 names, 4 → N company types, and 7 → more subscores without
+a rewrite.
+
+**The rule that makes it extensible: everything that varies by ticker is DATA, not control flow.**
+A new company type is a registry row plus one function. A new subscore is a registry row plus one
+function. Neither edits the pipeline. If adding a name requires an `if ticker ==` anywhere, the
+method has been broken.
+
+### 5.1 Pipeline contract
+
+Five stages. Every ticker, every run, no exceptions:
+
+```
+1 INGEST   raw statements + segments        → fundamental_statements, fundamental_segments
+2 DERIVE   TTM, growth, margins, ratios     → pure functions, no I/O
+3 SCORE    subscores → composite            → fundamental_score_daily
+4 ANCHOR   company-type-routed valuation    → valuation_anchors_daily
+5 NARRATE  DeepSeek prose over 3+4, audited → trade_insight_ai_analyses + fundamental_audit_results
+```
+
+Stages 1–4 are deterministic and reproducible from `inputs_hash`. Stage 5 is a **provider call
+inside a job**, not an agent: it is triggered by cron or by request, never by its own judgement, and
+it consumes 3+4 as read-only inputs. Nothing in the pipeline decides when to run itself — that is
+the loop harness, deferred to §10.
+
+Stage 5 degrades cleanly. If DeepSeek is unavailable, disabled, or its output fails the audit, the
+card renders stages 1–4 with the narrative block marked absent. **The deterministic surfaces never
+depend on the model.**
+
+**Trigger: ad-hoc first, cron later** (user ruling, 2026-08-10). v1 runs the whole pipeline
+on-demand per ticker from a button on the card, following the shipped
+`POST /stock/{ticker}/technicals/refresh` "Compute now" precedent — an explicit, deliberate write on
+an otherwise read-only router. A nightly job over the whole universe is added only once the method
+has stopped moving; scheduling an unstable method just fills tables with rows carrying dead
+`engine_version`s. The job function takes a `ticker_filter` from day one so the cron, when it comes,
+is a scheduler entry and not a rewrite.
+
+Invariants, in force at every stage:
+
+| # | Invariant | Enforced by |
+|---|---|---|
+| I1 | Stage 5 may not alter any output of stages 3–4 | the audit stage — mechanism, not trust |
+| I2 | Stages 2–4 are pure: same inputs → same outputs | `inputs_hash` equality on re-run. **`inputs_hash` covers `company_type` and the active parameter set**, not only the financial inputs — see §5.3 |
+| I3 | Every stage persists before returning | argon standing rule; CI-visible via row counts |
+| I4 | Any stage may emit `na`; a missing input never becomes a fabricated one | absence propagates to `unknowns` + downgrades `confidence` |
+| I5 | The composite is a **sort key**, never a return forecast | labelled "research priority" on every surface |
+
+I5 is not cosmetic. argon's theta-harvester ordered correctly (IC +0.075) and still selected a
+losing set. A composite that is allowed to read as a forecast will be traded as one.
+
+### 5.2 Subscore rubric — parameters live in Postgres
+
+Seven subscores, each `0–100`, each computed from a named input set, each independently overridable.
+
+**Weights are rows in `fundamental_method_params`, not constants in code** (user ruling, 2026-08-10).
+Three reasons, in order of weight:
+
+1. They are **unvalidated priors** — no backtest sits behind the seed values below, and the spec must
+   not pretend otherwise. Data that is known to be provisional does not belong in a deploy artifact.
+2. argon already owns a sweep harness (`backtest/` + `backtest_sweep_runs` / `_results`). Weights as
+   rows means a named `param_set` is directly sweepable, with the full trace persisted, the day
+   there is enough history to sweep against. Weights as constants means a code branch per trial.
+3. Retuning becomes a row update, not a release.
+
+| Subscore | Inputs (derived at stage 2) | Direction | seed weight |
+|---|---|---|---:|
+| `growth` | revenue TTM YoY, 2-quarter YoY acceleration | higher better | 0.20 |
+| `profitability` | gross + operating margin, level and 4-quarter trend | higher better | 0.20 |
+| `capital_efficiency` | FCF conversion, return on invested capital | higher better | 0.15 |
+| `balance_sheet` | net debt / EBITDA, interest coverage, current ratio | lower leverage better | 0.15 |
+| `valuation_position` | spot vs `observe_low..observe_high` band from stage 4 | cheaper better | 0.15 |
+| `concentration_risk` | top-customer %, its multi-year trend (§6) | lower better | 0.10 |
+| `expectations_gap` | our 1Y anchor vs `uw_positioning.target_avg`, insider net, short interest | wider positive gap better | 0.05 |
+
+Seeded by migration as `param_set='v1_prior'`, `active=true`. The table also holds the §5.4
+downgrade thresholds — anything a future sweep might want to move.
+
+**Mutable parameters force `engine_version` to be derived, not hand-written.** It is
+`{code_version}:{param_hash[:8]}`, where `param_hash` covers the active parameter set. A hand-bumped
+version would let someone edit a weight while the version stayed put, silently destroying
+comparability across `fundamental_score_daily` rows — the exact question §5.6 exists to answer.
+
+Ordering constraint: `valuation_position` consumes stage 4, so within stage 3 it is computed
+**last**, and stage 4 must never read the composite back. The dependency is one-directional or the
+score becomes self-referential.
+
+`concentration_risk` returns `na` until S2 P4 lands; `na` subscores are dropped and the remaining
+weights renormalize. Renormalization, not zero-fill — a zero would read as "no concentration risk",
+which is a fabricated fact.
+
+Field-level mapping onto massive `/v2`'s 103 columns is P1's job and is deliberately not guessed
+here.
+
+### 5.3 Company-type routing — a second axis, and its invalidation cascade
+
+`company_type` selects the valuation method. Persisted per ticker (`fundamental_company_type`,
+decision A5), seeded from sector+chain, hand-overridable, **never** derived live from the
+many-to-many taxonomy — a ticker in three chains has no unique layer, and valuation methods must
+not silently flip when someone edits a chain.
+
+**It is not a layer, and merging the two would be a mistake.** They are orthogonal partitions of the
+same node set:
+
+| Axis | Means | Example of divergence |
+|---|---|---|
+| `layer` (L1–L5) | position in the supply chain — who sells to whom | L3 holds both ANET (networking hardware) and CEG (merchant power) |
+| `company_type` | which valuation math is correct | those two need entirely different methods despite sharing a layer |
+
+Keeping them separate buys something concrete: **S2's matrix can pivot rows between the two** (§8).
+Rows-by-layer answers "where in the stack is the value"; rows-by-company-type answers "which
+valuation regime is stretched". Same cells, same engine, one more axis — nearly free once the matrix
+exists, and impossible if the axes were merged.
+
+**Editing either axis recalculates the graph — this is a real cascade, not a re-label.** The user's
+observation of 2026-08-10, and it exposes a requirement:
+
+```
+company_type change → valuation method changes → anchors recompute
+                    → valuation_position subscore → composite → S2 cell fill
+```
+
+Therefore `company_type` is an **input to stage 4 and must be inside `inputs_hash`** (I2). Without
+it, changing a ticker's type produces different anchors under an identical hash — the recompute
+looks like a no-op, the stale row survives, and reproducibility is silently broken. Same for the
+active `param_set` (§5.2).
+
+Invalidation rules, mechanical:
+
+| Change | Recompute | Scope |
+|---|---|---|
+| a ticker's `company_type` | stages 3–4 for that ticker; S2 cells containing it | one ticker |
+| add / remove a `company_type` | stages 3–4 for every ticker holding it | affected tickers |
+| any active weight or threshold | stages 3–4 for **all** tickers — `engine_version` moves | whole universe |
+| chain/layer membership | S2 rendering only — S1 is untouched | render |
+
+Only the last is a pure re-render. The first three change persisted numbers, so they append new
+`(ticker, as_of)` rows rather than mutating history; the old rows keep their old `engine_version`
+and stay valid as history under §5.6.
+
+| `company_type` | Method | Anchor basis |
+|---|---|---|
+| `chips_cyclical` | through-cycle EV/Sales with peak/trough margin normalization | cycle-normalized, not spot |
+| `platform_scale` | FCF multiple + segment-weighted sum | segment revenue from UW |
+| `software_growth` | EV/Sales banded by Rule-of-40 score | growth+margin composite |
+| `power_infra` | EV/EBITDA + contracted-backlog floor | asset-heavy, dividend-aware |
+| `high_risk_growth` | revenue multiple band, **mandatory confidence downgrade** | wide bands, stated as wide |
+
+Every method emits the same five anchors — `buy_below / observe_low / observe_mid / observe_high /
+risk_above` — plus base/bear/bull × 1y/3y. **Identical output contract across methods** is what
+makes the type extensible: the card, the schema, and the map read anchors without knowing which
+method produced them.
+
+### 5.4 Confidence — downgrades are mechanical
+
+`confidence ∈ {high, medium, low}`, starting at `high` and downgraded by rule, with every reason
+recorded in `confidence_reasons_jsonb`. Never assigned by judgement.
+
+| Trigger | Downgrade |
+|---|---|
+| < 8 quarters of statements | → `low` |
+| latest filing older than 120 days | one step |
+| `company_type = high_risk_growth` | one step, floor `medium` |
+| any subscore `na` | one step per two `na`s |
+| segment revenue missing | one step |
+
+A `low`-confidence analysis still ships. It ships *labelled*. Suppressing it would hide the
+coverage gap that the label exists to expose.
+
+### 5.5 Extension points
+
+The payoff. To add each thing, touch only the listed seam:
+
+| To add… | Touch | Do NOT touch |
+|---|---|---|
+| a ticker | `fundamental_universe` flag (must intersect the active watchlist) | anything else |
+| a company type | one row in the routing table + one method fn in `valuation_methods.py` | pipeline, schema, UI, prompt |
+| a subscore | one row in the rubric + one pure fn in `scoring.py` | composite logic — weights renormalize |
+| a data source | one fetcher + a `source` value on the row | derive/score/anchor stages |
+| a chain or layer | `watchlist_taxonomy.py` + re-seed `watchlist_chain` | S1 entirely |
+| a provider | a `RUNNERS` registry entry — the lane is already provider-parameterized | everything else |
+| an output field | the Pydantic model + one audit rule | storage — the outcome is JSONB |
+
+### 5.6 Versioning and comparability
+
+`engine_version` is stamped on `fundamental_score_daily` and `valuation_anchors_daily`, and bumps
+on **any** change to weights, rubric, routing, or a method. `inputs_hash` covers the derived inputs.
+Together they answer the only question that matters when the method evolves: *did this score move
+because the company changed, or because I changed the method?*
+
+Cross-version comparison is invalid by default. Rows carrying different `engine_version` values may
+be charted on the same axis only with the version break marked.
+
+## 6. Concentration ledger + edge overlay
+
+An anonymous-counterparty disclosure is a **concentration row, not an edge**. `dst_ticker` is
+`NOT NULL` on edges; the `curated` tier does not exist.
+
+```sql
+CREATE TABLE IF NOT EXISTS uw_scan.fundamental_edges (
+    edge_id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    src_ticker         TEXT NOT NULL,             -- the FILER making the disclosure
+    dst_ticker         TEXT NOT NULL,
+    edge_type          TEXT NOT NULL CHECK (edge_type IN
+                         ('customer','supplier','manufacturer','licensor','distributor','other')),
+    trust_tier         TEXT NOT NULL CHECK (trust_tier IN
+                         ('asc280_named','asc280_inferred','filing_mention')),
+    magnitude_pct      NUMERIC,
+    magnitude_basis    TEXT,
+    identity_inference TEXT,
+    filing_form        TEXT NOT NULL,             -- '10-K' | '20-F'
+    filing_accession   TEXT NOT NULL,             -- lock enforced: no accession, no row
+    filing_date        DATE NOT NULL,
+    fiscal_period      TEXT,
+    excerpt            TEXT NOT NULL,
+    first_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_confirmed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    status             TEXT NOT NULL DEFAULT 'active'
+                         CHECK (status IN ('active','stale','retired')),
+    CONSTRAINT inferred_needs_basis CHECK
+      (trust_tier <> 'asc280_inferred' OR identity_inference IS NOT NULL),
+    UNIQUE (src_ticker, dst_ticker, edge_type)
+);
+```
+
+**Pipeline** — one weekly pass, `edge_graph_refresh`:
+
+1. Per core ticker, `edgartools` pulls the newest **10-K or 20-F** (form chosen from
+   `data.sec.gov` submissions). Section-scoped scan (Item 1 / 1A / 7 + concentration-of-credit-risk
+   note) for concentration language. **Every** hit writes a `customer_concentration` row —
+   including `none_over_10pct` boilerplate, because absence of concentration is signal.
+2. The same sentences are re-scanned for proper-noun counterparties → the rare named hit becomes
+   an `asc280_named` edge. FTS co-mention search adds `filing_mention` candidates.
+3. **Deterministic gate before persist**: `magnitude_pct` must literally appear in `excerpt`, and
+   the accession must resolve. Extraction is regex-first. An LLM may optionally be used *offline in
+   this batch job* to locate ambiguous sentences — that is not the deferred live agent of §10, and
+   it never authors a row the gate did not verify. If regex recall proves adequate at P4, the LLM
+   step is not built at all.
+4. Refresh/expire: re-found in a newer filing → bump `last_confirmed_at`. Absent from the newest
+   same-form filing → `stale`. Stale > 400 days → `retired`. **Never DELETE** — audit trail.
+
+**Ops (runbook line):** every `sec.gov` / `efts.sec.gov` call **must bypass the local proxy** —
+`httpx(trust_env=False)`. Through `127.0.0.1:7897` the TLS handshake fails outright (curl exit 35,
+HTTP 000); DNS resolves fine. This mirrors the documented massive-WS `proxy=None` rule. The
+SEC-required `User-Agent` header (contact email) is mandatory.
+
+**Prompt payload block:**
+
+```json
+"supply_chain": {
+  "as_of": "2026-08-10",
+  "concentration": {
+    "top_customer_pct": 19.0, "basis": "pct_total_revenue", "named": false,
+    "filing": "10-K FY2026, acc 0001045810-26-000029, filed 2026-02-26",
+    "excerpt": "one direct customer accounted for 19% of total revenue...",
+    "trend": [{"period": "FY2025", "top_customer_pct": 13.0},
+              {"period": "FY2026", "top_customer_pct": 19.0}]
+  },
+  "edges_outbound": [],
+  "edges_inbound": [
+    {"counterparty": "ANET", "type": "customer_of_dst_disclosed_by_src",
+     "trust": "asc280_named", "filing": "10-K 2023, acc ...", "excerpt": "..."}
+  ],
+  "coverage_note": "Edges are sparse by construction: US GAAP does not require naming customers. Absence of an edge is NOT evidence of no relationship. KR-domiciled suppliers (Samsung, SK Hynix) file nothing with the SEC and are structurally absent.",
+  "rules": "Cite concentration and edges only by filing reference. trust='asc280_inferred' identities are inference — state as such, never as fact."
+}
+```
+
+The `trend` array carries the alpha: NVDA top-customer concentration rising 13% → 19% across
+fiscal years is a citable, deterministic risk trajectory that needed no graph. The
+`coverage_note` is load-bearing anti-hallucination text — without it the model reads sparse edges
+as "no dependencies".
+
+## 7. S1 — the fundamental card
+
+Every numeric element traces to a persisted row. The narrative block is the only generated content,
+and it renders *below* the numbers, never in place of them.
+
+| Block | Content | Source |
+|---|---|---|
+| composite + subscores | seven bars, each with its inputs on hover | `fundamental_score_daily` |
+| anchor band | spot marked against `buy_below / observe_low / observe_mid / observe_high / risk_above`; base/bear/bull × 1y/3y | `valuation_anchors_daily` |
+| method + confidence | `company_type`, method name, `confidence` and **every reason** | `valuation_anchors_daily.confidence_reasons_jsonb` |
+| target gap | our 1Y anchor vs `uw_positioning.target_avg`, as a number | join on the shipped `uw_positioning` |
+| concentration | top-customer %, multi-year trend, filing citation | `customer_concentration` (P4) |
+| coverage | what is `na` and why — the explicit absence list | `na` propagation from I4 |
+| provenance | `engine_version`, `inputs_hash`, `as_of` per block | every persisted row |
+| **narrative** | `headline` · `thesis` · `price_view` · `target_gap` · `bear_case` · numeric `invalidation` · `monitorables` · `evidence_ledger` · mandatory `unknowns` | stage 5, DeepSeek — Pydantic → `model_json_schema()` → strict function-calling, matching `TradeInsightAiOutcome` |
+| audit verdicts | per-claim `pass / warn / fail / unverifiable` | `fundamental_audit_results` |
+
+The narrative block carries its audit state visibly. A `fail` verdict suppresses the offending claim
+rather than the whole block, and says so — silent suppression would make the audit unfalsifiable to
+the reader.
+
+The coverage block is mandatory, not a footer, and it is computed from `na` propagation rather than
+written by the model. It is the deterministic backstop behind the narrative's `unknowns`: a card
+that renders only what it has, without stating what it lacks, reads as complete when it is partial.
+
+**The card is fully usable with the narrative absent** — model disabled, provider down, or audit
+failed. That is the practical meaning of "the deterministic surfaces never depend on the model".
+
+Confidence reasons render in full rather than collapsing to a badge. "medium because segment
+revenue is missing and the latest filing is 140 days old" is actionable; "medium" is not.
+
+## 8. S2 — `/industry_graph`
+
+**Goal, stated narrowly:** show where in the stack valuation and revenue-concentration risk are
+*clustering*, so attention goes to the right **layer** rather than the loudest **ticker**. S1 can say
+NVDA looks rich; only S2 can say all six L3 infra names are rich at once. Secondary goals: coverage
+(what is unanalysed) and crowding (how concentrated the watchlist's own attention is).
+
+**Form: a layer × chain heatmap, not a node-link diagram.** The name is `/industry_graph`; the v1
+rendering is a matrix.
+
+```
+          GPU  Foundry  Memory  Networking  Power  ...
+  L1  ▓▓▓   ▓▓      ▓▓▓▓      ·        ·
+  L2   ·     ·        ·        ·        ·
+  L3   ·     ·        ·       ▓▓▓      ▓▓▓▓
+  L4   ·     ·        ·        ·        ·
+  ↑ rows are supply-chain depth (L1 upstream → L5 downstream): position carries meaning
+```
+
+Cell = aggregate over that (layer, chain) — median composite, share rich vs cheap, or mean
+top-customer concentration, switchable. Click → the names in that cell → click again → S1.
+
+**Rows pivot between `layer` and `company_type`** (§5.3). By layer: *where in the stack is the
+value*. By company type: *which valuation regime is stretched*. Same cells, same engine, one extra
+axis — available only because the two classifications were kept orthogonal.
+
+**Why a matrix and not a graph.** The test for a visualization is whether *position* encodes
+anything. In a node-link layout of this taxonomy, node position would be decided by a force
+algorithm — arbitrary. In the matrix, row position is supply-chain depth — informative. A node-link
+diagram would also draw lines implying a *measured* supply chain, when the adjacency is a
+hand-authored ontology in `watchlist_taxonomy.py` plus the handful of edges §6 actually found. The
+matrix makes the same structural claim without the false precision, at roughly a fifth of the work.
+
+Every other question the map is asked — cheapest layer, worst concentration trend, what is
+unanalysed — is a `GROUP BY`, not a topology. Only propagation ("if L2 capex stops, what breaks and
+in what order") genuinely needs a graph, and propagation needs edges we do not have.
+
+**Skeleton (dense, exists today).** Measured 2026-08-10 from `watchlist_taxonomy.py`: **220 tickers,
+38 chains, 235 memberships across 7 populated layers** (L1 58 · L2 38 · L3 60 · L4 44 · L5 23 · X 7
+· THM 5), 10 tickers holding multiple chains. Already normalized into `watchlist_chain` by migration
+`113`, indexed in both directions. The structure needs no new ingestion — only the render.
+
+The module enumerates 220 tickers while the table is scoped to the watchlist; the rendered set is
+the **intersection with the active watchlist** (`removed_at IS NULL`), same rule as §4.3.
+
+**Encodings — the reason this is not the existing filter rail.** argon already ships a layer-rail
+chain filter (v0.11.4). Redrawing membership adds nothing. What is new is that every cell is
+computed from S1's engines:
+
+| Encoding | Source | Reads as |
+|---|---|---|
+| cell fill | median `fundamental_score_daily.composite` | research priority (§5 I5 — a sort key, not a forecast) |
+| cell texture | share of names rich vs cheap in the band | is this pocket stretched |
+| corner mark | mean `customer_concentration.top_customer_pct` + trend | revenue-concentration risk |
+| hatched | no S1 rows yet, or all `confidence = low` | not analysed / not trustworthy |
+
+Unanalysed cells render hatched rather than blank. A map that silently drops uncovered names
+misrepresents coverage as completeness.
+
+**Node-link graph: deferred behind a kill criterion.** Build it only if P4's named-edge yield comes
+back materially above the handful measured in §3.3. If it does not, the matrix was always the correct
+artifact and the renderer was never owed.
+
+**Aggregation.** All rollups are computed **read-time from S1 rows** (`reports/industry_graph.py`) —
+no new persisted table, no second scoring path. One engine, two renderings.
+
+## 9. Phases
+
+Two tracks plus a deferred one. S1 P0–P2 gate everything; S2 G1 is independent and can run in
+parallel from day one; the loop harness (§10) starts only after both surfaces are trusted.
+
+Every phase is **ad-hoc triggered** (§5.1). No cron is added until the method stops moving.
+
+### S1 — fundamental card
+
+| Phase | Ships | Gate | Verification |
+|---|---|---|---|
+| **P0** | Commit-bug fix + a test asserting on a **fresh connection** | Own PR — independent prod data-loss bug, deploys ahead of feature work | Mini's `massive_fundamentals` row count > 0 after a manual run |
+| **P1** | massive `/v2` migration (103 fields, full history) + UW segment revenue; registry entries | Scoring over 8 shallow quarters is the weakest possible imitation | NVDA quarters reach the 1990s; FY2026 segment revenue matches the filed 10-K to the dollar |
+| **P2** | `fundamental_score_daily` + `valuation_anchors_daily`; `fundamental_method_params` seeded; company-type routing; confidence downgrades; on-demand refresh endpoint | The method must be fixated before anything renders it | 3 hand-checked tickers reproduce hand-computed anchors; re-run with unchanged inputs is idempotent; **flipping one ticker's `company_type` changes `inputs_hash` and produces new anchors**; editing a weight row moves `engine_version` for every ticker |
+| **P3** | The card's deterministic blocks (§7) — subscores, anchor band, confidence reasons, coverage, provenance | — | Every rendered number resolves to a persisted row; the coverage block lists a real `na` |
+| **P4** | Concentration ledger + sparse edge overlay (§6) | After the card; the concentration block ships empty in P3 | NVDA yields a concentration row with a real accession and multi-year trend; ANET→META exists as the reference `asc280_named` edge; TSM yields a 20-F-sourced row proving the corpus extension |
+| **P5** | Stage 5 narrative — `analysis_kind='fundamental'`, DeepSeek, evidence ledger, staged numeric audit | Needs P3 (numbers to constrain it) and P4 (concentration facts worth citing) | Real worker-path smoke: enqueue from the card → worker claims → narrative renders with audit verdicts persisted; **disabling the provider leaves the card fully usable** |
+
+### S2 — `/industry_graph`
+
+| Phase | Ships | Gate | Verification |
+|---|---|---|---|
+| **G1** | Layer × chain matrix from `watchlist_chain`, cells empty, drill-down to ticker list → S1 | none — skeleton exists, runs parallel to S1 P0–P2 | Cell membership matches `watchlist_chain ∩ active watchlist`; the 10 multi-chain tickers appear in each of their cells |
+| **G2** | Cell encodings from S1 + read-time rollups | needs S1 P2 | A cell's fill equals the median of its members' `fundamental_score_daily`; uncovered cells hatch, never blank |
+| **G3** | Concentration corner marks | needs S1 P4 | Every mark traces to `customer_concentration` rows with real accessions |
+
+**Deferred:** ranked long/short book, congress/13F enrichment, true estimate gap (blocked on gated
+tier), cross-chain flow/weight sizing, node-link graph (kill criterion above).
+
+## 10. The loop harness (pi) — next stage, not this one
+
+The distinction that scopes this spec (user ruling, 2026-08-10):
+
+| | In v1 | Deferred |
+|---|---|---|
+| **Model call** — DeepSeek writes stage 5 prose over fixed numbers | ✅ §5.1 | |
+| **Loop harness** — decides *when* to recompute, re-analyse, re-plot; runs research loops | | ⏭ pi agent |
+
+A provider call inside a job is not an agent. Every stage here is triggered by a human clicking
+"Compute now" or, later, by cron. Nothing forms an intention. What is deferred is the layer that
+does: an external **pi agent** harness driving these jobs on its own schedule and judgement.
+
+**What this spec owes that harness — and already provides:** every stage is a callable job function
+with a `ticker_filter` · every output is a persisted, addressable row · `engine_version` +
+`inputs_hash` make any recompute decision checkable · §5.3's invalidation table tells a harness
+exactly what a change dirties. A harness driving this needs no new argon surface; it needs these
+jobs to be callable and their results durable, which they are by construction.
+
+**What it must not be handed:** write access to `fundamental_method_params`. A harness that can
+retune the weights it is also evaluating closes a loop nobody is watching. Parameter changes stay a
+human action — consistent with argon's invariant that every mutating agent action routes through a
+gate.
+
+**Entry gate — do not start before all three hold:** S1 P4 and S2 G2 are live; the composite has been
+inspected against outcomes for at least one quarter; and the per-subscore `na` rate is known, so
+coverage can be stated honestly rather than plausibly.
+
+This is argon goal-ladder **Stage 2** (self-tending desk). Scoping it here would import a stage-2
+problem into stage-1 work.
+
+## 11. Risks
+
+1. **The method is fixated on unvalidated priors.** The §5.2 weights have no backtest behind them
+   and the spec says so. Holding them in `fundamental_method_params` makes them sweepable and
+   `engine_version` makes a revision auditable; neither makes the current values right. Do not let
+   the composite acquire authority it has not earned.
+   Inherited from the blueprint, which also ships no backtest, hit-rate or P&L. The composite is a
+   **sort key** and must be labelled research priority on every surface — argon's own theta-harvester
+   precedent is correct ordering with a losing selection.
+2. **The concentration ledger is decorative rather than decision-useful.** MED confidence it
+   earns its place. The `trend` array is the specific bet; if concentration trends turn out flat
+   and uninformative across the core 25, P4 should be cut rather than extended.
+3. **S2 duplicates the existing filter rail.** Its defence is that cells carry computed attributes
+   (§8). If G2's encodings turn out to say nothing G1's drill-down list did not, S2 is a
+   `GROUP BY` with a colour ramp. Judge this at G2, before G3 is built.
+4. **The `na` rate makes the method look thinner than it is — or hides how thin it is.** Coverage is
+   rendered, not suppressed (§7), so this is a visible risk rather than a silent one. Measure the
+   per-subscore `na` rate at P2; it is also the harness entry gate (§10).
+5. **Fluent fabrication in the P5 narrative.** Real but bounded: it lands last, over numbers that
+   already exist and are already rendered; the audit stage diffs it; and the card works without it.
+   The `unknowns` field is mandatory, not optional. If audit `fail` rates stay high after prompt
+   iteration, ship the card without the narrative — that was a complete product at P4.
+
+## 12. Open items
+
+- Confirm massive has no segment-revenue endpoint before P1 locks segments to UW
+  (`[INFERRED]` from the capability audit's silence — MED-HIGH, needs a 2-minute live probe).
+- The UW capability audit is dated 2026-05-15 (~3 months stale). The live MCP surface exposes
+  `get_income_statement_screener` / `get_earnings_screener` names absent from local docs —
+  re-probe before assuming either availability or gating.
+- Audit the other `_repo()` consumers for the same no-commit pattern (out of scope here).

--- a/src/uw_scan/worker/jobs/fundamentals_jobs.py
+++ b/src/uw_scan/worker/jobs/fundamentals_jobs.py
@@ -109,8 +109,17 @@ def fundamentals_refresh_once(
                     ),
                     raw_jsonb=r.get("raw"),
                 )
+            # Commit per ticker. _repo() hands us a non-autocommit connection and
+            # closes it without committing, so without this every upsert above was
+            # discarded on close — the job logged success nightly and persisted
+            # nothing. Per-ticker (not once at the end) so one ticker's failure
+            # cannot discard the tickers already done.
+            repo.conn.commit()
             completed += 1
         except Exception as exc:  # noqa: BLE001
+            # Postgres aborts the whole transaction on any error, so without this
+            # rollback every *subsequent* ticker's upsert would fail too.
+            repo.conn.rollback()
             logger.exception(
                 "fundamentals_refresh failed for %s: %s", w.ticker, repr(exc)
             )

--- a/tests/integration/worker/test_fundamentals_job.py
+++ b/tests/integration/worker/test_fundamentals_job.py
@@ -1,11 +1,30 @@
-"""Integration test for fundamentals_refresh_once — real repo + fake provider."""
+"""Integration test for fundamentals_refresh_once — real repo + fake provider.
+
+Persistence assertions go through a **separate connection** (`_fetched_at`). The
+job's own connection is non-autocommit, so reading back on it proves only that
+the statements ran — which is exactly how the job shipped for months while
+committing nothing.
+"""
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
+import psycopg
+
 from uw_scan.worker.jobs.fundamentals_jobs import fundamentals_refresh_once
+
+
+def _fetched_at(settings, ticker: str) -> datetime | None:
+    """Read `fetched_at` over a NEW connection — sees only committed rows."""
+    with psycopg.connect(settings.db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT max(fetched_at) FROM uw_scan.massive_fundamentals "
+            "WHERE ticker = %s",
+            (ticker.upper(),),
+        )
+        return cur.fetchone()[0]
 
 
 class _FakeProvider:
@@ -121,6 +140,72 @@ def test_job_idempotent_on_rerun(seeded_db_empty_cards):
             (target.upper(),),
         )
         assert cur.fetchone()[0] == 5  # still 5, not 10
+
+
+def test_job_commits_visible_from_a_fresh_connection(
+    seeded_db_empty_cards, _migrated_settings
+):
+    """The regression that matters: rows must survive the job's connection.
+
+    A row-count gate would not catch this — production already held 669 rows
+    from another path while the scheduled job committed nothing. Assert that a
+    *freshness delta* crosses the transaction boundary.
+    """
+    repo = seeded_db_empty_cards
+    target = _first_active_ticker(repo)
+    shard = lambda t: t == target  # noqa: E731
+    assert _fetched_at(_migrated_settings, target) is None
+
+    assert fundamentals_refresh_once(repo, _FakeProvider(), ticker_filter=shard) == 1
+    first = _fetched_at(_migrated_settings, target)
+    assert first is not None, "job did not commit — rows died with the connection"
+
+    # `fetched_at=now()` on conflict, so a rerun that commits must ADVANCE it.
+    # Compared against the previous DB value rather than a Python timestamp:
+    # Postgres now() is transaction_timestamp(), pinned to the transaction's
+    # first statement, so it can legitimately predate a wall clock sampled here.
+    assert fundamentals_refresh_once(repo, _FakeProvider(), ticker_filter=shard) == 1
+    second = _fetched_at(_migrated_settings, target)
+    assert second > first
+
+
+def test_one_ticker_failure_keeps_earlier_tickers(
+    seeded_db_empty_cards, _migrated_settings
+):
+    """One ticker's DB error must not discard the tickers already processed."""
+
+    class _FailsOnSecond(_FakeProvider):
+        def __init__(self) -> None:
+            self.seen: list[str] = []
+
+        def fetch_financials(self, ticker, *, timeframe="quarterly", limit=8):
+            self.seen.append(ticker)
+            rows = super().fetch_financials(ticker, limit=limit)
+            if len(self.seen) == 2:
+                # Must fail SERVER-side, inside the upsert, so the transaction
+                # is left aborted — that is the state the rollback clears.
+                # `total_assets` is chosen deliberately: it is passed straight
+                # through to the numeric column and never enters a Python
+                # computation, so the bad value survives to the DB. Corrupting
+                # `revenue` instead raises TypeError in the margin division
+                # before any statement is sent, which tests nothing.
+                rows[0] = {**rows[0], "total_assets": "not-a-number"}
+            return rows
+
+    repo = seeded_db_empty_cards
+    tickers = [w.ticker for w in repo.list_active_watchlist()][:3]
+    assert len(tickers) == 3
+
+    provider = _FailsOnSecond()
+    completed = fundamentals_refresh_once(
+        repo, provider, ticker_filter=lambda t: t in tickers
+    )
+
+    # the failing ticker is skipped, the other two persist
+    assert completed == 2
+    assert _fetched_at(_migrated_settings, provider.seen[0]) is not None
+    assert _fetched_at(_migrated_settings, provider.seen[1]) is None
+    assert _fetched_at(_migrated_settings, provider.seen[2]) is not None
 
 
 def test_job_no_provider_is_noop(seeded_db_empty_cards):


### PR DESCRIPTION
## The bug

`fundamentals_refresh` has run nightly since migration `066`, logged
`"fundamentals_refresh refreshed %d tickers"` every time, and **never persisted a row**.

`_repo()` opens a psycopg connection with the default `autocommit=False` and closes it in
`finally` without committing; neither `worker/jobs/fundamentals_jobs.py` nor
`storage/fundamentals.py` called `.commit()`. Every upsert was discarded on close. The sibling
`positioning_refresh_once` survives only because `insert_scan_run`/`finish_scan_run` commit
internally on the same connection — fundamentals had no such accident.

Measured on the mini: `massive_fundamentals` holds **669 rows across 86 tickers, latest
`fetched_at` 2026-06-01**. Those arrived through some other historical path; the scheduled job
has contributed nothing.

A second bug was latent behind the first: Postgres aborts the whole transaction on any error, so
one bad ticker made every *subsequent* ticker fail with `InFailedSqlTransaction`. With nothing
ever committing, that cascade had nothing to lose. The fix commits **per successful ticker** and
rolls back on failure, so neither failure mode remains.

## Why the existing test passed

It asserted on the job's **own still-open connection**, which sees uncommitted rows. Assertions
now go through a separately opened connection, and the new gate is a **freshness delta** rather
than a row count — a count gate would have passed on production's pre-existing 669 rows *without
the bug being fixed*.

Both halves verified load-bearing by removing each and re-running:

| Removed | Failing test |
|---|---|
| `commit()` | `test_job_commits_visible_from_a_fresh_connection` |
| `rollback()` | `test_one_ticker_failure_keeps_earlier_tickers` (`InFailedSqlTransaction`) |

## Also in this PR

The design spec that found the bug: `docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md`
— a fixated, extensible fundamental-analysis method plus the two surfaces that render it
(`/stock/{ticker}` card, `/industry_graph` heatmap). **Status DRAFT**; it is documentation, nothing
in it is implemented here beyond P0. Five revisions across four review rounds, with the
load-bearing corrections recorded inline, including two live-probed findings:

- massive `/v2` is **frozen at 2020-Q1**; `/vX` is the live endpoint. The first draft picked the
  frozen one for its field count.
- massive covers only **23 of the core 25** — TSM and ASML return zero `/vX` rows because they are
  20-F filers and massive derives from domestic SEC XBRL. The same structural fact independently
  breaks EDGAR-based supply-chain edges.

## Verification

- `tests/integration/worker/` — **146 passed, 2 skipped**
- `ruff check` / `ruff format --check` clean
- CI Guardrail 2 satisfied (`logger.exception` + `repr(exc)` in the handler)

## Notes for reviewers of the test

- The failure injection targets `total_assets` because it passes straight through to the numeric
  column. Corrupting `revenue` instead raises `TypeError` in the margin division *before any
  statement is sent*, which tests nothing.
- Freshness is compared against the previous **DB** value, not a Python timestamp: Postgres `now()`
  is `transaction_timestamp()`, pinned to the transaction's first statement, so it can legitimately
  predate a wall clock sampled in the test.