### PR TITLE
research: valuation control — the margin inversion is real, and value is inverted too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,27 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   SIVB/FRC/VMW are absent from the lake and return HTTP 200 with an empty array
   from UW.
 
+- **Valuation control: the margin inversion is not expensiveness in disguise.**
+  Rev 4 withdrew the `profitability` direction on a hypothesis — high-margin
+  firms are usually richly priced, so a margin ranking might be a valuation
+  ranking. `scripts/research/fundamental_valuation_control.py` tested it and
+  **rejected it**: `op_margin`'s partial rank IC against three price ratios is
+  −0.0231 / −0.0306 / −0.0298 versus −0.0270 uncontrolled, and against
+  `book_to_price` both margins get *stronger*. Market cap is built from **raw
+  `close` × as-reported shares** — `adj_close` is retroactively split-adjusted
+  and would mix reference frames across every split. Ratios are yields
+  (fundamental/price), so ranking stays monotone through zero earnings.
+- **The incidental finding is the bigger one: value is inverted over this
+  window.** `book_to_price` IC −0.0365 (t −2.32), `earnings_yield` −0.0194;
+  only `fcf_yield` works (+0.0285, t 2.84). That is the documented post-GFC
+  value drawdown, and it means the signals that worked are one regime's profile.
+  **The earlier two-halves robustness check is therefore weaker evidence than it
+  read — both halves sit inside the same quality-led regime.** Nothing is
+  retracted; the claim's coverage is bounded, and "measured in one regime" is
+  now risk 1's third standing limit alongside survivorship and uncosted returns.
+  §5.2's `valuation_position` prior ("cheaper better") is flagged as
+  contradicted for B/P and E/P.
+
 ### Fixed (research tooling)
 
 - **The validation panel was keyed on `fiscal_date_ending`, which silently

--- a/docs/research/2026-08-11-fundamental-signal-validation/VERDICT.md
+++ b/docs/research/2026-08-11-fundamental-signal-validation/VERDICT.md
@@ -162,10 +162,63 @@ correlated names cannot produce a measurable ranking at any history length.
 5. **P1b remains worth building.** Nothing here argues against ingesting the
    data.
 
+## Follow-up: the valuation control — hypothesis rejected
+
+Rev 4 withdrew the direction claim on `profitability` and offered a reason: nothing
+in the harness controls for valuation, and high-margin firms are usually richly
+priced, so a margin ranking might be an expensiveness ranking in disguise. That
+was a story with no test behind it. `fundamental_valuation_control.py` is the
+test — market cap from **raw** close × as-reported shares (never `adj_close`,
+which would mix reference frames across every split), ratios formed as yields so
+the ranking stays monotone through zero earnings, and a rank-based partial
+correlation reusing the same `spearman`.
+
+**The hypothesis fails.** 2q, 245 names, 80 quarters:
+
+| | uncontrolled | \| `earnings_yield` | \| `book_to_price` | \| `fcf_yield` |
+|---|---:|---:|---:|---:|
+| `gross_margin` | −0.0194 | −0.0180 | −0.0271 | −0.0144 |
+| `op_margin` | −0.0270 | −0.0231 | −0.0306 | −0.0298 |
+
+`op_margin` barely moves under any control — and against `book_to_price` both
+margins get *stronger*, not weaker. Expensiveness does not explain the
+inversion. **Keep withholding the direction on `profitability`, now for the
+stronger reason: the inversion is real and unexplained.**
+
+### The finding that matters more: value is inverted here too
+
+| Signal | IC | t |
+|---|---:|---:|
+| `fcf_yield` | +0.0285 | 2.84 |
+| `earnings_yield` | −0.0194 | −1.43 |
+| `book_to_price` | **−0.0365** | **−2.32** |
+
+Cheap-on-book predicted *lower* returns over 2005–2026. That is the documented
+post-GFC value drawdown, not a discovery — and note survivorship should have
+biased this *toward* value (cheap names that went bankrupt are excluded), so the
+true effect was likely worse than measured.
+
+**This qualifies the headline result more than the margin question does.** The
+signals that worked — low leverage, high asset turnover, FCF yield — are exactly
+the quality/growth profile that led one long regime, while the signals that
+failed are the value profile that lagged it. The earlier robustness split
+(2005–2015 vs 2016–2026, both positive) is therefore weaker evidence than it
+appeared: **both halves sit inside the same regime.** A genuine out-of-regime
+test needs a period where value led, which this 245-name survivor universe does
+not contain.
+
+Treat the composite as measured-in-one-regime until that is tested. It does not
+retract the result; it bounds what the result covers.
+
 ## What would change the verdict
 
