### PR TITLE
feat(watchlist): merge the sector-inherited tags into the chain taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+
+- **The chain taxonomy now names every layer's members instead of half of them
+  inheriting from `watchlist.sector`.** `IDX`, `THM` and `DEF` previously held
+  empty tuples and seeded from the legacy `sector` column, which capped those 63
+  tickers at **exactly one chain each** — `sector` is a single column — and so
+  quietly excluded them from the many-to-many the join table was built for. Two
+  concrete cases it was hiding: MARA/RIOT are bitcoin miners that pivoted to AI
+  datacenters exactly like the six peers already tagged `AI-Cloud/NeoCloud`, but
+  could only be `Crypto`; and SPCX could not be both `M7` and `Space`. Both now
+  hold both. Sector ETFs (SMH/SOXX/SOXL/IGV/MAGS) are deliberately *not*
+  cross-listed into the company chains they track — a chain answers "which
+  companies are in this value chain", and a fund tracking it is a different
+  question. `inherit_sector_memberships` still runs as the safety net for a
+  ticker the module never names; it simply has nothing left to do here.
+
+### Fixed
+
+- **Two watchlist tickers were typos for the ones actually intended.** `NOV` is
+  National Oilwell Varco — oil drilling equipment, UW sector Energy — and was
+  carrying a `Healthcare` tag; the intended name was `NVO` (Novo Nordisk), now
+  added. `ELV` is Elevance Health, a common stock, and was carrying a
+  `Sector-ETF` tag; the intended name was the `XLV` ETF, which was already on
+  the watchlist and correctly tagged, so `ELV` is simply removed. Net UW burn is
+  down one ticker (~263 calls/day). `SPCX` keeps `M7` by operator decision and
+  additionally gains `Space`.
+
 ## [0.12.1] — 2026-08-17
 
 

