### PR TITLE
fix(healer): stop killed and finished heals from wedging the nightly job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,30 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
-- **A killed heal run no longer wedges the nightly healer forever.** The nightly
-  job skips itself while another `execute` run is `running`, but nothing ever
-  timed that out — a run whose process died (SSH drop, Watchtower container
-  recreate, OOM) never reaches `finish_run`, so its row stayed `running` and
-  every subsequent night returned `{"skipped": "run_active"}` silently. Four such
-  runs disabled the healer for a week in 2026-08 while the enable flag, cron,
-  adapters and migrations were all correct. The job now reaps stale runs before
-  the check: it cancels them and requeues the items they orphaned in `running`,
-  which `claim_next_items` skips and which were therefore unhealable. Staleness
-  is measured by **progress, not age** — the last item driven to a verdict — so a
-  legitimate multi-day manual backfill that keeps healing is never reaped, while
-  a corpse clears on the very next nightly run. Run-level twin of the item-level
-  recovery `resume_run` already did.
+- **A finished or killed heal run no longer wedges the nightly healer forever.**
+  The nightly job skips itself while another `execute` run is `running`, and
+  nothing ever cleared that flag. Two ways in: a run whose process died (SSH
+  drop, Watchtower container recreate, OOM) never reached `finish_run`; and
+  `resume_run` — the ordinary way an operator drains a backfill — never called
+  it *at all*, so even a fully successful resume left the row `running`. Either
+  way every subsequent night returned `{"skipped": "run_active"}` silently. Four
+  such runs disabled the healer for a week in 2026-08 while the enable flag,
+  cron, adapters and migrations were all correct. `resume_run` now closes its
+  run, and the nightly job reaps rows whose process is gone — cancelling them
+  and requeuing the items they stranded in `running`, a status
+  `claim_next_items` skips and which were therefore unhealable. Both fixes in
+  one atomic statement each, so a crash mid-reap cannot orphan items in a run
+  the reaper no longer matches.
+- **Manual heals now take the healer's single-flight lock.** `execute_into_run`
+  and `resume_run` hold `pg_try_advisory_lock(92010)` — the lock the nightly job
+  and the freshness autoheal already used — and raise `HealerBusy` (CLI exit 2)
+  rather than racing. A Postgres session lock is released when the process dies,
+  which is exactly the liveness guarantee a `status='running'` row does not
+  give; without it the new reaper could cancel a *live* manual heal, and the
+  nightly would then re-audit the same still-missing gaps into a fresh run and
+  heal them alongside it, double-charging the provider budget. Staleness is
+  measured by progress (last item driven to a verdict) rather than age, so the
+  heuristic stays conservative even if that ordering is ever loosened.
 
 ## [0.12.3] — 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A killed heal run no longer wedges the nightly healer forever.** The nightly
+  job skips itself while another `execute` run is `running`, but nothing ever
+  timed that out — a run whose process died (SSH drop, Watchtower container
+  recreate, OOM) never reaches `finish_run`, so its row stayed `running` and
+  every subsequent night returned `{"skipped": "run_active"}` silently. Four such
+  runs disabled the healer for a week in 2026-08 while the enable flag, cron,
+  adapters and migrations were all correct. The job now reaps stale runs before
+  the check: it cancels them and requeues the items they orphaned in `running`,
+  which `claim_next_items` skips and which were therefore unhealable. Staleness
+  is measured by **progress, not age** — the last item driven to a verdict — so a
+  legitimate multi-day manual backfill that keeps healing is never reaped, while
+  a corpse clears on the very next nightly run. Run-level twin of the item-level
+  recovery `resume_run` already did.
+
 ## [0.12.3] — 2026-08-17
 
 

--- a/docs/research/2026-08-16-outage-replay-heal-record.md
+++ b/docs/research/2026-08-16-outage-replay-heal-record.md
@@ -683,3 +683,36 @@ would be pure collateral damage.
 Covered by `tests/integration/worker/test_data_gap_healer_scheduler.py`:
 reaped-and-unwedged, spares-live-runs (young / still-verifying / audit-mode),
 and the job reaping before it checks the guard.
+
+### Review addendum — the reaper needed a lock under it
+
+The tribunal (Codex + Gemini, both at ~1.0 confidence) rejected the safety
+argument above. It was wrong in a specific way worth recording, because the
+mistake is easy to repeat.
+
+I checked that a reaped run's requeued items cannot be *claimed* by anyone else:
+`claim_next_items` filters on `run_id`, and the nightly job audits into a NEW run
+id, so no second process ever touches those rows. True — and irrelevant. The
+overlap is not on the item row, it is on the **underlying gap**. If the reaped run
+is actually alive and still healing gap G, the nightly's fresh audit sees G still
+missing in the warm store, writes its own item for G, and heals it a second time.
+Same gap, two runs, two provider charges.
+
+The row-based guard had been preventing exactly that. Reaping deliberately
+removes it, so reaping had to be paired with something that proves liveness. The
+codebase already had the answer, in `data_freshness_monitor`:
+
+> A bare `_another_run_active()` SELECT is check-then-act — it can't see a nightly
+> run that starts a moment later, so two `execute_into_run` callers could both
+> proceed and double-spend the same provider budget in the same window.
+
+That module takes `pg_try_advisory_lock(92010)` before healing. The CLI never did.
+Now `execute_into_run` and `resume_run` take it too, which makes the layering
+honest: **the lock is the liveness mechanism** (Postgres frees it when the process
+dies), the `status='running'` row is the durable record a lock cannot provide, and
+the reaper only ever runs once the lock is held — so every `running` row it sees
+is genuinely a corpse, not a slow worker.
+
+The general lesson: a persisted flag is not a mutex. It has no owner and no
+expiry, so it can only ever be a *record* of intent. If you need to know whether
+something is alive, ask something that dies with it.

--- a/docs/research/2026-08-16-outage-replay-heal-record.md
+++ b/docs/research/2026-08-16-outage-replay-heal-record.md
@@ -587,3 +587,99 @@ ticker's pre-existence window gets scored as REAL. It therefore over-reports
 loss for datasets rolled out ticker-by-ticker — which is precisely
 `exposures_summary`'s 05-12..05-20 window. Treat the REAL bucket as an upper
 bound until the clamp proposed above stores a per-ticker `first_seen`.
