### PR TITLE
fix(health): a kill-switched AI provider expects zero workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/api/health` reported codex and claude as permanently 0-of-2 healthy.** The
+  per-provider AI block read `TRADE_INSIGHTS_AI_{CODEX,CLAUDE}_WORKER_COUNT`
+  (default 2) as a claim that the pool runs, when it only describes pool width
+  *if* it runs. The containerized deployment runs neither by design — the CLI
+  runners need a subprocess plus keychain OAuth, so only DeepSeek survived the
+  2026-07-08 Docker cutover — and `TRADE_INSIGHTS_AI_ENABLED=false` /
+  `TRADE_INSIGHTS_AI_CLAUDE_ENABLED=false` in the mini's `.env` already said so.
+  A kill-switched provider now expects zero workers, so the block reads 0/0
+  instead of a standing red, while an *enabled* pool with no heartbeat still
+  reports unhealthy. Payload-only: the block never gated the top-level `ok`
+  (that comes from db / no-scan / missed-scans / record-coverage) and no web
+  component renders it, so nothing was masked — but a field that is wrong for
+  five weeks straight teaches the reader to skip it.
+
 ## [0.12.0] — 2026-08-16
 
 

--- a/docs/runbooks/2026-08-16-gap-heal-detached-run.md
+++ b/docs/runbooks/2026-08-16-gap-heal-detached-run.md
@@ -1,0 +1,166 @@
+# Detached gap-heal run — 2026-08-16
+
+Recovery card for the option-surface backfill launched 2026-08-16. Written so
+the run survives losing the Claude session that started it. The **durable trace
+is Postgres**, not the log file: `uw_scan.data_gap_runs` / `data_gap_items` carry
+run status and per-item outcome, so a lost log costs nothing.
+
+## The run
+
+| | |
+|---|---|
+| run_id | **75** |
+| dataset | `option_surface_grid_daily` |
+| window | `--start 2026-02-17` — **the wrong call, see "Retention" below** |
+| UW cap | 30,000 calls |
+| host pid | 34950 (`nohup docker exec …`, survives SSH exit) |
+| log | `/opt/argon/logs/gap-heal-surface-20260816.log` on the mini |
+
+Launched with:
+
+```bash
+ssh macmini 'export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; \
+  nohup docker exec argon-worker-uw-0-1 \
+    python scripts/backfill/data_gap_healer.py execute \
+      --start 2026-02-17 --datasets option_surface_grid_daily \
+      --max-uw-calls 30000 --confirm \
+  > /opt/argon/logs/gap-heal-surface-20260816.log 2>&1 < /dev/null & disown'
+```
+
+`setsid` does NOT exist on macOS — the first launch attempt silently failed with
+`command not found` and started nothing. `nohup … < /dev/null &` is the working
+form; always verify with `ps -p <pid>` rather than trusting the launch line.
+
+## Outcome — run 75 COMPLETE
+
+Ran 15:23:43 → 17:00:39 HKT (1h37m) and stopped on its budget cap, as designed.
+
+| | |
+|---|---|
+| healed | **1,491** ticker-dates |
+| no_data | 9 |
+| skipped_budget | **4,206** (still open) |
+| UW spent | 30,000 (exactly the cap) |
+| measured rate | **20.1 calls/heal** (probe predicted 21.4) |
+
+Verified against the table, not the healer's self-report: **914,661 rows** landed
+with `inserted_at` inside the run window, spanning exactly **1,491 distinct
+`(ticker, market_date)`** pairs over 2026-02-17→2026-07-31. The count matches the
+claimed `healed`, and the floor confirms `--start 2026-02-17` was honored, so no
+budget went to the pre-Feb-17 dates that are already past UW retention.
+
+**Remaining: 4,206 recoverable ticker-dates ≈ 84,500 UW calls** — more than one
+day's headroom. This needs several days, which is the argument for the nightly
+job below rather than more hand-launched runs.
+
+The SSH session watching this run died mid-flight (`Connection reset by peer`).
+The run was unaffected — which is the whole point of detaching. Never infer run
+state from the watcher's exit code; read `data_gap_runs`.
+
+## Check status
+
+```bash
+# is it alive?
+ssh macmini 'ps -o pid,etime,command -p 34950'
+
+# progress (authoritative — survives log loss)
+ssh macmini 'export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; \
+  docker exec argon-worker-uw-0-1 python -c "
+import psycopg
+from uw_scan.config import Settings
+s=Settings.from_env(); c=psycopg.connect(s.db_dsn()); cur=c.cursor()
+cur.execute(\"select id,status,started_at,finished_at from uw_scan.data_gap_runs where id=75\")
+print(cur.fetchone())
+cur.execute(\"select status,count(*) from uw_scan.data_gap_items where run_id=75 group by 1\")
+print(cur.fetchall())
+"'
+
+# UW budget burn
+ssh macmini 'curl -s http://127.0.0.1:8400/api/health' | python3 -c "import json,sys;print(json.load(sys.stdin)['uw_today'])"
+```
+
+## If it dies partway
+
+The healer is resumable by design — it re-reads unfinished items for the run:
+
+```bash
+ssh macmini 'export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; \
+  docker exec argon-worker-uw-0-1 python scripts/backfill/data_gap_healer.py \
+    resume --run-id 75 --max-uw-calls 30000'
+```
+
+A **Watchtower redeploy kills the container and therefore this run.** That is
+safe — resume picks it up. Do not restart with `execute`, which opens a new run.
+
+## Measured costs (probes, 2026-08-16)
+
+Both probes were bounded at 300 UW calls and are recorded as runs 73 and 74.
+
+| dataset | gaps | calls per heal | full-backfill cost |
+|---|---:|---:|---:|
+| `option_surface_grid_daily` | 7,056 | **21.4** (one call per expiry) | ~142k |
+| `uw_short_pressure_daily` | 8,121 | **3.0** | ~24.6k |
+| `uw_volatility_signal_daily` | 8,120 | unmeasured | ~24.6k if same shape |
+| `volatility_stats_history` | 8,120 | unmeasured | ~24.6k if same shape |
+| `uw_gex_levels_daily` | 8,120 | unmeasured | ~24.6k if same shape |
+| `vrp_daily` + `stock_analytics_daily` | 149 | 0 (db-derived) | **done — all `no_data`, unfillable** |
+
+Daily UW ceiling is 120,000. The surface backfill alone exceeds one full day, so
+it cannot complete in a single run.
+
+## Retention — the ~180-day cutoff is NOT a hard wall
+
+`--start 2026-02-17` was chosen by treating CLAUDE.md's "UW's ~180-day window"
+as a hard date (2026-08-16 minus 180 days). **That inference is wrong**, and run
+73 disproves it: with `--start 2026-01-01` it healed **2026-01-06 (CLSK)**,
+2026-01-13 (HPQ), 2026-02-02 (S) and 2026-02-13 (CSCO) — all comfortably older
+than the supposed edge — while its single `no_data` fell on 2026-02-18, *inside*
+the "safe" side. Availability does not fall off a cliff at 180 days.
+
+Consequence: run 75 needlessly excluded ~1,340 healable ticker-dates. Nothing was
+lost (they stay in the backlog), but do not repeat the exclusion, and do not cite
+"permanently lost before <date>" as fact — no measurement supports it. Let the
+healer discover unavailability by getting `no_data`.
+
+## What these gaps are NOT
+
+They are **not** the 2026-08-11→16 `full_scan` outage. Every gap item in the
+audit ends **2026-07-31**. The jump from `open_gaps: 0` to `39,877` on 2026-08-16
+was the audit WINDOW widening (runs 66–68 used `--start 2026-08-01`; runs 69–70
+used `--start 2026-01-01`), not new damage surfacing.
+
+The outage window itself audits to **zero gaps** (run 71, `--start 2026-08-11
+--end 2026-08-15`) because the expected-session calendar is itself a captured
+table — an outage erases the evidence of its own missing days. Rebuild that spine
+before trusting any audit that covers an outage.
+
+## The nightly healer is ALREADY ON — no hand-launched runs needed
+
+`data_gap_healer_enabled` defaults to `False` **in code**, and reading that
+default as the deployed state is a mistake. The mini's `/opt/argon/.env` carries:
+
+```
+DATA_GAP_HEALER_ENABLED=true
+DATA_GAP_HEALER_MAX_UW_CALLS=12000
+```
+
+Verified on the running `worker-uw-0` container: `_should_schedule_data_gap_healer`
+returns `True`, cron `0 20 * * 0-4` (20:00 ET Mon–Fri = 08:00 HKT), window from
+`2026-01-01`, all healable datasets. It audits **and** heals — `_run_nightly`
+calls `audit_into_run(mode="execute")` then `execute_run`.
+
+It has been firing every weekday for weeks. A sample from `data_gap_runs`:
+
+| run | started (HKT) | outcome |
+|---|---|---|
+| 57 | 2026-08-11 08:00 | healed **5,963**, no_data 339, skipped_budget 40,935 |
+| 56 | 2026-08-08 08:00 | healed 1, no_data 129 |
+| 55 | 2026-08-07 08:00 | healed 1, no_data 129 |
+
+**The gap in that series is the diagnostic:** no run on 2026-08-12, 13 or 14. The
+nightly healer rides the same `worker-uw-0` process as `full_scan`, so the outage
+took both. It has not fired since because 08-15/16 are the weekend; the next fire
+is the coming Monday 20:00 ET.
+
+So the backlog drains on its own at up to 12,000 UW calls/night. Before proposing
+to "enable" anything here, read the mini's `.env` — not the dataclass default.

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -288,6 +288,7 @@ def _provider_ai_health(
     repo: Repository,
     now_utc: datetime,
     provider: str,
+    enabled: bool,
     expected_count: int,
     fresh_window: timedelta,
 ) -> "TradeInsightsAiProviderHealth":
@@ -296,6 +297,15 @@ def _provider_ai_health(
     Looks up the provider-pinned heartbeat key (e.g. trade_insights_ai_tick_codex);
     falls back to the legacy key when the provider-pinned worker hasn't started
     yet. Healthiness is binary per pool — exact worker count isn't tracked yet.
+
+    A provider whose kill switch is off expects ZERO workers. The worker-count
+    setting describes pool width when the provider runs; it is not a claim that
+    the provider runs at all. Reading it unconditionally reported codex/claude as
+    0-of-2 healthy from the 2026-07-08 Docker cutover onward, because the
+    containerized deployment deliberately runs neither (only DeepSeek survives —
+    the CLI runners need subprocess + keychain OAuth) while
+    TRADE_INSIGHTS_AI_{,CLAUDE_}ENABLED=false in /opt/argon/.env already said so.
+    A health block that is permanently wrong trains the reader to ignore it.
     """
     pinned_key = f"trade_insights_ai_tick_{provider}"
     legacy_key = "trade_insights_ai_tick"
@@ -303,9 +313,10 @@ def _provider_ai_health(
     beat = heartbeats.get(pinned_key) or heartbeats.get(legacy_key)
     pool_alive = beat is not None and (now_utc - beat) < fresh_window
     depth = repo.count_queued_trade_insight_ai_analyses_by_provider(provider)
+    expected = expected_count if enabled else 0
     return TradeInsightsAiProviderHealth(
-        workers_expected=expected_count,
-        workers_healthy=expected_count if pool_alive else 0,
+        workers_expected=expected,
+        workers_healthy=expected if pool_alive else 0,
         queued_depth=depth,
         last_beat_at=beat,
     )
@@ -555,6 +566,7 @@ def health(
             repo=repo,
             now_utc=now_utc,
             provider="codex",
+            enabled=settings.trade_insights_ai_enabled,
             expected_count=settings.trade_insights_ai_codex_worker_count,
             fresh_window=ai_fresh_window,
         ),
@@ -562,6 +574,7 @@ def health(
             repo=repo,
             now_utc=now_utc,
             provider="claude",
+            enabled=settings.trade_insights_ai_claude_enabled,
             expected_count=settings.trade_insights_ai_claude_worker_count,
             fresh_window=ai_fresh_window,
         ),
@@ -569,6 +582,7 @@ def health(
             repo=repo,
             now_utc=now_utc,
             provider="deepseek",
+            enabled=settings.trade_insights_ai_deepseek_enabled,
             expected_count=settings.trade_insights_ai_deepseek_worker_count,
             fresh_window=ai_fresh_window,
         ),

--- a/tests/integration/api/test_health_ops_blocks.py
+++ b/tests/integration/api/test_health_ops_blocks.py
@@ -11,3 +11,32 @@ def test_health_reports_job_failure_streak(client, seeded_db_empty_cards):
     repo.conn.commit()
     body = client.get("/api/health").json()
     assert any(f["job_name"] == "full_scan" for f in body["job_failures"])
+
+
+def test_disabled_ai_provider_expects_zero_workers(seeded_db_empty_cards):
+    """A kill-switched provider expects ZERO workers, not its pool width.
+
+    The containerized deployment runs no codex/claude workers by design, so
+    reading the worker-count setting unconditionally reported a permanent
+    0-of-2 for both from the 2026-07-08 Docker cutover onward. Asserts both
+    directions: disabled -> 0/0 (quiet), enabled-but-absent -> 2/0 (loud).
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from uw_scan.api.routers.health import _provider_ai_health
+
+    common = {
+        "repo": seeded_db_empty_cards,
+        "now_utc": datetime.now(UTC),
+        "provider": "codex",
+        "expected_count": 2,
+        "fresh_window": timedelta(seconds=66),
+    }
+
+    off = _provider_ai_health(enabled=False, **common)
+    assert (off.workers_expected, off.workers_healthy) == (0, 0)
+
+    # No heartbeat seeded, so an ENABLED pool must still read as unhealthy —
+    # the fix must not silence a provider that is genuinely supposed to run.
+    on = _provider_ai_health(enabled=True, **common)
+    assert (on.workers_expected, on.workers_healthy) == (2, 0)


### PR DESCRIPTION
## What

`/api/health` reported **codex and claude as permanently 0-of-2 healthy** — every poll, since the 2026-07-08 Docker cutover.

The per-provider AI block read `TRADE_INSIGHTS_AI_{CODEX,CLAUDE}_WORKER_COUNT` (default `2`) as a claim that the pool *runs*. It only describes pool width **if** it runs. The containerized deployment runs neither by design — the CLI runners need a subprocess plus keychain OAuth, so only DeepSeek survived containerization — and the mini's `.env` already declared exactly that:

```
TRADE_INSIGHTS_AI_ENABLED=false
TRADE_INSIGHTS_AI_CLAUDE_ENABLED=false
TRADE_INSIGHTS_AI_DEEPSEEK_ENABLED=true
```

The intent was sitting in the same `Settings` object the whole time; health just ignored it.

## The fix

`expected = expected_count if enabled else 0`.

A disabled provider reads `0/0`. An **enabled** pool with no heartbeat still reports unhealthy — the fix must not silence a provider that is genuinely supposed to be running, and the test asserts both directions.

## Scope — deliberately narrow

This is **payload-only**, and I want to be precise rather than oversell it:

- the block **never gated** the top-level `ok` (that comes from db / no-scan / missed-scans / record-coverage)
- **no web component renders it** — it appears only in generated `types.ts`

So it masked nothing, mechanically or visually. It is worth fixing because a field that is wrong for five weeks straight teaches the reader to skip the payload, not because it hid an incident.

## Verification

- `36 passed` (`tests/integration/api/ -k "health or openapi"`), ruff clean
- **Mutation-checked**: reverting the single line fails the new test with `(2, 0) == (0, 0)` — the exact production symptom, so the test cannot pass vacuously
- OpenAPI snapshot unchanged — no contract churn, no `gen:types` needed

## Also included

`docs/runbooks/2026-08-16-gap-heal-detached-run.md` — the ops record for today's detached gap-heal (run 75: 1,491 ticker-dates, 914,661 rows, exactly its 30k budget cap). It rides along rather than opening a second PR for one markdown file.

It carries two corrections worth keeping:

1. **UW option-greek retention is not a hard 180-day wall.** Run 73 healed `2026-01-06`; its only `no_data` was `2026-02-18`, *inside* the supposedly-safe side. Don't cite "permanently lost before <date>" as fact.
2. **The nightly gap healer is already enabled** (`DATA_GAP_HEALER_ENABLED=true`, 12k calls/night, verified on the running `worker-uw-0`). Its absence on 08-12/13/14 is the `full_scan` outage taking the shared worker down — not a disabled job. Reading the code default as deployed state is the same mistake this PR fixes.