### PR TITLE
feat(macro): add immutable evidence contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **Immutable point-in-time macro evidence contract and top-down program plan.** New
+  `macro_source_artifacts` and `macro_observations` tables preserve exact source payloads,
+  revisions, source disagreement, publication/availability semantics, quality, and cost class
+  without changing the existing rates or Gold Compass read paths. Python and PostgreSQL recompute
+  artifact/observation content identities, enforce artifact time/quality bounds, and reject direct
+  historical rewrites, ambiguous timestamps, empty source precedence, and mock/static/demo sources
+  outside test databases. A read-only `option_wizard_local` inventory covers all 19 legacy
+  rates/gold relations and records the adapter sequence for inflation → policy/rates → USD → gold,
+  including future evidence-first Rates, Gold, unified Macro, and Fundamental PM context surfaces.
+
 ### Research
 
 - **Fundamental source contract measured; the planned backbone was the wrong

--- a/docs/research/2026-08-12-macro-legacy-inventory/README.md
+++ b/docs/research/2026-08-12-macro-legacy-inventory/README.md
@@ -1,0 +1,39 @@
+# Macro legacy inventory — MC0 baseline
+
+This directory is the measured dual-read baseline for migrating Argon's existing rates and gold
+data into the immutable macro evidence contract. It is an inventory of the local development warm
+store, not a claim about the Mac mini production database.
+
+## Scope and safety
+
+- Database: `option_wizard_local`
+- Schema: `uw_scan`
+- Access: one repeatable-read, read-only transaction
+- External provider calls: zero
+- Relations: 18 tables plus the `wgc_etf_monthly_canonical` view
+- Snapshot date: generated on 2026-08-12 from the local database state
+
+The script refuses any database name other than `option_wizard_local`. Automated tests remain on
+`option_wizard_test`; the inventory never runs migrations or writes application rows.
+
+## Reproduce
+
+```bash
+uv run python scripts/research/macro_legacy_inventory.py --self-check
+uv run python scripts/research/macro_legacy_inventory.py
+```
+
+The first command proves required-relation coverage, deterministic JSON ordering inside one database
+snapshot, read-only mode, and zero external calls. The second regenerates `inventory.json`.
+
+## Artifact map
+
+- `inventory.json` — machine-readable row counts, primary keys, date spans, per-series spans,
+  observed dimensions, time/revision semantics, consumers, risks, and adapter actions.
+- `VERDICT.md` — migration judgment and the ordered acceptance baseline for MC1–MC3.
+
+## Interpretation boundary
+
+Row counts and observed source/series values are current local facts and will drift. Contract fields
+are reviewed repository semantics. A non-empty table proves only that local rows exist; it does not
+prove that its source is currently reachable, official, durable, or point-in-time safe.

--- a/docs/research/2026-08-12-macro-legacy-inventory/VERDICT.md
+++ b/docs/research/2026-08-12-macro-legacy-inventory/VERDICT.md
@@ -1,0 +1,75 @@
+# Verdict — legacy rates/gold is usable as a read model, not as the macro evidence ledger
+
+**MC0 inventory result:** PASS for coverage and reproducibility; FAIL for direct cutover.
+
+The local snapshot covers all 19 declared rates/gold relations in a repeatable-read transaction and
+makes zero provider calls. Existing pages should remain on their legacy read paths. The new evidence
+tables can receive dual writes, but none of the legacy domains yet meets publication-time, revision,
+artifact-lineage, and replay parity together.
+
+## Load-bearing findings
+
+1. **Rates vintages are overwritten.** `rates_observations` has 3,535 rows across 31 series, but its
+   primary key is `(series_id, obs_date, source)` and the writer updates value, `realtime_start`, and
+   `realtime_end` in place. An updated FRED or Cleveland Fed value destroys the predecessor. This is
+   the first MC1 adapter because it blocks honest historical `as_of` reconstruction.
+
+2. **FOMC coverage is calendar-only.** `rates_policy_events` contains 24 meeting-date rows, but no
+   statements, minutes, vote records, transcripts, SEP tables, or dot-plot artifacts. Its
+   `(event_date, source)` identity also overwrites changed payloads. The FOMC/SEP adapter must be
+   artifact-led and must preserve each official publication/correction separately. A chair's view of
+   the dot plot is commentary metadata, not a reason to erase the official SEP evidence channel.
+
+3. **The implied policy path is a shadow source.** `rates_policy_path` contains 40 rows from a free,
+   delayed third-party FedWatch page. It is useful as a labeled market-expectations shadow, but it is
+   neither a Federal Reserve source nor a substitute for meeting artifacts. Same-day corrections can
+   overwrite because the key has day rather than publication instant/hash granularity.
+
+4. **Gold macro data mixes source classes.** `macro_series_daily` holds 72,929 rows across 17 series
+   from FRED, GPR, and Massive; `macro_series_monthly` holds CPI and M2. The tables preserve repeated
+   `as_of` pulls but have no artifact hash/parser version, and nullable `release_date` means `as_of`
+   cannot safely stand in for public availability.
+
+5. **WGC lineage is large but not fully durable.** `wgc_etf_monthly` has 1,338,260 rows across 78
+   workbook URLs, while its canonical view collapses to 26,460 latest rows. This is intentional
+   revision preservation at the file-URL level, but the view is latest-wins rather than PIT, and a
+   same-URL workbook replacement can overwrite normalized values. The observed URLs point into old
+   local worktrees rather than a durable artifact store.
+
+6. **Central-bank reserves contradict the old empty-table assumption.** The local table contains
+   2,827 rows for 27 countries, all tied to one `/tmp` workbook path. The scheduled anonymous WGC
+   source is still blocked, so these rows are useful research input but not durable production
+   provenance. MC3 must either store the exact workbook bytes or replace it with a proven free
+   official source; it must not silently call the local import "live WGC".
+
+7. **Derived pages already carry some replay scaffolding, but not evidence IDs.** `gold_posture_daily`
+   has 115 rows and `rates_snapshots` has 23. Gold pins legacy coordinates in `inputs_jsonb`; rates
+   embeds values in a payload. Both remain useful read models, but neither is sufficient as an
+   immutable upstream ledger.
+
+## Adapter order and acceptance baseline
+
+| Priority | Adapter | Required proof before read cutover |
+|---|---|---|
+| P0 | FRED/Cleveland rates | preserve every revised value; explicit `available_at`; row/value/unit/vintage parity |
+| P0 | FOMC + SEP | exact official bytes, statement/minutes/votes/SEP taxonomy, correction history, conservative release time |
+| P1 | CPI/M2 and daily macro | per-series source/cost mapping; no inference of availability from ingestion time |
+| P1 | CFTC TFF and gold COT | position date distinct from publication/strategy availability; exact official artifact link |
+| P1 | Treasury auctions/FiscalData | official response artifact plus normalized row parity |
+| P2 | ETF holdings/flows, LBMA/COMEX | exact issuer/exchange payload; source-specific units and publication clock |
+| P2 | WGC ETF/central-bank corpus | content-hashed workbook bytes; PIT revision selector; durable source identity |
+| P3 | gold posture/rates snapshot | observation/evidence IDs embedded in derived output; replay and rollback parity |
+
+For every adapter, the legacy relation stays authoritative until row identity, values/units,
+publication/availability time, revision counts, source disagreement, downstream replay, and rollback
+all pass. Empty/new evidence tables are not a cutover signal.
+
+## Self-check evidence
+
+```text
+Pytest: inventory contract tests passed
+self-check ok: 19 relations, read-only, deterministic, 0 provider calls
+```
+
+The inventory is intentionally local-only. A later Mac mini audit must compare relation coverage,
+spans, sources, and overwrite counts; it must not replace or edit this frozen baseline.