+
+---
+
+## 2026-08-17 (evening) — why the automation was actually broken
+
+v0.12.2 deployed to the mini at 17:23 HKT; the replay adapters, `grg.run(as_of=)`
+and the two-witness spine are now native (no `docker cp`). But the nightly job
+still would not have run, for a reason unrelated to any of that.
+
+### A killed manual run wedges the nightly healer forever
+
+`data_gap_healer_job` gates on `_another_run_active(gap)`:
+
+    SELECT ... FROM data_gap_runs WHERE status = 'running' AND mode = 'execute' LIMIT 1
+
+**There is no staleness timeout.** A manual `execute`/`resume` killed by an SSH
+drop or a container recreate never reaches `finish_run`, so its row stays
+`running` and every subsequent nightly job returns `{"skipped": "run_active"}` —
+silently, with no alert and no log line anyone was reading.
+
+Found on the mini: runs **78, 80, 87, 88**, stuck since 2026-08-16 23:36–00:19,
+holding **36,251** open items between them. The nightly healer had been skipping
+itself ever since. Enabled flag, cron expression, adapters and migrations were
+all correct the whole time.
+
+Cleared by requeuing each run's orphaned items to `planned` and setting the run
+to `cancelled` — not `complete`, because it did not complete, and `cancelled` is
+already in the schema's CHECK constraint while `_another_run_active` matches only
+`running`. Verified against the real predicate rather than by reading the runs
+table, which is what caught it: the first pass cancelled only run 101 and the
+gate still returned `True`, because the status view was scoped to `id >= 90`.
+
+    enabled:                 True
+    _another_run_active():   False
+    advisory lock free:      True
+    => tonight 20:00 ET fires: True
+
+This is the strongest argument yet for the healer owning its own recovery: a
+`running` run older than N hours should be auto-cancelled at job start, exactly
+as `resume_run` already auto-requeues `running` *items*. The item-level recovery
+exists; the run-level one does not.
+
+### The budget estimate is calibrated for un-scoped runs only
+
+`RequestBudget` charges `est_per_item`, never a measured call count. For
+`pipeline_replay` that estimate assumes all **nine** sibling datasets are present
+as items — the code says so:
+
+> `est_per_item=2 x 9 items = ~18 estimated against ~15 actual calls;
+> over-estimating is the safe direction for a budget governor`
+
+One `run_single_stock(market_date=...)` writes all nine tables and the other
+eight items cost nothing. So `--datasets exposures_summary` — one of the nine —
+buys the full ~15-call replay for a charge of 2.
+
+Measured: run 100 healed 823 items and reported `budget_spent uw=1646`, while
+UW's own account counter rose **+14,253** that hour, of which `full_scan`
+accounted for 2,908. Real cost ≈ 823 × ~15 ≈ 12,300.
+
+**Never dataset-scope a heal for a `pipeline_replay` dataset.** Scope by date
+window; the un-scoped nightly job is the calibrated case. And treat UW's
+`MAX(official_daily_count)` as ground truth for spend — our own telemetry showed
+~4,100 requests on a day UW counted ~32,000.
+
+### Where today ended
+
+    healed          5,882 items (runs 92-101)
+    no_data            66
+    requeued        36,251 items returned to 'planned' from the 4 wedged runs
+    UW spend        32,854 (UW's counter) against a 50,000 operator budget
+
+---
+
+## 2026-08-17 (late) — the run-level recovery now exists
+
+The gap named two paragraphs up is closed. `data_gap_healer_job` reaps stale
+`execute` runs before it consults `_another_run_active`, cancelling them and
+requeuing the items they stranded in `running`.
+
+The predicate is deliberately **progress, not age**:
+
+    COALESCE(max(item.verified_at over the run), run.started_at) < now() - 6h
+
+Age alone cannot separate a 30-hour live manual backfill from a 30-hour corpse,
+so an age threshold has to choose which failure to accept — reap live runs, or
+leave wedges standing for extra nights. The last-verified-item stamp separates
+them, which is what lets the window be short (6h) without false positives. A
+container recreate at 20:30 therefore costs one night, not two.
+
+Scope kept narrow on purpose: `mode='execute'` only, matching the gate's own
+predicate. A stuck `audit` run blocks nothing, and cancelling one mid-flight
+would be pure collateral damage.
+
+Covered by `tests/integration/worker/test_data_gap_healer_scheduler.py`:
+reaped-and-unwedged, spares-live-runs (young / still-verifying / audit-mode),
+and the job reaping before it checks the guard.

--- a/docs/runbooks/data-gap-healer.md
+++ b/docs/runbooks/data-gap-healer.md
@@ -45,15 +45,28 @@ re-runnable datasets (macro/FRED/rates/gold + DB rollups), writes the report,
 and refreshes `/api/health`. Single-flight via an advisory lock; it **skips if a
 prior healer run is still `running`** so it never fights an in-flight backfill.
 
-**Stale-run reaper.** Before that check, the job cancels any `execute` run left
-`running` with **no item verified for 6 hours** and requeues the items it
-orphaned. Without this a run whose process was killed (SSH drop, container
-recreate, OOM) never reaches `finish_run`, so its row stays `running` and the
-skip above fires every night, forever — this silently disabled the healer for a
-week in 2026-08. The staleness test is progress, not age, so a legitimate
-multi-day manual backfill that keeps healing items is never reaped. Reaped run
-ids appear in the job result as `reaped` and in the run's
-`summary_jsonb.cancelled_reason`.
+Single-flight is layered, and the order matters:
+
+1. **The advisory lock (`92010`) is the liveness mechanism.** Every path that
+   spends provider budget holds it — the nightly job, the freshness autoheal, and
+   (new) `execute_into_run` / `resume_run`, so `scripts/backfill/data_gap_healer.py
+   execute|resume` now refuses with `HealerBusy` and **exit code 2** rather than
+   racing another heal. Postgres releases a session lock when the process dies, so
+   this can never go stale.
+2. **The `status='running'` row check** catches what a lock cannot: it is not
+   session-scoped, so it outlives the process that wrote it.
+3. **The stale-run reaper** clears rows whose process is gone — any `execute` run
+   with **no item verified for 6 hours** — cancelling it and requeuing the items it
+   stranded in `running` (a status `claim_next_items` skips, so they were
+   unhealable). Because step 1 already proves no live heal is running by the time
+   this executes, every row it finds is genuinely a corpse. Logs at WARNING and
+   stamps `summary_jsonb.cancelled_reason`.
+
+Without step 3, a killed run wedged the nightly job **forever** — it silently
+disabled the healer for a week in 2026-08. `resume` also closes its run now
+(`status='complete'`, appending to `summary_jsonb.resumes`); it never used to, so
+even a fully *successful* resume left a `running` row behind and wedged the same
+guard through the ordinary operator path, not just the crash path.
 
 ```sql
 -- did the reaper fire, or is something genuinely live?

--- a/docs/runbooks/data-gap-healer.md
+++ b/docs/runbooks/data-gap-healer.md
@@ -45,6 +45,24 @@ re-runnable datasets (macro/FRED/rates/gold + DB rollups), writes the report,
 and refreshes `/api/health`. Single-flight via an advisory lock; it **skips if a
 prior healer run is still `running`** so it never fights an in-flight backfill.
 
+**Stale-run reaper.** Before that check, the job cancels any `execute` run left
+`running` with **no item verified for 6 hours** and requeues the items it
+orphaned. Without this a run whose process was killed (SSH drop, container
+recreate, OOM) never reaches `finish_run`, so its row stays `running` and the
+skip above fires every night, forever — this silently disabled the healer for a
+week in 2026-08. The staleness test is progress, not age, so a legitimate
+multi-day manual backfill that keeps healing items is never reaped. Reaped run
+ids appear in the job result as `reaped` and in the run's
+`summary_jsonb.cancelled_reason`.
+
+```sql
+-- did the reaper fire, or is something genuinely live?
+SELECT id, mode, status, started_at,
+       (SELECT max(verified_at) FROM data_gap_items i WHERE i.run_id = r.id) AS last_progress
+  FROM data_gap_runs r
+ WHERE status = 'running' AND mode = 'execute';
+```
+
 ## Manual commands
 
 ```bash

--- a/scripts/backfill/data_gap_healer.py
+++ b/scripts/backfill/data_gap_healer.py
@@ -32,6 +32,7 @@ from uw_scan.storage.repository import Repository
 # re-exported so the importlib-loaded CLI tests can call the core directly
 from uw_scan.worker.jobs.data_gap_healer import (  # noqa: F401
     OUTPUT_DIR,
+    HealerBusy,
     audit_into_run,
     execute_into_run,
     finalize_run,
@@ -317,7 +318,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()  # before Settings so --help needs no env
     settings = Settings.from_env()
-    return args.func(args, settings)
+    try:
+        return args.func(args, settings)
+    except HealerBusy as exc:
+        # The nightly job, the freshness autoheal, or another operator holds the
+        # single-flight lock. Refusing is the point: racing it would re-audit the
+        # same still-missing gaps and heal them twice, double-charging the
+        # provider budget. Exit 2 so a wrapper can tell "busy" from "broken".
+        logger.error("refusing to start: %s", repr(exc))
+        return 2
 
 
 if __name__ == "__main__":

--- a/src/uw_scan/worker/jobs/data_gap_healer.py
+++ b/src/uw_scan/worker/jobs/data_gap_healer.py
@@ -4,15 +4,20 @@ The CLI (`scripts/backfill/data_gap_healer.py`) is a thin argparse wrapper over
 the core functions here. The nightly job (`data_gap_healer_job`) runs at 20:00 ET
 (just after the UW quota reset), audits + heals strict gaps under a UW cap, then
 refreshes the re-runnable (macro/FRED/rates/gold + DB rollup) datasets, and
-writes the report artifact. Single-flight via an advisory lock; skips if a prior
-healer run is still active so it never fights a manual backfill -- but first
-reaps runs left 'running' by a killed process, which would otherwise wedge that
-skip forever (see _reap_stale_runs).
+writes the report artifact.
+
+Single-flight is layered, and the order matters: EVERY path that spends provider
+budget holds the session advisory lock (`_single_flight`), so a live heal makes
+the nightly job stand down before it touches anything; the `status='running'` row
+check then catches runs a lock cannot (it is not session-scoped, so it survives
+the process); and `_reap_stale_runs` clears rows whose process is gone, which
+that check would otherwise honour forever.
 """
 
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from datetime import date
 from pathlib import Path
 
@@ -41,6 +46,43 @@ logger = logging.getLogger(__name__)
 
 OUTPUT_DIR = Path(__file__).resolve().parents[4] / "output" / "data-gap"
 _LOCK_KEY = 92010  # advisory lock: single-flight for the gap healer
+
+
+class HealerBusy(RuntimeError):
+    """Another heal already holds the single-flight lock."""
+
+
+@contextmanager
+def _single_flight(gap: DataGapHealerRepository):
+    """Hold the gap-healer advisory lock for a heal that spends provider budget.
+
+    A Postgres SESSION lock is released when the connection dies, which is
+    exactly the liveness guarantee `data_gap_runs.status='running'` does NOT
+    give -- that gap is why the row-based guard needed a reaper at all. Holding
+    this around the operator heal paths means a live manual heal makes the
+    nightly job return `{"skipped": "locked"}` *before* it reaps anything, so a
+    running process can never be mistaken for a corpse.
+
+    The nightly job holds this lock itself and calls execute_run directly, so it
+    does not nest here. data_freshness_monitor's autoheal DOES take it and then
+    call execute_into_run -- same connection, and session locks are re-entrant
+    with a counter, so the nested acquire/release balances correctly.
+
+    Re-entrant on the same connection; raises HealerBusy on a different one.
+    """
+    with gap._conn.cursor() as cur:
+        cur.execute("SELECT pg_try_advisory_lock(%s)", (_LOCK_KEY,))
+        if not cur.fetchone()[0]:
+            raise HealerBusy(
+                "another gap-heal holds the single-flight lock (key "
+                f"{_LOCK_KEY}); refusing to race it and double-spend the "
+                "provider budget"
+            )
+    try:
+        yield
+    finally:
+        with gap._conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))
 
 
 # --- core orchestration (testable; take repo/gap, no settings construction) ---
@@ -147,33 +189,34 @@ def execute_into_run(
     specs: dict | None = None,
     active: list[str] | None = None,
 ) -> tuple[int, dict, RequestBudget, list[CoverageSummary], list[GapItem]]:
-    run_id, summaries, items = audit_into_run(
-        repo,
-        gap,
-        settings.db_schema,
-        start=start,
-        end=end,
-        datasets=datasets,
-        mode="execute",
-        active=active,
-    )
-    ctx = HealContext(
-        repo=repo,
-        gap=gap,
-        schema=settings.db_schema,
-        today=today,
-        budget=RequestBudget(max_uw_calls),
-        settings=settings,
-    )
-    outcome = execute_run(ctx, run_id, datasets=datasets, specs=specs)
-    finalize_run(
-        gap,
-        run_id,
-        summaries,
-        items,
-        extra={"outcome": outcome, "budget_spent": ctx.budget.as_dict()},
-    )
-    return run_id, outcome, ctx.budget, summaries, items
+    with _single_flight(gap):
+        run_id, summaries, items = audit_into_run(
+            repo,
+            gap,
+            settings.db_schema,
+            start=start,
+            end=end,
+            datasets=datasets,
+            mode="execute",
+            active=active,
+        )
+        ctx = HealContext(
+            repo=repo,
+            gap=gap,
+            schema=settings.db_schema,
+            today=today,
+            budget=RequestBudget(max_uw_calls),
+            settings=settings,
+        )
+        outcome = execute_run(ctx, run_id, datasets=datasets, specs=specs)
+        finalize_run(
+            gap,
+            run_id,
+            summaries,
+            items,
+            extra={"outcome": outcome, "budget_spent": ctx.budget.as_dict()},
+        )
+        return run_id, outcome, ctx.budget, summaries, items
 
 
 def resume_run(
@@ -186,23 +229,39 @@ def resume_run(
     max_uw_calls: int,
     specs: dict | None = None,
 ) -> tuple[dict, RequestBudget]:
-    # Recover items orphaned in 'running' by a killed/timed-out prior run, so
-    # resume actually picks up where it left off (claim skips 'running').
-    requeued = gap.requeue_running(run_id)
-    if requeued:
-        logger.info(
-            "resume run=%s requeued %d orphaned running items", run_id, requeued
+    with _single_flight(gap):
+        # Recover items orphaned in 'running' by a killed/timed-out prior run, so
+        # resume actually picks up where it left off (claim skips 'running').
+        requeued = gap.requeue_running(run_id)
+        if requeued:
+            logger.info(
+                "resume run=%s requeued %d orphaned running items", run_id, requeued
+            )
+        ctx = HealContext(
+            repo=repo,
+            gap=gap,
+            schema=settings.db_schema,
+            today=today,
+            budget=RequestBudget(max_uw_calls),
+            settings=settings,
         )
-    ctx = HealContext(
-        repo=repo,
-        gap=gap,
-        schema=settings.db_schema,
-        today=today,
-        budget=RequestBudget(max_uw_calls),
-        settings=settings,
-    )
-    outcome = execute_run(ctx, run_id, specs=specs)
-    return outcome, ctx.budget
+        outcome = execute_run(ctx, run_id, specs=specs)
+        # Close the run. Without this a resume that SUCCEEDS still left the row
+        # 'running' forever, wedging the nightly job exactly like a killed run
+        # does -- and resume is the ordinary way an operator drains a backfill,
+        # so this was the common path into that wedge, not the crash path.
+        # Merge rather than replace: the audit's per-dataset rollup is this run's
+        # durable record, and staged per-dataset resumes each deserve an entry.
+        summary = dict((gap.get_run(run_id) or {}).get("summary_jsonb") or {})
+        summary.setdefault("resumes", []).append(
+            {
+                "outcome": outcome,
+                "budget_spent": ctx.budget.as_dict(),
+                "requeued": requeued,
+            }
+        )
+        gap.finish_run(run_id, status="complete", summary=summary)
+        return outcome, ctx.budget
 
 
 def verify_run(
@@ -293,55 +352,93 @@ def _another_run_active(gap: DataGapHealerRepository) -> bool:
 # finish_run, so its row stays status='running' forever and _another_run_active
 # above skips every later nightly job -- silently, with no alert. Four such runs
 # disabled the healer for a week in 2026-08 while the flag, cron and adapters
-# were all correct. The staleness test is the run's own PROGRESS, not its age: a
-# legitimate multi-day manual backfill keeps verifying items and is never reaped,
-# while a corpse clears on the very next nightly. See
-# docs/research/2026-08-16-outage-replay-heal-record.md.
+# were all correct. See docs/research/2026-08-16-outage-replay-heal-record.md.
+#
+# Six hours is a floor, not a timeout: _single_flight already guarantees no live
+# heal is running by the time we reap, so this only decides how long a corpse's
+# row survives. Progress (max verified_at) rather than age keeps the window short
+# without punishing a slow-but-working run if that guarantee is ever loosened.
 _STALE_RUN_HOURS = 6
 
 
 def _reap_stale_runs(gap: DataGapHealerRepository) -> list[int]:
-    """Cancel execute-runs with no item progress for _STALE_RUN_HOURS, and requeue
+    """Cancel execute-runs with no item progress for _STALE_RUN_HOURS, requeuing
     the items they orphaned. The run-level twin of resume_run's requeue_running.
 
     'cancelled', never 'complete' -- the run did not finish, and only 'running'
     trips the active-run gate, so cancelling is enough to unwedge it.
+
+    This is a BACKSTOP, not the liveness mechanism. _single_flight is: every path
+    that spends provider budget holds the session advisory lock, and Postgres
+    frees a session lock when the process dies. So the caller (data_gap_healer_job)
+    only reaches this code once it already owns that lock, which means no live
+    heal is running and every 'running' row it finds is genuinely a corpse. Do not
+    weaken that ordering -- without the lock, a live-but-idle run could be reaped
+    and the nightly would then audit the same still-missing gaps into a NEW run
+    and heal them alongside the live process, double-charging the provider budget.
+    That is the exact hazard data_freshness_monitor documents at its own lock.
+
+    The heuristic's known blind spot, for when you are reading this after it fired
+    on something unexpected: verified_at is stamped by mark_item_healed and
+    mark_item_no_data, but NOT by mark_item_failed or mark_item_skipped_budget, so
+    a run producing only failures reads as idle. The heal loop has no backoff, so
+    failures drain a run in minutes; holding that state for six hours takes a
+    provider hard-down where every request burns its full client timeout.
     """
     reason = (
         f"auto-cancelled by data_gap_healer_job: "
         f"no item progress in {_STALE_RUN_HOURS}h"
     )
+    # One statement, one transaction: cancelling a run and requeuing its orphans
+    # must not be separable. Committing the cancel first and dying before the
+    # requeue would leave items stranded 'running' inside a run the reaper no
+    # longer matches (it only looks at status='running' RUNS), so nothing would
+    # ever free them again.
     with gap._conn.cursor() as cur:
         cur.execute(
             """
-            UPDATE data_gap_runs r
-               SET status = 'cancelled',
-                   finished_at = now(),
-                   summary_jsonb = r.summary_jsonb
-                                   || jsonb_build_object('cancelled_reason', %s::text)
-             WHERE r.status = 'running'
-               AND r.mode = 'execute'
-               -- heartbeat: last item driven to a verdict, else the run's own start
-               AND COALESCE(
-                     (SELECT max(i.verified_at) FROM data_gap_items i
-                       WHERE i.run_id = r.id),
-                     r.started_at
-                   ) < now() - make_interval(hours => %s)
-         RETURNING r.id
+            WITH stale AS (
+                SELECT r.id
+                  FROM data_gap_runs r
+                 WHERE r.status = 'running'
+                   AND r.mode = 'execute'
+                   -- heartbeat: last item driven to a verdict, else the run's start
+                   AND COALESCE(
+                         (SELECT max(i.verified_at) FROM data_gap_items i
+                           WHERE i.run_id = r.id),
+                         r.started_at
+                       ) < now() - make_interval(hours => %s)
+            ),
+            requeued AS (
+                UPDATE data_gap_items SET status = 'planned'
+                 WHERE run_id IN (SELECT id FROM stale)
+                   AND status = 'running'
+             RETURNING run_id
+            ),
+            cancelled AS (
+                UPDATE data_gap_runs
+                   SET status = 'cancelled',
+                       finished_at = now(),
+                       summary_jsonb = summary_jsonb
+                           || jsonb_build_object('cancelled_reason', %s::text)
+                 WHERE id IN (SELECT id FROM stale)
+             RETURNING id
+            )
+            SELECT c.id,
+                   (SELECT count(*) FROM requeued q WHERE q.run_id = c.id)
+              FROM cancelled c
             """,
-            (reason, _STALE_RUN_HOURS),
+            (_STALE_RUN_HOURS, reason),
         )
-        run_ids = [row[0] for row in cur.fetchall()]
+        reaped = cur.fetchall()
     gap._conn.commit()
-    for run_id in run_ids:
-        # Items left 'running' were never driven to a verdict, and claim_next_items
-        # skips that status -- without this they stay unhealable forever.
+    for run_id, requeued in reaped:
         logger.warning(
             "data_gap_healer: reaped stale run %s (requeued %d orphaned items)",
             run_id,
-            gap.requeue_running(run_id),
+            requeued,
         )
-    return run_ids
+    return [run_id for run_id, _ in reaped]
 
 
 def _refresh_targets(datasets: list[str] | None) -> list[str]:
@@ -374,13 +471,11 @@ def data_gap_healer_job(
             logger.info("data_gap_healer: lock held; skipping")
             return {"skipped": "locked"}
         try:
-            reaped = _reap_stale_runs(gap)
+            _reap_stale_runs(gap)
             if _another_run_active(gap):
                 logger.info("data_gap_healer: a prior run is active; skipping")
-                return {"skipped": "run_active", "reaped": reaped}
-            return _run_nightly(repo, gap, settings, today, out_dir) | {
-                "reaped": reaped
-            }
+                return {"skipped": "run_active"}
+            return _run_nightly(repo, gap, settings, today, out_dir)
         finally:
             with repo.conn.cursor() as cur:
                 cur.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))

--- a/src/uw_scan/worker/jobs/data_gap_healer.py
+++ b/src/uw_scan/worker/jobs/data_gap_healer.py
@@ -5,7 +5,9 @@ the core functions here. The nightly job (`data_gap_healer_job`) runs at 20:00 E
 (just after the UW quota reset), audits + heals strict gaps under a UW cap, then
 refreshes the re-runnable (macro/FRED/rates/gold + DB rollup) datasets, and
 writes the report artifact. Single-flight via an advisory lock; skips if a prior
-healer run is still active so it never fights a manual backfill.
+healer run is still active so it never fights a manual backfill -- but first
+reaps runs left 'running' by a killed process, which would otherwise wedge that
+skip forever (see _reap_stale_runs).
 """
 
 from __future__ import annotations
@@ -287,6 +289,61 @@ def _another_run_active(gap: DataGapHealerRepository) -> bool:
         return cur.fetchone() is not None
 
 
+# A run killed mid-flight (SSH drop, container recreate, OOM) never reaches
+# finish_run, so its row stays status='running' forever and _another_run_active
+# above skips every later nightly job -- silently, with no alert. Four such runs
+# disabled the healer for a week in 2026-08 while the flag, cron and adapters
+# were all correct. The staleness test is the run's own PROGRESS, not its age: a
+# legitimate multi-day manual backfill keeps verifying items and is never reaped,
+# while a corpse clears on the very next nightly. See
+# docs/research/2026-08-16-outage-replay-heal-record.md.
+_STALE_RUN_HOURS = 6
+
+
+def _reap_stale_runs(gap: DataGapHealerRepository) -> list[int]:
+    """Cancel execute-runs with no item progress for _STALE_RUN_HOURS, and requeue
+    the items they orphaned. The run-level twin of resume_run's requeue_running.
+
+    'cancelled', never 'complete' -- the run did not finish, and only 'running'
+    trips the active-run gate, so cancelling is enough to unwedge it.
+    """
+    reason = (
+        f"auto-cancelled by data_gap_healer_job: "
+        f"no item progress in {_STALE_RUN_HOURS}h"
+    )
+    with gap._conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE data_gap_runs r
+               SET status = 'cancelled',
+                   finished_at = now(),
+                   summary_jsonb = r.summary_jsonb
+                                   || jsonb_build_object('cancelled_reason', %s::text)
+             WHERE r.status = 'running'
+               AND r.mode = 'execute'
+               -- heartbeat: last item driven to a verdict, else the run's own start
+               AND COALESCE(
+                     (SELECT max(i.verified_at) FROM data_gap_items i
+                       WHERE i.run_id = r.id),
+                     r.started_at
+                   ) < now() - make_interval(hours => %s)
+         RETURNING r.id
+            """,
+            (reason, _STALE_RUN_HOURS),
+        )
+        run_ids = [row[0] for row in cur.fetchall()]
+    gap._conn.commit()
+    for run_id in run_ids:
+        # Items left 'running' were never driven to a verdict, and claim_next_items
+        # skips that status -- without this they stay unhealable forever.
+        logger.warning(
+            "data_gap_healer: reaped stale run %s (requeued %d orphaned items)",
+            run_id,
+            gap.requeue_running(run_id),
+        )
+    return run_ids
+
+
 def _refresh_targets(datasets: list[str] | None) -> list[str]:
     return [
         e.table_name
@@ -300,8 +357,9 @@ def _refresh_targets(datasets: list[str] | None) -> list[str]:
 def data_gap_healer_job(
     *, settings: Settings, today: date | None = None, out_dir: Path | None = None
 ) -> dict:
-    """Nightly: audit + heal strict gaps (UW-capped) + refresh re-runnable
-    datasets, then write the report. Off unless DATA_GAP_HEALER_ENABLED."""
+    """Nightly: reap stale runs, then audit + heal strict gaps (UW-capped) +
+    refresh re-runnable datasets and write the report. Off unless
+    DATA_GAP_HEALER_ENABLED."""
     if not settings.data_gap_healer_enabled:
         return {"skipped": "disabled"}
     today = today or date.today()
@@ -316,10 +374,13 @@ def data_gap_healer_job(
             logger.info("data_gap_healer: lock held; skipping")
             return {"skipped": "locked"}
         try:
+            reaped = _reap_stale_runs(gap)
             if _another_run_active(gap):
                 logger.info("data_gap_healer: a prior run is active; skipping")
-                return {"skipped": "run_active"}
-            return _run_nightly(repo, gap, settings, today, out_dir)
+                return {"skipped": "run_active", "reaped": reaped}
+            return _run_nightly(repo, gap, settings, today, out_dir) | {
+                "reaped": reaped
+            }
         finally:
             with repo.conn.cursor() as cur:
                 cur.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))