--- a/src/uw_scan/watchlist_taxonomy.py
+++ b/src/uw_scan/watchlist_taxonomy.py
@@ -110,6 +110,11 @@ LAYERS: tuple[Layer, ...] = (
                 "GLXY",
                 "BTDR",
                 "CLSK",
+                # Bitcoin miners that pivoted to AI/HPC datacenters, same thesis
+                # as the six above. They keep THM/Crypto too — this is the
+                # many-to-many case, not a reclassification.
+                "MARA",
+                "RIOT",
             ),
             "Data-Platform": (
                 "SNOW",
@@ -264,25 +269,63 @@ LAYERS: tuple[Layer, ...] = (
         key="X",
         name="Cross-cutting",
         focus=AI,
-        chains={"M7": ("AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA", "TSLA")},
+        # SPCX carries M7 by operator decision (scale, not index membership) and
+        # THM/Space by what it is. Both, not either — see the join table's reason
+        # for existing.
+        chains={
+            "M7": ("AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA", "TSLA", "SPCX")
+        },
     ),
-    # Non-AI focus areas. Their chains match the legacy `watchlist.sector` tags
-    # one-for-one, so membership seeds from the existing column rather than a
-    # ticker list here — except Quantum, which is new and therefore enumerated.
+    # Non-AI focus areas. These were previously left empty and seeded from the
+    # legacy `watchlist.sector` column, which made the taxonomy an incomplete
+    # picture: a sector-inherited name could hold exactly ONE chain, because
+    # `sector` is one column. That silently excluded them from the many-to-many
+    # the join table exists for — MARA/RIOT could not be both Crypto and
+    # NeoCloud, SPCX could not be both M7 and Space. Now enumerated here, so the
+    # module is the single source of truth for every layer.
+    #
+    # `inherit_sector_memberships` still runs and is still the safety net for a
+    # ticker the module never names — it just has nothing left to do for these.
     Layer(
         key="IDX",
         name="Index & Macro",
         focus=INDEX,
-        chains={"Beta": (), "Sector-ETF": (), "Credit": (), "Macro": ()},
+        chains={
+            "Beta": ("SPY", "QQQ", "IWM", "DIA"),
+            # Instrument-type tags, deliberately NOT cross-listed into the
+            # company chains they track: a chain answers "which companies are in
+            # this value chain", and a fund tracking it is a different question.
+            "Sector-ETF": (
+                "XLB",
+                "XLC",
+                "XLE",
+                "XLF",
+                "XLI",
+                "XLK",
+                "XLP",
+                "XLRE",
+                "XLU",
+                "XLV",
+                "XLY",
+                "SMH",
+                "SOXX",
+                "SOXL",
+                "IGV",
+                "MAGS",
+                "KORU",
+            ),
+            "Credit": ("HYG", "JNK"),
+            "Macro": ("GLD", "SLV", "TLT"),
+        },
     ),
     Layer(
         key="THM",
         name="Thematic",
         focus=THEMATIC,
         chains={
-            "Crypto": ("BMNR",),
-            "Fintech": ("PYPL",),
-            "Space": (),
+            "Crypto": ("BMNR", "COIN", "CRCL", "MARA", "MSTR", "RIOT"),
+            "Fintech": ("PYPL", "HOOD", "SOFI"),
+            "Space": ("ASTS", "BKSY", "FLY", "PL", "RKLB", "SPCX"),
             # IBM is here AND in L2 Cloud/Hyperscaler — the exact many-to-many
             # case that motivated the join table.
             "Quantum": ("IONQ", "RGTI", "IBM"),
@@ -292,7 +335,14 @@ LAYERS: tuple[Layer, ...] = (
         key="DEF",
         name="Defensive",
         focus=DEFENSIVE,
-        chains={"Healthcare": (), "Energy": (), "Banks": (), "Consumer": ()},
+        chains={
+            # NVO, not NOV: NOV is National Oilwell Varco (oil drilling
+            # equipment, UW sector Energy) and was a typo for Novo Nordisk.
+            "Healthcare": ("JNJ", "LLY", "PFE", "UNH", "HIMS", "NVO"),
+            "Energy": ("XOM", "CVX", "OXY"),
+            "Banks": ("JPM", "BAC", "WFC", "GS", "MS", "BLK"),
+            "Consumer": ("WMT", "COST", "HD", "MCD", "KO", "NKE", "SBUX", "TGT"),
+        },
     ),
 )
 
@@ -306,6 +356,7 @@ SELECTED_ADDS: frozenset[str] = frozenset(
     SNAP SOUN STX TEM TTD U UEC UMC VRT VST WULF ZM ZS
     BBAI BMNR FIG FRMI IONQ KEEL NFLX NVTS POET PYPL RGTI UBER
     CARR MTZ
+    NVO
     """.split()
 )
 

--- a/tests/unit/test_watchlist_taxonomy.py
+++ b/tests/unit/test_watchlist_taxonomy.py
@@ -60,8 +60,58 @@ def test_foundation_model_proxy_is_fully_covered() -> None:
 
 def test_selected_adds_count_is_pinned() -> None:
     """Budget is computed from this count; a silent change moves the UW spend."""
-    assert len(SELECTED_ADDS) == 59
+    assert len(SELECTED_ADDS) == 60
 
 
 def test_case_insensitive_lookup() -> None:
     assert chains_for("nvda") == chains_for("NVDA")
+
+
+def test_no_layer_is_empty() -> None:
+    """Every chain names its members.
+
+    IDX/THM/DEF used to hold empty tuples and seed from `watchlist.sector`.
+    That capped those names at ONE chain each, because `sector` is one column —
+    silently excluding them from the many-to-many the join table exists for.
+    An empty tuple here means a chain has quietly gone back to that.
+    """
+    empty = [
+        f"{layer.key}/{chain}"
+        for layer in LAYERS
+        for chain, tickers in layer.chains.items()
+        if not tickers
+    ]
+    assert not empty
+
+
+def test_merged_legacy_tags_can_hold_a_second_chain() -> None:
+    """The point of merging the sector-inherited tags into the module.
+
+    Under sector-inheritance each of these could hold exactly one chain.
+    """
+    # Bitcoin miners that pivoted to AI datacenters: both, not either.
+    assert chains_for("MARA") == ["AI-Cloud/NeoCloud", "Crypto"]
+    assert chains_for("RIOT") == ["AI-Cloud/NeoCloud", "Crypto"]
+    # SpaceX is M7 by operator decision and Space by what it is.
+    assert chains_for("SPCX") == ["M7", "Space"]
+
+
+def test_novo_nordisk_not_national_oilwell_varco() -> None:
+    """NVO is Novo Nordisk. NOV is National Oilwell Varco — oil drilling
+    equipment, UW sector Energy — and was a typo carrying a Healthcare tag.
+    """
+    assert chains_for("NVO") == ["Healthcare"]
+    assert chains_for("NOV") == []
+    # ELV (Elevance Health, a common stock) was a typo for the XLV ETF.
+    assert chains_for("ELV") == []
+    assert chains_for("XLV") == ["Sector-ETF"]
+
+
+def test_sector_etfs_are_not_cross_listed_into_company_chains() -> None:
+    """A chain answers "which companies are in this value chain".
+
+    A fund tracking it is a different question, so SMH/SOXX/IGV/MAGS carry
+    Sector-ETF and nothing else. Deliberate — revisit only on purpose.
+    """
+    for etf in ("SMH", "SOXX", "SOXL", "IGV", "MAGS"):
+        assert chains_for(etf) == ["Sector-ETF"], etf


### PR DESCRIPTION
## What was wrong

`IDX`, `THM` and `DEF` held **empty tuples** and seeded membership from the legacy `watchlist.sector` column:

```python
chains={"Beta": (), "Sector-ETF": (), "Credit": (), "Macro": ()},
```

That capped those **63 tickers at exactly one chain each** — `sector` is a single column — so they were silently excluded from the many-to-many the join table was built for.

Two cases it was hiding:

| ticker | could only be | should also be |
|---|---|---|
| `MARA`, `RIOT` | `Crypto` | `AI-Cloud/NeoCloud` — same AI-datacenter pivot as the six peers already there (APLD/BTDR/CIFR/CLSK/CORZ/WULF) |
| `SPCX` | `M7` | `Space` — it is SpaceX |

## What changed

Every layer now enumerates its members, so the module is the single source of truth. `inherit_sector_memberships` still runs as the safety net for a ticker the module never names — it just has nothing left to do here.

Mechanically safe: `replace_taxonomy_memberships` upserts `ON CONFLICT (ticker, chain) DO UPDATE SET source = 'taxonomy'`, so previously-inherited rows are **upgraded in place**, not duplicated.

**Sector ETFs are deliberately not cross-listed** into the company chains they track. `SMH`/`SOXX`/`SOXL`/`IGV`/`MAGS` carry `Sector-ETF` and nothing else — a chain answers *"which companies are in this value chain"*, and a fund tracking it is a different question. Pinned as a test so it gets revisited on purpose rather than by drift.

## Two ticker typos fixed

| on the watchlist | actually is | intended | action |
|---|---|---|---|
| **`NOV`** tagged `Healthcare` | National Oilwell Varco — oil drilling equipment, UW sector **Energy** | `NVO` (Novo Nordisk) | remove `NOV`, add `NVO` → `Healthcare` |
| **`ELV`** tagged `Sector-ETF` | Elevance Health — a **common stock**, not an ETF | `XLV` | remove `ELV`; `XLV` was already on the watchlist, correctly tagged |

Both identities verified against UW's company endpoint. Net UW burn is **down one ticker** (~263 calls/day).

`SPCX` keeps `M7` by operator decision and additionally gains `Space`.

## No card moves section

`MARA`/`RIOT`/`SPCX` are already active, so the seeder's add-path (which sets `sector = primary_sector(t)`) does not touch them. They keep their existing `sector` and only gain a second chain. Only `NVO` is new, and it lands on `sector = Healthcare`.

## Verification

- `uv run pytest tests/unit` — **1,829 passed**
- `tests/integration/storage/test_watchlist_chain.py` — 6 passed
- `ruff check` / `ruff format --check` — clean
- Five new invariant tests: no layer may be empty again, the merged names can hold a second chain, NVO≠NOV and ELV≠XLV, and ETFs stay out of company chains.

Post-merge: re-seed prod with `scripts/backfill/watchlist_chain_seed.py` and remove `NOV`/`ELV` via `DELETE /api/watchlist/{ticker}`.