--- a/docs/research/2026-08-12-macro-legacy-inventory/inventory.json
+++ b/docs/research/2026-08-12-macro-legacy-inventory/inventory.json
@@ -1,0 +1,1939 @@
+{
+  "relations": [
+    {
+      "contract": {
+        "adapter_action": "defer until free official IMF/WGC source is proven",
+        "date_column": "obs_month",
+        "dimensions": [
+          "source",
+          "bucket"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(country_iso3, obs_month, as_of)",
+        "risk_flags": [
+          "no live official fallback wired",
+          "local lineage points to a non-durable /tmp workbook path",
+          "estimated-vs-reported is typed but exact source artifact is absent"
+        ],
+        "source_status": "local workbook import present; scheduled WGC source remains blocked by login",
+        "timestamp_semantics": "release_date is publisher date when known; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-03-31",
+        "min": "2000-03-31"
+      },
+      "dimensions": {
+        "bucket": [
+          "reserve_diversifier",
+          "strategic_accumulator",
+          "tactical_defender"
+        ],
+        "source": [
+          "file:/tmp/wgc-gold-reserves/Quarterly_gold_and_FX_Reserves_Q1_2026.xlsx"
+        ]
+      },
+      "name": "cb_gold_reserves_monthly",
+      "primary_key": [
+        "country_iso3",
+        "obs_month",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 2827,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write CFTC rows with published_at=release timestamp",
+        "date_column": "obs_date",
+        "dimensions": [],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(obs_date, as_of)",
+        "risk_flags": [
+          "source URL retained but exact payload bytes are not linked"
+        ],
+        "source_status": "free official CFTC",
+        "timestamp_semantics": "obs_date is Tuesday position date; release_date is Friday publication; backtests require release_date + 3 trading days"
+      },
+      "date_span": {
+        "max": "2026-08-04",
+        "min": "2025-04-15"
+      },
+      "dimensions": {},
+      "name": "cot_gold_weekly",
+      "primary_key": [
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 2615,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "exclude from macro evidence adapters",
+        "date_column": "fetched_at",
+        "dimensions": [
+          "ticker"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "storage/market_data.py",
+          "scanner pipeline"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "ticker (overwriting cache)",
+        "risk_flags": [
+          "not macro evidence; historical values intentionally overwritten"
+        ],
+        "source_status": "already-entitled UW operational cache",
+        "timestamp_semantics": "fetched_at is cache refresh time, not a market observation date"
+      },
+      "date_span": {
+        "max": "2026-07-28 21:32:34.429070+08:00",
+        "min": "2026-06-11 21:35:03.858570+08:00"
+      },
+      "dimensions": {
+        "ticker": [
+          "ARKK",
+          "DIA",
+          "GLD",
+          "HYG",
+          "IGV",
+          "IWM",
+          "JNK",
+          "QQQ",
+          "SLV",
+          "SMH",
+          "SOXL",
+          "SOXX",
+          "SPY",
+          "TLT",
+          "XLB",
+          "XLC",
+          "XLE",
+          "XLF",
+          "XLI",
+          "XLK",
+          "XLP",
+          "XLRE",
+          "XLU",
+          "XLV",
+          "XLY"
+        ]
+      },
+      "name": "etf_aum_cache",
+      "primary_key": [
+        "ticker"
+      ],
+      "relation_kind": "table",
+      "row_count": 25,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write with UW artifact reference",
+        "date_column": "obs_date",
+        "dimensions": [
+          "ticker",
+          "source"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(ticker, obs_date, as_of)",
+        "risk_flags": [
+          "no source URL or exact payload link"
+        ],
+        "source_status": "already-entitled UW",
+        "timestamp_semantics": "obs_date is market date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-07-24",
+        "min": "2025-06-23"
+      },
+      "dimensions": {
+        "source": [
+          "UW"
+        ],
+        "ticker": [
+          "GLD",
+          "GLDM",
+          "IAU",
+          "IGV",
+          "SMH",
+          "SOXX",
+          "SPY",
+          "XLB",
+          "XLC",
+          "XLE",
+          "XLF",
+          "XLI",
+          "XLK",
+          "XLP",
+          "XLRE",
+          "XLU",
+          "XLV",
+          "XLY"
+        ]
+      },
+      "name": "etf_flows_daily",
+      "primary_key": [
+        "ticker",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 5247,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write issuer artifact and normalized holdings",
+        "date_column": "obs_date",
+        "dimensions": [
+          "ticker",
+          "source"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(ticker, obs_date, as_of)",
+        "risk_flags": [
+          "source label retained but exact issuer payload is not linked"
+        ],
+        "source_status": "free first-party fund publishers",
+        "timestamp_semantics": "obs_date is issuer observation date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-07-23",
+        "min": "2004-11-30"
+      },
+      "dimensions": {
+        "source": [
+          "SPDR",
+          "WGC"
+        ],
+        "ticker": [
+          "GLD",
+          "GLDM",
+          "IAU",
+          "PHYS"
+        ]
+      },
+      "name": "etf_holdings_daily",
+      "primary_key": [
+        "ticker",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 26555,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write discovered publisher file bytes",
+        "date_column": "obs_date",
+        "dimensions": [
+          "exchange"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(exchange, obs_date, as_of)",
+        "risk_flags": [
+          "COMEX source availability is fragile",
+          "source URL retained but workbook/report bytes are not linked"
+        ],
+        "source_status": "free publisher: LBMA live; CME endpoint fragile",
+        "timestamp_semantics": "obs_date is exchange report date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-04-01",
+        "min": "2025-05-01"
+      },
+      "dimensions": {
+        "exchange": [
+          "LBMA"
+        ]
+      },
+      "name": "exchange_inventory_daily",
+      "primary_key": [
+        "exchange",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 36,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "keep as legacy read model until evidence-reference parity passes",
+        "date_column": "obs_date",
+        "dimensions": [
+          "row_status",
+          "gauge_state"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "api/routers/gold.py",
+          "web/app/gold",
+          "gold replay page"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(obs_date, computed_at)",
+        "risk_flags": [
+          "replay fidelity is bounded by legacy input time semantics",
+          "not an upstream source and must not be adapted as an observation"
+        ],
+        "source_status": "derived",
+        "timestamp_semantics": "obs_date is posture date; computed_at is derivation time; inputs_jsonb pins legacy input coordinates"
+      },
+      "date_span": {
+        "max": "2026-07-24",
+        "min": "2026-05-14"
+      },
+      "dimensions": {
+        "gauge_state": [
+          "partial",
+          "suspended"
+        ],
+        "row_status": [
+          "active",
+          "invalidated"
+        ]
+      },
+      "name": "gold_posture_daily",
+      "primary_key": [
+        "obs_date",
+        "computed_at"
+      ],
+      "relation_kind": "table",
+      "row_count": 115,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "map each series explicitly; never infer availability from as_of",
+        "date_column": "obs_date",
+        "dimensions": [
+          "series_id",
+          "source"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py",
+          "api/routers/trade_insights.py",
+          "worker/jobs/regime_jobs.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(series_id, obs_date, as_of)",
+        "risk_flags": [
+          "mixed source classes share one table",
+          "no artifact hash/parser version",
+          "release_date nullable"
+        ],
+        "source_status": "mixed free official/publisher and derived series",
+        "timestamp_semantics": "release_date is optional; as_of is retrieval time and is not guaranteed to equal public availability time"
+      },
+      "date_span": {
+        "max": "2026-07-24",
+        "min": "2007-01-01"
+      },
+      "dimensions": {
+        "series_id": [
+          "ANFCI",
+          "BAMLH0A0HYM2",
+          "CBBTCUSD",
+          "DEXCHUS",
+          "DEXINUS",
+          "DEXJPUS",
+          "DFII10",
+          "DGS10",
+          "DTWEXBGS",
+          "GLD_CLOSE",
+          "GPRD",
+          "GVZCLS",
+          "NFCI",
+          "T10YIE",
+          "T5YIFR",
+          "USREC",
+          "VIXCLS"
+        ],
+        "source": [
+          "FRED",
+          "GPR",
+          "MASSIVE"
+        ]
+      },
+      "name": "macro_series_daily",
+      "primary_key": [
+        "series_id",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 72929,
+      "series_profiles": [
+        {
+          "date_span": {
+            "max": "2026-05-15",
+            "min": "2007-01-05"
+          },
+          "row_count": 1014,
+          "series_id": "ANFCI",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2023-05-16"
+          },
+          "row_count": 2985,
+          "series_id": "BAMLH0A0HYM2",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 4468,
+          "series_id": "CBBTCUSD",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-22",
+            "min": "2021-05-18"
+          },
+          "row_count": 2872,
+          "series_id": "DEXCHUS",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-22",
+            "min": "2021-05-18"
+          },
+          "row_count": 2720,
+          "series_id": "DEXINUS",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-22",
+            "min": "2021-05-18"
+          },
+          "row_count": 2930,
+          "series_id": "DEXJPUS",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3103,
+          "series_id": "DFII10",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3103,
+          "series_id": "DGS10",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-22",
+            "min": "2021-05-18"
+          },
+          "row_count": 2960,
+          "series_id": "DTWEXBGS",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-07-24",
+            "min": "2025-04-14"
+          },
+          "row_count": 27201,
+          "series_id": "GLD_CLOSE",
+          "sources": [
+            "MASSIVE"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-07-20",
+            "min": "2021-05-18"
+          },
+          "row_count": 5956,
+          "series_id": "GPRD",
+          "sources": [
+            "GPR"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3107,
+          "series_id": "GVZCLS",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-15",
+            "min": "2007-01-05"
+          },
+          "row_count": 1014,
+          "series_id": "NFCI",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3115,
+          "series_id": "T10YIE",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3022,
+          "series_id": "T5YIFR",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-04-01",
+            "min": "2007-01-01"
+          },
+          "row_count": 232,
+          "series_id": "USREC",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-05-28",
+            "min": "2021-05-18"
+          },
+          "row_count": 3127,
+          "series_id": "VIXCLS",
+          "sources": [
+            "FRED"
+          ]
+        }
+      ]
+    },
+    {
+      "contract": {
+        "adapter_action": "map CPI/M2 series with official release availability",
+        "date_column": "obs_month",
+        "dimensions": [
+          "series_id",
+          "source"
+        ],
+        "domain": "cross_domain",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(series_id, obs_month, as_of)",
+        "risk_flags": [
+          "no artifact hash/parser version",
+          "release_date nullable"
+        ],
+        "source_status": "mixed free official FRED series",
+        "timestamp_semantics": "release_date is optional; as_of is retrieval time and not a release clock"
+      },
+      "date_span": {
+        "max": "2026-05-01",
+        "min": "2021-06-01"
+      },
+      "dimensions": {
+        "series_id": [
+          "CPIAUCSL",
+          "M2SL"
+        ],
+        "source": [
+          "FRED"
+        ]
+      },
+      "name": "macro_series_monthly",
+      "primary_key": [
+        "series_id",
+        "obs_month",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 1680,
+      "series_profiles": [
+        {
+          "date_span": {
+            "max": "2026-05-01",
+            "min": "2021-06-01"
+          },
+          "row_count": 828,
+          "series_id": "CPIAUCSL",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-04-01",
+            "min": "2021-06-01"
+          },
+          "row_count": 852,
+          "series_id": "M2SL",
+          "sources": [
+            "FRED"
+          ]
+        }
+      ]
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write release-timed observations and source artifact",
+        "date_column": "obs_date",
+        "dimensions": [
+          "contract_code",
+          "tenor_bucket"
+        ],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates positioning panel"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(contract_code, obs_date, as_of)",
+        "risk_flags": [
+          "exact CFTC response is not linked to normalized rows"
+        ],
+        "source_status": "free official CFTC",
+        "timestamp_semantics": "obs_date is Tuesday position date; release_date is publication date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-06-09",
+        "min": "2025-12-23"
+      },
+      "dimensions": {
+        "contract_code": [
+          "020601",
+          "020604",
+          "042601",
+          "043602",
+          "043607",
+          "04360Y",
+          "044601"
+        ],
+        "tenor_bucket": [
+          "10Y",
+          "2Y",
+          "5Y",
+          "Bond",
+          "Micro 10Y Yield",
+          "Ultra 10Y",
+          "Ultra Bond"
+        ]
+      },
+      "name": "rates_cftc_tff_weekly",
+      "primary_key": [
+        "contract_code",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 1356,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write official FiscalData artifact",
+        "date_column": "record_date",
+        "dimensions": [],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates supply panel"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(record_date, as_of)",
+        "risk_flags": [
+          "source URL retained but response artifact is not linked"
+        ],
+        "source_status": "free official U.S. Treasury FiscalData",
+        "timestamp_semantics": "record_date is FiscalData date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-06-12",
+        "min": "2026-05-21"
+      },
+      "dimensions": {},
+      "name": "rates_fiscal_debt_daily",
+      "primary_key": [
+        "record_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 6,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "highest-priority MC1 dual-write; preserve every vintage",
+        "date_column": "obs_date",
+        "dimensions": [
+          "series_id",
+          "source"
+        ],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates curve/policy/plumbing panels"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(series_id, obs_date, source) overwrites revisions",
+        "risk_flags": [
+          "critical: ON CONFLICT overwrites value and vintage metadata",
+          "source precedence is implicit",
+          "no exact source artifact"
+        ],
+        "source_status": "free official FRED plus Cleveland Fed decomposition",
+        "timestamp_semantics": "FRED realtime_start/end are vintage metadata; first/last_seen are local sightings; release_date may be null"
+      },
+      "date_span": {
+        "max": "2026-06-15",
+        "min": "2025-11-24"
+      },
+      "dimensions": {
+        "series_id": [
+          "CLEVE_EXPECTED_INFLATION_10Y",
+          "CLEVE_INFLATION_RISK_PREMIUM_10Y",
+          "CLEVE_MODEL_REAL_YIELD_10Y",
+          "CLEVE_REAL_RISK_PREMIUM_10Y",
+          "DFEDTARL",
+          "DFEDTARU",
+          "DFII10",
+          "DFII20",
+          "DFII30",
+          "DFII5",
+          "DFII7",
+          "DGS1",
+          "DGS10",
+          "DGS1MO",
+          "DGS2",
+          "DGS20",
+          "DGS3",
+          "DGS30",
+          "DGS3MO",
+          "DGS5",
+          "DGS6MO",
+          "DGS7",
+          "EFFR",
+          "RRPONTSYD",
+          "SOFR",
+          "T10YIE",
+          "T5YIE",
+          "T5YIFR",
+          "WALCL",
+          "WRESBAL",
+          "WTREGEN"
+        ],
+        "source": [
+          "CLEVELAND_FED",
+          "FRED"
+        ]
+      },
+      "name": "rates_observations",
+      "primary_key": [
+        "series_id",
+        "obs_date",
+        "source"
+      ],
+      "relation_kind": "table",
+      "row_count": 3535,
+      "series_profiles": [
+        {
+          "date_span": {
+            "max": "2026-06-01",
+            "min": "2025-12-01"
+          },
+          "row_count": 7,
+          "series_id": "CLEVE_EXPECTED_INFLATION_10Y",
+          "sources": [
+            "CLEVELAND_FED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-01",
+            "min": "2025-12-01"
+          },
+          "row_count": 7,
+          "series_id": "CLEVE_INFLATION_RISK_PREMIUM_10Y",
+          "sources": [
+            "CLEVELAND_FED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-01",
+            "min": "2025-12-01"
+          },
+          "row_count": 7,
+          "series_id": "CLEVE_MODEL_REAL_YIELD_10Y",
+          "sources": [
+            "CLEVELAND_FED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-01",
+            "min": "2025-12-01"
+          },
+          "row_count": 7,
+          "series_id": "CLEVE_REAL_RISK_PREMIUM_10Y",
+          "sources": [
+            "CLEVELAND_FED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-12-18"
+          },
+          "row_count": 180,
+          "series_id": "DFEDTARL",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-12-18"
+          },
+          "row_count": 180,
+          "series_id": "DFEDTARU",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DFII10",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DFII20",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DFII30",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DFII5",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DFII7",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS1",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS10",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS1MO",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS2",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS20",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS3",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS30",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS3MO",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS5",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS6MO",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "DGS7",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "EFFR",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-11-24"
+          },
+          "row_count": 139,
+          "series_id": "RRPONTSYD",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-12",
+            "min": "2025-11-24"
+          },
+          "row_count": 138,
+          "series_id": "SOFR",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-11-24"
+          },
+          "row_count": 140,
+          "series_id": "T10YIE",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-11-24"
+          },
+          "row_count": 140,
+          "series_id": "T5YIE",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-15",
+            "min": "2025-11-24"
+          },
+          "row_count": 140,
+          "series_id": "T5YIFR",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-10",
+            "min": "2025-11-26"
+          },
+          "row_count": 29,
+          "series_id": "WALCL",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-10",
+            "min": "2025-11-26"
+          },
+          "row_count": 29,
+          "series_id": "WRESBAL",
+          "sources": [
+            "FRED"
+          ]
+        },
+        {
+          "date_span": {
+            "max": "2026-06-10",
+            "min": "2025-11-26"
+          },
+          "row_count": 29,
+          "series_id": "WTREGEN",
+          "sources": [
+            "FRED"
+          ]
+        }
+      ]
+    },
+    {
+      "contract": {
+        "adapter_action": "MC1 expand to artifact-led FOMC/SEP event model",
+        "date_column": "event_date",
+        "dimensions": [
+          "source"
+        ],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates event calendar"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(event_date, source) overwrites payload changes",
+        "risk_flags": [
+          "calendar only: no statements, minutes, votes, transcripts, SEP, or dot plot",
+          "payload changes overwrite history",
+          "no source artifact hash"
+        ],
+        "source_status": "free official Federal Reserve calendar",
+        "timestamp_semantics": "event_date is meeting date; first/last_seen are local sightings"
+      },
+      "date_span": {
+        "max": "2027-12-07",
+        "min": "2025-01-28"
+      },
+      "dimensions": {
+        "source": [
+          "FED_FOMC"
+        ]
+      },
+      "name": "rates_policy_events",
+      "primary_key": [
+        "event_date",
+        "source"
+      ],
+      "relation_kind": "table",
+      "row_count": 24,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "retain as labeled shadow; add official/event evidence separately",
+        "date_column": "snapshot_date",
+        "dimensions": [
+          "source"
+        ],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates implied path panel"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(snapshot_date, meeting_date, source)",
+        "risk_flags": [
+          "not official Fed data",
+          "same-day corrections overwrite",
+          "no exact HTML/JSON artifact"
+        ],
+        "source_status": "free third-party delayed FedWatch shadow",
+        "timestamp_semantics": "snapshot_date is provider snapshot day; first/last_seen are local sightings"
+      },
+      "date_span": {
+        "max": "2026-06-15",
+        "min": "2026-05-24"
+      },
+      "dimensions": {
+        "source": [
+          "FED_FUNDS_FUTURES_PATH"
+        ]
+      },
+      "name": "rates_policy_path",
+      "primary_key": [
+        "snapshot_date",
+        "meeting_date",
+        "source"
+      ],
+      "relation_kind": "table",
+      "row_count": 40,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "keep authoritative until dual-read evidence parity passes",
+        "date_column": "snapshot_date",
+        "dimensions": [],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "api/routers/rates.py",
+          "web/app/rates"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(snapshot_date, computed_at)",
+        "risk_flags": [
+          "payload embeds legacy values without normalized evidence IDs"
+        ],
+        "source_status": "derived",
+        "timestamp_semantics": "snapshot_date is page date; computed_at is derivation time"
+      },
+      "date_span": {
+        "max": "2026-06-12",
+        "min": "2026-05-19"
+      },
+      "dimensions": {},
+      "name": "rates_snapshots",
+      "primary_key": [
+        "snapshot_date",
+        "computed_at"
+      ],
+      "relation_kind": "table",
+      "row_count": 23,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write official auction artifact and observations",
+        "date_column": "auction_date",
+        "dimensions": [
+          "security_type",
+          "security_term"
+        ],
+        "domain": "policy_rates",
+        "downstream_consumers": [
+          "rates report assembler",
+          "web rates supply panel"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(cusip, auction_date, as_of)",
+        "risk_flags": [
+          "source URL retained but response artifact is not linked"
+        ],
+        "source_status": "free official TreasuryDirect",
+        "timestamp_semantics": "auction_date is official event date; as_of is ingestion time"
+      },
+      "date_span": {
+        "max": "2026-06-15",
+        "min": "2025-12-18"
+      },
+      "dimensions": {
+        "security_term": [
+          "1-Year 10-Month",
+          "1-Year 11-Month",
+          "10-Year",
+          "13-Week",
+          "17-Week",
+          "19-Year 10-Month",
+          "19-Year 11-Month",
+          "2-Year",
+          "20-Year",
+          "26-Week",
+          "27-Day",
+          "29-Year 10-Month",
+          "29-Year 11-Month",
+          "3-Year",
+          "30-Year",
+          "4-Week",
+          "4-Year 10-Month",
+          "5-Year",
+          "52-Week",
+          "6-Week",
+          "7-Year",
+          "8-Week",
+          "9-Year 10-Month",
+          "9-Year 11-Month",
+          "9-Year 8-Month"
+        ],
+        "security_type": [
+          "Bill",
+          "Bond",
+          "Note"
+        ]
+      },
+      "name": "rates_treasury_auctions",
+      "primary_key": [
+        "cusip",
+        "auction_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 790,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "dual-write endpoint artifacts; keep derived snapshot separate",
+        "date_column": "obs_date",
+        "dimensions": [
+          "ticker"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "reports/gold_posture.py",
+          "api/routers/gold.py"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(ticker, obs_date, as_of)",
+        "risk_flags": [
+          "composed from multiple endpoints without exact joined artifact IDs"
+        ],
+        "source_status": "already-entitled UW",
+        "timestamp_semantics": "obs_date is market date; as_of is composite fetch time"
+      },
+      "date_span": {
+        "max": "2026-07-25",
+        "min": "2026-05-17"
+      },
+      "dimensions": {
+        "ticker": [
+          "GDX",
+          "GLD",
+          "IAU"
+        ]
+      },
+      "name": "uw_gold_options_daily",
+      "primary_key": [
+        "ticker",
+        "obs_date",
+        "as_of"
+      ],
+      "relation_kind": "table",
+      "row_count": 186,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "store exact workbook bytes keyed by content hash",
+        "date_column": "obs_date",
+        "dimensions": [
+          "ticker",
+          "source"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "storage/gold_etf.py",
+          "gold ETF corpus research"
+        ],
+        "relation_kind": "table",
+        "revision_identity": "(ticker, obs_date, source_url)",
+        "risk_flags": [
+          "same-URL workbook changes overwrite normalized values"
+        ],
+        "source_status": "free first-party WGC workbook",
+        "timestamp_semantics": "obs_date is workbook period; as_of is ingestion time; source_url identifies a workbook revision"
+      },
+      "date_span": {
+        "max": "2026-03-31",
+        "min": "2003-03-31"
+      },
+      "dimensions": {
+        "source": [
+          "WGC"
+        ],
+        "ticker": [
+          "0072R0 KS EQUITY",
+          "1540 JT EQUITY",
+          "159812 CH EQUITY",
+          "159830 CH EQUITY",
+          "159831 CH EQUITY",
+          "159832 CH EQUITY",
+          "159833 CH EQUITY",
+          "159834 CH EQUITY",
+          "159934 CH EQUITY",
+          "159937 CH EQUITY",
+          "2830 HK EQUITY",
+          "3081 HK EQUITY",
+          "3170 HK EQUITY",
+          "360GERG IN EQUITY",
+          "411060 KS EQUITY",
+          "4GLD GR EQUITY",
+          "518600 CH EQUITY",
+          "518660 CH EQUITY",
+          "518680 CH EQUITY",
+          "518800 CH EQUITY",
+          "518850 CH EQUITY",
+          "518860 CH EQUITY",
+          "518880 CH EQUITY",
+          "518890 CH EQUITY",
+          "83168 HK EQUITY",
+          "8PSE GR EQUITY",
+          "929",
+          "930",
+          "AAAU US EQUITY",
+          "AGOL US EQUITY",
+          "ALBIGOLD AB EQUITY",
+          "ALOGDRG IN EQUITY",
+          "ANGELONE IN EQUITY",
+          "AUCHAH SW EQUITY",
+          "AUEUAH SW EQUITY",
+          "AUUSA SW EQUITY",
+          "AUUSI SW EQUITY",
+          "AXGOLD IN EQUITY",
+          "BAGOLRG IN EQUITY",
+          "BAR US EQUITY",
+          "BARS LN EQUITY",
+          "BBNPGET IN EQUITY",
+          "BCHAY TB EQUITY",
+          "BKBGLDA SW EQUITY",
+          "BKBGLDI SW EQUITY",
+          "BKBGLDJ SW EQUITY",
+          "BMGGLDBA CN EQUITY",
+          "BSLGOLD IS EQUITY",
+          "CEF/U CN EQUITY",
+          "CGL CN EQUITY",
+          "CGL/C CN EQUITY",
+          "CHOGORG IN EQUITY",
+          "CRGETF IN EQUITY",
+          "CSGBDAH SW EQUITY",
+          "CSGBFBH SW EQUITY",
+          "CSGBQBU SW EQUITY",
+          "CSGIMAC SW EQUITY",
+          "CSGIMAH SW EQUITY",
+          "CSGIMIA SW EQUITY",
+          "CSGIMUA SW EQUITY",
+          "CSGLDC SW EQUITY",
+          "CSGLDE SW EQUITY",
+          "CSGOLD SW EQUITY",
+          "CSGQBHC SW EQUITY",
+          "CSIFGBD SW EQUITY",
+          "CSIFGEA SW EQUITY",
+          "CSIGBDH SW EQUITY",
+          "CSIGBQE SW EQUITY",
+          "CSIMIAH SW EQUITY",
+          "CSIMUAH SW EQUITY",
+          "DGOLETF IN EQUITY",
+          "EDLGOLD IN EQUITY",
+          "ETFGLD SJ EQUITY",
+          "EWG2 GR EQUITY",
+          "EWGC GR EQUITY",
+          "EWGT GR EQUITY",
+          "FGDL US EQUITY",
+          "FGLD US EQUITY",
+          "FXGD RM EQUITY",
+          "GBEES IN EQUITY",
+          "GBS LN EQUITY",
+          "GBSE IM EQUITY",
+          "GBSP LN EQUITY",
+          "GHLD AU EQUITY",
+          "GLD",
+          "GLD SJ EQUITY",
+          "GLDCO2 SW EQUITY",
+          "GLDM",
+          "GLDTR TI EQUITY",
+          "GLDW US EQUITY",
+          "GLTR US EQUITY",
+          "GOLD AU EQUITY",
+          "GOLD DU EQUITY",
+          "GOLD FP EQUITY",
+          "GOLD GR EQUITY",
+          "GOLD1 IN EQUITY",
+          "GOLD99 TB EQUITY",
+          "GOLDETF IN EQUITY",
+          "GOLDETF MK EQUITY",
+          "GOLDIETF IN EQUITY",
+          "GOLDP TI EQUITY",
+          "GRGLDRG IN EQUITY",
+          "GTU US EQUITY",
+          "GXLD AU EQUITY",
+          "HDFGOLD IN EQUITY",
+          "IAU",
+          "IAUM US EQUITY",
+          "ICPGOLD IN EQUITY",
+          "IDBIGLD IN EQUITY",
+          "IGLD GR EQUITY",
+          "IGLG LN EQUITY",
+          "IGLN LN EQUITY",
+          "JBGOCA SW EQUITY",
+          "JBGOCX SW EQUITY",
+          "JBGOEA SW EQUITY",
+          "JBGOEX SW EQUITY",
+          "JBGOGA SW EQUITY",
+          "JBGOGX SW EQUITY",
+          "JBGOUA SW EQUITY",
+          "JBGOUX SW EQUITY",
+          "KG965 TB EQUITY",
+          "KILO CN EQUITY",
+          "KILO/B CN EQUITY",
+          "KILO/U CN EQUITY",
+          "KOGOLD IN EQUITY",
+          "LGOLDAA SP EQUITY",
+          "LGOLDAH SP EQUITY",
+          "LGOLDAU SP EQUITY",
+          "LGOLDIH SP EQUITY",
+          "LGOLDMH SP EQUITY",
+          "LGOLDSA SP EQUITY",
+          "LICMFGLD IN EQUITY",
+          "MAGOLDF IN EQUITY",
+          "MILLBULL CN EQUITY",
+          "MNT CN EQUITY",
+          "MOSLGRG IN EQUITY",
+          "MOSTGLD IN EQUITY",
+          "NUGG AU EQUITY",
+          "OUNZ US EQUITY",
+          "PHAU LN EQUITY",
+          "PHPM LN EQUITY",
+          "PHYS",
+          "PICMETH SW EQUITY",
+          "PICPGHI SW EQUITY",
+          "PICPGHZ SW EQUITY",
+          "PICPGIC SW EQUITY",
+          "PICPGIE SW EQUITY",
+          "PICPGIS SW EQUITY",
+          "PICPGIU SW EQUITY",
+          "PICPGIY SW EQUITY",
+          "PICPGPC SW EQUITY",
+          "PICPGPE SW EQUITY",
+          "PICPGPH SW EQUITY",
+          "PICPGPR SW EQUITY",
+          "PICPGPS SW EQUITY",
+          "PICPGPU SW EQUITY",
+          "PICPGRC SW EQUITY",
+          "PICPGRE SW EQUITY",
+          "PICPGRU SW EQUITY",
+          "PICPGZE SW EQUITY",
+          "PICPGZU SW EQUITY",
+          "PICPRMH SW EQUITY",
+          "PIMPGJD SW EQUITY",
+          "PMGOLD AU EQUITY",
+          "QAU AU EQUITY",
+          "QTGOLD IN EQUITY",
+          "REGGOLD IN EQUITY",
+          "REGOLD IN EQUITY",
+          "RFSGDAU SW EQUITY",
+          "RFSGDHC SW EQUITY",
+          "RGLDO SW EQUITY",
+          "RGLDOH SW EQUITY",
+          "RGLDOU SW EQUITY",
+          "RGLDS SW EQUITY",
+          "RGLDSH SW EQUITY",
+          "RGRT SW EQUITY",
+          "RGRTH SW EQUITY",
+          "RGRTU SW EQUITY",
+          "RM3H GR EQUITY",
+          "RMAU LN EQUITY",
+          "RMCH SW EQUITY",
+          "RMPH LN EQUITY",
+          "SESG US EQUITY",
+          "SETFGOLD IN EQUITY",
+          "SGBS LN EQUITY",
+          "SGETS IN EQUITY",
+          "SGLD LN EQUITY",
+          "SGLDBULA CN EQUITY",
+          "SGLDBULF CN EQUITY",
+          "SGLN LN EQUITY",
+          "SGLS LN EQUITY",
+          "SGOL US EQUITY",
+          "SPAUAGR LE EQUITY",
+          "SPPG95P LE EQUITY",
+          "SPPM95P LE EQUITY",
+          "TGLD LN EQUITY",
+          "TGOLDEF IN EQUITY",
+          "TGOLDETF TB EQUITY",
+          "TMGD GR EQUITY",
+          "TWCGERG IN EQUITY",
+          "UBGDAHC SW EQUITY",
+          "UBGDAHE SW EQUITY",
+          "UBGDAHU SW EQUITY",
+          "UBGDIHC SW EQUITY",
+          "UBGDIHU SW EQUITY",
+          "UNGOERG IN EQUITY",
+          "UTIGOL IN EQUITY",
+          "VALT CN EQUITY",
+          "VALT/B CN EQUITY",
+          "VALT/U CN EQUITY",
+          "WGLD LN EQUITY",
+          "XAD1 GR EQUITY",
+          "XAD5 GR EQUITY",
+          "XGDE GR EQUITY",
+          "XGDG LN EQUITY",
+          "XGDU GR EQUITY",
+          "XGLD LN EQUITY",
+          "XGLI LN EQUITY",
+          "XGLS LN EQUITY",
+          "XGOC SW EQUITY",
+          "XOB1 GR EQUITY",
+          "XOB2 GR EQUITY",
+          "ZGLD CN EQUITY",
+          "ZGLD SW EQUITY",
+          "ZGLD/U CN EQUITY",
+          "ZGLDETF IN EQUITY",
+          "ZGLDEU SW EQUITY",
+          "ZGLDGB SW EQUITY",
+          "ZGLDHC SW EQUITY",
+          "ZGLDHE SW EQUITY",
+          "ZGLDHG SW EQUITY",
+          "ZGLDUS SW EQUITY",
+          "ZGLH CN EQUITY",
+          "ZGOL AU EQUITY"
+        ]
+      },
+      "name": "wgc_etf_monthly",
+      "primary_key": [
+        "ticker",
+        "obs_date",
+        "source_url"
+      ],
+      "relation_kind": "table",
+      "row_count": 1338260,
+      "series_profiles": []
+    },
+    {
+      "contract": {
+        "adapter_action": "replace consumers with explicit PIT source precedence after parity",
+        "date_column": "obs_date",
+        "dimensions": [
+          "ticker",
+          "source"
+        ],
+        "domain": "gold",
+        "downstream_consumers": [
+          "storage/gold_etf.py::fetch_wgc_etf_monthly"
+        ],
+        "relation_kind": "view",
+        "revision_identity": "latest workbook revision selected per (ticker, obs_date)",
+        "risk_flags": [
+          "latest-wins selection is not an as-of query"
+        ],
+        "source_status": "derived view over free first-party WGC workbooks",
+        "timestamp_semantics": "inherits wgc_etf_monthly; canonical selection is query-time"
+      },
+      "date_span": {
+        "max": "2026-03-31",
+        "min": "2003-03-31"
+      },
+      "dimensions": {
+        "source": [
+          "WGC"
+        ],
+        "ticker": [
+          "0072R0 KS EQUITY",
+          "1540 JT EQUITY",
+          "159812 CH EQUITY",
+          "159830 CH EQUITY",
+          "159831 CH EQUITY",
+          "159832 CH EQUITY",
+          "159833 CH EQUITY",
+          "159834 CH EQUITY",
+          "159934 CH EQUITY",
+          "159937 CH EQUITY",
+          "2830 HK EQUITY",
+          "3081 HK EQUITY",
+          "3170 HK EQUITY",
+          "360GERG IN EQUITY",
+          "411060 KS EQUITY",
+          "4GLD GR EQUITY",
+          "518600 CH EQUITY",
+          "518660 CH EQUITY",
+          "518680 CH EQUITY",
+          "518800 CH EQUITY",
+          "518850 CH EQUITY",
+          "518860 CH EQUITY",
+          "518880 CH EQUITY",
+          "518890 CH EQUITY",
+          "83168 HK EQUITY",
+          "8PSE GR EQUITY",
+          "929",
+          "930",
+          "AAAU US EQUITY",
+          "AGOL US EQUITY",
+          "ALBIGOLD AB EQUITY",
+          "ALOGDRG IN EQUITY",
+          "ANGELONE IN EQUITY",
+          "AUCHAH SW EQUITY",
+          "AUEUAH SW EQUITY",
+          "AUUSA SW EQUITY",
+          "AUUSI SW EQUITY",
+          "AXGOLD IN EQUITY",
+          "BAGOLRG IN EQUITY",
+          "BAR US EQUITY",
+          "BARS LN EQUITY",
+          "BBNPGET IN EQUITY",
+          "BCHAY TB EQUITY",
+          "BKBGLDA SW EQUITY",
+          "BKBGLDI SW EQUITY",
+          "BKBGLDJ SW EQUITY",
+          "BMGGLDBA CN EQUITY",
+          "BSLGOLD IS EQUITY",
+          "CEF/U CN EQUITY",
+          "CGL CN EQUITY",
+          "CGL/C CN EQUITY",
+          "CHOGORG IN EQUITY",
+          "CRGETF IN EQUITY",
+          "CSGBDAH SW EQUITY",
+          "CSGBFBH SW EQUITY",
+          "CSGBQBU SW EQUITY",
+          "CSGIMAC SW EQUITY",
+          "CSGIMAH SW EQUITY",
+          "CSGIMIA SW EQUITY",
+          "CSGIMUA SW EQUITY",
+          "CSGLDC SW EQUITY",
+          "CSGLDE SW EQUITY",
+          "CSGOLD SW EQUITY",
+          "CSGQBHC SW EQUITY",
+          "CSIFGBD SW EQUITY",
+          "CSIFGEA SW EQUITY",
+          "CSIGBDH SW EQUITY",
+          "CSIGBQE SW EQUITY",
+          "CSIMIAH SW EQUITY",
+          "CSIMUAH SW EQUITY",
+          "DGOLETF IN EQUITY",
+          "EDLGOLD IN EQUITY",
+          "ETFGLD SJ EQUITY",
+          "EWG2 GR EQUITY",
+          "EWGC GR EQUITY",
+          "EWGT GR EQUITY",
+          "FGDL US EQUITY",
+          "FGLD US EQUITY",
+          "FXGD RM EQUITY",
+          "GBEES IN EQUITY",
+          "GBS LN EQUITY",
+          "GBSE IM EQUITY",
+          "GBSP LN EQUITY",
+          "GHLD AU EQUITY",
+          "GLD",
+          "GLD SJ EQUITY",
+          "GLDCO2 SW EQUITY",
+          "GLDM",
+          "GLDTR TI EQUITY",
+          "GLDW US EQUITY",
+          "GLTR US EQUITY",
+          "GOLD AU EQUITY",
+          "GOLD DU EQUITY",
+          "GOLD FP EQUITY",
+          "GOLD GR EQUITY",
+          "GOLD1 IN EQUITY",
+          "GOLD99 TB EQUITY",
+          "GOLDETF IN EQUITY",
+          "GOLDETF MK EQUITY",
+          "GOLDIETF IN EQUITY",
+          "GOLDP TI EQUITY",
+          "GRGLDRG IN EQUITY",
+          "GTU US EQUITY",
+          "GXLD AU EQUITY",
+          "HDFGOLD IN EQUITY",
+          "IAU",
+          "IAUM US EQUITY",
+          "ICPGOLD IN EQUITY",
+          "IDBIGLD IN EQUITY",
+          "IGLD GR EQUITY",
+          "IGLG LN EQUITY",
+          "IGLN LN EQUITY",
+          "JBGOCA SW EQUITY",
+          "JBGOCX SW EQUITY",
+          "JBGOEA SW EQUITY",
+          "JBGOEX SW EQUITY",
+          "JBGOGA SW EQUITY",
+          "JBGOGX SW EQUITY",
+          "JBGOUA SW EQUITY",
+          "JBGOUX SW EQUITY",
+          "KG965 TB EQUITY",
+          "KILO CN EQUITY",
+          "KILO/B CN EQUITY",
+          "KILO/U CN EQUITY",
+          "KOGOLD IN EQUITY",
+          "LGOLDAA SP EQUITY",
+          "LGOLDAH SP EQUITY",
+          "LGOLDAU SP EQUITY",
+          "LGOLDIH SP EQUITY",
+          "LGOLDMH SP EQUITY",
+          "LGOLDSA SP EQUITY",
+          "LICMFGLD IN EQUITY",
+          "MAGOLDF IN EQUITY",
+          "MILLBULL CN EQUITY",
+          "MNT CN EQUITY",
+          "MOSLGRG IN EQUITY",
+          "MOSTGLD IN EQUITY",
+          "NUGG AU EQUITY",
+          "OUNZ US EQUITY",
+          "PHAU LN EQUITY",
+          "PHPM LN EQUITY",
+          "PHYS",
+          "PICMETH SW EQUITY",
+          "PICPGHI SW EQUITY",
+          "PICPGHZ SW EQUITY",
+          "PICPGIC SW EQUITY",
+          "PICPGIE SW EQUITY",
+          "PICPGIS SW EQUITY",
+          "PICPGIU SW EQUITY",
+          "PICPGIY SW EQUITY",
+          "PICPGPC SW EQUITY",
+          "PICPGPE SW EQUITY",
+          "PICPGPH SW EQUITY",
+          "PICPGPR SW EQUITY",
+          "PICPGPS SW EQUITY",
+          "PICPGPU SW EQUITY",
+          "PICPGRC SW EQUITY",
+          "PICPGRE SW EQUITY",
+          "PICPGRU SW EQUITY",
+          "PICPGZE SW EQUITY",
+          "PICPGZU SW EQUITY",
+          "PICPRMH SW EQUITY",
+          "PIMPGJD SW EQUITY",
+          "PMGOLD AU EQUITY",
+          "QAU AU EQUITY",
+          "QTGOLD IN EQUITY",
+          "REGGOLD IN EQUITY",
+          "REGOLD IN EQUITY",
+          "RFSGDAU SW EQUITY",
+          "RFSGDHC SW EQUITY",
+          "RGLDO SW EQUITY",
+          "RGLDOH SW EQUITY",
+          "RGLDOU SW EQUITY",
+          "RGLDS SW EQUITY",
+          "RGLDSH SW EQUITY",
+          "RGRT SW EQUITY",
+          "RGRTH SW EQUITY",
+          "RGRTU SW EQUITY",
+          "RM3H GR EQUITY",
+          "RMAU LN EQUITY",
+          "RMCH SW EQUITY",
+          "RMPH LN EQUITY",
+          "SESG US EQUITY",
+          "SETFGOLD IN EQUITY",
+          "SGBS LN EQUITY",
+          "SGETS IN EQUITY",
+          "SGLD LN EQUITY",
+          "SGLDBULA CN EQUITY",
+          "SGLDBULF CN EQUITY",
+          "SGLN LN EQUITY",
+          "SGLS LN EQUITY",
+          "SGOL US EQUITY",
+          "SPAUAGR LE EQUITY",
+          "SPPG95P LE EQUITY",
+          "SPPM95P LE EQUITY",
+          "TGLD LN EQUITY",
+          "TGOLDEF IN EQUITY",
+          "TGOLDETF TB EQUITY",
+          "TMGD GR EQUITY",
+          "TWCGERG IN EQUITY",
+          "UBGDAHC SW EQUITY",
+          "UBGDAHE SW EQUITY",
+          "UBGDAHU SW EQUITY",
+          "UBGDIHC SW EQUITY",
+          "UBGDIHU SW EQUITY",
+          "UNGOERG IN EQUITY",
+          "UTIGOL IN EQUITY",
+          "VALT CN EQUITY",
+          "VALT/B CN EQUITY",
+          "VALT/U CN EQUITY",
+          "WGLD LN EQUITY",
+          "XAD1 GR EQUITY",
+          "XAD5 GR EQUITY",
+          "XGDE GR EQUITY",
+          "XGDG LN EQUITY",
+          "XGDU GR EQUITY",
+          "XGLD LN EQUITY",
+          "XGLI LN EQUITY",
+          "XGLS LN EQUITY",
+          "XGOC SW EQUITY",
+          "XOB1 GR EQUITY",
+          "XOB2 GR EQUITY",
+          "ZGLD CN EQUITY",
+          "ZGLD SW EQUITY",
+          "ZGLD/U CN EQUITY",
+          "ZGLDETF IN EQUITY",
+          "ZGLDEU SW EQUITY",
+          "ZGLDGB SW EQUITY",
+          "ZGLDHC SW EQUITY",
+          "ZGLDHE SW EQUITY",
+          "ZGLDHG SW EQUITY",
+          "ZGLDUS SW EQUITY",
+          "ZGLH CN EQUITY",
+          "ZGOL AU EQUITY"
+        ]
+      },
+      "name": "wgc_etf_monthly_canonical",
+      "primary_key": [],
+      "relation_kind": "view",
+      "row_count": 26460,
+      "series_profiles": []
+    }
+  ],
+  "scope": {
+    "database": "option_wizard_local",
+    "external_provider_calls": 0,
+    "mode": "read_only_snapshot",
+    "schema": "uw_scan"
+  }
+}