--- a/tests/integration/scripts/test_data_gap_healer_cli.py
+++ b/tests/integration/scripts/test_data_gap_healer_cli.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 import types
 from datetime import date, timedelta
+
+import psycopg
+import pytest
 
 from uw_scan.storage.data_gap_healer_repository import DataGapHealerRepository
 from uw_scan.worker.jobs.data_gap_adapters import HealSpec
@@ -167,6 +171,15 @@ def test_resume_requeues_orphaned_running_items(seeded_db_empty_cards):
             f"UPDATE {repo._schema}.data_gap_items SET status='running' WHERE run_id=%s",
             (run_id,),
         )
+        # audit_into_run does not write the rollup -- its caller finalizes. Seed
+        # it as a completed-then-re-resumed run would carry, so the assertion
+        # below proves resume MERGES into the summary instead of replacing it.
+        cur.execute(
+            f"UPDATE {repo._schema}.data_gap_runs "
+            'SET summary_jsonb = \'{"datasets": {"daily_ohlc": {}}}\'::jsonb '
+            "WHERE id=%s",
+            (run_id,),
+        )
     repo.conn.commit()
 
     def fake_range(ctx, ticker, lo, hi):
@@ -190,3 +203,81 @@ def test_resume_requeues_orphaned_running_items(seeded_db_empty_cards):
     )
     # the orphaned 'running' items were requeued and then healed
     assert outcome.get("healed") == len(items)