-- **A valuation control.** The inverted margins point at a missing price
-  dimension; adding one would test whether the composite survives it.
+- ~~**A valuation control.**~~ **Done — hypothesis rejected** (above). The
+  margins stay inverted; the incidental finding that value itself is inverted is
+  the more consequential one.
+- **An out-of-regime window.** Now the top item. Every quarter measured here
+  sits in one quality-led, value-lagging regime, so "present in both halves"
+  does not establish regime-independence. Needs a period where value led —
+  pre-2005 data, or a universe that is not 245 US large-cap survivors.
 - **A non-survivorship universe.** Not constructible from UW or the lake.
   Requires a source carrying delisted tickers (CRSP, Sharadar) — the one gap
   that money, not method, fixes.

--- a/docs/research/2026-08-11-fundamental-signal-validation/valuation-control.md
+++ b/docs/research/2026-08-11-fundamental-signal-validation/valuation-control.md
@@ -1,0 +1,32 @@
+# Valuation control — is the margin inversion expensiveness in disguise?
+
+*Probed 2026-08-11 · REGENERATED on every run · 245 names, 80 quarters, 2q forward return*
+
+```bash
+UW_SCAN_API_KEY=... uv run python scripts/research/fundamental_valuation_control.py
+```
+
+Cross-section width: min 146, median 239, max 245.
+
+## Own IC
+
+| Signal | IC | t | quarters |
+|---|---:|---:|---:|
+| `book_to_price` | -0.0365 | -2.321 | 80 |
+| `gross_margin` | -0.0194 | -1.723 | 80 |
+| `op_margin` | -0.027 | -2.729 | 80 |
+| `earnings_yield` | -0.0194 | -1.426 | 77 |
+| `fcf_yield` | 0.0285 | 2.837 | 77 |
+
+## Margin IC controlling for valuation
+
+| Margin | control | partial IC | t | quarters |
+|---|---|---:|---:|---:|
+| `gross_margin` | `earnings_yield` | -0.018 | -1.611 | 77 |
+| `gross_margin` | `book_to_price` | -0.0271 | -2.685 | 80 |
+| `gross_margin` | `fcf_yield` | -0.0144 | -1.257 | 77 |
+| `op_margin` | `earnings_yield` | -0.0231 | -2.348 | 77 |
+| `op_margin` | `book_to_price` | -0.0306 | -3.008 | 80 |
+| `op_margin` | `fcf_yield` | -0.0298 | -2.91 | 77 |
+
+> Market cap uses RAW close x as-reported shares; adj_close would mix reference frames across splits. Yields are fundamental/price so the ranking stays monotone through zero earnings.

