### PR TITLE
fix(watchlist): keep NOV and ELV, enumerate them and ISRG properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,20 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
-- **Two watchlist tickers were typos for the ones actually intended.** `NOV` is
-  National Oilwell Varco — oil drilling equipment, UW sector Energy — and was
-  carrying a `Healthcare` tag; the intended name was `NVO` (Novo Nordisk), now
-  added. `ELV` is Elevance Health, a common stock, and was carrying a
-  `Sector-ETF` tag; the intended name was the `XLV` ETF, which was already on
-  the watchlist and correctly tagged, so `ELV` is simply removed. Net UW burn is
-  down one ticker (~263 calls/day). `SPCX` keeps `M7` by operator decision and
-  additionally gains `Space`.
+- **Two pairs of lookalike tickers had been given each other's tags.** `NOV` is
+  National Oilwell Varco — oil drilling equipment, UW sector Energy — but was
+  carrying `Healthcare`, the tag meant for `NVO` (Novo Nordisk). `ELV` is
+  Elevance Health, a common stock, but was carrying `Sector-ETF`, the tag meant
+  for the `XLV` ETF. All four names are now held, each with its own tag: NOV →
+  `Energy`, NVO → `Healthcare`, ELV → `Healthcare`, XLV → `Sector-ETF`. NVO is
+  the only addition (~263 UW calls/day); NOV and ELV keep their accumulated
+  history. A test asserts the two pairs never share a chain, which is what the
+  mix-up looked like. `SPCX` keeps `M7` by operator decision and additionally
+  gains `Space`.
+- **`ISRG` was the last active ticker whose membership came from sector
+  inheritance rather than the taxonomy.** Now enumerated in both
+  `DEF/Healthcare` and `L4/Robotics/Automation` — surgical robotics is
+  genuinely both — so no active ticker depends on the fallback path.
 
 ## [0.12.1] — 2026-08-17
 

--- a/src/uw_scan/watchlist_taxonomy.py
+++ b/src/uw_scan/watchlist_taxonomy.py
@@ -336,10 +336,25 @@ LAYERS: tuple[Layer, ...] = (
         name="Defensive",
         focus=DEFENSIVE,
         chains={
-            # NVO, not NOV: NOV is National Oilwell Varco (oil drilling
-            # equipment, UW sector Energy) and was a typo for Novo Nordisk.
-            "Healthcare": ("JNJ", "LLY", "PFE", "UNH", "HIMS", "NVO"),
-            "Energy": ("XOM", "CVX", "OXY"),
+            # NVO and NOV are different companies that were briefly conflated:
+            # NVO is Novo Nordisk, NOV is National Oilwell Varco (oil drilling
+            # equipment). Both are held; NOV belongs in Energy, below.
+            # ELV is Elevance Health, a common stock — not the XLV ETF, which
+            # carries Sector-ETF. Both are held.
+            # ISRG sits here AND in L4 Robotics/Automation: surgical robotics is
+            # genuinely both. Enumerated rather than left to sector-inheritance
+            # so no active ticker depends on the fallback.
+            "Healthcare": (
+                "JNJ",
+                "LLY",
+                "PFE",
+                "UNH",
+                "HIMS",
+                "NVO",
+                "ELV",
+                "ISRG",
+            ),
+            "Energy": ("XOM", "CVX", "OXY", "NOV"),
             "Banks": ("JPM", "BAC", "WFC", "GS", "MS", "BLK"),
             "Consumer": ("WMT", "COST", "HD", "MCD", "KO", "NKE", "SBUX", "TGT"),
         },

--- a/tests/unit/test_watchlist_taxonomy.py
+++ b/tests/unit/test_watchlist_taxonomy.py
@@ -96,15 +96,21 @@ def test_merged_legacy_tags_can_hold_a_second_chain() -> None:
     assert chains_for("SPCX") == ["M7", "Space"]
 
 
-def test_novo_nordisk_not_national_oilwell_varco() -> None:
-    """NVO is Novo Nordisk. NOV is National Oilwell Varco — oil drilling
-    equipment, UW sector Energy — and was a typo carrying a Healthcare tag.
+def test_lookalike_tickers_are_not_conflated() -> None:
+    """Two pairs that were briefly given each other's tags.
+
+    NVO is Novo Nordisk; NOV is National Oilwell Varco, oil drilling equipment
+    (UW sector Energy) — NOV had been carrying Healthcare. ELV is Elevance
+    Health, a common stock; XLV is the health-care sector ETF — ELV had been
+    carrying Sector-ETF. All four are held, each with its own tag.
     """
     assert chains_for("NVO") == ["Healthcare"]
-    assert chains_for("NOV") == []
-    # ELV (Elevance Health, a common stock) was a typo for the XLV ETF.
-    assert chains_for("ELV") == []
+    assert chains_for("NOV") == ["Energy"]
+    assert chains_for("ELV") == ["Healthcare"]
     assert chains_for("XLV") == ["Sector-ETF"]
+    # The pairs must never share a chain — that is what the mix-up looked like.
+    assert set(chains_for("NVO")) & set(chains_for("NOV")) == set()
+    assert set(chains_for("ELV")) & set(chains_for("XLV")) == set()
 
 
 def test_sector_etfs_are_not_cross_listed_into_company_chains() -> None:


### PR DESCRIPTION
Follow-up to #338, which removed `NOV` and `ELV` on the reading that they were typos. They were **mis-tagged, not wrong tickers**, and both carry real accumulated history — so they stay, with correct tags.

## Two pairs of lookalikes, four names, four tags

| ticker | what it actually is | had | now |
|---|---|---|---|
| `NOV` | National Oilwell Varco — oil drilling equipment, UW sector Energy | `Healthcare` ❌ | **`Energy`** |
| `NVO` | Novo Nordisk | — (added in #338) | **`Healthcare`** |
| `ELV` | Elevance Health — a common stock | `Sector-ETF` ❌ | **`Healthcare`** |
| `XLV` | Health Care Select Sector SPDR — the ETF | `Sector-ETF` ✅ | **`Sector-ETF`** |

Each pair had been given the other's tag. A test now asserts the two pairs share **no** chain, which is precisely what the mix-up looked like.

## ISRG — the last inheritance holdout

After #338's merge the prod re-seed reported **186 taxonomy rows and 1 sector row**. That one was `ISRG`, whose `Healthcare` membership still came from the legacy `watchlist.sector` fallback because the module listed it only under `Robotics/Automation`.

Now enumerated in both — surgical robotics is genuinely both — so **no active ticker depends on the inheritance path**. It remains only as the safety net for a name the module never lists, which is its stated purpose.

## Verification

- `uv run pytest tests/unit` — **1,829 passed**
- `ruff check` / `ruff format --check` — clean
- Resolved: `NOV → ['Energy']`, `NVO → ['Healthcare']`, `ELV → ['Healthcare']`, `XLV → ['Sector-ETF']`, `ISRG → ['Robotics/Automation', 'Healthcare']`

Prod already holds all four (171 active); this PR makes the module agree, and a re-seed will move ISRG's row from `source='sector'` to `source='taxonomy'`.