+    # and the run is CLOSED. A resume that succeeded used to leave status
+    # 'running' forever, which wedges the nightly job's active-run guard just as
+    # a killed process does -- via the ordinary operator path, not a crash.
+    run = gap.get_run(run_id)
+    assert run["status"] == "complete"
+    assert run["finished_at"] is not None
+    # the audit's per-dataset rollup survives the merge
+    assert "datasets" in run["summary_jsonb"]
+    assert run["summary_jsonb"]["resumes"][-1]["outcome"] == outcome
+
+    # staged resumes APPEND. An operator draining a run dataset-by-dataset would
+    # otherwise lose every earlier stage's outcome and budget from the audit trail.
+    cli.resume_run(
+        repo,
+        gap,
+        _settings(repo),
+        run_id,
+        today=date(2026, 6, 30),
+        max_uw_calls=20000,
+        specs=specs,
+    )
+    assert len(gap.get_run(run_id)["summary_jsonb"]["resumes"]) == 2
+
+
+def test_cli_refuses_to_race_another_heal(seeded_db_empty_cards):
+    """`execute` and `resume` now take the healer's single-flight advisory lock.
+    Racing another heal would re-audit the same still-missing gaps and heal them
+    twice, double-charging the provider budget -- the hazard data_freshness_monitor
+    already documents at this same lock key. The CLI re-exports HealerBusy so
+    main() can map it to exit code 2 ("busy", not "broken")."""
+    cli = _load_cli()
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+
+    # a second connection stands in for the nightly job / another operator
+    info = repo.conn.info
+    dsn = f"host={info.host} port={info.port} dbname={info.dbname} user={info.user}"
+    with psycopg.connect(dsn) as holder, holder.cursor() as cur:
+        cur.execute("SELECT pg_try_advisory_lock(92010)")
+        assert cur.fetchone()[0] is True
+
+        with pytest.raises(cli.HealerBusy):
+            cli.execute_into_run(
+                repo,
+                gap,
+                _settings(repo),
+                start=date(2026, 6, 10),
+                end=date(2026, 6, 11),
+                datasets=["daily_ohlc"],
+                max_uw_calls=0,
+                today=date(2026, 6, 30),
+            )
+        with pytest.raises(cli.HealerBusy):
+            cli.resume_run(
+                repo,
+                gap,
+                _settings(repo),
+                1,
+                today=date(2026, 6, 30),
+                max_uw_calls=0,
+            )
+
+
+def test_main_maps_healer_busy_to_exit_code_2(monkeypatch):
+    """`2` is an operator contract, not an implementation detail: a wrapper needs
+    to tell "another heal holds the lock, try later" apart from "this run broke".
+    build_parser() resolves cmd_execute from module globals when main() calls it,
+    so patching the command is enough to drive the handler."""
+    cli = _load_cli()
+
+    def _busy(_args, _settings):
+        raise cli.HealerBusy("another gap-heal holds the single-flight lock")
+
+    monkeypatch.setattr(cli, "cmd_execute", _busy)
+    monkeypatch.setattr(
+        sys, "argv", ["data_gap_healer.py", "execute", "--start", "2026-01-01"]
+    )
+    assert cli.main() == 2