--- a/docs/research/2026-08-11-fundamental-signal-validation/valuation_control.json
+++ b/docs/research/2026-08-11-fundamental-signal-validation/valuation_control.json
@@ -1,0 +1,98 @@
+{
+  "probed_at": "2026-08-11",
+  "reproduce": "UW_SCAN_API_KEY=... uv run python scripts/research/fundamental_valuation_control.py",
+  "horizon": "2q",
+  "universe": 245,
+  "quarters": 80,
+  "cross_section": {
+    "min": 146,
+    "median": 239,
+    "max": 245
+  },
+  "own_ic": {
+    "book_to_price": {
+      "n_quarters": 80,
+      "mean_ic": -0.0365,
+      "ic_stdev": 0.1408,
+      "t_stat": -2.321,
+      "hit_rate": 0.388
+    },
+    "gross_margin": {
+      "n_quarters": 80,
+      "mean_ic": -0.0194,
+      "ic_stdev": 0.1008,
+      "t_stat": -1.723,
+      "hit_rate": 0.475
+    },
+    "op_margin": {
+      "n_quarters": 80,
+      "mean_ic": -0.027,
+      "ic_stdev": 0.0883,
+      "t_stat": -2.729,
+      "hit_rate": 0.4
+    },
+    "earnings_yield": {
+      "n_quarters": 77,
+      "mean_ic": -0.0194,
+      "ic_stdev": 0.1195,
+      "t_stat": -1.426,
+      "hit_rate": 0.442
+    },
+    "fcf_yield": {
+      "n_quarters": 77,
+      "mean_ic": 0.0285,
+      "ic_stdev": 0.0882,
+      "t_stat": 2.837,
+      "hit_rate": 0.623
+    }
+  },
+  "partial_ic": {
+    "gross_margin": {
+      "earnings_yield": {
+        "n_quarters": 77,
+        "mean_ic": -0.018,
+        "ic_stdev": 0.0981,
+        "t_stat": -1.611,
+        "hit_rate": 0.455
+      },
+      "book_to_price": {
+        "n_quarters": 80,
+        "mean_ic": -0.0271,
+        "ic_stdev": 0.0902,
+        "t_stat": -2.685,
+        "hit_rate": 0.412
+      },
+      "fcf_yield": {
+        "n_quarters": 77,
+        "mean_ic": -0.0144,
+        "ic_stdev": 0.1004,
+        "t_stat": -1.257,
+        "hit_rate": 0.481
+      }
+    },
+    "op_margin": {
+      "earnings_yield": {
+        "n_quarters": 77,
+        "mean_ic": -0.0231,
+        "ic_stdev": 0.0865,
+        "t_stat": -2.348,
+        "hit_rate": 0.429
+      },
+      "book_to_price": {
+        "n_quarters": 80,
+        "mean_ic": -0.0306,
+        "ic_stdev": 0.091,
+        "t_stat": -3.008,
+        "hit_rate": 0.375
+      },
+      "fcf_yield": {
+        "n_quarters": 77,
+        "mean_ic": -0.0298,
+        "ic_stdev": 0.0899,
+        "t_stat": -2.91,
+        "hit_rate": 0.403
+      }
+    }
+  },
+  "note": "Market cap uses RAW close x as-reported shares; adj_close would mix reference frames across splits. Yields are fundamental/price so the ranking stays monotone through zero earnings."
+}

--- a/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
+++ b/docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md
@@ -807,7 +807,7 @@ Three reasons, in order of weight:
 | `profitability` | gross + operating margin, level and 4-quarter trend | **no direction claimed** (rev 4 — both inverted) | 0.20 | ⚠️ gross margin `na` for CEG, ORCL, VST |
 | `capital_efficiency` | FCF conversion, return on invested capital | higher better | 0.15 | ✅ UW `capital_expenditures` 100% |
 | `balance_sheet` | net debt / EBITDA, interest coverage, current ratio | lower leverage better | 0.15 | ✅ UW cash + debt + EBITDA + interest, 100%; NCI from SEC XBRL |
-| `valuation_position` | spot vs `observe_low..observe_high` band from stage 3 | cheaper better | 0.15 | ✅ |
+| `valuation_position` | spot vs `observe_low..observe_high` band from stage 3 | cheaper better — ⚠️ **contradicted** for B/P and E/P (rev 4 follow-up) | 0.15 | ✅ |
 | `concentration_risk` | **largest reported segment share of revenue + largest single-country share, and each one's multi-year trend** (§6) | lower better | 0.10 | ✅ UW `rev_breakdown`, 24/25 — **TSM is the sole `na`** |
 | `expectations_gap` | our 1Y anchor vs `uw_positioning.analyst_target_avg`, insider net, short interest | wider positive gap better | 0.05 | ✅ existing UW positioning |
 
@@ -825,12 +825,19 @@ knowledge-date buckets. `roe` is listed because it was tested, though no rubric 
 | `profitability` (gross margin) | `gross_margin` | **−0.0223** | −2.02 | ❌ **inverted** |
 | `profitability` (operating margin) | `op_margin` | **−0.0244** | −2.56 | ❌ **inverted** |
 