--- a/docs/runbooks/data-gap-dataset-policy.md
+++ b/docs/runbooks/data-gap-dataset-policy.md
@@ -6,7 +6,7 @@ Generated from `REGISTRY` in `src/uw_scan/reports/data_gap_healer.py` (one sourc
 uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_policy_markdown as r; open('docs/runbooks/data-gap-dataset-policy.md','w').write(r())"
 ```
 
-**132 datasets** across 9 groups.
+**134 datasets** across 10 groups.
 
 ## core_watchlist
 
@@ -48,6 +48,13 @@ uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_pol
 | uw_gold_options_daily | freshness_only | uw | run_once | gold_uw_options | equity_session |  |
 | wgc_etf_monthly | freshness_only | none | none |  | monthly | source needs auth cookie / no historical API (audit-only) |
 | wgc_etf_monthly_canonical | freshness_only | none | none |  | monthly | source needs auth cookie / no historical API (audit-only) |
+
+## macro_evidence
+
+| table | audit_mode | provider | granularity | adapter | freq | reason |
+|---|---|---|---|---|---|---|
+| macro_observations | provenance | none | none |  | none |  |
+| macro_source_artifacts | provenance | none | none |  | none |  |
 
 ## operational_provenance
 

--- a/docs/superpowers/plans/2026-08-12-macro-mc0-evidence-contract.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc0-evidence-contract.md
@@ -1,0 +1,245 @@
+# Macro MC0 Evidence Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+> **Execution status (2026-08-12):** implementation verified on
+> `feat/macro-evidence-contract`; repository history records merge status. Live source adapters and
+> production cutover remain outside MC0.
+
+**Goal:** create the immutable, free-first, point-in-time evidence substrate that every macro domain
+uses, while preserving the existing rates and gold read paths during migration.
+
+**Architecture:** add an append-only artifact/observation store and typed evidence reference contract
+in a new macro domain. Existing rates/gold tables remain legacy read models; a measured dual-read
+inventory precedes any adapter or cutover. Mock/static/demo values are rejected at the persistence
+boundary and may exist only in test fixtures with explicit provenance.
+
+**Tech Stack:** PostgreSQL/psycopg, Pydantic v2, Python 3.13 via `uv`, existing repository mixin and
+dataset-registry conventions.
+
+---
+
+## Preconditions and PR boundary
+
+- Start from current `origin/main` in a new `.worktrees/<slug>` worktree; do not reuse
+  `feat/fundamental-tier1-ingest`.
+- Recheck the next migration number. This plan reserves `115_macro_evidence.sql` based on the current
+  branch; rename before coding if another migration has landed.
+- This PR adds schema, persistence, contracts, registry entries, and a legacy inventory only. It does
+  not add live source jobs, domain scores, UI, or PM integration.
+- No commit step is authorized merely by this document. Run the checkpoint only if the user has
+  explicitly authorized commits for the execution task.
+
+### Task 1: Freeze the evidence and time design
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-12-macro-evidence-contract-design.md`
+- Modify: `docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md`
+
+**Steps:**
+
+1. Define `published_at`, `available_at`, `first_observed_at`, artifact `retrieved_at`/`last_seen_at`,
+   and `period_end` with
+   examples for a revised CPI release, a daily market series, a weekly CFTC release, and an SEP
+   table.
+2. Freeze the artifact and observation identities:
+
+```text
+artifact unique: (source, source_record_id, content_hash)
+observation unique: (source, series_id, period_end, available_at, content_hash)
+```
+
+3. Define allowed `quality_status` values (`valid`, `invalid`, `partial`, `quarantined`) and
+   `cost_class` values (`free_official`, `free_publisher`, `already_entitled`,
+   `free_third_party_shadow`, `paid_authorized`).
+4. State that `source_kind in {mock, static, demo}` is rejected outside `option_wizard_test`.
+5. Record dual-read rules: legacy tables remain authoritative until an adapter proves row/value/time
+   parity and the read flag is explicitly flipped.
+6. Update MC0 status from `planned` to `specified`; do not mark it verified.
+
+**Verification:**
+
+Run `rg -n "available_at|free_official|mock|dual-read" docs/superpowers/specs/2026-08-12-macro-evidence-contract-design.md`.
+Expected: each invariant is present and defined once.
+
+### Task 2: Add failing migration and repository tests
+
+**Files:**
+- Create: `tests/integration/storage/test_macro_context_repository.py`
+- Create: `tests/unit/models/test_macro_models.py`
+
+**Steps:**
+
+1. Add an integration test that inserts one artifact and observation twice and expects one logical
+   row with `last_seen_at` advanced.
+2. Add a restatement test: same source/series/period with a new `available_at` and content hash must
+   create a second observation; an `as_of` query before the revision returns the predecessor.
+3. Add a source-disagreement test: official and third-party observations coexist and official
+   precedence is selected without deleting dissent.
+4. Add a rejection test for `source_kind="mock"` outside the test-only escape hatch.
+5. Add Pydantic tests for timezone-aware timestamps, numeric units, allowed cost classes, and an
+   evidence reference that round-trips without losing IDs.
+6. Run:
+
+```bash
+uv run pytest tests/integration/storage/test_macro_context_repository.py tests/unit/models/test_macro_models.py -q
+```
+
+Expected: FAIL because the migration, models, and repository domain do not exist.
+
+### Task 3: Add the immutable macro evidence schema
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/115_macro_evidence.sql`
+
+**Required tables:**
+
+```text
+macro_source_artifacts
+  artifact_id BIGSERIAL PRIMARY KEY
+  source, source_kind, source_record_id, source_url (domain-neutral payload identity)
+  published_at, available_at, retrieved_at, last_seen_at
+  content_hash, parser_version, quality_status, cost_class
+  media_type, content_length
+  raw_jsonb, raw_text, raw_bytes (exactly one non-null for a successful fetch)
+  UNIQUE (source, source_record_id, content_hash)
+
+macro_observations
+  obs_id BIGSERIAL PRIMARY KEY
+  artifact_id FK -> macro_source_artifacts
+  domain, series_id, period_end, frequency, unit
+  value_numeric, value_text, value_jsonb (exactly one non-null)
+  source, source_record_id, published_at, available_at
+  first_observed_at, last_seen_at, content_hash, parser_version
+  quality_status, cost_class
+  UNIQUE (source, series_id, period_end, available_at, content_hash)
+```
+
+**Steps:**
+
+1. Add checks for allowed observation-domain/source-kind/quality/cost values, one-of-three observation value
+   columns, and one-of-three artifact payload columns. `raw_bytes` is required for PDF/XLSX payloads
+   whose exact bytes cannot be reconstructed from parsed JSON/text.
+2. Recompute artifact hash/length and normalized observation hash in both Python and PostgreSQL.
+3. Add database guards that allow only monotonic sighting metadata, enforce artifact availability and
+   quality bounds, and reject evidence updates/deletes.
+4. Add PIT indexes on `(series_id, period_end, available_at DESC)` and artifact lookup indexes.
+5. Make the migration idempotent; do not alter/drop legacy rates or gold tables.
+6. Run migrations twice against the test database through the normal integration fixture.
+
+### Task 4: Implement the repository and typed contracts
+
+**Files:**
+- Create: `src/uw_scan/storage/macro_context.py`
+- Modify: `src/uw_scan/storage/repository.py`
+- Create: `src/uw_scan/models/macro.py`
+- Modify: `src/uw_scan/models/__init__.py`
+
+**Required repository surface:**
+
+```python
+insert_macro_artifact(...)->int
+insert_macro_observations(...)->int
+fetch_macro_observation_as_of(series_id, period_end, as_of, preferred_sources)->dict|None
+fetch_macro_series_as_of(series_id, as_of, from_date=None, preferred_sources)->list[dict]
+fetch_macro_observation_history(series_id, period_end)->list[dict]
+```
+
+**Steps:**
+
+1. Use explicit argument lists and `Jsonb`; do not add methods directly to the aggregate repository.
+2. `insert_macro_observations` may update only sighting metadata for the identical immutable identity.
+3. PIT queries require timezone-aware `as_of`, explicit non-empty source precedence, artifact and
+   observation `available_at <= as_of`, and exclude invalid/quarantined evidence by default.
+4. Implement `MacroEvidenceRef`, `MacroObservation`, `MacroSourceArtifact`, and literal enums in
+   `models/macro.py`; preserve public model identity through existing export helpers.
+5. Run the tests from Task 2. Expected: PASS.
+
+### Task 5: Register the temporal datasets and policy documentation
+
+**Files:**
+- Modify: `src/uw_scan/reports/data_gap_healer.py`
+- Modify: `docs/runbooks/data-gap-dataset-policy.md`
+- Test: `tests/integration/worker/test_data_gap_full_coverage.py`
+- Test: `tests/unit/reports/test_data_gap_dataset_policy.py`
+
+**Steps:**
+
+1. Register `macro_source_artifacts` and `macro_observations` as provenance/event-temporal datasets;
+   do not classify them as strict daily ticker coverage.
+2. Regenerate the policy document using the repository's existing renderer.
+3. Run:
+
+```bash
+uv run pytest tests/integration/worker/test_data_gap_full_coverage.py tests/unit/reports/test_data_gap_dataset_policy.py -q
+```
+
+Expected: PASS and the committed policy document matches the registry.
+
+### Task 6: Persist the legacy inventory and dual-read acceptance baseline
+
+**Files:**
+- Create: `scripts/research/macro_legacy_inventory.py`
+- Create: `docs/research/2026-08-12-macro-legacy-inventory/README.md`
+- Create: `docs/research/2026-08-12-macro-legacy-inventory/inventory.json`
+- Create: `docs/research/2026-08-12-macro-legacy-inventory/VERDICT.md`
+
+**Steps:**
+
+1. Inventory every existing rates/gold series/table, date span, revision key, source, timestamp
+   semantics, and downstream consumer.
+2. Flag overwriting identities, missing provenance, mixed/mock source status, and sources with no
+   official fallback.
+3. Persist the exact reproduce command and add `--self-check` for deterministic JSON ordering and
+   required table coverage.
+4. Do not write production rows or call paid providers.
+5. Run the self-check and record the output in `VERDICT.md`.
+
+### Task 7: Final verification and conditional checkpoint
+
+Run:
+
+```bash
+bash scripts/migrate.sh
+bash scripts/migrate.sh
+uv run pytest tests/integration/storage/test_macro_context_repository.py tests/unit/models/test_macro_models.py tests/integration/worker/test_data_gap_full_coverage.py tests/unit/reports/test_data_gap_dataset_policy.py -q
+uv run python scripts/research/macro_legacy_inventory.py --self-check
+git diff --check
+git status --short
+```
+
+Expected: migrations are idempotent, tests/self-check pass, and only MC0 files plus the required
+policy regeneration are changed.
+
+If and only if commits were explicitly authorized:
+
+```bash
+git add docs/superpowers/specs/2026-08-12-macro-evidence-contract-design.md docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md src/uw_scan/storage/migrations/115_macro_evidence.sql src/uw_scan/storage/macro_context.py src/uw_scan/storage/repository.py src/uw_scan/models/macro.py src/uw_scan/models/__init__.py src/uw_scan/reports/data_gap_healer.py docs/runbooks/data-gap-dataset-policy.md tests/integration/storage/test_macro_context_repository.py tests/unit/models/test_macro_models.py scripts/research/macro_legacy_inventory.py docs/research/2026-08-12-macro-legacy-inventory
+git commit -m "feat(macro): add immutable evidence contract"
+```
+
+## MC0 exit criteria
+
+- revisions survive and replay PIT;
+- identical refresh is idempotent;
+- source disagreement survives canonical selection;
+- mock/static/demo cannot enter production evidence;
+- cost/source/time semantics are typed;
+- legacy history remains untouched;
+- registry/policy gates pass;
+- the persisted inventory identifies every adapter required by MC1–MC3.
+
+## Execution record
+
+- Worktree: `.worktrees/macro-evidence-contract`
+- Development DB boundary: `option_wizard_local` read-only inventory only
+- Automated DB boundary: `option_wizard_test`
+- Migration replay: two consecutive full migration passes succeeded
+- Tests: 1,715 unit tests and 927 integration tests passed (11 integration skips), including
+  recomputed content identity, Python/PostgreSQL JSON parity, direct-SQL immutability and finite
+  numeric rejection, revisions, PIT source precedence, conservative availability, artifact quality
+  bounds, registry/policy, legacy rates/gold regressions, and public model exports
+- Inventory: 19 relations covered; deterministic inside a repeatable-read transaction; zero provider
+  calls
+- Static gates: Ruff check/format and `git diff --check` passed
+- Checkpoint: feature PR required; no direct push or deployment is authorized

--- a/docs/superpowers/plans/2026-08-12-macro-mc1-fomc-sep-policy-paths.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc1-fomc-sep-policy-paths.md
@@ -1,0 +1,180 @@
+# Macro MC1 FOMC, SEP, and Policy Paths Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** ingest free official FOMC decisions and SEP distributions, preserve revisions and release
+times, and expose actual, committee, dealer, and market-implied policy paths as separate contracts.
+
+**Architecture:** extend the existing FOMC calendar/statement source with dedicated Federal Reserve
+SEP and New York Fed survey adapters. Normalize all releases into MC0 artifacts/observations and
+assemble four independent policy-path objects; the existing Frenzy path remains a delayed,
+third-party market shadow and is never labeled official.
+
+**Tech Stack:** httpx/BeautifulSoup, `pdfplumber` for NY Fed SME tables, Postgres MC0 evidence store,
+APScheduler, Pydantic v2, FastAPI.
+
+---
+
+## Preconditions and PR boundary
+
+- MC0/GM0 is verified and merged.
+- Recheck official page structures before coding:
+  Federal Reserve FOMC calendars/statements, official SEP tables/FAQ, and New York Fed Survey of
+  Market Expectations.
+- Persist representative official HTML/PDF fixtures under `tests/fixtures/macro/`; do not unit-test
+  against the live internet.
+- No Chair-specific anonymous-dot inference and no combined “Fed path” score.
+
+### Task 1: Write source-parser fixtures and failing tests
+
+**Files:**
+- Create: `tests/fixtures/macro/fed_sep_2026_06.html`
+- Create: `tests/fixtures/macro/nyfed_sme_policy_expectations.pdf`
+- Modify: `tests/unit/sources/test_fomc_calendar.py`
+- Create: `tests/unit/sources/test_fed_sep.py`
+- Create: `tests/unit/sources/test_nyfed_sme.py`
+
+**Steps:**
+
+1. Pin one FOMC statement with target action and vote split.
+2. Pin one official SEP table containing the participant distribution and published medians.
+3. Pin one NY Fed SME release containing meeting-path/OIS/distribution fields.
+4. Test exact dates, units, participant-count totals, medians, source record IDs, and release times.
+5. Test malformed/missing tables raise a normalization error rather than returning an empty release.
+6. Run the three tests. Expected: new source modules are missing and tests FAIL.
+
+### Task 2: Implement official Federal Reserve SEP parsing
+
+**Files:**
+- Create: `src/uw_scan/sources/fed_sep.py`
+- Modify: `src/uw_scan/sources/fomc_calendar.py`
+- Test: `tests/unit/sources/test_fed_sep.py`
+- Test: `tests/unit/sources/test_fomc_calendar.py`
+
+**Required typed outputs:**
+
+```text
+SepRelease(release_date, meeting_date, source_url, source_record_id, projections)
+SepProjection(variable, horizon, central_tendency, range, median, participant_distribution)
+```
+
+**Steps:**
+
+1. Discover SEP links from official calendar/release pages rather than hardcoding the latest URL.
+2. Parse exact one-eighth-point dot distribution counts when the official table provides them; retain
+   published medians separately.
+3. Validate all distribution counts are nonnegative integers and totals are internally consistent per
+   horizon.
+4. Preserve anonymous distributions only. Do not expose a participant identity field.
+5. Emit audit metadata needed by MC0 before returning normalized rows.
+6. Run parser tests. Expected: PASS.
+
+### Task 3: Implement New York Fed dealer-expectations parsing
+
+**Files:**
+- Create: `src/uw_scan/sources/nyfed_sme.py`
+- Create: `tests/unit/sources/test_nyfed_sme.py`
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+
+**Steps:**
+
+1. Add and lock `pdfplumber` as the production PDF table dependency; do not rely on a desktop-only
+   workspace package or shell executable.
+2. Discover the latest SME release from the NY Fed publisher page and persist the exact PDF bytes,
+   media type, length, and artifact hash before parsing.
+3. Extract only preregistered policy-path/distribution tables. Store page/table coordinates in
+   `source_record_id` metadata so a reviewer can reproduce extraction.
+4. Reject a release if expected labels, units, or table totals change.
+5. Normalize to dealer path points without translating them into SEP or market-implied semantics.
+6. Run fixture tests. Expected: PASS.
+
+### Task 4: Persist four typed policy paths
+
+**Files:**
+- Create: `src/uw_scan/macro/policy.py`
+- Create: `src/uw_scan/macro/__init__.py`
+- Modify: `src/uw_scan/models/macro.py`
+- Modify: `src/uw_scan/storage/macro_context.py`
+- Create: `tests/unit/macro/test_policy_paths.py`
+- Modify: `tests/integration/storage/test_macro_context_repository.py`
+
+**Steps:**
+
+1. Add `PolicyPathKind = actual | committee_projection | dealer_expectations | market_implied`.
+2. Create a pure assembler that refuses duplicate kinds and never averages across kinds.
+3. Map official statements to `actual`, SEP to `committee_projection`, SME to
+   `dealer_expectations`, and futures/OIS observations to `market_implied`.
+4. Allow Frenzy rows only when evidence is labeled `free_third_party_shadow`; surface their delay and
+   source explicitly.
+5. Test disagreement remains visible and removing one path does not mutate another.
+6. Test an as-of before an SEP release cannot see that SEP.
+
+### Task 5: Add worker ingestion and immutable release persistence
+
+**Files:**
+- Create: `src/uw_scan/worker/jobs/macro_policy_jobs.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Create: `tests/integration/worker/test_macro_policy_jobs.py`
+
+**Steps:**
+
+1. Implement independent jobs for FOMC statements/calendar, SEP, and NY Fed SME; each writes raw
+   artifact/audit before normalized observations.
+2. Add explicit enable flags defaulting off and bounded retry/backoff at the orchestration layer.
+3. Do not make the official jobs depend on Frenzy availability.
+4. Test unchanged rerun writes no new fact; a changed artifact creates a new release/vintage.
+5. Test one source failure leaves other paths available and records degraded freshness.
+
+### Task 6: Expose a policy comparison API
+
+**Files:**
+- Create: `src/uw_scan/api/routers/macro.py`
+- Modify: `src/uw_scan/api/server.py`
+- Modify: `src/uw_scan/models/macro.py`
+- Create: `tests/integration/api/test_macro_policy_router.py`
+- Modify: `web/lib/types.ts` via generation
+
+**Endpoint:** `GET /api/macro/policy?as_of=YYYY-MM-DD`
+
+**Steps:**
+
+1. Return four separately keyed path objects, evidence refs, release times, freshness, and
+   contradictions.
+2. Return `null` plus a reason for a missing path; never synthesize a substitute path.
+3. Verify historical `as_of` replay and OpenAPI component stability.
+4. Regenerate TypeScript types.
+
+### Task 7: Real-source probe, documentation, and conditional checkpoint
+
+**Files:**
+- Create: `scripts/research/fomc_sep_source_probe.py`
+- Create: `docs/research/2026-08-12-fomc-sep-source-probe/README.md`
+- Create: `docs/research/2026-08-12-fomc-sep-source-probe/probe.json`
+- Create: `docs/research/2026-08-12-fomc-sep-source-probe/VERDICT.md`
+- Modify: `src/uw_scan/sources/CLAUDE.md`
+
+Run the probe against official free sources, persist status/content hash/table counts, and add a
+`--self-check`. Then run:
+
+```bash
+uv run pytest tests/unit/sources/test_fomc_calendar.py tests/unit/sources/test_fed_sep.py tests/unit/sources/test_nyfed_sme.py tests/unit/macro/test_policy_paths.py tests/integration/storage/test_macro_context_repository.py tests/integration/worker/test_macro_policy_jobs.py tests/integration/api/test_macro_policy_router.py -q
+cd web && npm run gen:types
+uv run python scripts/research/fomc_sep_source_probe.py --self-check
+git diff --check
+```
+
+Expected: all tests and self-check pass; the probe distinguishes HTTP/parse/empty states.
+
+If and only if explicitly authorized, checkpoint with a scoped `feat(macro): ingest official FOMC
+and SEP evidence` commit.
+
+## MC1 exit criteria
+
+- official decisions/votes/statements replay by release time;
+- SEP distributions and medians replay without participant attribution;
+- dealer expectations and market-implied pricing remain independent;
+- Frenzy is visibly third-party/delayed and non-load-bearing;
+- parser drift fails loudly with retained artifacts;
+- source failure degrades one path, not the whole policy view;
+- real official-source probe and worker/database/API tests pass.

--- a/docs/superpowers/plans/2026-08-12-macro-mc2-inflation-rates-state.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc2-inflation-rates-state.md
@@ -1,0 +1,194 @@
+# Macro MC2 Inflation and Rates State Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** build point-in-time inflation and policy/rates states from free official evidence, replace
+false precision with state/direction/velocity/confidence, and adapt the existing rates surface without
+deleting its history.
+
+**Architecture:** inflation and rates are pure domain engines over MC0 observations. Inflation owns
+realized inflation, breadth/stickiness, expectations, and momentum; rates owns policy paths, curve,
+decomposition, supply, positioning, and plumbing. Shared inputs are referenced once and causal roles
+are explicit. Legacy `RatesScorecard` remains available during dual-read but is not the new state
+contract.
+
+**Tech Stack:** existing FRED/Cleveland Fed/FOMC/CFTC/Treasury clients, new official BLS/BEA adapters,
+Postgres, Pydantic v2, FastAPI, Vitest/Playwright.
+
+---
+
+## Preconditions and PR boundary
+
+- MC0 and MC1 gates pass.
+- Recheck migration numbering; this plan reserves `116_macro_domain_states.sql`.
+- Source scope is intentionally bounded: BLS CPI, BEA PCE, FRED/ALFRED-compatible market series,
+  Cleveland Fed decomposition, FOMC/SEP, CFTC TFF, Treasury/FiscalData. Survey breadth can land only
+  after its own free-source fixture/probe.
+- Do not fit a forecasting model or promote duration BUY/SELL in this PR.
+
+### Task 1: Preregister state definitions and golden scenarios
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-12-inflation-rates-state-design.md`
+- Create: `tests/fixtures/macro/inflation_rates_golden.json`
+
+Define load-bearing inputs, units, release lags, horizons, missingness, contradiction rules, and
+state labels before implementation. Include at least:
+
+1. disinflation with sticky services;
+2. broad reacceleration;
+3. dovish SEP but hawkish market pricing;
+4. rising nominal yield driven by real yields;
+5. supply pressure with neutral macro inputs;
+6. stale or revised CPI/PCE.
+
+For every scenario specify expected state, direction, velocity, confidence reasons, and evidence
+roles. Curves/slopes may describe shape but cannot stand in for term premium.
+
+### Task 2: Add official BLS and BEA fixtures and failing parser tests
+
+**Files:**
+- Create: `src/uw_scan/sources/bls.py`
+- Create: `src/uw_scan/sources/bea.py`
+- Create: `tests/unit/sources/test_bls.py`
+- Create: `tests/unit/sources/test_bea.py`
+- Create: `tests/fixtures/macro/bls_cpi_release.json`
+- Create: `tests/fixtures/macro/bea_pce_release.json`
+
+**Steps:**
+
+1. Write tests first for release date, observation period, units, seasonal-adjustment identity,
+   headline/core components, and missing/changed schemas.
+2. Implement thin official-source clients with injected request-audit hooks.
+3. Normalize publisher rows into MC0 observations; do not calculate YoY in source modules.
+4. Test zero rows and HTTP errors remain distinct.
+5. Run tests. Expected: PASS after minimal implementation.
+
+### Task 3: Implement pure inflation state
+
+**Files:**
+- Create: `src/uw_scan/macro/contracts.py`
+- Create: `src/uw_scan/macro/inflation.py`
+- Create: `tests/unit/macro/test_inflation_state.py`
+
+**Required output:** `MacroDomainState(domain="inflation", state, direction, velocity,
+confidence, confidence_reasons, contradictions, factors, evidence_refs, engine_version,
+inputs_hash, as_of)`.
+
+**Steps:**
+
+1. Write failing golden-scenario tests.
+2. Compute publisher-defined MoM/YoY/annualized changes only from observations available by `as_of`.
+3. Separate realized headline/core, breadth/stickiness, survey/model expectations, and market
+   compensation. Do not call breakevens pure expectations.
+4. Make thresholds/transformations versioned parameters, not module constants hidden from hashes.
+5. Confidence is a deterministic function of completeness, freshness, source quality, revisions,
+   and contradictions; it is not the absolute value of the signal.
+6. Run unit tests and verify every golden scenario.
+
+### Task 4: Implement pure policy/rates state and remove proxy ambiguity
+
+**Files:**
+- Create: `src/uw_scan/macro/rates.py`
+- Modify: `src/uw_scan/rates/calculations.py`
+- Modify: `src/uw_scan/rates/scorecard.py`
+- Create: `tests/unit/macro/test_rates_state.py`
+- Modify: `tests/unit/rates/test_scorecard.py`
+
+**Steps:**
+
+1. Build policy stance from the four MC1 paths without averaging them.
+2. Build curve/decomposition state from nominal, real, inflation compensation, and the existing
+   Cleveland model's explicit components.
+3. Keep supply, positioning, and plumbing as separate factors with their own freshness.
+4. Rename or remove any UI/API field that describes slope as term premium; preserve compatibility
+   with a deprecation alias if required.
+5. Change legacy scorecard behavior so incomplete groups cannot produce a confident stance:
+   `duration_stance` remains neutral/unknown with explicit coverage when load-bearing groups are
+   missing.
+6. Test threshold edges, missing groups, stale inputs, path disagreement, and decompositions whose
+   components do not add within tolerance.
+
+### Task 5: Persist versioned domain states and evidence associations
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/116_macro_domain_states.sql`
+- Modify: `src/uw_scan/storage/macro_context.py`
+- Modify: `src/uw_scan/reports/data_gap_healer.py`
+- Modify: `docs/runbooks/data-gap-dataset-policy.md`
+- Modify: `tests/integration/storage/test_macro_context_repository.py`
+
+**Required tables:**
+
+```text
+macro_domain_states
+  state_id, domain, as_of, computed_at, engine_version, inputs_hash
+  state, direction, velocity_jsonb, confidence, confidence_reasons_jsonb
+  contradictions_jsonb, factors_jsonb, status
+  UNIQUE (domain, as_of, engine_version, inputs_hash)
+
+macro_domain_state_evidence
+  state_id FK, obs_id FK, causal_role, ordinal
+  PRIMARY KEY (state_id, obs_id, causal_role)
+```
+
+Add repository methods for insert/fetch/replay, immutable method identity, typed evidence FKs, and
+dataset-registry entries. Run migrations twice and the full registry-policy gate.
+
+### Task 6: Add worker jobs and dual-read rates API
+
+**Files:**
+- Create: `src/uw_scan/worker/jobs/macro_state_jobs.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Modify: `src/uw_scan/api/routers/macro.py`
+- Modify: `src/uw_scan/api/routers/rates.py`
+- Modify: `src/uw_scan/models/macro.py`
+- Create: `tests/integration/worker/test_macro_state_jobs.py`
+- Create: `tests/integration/api/test_macro_state_router.py`
+- Modify: `tests/integration/api/test_rates_router.py`
+
+**Steps:**
+
+1. Ingest official releases independently from state computation; state jobs read persisted evidence.
+2. Add `GET /api/macro/inflation` and `GET /api/macro/rates` with `as_of` replay.
+3. Add a feature-flagged state/confidence block to `/api/rates/snapshot`; keep the legacy payload
+   until web parity is measured.
+4. Test provider-down computation from persisted evidence, idempotent recompute, stale labeling, and
+   exact evidence references.
+
+### Task 7: Adapt the rates UI to evidence-first presentation
+
+**Files:**
+- Modify: `web/components/rates/RatesDesk.tsx`
+- Modify: `web/components/rates/RatesScorecard.tsx`
+- Create: `web/components/rates/PolicyPathComparison.tsx`
+- Modify: `web/tests/unit/rates/RatesScorecard.test.tsx`
+- Modify: `web/tests/unit/rates/RatesDesk.test.tsx`
+- Create: `web/tests/e2e/macro-rates-state.spec.ts`
+
+**Steps:**
+
+1. Lead with state, direction, velocity, confidence reasons, and contradictions.
+2. Render actual/SEP/dealer/market paths in separate lanes with source and release date.
+3. Demote legacy composite/stance behind an “experimental legacy” label while dual-read remains.
+4. Render missing/stale/mock-rejected states without fabricated zeros.
+5. Browser-test replay, partial paths, stale data, and no-score behavior.
+
+### Task 8: Verification and conditional checkpoint
+
+Run targeted source, macro, storage, worker, API, web-unit, type-generation, and Playwright suites;
+run migrations twice; run `git diff --check`. Then run the real source → worker → DB → API →
+browser smoke after restarting the worker stack.
+
+If and only if explicitly authorized, checkpoint with a scoped `feat(macro): add inflation and rates
+state engines` commit.
+
+## MC2 exit criteria
+
+- inflation and rates states replay under `available_at <= as_of`;
+- exact observation FKs reconstruct every state;
+- incomplete data abstains or degrades explicitly;
+- policy paths never merge;
+- slope is not presented as term premium;
+- legacy stance is visibly experimental and cannot become confident from missing groups;
+- real worker/database/API/browser path passes.

--- a/docs/superpowers/plans/2026-08-12-macro-mc3-usd-gold-state.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc3-usd-gold-state.md
@@ -1,0 +1,160 @@
+# Macro MC3 USD Transmission and Gold State Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** add a free-first USD-transmission state, adapt Gold Compass to the shared macro evidence
+contract, and guarantee that every gold output references all inputs it actually consumed.
+
+**Architecture:** USD is a transmission domain, not a duplicate inflation/rates score. It consumes
+shared upstream state IDs plus official broad-dollar, relative-policy, funding/liquidity, and
+positioning evidence. Gold preserves its three lenses—structural flow, regime-gated cyclical, and
+valuation overlay—but emits a versioned macro domain state with complete typed provenance.
+
+**Tech Stack:** FRED/Federal Reserve H.10, BIS SDMX/CSV, CFTC, existing Gold Compass sources and
+cards, MC0/MC2 storage/contracts, FastAPI and React.
+
+---
+
+## Preconditions and PR boundary
+
+- MC2 is verified; shared real-yield, inflation-compensation, policy-path, and broad-dollar ownership
+  is fixed.
+- Recheck endpoint availability before choosing BIS/Fed adapters and persist live-probe evidence.
+- Do not add Yahoo/yfinance, a DXY `static` fallback, a gold price target, allocation, or sizing.
+- Existing `/gold` remains usable throughout dual-read.
+
+### Task 1: Preregister USD and gold causal roles
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-12-usd-gold-state-design.md`
+- Create: `tests/fixtures/macro/usd_gold_golden.json`
+
+Define:
+
+- upstream shared inputs versus domain-owned inputs;
+- USD transmission factors: broad effective dollar, real/relative policy, funding/liquidity,
+  positioning, and risk transmission;
+- Gold Lens 1 structural flows, Lens 2 regime-gated cyclical factors, and Lens 3 valuation overlay;
+- contradiction, missingness, freshness, and confidence rules;
+- explicit prohibition on counting real yields, inflation compensation, or USD twice.
+
+Golden scenarios must include policy/USD disagreement, post-2022 gold/real-yield decoupling, strong
+central-bank/ETF flows with adverse cyclical inputs, and stale/missing COMEX/WGC inputs.
+
+### Task 2: Add official USD source probes and parsers
+
+**Files:**
+- Create: `src/uw_scan/sources/fed_h10.py`
+- Create: `src/uw_scan/sources/bis_eer.py`
+- Create: `tests/unit/sources/test_fed_h10.py`
+- Create: `tests/unit/sources/test_bis_eer.py`
+- Create: `scripts/research/usd_source_probe.py`
+- Create: `docs/research/2026-08-12-usd-source-probe/README.md`
+- Create: `docs/research/2026-08-12-usd-source-probe/probe.json`
+- Create: `docs/research/2026-08-12-usd-source-probe/VERDICT.md`
+
+**Steps:**
+
+1. Test/parse Federal Reserve broad-dollar/H.10 series and BIS nominal/real effective exchange-rate
+   metadata with units and country/basket identity.
+2. Preserve publisher release time and content hash; zero rows and transport errors remain distinct.
+3. Probe historical span, revision behavior, rate limits, and anonymous access.
+4. Select one official primary and one cross-check; record the rejected path if either is unstable.
+
+### Task 3: Implement pure USD transmission state
+
+**Files:**
+- Create: `src/uw_scan/macro/usd.py`
+- Create: `tests/unit/macro/test_usd_state.py`
+- Modify: `src/uw_scan/models/macro.py`
+
+**Steps:**
+
+1. Write golden-scenario tests first.
+2. Consume MC2 inflation/rates state IDs rather than recomputing their inputs.
+3. Treat broad-dollar level/momentum, relative policy, liquidity/funding, and CFTC positioning as
+   separate factors; preserve contradictions.
+4. Define velocity horizons in configuration and include them in `engine_version/inputs_hash`.
+5. Abstain when the official broad-dollar anchor is missing; no static or third-party substitute may
+   silently become primary.
+
+### Task 4: Build complete Gold Compass evidence mapping
+
+**Files:**
+- Create: `src/uw_scan/macro/gold.py`
+- Modify: `src/uw_scan/reports/gold_posture.py`
+- Modify: `src/uw_scan/storage/gold.py`
+- Create: `tests/unit/macro/test_gold_state.py`
+- Modify: `tests/integration/reports/test_gold_posture_orchestrator.py`
+- Modify: `tests/integration/e2e/test_gold_replay_acceptance.py`
+
+**Steps:**
+
+1. Add a failing test enumerating every consumed source: GLD/gold price, CPI, M2, T5YIFR, DFII10,
+   DXY/broad dollar, GPR, central-bank reserves, ETF holdings/flows, COMEX/LBMA, CFTC COT, and UW
+   options where present.
+2. Replace the four-entry `inputs_used` manifest with typed evidence associations for all consumed
+   rows. An optional absent input is recorded as an omission reason, not a fake evidence ID.
+3. Preserve the three lens outputs and the post-2022 regime gate. Lens 3 remains a valuation warning,
+   never a sizing input.
+4. Emit a `MacroDomainState(domain="gold")` referencing the existing deterministic lens result and
+   shared MC2/MC3 upstream states.
+5. Verify old replay dates still render and new replay reconstructs the exact evidence manifest.
+
+### Task 5: Persist USD/gold states and cross-domain lineage
+
+**Files:**
+- Modify: `src/uw_scan/storage/macro_context.py`
+- Modify: `src/uw_scan/storage/migrations/116_macro_domain_states.sql` only if MC2 left planned
+  generic fields unused; otherwise create the next additive migration
+- Modify: `tests/integration/storage/test_macro_context_repository.py`
+
+**Steps:**
+
+1. Persist USD/gold through the same `macro_domain_states` contract as inflation/rates.
+2. Add typed state-to-state dependency associations if they were not included in MC2:
+   `(downstream_state_id, upstream_state_id, causal_role)`.
+3. Test the same upstream state can be referenced by USD and gold without copying observations.
+4. Test a changed upstream state changes downstream `inputs_hash` and preserves the predecessor.
+
+### Task 6: Add jobs, API, and dual-read Gold/UI integration
+
+**Files:**
+- Modify: `src/uw_scan/worker/jobs/macro_state_jobs.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Modify: `src/uw_scan/api/routers/macro.py`
+- Modify: `src/uw_scan/api/routers/gold.py`
+- Create: `tests/integration/worker/test_macro_usd_gold_jobs.py`
+- Create: `tests/integration/api/test_macro_usd_gold_router.py`
+- Modify: `tests/integration/api/test_gold_router_state.py`
+- Modify: `web/components/gold/GoldCompassLayout.tsx`
+- Modify: `web/tests/e2e/gold-page.spec.ts`
+
+**Steps:**
+
+1. Add USD and gold state jobs reading persisted upstream state; source jobs remain independent.
+2. Add `GET /api/macro/usd` and `GET /api/macro/gold` with replay/evidence.
+3. Feature-flag the new state/confidence/provenance block on `/gold`; retain the existing response
+   during parity.
+4. Render structural/cyclical/valuation lenses, shared upstream state, confidence, contradictions,
+   missing-source reasons, and evidence drill-down.
+5. Remove or relabel any forecast/allocation-like output not backed by a promoted model.
+
+### Task 7: Verification and conditional checkpoint
+
+Run all new source/macro/storage/worker/API tests, existing Gold Compass integration/replay tests,
+web unit/e2e tests, type generation, migration idempotence, source probes, and the real worker → DB
+→ API → browser flow. Run `git diff --check`.
+
+If and only if explicitly authorized, checkpoint with a scoped `feat(macro): add USD and gold state
+adapters` commit.
+
+## MC3 exit criteria
+
+- USD state uses an official free primary and no static/Yahoo fallback;
+- upstream inflation/rates evidence is referenced, not duplicated;
+- every consumed gold input is present in typed provenance or explicit omissions;
+- post-2022 regime gating remains load-bearing;
+- Gold replay and legacy compatibility pass;
+- no forecast/allocation/sizing claim is promoted;
+- real source/worker/database/API/browser verification passes.

--- a/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
@@ -1,0 +1,276 @@
+# Macro MC4–MC6 Context Snapshot, PM Integration, and Validation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** assemble the four verified macro domains into a reproducible top-down context snapshot,
+attach it to Fundamental PM reports as a removable context block, and run a separate PIT/OOS gate
+before any macro state may influence ranking, sizing, or recommendations.
+
+**Architecture:** MC4 persists a snapshot DAG over existing domain-state IDs and renders a macro
+decision surface. MC5 joins the snapshot to companies/chains through effective-dated exposure
+mappings; the fundamental engine remains invariant. MC6 is research-only and uses the shared
+walk-forward harness plus full persisted traces to decide whether any precisely defined macro feature
+earns stronger authority.
+
+**Tech Stack:** PostgreSQL/psycopg, Pydantic/FastAPI, APScheduler, Next.js/React, existing Fundamental
+PM report/card contracts when landed, and `src/uw_scan/backtest/`.
+
+---
+
+## Preconditions and PR boundaries
+
+- MC2–MC3/GM2 are verified before MC4 code starts.
+- MC5 begins only after both MC4 and the Fundamental PM M3/report input-manifest contract are real.
+  Re-anchor file paths to the merged PM implementation before coding; do not edit the active P1b
+  ingest worktree.
+- MC4, MC5, and MC6 are separate PRs. MC6 failure does not roll back MC4/MC5 descriptive context.
+- Recheck migration numbering; this plan reserves `117_macro_context_snapshots.sql` for MC4 and
+  `118_company_macro_exposures.sql` for MC5.
+
+## MC4 — versioned context snapshot and macro surface
+
+### Task 1: Write snapshot invariants and failing pure tests
+
+**Files:**
+- Create: `src/uw_scan/macro/context.py`
+- Create: `tests/unit/macro/test_context_snapshot.py`
+- Modify: `src/uw_scan/models/macro.py`
+
+**Steps:**
+
+1. Test assembly requires exactly one compatible state for each available domain and never averages
+   their confidence/state into a composite score.
+2. Test causal order: inflation → rates → USD → gold, with explicit shared contradictions and
+   transmission statements.
+3. Test missing domains yield `partial` plus reasons; a missing load-bearing upstream domain prevents
+   a confident downstream transmission claim.
+4. Test same state IDs/method parameters produce the same `inputs_hash`; any changed state ID changes
+   it.
+5. Implement `MacroContextSnapshot` with domain-state IDs, top-down links, contradictions,
+   coverage/freshness, status, `engine_version`, `inputs_hash`, `as_of`, and `computed_at`.
+
+### Task 2: Persist snapshots and exact evidence lineage
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/117_macro_context_snapshots.sql`
+- Modify: `src/uw_scan/storage/macro_context.py`
+- Modify: `src/uw_scan/reports/data_gap_healer.py`
+- Modify: `docs/runbooks/data-gap-dataset-policy.md`
+- Create: `tests/integration/storage/test_macro_context_snapshots.py`
+
+**Required tables:**
+
+```text
+macro_context_snapshots
+  snapshot_id, as_of, computed_at, engine_version, inputs_hash
+  status, coverage_jsonb, freshness_jsonb, contradictions_jsonb, transmission_jsonb
+  UNIQUE (as_of, engine_version, inputs_hash)
+
+macro_context_domains
+  snapshot_id FK, domain, state_id FK, ordinal
+  PRIMARY KEY (snapshot_id, domain)
+
+macro_context_evidence
+  snapshot_id FK, obs_id FK, domain, causal_role
+  PRIMARY KEY (snapshot_id, obs_id, domain, causal_role)
+```
+
+Insert idempotently, retain prior versions, register every temporal table, regenerate the policy doc,
+and prove arbitrary-date replay reconstructs the same state/evidence DAG.
+
+### Task 3: Add snapshot worker and API
+
+**Files:**
+- Modify: `src/uw_scan/worker/jobs/macro_state_jobs.py`
+- Modify: `src/uw_scan/worker/scheduler.py`
+- Modify: `src/uw_scan/api/routers/macro.py`
+- Create: `tests/integration/worker/test_macro_context_job.py`
+- Create: `tests/integration/api/test_macro_context_router.py`
+- Modify: `web/lib/types.ts` via generation
+
+**Steps:**
+
+1. Assemble from latest compatible domain states available by `as_of`; never fetch providers inside
+   the snapshot job.
+2. Add `GET /api/macro/context` and `GET /api/macro/context/{as_of}` with evidence drill-down.
+3. Test idempotency, stale/partial behavior, mixed engine incompatibility, and provider-independent
+   replay.
+
+### Task 4: Build the top-down macro decision surface
+
+**Files:**
+- Create: `web/app/macro/page.tsx`
+- Create: `web/components/macro/MacroContextDesk.tsx`
+- Create: `web/components/macro/DomainStateCard.tsx`
+- Create: `web/components/macro/PolicyPathLanes.tsx`
+- Create: `web/components/macro/EvidenceDrawer.tsx`
+- Create: `web/tests/unit/macro/MacroContextDesk.test.tsx`
+- Create: `web/tests/e2e/macro-context.spec.ts`
+
+**Steps:**
+
+1. Render the causal sequence rather than four independent scorecards.
+2. Show state, direction, velocity, confidence reasons, contradictions, freshness, and evidence for
+   each domain.
+3. Show official/SEP/dealer/market policy paths as separate lanes.
+4. Show replay/as-of and previous-snapshot delta.
+5. Do not render a master score, probability, allocation, or target.
+6. Browser-test current, replay, missing domain, stale snapshot, and source-disagreement states.
+
+### Task 5: MC4 real-path verification and conditional checkpoint
+
+Run migrations twice, macro unit/storage/worker/API tests, type generation, web unit/build/e2e, and a
+real persisted-evidence → state → snapshot → API → browser smoke. Verify an old snapshot hash
+does not change after inserting a later revision.
+
+If and only if explicitly authorized, checkpoint with `feat(macro): add top-down context snapshots`.
+
+## MC5 — context-only Fundamental PM integration
+
+### Task 6: Freeze company/chain macro exposure semantics
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-12-company-macro-exposure-design.md`
+- Modify: `docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md`
+
+Define effective-dated, versioned exposure rows:
+
+```text
+ticker / chain_id
+factor_key
+transmission_channel
+direction (positive / negative / mixed / unknown)
+strength (disclosed numeric or bounded qualitative)
+status (disclosed / derived / inferred / disputed / unsupported)
+effective_from / effective_to
+evidence
+exposure_version
+```
+
+Do not estimate a beta in production unless a separately persisted PIT study supports it. Manual or
+inferred mappings require evidence/status/review; the model cannot silently author them.
+
+### Task 7: Add exposure schema, repository, and review fixtures
+
+**Files:**
+- Create: `src/uw_scan/storage/migrations/118_company_macro_exposures.sql`
+- Create: `src/uw_scan/storage/macro_exposures.py`
+- Modify: `src/uw_scan/storage/repository.py`
+- Modify: `src/uw_scan/models/macro.py`
+- Create: `tests/integration/storage/test_macro_exposures.py`
+- Create: `tests/unit/macro/test_macro_exposure_resolution.py`
+
+Add immutable exposure versions, effective-date overlap checks, typed evidence associations, and
+as-of resolution for company and chain. Test disclosed/derived/inferred precedence, expiry, disputes,
+and unsupported mappings.
+
+### Task 8: Attach a removable PM macro block
+
+**Files (re-anchor to merged PM paths before implementation):**
+- Modify: `src/uw_scan/models/fundamental.py`
+- Modify: `src/uw_scan/api/routers/fundamental.py`
+- Modify: `src/uw_scan/reports/fundamental_report.py`
+- Modify: `src/uw_scan/worker/jobs/fundamental_jobs.py`
+- Modify: `web/components/stock/tabs/FundamentalsTab.tsx`
+- Create: `tests/integration/api/test_fundamental_macro_context.py`
+- Create: `tests/integration/reports/test_fundamental_macro_invariance.py`
+- Create: `web/tests/e2e/fundamental-macro-context.spec.ts`
+
+**Steps:**
+
+1. Add optional `macro_context_snapshot_id` and `macro_exposure_version` to the report/card input
+   manifest and macro block hash.
+2. Assemble company/chain implications deterministically from the snapshot and effective exposure
+   rows; label disclosed/derived/inferred/unknown.
+3. Keep fundamental facts, derivations, valuation anchors, score dimensions, and their hashes
+   unchanged.
+4. Add the load-bearing byte-invariance test: run the same fundamental computation with macro block
+   enabled and disabled and assert every fundamental output is identical.
+5. Provider/macro failure yields an omitted/stale macro block and leaves the last compatible
+   fundamental result usable.
+6. Render context, evidence, exposure status, and invalidation conditions; do not show a macro-adjusted
+   fundamental score.
+
+### Task 9: MC5 real-path verification and conditional checkpoint
+
+Run macro and fundamental unit/integration/API/web suites plus the real report/card worker path. Prove
+the macro block can be toggled off without changing fundamental rows or hashes. Run `git diff --check`.
+
+If and only if explicitly authorized, checkpoint with `feat(fundamentals): attach versioned macro
+context`.
+
+## MC6 — empirical promotion gate
+
+### Task 10: Preregister the exact target and baselines
+
+**Files:**
+- Create: `docs/research/2026-08-12-macro-context-validation/PREREGISTRATION.md`
+
+Before fitting, fix:
+
+- the proposed feature/state and any allowed transformations;
+- the exact target (descriptive transition, forward asset return, drawdown risk, or company/chain
+  outcome—never a vague “works”);
+- horizon, rebalance/decision timing, availability lag, universe, benchmark, and costs;
+- train/validation/holdout dates and regime splits;
+- simple baselines, ablations, multiple-testing policy, kill thresholds, and promotion authority.
+
+MC6 must not retrofit an attractive target after seeing results.
+
+### Task 11: Build PIT panel and reuse the shared walk-forward harness
+
+**Files:**
+- Create: `scripts/research/macro_context_walkforward.py`
+- Create: `tests/unit/research/test_macro_context_walkforward.py`
+- Reuse: `src/uw_scan/backtest/engine.py`
+- Reuse: `src/uw_scan/backtest/gates.py`
+- Reuse: `src/uw_scan/backtest/splitters.py`
+- Reuse: `src/uw_scan/backtest/metrics.py`
+- Reuse: `src/uw_scan/backtest/sweep.py`
+
+**Steps:**
+
+1. Build every decision row with `available_at <= origin` and persist excluded rows/reasons.
+2. Use the shared holdout, quarter/regime gates, metrics, and persist-as-you-go sweep; do not copy
+   private split/gate math.
+3. Compare against price-only, rate-only, and simple-domain baselines appropriate to the target.
+4. Run factor and domain ablations, source-vintage sensitivity, regime splits, overlapping-horizon
+   robust inference, turnover/cost assumptions, and stability across engine versions.
+5. Persist every configuration, metric, gate, trade/event row, error, seed, code/data hash, and exact
+   reproduce command before the process exits.
+
+### Task 12: Publish a bounded verdict
+
+**Files:**
+- Create: `docs/research/2026-08-12-macro-context-validation/results.json`
+- Create: `docs/research/2026-08-12-macro-context-validation/VERDICT.md`
+- Create: `docs/research/2026-08-12-macro-context-validation/README.md`
+
+The verdict is one of:
+
+- `descriptive_only`: retain MC4/MC5; no score/ranking/sizing authority;
+- `monitor_only`: permit one precisely defined risk/transition monitor;
+- `candidate_for_operator_approval`: evidence passes the preregistered PIT/OOS gates, but authority
+  still requires a new plan and explicit operator decision.
+
+No MC6 result directly edits production weights or methods.
+
+### Task 13: MC6 verification and conditional checkpoint
+
+Run the research unit tests, reproduction command, `--self-check`, exact artifact-consistency check,
+and unchanged shared-backtest regression suites. Inspect the full persisted trace, not only headline
+metrics.
+
+If and only if explicitly authorized, checkpoint with `research: validate macro context promotion
+gate`.
+
+## MC4–MC6 exit criteria
+
+- context snapshot replays from exact state/observation FKs and remains stable after revisions;
+- macro UI exposes causal order, disagreements, confidence, freshness, and unknowns without a master
+  score;
+- PM integration is context-only and passes byte-invariance tests;
+- missing macro context cannot remove or alter fundamental results;
+- exposure mappings are versioned/effective-dated/evidence-backed;
+- MC6 persists the full PIT/OOS trace and publishes a bounded verdict;
+- no ranking, sizing, recommendation, or method change occurs without a new explicit approval gate.

--- a/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
+++ b/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
@@ -1,0 +1,286 @@
+# Top-Down Macro Context — Program Plan
+
+> **Status:** in progress. MC0 implementation is verified on branch
+> `feat/macro-evidence-contract`; repository and PR history are authoritative for merge status. This
+> is the macro program source of truth and child-plan registry. It does not authorize implementation
+> on the active Fundamental PM ingest branch.
+
+**Goal:** replace four disconnected dashboards with a reproducible top-down research system that
+explains inflation → policy/rates → USD transmission → gold, preserves every source and vintage,
+and publishes a stable context snapshot that the Fundamental PM Agent can consume without changing
+fundamental facts or scores.
+
+**Architecture:** official/free evidence lands in one immutable macro evidence store. Four typed
+domain engines derive state, direction, velocity, confidence, and contradictions in causal order;
+they do not collapse into one unexplained score. A versioned `MacroContextSnapshot` references exact
+observations and is joined to companies/chains through separately versioned exposure mappings.
+
+**Tech stack:** Python 3.13 via `uv`, psycopg/Postgres, FastAPI/Pydantic v2, APScheduler workers,
+Next.js/React/TypeScript, existing rates/Gold Compass modules, and the shared walk-forward harness.
+
+---
+
+## 1. Product boundary
+
+The system has six successive products:
+
+1. immutable macro source artifacts and observations;
+2. official FOMC/statement/SEP evidence plus independently typed policy paths;
+3. inflation and rates state engines;
+4. USD-transmission and gold state engines;
+5. a versioned top-down context snapshot and decision surface;
+6. a context-only Fundamental PM overlay, followed by a separate empirical promotion gate.
+
+Explicit non-goals for MC0–MC5:
+
+- one master macro score;
+- automatic asset allocation, duration sizing, gold sizing, or trade proposals;
+- treating static/demo/mock values as observed facts;
+- inferring which anonymous SEP dot belongs to the Fed Chair;
+- treating a third-party FedWatch page as official Federal Reserve guidance;
+- using yield-curve slope as a term-premium substitute;
+- putting macro observations in `fundamental_statement_obs`;
+- allowing macro state to move fundamental valuation anchors or dimensions;
+- claiming forecast or ranking value before MC6.
+
+## 2. Why the existing framework cannot be promoted as-is
+
+The original public framework is a useful hypothesis map, not evidence. Its author later identified
+short samples, IC decay, target leakage, nonlinear fragility, and regime instability. The live pages
+also mix real observations with mock/static/demo inputs while emitting exact probabilities, stance,
+and allocation-like outputs. That makes the current UI more confident than its evidence.
+
+Repository evidence confirms structural problems beneath the presentation:
+
+| Finding | Repository evidence | Required response |
+|---|---|---|
+| rates vintages overwrite | `052_rates_tables.sql` keys `(series_id, obs_date, source)`; `rates_repository.py` updates value and realtime fields on conflict | append-only macro observation identity |
+| policy payloads are mutable | `053_rates_policy_sources.sql` upserts by date/source without content identity | immutable artifact/path releases |
+| rates stance uses hard thresholds | `rates/scorecard.py` turns a partially populated scorecard into BUY/SELL/NEUTRAL | state/confidence first; no promoted stance until validated |
+| Gold provenance is incomplete | `gold_posture.py` consumes flows, COT, CB, inventory, DXY, GPR, LBMA and UW, but `inputs_used` pins only four macro series | typed snapshot-to-observation evidence |
+| shared inputs can be counted twice | inflation expectations, real yields and USD appear in multiple dashboards/lenses | one shared observation, explicit causal role per domain |
+| third-party path has weaker authority | `fed_funds_futures_path.py` uses Frenzy Capital SSR as free/delayed futures-derived data | keep as shadow market path, never official truth |
+
+No existing history is deleted during migration. Legacy rates/gold tables remain readable until
+dual-read parity is proven.
+
+## 3. Core contracts
+
+### 3.1 Evidence reference
+
+Every consumed datum resolves to:
+
+```text
+domain
+source
+source_url
+source_record_id
+period_end / obs_date
+published_at
+available_at
+first_observed_at
+content_hash
+parser_version
+quality_status
+cost_class
+```
+
+`available_at <= as_of` is the universal PIT predicate. `published_at` describes the publisher's
+release time; `first_observed_at` describes Argon's first sighting. A correction or changed payload
+creates a new observation with a new content hash. It never mutates the row used by an older
+snapshot.
+
+### 3.2 Domain state
+
+Each domain publishes, independently:
+
+```text
+state                 descriptive regime label
+direction             rising / falling / mixed / unknown
+velocity              typed change over a stated horizon
+confidence             mechanical completeness/quality score plus reasons
+contradictions         list of evidence conflicts
+evidence_refs          exact observation IDs grouped by causal role
+engine_version
+inputs_hash
+as_of
+computed_at
+```
+
+Confidence is not model certainty. Missing load-bearing inputs produce `unknown` or `partial`; they
+do not trigger neutral-by-default arithmetic.
+
+### 3.3 Four policy paths
+
+Rates must keep these separate:
+
+| Path | Meaning | Preferred free source |
+|---|---|---|
+| `policy_actual` | decisions, target range, votes, statements | Federal Reserve FOMC releases |
+| `committee_projection` | anonymous participant distributions/medians | Federal Reserve SEP tables |
+| `dealer_expectations` | primary-dealer/market participant distributions | New York Fed Survey of Market Expectations |
+| `market_implied` | futures/OIS pricing | exchange/OIS derivation; Frenzy only as labeled delayed shadow |
+
+Differences between paths are a first-class output. No weighted merge produces a fictional “Fed
+path.” A Chair's public communication is narrative evidence and cannot be assigned to an anonymous
+dot.
+
+### 3.4 Snapshot and PM boundary
+
+`MacroContextSnapshot` contains the four domain-state IDs, shared contradictions, cross-domain
+transmission statements, freshness/coverage, `engine_version`, `inputs_hash`, and exact evidence
+associations. The PM report/card stores or references:
+
+```text
+macro_context_snapshot_id
+macro_exposure_version
+```
+
+Those identifiers enter the report/card `inputs_hash` for the macro block only. A missing snapshot
+or exposure mapping yields an explicit omitted block. Fundamental statements, derivations, anchors,
+and scores remain byte-for-byte identical.
+
+## 4. Free-first source policy
+
+Runtime resolution order:
+
+1. already persisted compatible PIT result;
+2. already persisted official observation;
+3. free authoritative publisher;
+4. already-entitled provider under its budget;
+5. free third-party derived source as a labeled shadow/cross-check;
+6. authorized paid capability;
+7. explicit unsupported/omitted.
+
+| Domain | Preferred free/official sources | Secondary/cross-check |
+|---|---|---|
+| Inflation | BLS, BEA, FRED/ALFRED, Cleveland Fed, NY Fed SCE, Philadelphia Fed SPF, Atlanta Fed | already-entitled structured feeds |
+| Policy/rates | Federal Reserve, NY Fed, Treasury/FiscalData, Cleveland Fed, CFTC, TIC | Frenzy delayed futures path; authorized exchange/OIS source |
+| USD | Federal Reserve broad-dollar/H.10, BIS effective exchange rates, official central-bank policy rates, CFTC | already-entitled market data |
+| Gold | FRED, CFTC, SPDR issuer archive, LBMA, IMF IFS, GPR publisher | authenticated WGC; already-entitled UW options |
+
+Yahoo/yfinance remains prohibited. HTML or workbook endpoints are accepted only with artifact hash,
+parser version, schema-drift tests, and an official fallback or explicit degraded state.
+
+## 5. Target architecture
+
+```text
+OFFICIAL / FREE PUBLISHERS
+  └── raw artifact + request audit
+       └── immutable macro observation + quality verdict
+            ├── InflationState
+            ├── PolicyRatesState
+            ├── USDTransmissionState
+            └── GoldState
+                 └── MacroContextSnapshot
+                      ├── top-down macro UI/replay
+                      └── company/chain exposure overlay
+                           └── Fundamental PM report context
+```
+
+Storage boundaries:
+
+- `macro_source_artifacts` preserves publisher payload identity and retrieval audit;
+- `macro_observations` preserves releases/revisions and time semantics;
+- typed domain-state tables preserve deterministic outputs;
+- `macro_context_snapshots` and `macro_context_evidence` preserve assembly and provenance;
+- `company_macro_exposures` preserves effective-dated sensitivity mappings;
+- existing rates/gold tables remain legacy read models until parity and cutover.
+
+## 6. Milestones and child plans
+
+| ID | Status | Child plan | Exit gate |
+|---|---|---|---|
+| MC0 | implementation verified | `2026-08-12-macro-mc0-evidence-contract.md` | two migration replays; immutable hash/time/quality/SQL guards; 19-relation read-only inventory self-check; lint/format/diff gates |
+| MC1 | planned | `2026-08-12-macro-mc1-fomc-sep-policy-paths.md` | official FOMC/SEP evidence and four independent policy paths replay PIT |
+| MC2 | planned | `2026-08-12-macro-mc2-inflation-rates-state.md` | inflation/rates states abstain honestly and reproduce from exact observations |
+| MC3 | planned | `2026-08-12-macro-mc3-usd-gold-state.md` | USD/Gold states reuse shared inputs and Gold provenance is complete |
+| MC4–MC6 | planned | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | snapshot, context-only PM integration, then separate PIT/OOS promotion verdict |
+
+Every child is implemented through its own branch/PR sequence. Status changes only after its stated
+verification evidence exists. Child plans are implementation-ready but do not imply authorization to
+commit or publish.
+
+## 7. Dependency and release sequence
+
+```text
+MC0 evidence contract
+  └── MC1 official policy evidence
+       └── MC2 inflation + rates
+            └── MC3 USD + gold
+                 └── MC4 context snapshot
+                      ├── MC5 PM context-only integration
+                      └── MC6 empirical promotion research
+```
+
+MC2 may start its pure domain calculations while MC1 source fixtures are reviewed, but its release
+waits for MC1. MC3 waits for shared-input ownership from MC2. MC5 waits for a verified MC4 snapshot
+and the PM surface/report contract; it never waits for MC6. MC6 gates only numeric score/ranking or
+sizing influence.
+
+## 8. Validation and promotion gates
+
+| Gate | Required evidence | Unlocks |
+|---|---|---|
+| GM0 | immutable revision fixtures, `available_at` PIT query, source/cost registry, mock rejection | production source adapters |
+| GM1 | official statement/SEP fixtures, table-total checks, four-path type tests, replay | policy/rates state |
+| GM2 | domain golden fixtures, missing/stale/contradiction tests, evidence completeness | context snapshot/UI |
+| GM3 | real worker → DB → API → browser smoke, replay hash equality, PM byte-invariance test | context-only PM release |
+| GM4 | preregistered PIT walk-forward, ablation, regime splits, full trace, cost assumptions | separately approved score/ranking influence |
+
+MC6 must test the exact proposed target. A descriptive state does not become predictive because it
+looks intuitive. Tests include incremental value over simple baselines, factor ablation, overlapping
+horizon handling, multiple-testing control, regime stability, and source-vintage availability.
+
+## 9. Rollout, rollback, and failure behavior
+
+- migrations are additive and idempotent;
+- new macro jobs default off until migrations and source checks pass;
+- source failure writes an audit event and retains the last compatible snapshot with stale labeling;
+- parsing failure never converts to zero, neutral, or unchanged;
+- legacy rates/gold readers remain behind a dual-read flag until row/value/provenance parity is
+  measured;
+- rollback selects the prior engine version/read path; it never deletes observations;
+- a partial domain may publish only when load-bearing omissions and confidence reasons are explicit;
+- a PM macro block can be disabled independently without changing fundamental outputs;
+- provider calls, freshness, coverage, parser failures, revision counts, snapshot lag, and PM
+  omission rate are observable.
+
+## 10. Completion criteria
+
+At the descriptive scope, a user can ask:
+
+> What changed from inflation through policy/rates and the dollar into gold, what evidence supports
+> each link, where do official projections, dealers, and markets disagree, and which portfolio
+> companies are exposed?
+
+Argon can then:
+
+1. freeze `as_of`, source vintages, engine versions, and budget;
+2. show realized inflation, expectations, policy/rates, USD transmission, and gold state separately;
+3. distinguish policy actuals, SEP, dealer expectations, and market-implied pricing;
+4. show direction, velocity, confidence, contradictions, freshness, and explicit unknowns;
+5. replay every output from exact evidence without later revisions leaking backward;
+6. attach a versioned company/chain exposure overlay to a Fundamental PM report;
+7. remove that overlay without changing any fundamental number;
+8. decline score/ranking/sizing claims until MC6 and operator approval pass.
+
+## 11. Plan maintenance protocol
+
+This document owns macro scope, milestone status, dependency, and authority. Child plans own exact
+files, tests, commands, and PR boundaries. After each implementation PR:
+
+1. link the PR and exact verification evidence in the milestone row;
+2. update source status and any endpoint/schema drift;
+3. record killed sources or factors rather than leaving permanent mock fields;
+4. update the Fundamental PM program only if the integration boundary or dependency changed;
+5. archive a child plan only after its exit gate passes;
+6. never mark `verified` from unit tests when a real source, database, worker, or browser gate is
+   required.
+
+Status vocabulary:
+
+```text
+proposed → researched → specified → planned → in_progress → verified → merged
+                                      └────────→ killed
+```

--- a/docs/superpowers/specs/2026-08-12-macro-evidence-contract-design.md
+++ b/docs/superpowers/specs/2026-08-12-macro-evidence-contract-design.md
@@ -1,0 +1,190 @@
+# Macro Evidence Contract — Design
+
+**Status:** MC0 implementation verified; live-source adapters and read cutover remain out of scope.
+
+## 1. Purpose and boundary
+
+This contract is the common point-in-time evidence substrate for inflation, policy/rates, USD, and
+gold. It stores publisher artifacts and normalized observations without overwriting revisions, then
+lets downstream engines replay only information that was available at a requested `as_of`.
+
+MC0 does not change the current rates or Gold Compass read paths. It does not fetch a new provider,
+compute a macro state, create a score, or write macro data into fundamental statement tables.
+
+## 2. Time semantics
+
+All instants are timezone-aware `TIMESTAMPTZ`; economic periods are `DATE`.
+
+| Field | Meaning | Selection role |
+|---|---|---|
+| `period_end` | Economic period represented by an observation | identifies the measured period, never its knowledge time |
+| `published_at` | Publisher-declared release instant, if known | provenance; may be null when the publisher supplies no reliable instant |
+| `available_at` | Earliest instant the observation is allowed to enter an Argon decision | universal PIT predicate: `available_at <= as_of` |
+| `first_observed_at` | First instant Argon successfully normalized this immutable observation | operational evidence; never substitutes for an earlier verified release time |
+| observation `last_seen_at` | Latest instant Argon saw the identical immutable observation | idempotent sighting metadata only |
+| artifact `retrieved_at` | First instant Argon retrieved the exact artifact bytes/text/JSON | immutable first-sighting audit and source-latency measurement |
+| artifact `last_seen_at` | Latest instant Argon retrieved the identical payload | idempotent artifact sighting metadata only |
+
+Examples:
+
+- A January CPI value released on February 12 has January's economic `period_end`; its
+  `available_at` is the verified February 12 release instant. A later corrected payload creates a new
+  observation with its own correction `available_at` and content hash.
+- A daily broad-dollar close uses that market date as `period_end`; `available_at` is the first
+  defined post-close publication instant, not midnight at the start of the same date.
+- A CFTC report keeps the Tuesday position date as `period_end`, Friday publication as
+  `published_at`, and the strategy-safe configured lag as `available_at`. Downstream code never keys
+  knowledge to Tuesday.
+- An SEP projection uses the FOMC release date as the event `period_end`; `available_at` is the
+  official release instant. A corrected official table becomes a new artifact and observation set.
+
+When a publisher exposes only a release date, the adapter must apply a documented conservative time
+rule and include that rule in `parser_version`. It may not guess an earlier intraday timestamp.
+
+## 3. Immutable identities and hashes
+
+Artifact identity is:
+
+```text
+(source, source_record_id, content_hash)
+```
+
+`source_record_id` is mandatory and stable within a publisher: release ID, accession, canonical
+document URL, or another documented publisher key. Artifacts are domain-neutral because one official
+release (especially an SEP) may supply observations to multiple domains. Artifact `content_hash` is
+SHA-256 over the exact raw bytes; for native JSON it is over canonical UTF-8 JSON with Unicode code
+point key ordering, normalized finite numbers, and no insignificant whitespace. PostgreSQL uses
+`COLLATE "C"` to match Python ordering and rejects `NaN`/infinities at both function and table
+boundaries. `content_length` is recomputed over the
+same byte representation. A successful artifact stores exactly one of raw JSON, raw text, or raw
+bytes. Binary PDF/XLSX payloads retain exact bytes.
+
+Observation identity is:
+
+```text
+(source, series_id, period_end, available_at, content_hash)
+```
+
+Observation `content_hash` is SHA-256 over a canonical normalized record containing source identity,
+series, period, frequency, unit, typed value, publication/availability time, artifact ID, and
+`parser_version`. Therefore a mapper/parser change cannot silently reinterpret an old row: a changed
+normalization produces a new immutable observation even when the raw artifact is unchanged.
+
+An identical observation refresh may update only its `last_seen_at`; an identical artifact retrieval
+may advance artifact `last_seen_at` while preserving the earliest `retrieved_at`. Database triggers
+reject update/delete attempts against every other evidence field and recompute content identity, so
+direct SQL cannot bypass repository validation.
+
+## 4. Enumerated contracts
+
+Domains:
+
+```text
+inflation | policy_rates | usd | gold | cross_domain
+```
+
+Source kinds:
+
+```text
+official | first_party_publisher | entitled_provider | third_party_shadow
+mock | static | demo
+```
+
+`mock`, `static`, and `demo` are test-fixture identities. The database rejects them unless
+`current_database()` starts with `option_wizard_test`, including isolated xdist databases. An
+environment flag or caller argument cannot override this production boundary.
+
+Quality status:
+
+| Value | Meaning | Default PIT eligibility |
+|---|---|---|
+| `valid` | passed the adapter's required semantic and integrity checks | included |
+| `partial` | usable subset with explicit omissions | included but confidence must reflect it |
+| `invalid` | parsed but violates a required data rule | excluded |
+| `quarantined` | schema/source identity is uncertain pending review | excluded |
+
+Cost class:
+
+```text
+free_official | free_publisher | already_entitled
+free_third_party_shadow | paid_authorized
+```
+
+The class records the capability used for this observation. It is not inferred from provider name.
+Yahoo/yfinance is prohibited regardless of cost.
+
+Frequency:
+
+```text
+daily | weekly | monthly | quarterly | annual | event | irregular
+```
+
+Every observation has a non-empty unit and exactly one typed value: numeric, text, or JSON.
+
+## 5. PIT resolution and disagreement
+
+The default usable set requires both artifact and observation quality to be `valid` or `partial`,
+both `available_at` values to be no later than `as_of`, and observation availability to be no earlier
+than its artifact. A `valid` observation requires a `valid` artifact; a `partial` observation may use
+a `valid` or `partial` artifact. For one source and period, the latest eligible `available_at` wins.
+Across sources, the caller must pass a non-empty explicit ordered source list; unlisted sources follow
+after listed sources and never displace a preferred source merely because they arrived later.
+
+Canonical selection does not delete dissent. History queries return every vintage and source. A
+downstream state records the chosen observation ID plus contradictory observation IDs and their
+quality/source class.
+
+## 6. Storage and API boundary
+
+`macro_source_artifacts` owns exact publisher payload identity and retrieval metadata.
+`macro_observations` owns normalized immutable values and PIT semantics. Domain outputs reference
+observations through typed foreign-key association tables added with those outputs; opaque JSON ID
+arrays are not authoritative provenance.
+
+Repository methods live in `storage/macro_context.py` and are assembled into `Repository`; no query
+methods are added directly to the aggregate shim. Public Pydantic models live in `models/macro.py`
+and preserve `uw_scan.models` contract identity.
+
+## 7. Dual-read migration
+
+Existing `rates_observations`, policy tables, macro-series tables, and Gold Compass tables remain the
+authoritative read models until each adapter passes all of:
+
+1. row-identity parity for the intended source window;
+2. value/unit parity or a documented intentional correction;
+3. publication/availability-time parity;
+4. revision-count and source-disagreement accounting;
+5. downstream replay parity;
+6. explicit feature-flag cutover and rollback test.
+
+Migration is additive. Rollback selects the legacy read path; it never deletes MC0 observations.
+The local `option_wizard_local` database is permitted for read-only inventory and non-destructive
+smoke. Automated integration fixtures continue to use `option_wizard_test` because they drop the
+entire `uw_scan` schema.
+
+## 8. Failure behavior and observability
+
+- Transport failures create request-audit evidence but no successful artifact.
+- Empty payload, malformed payload, and valid zero observations are distinct outcomes.
+- Parser/schema drift stores the raw artifact and marks normalized output quarantined or emits no
+  observation; it never becomes zero/neutral.
+- Hash conflicts, invalid enums, multiple value representations, and non-production fixture sources
+  fail the write.
+- Required telemetry includes artifact/observation insert counts, unchanged sightings, revisions,
+  quarantines, invalid rows, source disagreements, newest `available_at`, and ingestion lag.
+
+## 9. Acceptance tests
+
+MC0 is verified only when tests prove:
+
+1. identical artifacts/observations remain one logical row while their `last_seen_at` advances;
+2. a revision creates a second row and historical `as_of` returns the predecessor;
+3. official and shadow observations coexist while explicit precedence is deterministic;
+4. invalid/quarantined observations are excluded by default;
+5. mock/static/demo writes fail outside a test database;
+6. timestamp-aware models reject naive instants and preserve typed values/IDs;
+7. migrations are idempotent and legacy tables are unchanged;
+8. both new temporal tables are registered in the dataset policy.
+9. artifact hash/length and observation hash are recomputed in Python and PostgreSQL;
+10. a domain-neutral artifact may supply multiple typed domains, but no observation may outrun its
+    artifact's availability or quality.

--- a/scripts/research/macro_legacy_inventory.py
+++ b/scripts/research/macro_legacy_inventory.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python
+"""Read-only inventory of the legacy rates and gold persistence surfaces.
+
+This script never calls an external provider and refuses every database except
+``option_wizard_local``. It captures live structural facts (row counts, primary
+keys, date spans, and source/series dimensions) alongside a reviewed static
+contract describing time semantics, consumers, and migration risks.
+
+Reproduce::
+
+    uv run python scripts/research/macro_legacy_inventory.py
+    uv run python scripts/research/macro_legacy_inventory.py --self-check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+from psycopg import sql
+
+DEFAULT_DB_NAME = "option_wizard_local"
+DEFAULT_SCHEMA = "uw_scan"
+DEFAULT_OUTPUT = Path("docs/research/2026-08-12-macro-legacy-inventory/inventory.json")
+ALLOWED_DOMAINS = frozenset(
+    {"inflation", "policy_rates", "usd", "gold", "cross_domain"}
+)
+
+
+def _contract(
+    *,
+    relation_kind: str = "table",
+    domain: str,
+    date_column: str,
+    revision_identity: str,
+    timestamp_semantics: str,
+    source_status: str,
+    consumers: list[str],
+    risks: list[str],
+    adapter_action: str,
+    dimensions: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "relation_kind": relation_kind,
+        "domain": domain,
+        "date_column": date_column,
+        "revision_identity": revision_identity,
+        "timestamp_semantics": timestamp_semantics,
+        "source_status": source_status,
+        "downstream_consumers": consumers,
+        "risk_flags": risks,
+        "adapter_action": adapter_action,
+        "dimensions": dimensions or [],
+    }
+
+
+RELATION_CONTRACTS: dict[str, dict[str, Any]] = {
+    "cb_gold_reserves_monthly": _contract(
+        domain="gold",
+        date_column="obs_month",
+        revision_identity="(country_iso3, obs_month, as_of)",
+        timestamp_semantics=(
+            "release_date is publisher date when known; as_of is ingestion time"
+        ),
+        source_status=(
+            "local workbook import present; scheduled WGC source remains blocked by login"
+        ),
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=[
+            "no live official fallback wired",
+            "local lineage points to a non-durable /tmp workbook path",
+            "estimated-vs-reported is typed but exact source artifact is absent",
+        ],
+        adapter_action="defer until free official IMF/WGC source is proven",
+        dimensions=["source", "bucket"],
+    ),
+    "cot_gold_weekly": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(obs_date, as_of)",
+        timestamp_semantics=(
+            "obs_date is Tuesday position date; release_date is Friday publication; "
+            "backtests require release_date + 3 trading days"
+        ),
+        source_status="free official CFTC",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=["source URL retained but exact payload bytes are not linked"],
+        adapter_action="dual-write CFTC rows with published_at=release timestamp",
+        dimensions=[],
+    ),
+    "etf_aum_cache": _contract(
+        domain="gold",
+        date_column="fetched_at",
+        revision_identity="ticker (overwriting cache)",
+        timestamp_semantics="fetched_at is cache refresh time, not a market observation date",
+        source_status="already-entitled UW operational cache",
+        consumers=["storage/market_data.py", "scanner pipeline"],
+        risks=["not macro evidence; historical values intentionally overwritten"],
+        adapter_action="exclude from macro evidence adapters",
+        dimensions=["ticker"],
+    ),
+    "etf_flows_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(ticker, obs_date, as_of)",
+        timestamp_semantics="obs_date is market date; as_of is ingestion time",
+        source_status="already-entitled UW",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=["no source URL or exact payload link"],
+        adapter_action="dual-write with UW artifact reference",
+        dimensions=["ticker", "source"],
+    ),
+    "etf_holdings_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(ticker, obs_date, as_of)",
+        timestamp_semantics="obs_date is issuer observation date; as_of is ingestion time",
+        source_status="free first-party fund publishers",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=["source label retained but exact issuer payload is not linked"],
+        adapter_action="dual-write issuer artifact and normalized holdings",
+        dimensions=["ticker", "source"],
+    ),
+    "exchange_inventory_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(exchange, obs_date, as_of)",
+        timestamp_semantics="obs_date is exchange report date; as_of is ingestion time",
+        source_status="free publisher: LBMA live; CME endpoint fragile",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=[
+            "COMEX source availability is fragile",
+            "source URL retained but workbook/report bytes are not linked",
+        ],
+        adapter_action="dual-write discovered publisher file bytes",
+        dimensions=["exchange"],
+    ),
+    "gold_posture_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(obs_date, computed_at)",
+        timestamp_semantics=(
+            "obs_date is posture date; computed_at is derivation time; inputs_jsonb pins "
+            "legacy input coordinates"
+        ),
+        source_status="derived",
+        consumers=["api/routers/gold.py", "web/app/gold", "gold replay page"],
+        risks=[
+            "replay fidelity is bounded by legacy input time semantics",
+            "not an upstream source and must not be adapted as an observation",
+        ],
+        adapter_action="keep as legacy read model until evidence-reference parity passes",
+        dimensions=["row_status", "gauge_state"],
+    ),
+    "macro_series_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(series_id, obs_date, as_of)",
+        timestamp_semantics=(
+            "release_date is optional; as_of is retrieval time and is not guaranteed to "
+            "equal public availability time"
+        ),
+        source_status="mixed free official/publisher and derived series",
+        consumers=[
+            "reports/gold_posture.py",
+            "api/routers/gold.py",
+            "api/routers/trade_insights.py",
+            "worker/jobs/regime_jobs.py",
+        ],
+        risks=[
+            "mixed source classes share one table",
+            "no artifact hash/parser version",
+            "release_date nullable",
+        ],
+        adapter_action="map each series explicitly; never infer availability from as_of",
+        dimensions=["series_id", "source"],
+    ),
+    "macro_series_monthly": _contract(
+        domain="cross_domain",
+        date_column="obs_month",
+        revision_identity="(series_id, obs_month, as_of)",
+        timestamp_semantics=(
+            "release_date is optional; as_of is retrieval time and not a release clock"
+        ),
+        source_status="mixed free official FRED series",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=["no artifact hash/parser version", "release_date nullable"],
+        adapter_action="map CPI/M2 series with official release availability",
+        dimensions=["series_id", "source"],
+    ),
+    "rates_cftc_tff_weekly": _contract(
+        domain="policy_rates",
+        date_column="obs_date",
+        revision_identity="(contract_code, obs_date, as_of)",
+        timestamp_semantics=(
+            "obs_date is Tuesday position date; release_date is publication date; "
+            "as_of is ingestion time"
+        ),
+        source_status="free official CFTC",
+        consumers=["rates report assembler", "web rates positioning panel"],
+        risks=["exact CFTC response is not linked to normalized rows"],
+        adapter_action="dual-write release-timed observations and source artifact",
+        dimensions=["contract_code", "tenor_bucket"],
+    ),
+    "rates_fiscal_debt_daily": _contract(
+        domain="policy_rates",
+        date_column="record_date",
+        revision_identity="(record_date, as_of)",
+        timestamp_semantics="record_date is FiscalData date; as_of is ingestion time",
+        source_status="free official U.S. Treasury FiscalData",
+        consumers=["rates report assembler", "web rates supply panel"],
+        risks=["source URL retained but response artifact is not linked"],
+        adapter_action="dual-write official FiscalData artifact",
+        dimensions=[],
+    ),
+    "rates_observations": _contract(
+        domain="policy_rates",
+        date_column="obs_date",
+        revision_identity="(series_id, obs_date, source) overwrites revisions",
+        timestamp_semantics=(
+            "FRED realtime_start/end are vintage metadata; first/last_seen are local "
+            "sightings; release_date may be null"
+        ),
+        source_status="free official FRED plus Cleveland Fed decomposition",
+        consumers=["rates report assembler", "web rates curve/policy/plumbing panels"],
+        risks=[
+            "critical: ON CONFLICT overwrites value and vintage metadata",
+            "source precedence is implicit",
+            "no exact source artifact",
+        ],
+        adapter_action="highest-priority MC1 dual-write; preserve every vintage",
+        dimensions=["series_id", "source"],
+    ),
+    "rates_policy_events": _contract(
+        domain="policy_rates",
+        date_column="event_date",
+        revision_identity="(event_date, source) overwrites payload changes",
+        timestamp_semantics="event_date is meeting date; first/last_seen are local sightings",
+        source_status="free official Federal Reserve calendar",
+        consumers=["rates report assembler", "web rates event calendar"],
+        risks=[
+            "calendar only: no statements, minutes, votes, transcripts, SEP, or dot plot",
+            "payload changes overwrite history",
+            "no source artifact hash",
+        ],
+        adapter_action="MC1 expand to artifact-led FOMC/SEP event model",
+        dimensions=["source"],
+    ),
+    "rates_policy_path": _contract(
+        domain="policy_rates",
+        date_column="snapshot_date",
+        revision_identity="(snapshot_date, meeting_date, source)",
+        timestamp_semantics=(
+            "snapshot_date is provider snapshot day; first/last_seen are local sightings"
+        ),
+        source_status="free third-party delayed FedWatch shadow",
+        consumers=["rates report assembler", "web rates implied path panel"],
+        risks=[
+            "not official Fed data",
+            "same-day corrections overwrite",
+            "no exact HTML/JSON artifact",
+        ],
+        adapter_action="retain as labeled shadow; add official/event evidence separately",
+        dimensions=["source"],
+    ),
+    "rates_snapshots": _contract(
+        domain="policy_rates",
+        date_column="snapshot_date",
+        revision_identity="(snapshot_date, computed_at)",
+        timestamp_semantics="snapshot_date is page date; computed_at is derivation time",
+        source_status="derived",
+        consumers=["api/routers/rates.py", "web/app/rates"],
+        risks=["payload embeds legacy values without normalized evidence IDs"],
+        adapter_action="keep authoritative until dual-read evidence parity passes",
+        dimensions=[],
+    ),
+    "rates_treasury_auctions": _contract(
+        domain="policy_rates",
+        date_column="auction_date",
+        revision_identity="(cusip, auction_date, as_of)",
+        timestamp_semantics="auction_date is official event date; as_of is ingestion time",
+        source_status="free official TreasuryDirect",
+        consumers=["rates report assembler", "web rates supply panel"],
+        risks=["source URL retained but response artifact is not linked"],
+        adapter_action="dual-write official auction artifact and observations",
+        dimensions=["security_type", "security_term"],
+    ),
+    "uw_gold_options_daily": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(ticker, obs_date, as_of)",
+        timestamp_semantics="obs_date is market date; as_of is composite fetch time",
+        source_status="already-entitled UW",
+        consumers=["reports/gold_posture.py", "api/routers/gold.py"],
+        risks=["composed from multiple endpoints without exact joined artifact IDs"],
+        adapter_action="dual-write endpoint artifacts; keep derived snapshot separate",
+        dimensions=["ticker"],
+    ),
+    "wgc_etf_monthly": _contract(
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="(ticker, obs_date, source_url)",
+        timestamp_semantics=(
+            "obs_date is workbook period; as_of is ingestion time; source_url identifies "
+            "a workbook revision"
+        ),
+        source_status="free first-party WGC workbook",
+        consumers=["storage/gold_etf.py", "gold ETF corpus research"],
+        risks=["same-URL workbook changes overwrite normalized values"],
+        adapter_action="store exact workbook bytes keyed by content hash",
+        dimensions=["ticker", "source"],
+    ),
+    "wgc_etf_monthly_canonical": _contract(
+        relation_kind="view",
+        domain="gold",
+        date_column="obs_date",
+        revision_identity="latest workbook revision selected per (ticker, obs_date)",
+        timestamp_semantics="inherits wgc_etf_monthly; canonical selection is query-time",
+        source_status="derived view over free first-party WGC workbooks",
+        consumers=["storage/gold_etf.py::fetch_wgc_etf_monthly"],
+        risks=["latest-wins selection is not an as-of query"],
+        adapter_action="replace consumers with explicit PIT source precedence after parity",
+        dimensions=["ticker", "source"],
+    ),
+}
+
+REQUIRED_RELATIONS = frozenset(RELATION_CONTRACTS)
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, (date, datetime, Decimal)):
+        return str(value)
+    raise TypeError(f"cannot serialize {type(value).__name__}")
+
+
+def _serialized(payload: dict[str, Any]) -> str:
+    return (
+        json.dumps(
+            payload,
+            default=_json_default,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+
+
+def _relation_kind(conn: psycopg.Connection, schema: str, name: str) -> str | None:
+    row = conn.execute(
+        """
+        SELECT c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = %s AND c.relname = %s
+        """,
+        (schema, name),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"r": "table", "p": "table", "v": "view", "m": "view"}.get(row[0])
+
+
+def _primary_key(conn: psycopg.Connection, schema: str, name: str) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN unnest(i.indkey) WITH ORDINALITY AS keys(attnum, ord) ON true
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = keys.attnum
+        WHERE n.nspname = %s AND c.relname = %s AND i.indisprimary
+        ORDER BY keys.ord
+        """,
+        (schema, name),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _columns(conn: psycopg.Connection, schema: str, name: str) -> set[str]:
+    rows = conn.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s
+        """,
+        (schema, name),
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def _scalar(conn: psycopg.Connection, query: sql.Composed) -> Any:
+    return conn.execute(query).fetchone()[0]
+
+
+def _relation_inventory(
+    conn: psycopg.Connection,
+    *,
+    schema: str,
+    name: str,
+    contract: dict[str, Any],
+) -> dict[str, Any]:
+    actual_kind = _relation_kind(conn, schema, name)
+    if actual_kind is None:
+        raise ValueError(f"required relation missing: {schema}.{name}")
+    if actual_kind != contract["relation_kind"]:
+        raise ValueError(
+            f"relation kind mismatch for {name}: {actual_kind} != "
+            f"{contract['relation_kind']}"
+        )
+    columns = _columns(conn, schema, name)
+    qualified = sql.SQL("{}.{}").format(sql.Identifier(schema), sql.Identifier(name))
+    row_count = _scalar(conn, sql.SQL("SELECT count(*) FROM {}").format(qualified))
+
+    date_column = contract["date_column"]
+    if date_column not in columns:
+        raise ValueError(f"{name} lacks declared date column {date_column}")
+    span_row = conn.execute(
+        sql.SQL("SELECT min({0}), max({0}) FROM {1}").format(
+            sql.Identifier(date_column), qualified
+        )
+    ).fetchone()
+
+    dimensions: dict[str, list[Any]] = {}
+    for dimension in contract["dimensions"]:
+        if dimension not in columns:
+            raise ValueError(f"{name} lacks declared dimension {dimension}")
+        rows = conn.execute(
+            sql.SQL(
+                "SELECT DISTINCT {0} FROM {1} WHERE {0} IS NOT NULL ORDER BY {0}"
+            ).format(sql.Identifier(dimension), qualified)
+        ).fetchall()
+        dimensions[dimension] = [row[0] for row in rows]
+
+    series_profiles: list[dict[str, Any]] = []
+    if "series_id" in columns:
+        source_expr = (
+            sql.SQL(
+                "array_agg(DISTINCT source ORDER BY source) FILTER "
+                "(WHERE source IS NOT NULL)"
+            )
+            if "source" in columns
+            else sql.SQL("ARRAY[]::text[]")
+        )
+        rows = conn.execute(
+            sql.SQL(
+                "SELECT series_id, count(*), min({0}), max({0}), {1} "
+                "FROM {2} GROUP BY series_id ORDER BY series_id"
+            ).format(sql.Identifier(date_column), source_expr, qualified)
+        ).fetchall()
+        series_profiles = [
+            {
+                "series_id": row[0],
+                "row_count": row[1],
+                "date_span": {"min": row[2], "max": row[3]},
+                "sources": row[4],
+            }
+            for row in rows
+        ]
+
+    return {
+        "name": name,
+        "relation_kind": actual_kind,
+        "row_count": row_count,
+        "primary_key": _primary_key(conn, schema, name),
+        "date_span": {"min": span_row[0], "max": span_row[1]},
+        "dimensions": dimensions,
+        "series_profiles": series_profiles,
+        "contract": contract,
+    }
+
+
+def build_inventory(
+    conn: psycopg.Connection,
+    *,
+    database: str,
+    schema: str = DEFAULT_SCHEMA,
+) -> dict[str, Any]:
+    relations = [
+        _relation_inventory(
+            conn,
+            schema=schema,
+            name=name,
+            contract=RELATION_CONTRACTS[name],
+        )
+        for name in sorted(REQUIRED_RELATIONS)
+    ]
+    return {
+        "scope": {
+            "database": database,
+            "schema": schema,
+            "mode": "read_only_snapshot",
+            "external_provider_calls": 0,
+        },
+        "relations": relations,
+    }
+
+
+def validate_inventory(payload: dict[str, Any]) -> None:
+    relations = payload.get("relations")
+    if not isinstance(relations, list):
+        raise ValueError("relations must be a list")
+    names = [row.get("name") for row in relations]
+    if names != sorted(names):
+        raise ValueError("relation inventory is not sorted")
+    actual = set(names)
+    if actual != REQUIRED_RELATIONS:
+        missing = sorted(REQUIRED_RELATIONS - actual)
+        extra = sorted(actual - REQUIRED_RELATIONS)
+        raise ValueError(
+            f"relation coverage mismatch: missing={missing}, extra={extra}"
+        )
+    for row in relations:
+        domain = row.get("contract", {}).get("domain")
+        if domain not in ALLOWED_DOMAINS:
+            raise ValueError(
+                f"relation {row.get('name')} has unknown domain {domain!r}"
+            )
+    for row in relations:
+        contract = row.get("contract", {})
+        required = {
+            "domain",
+            "revision_identity",
+            "timestamp_semantics",
+            "source_status",
+            "downstream_consumers",
+            "risk_flags",
+            "adapter_action",
+        }
+        missing_keys = sorted(required - set(contract))
+        if missing_keys:
+            raise ValueError(f"{row['name']} contract missing: {missing_keys}")
+
+
+def _connect_read_only(db_name: str) -> psycopg.Connection:
+    if db_name != DEFAULT_DB_NAME:
+        raise ValueError(
+            f"refusing database {db_name!r}; inventory is pinned to {DEFAULT_DB_NAME!r}"
+        )
+    conn = psycopg.connect(dbname=db_name)
+    conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+    current_db, read_only = conn.execute(
+        "SELECT current_database(), current_setting('transaction_read_only')::boolean"
+    ).fetchone()
+    if current_db != DEFAULT_DB_NAME or not read_only:
+        conn.close()
+        raise RuntimeError(
+            f"read-only boundary failed: database={current_db!r}, read_only={read_only!r}"
+        )
+    return conn
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db-name", default=DEFAULT_DB_NAME)
+    parser.add_argument("--schema", default=DEFAULT_SCHEMA)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--self-check", action="store_true")
+    args = parser.parse_args()
+
+    if args.schema != DEFAULT_SCHEMA:
+        raise ValueError(
+            f"refusing schema {args.schema!r}; expected {DEFAULT_SCHEMA!r}"
+        )
+
+    with _connect_read_only(args.db_name) as conn:
+        payload = build_inventory(conn, database=args.db_name, schema=args.schema)
+        validate_inventory(payload)
+        encoded = _serialized(payload)
+        if args.self_check:
+            second = _serialized(
+                build_inventory(conn, database=args.db_name, schema=args.schema)
+            )
+            if encoded != second:
+                raise ValueError(
+                    "inventory is not deterministic within one DB snapshot"
+                )
+            print(
+                f"self-check ok: {len(payload['relations'])} relations, "
+                "read-only, deterministic, 0 provider calls"
+            )
+            return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(encoded)
+    nonempty = sum(row["row_count"] > 0 for row in payload["relations"])
+    print(
+        f"wrote {args.output}: {len(payload['relations'])} relations, "
+        f"{nonempty} non-empty, 0 provider calls"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/uw_scan/macro_evidence.py
+++ b/src/uw_scan/macro_evidence.py
@@ -1,0 +1,146 @@
+"""Canonical content identities for immutable macro evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+
+def macro_artifact_content_identity(
+    *,
+    raw_json: dict[str, Any] | list[Any] | None = None,
+    raw_text: str | None = None,
+    raw_bytes: bytes | None = None,
+) -> tuple[str, int]:
+    """Return the SHA-256 and byte length of one exact payload representation."""
+    payload = canonical_macro_artifact_bytes(
+        raw_json=raw_json,
+        raw_text=raw_text,
+        raw_bytes=raw_bytes,
+    )
+    return hashlib.sha256(payload).hexdigest(), len(payload)
+
+
+def canonical_macro_artifact_bytes(
+    *,
+    raw_json: dict[str, Any] | list[Any] | None = None,
+    raw_text: str | None = None,
+    raw_bytes: bytes | None = None,
+) -> bytes:
+    """Serialize exactly one artifact representation to its hashed bytes."""
+    candidates = (raw_json, raw_text, raw_bytes)
+    if sum(value is not None for value in candidates) != 1:
+        raise ValueError("exactly one raw payload representation is required")
+    if raw_json is not None:
+        return _canonical_json_bytes(raw_json)
+    if raw_text is not None:
+        return raw_text.encode("utf-8")
+    assert raw_bytes is not None
+    return raw_bytes
+
+
+def macro_observation_content_hash(row: dict[str, Any]) -> str:
+    """Hash the normalized fields that define one immutable observation."""
+    value = _typed_value(row)
+    record = {
+        "artifact_id": int(row["artifact_id"]),
+        "available_at": _canonical_instant(row["available_at"]),
+        "domain": row["domain"],
+        "frequency": row["frequency"],
+        "parser_version": row["parser_version"],
+        "period_end": _canonical_date(row["period_end"]),
+        "published_at": _canonical_optional_instant(row.get("published_at")),
+        "series_id": row["series_id"],
+        "source": row["source"],
+        "source_record_id": row["source_record_id"],
+        "unit": row["unit"],
+        "value": value,
+    }
+    return hashlib.sha256(_canonical_json_bytes(record)).hexdigest()
+
+
+def _typed_value(row: dict[str, Any]) -> dict[str, Any]:
+    numeric = row.get("value_numeric")
+    text = row.get("value_text")
+    json_value = row.get("value_json")
+    candidates = (numeric, text, json_value)
+    if sum(value is not None for value in candidates) != 1:
+        raise ValueError("exactly one typed observation value is required")
+    if numeric is not None:
+        return {"type": "numeric", "value": _canonical_decimal(numeric)}
+    if text is not None:
+        return {"type": "text", "value": text}
+    return {"type": "json", "value": json_value}
+
+
+def _canonical_decimal(value: Any) -> str:
+    decimal_value = value if isinstance(value, Decimal) else Decimal(str(value))
+    if not decimal_value.is_finite():
+        raise ValueError("numeric observation value must be finite")
+    rendered = format(decimal_value, "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    if rendered in {"-0", ""}:
+        return "0"
+    return rendered
+
+
+def _canonical_optional_instant(value: Any) -> str | None:
+    return None if value is None else _canonical_instant(value)
+
+
+def _canonical_instant(value: Any) -> str:
+    if not isinstance(value, datetime):
+        raise ValueError("observation instant must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("observation instant must be timezone-aware")
+    return (
+        value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    )
+
+
+def _canonical_date(value: Any) -> str:
+    if not isinstance(value, date) or isinstance(value, datetime):
+        raise ValueError("period_end must be a date")
+    return value.isoformat()
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return _canonical_json_text(value).encode("utf-8")
+
+
+def _canonical_json_text(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, Decimal):
+        return _canonical_decimal(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("JSON numbers must be finite")
+        return _canonical_decimal(Decimal(str(value)))
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canonical_json_text(item) for item in value) + "]"
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise ValueError("JSON object keys must be strings")
+        return (
+            "{"
+            + ",".join(
+                f"{_canonical_json_text(key)}:{_canonical_json_text(value[key])}"
+                for key in sorted(value)
+            )
+            + "}"
+        )
+    raise ValueError(f"unsupported JSON value type: {type(value).__name__}")

--- a/src/uw_scan/models/__init__.py
+++ b/src/uw_scan/models/__init__.py
@@ -74,6 +74,16 @@ from .magnets import (
     MagnetPivot,
     MagnetsResponse,
 )
+from .macro import (
+    MacroCostClass,
+    MacroDomain,
+    MacroEvidenceRef,
+    MacroFrequency,
+    MacroObservation,
+    MacroQualityStatus,
+    MacroSourceArtifact,
+    MacroSourceKind,
+)
 from .matrix import MatrixSourceFreshness, MatrixState, SetupClassification
 from .options import (
     MaxPainRow,
@@ -295,6 +305,14 @@ __all__ = [
     "CharmRegime",
     "SkewRegime",
     "FlowFootprintLabel",
+    "MacroDomain",
+    "MacroSourceKind",
+    "MacroQualityStatus",
+    "MacroCostClass",
+    "MacroFrequency",
+    "MacroSourceArtifact",
+    "MacroObservation",
+    "MacroEvidenceRef",
     "ChanlunLifecycleMark",
     "ChanlunLifecycleResponse",
     "FlowAlert",

--- a/src/uw_scan/models/macro.py
+++ b/src/uw_scan/models/macro.py
@@ -1,0 +1,171 @@
+"""Shared point-in-time macro evidence contracts."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import AwareDatetime, field_validator, model_validator
+
+from uw_scan.macro_evidence import (
+    macro_artifact_content_identity,
+    macro_observation_content_hash,
+)
+
+from ._base import _UwBase, _preserve_public_module
+
+
+MacroDomain = Literal["inflation", "policy_rates", "usd", "gold", "cross_domain"]
+MacroSourceKind = Literal[
+    "official",
+    "first_party_publisher",
+    "entitled_provider",
+    "third_party_shadow",
+    "mock",
+    "static",
+    "demo",
+]
+MacroQualityStatus = Literal["valid", "invalid", "partial", "quarantined"]
+MacroCostClass = Literal[
+    "free_official",
+    "free_publisher",
+    "already_entitled",
+    "free_third_party_shadow",
+    "paid_authorized",
+]
+MacroFrequency = Literal[
+    "daily", "weekly", "monthly", "quarterly", "annual", "event", "irregular"
+]
+
+
+class MacroSourceArtifact(_UwBase):
+    artifact_id: int | None = None
+    source: str
+    source_kind: MacroSourceKind
+    source_record_id: str
+    source_url: str | None = None
+    published_at: AwareDatetime | None = None
+    available_at: AwareDatetime
+    retrieved_at: AwareDatetime
+    last_seen_at: AwareDatetime
+    content_hash: str
+    parser_version: str
+    quality_status: MacroQualityStatus
+    cost_class: MacroCostClass
+    media_type: str
+    content_length: int
+    raw_json: dict[str, Any] | list[Any] | None = None
+    raw_text: str | None = None
+    raw_bytes: bytes | None = None
+
+    @field_validator("content_hash")
+    @classmethod
+    def _sha256_hash(cls, value: str) -> str:
+        return _validate_sha256(value)
+
+    @model_validator(mode="after")
+    def _one_raw_representation(self) -> "MacroSourceArtifact":
+        if (
+            sum(
+                value is not None
+                for value in (self.raw_json, self.raw_text, self.raw_bytes)
+            )
+            != 1
+        ):
+            raise ValueError("exactly one raw payload representation is required")
+        if self.published_at is not None and self.published_at > self.available_at:
+            raise ValueError("published_at must not follow available_at")
+        if self.retrieved_at > self.last_seen_at:
+            raise ValueError("retrieved_at must not follow last_seen_at")
+        actual_hash, actual_length = macro_artifact_content_identity(
+            raw_json=self.raw_json,
+            raw_text=self.raw_text,
+            raw_bytes=self.raw_bytes,
+        )
+        if self.content_hash != actual_hash:
+            raise ValueError("content_hash does not match the raw artifact")
+        if self.content_length != actual_length:
+            raise ValueError("content_length does not match the raw artifact")
+        return self
+
+
+class MacroObservation(_UwBase):
+    obs_id: int | None = None
+    artifact_id: int
+    domain: MacroDomain
+    series_id: str
+    period_end: date
+    frequency: MacroFrequency
+    unit: str
+    value_numeric: Decimal | None = None
+    value_text: str | None = None
+    value_json: dict[str, Any] | list[Any] | None = None
+    source: str
+    source_record_id: str
+    published_at: AwareDatetime | None = None
+    available_at: AwareDatetime
+    first_observed_at: AwareDatetime
+    last_seen_at: AwareDatetime
+    content_hash: str
+    parser_version: str
+    quality_status: MacroQualityStatus
+    cost_class: MacroCostClass
+
+    @field_validator("content_hash")
+    @classmethod
+    def _sha256_hash(cls, value: str) -> str:
+        return _validate_sha256(value)
+
+    @model_validator(mode="after")
+    def _one_typed_value(self) -> "MacroObservation":
+        if (
+            sum(
+                value is not None
+                for value in (self.value_numeric, self.value_text, self.value_json)
+            )
+            != 1
+        ):
+            raise ValueError("exactly one typed observation value is required")
+        if self.published_at is not None and self.published_at > self.available_at:
+            raise ValueError("published_at must not follow available_at")
+        if self.first_observed_at > self.last_seen_at:
+            raise ValueError("first_observed_at must not follow last_seen_at")
+        if self.content_hash != macro_observation_content_hash(self.model_dump()):
+            raise ValueError("content_hash does not match the normalized observation")
+        return self
+
+
+class MacroEvidenceRef(_UwBase):
+    obs_id: int
+    artifact_id: int
+    domain: MacroDomain
+    source: str
+    source_url: str | None = None
+    source_record_id: str
+    period_end: date
+    published_at: AwareDatetime | None = None
+    available_at: AwareDatetime
+    first_observed_at: AwareDatetime
+    content_hash: str
+    parser_version: str
+    quality_status: MacroQualityStatus
+    cost_class: MacroCostClass
+
+    @field_validator("content_hash")
+    @classmethod
+    def _sha256_hash(cls, value: str) -> str:
+        return _validate_sha256(value)
+
+
+def _validate_sha256(value: str) -> str:
+    if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError("content_hash must be lowercase SHA-256 hex")
+    return value
+
+
+_preserve_public_module(
+    MacroSourceArtifact,
+    MacroObservation,
+    MacroEvidenceRef,
+)

--- a/src/uw_scan/reports/data_gap_healer.py
+++ b/src/uw_scan/reports/data_gap_healer.py
@@ -378,6 +378,23 @@ REGISTRY: list[DatasetRegistryEntry] = [
         "provenance",
         expected_frequency="none",
     ),
+    # Immutable macro evidence substrate (migration 115). These rows preserve
+    # exact source payloads and publication-time observations for PIT replay;
+    # gap healing must never rewrite or synthesize their history.
+    DatasetRegistryEntry(
+        "macro_source_artifacts",
+        "macro_evidence",
+        "provenance",
+        expected_frequency="none",
+        source_system="multi-source",
+    ),
+    DatasetRegistryEntry(
+        "macro_observations",
+        "macro_evidence",
+        "provenance",
+        expected_frequency="none",
+        source_system="multi-source",
+    ),
     DatasetRegistryEntry(
         "ws_consumer_state",
         "operational_provenance",

--- a/src/uw_scan/storage/macro_context.py
+++ b/src/uw_scan/storage/macro_context.py
@@ -1,0 +1,398 @@
+"""Immutable point-in-time macro artifact and observation persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import date, datetime
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from uw_scan.macro_evidence import (
+    macro_artifact_content_identity,
+    macro_observation_content_hash,
+)
+
+
+class _MacroContextMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_macro_artifact(
+        self,
+        *,
+        source: str,
+        source_kind: str,
+        source_record_id: str,
+        source_url: str | None,
+        published_at: datetime | None,
+        available_at: datetime,
+        retrieved_at: datetime,
+        content_hash: str,
+        parser_version: str,
+        quality_status: str,
+        cost_class: str,
+        media_type: str,
+        content_length: int,
+        raw_json: dict[str, Any] | list[Any] | None = None,
+        raw_text: str | None = None,
+        raw_bytes: bytes | None = None,
+    ) -> int:
+        _require_aware("published_at", published_at, optional=True)
+        _require_aware("available_at", available_at)
+        _require_aware("retrieved_at", retrieved_at)
+        _require_sha256(content_hash)
+        actual_hash, actual_length = macro_artifact_content_identity(
+            raw_json=raw_json,
+            raw_text=raw_text,
+            raw_bytes=raw_bytes,
+        )
+        if content_hash != actual_hash:
+            raise ValueError("artifact content_hash does not match raw payload")
+        if content_length != actual_length:
+            raise ValueError("artifact content_length does not match raw payload")
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.macro_source_artifacts (
+                  source, source_kind, source_record_id, source_url,
+                  published_at, available_at, retrieved_at, last_seen_at,
+                  content_hash, parser_version, quality_status, cost_class,
+                  media_type, content_length, raw_jsonb, raw_text, raw_bytes
+                )
+                VALUES (
+                  %s, %s, %s, %s,
+                  %s, %s, %s, %s,
+                  %s, %s, %s, %s,
+                  %s, %s, %s, %s, %s
+                )
+                ON CONFLICT (source, source_record_id, content_hash)
+                DO UPDATE SET
+                  retrieved_at = LEAST(
+                    {self._schema}.macro_source_artifacts.retrieved_at,
+                    EXCLUDED.retrieved_at
+                  ),
+                  last_seen_at = GREATEST(
+                    {self._schema}.macro_source_artifacts.last_seen_at,
+                    EXCLUDED.last_seen_at
+                  )
+                WHERE
+                  {self._schema}.macro_source_artifacts.source_kind
+                    IS NOT DISTINCT FROM EXCLUDED.source_kind
+                  AND {self._schema}.macro_source_artifacts.source_url
+                    IS NOT DISTINCT FROM EXCLUDED.source_url
+                  AND {self._schema}.macro_source_artifacts.published_at
+                    IS NOT DISTINCT FROM EXCLUDED.published_at
+                  AND {self._schema}.macro_source_artifacts.available_at
+                    IS NOT DISTINCT FROM EXCLUDED.available_at
+                  AND {self._schema}.macro_source_artifacts.parser_version
+                    IS NOT DISTINCT FROM EXCLUDED.parser_version
+                  AND {self._schema}.macro_source_artifacts.quality_status
+                    IS NOT DISTINCT FROM EXCLUDED.quality_status
+                  AND {self._schema}.macro_source_artifacts.cost_class
+                    IS NOT DISTINCT FROM EXCLUDED.cost_class
+                  AND {self._schema}.macro_source_artifacts.media_type
+                    IS NOT DISTINCT FROM EXCLUDED.media_type
+                  AND {self._schema}.macro_source_artifacts.content_length
+                    IS NOT DISTINCT FROM EXCLUDED.content_length
+                  AND {self._schema}.macro_source_artifacts.raw_jsonb
+                    IS NOT DISTINCT FROM EXCLUDED.raw_jsonb
+                  AND {self._schema}.macro_source_artifacts.raw_text
+                    IS NOT DISTINCT FROM EXCLUDED.raw_text
+                  AND {self._schema}.macro_source_artifacts.raw_bytes
+                    IS NOT DISTINCT FROM EXCLUDED.raw_bytes
+                RETURNING artifact_id
+                """,
+                (
+                    source,
+                    source_kind,
+                    source_record_id,
+                    source_url,
+                    published_at,
+                    available_at,
+                    retrieved_at,
+                    retrieved_at,
+                    content_hash,
+                    parser_version,
+                    quality_status,
+                    cost_class,
+                    media_type,
+                    content_length,
+                    Jsonb(raw_json) if raw_json is not None else None,
+                    raw_text,
+                    raw_bytes,
+                ),
+            )
+            row = cur.fetchone()
+        if row is None:
+            raise ValueError(
+                "artifact identity collision: immutable metadata differs for "
+                f"({source}, {source_record_id}, {content_hash})"
+            )
+        return int(row[0])
+
+    def insert_macro_observations(
+        self,
+        rows: Iterable[dict[str, Any]],
+        *,
+        seen_at: datetime,
+    ) -> int:
+        _require_aware("seen_at", seen_at)
+        materialized_rows = list(rows)
+        for row in materialized_rows:
+            _require_aware("published_at", row.get("published_at"), optional=True)
+            _require_aware("available_at", row.get("available_at"))
+            _require_sha256(row.get("content_hash"))
+            if row["content_hash"] != macro_observation_content_hash(row):
+                raise ValueError(
+                    "observation content_hash does not match normalized record"
+                )
+        values = [
+            (
+                row["artifact_id"],
+                row["domain"],
+                row["series_id"],
+                row["period_end"],
+                row["frequency"],
+                row["unit"],
+                row.get("value_numeric"),
+                row.get("value_text"),
+                Jsonb(row["value_json"]) if row.get("value_json") is not None else None,
+                row["source"],
+                row["source_record_id"],
+                row.get("published_at"),
+                row["available_at"],
+                seen_at,
+                seen_at,
+                row["content_hash"],
+                row["parser_version"],
+                row["quality_status"],
+                row["cost_class"],
+            )
+            for row in materialized_rows
+        ]
+        if not values:
+            return 0
+        with self._conn.transaction():
+            with self._conn.cursor() as cur:
+                _validate_artifact_bounds(cur, self._schema, materialized_rows)
+                cur.executemany(
+                    f"""
+                    INSERT INTO {self._schema}.macro_observations (
+                      artifact_id, domain, series_id, period_end, frequency, unit,
+                      value_numeric, value_text, value_jsonb,
+                      source, source_record_id, published_at, available_at,
+                      first_observed_at, last_seen_at,
+                      content_hash, parser_version, quality_status, cost_class
+                    )
+                    VALUES (
+                      %s, %s, %s, %s, %s, %s,
+                      %s, %s, %s,
+                      %s, %s, %s, %s,
+                      %s, %s,
+                      %s, %s, %s, %s
+                    )
+                    ON CONFLICT (
+                      source, series_id, period_end, available_at, content_hash
+                    )
+                    DO UPDATE SET last_seen_at =
+                      GREATEST(
+                        {self._schema}.macro_observations.last_seen_at,
+                        EXCLUDED.last_seen_at
+                      )
+                    WHERE
+                      {self._schema}.macro_observations.artifact_id
+                        IS NOT DISTINCT FROM EXCLUDED.artifact_id
+                      AND {self._schema}.macro_observations.domain
+                        IS NOT DISTINCT FROM EXCLUDED.domain
+                      AND {self._schema}.macro_observations.frequency
+                        IS NOT DISTINCT FROM EXCLUDED.frequency
+                      AND {self._schema}.macro_observations.unit
+                        IS NOT DISTINCT FROM EXCLUDED.unit
+                      AND {self._schema}.macro_observations.value_numeric
+                        IS NOT DISTINCT FROM EXCLUDED.value_numeric
+                      AND {self._schema}.macro_observations.value_text
+                        IS NOT DISTINCT FROM EXCLUDED.value_text
+                      AND {self._schema}.macro_observations.value_jsonb
+                        IS NOT DISTINCT FROM EXCLUDED.value_jsonb
+                      AND {self._schema}.macro_observations.source_record_id
+                        IS NOT DISTINCT FROM EXCLUDED.source_record_id
+                      AND {self._schema}.macro_observations.published_at
+                        IS NOT DISTINCT FROM EXCLUDED.published_at
+                      AND {self._schema}.macro_observations.parser_version
+                        IS NOT DISTINCT FROM EXCLUDED.parser_version
+                      AND {self._schema}.macro_observations.quality_status
+                        IS NOT DISTINCT FROM EXCLUDED.quality_status
+                      AND {self._schema}.macro_observations.cost_class
+                        IS NOT DISTINCT FROM EXCLUDED.cost_class
+                    """,
+                    values,
+                )
+                if cur.rowcount != len(values):
+                    raise ValueError(
+                        "observation identity collision: immutable metadata differs"
+                    )
+        return len(values)
+
+    def fetch_macro_observation_as_of(
+        self,
+        series_id: str,
+        period_end: date,
+        as_of: datetime,
+        *,
+        preferred_sources: Sequence[str],
+    ) -> dict[str, Any] | None:
+        _require_aware("as_of", as_of)
+        rank_sql, rank_params = _source_rank_sql(preferred_sources)
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT o.*, a.source_url, a.source_kind, a.media_type
+                FROM {self._schema}.macro_observations o
+                JOIN {self._schema}.macro_source_artifacts a
+                  ON a.artifact_id = o.artifact_id
+                WHERE o.series_id = %s
+                  AND o.period_end = %s
+                  AND o.available_at <= %s
+                  AND o.quality_status IN ('valid', 'partial')
+                  AND a.available_at <= %s
+                  AND a.quality_status IN ('valid', 'partial')
+                ORDER BY {rank_sql}, o.available_at DESC,
+                         o.first_observed_at DESC, o.obs_id DESC
+                LIMIT 1
+                """,
+                (series_id, period_end, as_of, as_of, *rank_params),
+            )
+            return cur.fetchone()
+
+    def fetch_macro_series_as_of(
+        self,
+        series_id: str,
+        as_of: datetime,
+        *,
+        from_date: date | None = None,
+        preferred_sources: Sequence[str],
+    ) -> list[dict[str, Any]]:
+        _require_aware("as_of", as_of)
+        clauses = [
+            "o.series_id = %s",
+            "o.available_at <= %s",
+            "o.quality_status IN ('valid', 'partial')",
+            "a.available_at <= %s",
+            "a.quality_status IN ('valid', 'partial')",
+        ]
+        params: list[Any] = [series_id, as_of, as_of]
+        if from_date is not None:
+            clauses.append("o.period_end >= %s")
+            params.append(from_date)
+        rank_sql, rank_params = _source_rank_sql(preferred_sources)
+        params.extend(rank_params)
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT DISTINCT ON (o.period_end)
+                  o.*, a.source_url, a.source_kind, a.media_type
+                FROM {self._schema}.macro_observations o
+                JOIN {self._schema}.macro_source_artifacts a
+                  ON a.artifact_id = o.artifact_id
+                WHERE {" AND ".join(clauses)}
+                ORDER BY o.period_end ASC, {rank_sql}, o.available_at DESC,
+                         o.first_observed_at DESC, o.obs_id DESC
+                """,
+                params,
+            )
+            return list(cur.fetchall())
+
+    def fetch_macro_observation_history(
+        self,
+        series_id: str,
+        period_end: date,
+    ) -> list[dict[str, Any]]:
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT o.*, a.source_url, a.source_kind, a.media_type
+                FROM {self._schema}.macro_observations o
+                JOIN {self._schema}.macro_source_artifacts a
+                  ON a.artifact_id = o.artifact_id
+                WHERE o.series_id = %s AND o.period_end = %s
+                ORDER BY o.available_at DESC, o.first_observed_at DESC,
+                         o.source, o.obs_id DESC
+                """,
+                (series_id, period_end),
+            )
+            return list(cur.fetchall())
+
+
+def _source_rank_sql(preferred_sources: Sequence[str]) -> tuple[str, list[str]]:
+    if not preferred_sources:
+        raise ValueError("preferred_sources must not be empty")
+    if any(not source.strip() for source in preferred_sources):
+        raise ValueError("preferred_sources must contain non-empty source names")
+    if len(set(preferred_sources)) != len(preferred_sources):
+        raise ValueError("preferred_sources must not contain duplicates")
+    clauses = [f"WHEN %s THEN {rank}" for rank, _ in enumerate(preferred_sources)]
+    return f"CASE o.source {' '.join(clauses)} ELSE {len(clauses)} END", list(
+        preferred_sources
+    )
+
+
+def _require_aware(
+    name: str,
+    value: datetime | None,
+    *,
+    optional: bool = False,
+) -> None:
+    if value is None:
+        if optional:
+            return
+        raise ValueError(f"{name} is required")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")
+
+
+def _require_sha256(value: object) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise ValueError("content_hash must be lowercase SHA-256 hex")
+
+
+def _validate_artifact_bounds(
+    cur: psycopg.Cursor[Any],
+    schema: str,
+    rows: Sequence[dict[str, Any]],
+) -> None:
+    artifact_ids = sorted({int(row["artifact_id"]) for row in rows})
+    cur.execute(
+        f"""
+        SELECT artifact_id, source, source_record_id, available_at, quality_status
+        FROM {schema}.macro_source_artifacts
+        WHERE artifact_id = ANY(%s)
+        FOR KEY SHARE
+        """,
+        (artifact_ids,),
+    )
+    artifacts = {int(row[0]): row for row in cur.fetchall()}
+    for row in rows:
+        artifact_id = int(row["artifact_id"])
+        artifact = artifacts.get(artifact_id)
+        if artifact is None:
+            raise ValueError(f"macro artifact {artifact_id} does not exist")
+        _, source, source_record_id, available_at, quality_status = artifact
+        if (row["source"], row["source_record_id"]) != (
+            source,
+            source_record_id,
+        ):
+            raise ValueError("observation source identity differs from its artifact")
+        if row["available_at"] < available_at:
+            raise ValueError("observation available_at precedes artifact available_at")
+        if (row["quality_status"] == "valid" and quality_status != "valid") or (
+            row["quality_status"] == "partial"
+            and quality_status not in {"valid", "partial"}
+        ):
+            raise ValueError("observation quality exceeds artifact quality")

--- a/src/uw_scan/storage/migrations/115_macro_evidence.sql
+++ b/src/uw_scan/storage/migrations/115_macro_evidence.sql
@@ -1,0 +1,376 @@
+-- 115_macro_evidence.sql — immutable point-in-time evidence for macro domains.
+--
+-- Additive only: legacy rates/gold read models remain untouched during dual-read.
+-- Source artifacts preserve exact publisher payloads; normalized observations preserve
+-- releases/revisions and are selected with available_at <= decision as_of.
+
+SET search_path TO uw_scan, public;
+
+CREATE OR REPLACE FUNCTION uw_scan.macro_source_kind_allowed(
+  candidate TEXT,
+  database_name TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT candidate NOT IN ('mock', 'static', 'demo')
+    OR database_name LIKE 'option_wizard_test%'
+$$;
+
+CREATE OR REPLACE FUNCTION uw_scan.macro_canonical_numeric(candidate NUMERIC)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+STRICT
+AS $$
+BEGIN
+  IF candidate::TEXT IN ('NaN', 'Infinity', '-Infinity') THEN
+    RAISE EXCEPTION 'macro numeric values must be finite'
+      USING ERRCODE = '22003';
+  END IF;
+  RETURN CASE
+    WHEN candidate = 0 THEN '0'
+    WHEN position('.' IN candidate::TEXT) = 0 THEN candidate::TEXT
+    ELSE rtrim(rtrim(candidate::TEXT, '0'), '.')
+  END;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION uw_scan.macro_canonical_jsonb(candidate JSONB)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+STRICT
+AS $$
+DECLARE
+  rendered TEXT;
+BEGIN
+  CASE jsonb_typeof(candidate)
+    WHEN 'object' THEN
+      SELECT '{' || COALESCE(
+        string_agg(to_jsonb(item.key)::TEXT || ':' ||
+          uw_scan.macro_canonical_jsonb(item.value),
+          ',' ORDER BY item.key COLLATE "C"),
+        ''
+      ) || '}'
+      INTO rendered
+      FROM jsonb_each(candidate) AS item;
+    WHEN 'array' THEN
+      SELECT '[' || COALESCE(
+        string_agg(uw_scan.macro_canonical_jsonb(item.value), ',' ORDER BY item.ordinality),
+        ''
+      ) || ']'
+      INTO rendered
+      FROM jsonb_array_elements(candidate) WITH ORDINALITY AS item(value, ordinality);
+    WHEN 'number' THEN
+      rendered := uw_scan.macro_canonical_numeric((candidate #>> '{}')::NUMERIC);
+    ELSE
+      rendered := candidate::TEXT;
+  END CASE;
+  RETURN rendered;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS uw_scan.macro_source_artifacts (
+  artifact_id       BIGSERIAL   PRIMARY KEY,
+  source            TEXT        NOT NULL CHECK (btrim(source) <> ''),
+  source_kind       TEXT        NOT NULL
+    CHECK (
+      source_kind IN (
+        'official',
+        'first_party_publisher',
+        'entitled_provider',
+        'third_party_shadow',
+        'mock',
+        'static',
+        'demo'
+      )
+    ),
+  source_record_id  TEXT        NOT NULL CHECK (btrim(source_record_id) <> ''),
+  source_url        TEXT        NULL,
+  published_at      TIMESTAMPTZ NULL,
+  available_at      TIMESTAMPTZ NOT NULL,
+  retrieved_at      TIMESTAMPTZ NOT NULL,
+  last_seen_at      TIMESTAMPTZ NOT NULL,
+  content_hash      TEXT        NOT NULL
+    CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+  parser_version    TEXT        NOT NULL CHECK (btrim(parser_version) <> ''),
+  quality_status    TEXT        NOT NULL
+    CHECK (quality_status IN ('valid', 'invalid', 'partial', 'quarantined')),
+  cost_class        TEXT        NOT NULL
+    CHECK (
+      cost_class IN (
+        'free_official',
+        'free_publisher',
+        'already_entitled',
+        'free_third_party_shadow',
+        'paid_authorized'
+      )
+    ),
+  media_type        TEXT        NOT NULL CHECK (btrim(media_type) <> ''),
+  content_length    BIGINT      NOT NULL CHECK (content_length >= 0),
+  raw_jsonb         JSONB       NULL,
+  raw_text          TEXT        NULL,
+  raw_bytes         BYTEA       NULL,
+  CHECK (num_nonnulls(raw_jsonb, raw_text, raw_bytes) = 1),
+  CHECK (published_at IS NULL OR published_at <= available_at),
+  CHECK (retrieved_at <= last_seen_at),
+  CHECK (uw_scan.macro_source_kind_allowed(source_kind, current_database())),
+  UNIQUE (source, source_record_id, content_hash),
+  UNIQUE (artifact_id, source, source_record_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_macro_source_artifacts_lookup
+  ON uw_scan.macro_source_artifacts (
+    source,
+    source_record_id,
+    retrieved_at DESC
+  );
+
+CREATE INDEX IF NOT EXISTS idx_macro_source_artifacts_available
+  ON uw_scan.macro_source_artifacts (available_at DESC, source);
+
+COMMENT ON COLUMN uw_scan.macro_source_artifacts.published_at IS
+  'Publisher-declared release instant; NULL when the publisher supplies no reliable instant.';
+COMMENT ON COLUMN uw_scan.macro_source_artifacts.available_at IS
+  'Earliest instant the artifact is allowed to enter an Argon point-in-time decision.';
+COMMENT ON COLUMN uw_scan.macro_source_artifacts.retrieved_at IS
+  'First wall-clock instant Argon retrieved this exact payload representation.';
+COMMENT ON COLUMN uw_scan.macro_source_artifacts.last_seen_at IS
+  'Latest wall-clock instant Argon retrieved this identical payload representation.';
+
+CREATE TABLE IF NOT EXISTS uw_scan.macro_observations (
+  obs_id             BIGSERIAL   PRIMARY KEY,
+  artifact_id        BIGINT      NOT NULL,
+  domain             TEXT        NOT NULL
+    CHECK (domain IN ('inflation', 'policy_rates', 'usd', 'gold', 'cross_domain')),
+  series_id          TEXT        NOT NULL CHECK (btrim(series_id) <> ''),
+  period_end         DATE        NOT NULL,
+  frequency          TEXT        NOT NULL
+    CHECK (frequency IN ('daily', 'weekly', 'monthly', 'quarterly', 'annual', 'event', 'irregular')),
+  unit               TEXT        NOT NULL CHECK (btrim(unit) <> ''),
+  value_numeric      NUMERIC     NULL,
+  value_text         TEXT        NULL,
+  value_jsonb        JSONB       NULL,
+  source             TEXT        NOT NULL CHECK (btrim(source) <> ''),
+  source_record_id   TEXT        NOT NULL CHECK (btrim(source_record_id) <> ''),
+  published_at       TIMESTAMPTZ NULL,
+  available_at       TIMESTAMPTZ NOT NULL,
+  first_observed_at  TIMESTAMPTZ NOT NULL,
+  last_seen_at       TIMESTAMPTZ NOT NULL,
+  content_hash       TEXT        NOT NULL
+    CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+  parser_version     TEXT        NOT NULL CHECK (btrim(parser_version) <> ''),
+  quality_status     TEXT        NOT NULL
+    CHECK (quality_status IN ('valid', 'invalid', 'partial', 'quarantined')),
+  cost_class         TEXT        NOT NULL
+    CHECK (
+      cost_class IN (
+        'free_official',
+        'free_publisher',
+        'already_entitled',
+        'free_third_party_shadow',
+        'paid_authorized'
+      )
+    ),
+  CHECK (num_nonnulls(value_numeric, value_text, value_jsonb) = 1),
+  CHECK (
+    value_numeric IS NULL
+    OR value_numeric::TEXT NOT IN ('NaN', 'Infinity', '-Infinity')
+  ),
+  CHECK (published_at IS NULL OR published_at <= available_at),
+  CHECK (first_observed_at <= last_seen_at),
+  FOREIGN KEY (artifact_id, source, source_record_id)
+    REFERENCES uw_scan.macro_source_artifacts (
+      artifact_id,
+      source,
+      source_record_id
+    )
+    ON DELETE RESTRICT,
+  UNIQUE (source, series_id, period_end, available_at, content_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_macro_observations_pit
+  ON uw_scan.macro_observations (
+    series_id,
+    period_end,
+    available_at DESC,
+    source
+  );
+
+CREATE INDEX IF NOT EXISTS idx_macro_observations_series_pit
+  ON uw_scan.macro_observations (
+    series_id,
+    available_at DESC,
+    period_end DESC
+  )
+  WHERE quality_status IN ('valid', 'partial');
+
+CREATE INDEX IF NOT EXISTS idx_macro_observations_artifact
+  ON uw_scan.macro_observations (artifact_id);
+
+COMMENT ON COLUMN uw_scan.macro_observations.period_end IS
+  'Economic period represented by the observation; never the market knowledge time.';
+COMMENT ON COLUMN uw_scan.macro_observations.published_at IS
+  'Publisher-declared release instant; NULL when no reliable instant is supplied.';
+COMMENT ON COLUMN uw_scan.macro_observations.available_at IS
+  'Earliest instant this observation may enter a point-in-time decision.';
+COMMENT ON COLUMN uw_scan.macro_observations.first_observed_at IS
+  'First wall-clock instant Argon normalized this immutable observation.';
+COMMENT ON COLUMN uw_scan.macro_observations.last_seen_at IS
+  'Latest wall-clock instant Argon saw the identical immutable observation.';
+
+CREATE OR REPLACE FUNCTION uw_scan.macro_artifact_write_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  payload BYTEA;
+  actual_hash TEXT;
+  actual_length BIGINT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'macro source artifacts are immutable'
+      USING ERRCODE = '23514';
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF (to_jsonb(NEW) - ARRAY['retrieved_at', 'last_seen_at'])
+        IS DISTINCT FROM
+       (to_jsonb(OLD) - ARRAY['retrieved_at', 'last_seen_at'])
+       OR NEW.retrieved_at > OLD.retrieved_at
+       OR NEW.last_seen_at < OLD.last_seen_at THEN
+      RAISE EXCEPTION 'macro source artifacts are immutable'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  payload := CASE
+    WHEN NEW.raw_jsonb IS NOT NULL THEN
+      convert_to(uw_scan.macro_canonical_jsonb(NEW.raw_jsonb), 'UTF8')
+    WHEN NEW.raw_text IS NOT NULL THEN convert_to(NEW.raw_text, 'UTF8')
+    ELSE NEW.raw_bytes
+  END;
+  actual_hash := encode(sha256(payload), 'hex');
+  actual_length := octet_length(payload);
+  IF NEW.content_hash <> actual_hash THEN
+    RAISE EXCEPTION 'artifact content_hash does not match raw payload'
+      USING ERRCODE = '23514';
+  END IF;
+  IF NEW.content_length <> actual_length THEN
+    RAISE EXCEPTION 'artifact content_length does not match raw payload'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS trg_macro_artifact_write_guard
+  ON uw_scan.macro_source_artifacts;
+CREATE TRIGGER trg_macro_artifact_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON uw_scan.macro_source_artifacts
+FOR EACH ROW EXECUTE FUNCTION uw_scan.macro_artifact_write_guard();
+
+CREATE OR REPLACE FUNCTION uw_scan.macro_observation_write_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  artifact uw_scan.macro_source_artifacts%ROWTYPE;
+  typed_value JSONB;
+  canonical_record JSONB;
+  actual_hash TEXT;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'macro observations are immutable'
+      USING ERRCODE = '23514';
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF (to_jsonb(NEW) - 'last_seen_at')
+        IS DISTINCT FROM
+       (to_jsonb(OLD) - 'last_seen_at')
+       OR NEW.last_seen_at < OLD.last_seen_at THEN
+      RAISE EXCEPTION 'macro observations are immutable'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  SELECT * INTO artifact
+  FROM uw_scan.macro_source_artifacts
+  WHERE artifact_id = NEW.artifact_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'macro artifact % does not exist', NEW.artifact_id
+      USING ERRCODE = '23503';
+  END IF;
+  IF (NEW.source, NEW.source_record_id)
+      IS DISTINCT FROM (artifact.source, artifact.source_record_id) THEN
+    RAISE EXCEPTION 'observation source identity differs from its artifact'
+      USING ERRCODE = '23514';
+  END IF;
+  IF NEW.available_at < artifact.available_at THEN
+    RAISE EXCEPTION 'observation available_at precedes artifact available_at'
+      USING ERRCODE = '23514';
+  END IF;
+  IF (NEW.quality_status = 'valid' AND artifact.quality_status <> 'valid')
+      OR (
+        NEW.quality_status = 'partial'
+        AND artifact.quality_status NOT IN ('valid', 'partial')
+      ) THEN
+    RAISE EXCEPTION 'observation quality exceeds artifact quality'
+      USING ERRCODE = '23514';
+  END IF;
+
+  typed_value := CASE
+    WHEN NEW.value_numeric IS NOT NULL THEN
+      jsonb_build_object(
+        'type', 'numeric',
+        'value', uw_scan.macro_canonical_numeric(NEW.value_numeric)
+      )
+    WHEN NEW.value_text IS NOT NULL THEN
+      jsonb_build_object('type', 'text', 'value', NEW.value_text)
+    ELSE jsonb_build_object('type', 'json', 'value', NEW.value_jsonb)
+  END;
+  canonical_record := jsonb_build_object(
+    'artifact_id', NEW.artifact_id,
+    'available_at', to_char(
+      NEW.available_at AT TIME ZONE 'UTC',
+      'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+    ),
+    'domain', NEW.domain,
+    'frequency', NEW.frequency,
+    'parser_version', NEW.parser_version,
+    'period_end', to_char(NEW.period_end, 'YYYY-MM-DD'),
+    'published_at', CASE
+      WHEN NEW.published_at IS NULL THEN NULL
+      ELSE to_jsonb(to_char(
+        NEW.published_at AT TIME ZONE 'UTC',
+        'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      ))
+    END,
+    'series_id', NEW.series_id,
+    'source', NEW.source,
+    'source_record_id', NEW.source_record_id,
+    'unit', NEW.unit,
+    'value', typed_value
+  );
+  actual_hash := encode(
+    sha256(convert_to(uw_scan.macro_canonical_jsonb(canonical_record), 'UTF8')),
+    'hex'
+  );
+  IF NEW.content_hash <> actual_hash THEN
+    RAISE EXCEPTION 'observation content_hash does not match normalized record'
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS trg_macro_observation_write_guard
+  ON uw_scan.macro_observations;
+CREATE TRIGGER trg_macro_observation_write_guard
+BEFORE INSERT OR UPDATE OR DELETE ON uw_scan.macro_observations
+FOR EACH ROW EXECUTE FUNCTION uw_scan.macro_observation_write_guard();

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -33,6 +33,7 @@ from .gold_etf import _GoldEtfMixin
 from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
+from .macro_context import _MacroContextMixin
 from .matrix_state import _MatrixStateMixin
 from .option_surface import _OptionSurfaceMixin
 from .options import _OptionsMixin
@@ -118,6 +119,7 @@ class Repository(
     _HealthMixin,
     _JobsMixin,
     _MarketDataMixin,
+    _MacroContextMixin,
     _MatrixStateMixin,
     _OptionSurfaceMixin,
     _OptionsMixin,

--- a/tests/integration/storage/test_macro_context_repository.py
+++ b/tests/integration/storage/test_macro_context_repository.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+from psycopg.types.json import Jsonb
+
+from uw_scan.macro_evidence import (
+    macro_artifact_content_identity,
+    macro_observation_content_hash,
+)
+from uw_scan.storage.repository import Repository
+
+RAW_CPI = {"series": "CPIAUCSL", "value": "319.1"}
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
+
+
+def _insert_artifact(
+    repo: Repository,
+    *,
+    source: str = "BLS",
+    source_kind: str = "official",
+    source_record_id: str = "cpi-2026-02-12",
+    cost_class: str = "free_official",
+    quality_status: str = "valid",
+    available_at: datetime = datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+    retrieved_at: datetime = datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+    raw_json: dict[str, object] | None = None,
+    content_hash: str | None = None,
+    content_length: int | None = None,
+) -> int:
+    raw_json = raw_json or RAW_CPI
+    actual_hash, actual_length = macro_artifact_content_identity(raw_json=raw_json)
+    return repo.insert_macro_artifact(
+        source=source,
+        source_kind=source_kind,
+        source_record_id=source_record_id,
+        source_url="https://example.test/release",
+        published_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        available_at=available_at,
+        retrieved_at=retrieved_at,
+        content_hash=content_hash or actual_hash,
+        parser_version="bls-cpi-v1",
+        quality_status=quality_status,
+        cost_class=cost_class,
+        media_type="application/json",
+        content_length=actual_length if content_length is None else content_length,
+        raw_json=raw_json,
+    )
+
+
+def _observation(
+    artifact_id: int,
+    *,
+    source: str = "BLS",
+    source_record_id: str = "cpi-2026-02-12",
+    available_at: datetime = datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+    value: Decimal = Decimal("319.1"),
+    domain: str = "inflation",
+    series_id: str = "CPI_ALL_ITEMS",
+    quality_status: str = "valid",
+    cost_class: str = "free_official",
+    content_hash: str | None = None,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "artifact_id": artifact_id,
+        "domain": domain,
+        "series_id": series_id,
+        "period_end": date(2026, 1, 31),
+        "frequency": "monthly",
+        "unit": "index_1982_1984_100",
+        "value_numeric": value,
+        "value_text": None,
+        "value_json": None,
+        "source": source,
+        "source_record_id": source_record_id,
+        "published_at": available_at,
+        "available_at": available_at,
+        "parser_version": "bls-cpi-v1",
+        "quality_status": quality_status,
+        "cost_class": cost_class,
+    }
+    row["content_hash"] = content_hash or macro_observation_content_hash(row)
+    return row
+
+
+def test_identical_observation_updates_only_last_seen(repo: Repository) -> None:
+    artifact_id = _insert_artifact(repo)
+    first_seen = datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+    later_seen = datetime(2026, 2, 13, 9, tzinfo=UTC)
+
+    assert (
+        repo.insert_macro_observations([_observation(artifact_id)], seen_at=first_seen)
+        == 1
+    )
+    assert (
+        repo.insert_macro_observations([_observation(artifact_id)], seen_at=later_seen)
+        == 1
+    )
+
+    rows = repo.fetch_macro_observation_history("CPI_ALL_ITEMS", date(2026, 1, 31))
+    assert len(rows) == 1
+    assert rows[0]["value_numeric"] == Decimal("319.1")
+    assert rows[0]["first_observed_at"] == first_seen
+    assert rows[0]["last_seen_at"] == later_seen
+
+
+def test_restatement_preserves_predecessor_for_as_of_replay(repo: Repository) -> None:
+    first_artifact = _insert_artifact(repo)
+    revised_artifact = _insert_artifact(
+        repo,
+        source_record_id="cpi-2026-03-01-correction",
+        raw_json={"series": "CPIAUCSL", "value": "319.3"},
+    )
+    first_available = datetime(2026, 2, 12, 13, 30, tzinfo=UTC)
+    revised_available = datetime(2026, 3, 1, 15, tzinfo=UTC)
+
+    repo.insert_macro_observations(
+        [_observation(first_artifact, available_at=first_available)],
+        seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+    )
+    repo.insert_macro_observations(
+        [
+            _observation(
+                revised_artifact,
+                source_record_id="cpi-2026-03-01-correction",
+                available_at=revised_available,
+                value=Decimal("319.3"),
+            )
+        ],
+        seen_at=datetime(2026, 3, 1, 15, 1, tzinfo=UTC),
+    )
+
+    before_revision = repo.fetch_macro_observation_as_of(
+        "CPI_ALL_ITEMS",
+        date(2026, 1, 31),
+        datetime(2026, 2, 20, tzinfo=UTC),
+        preferred_sources=["BLS"],
+    )
+    after_revision = repo.fetch_macro_observation_as_of(
+        "CPI_ALL_ITEMS",
+        date(2026, 1, 31),
+        datetime(2026, 3, 2, tzinfo=UTC),
+        preferred_sources=["BLS"],
+    )
+
+    assert before_revision is not None
+    assert before_revision["value_numeric"] == Decimal("319.1")
+    assert after_revision is not None
+    assert after_revision["value_numeric"] == Decimal("319.3")
+    assert (
+        len(repo.fetch_macro_observation_history("CPI_ALL_ITEMS", date(2026, 1, 31)))
+        == 2
+    )
+
+
+def test_source_precedence_selects_official_without_deleting_shadow(
+    repo: Repository,
+) -> None:
+    official_artifact = _insert_artifact(repo)
+    shadow_artifact = _insert_artifact(
+        repo,
+        source="SHADOW",
+        source_kind="third_party_shadow",
+        source_record_id="shadow-cpi-2026-02-13",
+        cost_class="free_third_party_shadow",
+    )
+    repo.insert_macro_observations(
+        [_observation(official_artifact)],
+        seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+    )
+    repo.insert_macro_observations(
+        [
+            {
+                **_observation(
+                    shadow_artifact,
+                    source="SHADOW",
+                    source_record_id="shadow-cpi-2026-02-13",
+                    available_at=datetime(2026, 2, 13, 13, 30, tzinfo=UTC),
+                    value=Decimal("319.8"),
+                    cost_class="free_third_party_shadow",
+                ),
+            }
+        ],
+        seen_at=datetime(2026, 2, 13, 13, 31, tzinfo=UTC),
+    )
+
+    selected = repo.fetch_macro_observation_as_of(
+        "CPI_ALL_ITEMS",
+        date(2026, 1, 31),
+        datetime(2026, 2, 14, tzinfo=UTC),
+        preferred_sources=["BLS", "SHADOW"],
+    )
+    history = repo.fetch_macro_observation_history("CPI_ALL_ITEMS", date(2026, 1, 31))
+    series = repo.fetch_macro_series_as_of(
+        "CPI_ALL_ITEMS",
+        datetime(2026, 2, 14, tzinfo=UTC),
+        preferred_sources=["BLS", "SHADOW"],
+    )
+
+    assert selected is not None
+    assert selected["source"] == "BLS"
+    assert [row["source"] for row in series] == ["BLS"]
+    assert {row["source"] for row in history} == {"BLS", "SHADOW"}
+
+
+def test_artifact_hash_identity_rejects_conflicting_immutable_metadata(
+    repo: Repository,
+) -> None:
+    artifact_id = _insert_artifact(repo)
+
+    with pytest.raises(ValueError, match="artifact identity collision"):
+        repo.insert_macro_artifact(
+            source="BLS",
+            source_kind="official",
+            source_record_id="cpi-2026-02-12",
+            source_url="https://example.test/different-release",
+            published_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+            available_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+            retrieved_at=datetime(2026, 2, 13, 13, 31, tzinfo=UTC),
+            content_hash=macro_artifact_content_identity(raw_json=RAW_CPI)[0],
+            parser_version="bls-cpi-v2",
+            quality_status="valid",
+            cost_class="free_official",
+            media_type="application/json",
+            content_length=macro_artifact_content_identity(raw_json=RAW_CPI)[1],
+            raw_json=RAW_CPI,
+        )
+
+    assert artifact_id == _insert_artifact(repo)
+
+
+def test_observation_hash_identity_rejects_conflicting_immutable_value(
+    repo: Repository,
+) -> None:
+    artifact_id = _insert_artifact(repo)
+    row = _observation(artifact_id)
+    seen_at = datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+    repo.insert_macro_observations([row], seen_at=seen_at)
+
+    with pytest.raises(ValueError, match="observation content_hash does not match"):
+        repo.insert_macro_observations(
+            [{**row, "value_numeric": Decimal("999.9")}],
+            seen_at=datetime(2026, 2, 13, 13, 31, tzinfo=UTC),
+        )
+
+    history = repo.fetch_macro_observation_history("CPI_ALL_ITEMS", date(2026, 1, 31))
+    assert len(history) == 1
+    assert history[0]["value_numeric"] == Decimal("319.1")
+
+
+def test_invalid_and_quarantined_observations_are_not_pit_eligible(
+    repo: Repository,
+) -> None:
+    artifact_id = _insert_artifact(repo)
+    for quality, value, suffix in (
+        ("invalid", Decimal("999.0"), "invalid"),
+        ("quarantined", Decimal("998.0"), "quarantined"),
+    ):
+        repo.insert_macro_observations(
+            [
+                {
+                    **_observation(
+                        artifact_id,
+                        value=value,
+                        quality_status=quality,
+                    ),
+                }
+            ],
+            seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        )
+
+    assert (
+        repo.fetch_macro_observation_as_of(
+            "CPI_ALL_ITEMS",
+            date(2026, 1, 31),
+            datetime(2026, 2, 20, tzinfo=UTC),
+            preferred_sources=["BLS"],
+        )
+        is None
+    )
+
+
+def test_conservative_availability_may_follow_first_observation(
+    repo: Repository,
+) -> None:
+    artifact_id = _insert_artifact(repo)
+    seen_at = datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+    safe_at = datetime(2026, 2, 17, 13, 30, tzinfo=UTC)
+    row = {
+        **_observation(artifact_id, available_at=safe_at),
+        "published_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+    }
+    row["content_hash"] = macro_observation_content_hash(row)
+
+    repo.insert_macro_observations([row], seen_at=seen_at)
+
+    assert (
+        repo.fetch_macro_observation_as_of(
+            "CPI_ALL_ITEMS",
+            date(2026, 1, 31),
+            datetime(2026, 2, 16, tzinfo=UTC),
+            preferred_sources=["BLS"],
+        )
+        is None
+    )
+    after_lag = repo.fetch_macro_observation_as_of(
+        "CPI_ALL_ITEMS",
+        date(2026, 1, 31),
+        datetime(2026, 2, 18, tzinfo=UTC),
+        preferred_sources=["BLS"],
+    )
+    assert after_lag is not None
+    assert after_lag["first_observed_at"] == seen_at
+    assert after_lag["available_at"] == safe_at
+
+
+def test_repository_rejects_naive_time_and_non_sha256_hash(repo: Repository) -> None:
+    with pytest.raises(ValueError, match="retrieved_at must be timezone-aware"):
+        repo.insert_macro_artifact(
+            source="BLS",
+            source_kind="official",
+            source_record_id="naive-time",
+            source_url=None,
+            published_at=None,
+            available_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+            retrieved_at=datetime(2026, 2, 12, 13, 31),
+            content_hash=macro_artifact_content_identity(raw_json={})[0],
+            parser_version="bls-cpi-v1",
+            quality_status="valid",
+            cost_class="free_official",
+            media_type="application/json",
+            content_length=2,
+            raw_json={},
+        )
+
+    with pytest.raises(ValueError, match="content_hash must be lowercase SHA-256"):
+        repo.insert_macro_artifact(
+            source="BLS",
+            source_kind="official",
+            source_record_id="bad-hash",
+            source_url=None,
+            published_at=None,
+            available_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+            retrieved_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+            content_hash="not-a-sha256",
+            parser_version="bls-cpi-v1",
+            quality_status="valid",
+            cost_class="free_official",
+            media_type="application/json",
+            content_length=2,
+            raw_json={},
+        )
+
+
+def test_artifact_hash_length_and_sighting_are_content_derived(
+    repo: Repository,
+) -> None:
+    with pytest.raises(ValueError, match="artifact content_hash does not match"):
+        _insert_artifact(repo, source_record_id="wrong-hash", content_hash="a" * 64)
+
+    with pytest.raises(ValueError, match="artifact content_length does not match"):
+        _insert_artifact(repo, source_record_id="wrong-length", content_length=999)
+
+    first = datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+    later = datetime(2026, 2, 13, 13, 31, tzinfo=UTC)
+    artifact_id = _insert_artifact(repo, retrieved_at=first)
+    assert artifact_id == _insert_artifact(repo, retrieved_at=later)
+
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT retrieved_at, last_seen_at FROM uw_scan.macro_source_artifacts "
+            "WHERE artifact_id = %s",
+            (artifact_id,),
+        )
+        assert cur.fetchone() == (first, later)
+
+
+def test_one_artifact_can_supply_multiple_macro_domains(repo: Repository) -> None:
+    artifact_id = _insert_artifact(
+        repo,
+        source="FED",
+        source_record_id="fomc-2026-06-17-sep",
+    )
+    rows = [
+        _observation(
+            artifact_id,
+            source="FED",
+            source_record_id="fomc-2026-06-17-sep",
+            domain="inflation",
+            series_id="SEP_PCE_MEDIAN",
+            value=Decimal("2.2"),
+        ),
+        _observation(
+            artifact_id,
+            source="FED",
+            source_record_id="fomc-2026-06-17-sep",
+            domain="policy_rates",
+            series_id="SEP_FED_FUNDS_MEDIAN",
+            value=Decimal("3.4"),
+        ),
+    ]
+
+    assert (
+        repo.insert_macro_observations(
+            rows, seen_at=datetime(2026, 6, 17, 18, 1, tzinfo=UTC)
+        )
+        == 2
+    )
+
+
+def test_artifact_bounds_observation_availability_and_quality(
+    repo: Repository,
+) -> None:
+    artifact_available = datetime(2026, 2, 12, 13, 30, tzinfo=UTC)
+    artifact_id = _insert_artifact(repo, available_at=artifact_available)
+    early = _observation(
+        artifact_id,
+        available_at=datetime(2026, 2, 12, 13, 29, tzinfo=UTC),
+    )
+    with pytest.raises(ValueError, match="precedes artifact available_at"):
+        repo.insert_macro_observations(
+            [early], seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+        )
+
+    quarantined_artifact = _insert_artifact(
+        repo,
+        source_record_id="quarantined-artifact",
+        quality_status="quarantined",
+    )
+    with pytest.raises(ValueError, match="quality exceeds artifact quality"):
+        repo.insert_macro_observations(
+            [
+                _observation(
+                    quarantined_artifact,
+                    source_record_id="quarantined-artifact",
+                )
+            ],
+            seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        )
+
+    partial_artifact = _insert_artifact(
+        repo,
+        source_record_id="partial-artifact",
+        quality_status="partial",
+    )
+    with pytest.raises(ValueError, match="quality exceeds artifact quality"):
+        repo.insert_macro_observations(
+            [
+                _observation(
+                    partial_artifact,
+                    source_record_id="partial-artifact",
+                )
+            ],
+            seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        )
+
+
+def test_database_triggers_prevent_historical_rewrites(repo: Repository) -> None:
+    artifact_id = _insert_artifact(repo)
+    repo.insert_macro_observations(
+        [_observation(artifact_id)],
+        seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+    )
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with repo.conn.transaction():
+            repo.conn.execute(
+                "UPDATE uw_scan.macro_source_artifacts "
+                "SET quality_status = 'quarantined' WHERE artifact_id = %s",
+                (artifact_id,),
+            )
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with repo.conn.transaction():
+            repo.conn.execute(
+                "DELETE FROM uw_scan.macro_observations WHERE artifact_id = %s",
+                (artifact_id,),
+            )
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with repo.conn.transaction():
+            repo.conn.execute(
+                "UPDATE uw_scan.macro_observations "
+                "SET value_numeric = 999 WHERE artifact_id = %s",
+                (artifact_id,),
+            )
+
+
+def test_database_triggers_recompute_artifact_identity(repo: Repository) -> None:
+    params = (
+        "BLS",
+        "official",
+        "direct-sql-invalid-hash",
+        datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        "a" * 64,
+        "direct-v1",
+        "valid",
+        "free_official",
+        "application/json",
+        2,
+        Jsonb({}),
+    )
+    with pytest.raises(
+        psycopg.errors.CheckViolation,
+        match="content_hash does not match",
+    ):
+        with repo.conn.transaction():
+            repo.conn.execute(
+                """
+                INSERT INTO uw_scan.macro_source_artifacts (
+                  source, source_kind, source_record_id,
+                  available_at, retrieved_at, last_seen_at,
+                  content_hash, parser_version, quality_status, cost_class,
+                  media_type, content_length, raw_jsonb
+                ) VALUES (
+                  %s, %s, %s, %s, %s, %s,
+                  %s, %s, %s, %s, %s, %s, %s
+                )
+                """,
+                (*params[:5], params[4], *params[5:]),
+            )
+
+
+def test_database_json_canonicalization_matches_python(repo: Repository) -> None:
+    raw_json = {
+        "a": 1,
+        "B": 2,
+        "é": 3,
+        "黄金": {"Z": 6, "a": 1},
+    }
+    artifact_id = _insert_artifact(
+        repo,
+        source_record_id="mixed-json-keys",
+        raw_json=raw_json,
+    )
+    row = _observation(
+        artifact_id,
+        source_record_id="mixed-json-keys",
+        series_id="MIXED_JSON_VALUE",
+    )
+    row.update(
+        value_numeric=None,
+        value_json={"黄金": "x", "a": 1, "B": 2},
+    )
+    row["content_hash"] = macro_observation_content_hash(row)
+
+    assert (
+        repo.insert_macro_observations(
+            [row], seen_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+        )
+        == 1
+    )
+
+
+def test_database_rejects_nonfinite_numeric_observation(repo: Repository) -> None:
+    artifact_id = _insert_artifact(repo, source_record_id="direct-sql-nan")
+    with pytest.raises(
+        psycopg.errors.NumericValueOutOfRange,
+        match="macro numeric values must be finite",
+    ):
+        with repo.conn.transaction():
+            repo.conn.execute(
+                """
+                INSERT INTO uw_scan.macro_observations (
+                  artifact_id, domain, series_id, period_end, frequency, unit,
+                  value_numeric, source, source_record_id,
+                  available_at, first_observed_at, last_seen_at,
+                  content_hash, parser_version, quality_status, cost_class
+                ) VALUES (
+                  %s, 'inflation', 'DIRECT_SQL_NAN', '2026-01-31',
+                  'monthly', 'index', 'NaN'::numeric,
+                  'BLS', 'direct-sql-nan',
+                  '2026-02-12 13:30:00+00', '2026-02-12 13:31:00+00',
+                  '2026-02-12 13:31:00+00', %s,
+                  'direct-v1', 'valid', 'free_official'
+                )
+                """,
+                (artifact_id, "a" * 64),
+            )
+
+
+def test_pit_reads_require_aware_as_of_and_explicit_source_order(
+    repo: Repository,
+) -> None:
+    with pytest.raises(ValueError, match="preferred_sources must not be empty"):
+        repo.fetch_macro_observation_as_of(
+            "CPI_ALL_ITEMS",
+            date(2026, 1, 31),
+            datetime(2026, 2, 20, tzinfo=UTC),
+            preferred_sources=[],
+        )
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        repo.fetch_macro_series_as_of(
+            "CPI_ALL_ITEMS",
+            datetime(2026, 2, 20, tzinfo=UTC),
+            preferred_sources=["BLS", "BLS"],
+        )
+    with pytest.raises(ValueError, match="preferred_sources must not be empty"):
+        repo.fetch_macro_series_as_of(
+            "CPI_ALL_ITEMS",
+            datetime(2026, 2, 20, tzinfo=UTC),
+            preferred_sources=[],
+        )
+    with pytest.raises(ValueError, match="as_of must be timezone-aware"):
+        repo.fetch_macro_series_as_of(
+            "CPI_ALL_ITEMS",
+            datetime(2026, 2, 20),
+            preferred_sources=["BLS"],
+        )
+
+
+def test_nonproduction_source_predicate_rejects_local_database(
+    repo: Repository,
+) -> None:
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "SELECT uw_scan.macro_source_kind_allowed(%s, %s)",
+            ("mock", "option_wizard_local"),
+        )
+        assert cur.fetchone() == (False,)
+        cur.execute(
+            "SELECT uw_scan.macro_source_kind_allowed(%s, %s)",
+            ("mock", "option_wizard_test_gw0"),
+        )
+        assert cur.fetchone() == (True,)

--- a/tests/unit/models/test_macro_models.py
+++ b/tests/unit/models/test_macro_models.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from uw_scan.macro_evidence import (
+    macro_artifact_content_identity,
+    macro_observation_content_hash,
+)
+from uw_scan.models import MacroEvidenceRef, MacroObservation, MacroSourceArtifact
+
+RAW_ARTIFACT = {"value": "319.1"}
+HASH_A, CONTENT_LENGTH = macro_artifact_content_identity(raw_json=RAW_ARTIFACT)
+
+
+def _artifact_payload() -> dict[str, object]:
+    return {
+        "artifact_id": 7,
+        "source": "BLS",
+        "source_kind": "official",
+        "source_record_id": "cpi-2026-02-12",
+        "source_url": "https://example.test/release",
+        "published_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        "available_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        "retrieved_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        "last_seen_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        "content_hash": HASH_A,
+        "parser_version": "bls-cpi-v1",
+        "quality_status": "valid",
+        "cost_class": "free_official",
+        "media_type": "application/json",
+        "content_length": CONTENT_LENGTH,
+        "raw_json": RAW_ARTIFACT,
+    }
+
+
+def test_macro_source_artifact_requires_timezone_aware_instants() -> None:
+    payload = _artifact_payload()
+    payload["retrieved_at"] = datetime(2026, 2, 12, 13, 31)
+
+    with pytest.raises(ValidationError):
+        MacroSourceArtifact.model_validate(payload)
+
+
+def test_macro_source_artifact_requires_exactly_one_raw_payload() -> None:
+    payload = _artifact_payload()
+    payload["raw_text"] = "duplicate representation"
+
+    with pytest.raises(ValidationError):
+        MacroSourceArtifact.model_validate(payload)
+
+
+def test_macro_source_artifact_rejects_unknown_cost_class() -> None:
+    payload = _artifact_payload()
+    payload["cost_class"] = "free_maybe"
+
+    with pytest.raises(ValidationError):
+        MacroSourceArtifact.model_validate(payload)
+
+
+def test_canonical_artifact_identity_normalizes_json_order_and_numbers() -> None:
+    first = macro_artifact_content_identity(raw_json={"b": 1.0, "a": "黄金"})
+    second = macro_artifact_content_identity(raw_json={"a": "黄金", "b": 1})
+
+    assert first == second
+
+
+def test_macro_observation_preserves_decimal_and_unit() -> None:
+    payload = {
+        "obs_id": 11,
+        "artifact_id": 7,
+        "domain": "inflation",
+        "series_id": "CPI_ALL_ITEMS",
+        "period_end": date(2026, 1, 31),
+        "frequency": "monthly",
+        "unit": "index_1982_1984_100",
+        "value_numeric": Decimal("319.1000"),
+        "source": "BLS",
+        "source_record_id": "cpi-2026-02-12",
+        "published_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        "available_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        "first_observed_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        "last_seen_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        "parser_version": "bls-cpi-v1",
+        "quality_status": "valid",
+        "cost_class": "free_official",
+    }
+    payload["content_hash"] = macro_observation_content_hash(payload)
+    observation = MacroObservation.model_validate(payload)
+
+    assert observation.value_numeric == Decimal("319.1000")
+    assert observation.unit == "index_1982_1984_100"
+    assert observation.__class__.__module__ == "uw_scan.models"
+
+    equivalent = {**payload, "value_numeric": Decimal("319.1")}
+    assert macro_observation_content_hash(equivalent) == payload["content_hash"]
+
+
+def test_macro_observation_requires_exactly_one_value() -> None:
+    with pytest.raises(ValidationError):
+        MacroObservation.model_validate(
+            {
+                "artifact_id": 7,
+                "domain": "inflation",
+                "series_id": "CPI_ALL_ITEMS",
+                "period_end": date(2026, 1, 31),
+                "frequency": "monthly",
+                "unit": "index_1982_1984_100",
+                "value_numeric": Decimal("319.1"),
+                "value_text": "319.1",
+                "source": "BLS",
+                "source_record_id": "cpi-2026-02-12",
+                "available_at": datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+                "first_observed_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+                "last_seen_at": datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+                "content_hash": HASH_A,
+                "parser_version": "bls-cpi-v1",
+                "quality_status": "valid",
+                "cost_class": "free_official",
+            }
+        )
+
+
+def test_macro_evidence_ref_round_trips_ids_and_times() -> None:
+    evidence = MacroEvidenceRef(
+        obs_id=11,
+        artifact_id=7,
+        domain="inflation",
+        source="BLS",
+        source_url="https://example.test/release",
+        source_record_id="cpi-2026-02-12",
+        period_end=date(2026, 1, 31),
+        published_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        available_at=datetime(2026, 2, 12, 13, 30, tzinfo=UTC),
+        first_observed_at=datetime(2026, 2, 12, 13, 31, tzinfo=UTC),
+        content_hash=HASH_A,
+        parser_version="bls-cpi-v1",
+        quality_status="valid",
+        cost_class="free_official",
+    )
+
+    restored = MacroEvidenceRef.model_validate_json(evidence.model_dump_json())
+
+    assert restored.obs_id == 11
+    assert restored.artifact_id == 7
+    assert restored.available_at == evidence.available_at
+
+
+def test_macro_models_reject_non_sha256_hash_and_reversed_times() -> None:
+    payload = _artifact_payload()
+    payload["content_hash"] = "placeholder"
+    with pytest.raises(ValidationError):
+        MacroSourceArtifact.model_validate(payload)
+
+    payload = _artifact_payload()
+    payload["published_at"] = datetime(2026, 2, 12, 13, 32, tzinfo=UTC)
+    payload["available_at"] = datetime(2026, 2, 12, 13, 31, tzinfo=UTC)
+    with pytest.raises(
+        ValidationError, match="published_at must not follow available_at"
+    ):
+        MacroSourceArtifact.model_validate(payload)

--- a/tests/unit/scripts/test_macro_legacy_inventory.py
+++ b/tests/unit/scripts/test_macro_legacy_inventory.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from scripts.research.macro_legacy_inventory import (
+    ALLOWED_DOMAINS,
+    RELATION_CONTRACTS,
+    REQUIRED_RELATIONS,
+    validate_inventory,
+)
+
+
+def _inventory() -> dict:
+    relations = []
+    for name in sorted(REQUIRED_RELATIONS):
+        contract = RELATION_CONTRACTS[name]
+        relations.append(
+            {
+                "name": name,
+                "relation_kind": contract["relation_kind"],
+                "row_count": 0,
+                "primary_key": [],
+                "date_span": {"min": None, "max": None},
+                "dimensions": {},
+                "contract": contract,
+            }
+        )
+    return {"relations": relations}
+
+
+def test_inventory_contract_covers_current_rates_and_gold_relations() -> None:
+    assert len(REQUIRED_RELATIONS) == 19
+    assert set(RELATION_CONTRACTS) == REQUIRED_RELATIONS
+    assert RELATION_CONTRACTS["wgc_etf_monthly_canonical"]["relation_kind"] == "view"
+    assert {
+        contract["domain"] for contract in RELATION_CONTRACTS.values()
+    } <= ALLOWED_DOMAINS
+
+
+def test_validate_inventory_rejects_unknown_contract_domain() -> None:
+    inventory = _inventory()
+    inventory["relations"][0]["contract"] = {
+        **inventory["relations"][0]["contract"],
+        "domain": "inflation_gold",
+    }
+
+    with pytest.raises(ValueError, match="unknown domain"):
+        validate_inventory(inventory)
+
+
+def test_validate_inventory_accepts_complete_sorted_inventory() -> None:
+    validate_inventory(_inventory())
+
+
+def test_validate_inventory_rejects_missing_or_unsorted_relations() -> None:
+    missing = _inventory()
+    missing["relations"].pop()
+    with pytest.raises(ValueError, match="coverage mismatch"):
+        validate_inventory(missing)
+
+    unsorted = deepcopy(_inventory())
+    unsorted["relations"].reverse()
+    with pytest.raises(ValueError, match="not sorted"):
+        validate_inventory(unsorted)


### PR DESCRIPTION
## Summary

- add the immutable, point-in-time macro artifact and observation substrate for inflation, rates, USD, and gold
- enforce cross-language content identity, append-only database guards, artifact availability/quality bounds, and explicit source precedence
- persist the 19-relation local rates/gold inventory plus the master plan and MC0–MC6 child plans
- keep existing Rates and Gold Compass reads unchanged; live adapters, UI, and Fundamental PM integration remain later milestones

## Why

The legacy rates and gold stores overwrite some revisions, do not retain exact source artifacts, and mix observation time with retrieval time. MC0 establishes a free-first evidence contract before any source or UI cutover.

## Verification

- `uv run pytest tests/unit/ -q` — 1,715 passed
- `UW_SCAN_TEST_DB_NAME=option_wizard_test_macro_mc0 uv run pytest tests/integration/ -n 4 -q` — 927 passed, 11 skipped
- full migration replay twice on dedicated `option_wizard_test_macro_mc0`
- `uv run ruff check src scripts tests`
- changed-file `ruff format --check`; repository-wide check reports 95 pre-existing formatting deviations outside this PR
- `uv run python scripts/check_migration_prefixes.py`
- `uv run python scripts/check_runtime_assets.py`
- `uv run python scripts/check_no_yahoo.py`
- `uv run python scripts/research/macro_legacy_inventory.py --self-check`
- independent code review: no remaining actionable findings