--- a/tests/integration/scripts/test_data_gap_healer_cli.py
+++ b/tests/integration/scripts/test_data_gap_healer_cli.py
@@ -227,7 +227,7 @@ def test_resume_requeues_orphaned_running_items(seeded_db_empty_cards):
     assert len(gap.get_run(run_id)["summary_jsonb"]["resumes"]) == 2
 
 
-def test_cli_refuses_to_race_another_heal(seeded_db_empty_cards):
+def test_cli_refuses_to_race_another_heal(seeded_db_empty_cards, _migrated_settings):
     """`execute` and `resume` now take the healer's single-flight advisory lock.
     Racing another heal would re-audit the same still-missing gaps and heal them
     twice, double-charging the provider budget -- the hazard data_freshness_monitor
@@ -237,10 +237,11 @@ def test_cli_refuses_to_race_another_heal(seeded_db_empty_cards):
     repo = seeded_db_empty_cards
     gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
 
-    # a second connection stands in for the nightly job / another operator
-    info = repo.conn.info
-    dsn = f"host={info.host} port={info.port} dbname={info.dbname} user={info.user}"
-    with psycopg.connect(dsn) as holder, holder.cursor() as cur:
+    # A second connection stands in for the nightly job / another operator. Take
+    # the DSN from the fixture's own Settings -- conn.info deliberately withholds
+    # the password, so a hand-built DSN passes on a trust-auth dev box and fails
+    # against CI's password-authenticated Postgres service.
+    with psycopg.connect(_migrated_settings.db_dsn()) as holder, holder.cursor() as cur:
         cur.execute("SELECT pg_try_advisory_lock(92010)")
         assert cur.fetchone()[0] is True
 

--- a/tests/integration/worker/test_data_gap_healer_scheduler.py
+++ b/tests/integration/worker/test_data_gap_healer_scheduler.py
@@ -9,13 +9,18 @@ import os
 import types
 from datetime import date
 
+import psycopg
+import pytest
+
 from uw_scan.config import Settings
 from uw_scan.reports.data_gap_healer import GapItem
 from uw_scan.storage.data_gap_healer_repository import DataGapHealerRepository
 from uw_scan.worker.jobs.data_gap_healer import (
+    HealerBusy,
     _another_run_active,
     _reap_stale_runs,
     _refresh_targets,
+    _single_flight,
     data_gap_healer_job,
 )
 from uw_scan.worker.scheduler import _should_schedule_data_gap_healer
@@ -75,7 +80,7 @@ def test_run_active_guard_skips(seeded_db_empty_cards):
         mode="execute", start_date=None, end_date=None, datasets=[], status="running"
     )
     out = data_gap_healer_job(settings=_enabled_db_settings(), today=date(2026, 6, 30))
-    assert out == {"skipped": "run_active", "reaped": []}
+    assert out == {"skipped": "run_active"}
 
 
 def _killed_run(
@@ -140,6 +145,48 @@ def test_stale_run_is_reaped_and_unwedges_the_guard(seeded_db_empty_cards):
     assert _another_run_active(gap) is False
 
 
+def test_reaping_never_rolls_back_a_verdict(seeded_db_empty_cards):
+    """The property that makes the one reachable false positive harmless: a live
+    run reaped mid-flight (provider hard-down, every request burning its timeout,
+    so verified_at never advances) must keep every verdict it already reached.
+    Only 'running' rows move."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    run_id = _killed_run(gap, repo.conn, started_hours_ago=48)
+    # give the run one item in each terminal-ish status alongside the 'running' one
+    gap.upsert_items(
+        run_id,
+        [
+            GapItem(
+                dataset="daily_ohlc",
+                scope_key=f"2026-06-30|{ticker}",
+                data_date=date(2026, 6, 30),
+                ticker=ticker,
+                expected_count=1,
+                covered_count=0,
+                status=status,
+            )
+            for ticker, status in (
+                ("AAPL", "healed"),
+                ("NVDA", "no_data"),
+                ("MSFT", "failed"),
+                ("AMD", "skipped_budget"),
+                ("TSLA", "planned"),
+            )
+        ],
+    )
+
+    assert _reap_stale_runs(gap) == [run_id]
+
+    counts = gap.count_items_by_status(run_id)
+    assert counts["healed"] == 1
+    assert counts["no_data"] == 1
+    assert counts["failed"] == 1
+    assert counts["skipped_budget"] == 1
+    assert counts["planned"] == 2  # the pre-existing one + the requeued 'running'
+    assert "running" not in counts
+
+
 def test_reaper_spares_live_runs(seeded_db_empty_cards):
     """Three runs the reaper must not touch: a young one, a long-running manual
     backfill that is still verifying items, and an audit-mode run (the gate only
@@ -155,6 +202,47 @@ def test_reaper_spares_live_runs(seeded_db_empty_cards):
         assert gap.get_run(run_id)["status"] == "running"
 
 
+def test_single_flight_refuses_a_second_connection(seeded_db_empty_cards):
+    """The lock is what makes the reaper safe: it is session-scoped, so Postgres
+    frees it when a process dies, and a LIVE heal therefore blocks the nightly job
+    at `{"skipped": "locked"}` before the reaper ever inspects a row. Without it a
+    live-but-idle run could be reaped and then raced by a fresh nightly run over
+    the same still-missing gaps -- double-charging the provider budget."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    settings = _enabled_db_settings()
+
+    with psycopg.connect(settings.db_dsn()) as other_conn:
+        other = DataGapHealerRepository(other_conn, schema=repo._schema)
+        with _single_flight(gap):  # stands in for a live manual heal
+            with pytest.raises(HealerBusy):
+                with _single_flight(other):
+                    pass
+            # ...and the nightly job stands down entirely rather than reaping
+            out = data_gap_healer_job(settings=settings, today=date(2026, 6, 30))
+            assert out == {"skipped": "locked"}
+        # released on exit, so the next caller gets it
+        with _single_flight(other):
+            pass
+
+
+def test_single_flight_is_reentrant_on_one_connection(seeded_db_empty_cards):
+    """data_freshness_monitor takes this lock and then calls execute_into_run,
+    which takes it again on the same connection. Session locks are counted, so
+    the nested acquire must succeed and the counter must balance."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    settings = _enabled_db_settings()
+
+    with _single_flight(gap):
+        with _single_flight(gap):  # nested, same session
+            pass
+    # fully released: a different connection can now take it
+    with psycopg.connect(settings.db_dsn()) as other_conn:
+        with _single_flight(DataGapHealerRepository(other_conn, schema=repo._schema)):
+            pass
+
+
 def test_job_reaps_before_it_checks_the_guard(seeded_db_empty_cards):
     """The job itself must reap, not just the helper. A genuinely live run is kept
     alongside so the job still short-circuits at the guard instead of running a