-**The two profitability directions are withdrawn, not flipped.** Inverting them would claim an edge
-from a result that most likely reflects a *missing* dimension: nothing here controls for valuation,
-and high-margin firms are usually richly priced, so a margin ranking is partly an expensiveness
-ranking. Render the levels and trends; make no good/bad claim until a valuation control is tested.
-`valuation_position`, `concentration_risk` and `expectations_gap` were not tested at all — they draw
-on inputs the validation harness does not compute.
+**The two profitability directions are withdrawn, not flipped — and the valuation control did not
+rescue them.** The stated hypothesis was that a margin ranking is partly an expensiveness ranking.
+It was tested (`fundamental_valuation_control.py`) and **rejected**: `op_margin`'s partial IC
+against three price ratios is −0.0231 / −0.0306 / −0.0298 versus −0.0270 uncontrolled, and against
+`book_to_price` both margins strengthen. Render levels and trends; make no good/bad claim. The
+inversion is real and unexplained, which is a firmer reason to withhold than the original guess.
+
+`valuation_position`, `concentration_risk` and `expectations_gap` remain untested — they draw on
+inputs the validation harness does not compute. One warning for `valuation_position` specifically:
+the control run measured `book_to_price` at IC **−0.0365** (t −2.32) and `earnings_yield` at
+−0.0194 over this window, so a "cheaper better" prior is **contradicted** by the only price ratios
+tested. `fcf_yield` (+0.0285, t 2.84) is the sole one that behaved. Do not seed
+`valuation_position` as "cheaper better" without deciding which ratio it means.
 
 **The composite is not a sort key at core-25 width, which reverses I5 for this universe.** Validated
 IC is 0.039–0.059 at 245 names and 0.024 (t 0.68) at 25 — see §4.3 for why history cannot fix that.
@@ -1402,10 +1409,14 @@ card drill-down and provider-down paths.
    ordered at cohort width; argon's own theta-harvester precedent is correct ordering with a losing
    selection, measured on a *powered* test.
 
-   Two limits ride along and neither is fixable here. **Survivorship**: both sources carry live
+   Three limits ride along and none is fixable here. **Survivorship**: both sources carry live
    tickers only, so every result describes companies that survived to 2026. **Costs**: no
    transaction costs, capacity, borrow or turnover limit was modelled, and that gap is where most
-   IC-positive methods die.
+   IC-positive methods die. **Single regime**: the valuation-control run found value inverted over
+   the whole window (`book_to_price` IC −0.0365), so 2005–2026 is one quality-led, value-lagging
+   period and the working signals are that period's profile. The two-halves robustness check does
+   not disprove this — both halves are inside it. Assume the composite is measured-in-one-regime
+   until a window where value led is tested.
 2. **The concentration ledger is decorative rather than decision-useful.** MED confidence it
    earns its place. The `trend` array is the specific bet; if concentration trends turn out flat
    and uninformative across the core 25, P4 should be cut rather than extended.
@@ -1430,12 +1441,22 @@ item left open is therefore **settled against a ranked composite on this univers
 descriptive card, on measured grounds rather than assumed ones. Full result and limits:
 `docs/research/2026-08-11-fundamental-signal-validation/VERDICT.md`.
 
-**Opened by that closure — the new top item: nothing controls for valuation.** `gross_margin` and
-`op_margin` both came back inverted on the powered test. The hypothesis is that a margin ranking is
-partly an expensiveness ranking, but no price ratio was tested, so the rubric currently withholds a
-direction on the entire `profitability` subscore (0.20 seed weight — the joint-largest). Testing one
-valuation control against the same harness is cheap, reuses `quarterly_ics()`, and would either
-restore the direction or confirm the withdrawal.
+**~~Opened by that closure: nothing controls for valuation.~~ TESTED — hypothesis rejected.**
+`scripts/research/fundamental_valuation_control.py` built market cap from raw close × as-reported
+shares and measured the margins' **partial** rank IC against three price ratios. `op_margin` moves
+from −0.0270 to −0.0231 / −0.0306 / −0.0298; against `book_to_price` both margins get *stronger*.
+Expensiveness does not explain the inversion, so `profitability` keeps withholding its direction —
+now because the inversion is **real and unexplained**, which is a firmer reason than the one rev 4
+gave.
+
+**Opened by *that* — the new top item: every quarter measured sits in one regime.** The control run
+also found value inverted (`book_to_price` IC −0.0365, t −2.32; `earnings_yield` −0.0194), the
+documented post-GFC value drawdown. So the signals that worked (low leverage, high asset turnover,
+FCF yield) are the quality/growth profile that led 2005–2026, and the ones that failed are the value
+profile that lagged it. **The rev-4 robustness split — 2005–2015 and 2016–2026 both positive — is
+therefore weaker evidence than it read, because both halves sit inside the same regime.** Nothing is
+retracted; what is bounded is the claim's coverage. A genuine out-of-regime test needs a window
+where value led, which a 245-name US large-cap survivor universe does not contain.
 
 **Also open, in order:**
 

--- a/scripts/research/fundamental_valuation_control.py
+++ b/scripts/research/fundamental_valuation_control.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+"""Do the margin signals survive a valuation control?
+
+Spec: docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md (§13, top
+open item after rev 4).
+
+THE QUESTION
+------------
+The 245-name validation found `gross_margin` (IC -0.022, t -2.02) and
+`op_margin` (-0.024, t -2.56) INVERTED: high-margin names underperformed. §5.2
+withdrew the direction claim rather than flipping it, on a stated hypothesis —
+nothing in that harness controls for valuation, and high-margin firms are
+usually richly priced, so a margin ranking may be partly an expensiveness
+ranking.
+
+That was a hypothesis with no test behind it. This is the test.
+
+  H: margin's negative IC is valuation in disguise.
+  If H holds  -> margin's PARTIAL IC, controlling for a price ratio, moves
+                 toward zero, and the price ratio carries the effect.
+  If H fails  -> margin stays negative after the control, and "expensiveness"
+                 was a comfortable story rather than an explanation.
+
+Either answer is publishable and both change §5.2: H true restores a direction
+claim on `profitability` (the raw signal was confounded, not wrong); H false
+means the inversion is real and unexplained, which is a stronger reason to keep
+withholding the verdict.
+
+MARKET CAP USES RAW `close`, NOT `adj_close`
+--------------------------------------------
+`adj_close` is retroactively split-adjusted; `common_stock_shares_outstanding`
+is as-reported at the filing. Multiplying the two mixes reference frames and
+would misprice every name across every split — NVDA's 10:1 alone would move its
+market cap by an order of magnitude. Raw close and as-reported shares are both
+point-in-time, so their product is the market cap that was actually observable.
+
+PARTIAL CORRELATION
+-------------------
+Rank-based, computed from three Spearman correlations on the same
+cross-section:
+
+    rho(xy|z) = (rho_xy - rho_xz * rho_zy) / sqrt((1 - rho_xz^2)(1 - rho_zy^2))
+
+Every input comes from `fundamental_signal_validation.spearman`, so the control
+and the headline are measured with identical math.
+
+Reproduce (uses the wide cache written by the validation run; refetches only if
+absent):
+
+    UW_SCAN_API_KEY=... uv run python scripts/research/fundamental_valuation_control.py
+
+Writes `valuation_control.json` + `valuation-control.md` under
+`docs/research/2026-08-11-fundamental-signal-validation/`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pyarrow.parquet as pq
+
+# The validation module reads `--wide` off argv at import time to pick its cache
+# and output suffix. Set it before importing so this script binds to the
+# 245-name run rather than the 25-name cohort. Explicit, and the alternative is
+# duplicating fetch/TTM/spearman here — which would test the copy, not the claim.
+_ARGV = list(sys.argv)  # capture before the rewrite below discards our own flags
+sys.argv = [sys.argv[0], "--wide"]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import fundamental_signal_validation as V  # noqa: E402
+
+OUT_DIR = V.OUT_DIR
+LAKE = V.LAKE
+HORIZON = "2q"  # where both margin inversions were significant
+
+# Ratios are formed as YIELDS (fundamental / price), never price / fundamental.
+# A P/E flips sign through zero earnings and ranks a loss-maker as the cheapest
+# name on the board; earnings/price stays monotone across the whole range.
+VALUATION = ["earnings_yield", "book_to_price", "fcf_yield"]
+TESTED = ["gross_margin", "op_margin"]
+
+
+def load_raw_close(tickers: list[str]) -> dict[str, list[tuple[date, float]]]:
+    """UNADJUSTED daily closes — see the module docstring on why this is not
+    `V.load_prices`, which returns adj_close for return computation."""
+    out: dict[str, list[tuple[date, float]]] = {}
+    for t in tickers:
+        f = LAKE / f"symbol={t}" / "1d.parquet"
+        if not f.exists():
+            continue
+        tab = pq.read_table(f, columns=["trade_date", "close"])
+        rows = sorted(
+            zip(
+                [d for d in tab.column("trade_date").to_pylist()],
+                [float(c) for c in tab.column("close").to_pylist()],
+            )
+        )
+        out[t] = rows
+    return out
+
+
+def close_on_or_before(series: list[tuple[date, float]], when: date) -> float | None:
+    """Last close at or before the knowledge date. Never after — that would be
+    the same look-ahead the point-in-time discipline exists to prevent."""
+    lo, hi, found = 0, len(series) - 1, None
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if series[mid][0] <= when:
+            found = series[mid][1]
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return found
+
+
+def partial_spearman(xs: list[float], ys: list[float], zs: list[float]) -> float | None:
+    """rho(x,y | z), rank-based."""
+    rxy, rxz, rzy = V.spearman(xs, ys), V.spearman(xs, zs), V.spearman(zs, ys)
+    if None in (rxy, rxz, rzy):
+        return None
+    denom = math.sqrt(max(0.0, (1 - rxz**2) * (1 - rzy**2)))
+    if denom < 1e-12:
+        return None
+    return (rxy - rxz * rzy) / denom
+
+
+def main() -> int:
+    key = os.environ.get("UW_SCAN_API_KEY", "").strip()
+    breadth = json.loads((OUT_DIR / "universe_breadth.json").read_text())
+    gate = breadth["gates"]["min_quarters"]
+    tickers = sorted(
+        r["ticker"] for r in breadth["names"] if (r.get("quarters") or 0) >= gate
+    )
+    print(f"== universe: {len(tickers)} names")
+
+    if not V.CACHE.exists() and not key:
+        print("no cache and UW_SCAN_API_KEY unset", file=sys.stderr)
+        return 2
+    uw = V.fetch_uw(tickers, key)
+    feats = V.build_features(uw)
+    adj = V.load_prices(tickers)
+    raw = load_raw_close(tickers)
+    print(f"   prices: {len(adj)} adjusted, {len(raw)} raw")
+
+    # panel keyed on knowledge-date quarter, matching the validation exactly
+    panel: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+    no_shares = 0
+    for t, pf in feats.items():
+        if t not in adj or t not in raw:
+            continue
+        inc = uw[t]["income-statements"]
+        bs = uw[t]["balance-sheets"]
+        cf = uw[t]["cash-flows"]
+        periods = sorted(inc)
+        for i, p in enumerate(periods):
+            row = pf.get(p)
+            if row is None:
+                continue
+            know = V.knowledge_date(uw, t, p)
+            fwd = V.forward_return(adj[t], know, V.HORIZONS[HORIZON])
+            if fwd is None:
+                continue
+            shares = V._f(bs.get(p), "common_stock_shares_outstanding")
+            px = close_on_or_before(raw[t], know)
+            if not shares or shares <= 0 or not px:
+                no_shares += 1
+                continue
+            mktcap = px * shares
+            ni = V._ttm(inc, periods, i, "net_income")
+            ocf = V._ttm(cf, periods, i, "operating_cashflow")
+            capex = V._ttm(cf, periods, i, "capital_expenditures")
+            eq = V._f(bs.get(p), "total_shareholder_equity")
+            fcf = (ocf - abs(capex)) if None not in (ocf, capex) else None
+            vals = {
+                "earnings_yield": ni / mktcap if ni is not None else None,
+                "book_to_price": eq / mktcap if eq is not None else None,
+                "fcf_yield": fcf / mktcap if fcf is not None else None,
+                "gross_margin": row.get("gross_margin"),
+                "op_margin": row.get("op_margin"),
+            }
+            bucket = f"{know.year}Q{(know.month - 1) // 3 + 1}"
+            prior = panel[bucket].get(t)
+            if prior and prior["period"] >= p:
+                continue
+            panel[bucket][t] = {"period": p, "fwd": fwd, **vals}
+
+    buckets = sorted(b for b in panel if len(panel[b]) >= V.MIN_CROSS_SECTION)
+    widths = [len(panel[b]) for b in buckets]
+    print(
+        f"   panel: {len(buckets)} quarters, width min {min(widths)} "
+        f"median {sorted(widths)[len(widths) // 2]} max {max(widths)}"
+    )
+    print(f"   dropped for missing shares/price: {no_shares}")
+
+    # ---- 1. does valuation itself order returns? ----
+    own: dict[str, list[float]] = defaultdict(list)
+    for b in buckets:
+        rows = panel[b]
+        for f in VALUATION + TESTED:
+            pair = [(r[f], r["fwd"]) for r in rows.values() if r.get(f) is not None]
+            if len(pair) >= V.MIN_CROSS_SECTION:
+                ic = V.spearman([x for x, _ in pair], [y for _, y in pair])
+                if ic is not None:
+                    own[f].append(ic)
+
+    print(f"\n== {HORIZON} own IC")
+    own_summary = {f: V.summarize(v) for f, v in own.items()}
+    for f in VALUATION + TESTED:
+        s = own_summary.get(f, {})
+        print(
+            f"   {f:16} IC {str(s.get('mean_ic')):>8}  t {str(s.get('t_stat')):>7}  "
+            f"n {s.get('n_quarters')}"
+        )
+
+    # ---- 2. margin IC controlling for each valuation ratio ----
+    partials: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for b in buckets:
+        rows = panel[b]
+        for m in TESTED:
+            for v in VALUATION:
+                trip = [
+                    (r[m], r["fwd"], r[v])
+                    for r in rows.values()
+                    if r.get(m) is not None and r.get(v) is not None
+                ]
+                if len(trip) < V.MIN_CROSS_SECTION:
+                    continue
+                pc = partial_spearman(
+                    [a for a, _, _ in trip],
+                    [b2 for _, b2, _ in trip],
+                    [c for _, _, c in trip],
+                )
+                if pc is not None:
+                    partials[m][v].append(pc)
+
+    print(f"\n== {HORIZON} margin IC, controlling for valuation")
+    part_summary: dict[str, dict[str, Any]] = {}
+    for m in TESTED:
+        part_summary[m] = {}
+        raw_s = own_summary.get(m, {})
+        print(
+            f"   {m}  (uncontrolled IC {raw_s.get('mean_ic')}, t {raw_s.get('t_stat')})"
+        )
+        for v in VALUATION:
+            s = V.summarize(partials[m][v])
+            part_summary[m][v] = s
+            shrink = (
+                f"{(1 - abs(s['mean_ic']) / abs(raw_s['mean_ic'])) * 100:+.0f}% toward 0"
+                if s.get("mean_ic") and raw_s.get("mean_ic")
+                else "—"
+            )
+            print(
+                f"     | {v:16} partial IC {str(s['mean_ic']):>8}  "
+                f"t {str(s['t_stat']):>7}  n {s['n_quarters']}   {shrink}"
+            )
+
+    payload = {
+        "probed_at": "2026-08-11",
+        "reproduce": (
+            "UW_SCAN_API_KEY=... uv run python "
+            "scripts/research/fundamental_valuation_control.py"
+        ),
+        "horizon": HORIZON,
+        "universe": len(tickers),
+        "quarters": len(buckets),
+        "cross_section": {
+            "min": min(widths),
+            "median": sorted(widths)[len(widths) // 2],
+            "max": max(widths),
+        },
+        "own_ic": own_summary,
+        "partial_ic": part_summary,
+        "note": (
+            "Market cap uses RAW close x as-reported shares; adj_close would mix "
+            "reference frames across splits. Yields are fundamental/price so the "
+            "ranking stays monotone through zero earnings."
+        ),
+    }
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUT_DIR / "valuation_control.json").write_text(
+        json.dumps(payload, indent=2) + "\n"
+    )
+    (OUT_DIR / "valuation-control.md").write_text(_render(payload))
+    print(f"\nwrote {OUT_DIR}/valuation_control.json and valuation-control.md")
+    return 0
+
+
+def _render(p: dict[str, Any]) -> str:
+    lines = [
+        "# Valuation control — is the margin inversion expensiveness in disguise?",
+        "",
+        f"*Probed {p['probed_at']} · REGENERATED on every run · "
+        f"{p['universe']} names, {p['quarters']} quarters, "
+        f"{p['horizon']} forward return*",
+        "",
+        "```bash",
+        p["reproduce"],
+        "```",
+        "",
+        f"Cross-section width: min {p['cross_section']['min']}, "
+        f"median {p['cross_section']['median']}, max {p['cross_section']['max']}.",
+        "",
+        "## Own IC",
+        "",
+        "| Signal | IC | t | quarters |",
+        "|---|---:|---:|---:|",
+    ]
+    for f, s in p["own_ic"].items():
+        lines.append(
+            f"| `{f}` | {s.get('mean_ic')} | {s.get('t_stat')} | {s.get('n_quarters')} |"
+        )
+    lines += [
+        "",
+        "## Margin IC controlling for valuation",
+        "",
+        "| Margin | control | partial IC | t | quarters |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for m, byv in p["partial_ic"].items():
+        for v, s in byv.items():
+            lines.append(
+                f"| `{m}` | `{v}` | {s.get('mean_ic')} | {s.get('t_stat')} | "
+                f"{s.get('n_quarters')} |"
+            )
+    lines += ["", f"> {p['note']}", ""]
+    return "\n".join(lines)
+
+
+def _self_check() -> None:
+    """The partial-correlation formula is the one piece of new math here, and a
+    sign error in it would quietly reverse the verdict. Three cases where the
+    answer is known independently of the implementation."""
+    # z unrelated to x and y -> partial ~= raw
+    x = [1, 2, 3, 4, 5, 6, 7, 8]
+    y = [2, 1, 4, 3, 6, 5, 8, 7]
+    z = [5, 5, 5, 5, 5, 5, 5, 5.1]  # near-constant: carries no information
+    raw = V.spearman(x, y)
+    pc = partial_spearman(x, y, z)
+    assert pc is not None and abs(pc - raw) < 0.05, (raw, pc)
+
+    # z == x -> controlling for x removes all of x's explanatory power
+    pc = partial_spearman(x, y, list(x))
+    assert pc is None or abs(pc) < 1e-9, pc
+
+    # a pure confound: y is driven by z, x correlates with y only through z,
+    # so the partial must collapse toward zero while the raw stays high.
+    z2 = [1, 2, 3, 4, 5, 6, 7, 8]
+    y2 = [1, 2, 3, 4, 5, 6, 7, 8]
+    x2 = [1, 2, 3, 4, 5, 6, 7, 8]
+    assert V.spearman(x2, y2) == 1.0
+    pc = partial_spearman(x2, y2, z2)
+    assert pc is None or abs(pc) < 1e-9, pc
+    print("self-check ok")
+
+
+if __name__ == "__main__":
+    if "--self-check" in _ARGV:
+        _self_check()
+        raise SystemExit(0)
+    raise SystemExit(main())


### PR DESCRIPTION
Tests the top open item left by #329's revision 4, and the answer moved a
caveat onto the headline result.

## The question

Rev 4 withdrew the `profitability` direction claim after `gross_margin` and
`op_margin` both came back **inverted** on the 245-name test, and offered a
reason: nothing in that harness controls for valuation, and high-margin firms
are usually richly priced, so a margin ranking might be an expensiveness ranking
in disguise. That was a hypothesis with no test behind it.

## Answer: rejected

2q forward return, 245 names, 80 quarters, partial rank IC:

| | uncontrolled | \| `earnings_yield` | \| `book_to_price` | \| `fcf_yield` |
|---|---:|---:|---:|---:|
| `gross_margin` | −0.0194 | −0.0180 | −0.0271 | −0.0144 |
| `op_margin` | −0.0270 | −0.0231 | −0.0306 | −0.0298 |

`op_margin` barely moves under any control, and against `book_to_price` both
margins get **stronger**. Expensiveness does not explain the inversion.
`profitability` keeps withholding its direction — now because the effect is real
and unexplained, which is a firmer reason than the guess it replaces.

## The incidental finding matters more

| Signal | IC | t |
|---|---:|---:|
| `fcf_yield` | +0.0285 | 2.84 |
| `earnings_yield` | −0.0194 | −1.43 |
| `book_to_price` | **−0.0365** | **−2.32** |

Cheap-on-book predicted *lower* returns over 2005–2026 — the documented post-GFC
value drawdown. Survivorship should have biased this toward value (cheap names
that went bankrupt are excluded), so the true effect was likely worse.

**This qualifies #329's headline.** The signals that worked (low leverage, high
asset turnover, FCF yield) are the quality/growth profile that led this window;
the ones that failed are the value profile that lagged it. So rev 4's robustness
split — 2005–2015 and 2016–2026 both positive — is weaker evidence than it read,
because **both halves sit inside the same regime.** Nothing is retracted; the
claim's coverage is bounded. "Measured in one regime" joins survivorship and
uncosted returns as a standing limit in §12 risk 1.

## Method notes that are load-bearing

- **Market cap uses raw `close` × as-reported shares.** `adj_close` is
  retroactively split-adjusted while the share count is point-in-time; the
  product would misprice every name across every split (NVDA's 10:1 alone moves
  market cap an order of magnitude).
- **Ratios are yields, never P/E.** A price multiple flips sign through zero
  earnings and ranks a loss-maker as the cheapest name on the board.
- **Partial correlation reuses the validation's own `spearman`**, so the control
  and the headline share identical math, and carries a `--self-check` — a sign
  error there would quietly reverse the verdict.

## Spec changes

§13's top item closed and replaced (regime coverage is the new one); §5.2's
withdrawal restated on the firmer reason; §12 risk 1 gains the third limit;
`valuation_position`'s "cheaper better" prior flagged as **contradicted** for
B/P and E/P — it should not be seeded without deciding which ratio it means.

No application code changed.