@@ -167,5 +255,6 @@ def test_job_reaps_before_it_checks_the_guard(seeded_db_empty_cards):
     )
 
     out = data_gap_healer_job(settings=_enabled_db_settings(), today=date(2026, 6, 30))
-    assert out == {"skipped": "run_active", "reaped": [stale]}
+    assert out == {"skipped": "run_active"}
+    # the durable effect is the proof the reap ran inside the job, before the gate
     assert gap.get_run(stale)["status"] == "cancelled"

--- a/tests/integration/worker/test_data_gap_healer_scheduler.py
+++ b/tests/integration/worker/test_data_gap_healer_scheduler.py
@@ -1,6 +1,7 @@
 """Nightly gap-healer job: off by default, single-process scheduling, refresh
-targets, and the guard that skips when a prior run is still active (so it never
-fights a manual backfill)."""
+targets, the guard that skips when a prior run is still active (so it never
+fights a manual backfill), and the reaper that stops that guard from wedging
+forever on a run whose process was killed."""
 
 from __future__ import annotations
 
@@ -9,8 +10,11 @@ import types
 from datetime import date
 
 from uw_scan.config import Settings
+from uw_scan.reports.data_gap_healer import GapItem
 from uw_scan.storage.data_gap_healer_repository import DataGapHealerRepository
 from uw_scan.worker.jobs.data_gap_healer import (
+    _another_run_active,
+    _reap_stale_runs,
     _refresh_targets,
     data_gap_healer_job,
 )
@@ -65,9 +69,103 @@ def _enabled_db_settings() -> Settings:
 def test_run_active_guard_skips(seeded_db_empty_cards):
     repo = seeded_db_empty_cards
     gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
-    # a prior execute run still 'running' must block the nightly job
+    # a prior execute run still 'running' must block the nightly job. It started
+    # just now, so the reaper leaves it alone -- the guard is what fires.
     gap.create_run(
         mode="execute", start_date=None, end_date=None, datasets=[], status="running"
     )
     out = data_gap_healer_job(settings=_enabled_db_settings(), today=date(2026, 6, 30))
-    assert out == {"skipped": "run_active"}
+    assert out == {"skipped": "run_active", "reaped": []}
+
+
+def _killed_run(
+    gap: DataGapHealerRepository,
+    conn,
+    *,
+    started_hours_ago: int,
+    verified_hours_ago: int | None = None,
+    mode: str = "execute",
+) -> int:
+    """A run whose process died: run row stuck 'running', one item stranded
+    'running' (claim_next_items skips that status, so it is unhealable)."""
+    run_id = gap.create_run(
+        mode=mode, start_date=None, end_date=None, datasets=[], status="running"
+    )
+    gap.upsert_items(
+        run_id,
+        [
+            GapItem(
+                dataset="daily_ohlc",
+                scope_key="2026-06-30|SPY",
+                data_date=date(2026, 6, 30),
+                ticker="SPY",
+                expected_count=1,
+                covered_count=0,
+                status="running",
+            )
+        ],
+    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE data_gap_runs SET started_at = now() - make_interval(hours => %s) "
+            "WHERE id = %s",
+            (started_hours_ago, run_id),
+        )
+        if verified_hours_ago is not None:
+            cur.execute(
+                "UPDATE data_gap_items SET verified_at = now() - "
+                "make_interval(hours => %s) WHERE run_id = %s",
+                (verified_hours_ago, run_id),
+            )
+    conn.commit()
+    return run_id
+
+
+def test_stale_run_is_reaped_and_unwedges_the_guard(seeded_db_empty_cards):
+    """The defect this fixes: nothing ever timed out a killed run, so
+    _another_run_active stayed True and the nightly job skipped itself forever."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    run_id = _killed_run(gap, repo.conn, started_hours_ago=48)
+
+    assert _another_run_active(gap) is True  # wedged
+    assert _reap_stale_runs(gap) == [run_id]
+
+    run = gap.get_run(run_id)
+    assert run["status"] == "cancelled"  # not 'complete' -- it did not finish
+    assert run["finished_at"] is not None
+    assert "cancelled_reason" in run["summary_jsonb"]
+    # the orphaned item is claimable again
+    assert gap.count_items_by_status(run_id) == {"planned": 1}
+    assert _another_run_active(gap) is False
+
+
+def test_reaper_spares_live_runs(seeded_db_empty_cards):
+    """Three runs the reaper must not touch: a young one, a long-running manual
+    backfill that is still verifying items, and an audit-mode run (the gate only
+    looks at execute runs, so cancelling those would be pure collateral damage)."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    young = _killed_run(gap, repo.conn, started_hours_ago=1)
+    busy = _killed_run(gap, repo.conn, started_hours_ago=72, verified_hours_ago=0)
+    auditing = _killed_run(gap, repo.conn, started_hours_ago=72, mode="audit")
+
+    assert _reap_stale_runs(gap) == []
+    for run_id in (young, busy, auditing):
+        assert gap.get_run(run_id)["status"] == "running"
+
+
+def test_job_reaps_before_it_checks_the_guard(seeded_db_empty_cards):
+    """The job itself must reap, not just the helper. A genuinely live run is kept
+    alongside so the job still short-circuits at the guard instead of running a
+    full audit+heal (which would reach out to providers) inside a test."""
+    repo = seeded_db_empty_cards
+    gap = DataGapHealerRepository(repo.conn, schema=repo._schema)
+    stale = _killed_run(gap, repo.conn, started_hours_ago=48)
+    gap.create_run(
+        mode="execute", start_date=None, end_date=None, datasets=[], status="running"
+    )
+
+    out = data_gap_healer_job(settings=_enabled_db_settings(), today=date(2026, 6, 30))
+    assert out == {"skipped": "run_active", "reaped": [stale]}
+    assert gap.get_run(stale)["status"] == "cancelled"


### PR DESCRIPTION
## The defect

`data_gap_healer_job` skips itself while another `execute` run is `running`:

```sql
SELECT 1 FROM data_gap_runs WHERE status = 'running' AND mode = 'execute' LIMIT 1
```

**Nothing ever cleared that flag.** Two ways in:

- a run whose process died (SSH drop, Watchtower container recreate, OOM) never reached `finish_run`;
- **`resume_run` never called `finish_run` at all**, so even a fully successful resume — the ordinary way an operator drains a backfill — left the row `running`.

Either way every subsequent night returned `{"skipped": "run_active"}` silently. Found on the mini: runs **78, 80, 87, 88**, stuck since 2026-08-16 23:36–00:19, holding **36,251** open items. The enable flag, cron, adapters and migrations were all correct the whole time.

## The fix, in layers

A persisted flag is not a mutex — it has no owner and no expiry, so it can only be a *record* of intent. The fix separates the two jobs it was doing:

| Layer | Guarantees |
|---|---|
| `pg_try_advisory_lock(92010)` | **Liveness** — Postgres frees a session lock when the process dies |
| `status='running'` row | **Durability** — survives the process, which a lock cannot |
| `_reap_stale_runs` | Clears rows whose process is gone — a backstop, not the mechanism |

**1. Manual heals now take the lock.** `execute_into_run` and `resume_run` hold `pg_try_advisory_lock(92010)` and raise `HealerBusy` (CLI exit **2**, so a wrapper can tell "busy" from "broken") rather than racing. `data_freshness_monitor.py:70-79` already documents this exact hazard at this exact key — the CLI was the one caller that never took it.

**2. `resume_run` closes its run**, appending to a `resumes` list in `summary_jsonb` so staged per-dataset resumes each keep their outcome and budget.

**3. The reaper** cancels `execute` runs with no item verified for 6 hours and requeues the items they stranded in `running` — a status `claim_next_items` skips, so those were unhealable. **One data-modifying-CTE statement**, so a crash mid-reap cannot orphan items inside a run the reaper no longer matches.

Staleness is measured by **progress, not age** (`max(verified_at)`, falling back to `started_at`). Age alone cannot separate a 30-hour live backfill from a 30-hour corpse. With the lock in place the reaper only ever sees corpses anyway, so this keeps the window short while staying conservative if that ordering is ever loosened.

## Why the lock was necessary — a review correction

The first version of this PR reaped without a lock. That was unsafe, and the reasoning that cleared it was wrong in an instructive way:

> I verified that a reaped run's requeued items cannot be *claimed* by anyone else — `claim_next_items` filters on `run_id`, and the nightly audits into a **new** run id.

True, and irrelevant. The collision is not on the item row, it is on the **underlying gap**. If the reaped run is actually alive and still healing gap G, the nightly's fresh audit sees G still missing in the warm store, writes its own item for G, and heals it again. Same gap, two runs, two provider charges. The row-based guard had been preventing precisely that; reaping removes it, so reaping had to be paired with a real liveness signal.

Both external reviewers flagged this independently at ~1.0 confidence. Recorded in `docs/research/2026-08-16-outage-replay-heal-record.md`.

## Known false positive, deliberately tolerated

`verified_at` is stamped by `mark_item_healed`/`mark_item_no_data` but **not** by `mark_item_failed`, so a run producing only failures reads as idle. The heal loop has no backoff, so failures drain a run in minutes — holding that state for six hours takes a provider hard-down where every request burns its full client timeout. Documented at the function, and `test_reaping_never_rolls_back_a_verdict` pins the property that makes it harmless: only `'running'` rows move, so no verdict is ever rolled back.

## Tests

`tests/integration/worker/test_data_gap_healer_scheduler.py` (+5) and `tests/integration/scripts/test_data_gap_healer_cli.py` (+2):

- reaped-and-unwedged: `_another_run_active` `True` → `False`, run `cancelled` with a `cancelled_reason`, orphan back to `planned`
- spares live runs: young / still-verifying / audit-mode
- never rolls back a verdict: `healed`/`no_data`/`failed`/`skipped_budget` all survive a reap
- single-flight refuses a second connection, and the nightly job returns `{"skipped": "locked"}` instead of reaping
- single-flight is re-entrant on one connection (`data_freshness_monitor` nests through `execute_into_run`)
- the job reaps *before* it checks the guard
- CLI refuses to race; `main()` maps `HealerBusy` to exit 2
- resume closes its run, merges rather than replaces, and appends across staged resumes

**Mutation-checked:** replacing the heartbeat clause with plain `started_at < now() - 6h` makes `test_reaper_spares_live_runs` fail on the live-backfill case, so the test discriminates the design decision rather than the happy path.

## Verification

- Full CI static chain green locally: version sync, `ruff check src/ tests/ scripts/`, Guardrail 2 AST except check, no-Yahoo, runtime assets, Guardrail 3/5/9 greps, migration prefixes
- `uv run pytest tests/unit/` — **1870 passed**
- `uv run pytest tests/integration/ -n auto` (CI's xdist config) — **1065 passed, 9 skipped**
- Advisory locks confirmed **per-database** empirically, so xdist's one-DB-per-worker sharding cannot contend on key 92010
- Reap plan measured: index scan + correlated `max(verified_at)`, **30 ms over 41,558 rows**, at most a handful of executions per night — no index or migration warranted

## Notes

No schema change (`cancelled` is already in migration 092's CHECK constraint), no new env var. `_STALE_RUN_HOURS` is a module constant — a safety floor, not an operator knob.

`src/uw_scan/worker/jobs/data_gap_healer.py` grows to **571 lines**, over the 500-line target in CLAUDE.md but well under the 1000-line stop-and-split threshold; flagging rather than splitting, since a split would churn imports across the freshness monitor, the CLI and their tests.

**Not verified:** behaviour on the actual mini deployment, and `_STALE_RUN_HOURS = 6` against real nightly runtimes (reasoned from the 24k UW cap, not measured in production).
