### PR TITLE
research(fundamentals): lake depth is not the band gate — D5 overturned, program plan state corrected

### DIFF
--- a/docs/research/2026-08-18-fundamental-lake-depth/VERDICT.md
+++ b/docs/research/2026-08-18-fundamental-lake-depth/VERDICT.md
@@ -1,0 +1,78 @@
+# Lake price depth does NOT gate the valuation band on the production host
+
+**Verdict:** D5 of `docs/superpowers/plans/2026-08-13-fundamental-lane-next.md` is **overturned**.
+It concluded that widening the fundamental universe buys ~29 extra valuation bands because the
+144 candidate names lack unadjusted daily closes, and therefore that "the real gate on the
+valuable half is lake price depth, not universe membership." That was measured on the MacBook
+mirror. On the mini — the host that actually computes the bands — **the gate is membership, and
+the yield is up to 132, not 29.**
+
+**Trace:** `depth_macbook.json`, `depth_mini.json` (per-ticker file presence, row count, first/last
+close, and depth flags at both band thresholds, for all 401 names).
+**Probe:** `scripts/research/fundamental_lake_depth_probe.py` — reproduce commands in its docstring.
+**As-of:** 2026-08-18, passed explicitly as `--as-of` so re-runs are comparable.
+
+## What was measured, and why not file existence
+
+D5 counted `1d.parquet` presence. That is coverage, not computability — the same conflation that
+produced the retracted `0/257` concentration verdict two rounds ago
+(`docs/research/2026-08-13-fundamental-concentration-axis/VERDICT.md`). A band is refused unless
+`MIN_HISTORY` (12) of the trailing `WINDOW_QUARTERS` (20) quarters carry **both** a statement and a
+close at that quarter's own knowledge date (`src/uw_scan/fundamentals/valuation.py:146-151`). So the
+probe reports depth at both thresholds and measures the statement leg separately.
+
+## Result
+
+| cohort | metric | MacBook mirror | **mini `/lake`** |
+|---|---|---:|---:|
+| 257 universe | has `1d.parquet` | 254 | **257** |
+| | price depth ≥ 12q | 252 | **256** |
+| | price depth ≥ 20q | 251 | **255** |
+| 144 excluded | has `1d.parquet` | 29 | **141** |
+| | price depth ≥ 12q | 23 | **132** |
+| | price depth ≥ 20q | 21 | **120** |
+| | statement depth ≥ 12q | 143 | 143 |
+| | statement depth ≥ 20q | 139 | 139 |
+
+The mirrors are not the same object: the MacBook holds **653** equity symbol directories, the mini
+**14,689**. D5's 254/257 and 29/144 reproduce exactly on the MacBook, so the original measurement
+was correct — it was taken on the wrong host.
+
+**The statement leg is not the constraint** (143/144 clear 12 quarters). Price depth binds, and on
+the mini it binds at 132, not 29.
+
+## What this does to PR-1
+
+| | D5 | measured on the mini |
+|---|---|---|
+| extra valuation bands | +29 | **up to +132** |
+| panel | 254 → 283 (+11%) | 254 → **up to 386 (+52%)** |
+
+D5 argued the raw +56% panel-width figure was an illusion and the real gain was ~+11%. On the
+production host the raw figure was approximately right. **PR-1 is worth roughly 4.5× what the plan
+credits it with.**
+
+## The bound is an upper bound, and this is the honest limit
+
+132 is *necessary*, not *sufficient*. The method also refuses on non-positive enterprise value,
+a non-positive numerator, and a stale filing. Observed conversion on the universe cohort: 256 names
+clear the 12q price gate on the mini and prod carries **254** `valuation_anchors` — 99.2%. That rate
+must **not** be transferred to the 144: the universe was selected for marketcap ≥ $30B, while the
+144 are the capex-chain research cohort and carry more unprofitable and negative-EV names, which is
+exactly what the EV guard refuses (`valuation.py:406-413`). The true count is unmeasurable until those
+statements exist in prod — which is PR-1's own ingest step, so PR-1 should carry the count as its
+verification rather than assert it up front.
+
+## Two incidental findings
+
+**Prod is not dark.** The mini's `option_wizard` holds `fundamental_universe` 257,
+`fundamental_statement_obs` 257 tickers, `fundamental_scores` 257, `valuation_anchors` 254. An
+earlier record that the fundamentals lane "shipped DARK / prod unseeded" is stale. Prod ingested the
+universe only — the 144 exist solely in `option_wizard_local`, from the capex research backfill.
+
+**Three names are absent from the mini lake entirely:** `CFLT`, `CYBR`, `PSTG`. Real, liquid US
+listings, so this is a livewire coverage gap rather than a probe artifact. Not chased here.
+
+**Apex answered 200.** D5 recorded a 502 when it probed apex and left the mini depth unverified on
+that basis; `http://100.66.147.98:8322/health` is up. The measurement above does not use apex —
+the band reads parquet directly — but the reason D5 gave for not checking no longer holds.

--- a/docs/research/2026-08-18-fundamental-lake-depth/depth_macbook.json
+++ b/docs/research/2026-08-18-fundamental-lake-depth/depth_macbook.json
@@ -1,0 +1,3460 @@
+{
+ "as_of": "2026-08-18",
+ "cohorts": {
+  "excluded": [
+   "AAOI",
+   "AAON",
+   "ABNB",
+   "ACM",
+   "AEIS",
+   "AI",
+   "ALAB",
+   "ALGM",
+   "AMKR",
+   "ARM",
+   "ASX",
+   "ATKR",
+   "AYI",
+   "BABA",
+   "BBAI",
+   "BE",
+   "BTDR",
+   "CAMT",
+   "CARR",
+   "CCJ",
+   "CFLT",
+   "CHKP",
+   "CIEN",
+   "CIFR",
+   "CLSK",
+   "COHU",
+   "CORZ",
+   "CRDO",
+   "CRWV",
+   "CXAI",
+   "CYBR",
+   "DASH",
+   "DDOG",
+   "DIOD",
+   "DNA",
+   "DOCN",
+   "DOCU",
+   "DT",
+   "DXC",
+   "DY",
+   "EPAM",
+   "ESTC",
+   "EXTR",
+   "FIG",
+   "FORM",
+   "FROG",
+   "GFS",
+   "GLOB",
+   "GLXY",
+   "GRMN",
+   "GTLB",
+   "HPE",
+   "HPQ",
+   "HUBB",
+   "HUBS",
+   "HUT",
+   "IBM",
+   "ICHR",
+   "IESC",
+   "ILMN",
+   "INFY",
+   "INOD",
+   "IREN",
+   "IRM",
+   "J",
+   "JCI",
+   "LEU",
+   "LII",
+   "LITE",
+   "LOGI",
+   "LSCC",
+   "MDB",
+   "MOD",
+   "MTZ",
+   "NET",
+   "NNE",
+   "NRG",
+   "NTAP",
+   "NVMI",
+   "NVT",
+   "NVTS",
+   "OKLO",
+   "OKTA",
+   "ON",
+   "ONTO",
+   "OSIS",
+   "PATH",
+   "PD",
+   "PEG",
+   "PINS",
+   "POET",
+   "POWI",
+   "POWL",
+   "PSTG",
+   "PWR",
+   "QLYS",
+   "QRVO",
+   "RBLX",
+   "RDDT",
+   "RMBS",
+   "ROK",
+   "RPD",
+   "RXRX",
+   "S",
+   "SHOP",
+   "SLAB",
+   "SMR",
+   "SNAP",
+   "SNDK",
+   "SNOW",
+   "SO",
+   "SONY",
+   "SOUN",
+   "SPOT",
+   "SPXC",
+   "STRL",
+   "SWKS",
+   "SYM",
+   "TDC",
+   "TEAM",
+   "TEL",
+   "TEM",
+   "TENB",
+   "TER",
+   "TLN",
+   "TMO",
+   "TT",
+   "TTD",
+   "TWLO",
+   "U",
+   "UBER",
+   "UCTT",
+   "UEC",
+   "UMC",
+   "VECO",
+   "VEEV",
+   "VRNS",
+   "VSH",
+   "WDAY",
+   "WIT",
+   "WULF",
+   "ZBRA",
+   "ZM",
+   "ZS"
+  ],
+  "stmt_quarters": {
+   "A": 82,
+   "AAOI": 62,
+   "AAON": 83,
+   "AAP": 82,
+   "AAPL": 83,
+   "AAT": 69,
+   "ABBV": 63,
+   "ABCB": 83,
+   "ABEO": 83,
+   "ABG": 83,
+   "ABM": 83,
+   "ABNB": 28,
+   "ABR": 83,
+   "ABT": 83,
+   "ABUS": 83,
+   "ACAD": 83,
+   "ACCO": 83,
+   "ACGL": 83,
+   "ACH": 82,
+   "ACIW": 83,
+   "ACLS": 83,
+   "ACM": 83,
+   "ACN": 83,
+   "ACNT": 83,
+   "ACRE": 59,
+   "ACTG": 84,
+   "ADBE": 83,
+   "ADI": 82,
+   "ADM": 83,
+   "ADP": 83,
+   "ADSK": 82,
+   "AEE": 83,
+   "AEHR": 83,
+   "AEIS": 83,
+   "AEO": 82,
+   "AEP": 83,
+   "AES": 83,
+   "AFL": 83,
+   "AI": 28,
+   "AIG": 83,
+   "AIZ": 83,
+   "AJG": 83,
+   "AKAM": 83,
+   "ALAB": 18,
+   "ALB": 83,
+   "ALGM": 30,
+   "ALGN": 83,
+   "ALL": 83,
+   "ALNY": 83,
+   "AMAT": 82,
+   "AMD": 83,
+   "AME": 83,
+   "AMGN": 83,
+   "AMKR": 83,
+   "AMP": 83,
+   "AMT": 83,
+   "AMZN": 83,
+   "ANET": 55,
+   "ANGO": 83,
+   "AON": 83,
+   "AOS": 83,
+   "APA": 83,
+   "APD": 83,
+   "APH": 83,
+   "APLD": 55,
+   "APP": 31,
+   "APTV": 84,
+   "ARE": 83,
+   "ARM": 65,
+   "ASML": 83,
+   "ASX": 84,
+   "ATKR": 57,
+   "ATO": 83,
+   "AVB": 83,
+   "AVGO": 78,
+   "AVY": 83,
+   "AWK": 86,
+   "AXON": 83,
+   "AXP": 83,
+   "AYI": 83,
+   "AZO": 82,
+   "BA": 83,
+   "BABA": 63,
+   "BAC": 83,
+   "BALL": 83,
+   "BAX": 83,
+   "BBAI": 26,
+   "BBY": 82,
+   "BCRX": 83,
+   "BDX": 83,
+   "BE": 46,
+   "BELFB": 83,
+   "BEN": 83,
+   "BIIB": 83,
+   "BKNG": 83,
+   "BLK": 83,
+   "BMY": 83,
+   "BR": 83,
+   "BRO": 83,
+   "BSX": 83,
+   "BTDR": 25,
+   "BXP": 83,
+   "CAH": 82,
+   "CAMT": 89,
+   "CARR": 30,
+   "CB": 83,
+   "CBRE": 83,
+   "CBZ": 83,
+   "CCEP": 82,
+   "CCJ": 83,
+   "CCOI": 83,
+   "CDE": 83,
+   "CDNS": 83,
+   "CEG": 56,
+   "CFLT": 24,
+   "CHD": 83,
+   "CHKP": 83,
+   "CHRW": 83,
+   "CHTR": 83,
+   "CI": 83,
+   "CIEN": 82,
+   "CIFR": 25,
+   "CINF": 83,
+   "CL": 83,
+   "CLDX": 83,
+   "CLSK": 71,
+   "CLX": 83,
+   "CMCSA": 83,
+   "CMI": 83,
+   "CMS": 83,
+   "CNC": 83,
+   "COF": 83,
+   "COHR": 82,
+   "COHU": 83,
+   "CORZ": 20,
+   "COST": 82,
+   "CPRT": 82,
+   "CRDO": 24,
+   "CRL": 83,
+   "CRM": 82,
+   "CRS": 83,
+   "CRWD": 34,
+   "CRWV": 10,
+   "CSCO": 82,
+   "CSGP": 83,
+   "CSR": 83,
+   "CTAS": 83,
+   "CTSH": 83,
+   "CVS": 83,
+   "CVX": 83,
+   "CWST": 83,
+   "CXAI": 24,
+   "CXW": 83,
+   "CYBR": 56,
+   "D": 83,
+   "DAL": 83,
+   "DASH": 30,
+   "DDOG": 34,
+   "DE": 82,
+   "DECK": 83,
+   "DELL": 53,
+   "DG": 83,
+   "DGX": 83,
+   "DHI": 83,
+   "DHR": 83,
+   "DHT": 83,
+   "DIOD": 83,
+   "DIS": 83,
+   "DJCO": 82,
+   "DLR": 83,
+   "DLTR": 83,
+   "DMRC": 78,
+   "DNA": 26,
+   "DOCN": 34,
+   "DOCU": 41,
+   "DOV": 83,
+   "DRI": 83,
+   "DT": 37,
+   "DTE": 83,
+   "DUK": 83,
+   "DVA": 83,
+   "DXC": 83,
+   "DXCM": 83,
+   "DY": 82,
+   "EA": 83,
+   "EBAY": 83,
+   "ECL": 83,
+   "ED": 83,
+   "EFX": 83,
+   "EIX": 83,
+   "EME": 83,
+   "EMR": 83,
+   "EOG": 83,
+   "EPAM": 67,
+   "EQIX": 83,
+   "EQR": 83,
+   "ERIE": 83,
+   "ES": 83,
+   "ESE": 83,
+   "ESTC": 40,
+   "ETN": 83,
+   "ETR": 83,
+   "EW": 83,
+   "EXC": 83,
+   "EXPD": 83,
+   "EXR": 83,
+   "EXTR": 83,
+   "FANG": 64,
+   "FAST": 83,
+   "FC": 83,
+   "FDS": 83,
+   "FDX": 83,
+   "FE": 83,
+   "FEIM": 83,
+   "FIG": 12,
+   "FIS": 83,
+   "FISV": 83,
+   "FIX": 83,
+   "FLG": 83,
+   "FN": 80,
+   "FORM": 83,
+   "FROG": 32,
+   "FRT": 83,
+   "FSLR": 84,
+   "FTNT": 78,
+   "GD": 83,
+   "GE": 83,
+   "GEV": 14,
+   "GFS": 26,
+   "GILD": 83,
+   "GLOB": 57,
+   "GLW": 83,
+   "GLXY": 81,
+   "GOOGL": 83,
+   "GRMN": 83,
+   "GS": 83,
+   "GTLB": 25,
+   "HD": 82,
+   "HON": 83,
+   "HPE": 51,
+   "HPQ": 82,
+   "HUBB": 83,
+   "HUBS": 54,
+   "HUT": 60,
+   "IBM": 83,
+   "ICHR": 50,
+   "IDXX": 83,
+   "IESC": 83,
+   "ILMN": 83,
+   "INFY": 83,
+   "INOD": 83,
+   "INSM": 83,
+   "INTC": 83,
+   "INTU": 82,
+   "IREN": 27,
+   "IRM": 83,
+   "ISRG": 83,
+   "J": 83,
+   "JCI": 83,
+   "JNJ": 83,
+   "JPM": 83,
+   "KDP": 83,
+   "KLAC": 83,
+   "KO": 83,
+   "LEU": 83,
+   "LII": 83,
+   "LITE": 52,
+   "LLY": 83,
+   "LMT": 83,
+   "LOGI": 83,
+   "LRCX": 83,
+   "LSCC": 83,
+   "MCD": 83,
+   "MCHP": 83,
+   "MDB": 45,
+   "MDLZ": 83,
+   "MELI": 83,
+   "META": 66,
+   "MOD": 83,
+   "MPWR": 83,
+   "MRK": 83,
+   "MRVL": 82,
+   "MS": 83,
+   "MSFT": 83,
+   "MSTR": 83,
+   "MTZ": 83,
+   "MU": 83,
+   "NBIS": 65,
+   "NET": 34,
+   "NFLX": 83,
+   "NKE": 83,
+   "NNE": 13,
+   "NOK": 83,
+   "NOW": 64,
+   "NRG": 83,
+   "NTAP": 82,
+   "NVDA": 82,
+   "NVMI": 88,
+   "NVT": 39,
+   "NVTS": 26,
+   "NXPI": 71,
+   "OKLO": 23,
+   "OKTA": 45,
+   "ON": 83,
+   "ONTO": 83,
+   "ORCL": 83,
+   "ORLY": 83,
+   "OSIS": 82,
+   "OXY": 83,
+   "PANW": 64,
+   "PATH": 25,
+   "PAYX": 83,
+   "PCAR": 83,
+   "PD": 34,
+   "PEG": 83,
+   "PFE": 83,
+   "PINS": 35,
+   "PLTR": 30,
+   "POET": 83,
+   "POWI": 83,
+   "POWL": 83,
+   "PSTG": 49,
+   "PWR": 83,
+   "QCOM": 83,
+   "QLYS": 64,
+   "QRVO": 83,
+   "RBLX": 30,
+   "RDDT": 23,
+   "REGN": 83,
+   "RIOT": 82,
+   "RMBS": 83,
+   "ROK": 83,
+   "ROP": 83,
+   "ROST": 82,
+   "RPD": 54,
+   "RTX": 83,
+   "RXRX": 26,
+   "S": 26,
+   "SBUX": 83,
+   "SHOP": 54,
+   "SLAB": 82,
+   "SMCI": 82,
+   "SMR": 23,
+   "SNAP": 46,
+   "SNDK": 13,
+   "SNOW": 46,
+   "SNPS": 82,
+   "SO": 83,
+   "SONY": 83,
+   "SOUN": 23,
+   "SPOT": 42,
+   "SPXC": 83,
+   "STRL": 83,
+   "STX": 83,
+   "SWKS": 83,
+   "SYM": 24,
+   "T": 83,
+   "TDC": 83,
+   "TEAM": 52,
+   "TEL": 82,
+   "TEM": 24,
+   "TENB": 42,
+   "TER": 83,
+   "TGT": 82,
+   "TLN": 22,
+   "TMO": 83,
+   "TMUS": 83,
+   "TRI": 83,
+   "TSEM": 83,
+   "TSLA": 75,
+   "TSM": 83,
+   "TT": 83,
+   "TTD": 50,
+   "TTWO": 83,
+   "TWLO": 50,
+   "TXN": 83,
+   "U": 30,
+   "UBER": 38,
+   "UCTT": 83,
+   "UEC": 83,
+   "UMC": 87,
+   "VECO": 83,
+   "VEEV": 58,
+   "VRNS": 58,
+   "VRSK": 77,
+   "VRT": 38,
+   "VRTX": 83,
+   "VSH": 83,
+   "VST": 87,
+   "VZ": 83,
+   "WBD": 83,
+   "WDAY": 62,
+   "WDC": 83,
+   "WFC": 83,
+   "WIT": 83,
+   "WMT": 82,
+   "WULF": 84,
+   "XOM": 83,
+   "ZBRA": 83,
+   "ZM": 33,
+   "ZS": 43
+  },
+  "universe": [
+   "A",
+   "AAP",
+   "AAPL",
+   "AAT",
+   "ABBV",
+   "ABCB",
+   "ABEO",
+   "ABG",
+   "ABM",
+   "ABR",
+   "ABT",
+   "ABUS",
+   "ACAD",
+   "ACCO",
+   "ACGL",
+   "ACH",
+   "ACIW",
+   "ACLS",
+   "ACN",
+   "ACNT",
+   "ACRE",
+   "ACTG",
+   "ADBE",
+   "ADI",
+   "ADM",
+   "ADP",
+   "ADSK",
+   "AEE",
+   "AEHR",
+   "AEO",
+   "AEP",
+   "AES",
+   "AFL",
+   "AIG",
+   "AIZ",
+   "AJG",
+   "AKAM",
+   "ALB",
+   "ALGN",
+   "ALL",
+   "ALNY",
+   "AMAT",
+   "AMD",
+   "AME",
+   "AMGN",
+   "AMP",
+   "AMT",
+   "AMZN",
+   "ANET",
+   "ANGO",
+   "AON",
+   "AOS",
+   "APA",
+   "APD",
+   "APH",
+   "APLD",
+   "APP",
+   "APTV",
+   "ARE",
+   "ASML",
+   "ATO",
+   "AVB",
+   "AVGO",
+   "AVY",
+   "AWK",
+   "AXON",
+   "AXP",
+   "AZO",
+   "BA",
+   "BAC",
+   "BALL",
+   "BAX",
+   "BBY",
+   "BCRX",
+   "BDX",
+   "BELFB",
+   "BEN",
+   "BIIB",
+   "BKNG",
+   "BLK",
+   "BMY",
+   "BR",
+   "BRO",
+   "BSX",
+   "BXP",
+   "CAH",
+   "CB",
+   "CBRE",
+   "CBZ",
+   "CCEP",
+   "CCOI",
+   "CDE",
+   "CDNS",
+   "CEG",
+   "CHD",
+   "CHRW",
+   "CHTR",
+   "CI",
+   "CINF",
+   "CL",
+   "CLDX",
+   "CLX",
+   "CMCSA",
+   "CMI",
+   "CMS",
+   "CNC",
+   "COF",
+   "COHR",
+   "COST",
+   "CPRT",
+   "CRL",
+   "CRM",
+   "CRS",
+   "CRWD",
+   "CSCO",
+   "CSGP",
+   "CSR",
+   "CTAS",
+   "CTSH",
+   "CVS",
+   "CVX",
+   "CWST",
+   "CXW",
+   "D",
+   "DAL",
+   "DE",
+   "DECK",
+   "DELL",
+   "DG",
+   "DGX",
+   "DHI",
+   "DHR",
+   "DHT",
+   "DIS",
+   "DJCO",
+   "DLR",
+   "DLTR",
+   "DMRC",
+   "DOV",
+   "DRI",
+   "DTE",
+   "DUK",
+   "DVA",
+   "DXCM",
+   "EA",
+   "EBAY",
+   "ECL",
+   "ED",
+   "EFX",
+   "EIX",
+   "EME",
+   "EMR",
+   "EOG",
+   "EQIX",
+   "EQR",
+   "ERIE",
+   "ES",
+   "ESE",
+   "ETN",
+   "ETR",
+   "EW",
+   "EXC",
+   "EXPD",
+   "EXR",
+   "FANG",
+   "FAST",
+   "FC",
+   "FDS",
+   "FDX",
+   "FE",
+   "FEIM",
+   "FIS",
+   "FISV",
+   "FIX",
+   "FLG",
+   "FN",
+   "FRT",
+   "FSLR",
+   "FTNT",
+   "GD",
+   "GE",
+   "GEV",
+   "GILD",
+   "GLW",
+   "GOOGL",
+   "GS",
+   "HD",
+   "HON",
+   "IDXX",
+   "INSM",
+   "INTC",
+   "INTU",
+   "ISRG",
+   "JNJ",
+   "JPM",
+   "KDP",
+   "KLAC",
+   "KO",
+   "LLY",
+   "LMT",
+   "LRCX",
+   "MCD",
+   "MCHP",
+   "MDLZ",
+   "MELI",
+   "META",
+   "MPWR",
+   "MRK",
+   "MRVL",
+   "MS",
+   "MSFT",
+   "MSTR",
+   "MU",
+   "NBIS",
+   "NFLX",
+   "NKE",
+   "NOK",
+   "NOW",
+   "NVDA",
+   "NXPI",
+   "ORCL",
+   "ORLY",
+   "OXY",
+   "PANW",
+   "PAYX",
+   "PCAR",
+   "PFE",
+   "PLTR",
+   "QCOM",
+   "REGN",
+   "RIOT",
+   "ROP",
+   "ROST",
+   "RTX",
+   "SBUX",
+   "SMCI",
+   "SNPS",
+   "STX",
+   "T",
+   "TGT",
+   "TMUS",
+   "TRI",
+   "TSEM",
+   "TSLA",
+   "TSM",
+   "TTWO",
+   "TXN",
+   "VRSK",
+   "VRT",
+   "VRTX",
+   "VST",
+   "VZ",
+   "WBD",
+   "WDC",
+   "WFC",
+   "WMT",
+   "XOM"
+  ]
+ },
+ "excluded": {
+  "cohort_n": 144,
+  "cutoff_12q": "2023-08-18",
+  "cutoff_20q": "2021-08-18",
+  "depth_12q": 23,
+  "depth_20q": 21,
+  "has_file": 29,
+  "per_ticker": {
+   "AAOI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2013-09-26",
+    "last": "2026-04-14",
+    "rows": 3155
+   },
+   "AAON": {
+    "file": false
+   },
+   "ABNB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-10",
+    "last": "2026-05-15",
+    "rows": 1363
+   },
+   "ACM": {
+    "file": false
+   },
+   "AEIS": {
+    "file": false
+   },
+   "AI": {
+    "file": false
+   },
+   "ALAB": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-03-20",
+    "last": "2026-04-14",
+    "rows": 518
+   },
+   "ALGM": {
+    "file": false
+   },
+   "AMKR": {
+    "file": false
+   },
+   "ARM": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2023-09-14",
+    "last": "2026-04-14",
+    "rows": 647
+   },
+   "ASX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "ATKR": {
+    "file": false
+   },
+   "AYI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "BABA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "BBAI": {
+    "file": false
+   },
+   "BE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-07-25",
+    "last": "2026-04-14",
+    "rows": 1940
+   },
+   "BTDR": {
+    "file": false
+   },
+   "CAMT": {
+    "file": false
+   },
+   "CARR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-05-29",
+    "last": "2026-05-29",
+    "rows": 1508
+   },
+   "CCJ": {
+    "file": false
+   },
+   "CFLT": {
+    "file": false
+   },
+   "CHKP": {
+    "file": false
+   },
+   "CIEN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "CIFR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-07",
+    "last": "2026-04-14",
+    "rows": 1343
+   },
+   "CLSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-03-31",
+    "last": "2026-04-14",
+    "rows": 2974
+   },
+   "COHU": {
+    "file": false
+   },
+   "CORZ": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-01-24",
+    "last": "2026-04-14",
+    "rows": 557
+   },
+   "CRDO": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-01-27",
+    "last": "2026-04-14",
+    "rows": 1056
+   },
+   "CRWV": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-03-28",
+    "last": "2026-04-14",
+    "rows": 262
+   },
+   "CXAI": {
+    "file": false
+   },
+   "CYBR": {
+    "file": false
+   },
+   "DASH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-09",
+    "last": "2026-04-14",
+    "rows": 1341
+   },
+   "DDOG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-09-19",
+    "last": "2026-05-15",
+    "rows": 1673
+   },
+   "DIOD": {
+    "file": false
+   },
+   "DNA": {
+    "file": false
+   },
+   "DOCN": {
+    "file": false
+   },
+   "DOCU": {
+    "file": false
+   },
+   "DT": {
+    "file": false
+   },
+   "DXC": {
+    "file": false
+   },
+   "DY": {
+    "file": false
+   },
+   "EPAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-06-03",
+    "last": "2026-05-29",
+    "rows": 2764
+   },
+   "ESTC": {
+    "file": false
+   },
+   "EXTR": {
+    "file": false
+   },
+   "FIG": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-07-31",
+    "last": "2026-04-14",
+    "rows": 177
+   },
+   "FORM": {
+    "file": false
+   },
+   "FROG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "GFS": {
+    "file": false
+   },
+   "GLOB": {
+    "file": false
+   },
+   "GLXY": {
+    "file": false
+   },
+   "GRMN": {
+    "file": false
+   },
+   "GTLB": {
+    "file": false
+   },
+   "HPE": {
+    "file": false
+   },
+   "HPQ": {
+    "file": false
+   },
+   "HUBB": {
+    "file": false
+   },
+   "HUBS": {
+    "file": false
+   },
+   "HUT": {
+    "file": false
+   },
+   "IBM": {
+    "file": false
+   },
+   "ICHR": {
+    "file": false
+   },
+   "IESC": {
+    "file": false
+   },
+   "ILMN": {
+    "file": false
+   },
+   "INFY": {
+    "file": false
+   },
+   "INOD": {
+    "file": false
+   },
+   "IREN": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2021-11-17",
+    "last": "2026-05-15",
+    "rows": 1127
+   },
+   "IRM": {
+    "file": false
+   },
+   "J": {
+    "file": false
+   },
+   "JCI": {
+    "file": false
+   },
+   "LEU": {
+    "file": false
+   },
+   "LII": {
+    "file": false
+   },
+   "LITE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-07-23",
+    "last": "2026-05-15",
+    "rows": 2720
+   },
+   "LOGI": {
+    "file": false
+   },
+   "LSCC": {
+    "file": false
+   },
+   "MDB": {
+    "file": false
+   },
+   "MOD": {
+    "file": false
+   },
+   "MTZ": {
+    "file": false
+   },
+   "NET": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-09-13",
+    "last": "2026-05-15",
+    "rows": 1677
+   },
+   "NNE": {
+    "file": false
+   },
+   "NRG": {
+    "file": false
+   },
+   "NTAP": {
+    "file": false
+   },
+   "NVMI": {
+    "file": false
+   },
+   "NVT": {
+    "file": false
+   },
+   "NVTS": {
+    "file": false
+   },
+   "OKLO": {
+    "file": false
+   },
+   "OKTA": {
+    "file": false
+   },
+   "ON": {
+    "file": false
+   },
+   "ONTO": {
+    "file": false
+   },
+   "OSIS": {
+    "file": false
+   },
+   "PATH": {
+    "file": false
+   },
+   "PD": {
+    "file": false
+   },
+   "PEG": {
+    "file": false
+   },
+   "PINS": {
+    "file": false
+   },
+   "POET": {
+    "file": false
+   },
+   "POWI": {
+    "file": false
+   },
+   "POWL": {
+    "file": false
+   },
+   "PSTG": {
+    "file": false
+   },
+   "PWR": {
+    "file": false
+   },
+   "QLYS": {
+    "file": false
+   },
+   "QRVO": {
+    "file": false
+   },
+   "RBLX": {
+    "file": false
+   },
+   "RDDT": {
+    "file": false
+   },
+   "RMBS": {
+    "file": false
+   },
+   "ROK": {
+    "file": false
+   },
+   "RPD": {
+    "file": false
+   },
+   "RXRX": {
+    "file": false
+   },
+   "S": {
+    "file": false
+   },
+   "SHOP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-05-20",
+    "last": "2026-05-15",
+    "rows": 2764
+   },
+   "SLAB": {
+    "file": false
+   },
+   "SMR": {
+    "file": false
+   },
+   "SNAP": {
+    "file": false
+   },
+   "SNDK": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-02-13",
+    "last": "2026-05-15",
+    "rows": 315
+   },
+   "SNOW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-09-16",
+    "last": "2026-05-15",
+    "rows": 1423
+   },
+   "SO": {
+    "file": false
+   },
+   "SONY": {
+    "file": false
+   },
+   "SOUN": {
+    "file": false
+   },
+   "SPOT": {
+    "file": false
+   },
+   "SPXC": {
+    "file": false
+   },
+   "STRL": {
+    "file": false
+   },
+   "SWKS": {
+    "file": false
+   },
+   "SYM": {
+    "file": false
+   },
+   "TDC": {
+    "file": false
+   },
+   "TEAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-12-10",
+    "last": "2026-05-15",
+    "rows": 2622
+   },
+   "TEL": {
+    "file": false
+   },
+   "TEM": {
+    "file": false
+   },
+   "TENB": {
+    "file": false
+   },
+   "TER": {
+    "file": false
+   },
+   "TLN": {
+    "file": false
+   },
+   "TMO": {
+    "file": false
+   },
+   "TT": {
+    "file": false
+   },
+   "TTD": {
+    "file": false
+   },
+   "TWLO": {
+    "file": false
+   },
+   "U": {
+    "file": false
+   },
+   "UBER": {
+    "file": false
+   },
+   "UCTT": {
+    "file": false
+   },
+   "UEC": {
+    "file": false
+   },
+   "UMC": {
+    "file": false
+   },
+   "VECO": {
+    "file": false
+   },
+   "VEEV": {
+    "file": false
+   },
+   "VRNS": {
+    "file": false
+   },
+   "VSH": {
+    "file": false
+   },
+   "WDAY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2017-09-20",
+    "last": "2026-05-15",
+    "rows": 2175
+   },
+   "WIT": {
+    "file": false
+   },
+   "WULF": {
+    "file": false
+   },
+   "ZBRA": {
+    "file": false
+   },
+   "ZM": {
+    "file": false
+   },
+   "ZS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-03-16",
+    "last": "2026-05-15",
+    "rows": 2053
+   }
+  }
+ },
+ "excluded_stmt_depth": {
+  "ge_12q": 143,
+  "ge_20q": 139
+ },
+ "label": "macbook",
+ "lake_root": "/Users/chenxi/market-warehouse/data-lake/bronze/asset_class=equity",
+ "min_history": 12,
+ "probe": "fundamental lake price depth vs universe membership",
+ "universe": {
+  "cohort_n": 257,
+  "cutoff_12q": "2023-08-18",
+  "cutoff_20q": "2021-08-18",
+  "depth_12q": 252,
+  "depth_20q": 251,
+  "has_file": 254,
+  "per_ticker": {
+   "A": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-11-18",
+    "last": "2026-05-15",
+    "rows": 6655
+   },
+   "AAP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-11-29",
+    "last": "2026-05-15",
+    "rows": 6149
+   },
+   "AAPL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-12-12",
+    "last": "2026-05-15",
+    "rows": 11447
+   },
+   "AAT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-01-14",
+    "last": "2026-05-15",
+    "rows": 3856
+   },
+   "ABBV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-10",
+    "last": "2026-04-14",
+    "rows": 3355
+   },
+   "ABCB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-05-19",
+    "last": "2026-05-15",
+    "rows": 7606
+   },
+   "ABEO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-07-23",
+    "last": "2026-05-15",
+    "rows": 3469
+   },
+   "ABG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-03-14",
+    "last": "2026-05-15",
+    "rows": 5575
+   },
+   "ABM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 3821
+   },
+   "ABR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-06-04",
+    "last": "2026-05-29",
+    "rows": 3265
+   },
+   "ABT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-04-17",
+    "last": "2026-04-14",
+    "rows": 4034
+   },
+   "ABUS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-06-03",
+    "last": "2026-05-29",
+    "rows": 3259
+   },
+   "ACAD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-27",
+    "last": "2026-05-29",
+    "rows": 2770
+   },
+   "ACCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-06-04",
+    "last": "2026-05-29",
+    "rows": 3016
+   },
+   "ACGL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-09-14",
+    "last": "2026-05-15",
+    "rows": 7671
+   },
+   "ACH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2023-05-31",
+    "rows": 4528
+   },
+   "ACIW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-06-04",
+    "last": "2026-05-29",
+    "rows": 4276
+   },
+   "ACLS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-07-11",
+    "last": "2026-05-29",
+    "rows": 3245
+   },
+   "ACN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-04-12",
+    "last": "2026-04-14",
+    "rows": 4029
+   },
+   "ACNT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-06-11",
+    "last": "2026-05-29",
+    "rows": 4831
+   },
+   "ACRE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-04-26",
+    "last": "2026-05-29",
+    "rows": 3039
+   },
+   "ACTG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-06-05",
+    "last": "2026-05-29",
+    "rows": 2513
+   },
+   "ADBE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-08-13",
+    "last": "2026-04-14",
+    "rows": 9742
+   },
+   "ADI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-04-02",
+    "last": "2026-05-15",
+    "rows": 3551
+   },
+   "ADM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11622
+   },
+   "ADP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-21",
+    "last": "2026-04-14",
+    "rows": 4396
+   },
+   "ADSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-28",
+    "last": "2026-05-15",
+    "rows": 10039
+   },
+   "AEE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-01-02",
+    "last": "2026-05-15",
+    "rows": 7128
+   },
+   "AEHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-08-15",
+    "last": "2026-04-14",
+    "rows": 6707
+   },
+   "AEO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-08",
+    "last": "2026-04-14",
+    "rows": 4556
+   },
+   "AEP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "AES": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-04-14",
+    "last": "2026-04-14",
+    "rows": 3780
+   },
+   "AFL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11369
+   },
+   "AIG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11133
+   },
+   "AIZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-02-05",
+    "last": "2026-05-15",
+    "rows": 5579
+   },
+   "AJG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-06-20",
+    "last": "2026-05-15",
+    "rows": 10186
+   },
+   "AKAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-10-29",
+    "last": "2026-05-15",
+    "rows": 6672
+   },
+   "ALB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-02-22",
+    "last": "2026-05-15",
+    "rows": 8103
+   },
+   "ALGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-01-26",
+    "last": "2026-05-15",
+    "rows": 6360
+   },
+   "ALL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-06-03",
+    "last": "2026-05-15",
+    "rows": 8286
+   },
+   "ALNY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-28",
+    "last": "2026-05-15",
+    "rows": 5524
+   },
+   "AMAT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11360
+   },
+   "AMD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-01-02",
+    "last": "2026-04-14",
+    "rows": 2836
+   },
+   "AME": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11621
+   },
+   "AMGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-06-17",
+    "last": "2026-05-15",
+    "rows": 10801
+   },
+   "AMP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-09-15",
+    "last": "2026-05-15",
+    "rows": 5196
+   },
+   "AMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-04-13",
+    "last": "2026-04-14",
+    "rows": 3525
+   },
+   "AMZN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-05-15",
+    "last": "2026-04-14",
+    "rows": 7274
+   },
+   "ANET": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-06-06",
+    "last": "2026-04-14",
+    "rows": 2981
+   },
+   "ANGO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-27",
+    "last": "2026-04-14",
+    "rows": 5504
+   },
+   "AON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-02",
+    "last": "2026-05-15",
+    "rows": 11581
+   },
+   "AOS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-09-30",
+    "last": "2026-05-15",
+    "rows": 10574
+   },
+   "APA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 3544
+   },
+   "APD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11621
+   },
+   "APH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-04-14",
+    "last": "2026-04-14",
+    "rows": 4031
+   },
+   "APLD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-12-10",
+    "last": "2026-04-14",
+    "rows": 3579
+   },
+   "APP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-15",
+    "last": "2026-04-14",
+    "rows": 1255
+   },
+   "APTV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-11-17",
+    "last": "2026-05-15",
+    "rows": 3643
+   },
+   "ARE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-05-28",
+    "last": "2026-05-15",
+    "rows": 7279
+   },
+   "ASML": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-03-15",
+    "last": "2026-04-14",
+    "rows": 7823
+   },
+   "ATO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-12-28",
+    "last": "2026-05-15",
+    "rows": 10660
+   },
+   "AVB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-11",
+    "last": "2026-05-15",
+    "rows": 7838
+   },
+   "AVGO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-02-02",
+    "last": "2026-04-14",
+    "rows": 2563
+   },
+   "AVY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11618
+   },
+   "AWK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-04-23",
+    "last": "2026-05-15",
+    "rows": 4545
+   },
+   "AXON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-07",
+    "last": "2026-05-15",
+    "rows": 6272
+   },
+   "AXP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 7610
+   },
+   "AZO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-04-02",
+    "last": "2026-05-29",
+    "rows": 6594
+   },
+   "BA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11612
+   },
+   "BAC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-01-02",
+    "last": "2026-04-14",
+    "rows": 11663
+   },
+   "BALL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-11",
+    "last": "2026-05-29",
+    "rows": 5788
+   },
+   "BAX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 3801
+   },
+   "BBY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-10",
+    "last": "2026-05-29",
+    "rows": 6796
+   },
+   "BCRX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-04",
+    "last": "2026-04-14",
+    "rows": 7823
+   },
+   "BDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 6861
+   },
+   "BELFB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-07-10",
+    "last": "2026-04-14",
+    "rows": 6984
+   },
+   "BEN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-10",
+    "last": "2026-05-29",
+    "rows": 4787
+   },
+   "BIIB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-06-08",
+    "last": "2026-05-29",
+    "rows": 4527
+   },
+   "BKNG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-03-30",
+    "last": "2026-04-14",
+    "rows": 6803
+   },
+   "BLK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-10-04",
+    "last": "2026-05-15",
+    "rows": 6693
+   },
+   "BMY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 4051
+   },
+   "BR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-22",
+    "last": "2026-05-29",
+    "rows": 3319
+   },
+   "BRO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-02-11",
+    "last": "2026-05-29",
+    "rows": 5266
+   },
+   "BSX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-04-14",
+    "last": "2026-04-14",
+    "rows": 5032
+   },
+   "BXP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-06-18",
+    "last": "2026-05-29",
+    "rows": 3765
+   },
+   "CAH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-04",
+    "last": "2026-05-29",
+    "rows": 5473
+   },
+   "CB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-25",
+    "last": "2026-05-29",
+    "rows": 3823
+   },
+   "CBRE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-06-10",
+    "last": "2026-05-29",
+    "rows": 3766
+   },
+   "CBZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-24",
+    "last": "2026-04-14",
+    "rows": 7499
+   },
+   "CCEP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-11-24",
+    "last": "2026-05-15",
+    "rows": 9689
+   },
+   "CCOI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-02-05",
+    "last": "2026-04-14",
+    "rows": 6069
+   },
+   "CDE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11584
+   },
+   "CDNS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-06-10",
+    "last": "2026-05-15",
+    "rows": 9796
+   },
+   "CEG": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-01-19",
+    "last": "2026-04-14",
+    "rows": 1062
+   },
+   "CHD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-06-11",
+    "last": "2026-05-29",
+    "rows": 4997
+   },
+   "CHRW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-06-07",
+    "last": "2026-05-29",
+    "rows": 4272
+   },
+   "CHTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-09-14",
+    "last": "2026-04-14",
+    "rows": 3919
+   },
+   "CI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2003-06-06",
+    "last": "2026-05-29",
+    "rows": 3519
+   },
+   "CINF": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2025-05-30",
+    "rows": 5341
+   },
+   "CL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-11",
+    "last": "2026-05-29",
+    "rows": 5792
+   },
+   "CLDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-01",
+    "last": "2026-04-14",
+    "rows": 4410
+   },
+   "CLX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-06-10",
+    "last": "2026-05-29",
+    "rows": 4528
+   },
+   "CMCSA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11606
+   },
+   "CMI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-06-11",
+    "last": "2026-05-29",
+    "rows": 4277
+   },
+   "CMS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2023-05-31",
+    "rows": 3841
+   },
+   "CNC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2006-06-05",
+    "last": "2026-05-29",
+    "rows": 3263
+   },
+   "COF": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-06-08",
+    "last": "2026-05-29",
+    "rows": 3268
+   },
+   "COHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-10-02",
+    "last": "2026-04-14",
+    "rows": 9352
+   },
+   "COST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-01-03",
+    "last": "2026-04-14",
+    "rows": 8125
+   },
+   "CPRT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-17",
+    "last": "2026-04-14",
+    "rows": 8063
+   },
+   "CRL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2003-06-06",
+    "last": "2026-05-29",
+    "rows": 3772
+   },
+   "CRM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-06-23",
+    "last": "2026-04-14",
+    "rows": 5486
+   },
+   "CRS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "CRWD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-06-12",
+    "last": "2026-05-15",
+    "rows": 1742
+   },
+   "CSCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1990-02-16",
+    "last": "2026-04-14",
+    "rows": 9105
+   },
+   "CSGP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-07-01",
+    "last": "2026-05-15",
+    "rows": 6999
+   },
+   "CSR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-18",
+    "last": "2026-04-14",
+    "rows": 3348
+   },
+   "CTAS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-19",
+    "last": "2026-05-15",
+    "rows": 10710
+   },
+   "CTSH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-06-19",
+    "last": "2026-05-15",
+    "rows": 7015
+   },
+   "CVS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-06-11",
+    "last": "2022-05-31",
+    "rows": 4031
+   },
+   "CVX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11612
+   },
+   "CWST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-10-29",
+    "last": "2026-04-14",
+    "rows": 6906
+   },
+   "CXW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-12-15",
+    "last": "2026-04-14",
+    "rows": 7093
+   },
+   "D": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-11",
+    "last": "2026-05-29",
+    "rows": 5537
+   },
+   "DAL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-04-26",
+    "last": "2026-04-14",
+    "rows": 4751
+   },
+   "DE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 4594
+   },
+   "DECK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-07",
+    "last": "2026-05-29",
+    "rows": 3510
+   },
+   "DELL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-07",
+    "last": "2026-04-14",
+    "rows": 1261
+   },
+   "DG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-11-13",
+    "last": "2026-05-29",
+    "rows": 3155
+   },
+   "DGX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-06-06",
+    "last": "2026-05-29",
+    "rows": 3517
+   },
+   "DHI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-05",
+    "last": "2026-05-29",
+    "rows": 3269
+   },
+   "DHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 4275
+   },
+   "DHT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-10-13",
+    "last": "2026-04-14",
+    "rows": 5155
+   },
+   "DIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "DJCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-06-11",
+    "last": "2026-04-14",
+    "rows": 6202
+   },
+   "DLR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-10-29",
+    "last": "2026-05-29",
+    "rows": 3670
+   },
+   "DLTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-06",
+    "last": "2026-05-29",
+    "rows": 2765
+   },
+   "DMRC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-17",
+    "last": "2026-04-14",
+    "rows": 4398
+   },
+   "DOV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-10",
+    "last": "2026-05-29",
+    "rows": 4272
+   },
+   "DRI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-05-09",
+    "last": "2026-05-29",
+    "rows": 4294
+   },
+   "DTE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2025-05-30",
+    "rows": 6103
+   },
+   "DUK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2006-06-05",
+    "last": "2026-05-29",
+    "rows": 3518
+   },
+   "DVA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-07",
+    "last": "2026-05-29",
+    "rows": 5286
+   },
+   "DXCM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-04-14",
+    "last": "2026-05-15",
+    "rows": 5303
+   },
+   "EA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1989-09-20",
+    "last": "2026-05-15",
+    "rows": 8971
+   },
+   "EBAY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-09-24",
+    "last": "2026-05-29",
+    "rows": 4196
+   },
+   "ECL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-06-11",
+    "last": "2026-05-29",
+    "rows": 4026
+   },
+   "ED": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-06-11",
+    "last": "2026-05-29",
+    "rows": 5541
+   },
+   "EFX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 4841
+   },
+   "EIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 5344
+   },
+   "EME": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-07",
+    "last": "2026-05-29",
+    "rows": 3757
+   },
+   "EMR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-06-11",
+    "last": "2026-05-29",
+    "rows": 4779
+   },
+   "EOG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-06-08",
+    "last": "2026-05-29",
+    "rows": 3017
+   },
+   "EQIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-08-11",
+    "last": "2026-05-29",
+    "rows": 2717
+   },
+   "EQR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-06-08",
+    "last": "2026-05-29",
+    "rows": 4522
+   },
+   "ERIE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2003-06-06",
+    "last": "2026-05-29",
+    "rows": 3772
+   },
+   "ES": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-06-10",
+    "last": "2026-05-29",
+    "rows": 6544
+   },
+   "ESE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1990-10-01",
+    "last": "2026-04-14",
+    "rows": 8943
+   },
+   "ETN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 4593
+   },
+   "ETR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-06-11",
+    "last": "2026-05-29",
+    "rows": 4276
+   },
+   "EW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-03-27",
+    "last": "2023-05-31",
+    "rows": 3574
+   },
+   "EXC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-04-14",
+    "rows": 11610
+   },
+   "EXPD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-11",
+    "last": "2026-05-29",
+    "rows": 3746
+   },
+   "EXR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-06-03",
+    "last": "2026-05-29",
+    "rows": 3518
+   },
+   "FANG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-10-12",
+    "last": "2026-05-15",
+    "rows": 3416
+   },
+   "FAST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-08-20",
+    "last": "2026-04-14",
+    "rows": 9725
+   },
+   "FC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-03",
+    "last": "2026-04-14",
+    "rows": 8523
+   },
+   "FDS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-28",
+    "last": "2026-05-29",
+    "rows": 4503
+   },
+   "FDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-11",
+    "last": "2026-05-29",
+    "rows": 4785
+   },
+   "FE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-06-06",
+    "last": "2026-05-29",
+    "rows": 3518
+   },
+   "FEIM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-18",
+    "last": "2026-04-14",
+    "rows": 11085
+   },
+   "FIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-20",
+    "last": "2026-05-29",
+    "rows": 3757
+   },
+   "FISV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-09-25",
+    "last": "2025-05-30",
+    "rows": 3954
+   },
+   "FIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-06-05",
+    "last": "2026-05-29",
+    "rows": 4524
+   },
+   "FLG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-11-23",
+    "last": "2026-04-14",
+    "rows": 8141
+   },
+   "FN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-06-25",
+    "last": "2026-04-14",
+    "rows": 3974
+   },
+   "FRT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 5081
+   },
+   "FSLR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2006-11-17",
+    "last": "2026-05-29",
+    "rows": 2646
+   },
+   "FTNT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-11-18",
+    "last": "2026-05-15",
+    "rows": 4147
+   },
+   "GD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-10",
+    "last": "2026-05-29",
+    "rows": 4779
+   },
+   "GE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-29",
+    "rows": 3835
+   },
+   "GEV": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-05-31",
+    "last": "2026-05-29",
+    "rows": 500
+   },
+   "GILD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-01-22",
+    "last": "2026-05-15",
+    "rows": 8376
+   },
+   "GLW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "GOOGL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-08-19",
+    "last": "2026-05-15",
+    "rows": 5471
+   },
+   "GS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-05-04",
+    "last": "2026-05-15",
+    "rows": 6799
+   },
+   "HD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-09-22",
+    "last": "2026-05-15",
+    "rows": 11247
+   },
+   "HON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11128
+   },
+   "IDXX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-06-21",
+    "last": "2026-05-15",
+    "rows": 8780
+   },
+   "INSM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-02-15",
+    "last": "2026-05-15",
+    "rows": 8851
+   },
+   "INTC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11637
+   },
+   "INTU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-12",
+    "last": "2026-05-15",
+    "rows": 8345
+   },
+   "ISRG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-13",
+    "last": "2026-05-15",
+    "rows": 6517
+   },
+   "JNJ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11633
+   },
+   "JPM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "KDP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-04-28",
+    "last": "2026-05-15",
+    "rows": 4291
+   },
+   "KLAC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-10-08",
+    "last": "2026-05-15",
+    "rows": 11219
+   },
+   "KO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "LLY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11632
+   },
+   "LMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-03-16",
+    "last": "2026-05-15",
+    "rows": 7842
+   },
+   "LRCX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-05-04",
+    "last": "2026-05-15",
+    "rows": 10591
+   },
+   "MCD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "MCHP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-19",
+    "last": "2026-05-15",
+    "rows": 8340
+   },
+   "MDLZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-13",
+    "last": "2026-05-15",
+    "rows": 6266
+   },
+   "MELI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-08-10",
+    "last": "2026-05-15",
+    "rows": 4721
+   },
+   "META": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-05-18",
+    "last": "2026-05-15",
+    "rows": 3518
+   },
+   "MPWR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-11-19",
+    "last": "2026-05-15",
+    "rows": 5402
+   },
+   "MRK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "MRVL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-27",
+    "last": "2026-05-15",
+    "rows": 6511
+   },
+   "MS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-02-23",
+    "last": "2026-05-15",
+    "rows": 8362
+   },
+   "MSFT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-03-13",
+    "last": "2026-05-15",
+    "rows": 10123
+   },
+   "MSTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-06-11",
+    "last": "2026-05-15",
+    "rows": 7027
+   },
+   "MU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-12-30",
+    "last": "2026-05-15",
+    "rows": 4119
+   },
+   "NBIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-05-24",
+    "last": "2026-05-15",
+    "rows": 3767
+   },
+   "NFLX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-05-23",
+    "last": "2026-05-15",
+    "rows": 6032
+   },
+   "NKE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-12-02",
+    "last": "2026-05-15",
+    "rows": 11454
+   },
+   "NOK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-07-01",
+    "last": "2026-05-15",
+    "rows": 8020
+   },
+   "NOW": {
+    "file": false
+   },
+   "NVDA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-01-22",
+    "last": "2026-04-14",
+    "rows": 6849
+   },
+   "NXPI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-08-06",
+    "last": "2026-05-15",
+    "rows": 3968
+   },
+   "ORCL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-03-12",
+    "last": "2026-05-15",
+    "rows": 10124
+   },
+   "ORLY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-04-23",
+    "last": "2026-05-15",
+    "rows": 8321
+   },
+   "OXY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "PANW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-07-20",
+    "last": "2026-05-15",
+    "rows": 3475
+   },
+   "PAYX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-26",
+    "last": "2026-05-15",
+    "rows": 10748
+   },
+   "PCAR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11115
+   },
+   "PFE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "PLTR": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-05-17",
+    "last": "2026-05-15",
+    "rows": 500
+   },
+   "QCOM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-12-13",
+    "last": "2026-05-15",
+    "rows": 8667
+   },
+   "REGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-04-02",
+    "last": "2026-05-15",
+    "rows": 8837
+   },
+   "RIOT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-20",
+    "last": "2026-05-15",
+    "rows": 3370
+   },
+   "ROP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-02-13",
+    "last": "2026-05-15",
+    "rows": 8368
+   },
+   "ROST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-08-08",
+    "last": "2026-05-15",
+    "rows": 10009
+   },
+   "RTX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "SBUX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-26",
+    "last": "2026-05-15",
+    "rows": 8532
+   },
+   "SMCI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-29",
+    "last": "2026-05-15",
+    "rows": 4814
+   },
+   "SNPS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-02-26",
+    "last": "2026-05-15",
+    "rows": 8608
+   },
+   "STX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-01-23",
+    "last": "2026-05-15",
+    "rows": 5609
+   },
+   "T": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-11-21",
+    "last": "2026-05-15",
+    "rows": 10703
+   },
+   "TGT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11633
+   },
+   "TMUS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-04-19",
+    "last": "2026-05-15",
+    "rows": 4029
+   },
+   "TRI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-06-12",
+    "last": "2026-05-15",
+    "rows": 5767
+   },
+   "TSEM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-10-26",
+    "last": "2026-05-15",
+    "rows": 7938
+   },
+   "TSLA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-06-29",
+    "last": "2026-05-15",
+    "rows": 3995
+   },
+   "TSM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-10-08",
+    "last": "2026-05-15",
+    "rows": 7193
+   },
+   "TTWO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-04-15",
+    "last": "2026-05-15",
+    "rows": 7291
+   },
+   "TXN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-01-03",
+    "last": "2026-05-15",
+    "rows": 3613
+   },
+   "VRSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-10-07",
+    "last": "2026-05-15",
+    "rows": 4177
+   },
+   "VRT": {
+    "file": false
+   },
+   "VRTX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-07-24",
+    "last": "2026-05-15",
+    "rows": 8755
+   },
+   "VST": {
+    "file": false
+   },
+   "VZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-11-21",
+    "last": "2026-05-15",
+    "rows": 10700
+   },
+   "WBD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-07-21",
+    "last": "2026-05-15",
+    "rows": 4364
+   },
+   "WDC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-06-01",
+    "last": "2026-05-15",
+    "rows": 3509
+   },
+   "WFC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11634
+   },
+   "WMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11635
+   },
+   "XOM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-05-15",
+    "rows": 11635
+   }
+  }
+ },
+ "window_quarters": 20
+}

--- a/docs/research/2026-08-18-fundamental-lake-depth/depth_mini.json
+++ b/docs/research/2026-08-18-fundamental-lake-depth/depth_mini.json
@@ -1,0 +1,4035 @@
+{
+ "as_of": "2026-08-18",
+ "cohorts": {
+  "excluded": [
+   "AAOI",
+   "AAON",
+   "ABNB",
+   "ACM",
+   "AEIS",
+   "AI",
+   "ALAB",
+   "ALGM",
+   "AMKR",
+   "ARM",
+   "ASX",
+   "ATKR",
+   "AYI",
+   "BABA",
+   "BBAI",
+   "BE",
+   "BTDR",
+   "CAMT",
+   "CARR",
+   "CCJ",
+   "CFLT",
+   "CHKP",
+   "CIEN",
+   "CIFR",
+   "CLSK",
+   "COHU",
+   "CORZ",
+   "CRDO",
+   "CRWV",
+   "CXAI",
+   "CYBR",
+   "DASH",
+   "DDOG",
+   "DIOD",
+   "DNA",
+   "DOCN",
+   "DOCU",
+   "DT",
+   "DXC",
+   "DY",
+   "EPAM",
+   "ESTC",
+   "EXTR",
+   "FIG",
+   "FORM",
+   "FROG",
+   "GFS",
+   "GLOB",
+   "GLXY",
+   "GRMN",
+   "GTLB",
+   "HPE",
+   "HPQ",
+   "HUBB",
+   "HUBS",
+   "HUT",
+   "IBM",
+   "ICHR",
+   "IESC",
+   "ILMN",
+   "INFY",
+   "INOD",
+   "IREN",
+   "IRM",
+   "J",
+   "JCI",
+   "LEU",
+   "LII",
+   "LITE",
+   "LOGI",
+   "LSCC",
+   "MDB",
+   "MOD",
+   "MTZ",
+   "NET",
+   "NNE",
+   "NRG",
+   "NTAP",
+   "NVMI",
+   "NVT",
+   "NVTS",
+   "OKLO",
+   "OKTA",
+   "ON",
+   "ONTO",
+   "OSIS",
+   "PATH",
+   "PD",
+   "PEG",
+   "PINS",
+   "POET",
+   "POWI",
+   "POWL",
+   "PSTG",
+   "PWR",
+   "QLYS",
+   "QRVO",
+   "RBLX",
+   "RDDT",
+   "RMBS",
+   "ROK",
+   "RPD",
+   "RXRX",
+   "S",
+   "SHOP",
+   "SLAB",
+   "SMR",
+   "SNAP",
+   "SNDK",
+   "SNOW",
+   "SO",
+   "SONY",
+   "SOUN",
+   "SPOT",
+   "SPXC",
+   "STRL",
+   "SWKS",
+   "SYM",
+   "TDC",
+   "TEAM",
+   "TEL",
+   "TEM",
+   "TENB",
+   "TER",
+   "TLN",
+   "TMO",
+   "TT",
+   "TTD",
+   "TWLO",
+   "U",
+   "UBER",
+   "UCTT",
+   "UEC",
+   "UMC",
+   "VECO",
+   "VEEV",
+   "VRNS",
+   "VSH",
+   "WDAY",
+   "WIT",
+   "WULF",
+   "ZBRA",
+   "ZM",
+   "ZS"
+  ],
+  "stmt_quarters": {
+   "A": 82,
+   "AAOI": 62,
+   "AAON": 83,
+   "AAP": 82,
+   "AAPL": 83,
+   "AAT": 69,
+   "ABBV": 63,
+   "ABCB": 83,
+   "ABEO": 83,
+   "ABG": 83,
+   "ABM": 83,
+   "ABNB": 28,
+   "ABR": 83,
+   "ABT": 83,
+   "ABUS": 83,
+   "ACAD": 83,
+   "ACCO": 83,
+   "ACGL": 83,
+   "ACH": 82,
+   "ACIW": 83,
+   "ACLS": 83,
+   "ACM": 83,
+   "ACN": 83,
+   "ACNT": 83,
+   "ACRE": 59,
+   "ACTG": 84,
+   "ADBE": 83,
+   "ADI": 82,
+   "ADM": 83,
+   "ADP": 83,
+   "ADSK": 82,
+   "AEE": 83,
+   "AEHR": 83,
+   "AEIS": 83,
+   "AEO": 82,
+   "AEP": 83,
+   "AES": 83,
+   "AFL": 83,
+   "AI": 28,
+   "AIG": 83,
+   "AIZ": 83,
+   "AJG": 83,
+   "AKAM": 83,
+   "ALAB": 18,
+   "ALB": 83,
+   "ALGM": 30,
+   "ALGN": 83,
+   "ALL": 83,
+   "ALNY": 83,
+   "AMAT": 82,
+   "AMD": 83,
+   "AME": 83,
+   "AMGN": 83,
+   "AMKR": 83,
+   "AMP": 83,
+   "AMT": 83,
+   "AMZN": 83,
+   "ANET": 55,
+   "ANGO": 83,
+   "AON": 83,
+   "AOS": 83,
+   "APA": 83,
+   "APD": 83,
+   "APH": 83,
+   "APLD": 55,
+   "APP": 31,
+   "APTV": 84,
+   "ARE": 83,
+   "ARM": 65,
+   "ASML": 83,
+   "ASX": 84,
+   "ATKR": 57,
+   "ATO": 83,
+   "AVB": 83,
+   "AVGO": 78,
+   "AVY": 83,
+   "AWK": 86,
+   "AXON": 83,
+   "AXP": 83,
+   "AYI": 83,
+   "AZO": 82,
+   "BA": 83,
+   "BABA": 63,
+   "BAC": 83,
+   "BALL": 83,
+   "BAX": 83,
+   "BBAI": 26,
+   "BBY": 82,
+   "BCRX": 83,
+   "BDX": 83,
+   "BE": 46,
+   "BELFB": 83,
+   "BEN": 83,
+   "BIIB": 83,
+   "BKNG": 83,
+   "BLK": 83,
+   "BMY": 83,
+   "BR": 83,
+   "BRO": 83,
+   "BSX": 83,
+   "BTDR": 25,
+   "BXP": 83,
+   "CAH": 82,
+   "CAMT": 89,
+   "CARR": 30,
+   "CB": 83,
+   "CBRE": 83,
+   "CBZ": 83,
+   "CCEP": 82,
+   "CCJ": 83,
+   "CCOI": 83,
+   "CDE": 83,
+   "CDNS": 83,
+   "CEG": 56,
+   "CFLT": 24,
+   "CHD": 83,
+   "CHKP": 83,
+   "CHRW": 83,
+   "CHTR": 83,
+   "CI": 83,
+   "CIEN": 82,
+   "CIFR": 25,
+   "CINF": 83,
+   "CL": 83,
+   "CLDX": 83,
+   "CLSK": 71,
+   "CLX": 83,
+   "CMCSA": 83,
+   "CMI": 83,
+   "CMS": 83,
+   "CNC": 83,
+   "COF": 83,
+   "COHR": 82,
+   "COHU": 83,
+   "CORZ": 20,
+   "COST": 82,
+   "CPRT": 82,
+   "CRDO": 24,
+   "CRL": 83,
+   "CRM": 82,
+   "CRS": 83,
+   "CRWD": 34,
+   "CRWV": 10,
+   "CSCO": 82,
+   "CSGP": 83,
+   "CSR": 83,
+   "CTAS": 83,
+   "CTSH": 83,
+   "CVS": 83,
+   "CVX": 83,
+   "CWST": 83,
+   "CXAI": 24,
+   "CXW": 83,
+   "CYBR": 56,
+   "D": 83,
+   "DAL": 83,
+   "DASH": 30,
+   "DDOG": 34,
+   "DE": 82,
+   "DECK": 83,
+   "DELL": 53,
+   "DG": 83,
+   "DGX": 83,
+   "DHI": 83,
+   "DHR": 83,
+   "DHT": 83,
+   "DIOD": 83,
+   "DIS": 83,
+   "DJCO": 82,
+   "DLR": 83,
+   "DLTR": 83,
+   "DMRC": 78,
+   "DNA": 26,
+   "DOCN": 34,
+   "DOCU": 41,
+   "DOV": 83,
+   "DRI": 83,
+   "DT": 37,
+   "DTE": 83,
+   "DUK": 83,
+   "DVA": 83,
+   "DXC": 83,
+   "DXCM": 83,
+   "DY": 82,
+   "EA": 83,
+   "EBAY": 83,
+   "ECL": 83,
+   "ED": 83,
+   "EFX": 83,
+   "EIX": 83,
+   "EME": 83,
+   "EMR": 83,
+   "EOG": 83,
+   "EPAM": 67,
+   "EQIX": 83,
+   "EQR": 83,
+   "ERIE": 83,
+   "ES": 83,
+   "ESE": 83,
+   "ESTC": 40,
+   "ETN": 83,
+   "ETR": 83,
+   "EW": 83,
+   "EXC": 83,
+   "EXPD": 83,
+   "EXR": 83,
+   "EXTR": 83,
+   "FANG": 64,
+   "FAST": 83,
+   "FC": 83,
+   "FDS": 83,
+   "FDX": 83,
+   "FE": 83,
+   "FEIM": 83,
+   "FIG": 12,
+   "FIS": 83,
+   "FISV": 83,
+   "FIX": 83,
+   "FLG": 83,
+   "FN": 80,
+   "FORM": 83,
+   "FROG": 32,
+   "FRT": 83,
+   "FSLR": 84,
+   "FTNT": 78,
+   "GD": 83,
+   "GE": 83,
+   "GEV": 14,
+   "GFS": 26,
+   "GILD": 83,
+   "GLOB": 57,
+   "GLW": 83,
+   "GLXY": 81,
+   "GOOGL": 83,
+   "GRMN": 83,
+   "GS": 83,
+   "GTLB": 25,
+   "HD": 82,
+   "HON": 83,
+   "HPE": 51,
+   "HPQ": 82,
+   "HUBB": 83,
+   "HUBS": 54,
+   "HUT": 60,
+   "IBM": 83,
+   "ICHR": 50,
+   "IDXX": 83,
+   "IESC": 83,
+   "ILMN": 83,
+   "INFY": 83,
+   "INOD": 83,
+   "INSM": 83,
+   "INTC": 83,
+   "INTU": 82,
+   "IREN": 27,
+   "IRM": 83,
+   "ISRG": 83,
+   "J": 83,
+   "JCI": 83,
+   "JNJ": 83,
+   "JPM": 83,
+   "KDP": 83,
+   "KLAC": 83,
+   "KO": 83,
+   "LEU": 83,
+   "LII": 83,
+   "LITE": 52,
+   "LLY": 83,
+   "LMT": 83,
+   "LOGI": 83,
+   "LRCX": 83,
+   "LSCC": 83,
+   "MCD": 83,
+   "MCHP": 83,
+   "MDB": 45,
+   "MDLZ": 83,
+   "MELI": 83,
+   "META": 66,
+   "MOD": 83,
+   "MPWR": 83,
+   "MRK": 83,
+   "MRVL": 82,
+   "MS": 83,
+   "MSFT": 83,
+   "MSTR": 83,
+   "MTZ": 83,
+   "MU": 83,
+   "NBIS": 65,
+   "NET": 34,
+   "NFLX": 83,
+   "NKE": 83,
+   "NNE": 13,
+   "NOK": 83,
+   "NOW": 64,
+   "NRG": 83,
+   "NTAP": 82,
+   "NVDA": 82,
+   "NVMI": 88,
+   "NVT": 39,
+   "NVTS": 26,
+   "NXPI": 71,
+   "OKLO": 23,
+   "OKTA": 45,
+   "ON": 83,
+   "ONTO": 83,
+   "ORCL": 83,
+   "ORLY": 83,
+   "OSIS": 82,
+   "OXY": 83,
+   "PANW": 64,
+   "PATH": 25,
+   "PAYX": 83,
+   "PCAR": 83,
+   "PD": 34,
+   "PEG": 83,
+   "PFE": 83,
+   "PINS": 35,
+   "PLTR": 30,
+   "POET": 83,
+   "POWI": 83,
+   "POWL": 83,
+   "PSTG": 49,
+   "PWR": 83,
+   "QCOM": 83,
+   "QLYS": 64,
+   "QRVO": 83,
+   "RBLX": 30,
+   "RDDT": 23,
+   "REGN": 83,
+   "RIOT": 82,
+   "RMBS": 83,
+   "ROK": 83,
+   "ROP": 83,
+   "ROST": 82,
+   "RPD": 54,
+   "RTX": 83,
+   "RXRX": 26,
+   "S": 26,
+   "SBUX": 83,
+   "SHOP": 54,
+   "SLAB": 82,
+   "SMCI": 82,
+   "SMR": 23,
+   "SNAP": 46,
+   "SNDK": 13,
+   "SNOW": 46,
+   "SNPS": 82,
+   "SO": 83,
+   "SONY": 83,
+   "SOUN": 23,
+   "SPOT": 42,
+   "SPXC": 83,
+   "STRL": 83,
+   "STX": 83,
+   "SWKS": 83,
+   "SYM": 24,
+   "T": 83,
+   "TDC": 83,
+   "TEAM": 52,
+   "TEL": 82,
+   "TEM": 24,
+   "TENB": 42,
+   "TER": 83,
+   "TGT": 82,
+   "TLN": 22,
+   "TMO": 83,
+   "TMUS": 83,
+   "TRI": 83,
+   "TSEM": 83,
+   "TSLA": 75,
+   "TSM": 83,
+   "TT": 83,
+   "TTD": 50,
+   "TTWO": 83,
+   "TWLO": 50,
+   "TXN": 83,
+   "U": 30,
+   "UBER": 38,
+   "UCTT": 83,
+   "UEC": 83,
+   "UMC": 87,
+   "VECO": 83,
+   "VEEV": 58,
+   "VRNS": 58,
+   "VRSK": 77,
+   "VRT": 38,
+   "VRTX": 83,
+   "VSH": 83,
+   "VST": 87,
+   "VZ": 83,
+   "WBD": 83,
+   "WDAY": 62,
+   "WDC": 83,
+   "WFC": 83,
+   "WIT": 83,
+   "WMT": 82,
+   "WULF": 84,
+   "XOM": 83,
+   "ZBRA": 83,
+   "ZM": 33,
+   "ZS": 43
+  },
+  "universe": [
+   "A",
+   "AAP",
+   "AAPL",
+   "AAT",
+   "ABBV",
+   "ABCB",
+   "ABEO",
+   "ABG",
+   "ABM",
+   "ABR",
+   "ABT",
+   "ABUS",
+   "ACAD",
+   "ACCO",
+   "ACGL",
+   "ACH",
+   "ACIW",
+   "ACLS",
+   "ACN",
+   "ACNT",
+   "ACRE",
+   "ACTG",
+   "ADBE",
+   "ADI",
+   "ADM",
+   "ADP",
+   "ADSK",
+   "AEE",
+   "AEHR",
+   "AEO",
+   "AEP",
+   "AES",
+   "AFL",
+   "AIG",
+   "AIZ",
+   "AJG",
+   "AKAM",
+   "ALB",
+   "ALGN",
+   "ALL",
+   "ALNY",
+   "AMAT",
+   "AMD",
+   "AME",
+   "AMGN",
+   "AMP",
+   "AMT",
+   "AMZN",
+   "ANET",
+   "ANGO",
+   "AON",
+   "AOS",
+   "APA",
+   "APD",
+   "APH",
+   "APLD",
+   "APP",
+   "APTV",
+   "ARE",
+   "ASML",
+   "ATO",
+   "AVB",
+   "AVGO",
+   "AVY",
+   "AWK",
+   "AXON",
+   "AXP",
+   "AZO",
+   "BA",
+   "BAC",
+   "BALL",
+   "BAX",
+   "BBY",
+   "BCRX",
+   "BDX",
+   "BELFB",
+   "BEN",
+   "BIIB",
+   "BKNG",
+   "BLK",
+   "BMY",
+   "BR",
+   "BRO",
+   "BSX",
+   "BXP",
+   "CAH",
+   "CB",
+   "CBRE",
+   "CBZ",
+   "CCEP",
+   "CCOI",
+   "CDE",
+   "CDNS",
+   "CEG",
+   "CHD",
+   "CHRW",
+   "CHTR",
+   "CI",
+   "CINF",
+   "CL",
+   "CLDX",
+   "CLX",
+   "CMCSA",
+   "CMI",
+   "CMS",
+   "CNC",
+   "COF",
+   "COHR",
+   "COST",
+   "CPRT",
+   "CRL",
+   "CRM",
+   "CRS",
+   "CRWD",
+   "CSCO",
+   "CSGP",
+   "CSR",
+   "CTAS",
+   "CTSH",
+   "CVS",
+   "CVX",
+   "CWST",
+   "CXW",
+   "D",
+   "DAL",
+   "DE",
+   "DECK",
+   "DELL",
+   "DG",
+   "DGX",
+   "DHI",
+   "DHR",
+   "DHT",
+   "DIS",
+   "DJCO",
+   "DLR",
+   "DLTR",
+   "DMRC",
+   "DOV",
+   "DRI",
+   "DTE",
+   "DUK",
+   "DVA",
+   "DXCM",
+   "EA",
+   "EBAY",
+   "ECL",
+   "ED",
+   "EFX",
+   "EIX",
+   "EME",
+   "EMR",
+   "EOG",
+   "EQIX",
+   "EQR",
+   "ERIE",
+   "ES",
+   "ESE",
+   "ETN",
+   "ETR",
+   "EW",
+   "EXC",
+   "EXPD",
+   "EXR",
+   "FANG",
+   "FAST",
+   "FC",
+   "FDS",
+   "FDX",
+   "FE",
+   "FEIM",
+   "FIS",
+   "FISV",
+   "FIX",
+   "FLG",
+   "FN",
+   "FRT",
+   "FSLR",
+   "FTNT",
+   "GD",
+   "GE",
+   "GEV",
+   "GILD",
+   "GLW",
+   "GOOGL",
+   "GS",
+   "HD",
+   "HON",
+   "IDXX",
+   "INSM",
+   "INTC",
+   "INTU",
+   "ISRG",
+   "JNJ",
+   "JPM",
+   "KDP",
+   "KLAC",
+   "KO",
+   "LLY",
+   "LMT",
+   "LRCX",
+   "MCD",
+   "MCHP",
+   "MDLZ",
+   "MELI",
+   "META",
+   "MPWR",
+   "MRK",
+   "MRVL",
+   "MS",
+   "MSFT",
+   "MSTR",
+   "MU",
+   "NBIS",
+   "NFLX",
+   "NKE",
+   "NOK",
+   "NOW",
+   "NVDA",
+   "NXPI",
+   "ORCL",
+   "ORLY",
+   "OXY",
+   "PANW",
+   "PAYX",
+   "PCAR",
+   "PFE",
+   "PLTR",
+   "QCOM",
+   "REGN",
+   "RIOT",
+   "ROP",
+   "ROST",
+   "RTX",
+   "SBUX",
+   "SMCI",
+   "SNPS",
+   "STX",
+   "T",
+   "TGT",
+   "TMUS",
+   "TRI",
+   "TSEM",
+   "TSLA",
+   "TSM",
+   "TTWO",
+   "TXN",
+   "VRSK",
+   "VRT",
+   "VRTX",
+   "VST",
+   "VZ",
+   "WBD",
+   "WDC",
+   "WFC",
+   "WMT",
+   "XOM"
+  ]
+ },
+ "excluded": {
+  "cohort_n": 144,
+  "cutoff_12q": "2023-08-18",
+  "cutoff_20q": "2021-08-18",
+  "depth_12q": 132,
+  "depth_20q": 120,
+  "has_file": 141,
+  "per_ticker": {
+   "AAOI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2013-09-26",
+    "last": "2026-08-14",
+    "rows": 3240
+   },
+   "AAON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "ABNB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-10",
+    "last": "2026-08-14",
+    "rows": 1425
+   },
+   "ACM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "AEIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-11-17",
+    "last": "2026-08-14",
+    "rows": 7734
+   },
+   "AI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-09",
+    "last": "2026-08-14",
+    "rows": 1426
+   },
+   "ALAB": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-03-20",
+    "last": "2026-08-14",
+    "rows": 603
+   },
+   "ALGM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "AMKR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "ARM": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2023-09-14",
+    "last": "2026-08-14",
+    "rows": 732
+   },
+   "ASX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "ATKR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-06-10",
+    "last": "2026-08-14",
+    "rows": 2559
+   },
+   "AYI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "BABA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "BBAI": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2021-12-08",
+    "last": "2026-08-14",
+    "rows": 1175
+   },
+   "BE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-07-25",
+    "last": "2026-08-14",
+    "rows": 2025
+   },
+   "BTDR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-07-28",
+    "last": "2026-08-14",
+    "rows": 1268
+   },
+   "CAMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "CARR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-03-19",
+    "last": "2026-08-14",
+    "rows": 1610
+   },
+   "CCJ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "CFLT": {
+    "file": false
+   },
+   "CHKP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "CIEN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-02-07",
+    "last": "2026-08-14",
+    "rows": 7426
+   },
+   "CIFR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-07",
+    "last": "2026-08-14",
+    "rows": 1428
+   },
+   "CLSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-03-31",
+    "last": "2026-08-14",
+    "rows": 2558
+   },
+   "COHU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11563
+   },
+   "CORZ": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-01-20",
+    "last": "2026-08-14",
+    "rows": 881
+   },
+   "CRDO": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-01-27",
+    "last": "2026-08-14",
+    "rows": 1141
+   },
+   "CRWV": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-03-28",
+    "last": "2026-08-14",
+    "rows": 347
+   },
+   "CXAI": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2023-03-15",
+    "last": "2026-08-14",
+    "rows": 858
+   },
+   "CYBR": {
+    "file": false
+   },
+   "DASH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-12-09",
+    "last": "2026-08-14",
+    "rows": 1426
+   },
+   "DDOG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-09-19",
+    "last": "2026-08-14",
+    "rows": 1735
+   },
+   "DIOD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 10896
+   },
+   "DNA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-19",
+    "last": "2026-08-14",
+    "rows": 1338
+   },
+   "DOCN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-03-24",
+    "last": "2026-08-14",
+    "rows": 1355
+   },
+   "DOCU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "DT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "DXC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "DY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-06-04",
+    "last": "2026-08-14",
+    "rows": 10407
+   },
+   "EPAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-02-08",
+    "last": "2026-08-14",
+    "rows": 3650
+   },
+   "ESTC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "EXTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-04-09",
+    "last": "2026-08-14",
+    "rows": 6881
+   },
+   "FIG": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-05-17",
+    "last": "2026-08-14",
+    "rows": 1020
+   },
+   "FORM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2003-06-12",
+    "last": "2026-08-14",
+    "rows": 5832
+   },
+   "FROG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "GFS": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2021-10-28",
+    "last": "2026-08-14",
+    "rows": 1203
+   },
+   "GLOB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "GLXY": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-05-16",
+    "last": "2026-08-14",
+    "rows": 313
+   },
+   "GRMN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-12-08",
+    "last": "2026-08-14",
+    "rows": 6458
+   },
+   "GTLB": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2021-10-14",
+    "last": "2026-08-14",
+    "rows": 1213
+   },
+   "HPE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-10-19",
+    "last": "2026-08-14",
+    "rows": 2721
+   },
+   "HPQ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "HUBB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11404
+   },
+   "HUBS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "HUT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-26",
+    "last": "2026-08-14",
+    "rows": 1311
+   },
+   "IBM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "ICHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-12-09",
+    "last": "2026-08-14",
+    "rows": 2432
+   },
+   "IESC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2006-05-15",
+    "last": "2026-08-14",
+    "rows": 5059
+   },
+   "ILMN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "INFY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "INOD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-08-10",
+    "last": "2026-08-14",
+    "rows": 8238
+   },
+   "IREN": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2021-11-17",
+    "last": "2026-08-14",
+    "rows": 1189
+   },
+   "IRM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-04-26",
+    "last": "2026-08-14",
+    "rows": 6615
+   },
+   "J": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11618
+   },
+   "JCI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-03-17",
+    "last": "2026-08-14",
+    "rows": 4381
+   },
+   "LEU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-07-23",
+    "last": "2026-08-14",
+    "rows": 6806
+   },
+   "LII": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-07-29",
+    "last": "2026-08-14",
+    "rows": 6801
+   },
+   "LITE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "LOGI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "LSCC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "MDB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "MOD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-09-20",
+    "last": "2026-08-14",
+    "rows": 6476
+   },
+   "MTZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "NET": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "NNE": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-05-08",
+    "last": "2026-08-14",
+    "rows": 569
+   },
+   "NRG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2003-12-02",
+    "last": "2026-08-14",
+    "rows": 5708
+   },
+   "NTAP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-11-22",
+    "last": "2026-08-14",
+    "rows": 7731
+   },
+   "NVMI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "NVT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "NVTS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-01-25",
+    "last": "2026-08-14",
+    "rows": 1396
+   },
+   "OKLO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-07-08",
+    "last": "2026-08-14",
+    "rows": 1038
+   },
+   "OKTA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "ON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-04-28",
+    "last": "2026-08-14",
+    "rows": 6614
+   },
+   "ONTO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "OSIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-10-02",
+    "last": "2026-08-14",
+    "rows": 4988
+   },
+   "PATH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "PD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-04-11",
+    "last": "2026-08-14",
+    "rows": 1846
+   },
+   "PEG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-01-23",
+    "last": "2026-08-14",
+    "rows": 5672
+   },
+   "PINS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "POET": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-03-14",
+    "last": "2026-08-14",
+    "rows": 1110
+   },
+   "POWI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-08-13",
+    "last": "2026-08-14",
+    "rows": 4029
+   },
+   "POWL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 7594
+   },
+   "PSTG": {
+    "file": false
+   },
+   "PWR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-02-12",
+    "last": "2026-08-14",
+    "rows": 7168
+   },
+   "QLYS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-09-28",
+    "last": "2026-08-14",
+    "rows": 3488
+   },
+   "QRVO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "RBLX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "RDDT": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-03-21",
+    "last": "2026-08-14",
+    "rows": 602
+   },
+   "RMBS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-05-14",
+    "last": "2026-08-14",
+    "rows": 6353
+   },
+   "ROK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11440
+   },
+   "RPD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-07-17",
+    "last": "2026-08-14",
+    "rows": 2786
+   },
+   "RXRX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-16",
+    "last": "2026-08-14",
+    "rows": 1339
+   },
+   "S": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-30",
+    "last": "2026-08-14",
+    "rows": 1287
+   },
+   "SHOP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-05-20",
+    "last": "2026-08-14",
+    "rows": 2826
+   },
+   "SLAB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-03-24",
+    "last": "2026-08-14",
+    "rows": 6135
+   },
+   "SMR": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-05-03",
+    "last": "2026-08-14",
+    "rows": 1075
+   },
+   "SNAP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "SNDK": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2025-02-13",
+    "last": "2026-08-14",
+    "rows": 377
+   },
+   "SNOW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "SO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "SONY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "SOUN": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-04-28",
+    "last": "2026-08-14",
+    "rows": 1078
+   },
+   "SPOT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "SPXC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 9164
+   },
+   "STRL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-07-12",
+    "last": "2026-08-14",
+    "rows": 6173
+   },
+   "SWKS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11622
+   },
+   "SYM": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-06-08",
+    "last": "2026-08-14",
+    "rows": 1050
+   },
+   "TDC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "TEAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-12-10",
+    "last": "2026-08-14",
+    "rows": 2684
+   },
+   "TEL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-06-14",
+    "last": "2026-08-14",
+    "rows": 4821
+   },
+   "TEM": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-06-14",
+    "last": "2026-08-14",
+    "rows": 543
+   },
+   "TENB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-07-26",
+    "last": "2026-08-14",
+    "rows": 2024
+   },
+   "TER": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "TLN": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-07-10",
+    "last": "2026-08-14",
+    "rows": 527
+   },
+   "TMO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "TT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11442
+   },
+   "TTD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-09-21",
+    "last": "2026-08-14",
+    "rows": 2488
+   },
+   "TWLO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "U": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "UBER": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-05-10",
+    "last": "2026-08-14",
+    "rows": 1826
+   },
+   "UCTT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-03-25",
+    "last": "2026-08-14",
+    "rows": 4625
+   },
+   "UEC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-09-28",
+    "last": "2026-08-14",
+    "rows": 4497
+   },
+   "UMC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "VECO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-11-29",
+    "last": "2026-08-14",
+    "rows": 7480
+   },
+   "VEEV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "VRNS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-02-28",
+    "last": "2026-08-14",
+    "rows": 3134
+   },
+   "VSH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 10414
+   },
+   "WDAY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2017-09-20",
+    "last": "2026-08-14",
+    "rows": 2237
+   },
+   "WIT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "WULF": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-04-05",
+    "last": "2026-08-14",
+    "rows": 4259
+   },
+   "ZBRA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-08-15",
+    "last": "2026-08-14",
+    "rows": 8813
+   },
+   "ZM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "ZS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-03-16",
+    "last": "2026-08-14",
+    "rows": 2115
+   }
+  }
+ },
+ "excluded_stmt_depth": {
+  "ge_12q": 143,
+  "ge_20q": 139
+ },
+ "label": "mini",
+ "lake_root": "/lake/bronze/asset_class=equity",
+ "min_history": 12,
+ "probe": "fundamental lake price depth vs universe membership",
+ "universe": {
+  "cohort_n": 257,
+  "cutoff_12q": "2023-08-18",
+  "cutoff_20q": "2021-08-18",
+  "depth_12q": 256,
+  "depth_20q": 255,
+  "has_file": 257,
+  "per_ticker": {
+   "A": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-11-18",
+    "last": "2026-08-14",
+    "rows": 6722
+   },
+   "AAP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-11-29",
+    "last": "2026-08-14",
+    "rows": 6214
+   },
+   "AAPL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-12-12",
+    "last": "2026-08-14",
+    "rows": 11509
+   },
+   "AAT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-01-14",
+    "last": "2026-08-14",
+    "rows": 3918
+   },
+   "ABBV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-10",
+    "last": "2026-08-14",
+    "rows": 3440
+   },
+   "ABCB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-05-19",
+    "last": "2026-08-14",
+    "rows": 7919
+   },
+   "ABEO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-07-23",
+    "last": "2026-08-14",
+    "rows": 3281
+   },
+   "ABG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-03-14",
+    "last": "2026-08-14",
+    "rows": 6143
+   },
+   "ABM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11652
+   },
+   "ABR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-04-07",
+    "last": "2026-08-14",
+    "rows": 5623
+   },
+   "ABT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "ABUS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-11-15",
+    "last": "2026-08-14",
+    "rows": 3703
+   },
+   "ACAD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-27",
+    "last": "2026-08-14",
+    "rows": 5588
+   },
+   "ACCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-08-09",
+    "last": "2026-08-14",
+    "rows": 5283
+   },
+   "ACGL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-09-14",
+    "last": "2026-08-14",
+    "rows": 7739
+   },
+   "ACH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11562
+   },
+   "ACIW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-07-25",
+    "last": "2026-08-14",
+    "rows": 4795
+   },
+   "ACLS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-07-11",
+    "last": "2026-08-14",
+    "rows": 6564
+   },
+   "ACN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-07-19",
+    "last": "2026-08-14",
+    "rows": 6303
+   },
+   "ACNT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 10830
+   },
+   "ACRE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-04-26",
+    "last": "2026-08-14",
+    "rows": 3596
+   },
+   "ACTG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-07-10",
+    "last": "2026-08-14",
+    "rows": 7518
+   },
+   "ADBE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-08-13",
+    "last": "2026-08-14",
+    "rows": 10078
+   },
+   "ADI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-04-02",
+    "last": "2026-08-14",
+    "rows": 3613
+   },
+   "ADM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "ADP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-21",
+    "last": "2026-08-14",
+    "rows": 4481
+   },
+   "ADSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-06-28",
+    "last": "2026-08-14",
+    "rows": 9859
+   },
+   "AEE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-01-02",
+    "last": "2026-08-14",
+    "rows": 7196
+   },
+   "AEHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-08-15",
+    "last": "2026-08-14",
+    "rows": 7023
+   },
+   "AEO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-08",
+    "last": "2026-08-14",
+    "rows": 4891
+   },
+   "AEP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11444
+   },
+   "AES": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-06-26",
+    "last": "2026-08-14",
+    "rows": 8594
+   },
+   "AFL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11445
+   },
+   "AIG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11694
+   },
+   "AIZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-02-05",
+    "last": "2026-08-14",
+    "rows": 5644
+   },
+   "AJG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-06-20",
+    "last": "2026-08-14",
+    "rows": 10510
+   },
+   "AKAM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-10-29",
+    "last": "2026-08-14",
+    "rows": 6739
+   },
+   "ALB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-02-22",
+    "last": "2026-08-14",
+    "rows": 8172
+   },
+   "ALGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-01-26",
+    "last": "2026-08-14",
+    "rows": 6426
+   },
+   "ALL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-06-03",
+    "last": "2026-08-14",
+    "rows": 8102
+   },
+   "ALNY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-28",
+    "last": "2026-08-14",
+    "rows": 5589
+   },
+   "AMAT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11699
+   },
+   "AMD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2015-01-02",
+    "last": "2026-08-14",
+    "rows": 2921
+   },
+   "AME": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 9930
+   },
+   "AMGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-06-17",
+    "last": "2026-08-14",
+    "rows": 10622
+   },
+   "AMP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-09-15",
+    "last": "2026-08-14",
+    "rows": 5010
+   },
+   "AMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-02-27",
+    "last": "2026-08-14",
+    "rows": 7157
+   },
+   "AMZN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-05-15",
+    "last": "2026-08-14",
+    "rows": 7359
+   },
+   "ANET": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2014-06-06",
+    "last": "2026-08-14",
+    "rows": 3066
+   },
+   "ANGO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-05-27",
+    "last": "2026-08-14",
+    "rows": 5589
+   },
+   "AON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-02",
+    "last": "2026-08-14",
+    "rows": 11392
+   },
+   "AOS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-09-30",
+    "last": "2026-08-14",
+    "rows": 10648
+   },
+   "APA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "APD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "APH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-11-08",
+    "last": "2026-08-14",
+    "rows": 8748
+   },
+   "APLD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-12-10",
+    "last": "2026-08-14",
+    "rows": 3664
+   },
+   "APP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-04-15",
+    "last": "2026-08-14",
+    "rows": 1340
+   },
+   "APTV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2011-11-17",
+    "last": "2026-08-14",
+    "rows": 3705
+   },
+   "ARE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-05-28",
+    "last": "2026-08-14",
+    "rows": 7347
+   },
+   "ASML": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-03-15",
+    "last": "2026-08-14",
+    "rows": 7908
+   },
+   "ATO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-12-28",
+    "last": "2026-08-14",
+    "rows": 10734
+   },
+   "AVB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-11",
+    "last": "2026-08-14",
+    "rows": 8158
+   },
+   "AVGO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-02-02",
+    "last": "2026-08-14",
+    "rows": 2648
+   },
+   "AVY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11693
+   },
+   "AWK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-04-23",
+    "last": "2026-08-14",
+    "rows": 4607
+   },
+   "AXON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-07",
+    "last": "2026-08-14",
+    "rows": 6082
+   },
+   "AXP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "AZO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-04-02",
+    "last": "2026-08-14",
+    "rows": 8905
+   },
+   "BA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11445
+   },
+   "BAC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-01-02",
+    "last": "2026-08-14",
+    "rows": 11498
+   },
+   "BALL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11442
+   },
+   "BAX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11444
+   },
+   "BBY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-04-18",
+    "last": "2026-08-14",
+    "rows": 10409
+   },
+   "BCRX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-04",
+    "last": "2026-08-14",
+    "rows": 8161
+   },
+   "BDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11444
+   },
+   "BELFB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-07-10",
+    "last": "2026-08-14",
+    "rows": 7069
+   },
+   "BEN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-09-23",
+    "last": "2026-08-14",
+    "rows": 10759
+   },
+   "BIIB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-09-17",
+    "last": "2026-08-14",
+    "rows": 8789
+   },
+   "BKNG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-03-30",
+    "last": "2026-08-14",
+    "rows": 6888
+   },
+   "BLK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-10-04",
+    "last": "2026-08-14",
+    "rows": 6755
+   },
+   "BMY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "BR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-22",
+    "last": "2026-08-14",
+    "rows": 4629
+   },
+   "BRO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-02-11",
+    "last": "2026-08-14",
+    "rows": 9945
+   },
+   "BSX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-05-19",
+    "last": "2026-08-14",
+    "rows": 8618
+   },
+   "BXP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-06-18",
+    "last": "2026-08-14",
+    "rows": 7082
+   },
+   "CAH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-04",
+    "last": "2026-08-14",
+    "rows": 10784
+   },
+   "CB": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-25",
+    "last": "2026-08-14",
+    "rows": 8402
+   },
+   "CBRE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-06-10",
+    "last": "2026-08-14",
+    "rows": 5578
+   },
+   "CBZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-24",
+    "last": "2026-08-14",
+    "rows": 7583
+   },
+   "CCEP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-11-24",
+    "last": "2026-08-14",
+    "rows": 9752
+   },
+   "CCOI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-02-05",
+    "last": "2026-08-14",
+    "rows": 6154
+   },
+   "CDE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11669
+   },
+   "CDNS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-06-10",
+    "last": "2026-08-14",
+    "rows": 9867
+   },
+   "CEG": {
+    "depth_12q": true,
+    "depth_20q": false,
+    "file": true,
+    "first": "2022-01-19",
+    "last": "2026-08-14",
+    "rows": 1147
+   },
+   "CHD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11531
+   },
+   "CHRW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-10-15",
+    "last": "2026-08-14",
+    "rows": 7252
+   },
+   "CHTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-09-14",
+    "last": "2026-08-14",
+    "rows": 4004
+   },
+   "CI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1982-04-01",
+    "last": "2026-08-14",
+    "rows": 11180
+   },
+   "CINF": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11434
+   },
+   "CL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11443
+   },
+   "CLDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-01",
+    "last": "2026-08-14",
+    "rows": 4495
+   },
+   "CLX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "CMCSA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11439
+   },
+   "CMI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11443
+   },
+   "CMS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "CNC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-12-13",
+    "last": "2026-08-14",
+    "rows": 6204
+   },
+   "COF": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-11-16",
+    "last": "2026-08-14",
+    "rows": 7986
+   },
+   "COHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1316
+   },
+   "COST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-01-03",
+    "last": "2026-08-14",
+    "rows": 8210
+   },
+   "CPRT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1994-03-17",
+    "last": "2026-08-14",
+    "rows": 8148
+   },
+   "CRL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-23",
+    "last": "2026-08-14",
+    "rows": 6572
+   },
+   "CRM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-06-23",
+    "last": "2026-08-14",
+    "rows": 5571
+   },
+   "CRS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "CRWD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2019-06-12",
+    "last": "2026-08-14",
+    "rows": 1804
+   },
+   "CSCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1990-02-16",
+    "last": "2026-08-14",
+    "rows": 9190
+   },
+   "CSGP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-07-01",
+    "last": "2026-08-14",
+    "rows": 7067
+   },
+   "CSR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-18",
+    "last": "2026-08-14",
+    "rows": 3433
+   },
+   "CTAS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-19",
+    "last": "2026-08-14",
+    "rows": 10784
+   },
+   "CTSH": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-06-19",
+    "last": "2026-08-14",
+    "rows": 7083
+   },
+   "CVS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11443
+   },
+   "CVX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "CWST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-10-29",
+    "last": "2026-08-14",
+    "rows": 6738
+   },
+   "CXW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-12-15",
+    "last": "2026-08-14",
+    "rows": 7178
+   },
+   "D": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11694
+   },
+   "DAL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-04-26",
+    "last": "2026-08-14",
+    "rows": 4857
+   },
+   "DE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "DECK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-10-15",
+    "last": "2026-08-14",
+    "rows": 8227
+   },
+   "DELL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2018-12-21",
+    "last": "2026-08-14",
+    "rows": 1921
+   },
+   "DG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-11-13",
+    "last": "2026-08-14",
+    "rows": 4212
+   },
+   "DGX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-12-17",
+    "last": "2026-08-14",
+    "rows": 7459
+   },
+   "DHI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-05",
+    "last": "2026-08-14",
+    "rows": 8594
+   },
+   "DHR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11631
+   },
+   "DHT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-10-13",
+    "last": "2026-08-14",
+    "rows": 5240
+   },
+   "DIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "DJCO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-06-11",
+    "last": "2026-08-14",
+    "rows": 6035
+   },
+   "DLR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-10-29",
+    "last": "2026-08-14",
+    "rows": 5481
+   },
+   "DLTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-03-07",
+    "last": "2026-08-14",
+    "rows": 7663
+   },
+   "DMRC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-10-17",
+    "last": "2026-08-14",
+    "rows": 4233
+   },
+   "DOV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "DRI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-05-09",
+    "last": "2026-08-14",
+    "rows": 7866
+   },
+   "DTE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11444
+   },
+   "DUK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-01-23",
+    "last": "2026-08-14",
+    "rows": 5170
+   },
+   "DVA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-10-31",
+    "last": "2026-08-14",
+    "rows": 7745
+   },
+   "DXCM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-04-14",
+    "last": "2026-08-14",
+    "rows": 5368
+   },
+   "EA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1989-09-20",
+    "last": "2026-08-04",
+    "rows": 9285
+   },
+   "EBAY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-09-24",
+    "last": "2026-08-14",
+    "rows": 7016
+   },
+   "ECL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11192
+   },
+   "ED": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11193
+   },
+   "EFX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11675
+   },
+   "EIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "EME": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-01-10",
+    "last": "2026-08-14",
+    "rows": 7842
+   },
+   "EMR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "EOG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1989-10-04",
+    "last": "2026-08-14",
+    "rows": 9281
+   },
+   "EQIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-08-11",
+    "last": "2026-08-14",
+    "rows": 6540
+   },
+   "EQR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-08-12",
+    "last": "2026-08-14",
+    "rows": 8055
+   },
+   "ERIE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-10-02",
+    "last": "2026-08-14",
+    "rows": 7750
+   },
+   "ES": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "ESE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1990-10-01",
+    "last": "2026-08-14",
+    "rows": 9028
+   },
+   "ETN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "ETR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11697
+   },
+   "EW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-03-27",
+    "last": "2026-08-14",
+    "rows": 6634
+   },
+   "EXC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "EXPD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-09-26",
+    "last": "2026-08-14",
+    "rows": 10469
+   },
+   "EXR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-08-12",
+    "last": "2026-08-14",
+    "rows": 5536
+   },
+   "FANG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-10-12",
+    "last": "2026-08-14",
+    "rows": 3478
+   },
+   "FAST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1987-08-20",
+    "last": "2026-08-14",
+    "rows": 9810
+   },
+   "FC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-03",
+    "last": "2026-08-14",
+    "rows": 8608
+   },
+   "FDS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1996-06-28",
+    "last": "2026-08-14",
+    "rows": 7568
+   },
+   "FDX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11445
+   },
+   "FE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-11-10",
+    "last": "2026-08-14",
+    "rows": 7232
+   },
+   "FEIM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-06-18",
+    "last": "2026-08-14",
+    "rows": 11170
+   },
+   "FIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-20",
+    "last": "2026-08-14",
+    "rows": 6324
+   },
+   "FISV": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-09-25",
+    "last": "2026-08-14",
+    "rows": 10031
+   },
+   "FIX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-06-27",
+    "last": "2026-08-14",
+    "rows": 7326
+   },
+   "FLG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-11-23",
+    "last": "2026-08-14",
+    "rows": 8226
+   },
+   "FN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-06-25",
+    "last": "2026-08-14",
+    "rows": 4059
+   },
+   "FRT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11646
+   },
+   "FSLR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2006-11-17",
+    "last": "2026-08-14",
+    "rows": 4964
+   },
+   "FTNT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-11-18",
+    "last": "2026-08-14",
+    "rows": 4209
+   },
+   "GD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "GE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "GEV": {
+    "depth_12q": false,
+    "depth_20q": false,
+    "file": true,
+    "first": "2024-03-27",
+    "last": "2026-08-14",
+    "rows": 598
+   },
+   "GILD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-01-22",
+    "last": "2026-08-14",
+    "rows": 8699
+   },
+   "GLW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "GOOGL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-08-19",
+    "last": "2026-08-14",
+    "rows": 5533
+   },
+   "GS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-05-04",
+    "last": "2026-08-14",
+    "rows": 6861
+   },
+   "HD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1981-09-22",
+    "last": "2026-08-14",
+    "rows": 11309
+   },
+   "HON": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11441
+   },
+   "IDXX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-06-21",
+    "last": "2026-08-14",
+    "rows": 8851
+   },
+   "INSM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-02-15",
+    "last": "2026-08-14",
+    "rows": 8913
+   },
+   "INTC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11699
+   },
+   "INTU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-12",
+    "last": "2026-08-14",
+    "rows": 8415
+   },
+   "ISRG": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-13",
+    "last": "2026-08-14",
+    "rows": 6583
+   },
+   "JNJ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11695
+   },
+   "JPM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "KDP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2008-04-28",
+    "last": "2026-08-14",
+    "rows": 4604
+   },
+   "KLAC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-10-08",
+    "last": "2026-08-14",
+    "rows": 11040
+   },
+   "KO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "LLY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11442
+   },
+   "LMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1995-03-16",
+    "last": "2026-08-14",
+    "rows": 7904
+   },
+   "LRCX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1984-05-04",
+    "last": "2026-08-14",
+    "rows": 10653
+   },
+   "MCD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "MCHP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-03-19",
+    "last": "2026-08-14",
+    "rows": 8410
+   },
+   "MDLZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2001-06-13",
+    "last": "2026-08-14",
+    "rows": 6078
+   },
+   "MELI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-08-10",
+    "last": "2026-08-14",
+    "rows": 4783
+   },
+   "META": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-05-18",
+    "last": "2026-08-14",
+    "rows": 3580
+   },
+   "MPWR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-11-19",
+    "last": "2026-08-14",
+    "rows": 5467
+   },
+   "MRK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "MRVL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2000-06-27",
+    "last": "2026-08-14",
+    "rows": 6573
+   },
+   "MS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-02-23",
+    "last": "2026-08-14",
+    "rows": 8424
+   },
+   "MSFT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-03-13",
+    "last": "2026-08-14",
+    "rows": 10185
+   },
+   "MSTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1998-06-11",
+    "last": "2026-08-14",
+    "rows": 7089
+   },
+   "MU": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-12-30",
+    "last": "2026-08-14",
+    "rows": 4181
+   },
+   "NBIS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "NFLX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-05-23",
+    "last": "2026-08-14",
+    "rows": 6097
+   },
+   "NKE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-12-02",
+    "last": "2026-08-14",
+    "rows": 11516
+   },
+   "NOK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "NOW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-06-29",
+    "last": "2026-08-14",
+    "rows": 3551
+   },
+   "NVDA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1999-01-22",
+    "last": "2026-08-14",
+    "rows": 6934
+   },
+   "NXPI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-08-06",
+    "last": "2026-08-14",
+    "rows": 4030
+   },
+   "ORCL": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1986-03-12",
+    "last": "2026-08-14",
+    "rows": 10186
+   },
+   "ORLY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1993-04-23",
+    "last": "2026-08-14",
+    "rows": 8383
+   },
+   "OXY": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "PANW": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-07-20",
+    "last": "2026-08-14",
+    "rows": 3537
+   },
+   "PAYX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-08-26",
+    "last": "2026-08-14",
+    "rows": 10569
+   },
+   "PCAR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11694
+   },
+   "PFE": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "PLTR": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2020-09-30",
+    "last": "2026-08-14",
+    "rows": 1475
+   },
+   "QCOM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-12-13",
+    "last": "2026-08-14",
+    "rows": 8729
+   },
+   "REGN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-04-02",
+    "last": "2026-08-14",
+    "rows": 8908
+   },
+   "RIOT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-12-20",
+    "last": "2026-08-14",
+    "rows": 3432
+   },
+   "ROP": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-02-13",
+    "last": "2026-08-14",
+    "rows": 8681
+   },
+   "ROST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1985-08-08",
+    "last": "2026-08-14",
+    "rows": 10334
+   },
+   "RTX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "SBUX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-06-26",
+    "last": "2026-08-14",
+    "rows": 8342
+   },
+   "SMCI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-03-29",
+    "last": "2026-08-14",
+    "rows": 4876
+   },
+   "SNPS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1992-02-26",
+    "last": "2026-08-14",
+    "rows": 8679
+   },
+   "STX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2004-01-23",
+    "last": "2026-08-14",
+    "rows": 5671
+   },
+   "T": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-11-21",
+    "last": "2026-08-14",
+    "rows": 10765
+   },
+   "TGT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11442
+   },
+   "TMUS": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2007-04-19",
+    "last": "2026-08-14",
+    "rows": 4233
+   },
+   "TRI": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2002-06-12",
+    "last": "2026-08-14",
+    "rows": 6081
+   },
+   "TSEM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "TSLA": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2010-06-29",
+    "last": "2026-08-14",
+    "rows": 4057
+   },
+   "TSM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-05-18",
+    "last": "2026-08-14",
+    "rows": 1317
+   },
+   "TTWO": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1997-04-15",
+    "last": "2026-08-14",
+    "rows": 7359
+   },
+   "TXN": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-01-03",
+    "last": "2026-08-14",
+    "rows": 3675
+   },
+   "VRSK": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2009-10-07",
+    "last": "2026-08-14",
+    "rows": 4239
+   },
+   "VRT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2021-06-11",
+    "last": "2026-08-14",
+    "rows": 1299
+   },
+   "VRTX": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1991-07-24",
+    "last": "2026-08-14",
+    "rows": 8579
+   },
+   "VST": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2016-10-05",
+    "last": "2026-08-14",
+    "rows": 2478
+   },
+   "VZ": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1983-11-21",
+    "last": "2026-08-14",
+    "rows": 10762
+   },
+   "WBD": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2005-07-21",
+    "last": "2026-08-14",
+    "rows": 4426
+   },
+   "WDC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "2012-06-01",
+    "last": "2026-08-14",
+    "rows": 3571
+   },
+   "WFC": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11696
+   },
+   "WMT": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11196
+   },
+   "XOM": {
+    "depth_12q": true,
+    "depth_20q": true,
+    "file": true,
+    "first": "1980-03-17",
+    "last": "2026-08-14",
+    "rows": 11197
+   }
+  }
+ },
+ "window_quarters": 20
+}

--- a/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
+++ b/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
@@ -52,15 +52,17 @@ The work remains aligned with Argon's goal ladder:
 
 ## 2. Current state and evidence boundary
 
-Snapshot at the plan baseline, commit `d912d5d` on 2026-08-12:
+The plan branch started from commit `d912d5d`. Repository and PR state below was rechecked on
+2026-08-12; later status changes must be recorded rather than inferred from this snapshot.
 
 | Area | State | Evidence / constraint |
 |---|---|---|
 | P0 persistence bug | **landed** | PR #328 fixed `fundamentals_refresh` transaction behavior |
 | P1a provider/data probes | **landed** | PR #329 committed coverage, field-contract, UW, and SEC probes |
 | Fundamental method validation | **landed** | PR #329 found the composite informative at broad width but noise at core-25 width |
-| Valuation-control follow-up | **parallel research branch** | `research/fundamental-valuation-control`; not part of this plan branch baseline |
-| P1b PIT ingest | **not started** | no immutable fundamental observation tables or canonical views yet |
+| Valuation-control follow-up | **landed** | PR #330 merged with all checks passing; research evidence only, no production scoring capability |
+| Core-25 own-history test | **planned / unblocked** | test whether a name's own deterioration precedes its own drawdown; not a cross-sectional rank test |
+| P1b PIT ingest | **not started / blocked** | M0.2 remains a design gate; data-dependent execution also awaits the mini at this snapshot |
 | P2 valuation/score runtime | **not started** | only design and research artifacts exist |
 | P3 fundamental card | **not started** | no production API or UI surface yet |
 | P4 concentration/edge work | **not started** | must begin with a discovery gate |
@@ -75,11 +77,31 @@ The current broad-universe validation supports a descriptive product, not an unr
 - the core-25 AI cohort is too narrow for defensible cross-sectional ranking;
 - survivorship bias remains because current sources do not carry a complete delisted universe;
 - the study has not modeled turnover, costs, capacity, or borrow;
-- the valuation-control branch indicates that simple value directions are metric- and regime-specific;
+- margin inversion survives controls for earnings yield, book-to-price, and FCF yield, so the tested
+  expensiveness explanation is rejected and profitability direction remains withheld;
+- in the survivor-only 2005–2026 sample, book-to-price IC was `-0.0365` (`t=-2.32`), earnings yield
+  IC was `-0.0194`, and FCF yield IC was `+0.0285` (`t=2.84`); a generic
+  `valuation_position = cheaper is better` prior is contradicted;
+- the 2005–2015 and 2016–2026 split does not establish regime independence: both halves occupy the
+  same broad quality/growth-led, value-lagging window, so the evidence is explicitly “measured in one
+  regime”;
+- survivorship may have biased the observed value result toward zero or toward value, but the size of
+  that effect is unmeasured until active-plus-delisted validation exists;
 - historical estimate revisions have not been tested with a true PIT consensus dataset.
 
 No later phase may silently strengthen those statements. Stronger claims require their own recorded
 evidence and gate.
+
+Operational boundary at this snapshot:
+
+- the Mac mini is unavailable and hosts both the `option_wizard` P1b write target and the full lake
+  copy, so P1b migrations, ingest, and real-worker smoke are blocked;
+- `option_wizard_local` is not a substitute write target for P1b; doing so would violate the intended
+  environment contract and create work that must be repeated;
+- the local mirror plus UW API are sufficient for the historical core-25 M0.3 test, but the mirror's
+  stale endpoint makes it unsuitable for claims requiring current data;
+- provider-sensitive and data-current tasks resume only after the target environment is restored and
+  rechecked. A stale historical research run must never be presented as current production coverage.
 
 ## 3. Non-negotiable invariants
 
@@ -284,6 +306,9 @@ Two aggregates, if retained, must stay distinct:
 - `valuation_position` is **metric-specific / direction withheld** until the actual anchor-position
   method is validated; book-to-price, earnings yield, and FCF yield cannot be treated as one empirical
   signal;
+- no runtime schema, seed, fixture, or UI color may encode a default `cheaper_is_better` direction;
+  every valuation submetric must name its ratio, direction state, evidence version, and applicable
+  universe/regime;
 - technicals remain a separate block and do not enter the fundamental composite;
 - a score calculated over missing subdimensions records the absent set and the renormalization or
   abstention rule;
@@ -311,6 +336,29 @@ Failure of this gate does not block descriptive reports.
 The valuation-control research is a factor-control experiment, not the production valuation engine.
 The production engine has four layers.
 
+#### Valuation-control measurement contract
+
+PR #330 makes the following rules load-bearing for any reproduction or successor research:
+
+| Measurement | Required construction | Failure prevented |
+|---|---|---|
+| equity market cap | raw point-in-time `close` × as-reported shares | combining retroactively split-adjusted price with then-current shares |
+| value ratios | economic numerator ÷ raw market cap, expressed as yields | P/E changing sign through zero earnings and making a loss-maker appear cheapest |
+| rank association | the validation harness's shared Spearman implementation | control and headline results using different rank math |
+| partial rank IC | same implementation plus mandatory `--self-check` | a residualization or sign error silently reversing the verdict |
+
+The accepted control result for two-quarter forward return, 245 names, and 80 quarters is:
+
+| Signal | Uncontrolled | controlling earnings yield | controlling book-to-price | controlling FCF yield |
+|---|---:|---:|---:|---:|
+| gross margin | -0.0194 | -0.0180 | -0.0271 | -0.0144 |
+| operating margin | -0.0270 | -0.0231 | -0.0306 | -0.0298 |
+
+These values reject the stated “margin inversion is an expensiveness proxy” hypothesis. They do not
+validate a production valuation formula, establish causality, or authorize a profitability direction.
+Successor research must preserve the exact raw-price/share reference frame or declare itself a new,
+non-comparable experiment.
+
 #### D1. Normalized inputs
 
 - TTM and normalized revenue, EPS, EBITDA, EBIT, and FCF;
@@ -318,6 +366,7 @@ The production engine has four layers.
 - segment economics and company-specific KPIs;
 - reporting currency, translation rules, and ADR ratio;
 - current spot and corporate-action reference frame;
+- raw price and as-reported share reference frame for historical market-cap/yield research;
 - comparable-company observations under a versioned peer set;
 - current analyst targets as an external cross-check;
 - PIT analyst estimates only when a licensed PIT dataset is present.
@@ -591,16 +640,19 @@ policy.
 
 #### PR M0.1 — valuation-control research
 
-Scope:
+Status: **merged in PR #330** on 2026-08-12; all reported CI checks passed. This closes the control
+hypothesis, not the production valuation method.
 
-- merge the bounded valuation-control experiment and full artifacts;
+Delivered scope:
+
+- bounded valuation-control experiment and full artifacts;
 - record that controlling for tested valuation ratios does not explain margin inversion;
 - mark profitability direction as withheld;
 - mark valuation direction as metric-specific/withheld rather than generic cheaper-is-better;
 - record single-regime, survivorship, and no-cost limitations;
 - no application code.
 
-Exit checks:
+Closed checks:
 
 - self-check passes;
 - artifact regenerates deterministically from the stated command;
@@ -627,7 +679,55 @@ Exit checks:
 - the primary spec contains no stale claim that already-landed or parallel research is production
   capability.
 
-**M0 gate:** P1b is blocked until M0.2 is merged. Other research may continue.
+#### Research M0.3 — core-25 own-history deterioration test
+
+Status: **planned / unblocked**. This is the next research task that can proceed without the mini. It
+does not reopen the failed core-25 cross-sectional ranking claim.
+
+Question:
+
+> After information becomes public, does deterioration relative to a company's own history precede
+> that same company's subsequent drawdown or weak return?
+
+Preregister before running:
+
+- core-25 membership snapshot and inclusion rules;
+- knowledge-date construction and minimum history per company;
+- primary deterioration feature, transformation, lookback, threshold, and direction; profitability
+  and book/earnings value directions remain excluded unless separately justified;
+- primary outcome fixed as forward maximum drawdown; two-quarter forward total return is a secondary
+  outcome and must not replace the primary after results are seen;
+- overlap handling, missingness rules, winsorization, benchmark/market adjustment, and corporate
+  action reference frame;
+- primary statistical test, block length or clustered inference, multiple-testing policy, and fixed
+  kill thresholds;
+- expanding or walk-forward holdout dates; no full-sample threshold tuning.
+
+Required analysis:
+
+1. express each approved input as a within-company change or own-history percentile, never as a
+   contemporaneous cross-company rank;
+2. form deterioration events only from facts available by the knowledge date;
+3. compare each company's post-event outcome with its own non-event baseline and a matched market or
+   industry state;
+4. estimate pooled results with company effects and time-aware/clustered uncertainty, then show each
+   company's contribution so one name cannot dominate the verdict;
+5. run expanding-window or walk-forward evaluation and sensitivity around the preregistered threshold,
+   lookback, and horizon;
+6. persist every event, configuration, metric, exclusion, and holdout result with the exact reproduce
+   command and `--self-check` output.
+
+Exit decision:
+
+- **pass:** a stable, held-out own-history effect may seed a separately labeled deterioration/risk
+  monitor and numeric invalidation condition;
+- **fail or mixed:** keep own-history changes descriptive and record the direction as withheld;
+- either verdict does **not** unlock a cross-company composite, buy/sell ranking, or recommendation;
+- later active-plus-delisted work in M9.B must quantify whether sample selection changes this result.
+
+**M0 gate:** P1b is blocked until M0.2 is merged and the required environment is available. M0.3 may
+run in parallel and gates only a directional own-history deterioration signal, not M1 or the
+descriptive M3 product.
 
 ### M1 — immutable PIT fundamentals backbone
 
@@ -967,7 +1067,8 @@ product.
 - construct the historical universe by knowledge date;
 - include delisting returns;
 - rerun score dimensions and composite;
-- test time-series deterioration separately;
+- repeat M0.3's own-history deterioration test under the active-plus-delisted membership contract and
+  measure the survivor-only delta;
 - measure turnover, liquidity, transaction-cost assumptions, and regime stability;
 - update ranking permission from evidence.
 
@@ -1018,6 +1119,10 @@ M6 + M7
 M9 optional datasets/research run alongside M1–M8
   ├── never block descriptive M3/M4/M7
   └── do gate stronger ranking, recommendation, and revision claims
+
+M0.3 core-25 own-history research
+  └── gates only a directional deterioration/risk monitor
+      (never blocks descriptive M1/M3 and never unlocks cross-company ranking)
 ```
 
 M4 can begin its schema/matrix skeleton alongside M2, but the route cannot ship comparative
@@ -1030,6 +1135,7 @@ M6, but M8 requires both the report ledger and the narrative/audit boundary.
 | Gate | Required evidence | Unlocks |
 |---|---|---|
 | G0 — spec consistent | one source policy, compatible acceptance tests, research limits recorded | P1b implementation |
+| G0T — own-history direction supported | preregistered PIT events, time-aware inference, held-out stability, full trace | deterioration/risk monitor only |
 | G1 — data trustworthy | PIT replay, restatement preservation, violation handling, measured coverage | deterministic engine |
 | G2 — method fixed | worked examples, version/hash identity, abstention and confidence rules | UI rendering |
 | G3 — deterministic product | worker-path smoke, provenance drill-down, stale/partial behavior | narrative and reports |
@@ -1050,7 +1156,7 @@ into the child PRs already listed; no PR inherits the milestone size as one unit
 
 | Milestone | Size | Primary risk driver | Lower-risk release shape |
 |---|---:|---|---|
-| M0 method/spec | S | encoding contradictory research conclusions | docs/research only, no runtime changes |
+| M0 method/spec | S/M | encoding contradictory research conclusions or overreading own-history evidence | docs/research only, no runtime changes |
 | M1 PIT data | L | immutable identity, backfill, source disagreement, foreign issuers | additive tables → backfill → verify → canonical views |
 | M2 valuation/score | L | method ambiguity and false comparability | pure derivations → anchors → dimensions/runs |
 | M3 company card | M | stale/partial state and provenance trust | hidden tab/flag, deterministic only |
@@ -1116,6 +1222,12 @@ fresh browser request; in-process success alone is not evidence of durable state
 - persist every configuration and metric, not only the headline;
 - keep exact reproduce command and data/version manifest;
 - verify realized cross-section width and knowledge-time bucketing;
+- test raw-close × as-reported-shares construction across split events and forbid adjusted-close/raw-
+  shares mixtures;
+- define valuation research as yields across zero and negative numerators; do not substitute P/E;
+- run the shared Spearman/partial-correlation self-check before accepting any directional verdict;
+- distinguish broad-sample cross-sectional evidence from core-25 own-history evidence and label the
+  2005–2026 result as single-regime;
 - separate factor ordering, investment strategy, and live utility claims.
 
 ### Storage and compute

--- a/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
+++ b/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
@@ -1,0 +1,1247 @@
+# Fundamental PM Agent — Program Plan
+
+> **Status:** active program plan. This is the cross-phase roadmap, not a claim that one PR can
+> deliver the system. Every build milestone below gets its own child implementation plan before
+> code starts.
+
+**Goal:** turn Argon into a trustworthy, extensible research surface where an operator can ask about
+a company, an industry chain, or a narrow sub-chain and receive a versioned, evidence-linked report
+covering fundamentals, valuation, score dimensions, catalysts, risks, technical context, and explicit
+unknowns.
+
+**Architecture:** Argon owns point-in-time facts, deterministic computations, typed jobs, audit
+results, report persistence, permissions, and UI. Model providers may synthesize prose over those
+fixed outputs but may not change facts, valuation anchors, scores, taxonomy evidence, or method
+parameters. A later external harness may plan and trigger bounded research workflows through narrow
+Argon command APIs; it does not receive raw database write access.
+
+**Primary design:** `docs/superpowers/specs/2026-08-10-fundamental-pm-agent-design.md`
+
+**Tech stack:** Python 3 via `uv`, FastAPI/Pydantic v2, psycopg/Postgres, APScheduler workers,
+Next.js/React/TypeScript, existing Argon provider runners, SEC/UW/Massive/livewire inputs, and
+optional separately licensed research datasets.
+
+---
+
+## 1. Program boundary
+
+This program has four successive products. They must not be collapsed into one PR or one release:
+
+1. **Deterministic research engine** — point-in-time observations, financial derivations, valuation
+   anchors, score dimensions, confidence, and provenance.
+2. **Decision surfaces** — a single-stock fundamental card and a generalizable industry-chain view.
+3. **Audited research reports** — structured narrative, claims, evidence links, versions, deltas,
+   and publication gates.
+4. **Agent harness** — a later control plane that interprets a research request, constructs a bounded
+   task graph, calls approved Argon jobs, and produces or refreshes report drafts.
+
+The following are explicitly outside the first three products:
+
+- automatic trading or order staging;
+- an automatically reweighted score;
+- autonomous edits to valuation assumptions or taxonomy facts;
+- an implied promise that a score forecasts returns;
+- mandatory dependence on Sharadar, LSEG, or FactSet;
+- a ranked long/short book.
+
+The work remains aligned with Argon's goal ladder:
+
+- deterministic facts and surfaces belong to Stage 1, trustworthy foundation;
+- the report control plane and self-tending harness belong to Stage 2;
+- recommendations or proposals require separate, stronger gates and are not implied by this plan.
+
+## 2. Current state and evidence boundary
+
+Snapshot at the plan baseline, commit `d912d5d` on 2026-08-12:
+
+| Area | State | Evidence / constraint |
+|---|---|---|
+| P0 persistence bug | **landed** | PR #328 fixed `fundamentals_refresh` transaction behavior |
+| P1a provider/data probes | **landed** | PR #329 committed coverage, field-contract, UW, and SEC probes |
+| Fundamental method validation | **landed** | PR #329 found the composite informative at broad width but noise at core-25 width |
+| Valuation-control follow-up | **parallel research branch** | `research/fundamental-valuation-control`; not part of this plan branch baseline |
+| P1b PIT ingest | **not started** | no immutable fundamental observation tables or canonical views yet |
+| P2 valuation/score runtime | **not started** | only design and research artifacts exist |
+| P3 fundamental card | **not started** | no production API or UI surface yet |
+| P4 concentration/edge work | **not started** | must begin with a discovery gate |
+| P5 narrative/audit queue | **not started** | current trade-insight queue is not a legal or semantic parent |
+| General industry research | **taxonomy skeleton only** | current watchlist has layer/chain membership, not a versioned exposure graph |
+| Versioned report object | **not started** | a narrative row is not yet a report control plane |
+| Loop harness | **deliberately deferred** | §10 of the primary design; not a missing task in the current research PR |
+
+The current broad-universe validation supports a descriptive product, not an unrestricted ranking:
+
+- the 245-name run found measurable two-quarter ordering;
+- the core-25 AI cohort is too narrow for defensible cross-sectional ranking;
+- survivorship bias remains because current sources do not carry a complete delisted universe;
+- the study has not modeled turnover, costs, capacity, or borrow;
+- the valuation-control branch indicates that simple value directions are metric- and regime-specific;
+- historical estimate revisions have not been tested with a true PIT consensus dataset.
+
+No later phase may silently strengthen those statements. Stronger claims require their own recorded
+evidence and gate.
+
+## 3. Non-negotiable invariants
+
+### 3.1 Evidence and time
+
+1. Every source fact records provider identity, economic period, publication/knowledge time, first
+   observation time, and source payload identity.
+2. A restatement creates a new immutable observation. It does not overwrite the fact consumed by an
+   old report.
+3. Point-in-time queries filter on when the market could have known the fact, not when Argon fetched
+   it.
+4. Provider disagreements are persisted and rendered; canonical selection is rule-based and
+   versioned.
+5. A missing or invalid input produces `na` with a reason. No model fills it by plausibility.
+
+### 3.2 Deterministic method
+
+1. Python computes every number.
+2. Every deterministic output carries `engine_version`, `inputs_hash`, and exact source observation
+   references.
+3. Same method plus same inputs produces the same result.
+4. Method parameters are immutable per version and activated through one explicit pointer.
+5. An agent may request recomputation but cannot edit the active method or its weights.
+
+### 3.3 Model behavior
+
+1. Models consume a bounded, persisted payload.
+2. Models cannot move valuation anchors, score values, source facts, or relationship confidence.
+3. Claims distinguish disclosed fact, deterministic derivation, inference, and unsupported unknown.
+4. Numeric and evidence audits run before publication.
+5. Provider failure degrades to deterministic surfaces; it never removes the underlying analysis.
+
+### 3.4 Cost and licensing
+
+1. Every provider capability has a cost, entitlement, retention, display, and LLM-processing policy.
+2. Website reads use persisted data; they do not trigger uncontrolled full-provider refreshes.
+3. A report declares omitted capabilities when the data is unavailable or over budget.
+4. A personal-use license cannot be assumed valid for professional, entity, multi-user, or commercial
+   use.
+5. Trial success does not grant production rights; legal/contract fields are part of the data gate.
+
+## 4. Target architecture
+
+```text
+TRIGGER
+  manual question | page action | schedule | filing | earnings | licensed news/event
+      ↓
+SCOPE
+  report type | domain | chain | ticker set | as-of | freshness | budget
+      ↓
+EVIDENCE
+  immutable observations → validation verdicts → PIT canonical views
+      ↓
+DETERMINISTIC COMPUTE
+  DERIVE → ANCHOR → SCORE → chain rollups
+      ↓
+REPORT ASSEMBLY
+  fixed blocks + optional model narrative + claims/evidence links
+      ↓
+AUDIT AND GATE
+  numeric | source | PIT | inference | coverage | contradiction | authorization
+      ↓
+PERSIST AND RENDER
+  report version | delta from prior | approval state | feedback
+```
+
+The later harness sits above this flow. It does not replace it:
+
+```text
+external harness
+  ├── read research state and previous reports
+  ├── build a bounded task DAG
+  ├── enqueue typed Argon jobs
+  ├── wait for persisted outputs
+  ├── request report assembly
+  └── propose follow-up work
+
+external harness MUST NOT
+  ├── write raw observations
+  ├── edit score/valuation parameters
+  ├── approve inferred taxonomy facts
+  ├── bypass report audits
+  └── trade
+```
+
+## 5. Workstreams
+
+The milestones in §7 sequence delivery. These workstreams define the enduring capabilities each
+milestone contributes.
+
+### Workstream A — point-in-time data and evidence
+
+#### Source roles
+
+The intended fundamentals policy is:
+
+| Priority | Source | Role |
+|---:|---|---|
+| 1 | UW statements | quarterly backbone and reported currency |
+| 2 | Massive `/vX` | filing-date enrichment and independent drift/discrepancy check |
+| 3 | SEC XBRL | authoritative gap fill, including NCI/current debt where available |
+| 4 | Massive `/v2` | narrow historical metadata such as ADR share factor, not current backbone |
+| — | explicit `na` | all sources absent, invalid, or non-comparable |
+
+**Precondition:** the primary design still contains a stale architecture row that reverses this
+precedence. Milestone M0 must reconcile the decision table, canonical-view text, P1b description,
+tests, and field contract before an ingest implementation is allowed to encode the rule.
+
+#### Required data layers
+
+1. **Source observations** — immutable statements, segments, SEC filings, extracted relationships,
+   and validation violations.
+2. **Canonical PIT views** — one selected usable fact per company/period/field under a documented
+   precedence and as-of boundary.
+3. **Derived facts** — TTM, growth, margins, balance-sheet and segment measures, computed by pure
+   functions.
+4. **Versioned results** — valuation anchors, score dimensions, chain rollups, confidence, and
+   coverage.
+5. **Report evidence** — exact result and observation references used by every published claim.
+
+References are enforceable data, not opaque JSON arrays. Before M1.1 freezes migrations, the child
+design must choose typed association tables for result → observation provenance. M7 similarly uses a
+typed claim-evidence table that identifies evidence kind and a real foreign-key target (or separate
+association table per target kind); one polymorphic `evidence_id` with no enforceable foreign key is
+not accepted. JSON may cache a rendered manifest, but it is not the authoritative relationship.
+
+#### Data-quality minimums
+
+- absolute accounting identities are checked during ingest;
+- invalid observations remain stored but are excluded from downstream arithmetic;
+- fiscal periods key on economic period end, not convenient calendar labels;
+- foreign issuers carry explicit currency, translation, ADR, and NCI treatment;
+- each ticker reports its own usable history rather than inheriting a global coverage claim;
+- all provider probes retain HTTP/result state so zero rows cannot be confused with an error.
+
+### Workstream B — general industry-chain model
+
+The current AI taxonomy is the first content pack, not the permanent schema.
+
+```text
+research_domain
+  └── industry
+       └── layer
+            └── chain
+                 └── company_exposure
+                      └── evidence
+```
+
+A company exposure needs more than membership:
+
+| Field | Meaning |
+|---|---|
+| role | supplier, customer, equipment, material, substitute, end demand, or other typed role |
+| exposure strength | disclosed share where available; otherwise bounded qualitative level |
+| valid period | when the relationship or classification is believed to hold |
+| evidence | filing, company disclosure, provider record, or reviewed inference |
+| status | disclosed, derived, inferred, disputed, expired, or unsupported |
+| confidence | mechanical score with reasons, not model sentiment |
+| version | taxonomy/exposure version used by a report |
+
+Domain-specific metrics are plugins, not branches in the central pipeline:
+
+| Domain | Example additions |
+|---|---|
+| semiconductor | node, capacity, utilization, book-to-bill, equipment exposure |
+| optical communication | 400G/800G/1.6T mix, DSP, EML, silicon photonics, module/customer mix |
+| robotics | sensors, motion control, reducers, motors, controllers, backlog, penetration |
+| power/energy | capacity, rate base, PPA, load growth, fuel/commodity sensitivity |
+| metals/mining | reserves, grade, AISC, production, jurisdiction, commodity scenario |
+| software | ARR, NRR, RPO, SBC, FCF margin, cohort/seat exposure |
+
+Adding a domain must not require changes to run orchestration, report versioning, or audit logic.
+
+### Workstream C — score stack
+
+The product must not compress unlike questions into one unexplained number.
+
+#### Persisted dimensions
+
+| Dimension | Question |
+|---|---|
+| fundamental quality | is the operating and cash-generation base durable? |
+| growth | what is growing, and is growth accelerating or decelerating? |
+| balance sheet | how much financial fragility exists? |
+| valuation position | where is spot relative to applicable valuation anchors? |
+| technical state | what does the market currently confirm or reject? Kept outside fundamentals |
+| catalyst/expectation | what could change the market's information set? |
+| research confidence | how complete, fresh, comparable, and well-sourced is the analysis? |
+| research priority | which unresolved or changing names deserve attention first? |
+
+Two aggregates, if retained, must stay distinct:
+
+- **investment attractiveness** summarizes approved investment dimensions but is not called a return
+  forecast and is not automatically actionable;
+- **research priority** ranks attention using change, uncertainty, event importance, disagreement,
+  stale coverage, and catalyst timing; it does not mean “buy first.”
+
+#### Direction policy at this program baseline
+
+- profitability levels and trends render descriptively; no good/bad direction is claimed while the
+  observed margin inversion remains unexplained;
+- `valuation_position` is **metric-specific / direction withheld** until the actual anchor-position
+  method is validated; book-to-price, earnings yield, and FCF yield cannot be treated as one empirical
+  signal;
+- technicals remain a separate block and do not enter the fundamental composite;
+- a score calculated over missing subdimensions records the absent set and the renormalization or
+  abstention rule;
+- core-25 surfaces may display a company's own dimensions but may not order multiple companies by the
+  composite.
+
+#### Ranking gate
+
+Cross-company ranking is allowed only for the exact population and method that satisfy all of:
+
+1. comparable inputs and recorded missingness;
+2. realized cross-section broad enough for the intended test;
+3. correct knowledge-time/PIT construction;
+4. active and delisted membership or a measured survivorship bound;
+5. held-out/out-of-sample evidence;
+6. multiple market regimes or an explicit regime limitation;
+7. turnover, cost, liquidity, capacity, and shorting assumptions where relevant;
+8. stable score behavior under reasonable parameter perturbation;
+9. versioned validation artifact and a stated horizon.
+
+Failure of this gate does not block descriptive reports.
+
+### Workstream D — valuation engine
+
+The valuation-control research is a factor-control experiment, not the production valuation engine.
+The production engine has four layers.
+
+#### D1. Normalized inputs
+
+- TTM and normalized revenue, EPS, EBITDA, EBIT, and FCF;
+- cash, debt, net debt, diluted shares, and enterprise value;
+- segment economics and company-specific KPIs;
+- reporting currency, translation rules, and ADR ratio;
+- current spot and corporate-action reference frame;
+- comparable-company observations under a versioned peer set;
+- current analyst targets as an external cross-check;
+- PIT analyst estimates only when a licensed PIT dataset is present.
+
+#### D2. Company-type routing
+
+| Company type | Candidate methods |
+|---|---|
+| semiconductor/hardware | normalized EPS, FCF, EV/EBITDA, cycle-adjusted scenarios |
+| cloud/platform | SOTP, FCF, EPS, segment multiples |
+| SaaS/high-growth software | revenue multiple, FCF path, margin scenarios |
+| data-center/electrical equipment | EV/EBITDA, FCF, backlog/order sensitivity |
+| utility/power | DCF, EV/EBITDA, rate-base/capacity cases |
+| energy/metals | NAV, commodity cases, normalized FCF |
+| industrial/robotics | EBIT/FCF, EV/EBITDA, order/backlog cycle |
+
+Company type is historized input data. The agent does not choose it during prose generation.
+
+#### D3. Scenario and method outputs
+
+Each applicable method produces independently persisted bear/base/bull assumptions and price outputs
+for the declared horizon. The blend then produces:
+
+```text
+buy_below
+observe_low
+observe_mid
+observe_high
+risk_above
+```
+
+These are decision anchors, not a point prediction. Each result includes applicability, sensitivity,
+confidence, and abstention reasons.
+
+#### D4. Blend and validation
+
+- method weights are versioned by company type and coverage, never authored by an LLM;
+- analyst targets are external evidence, not ground truth;
+- greater disagreement between applicable methods mechanically lowers confidence;
+- missing critical inputs cause the affected method to abstain;
+- peer set, spot date, share count, currency, and net-debt reference date are included in
+  `inputs_hash`;
+- validation covers reproducibility, sensitivity, band width, forward coverage, regime dependence,
+  and whether a valuation gap is merely quality/industry/momentum exposure.
+
+### Workstream E — company and chain analysis
+
+The single-company surface supplies the atomic rows; the chain surface is a read-time comparison over
+compatible versions.
+
+Every chain/layer report may show separately:
+
+1. operating strength;
+2. valuation pressure and method disagreement;
+3. technical breadth;
+4. catalyst density;
+5. customer/segment/geographic concentration;
+6. upstream/downstream dependency;
+7. estimate-revision state, only when true PIT data exists;
+8. coverage and research confidence;
+9. explicit unknowns.
+
+The first chain view must not color small cells by an unvalidated composite. Initial comparative
+encodings use coverage, confidence, valuation distributions, raw financial trends, and separately
+labeled technical breadth. Every rollup drills down to companies and evidence.
+
+### Workstream F — audited reports and harness
+
+#### Report types
+
+- single-company deep dive;
+- two-to-five company comparison;
+- full industry-chain report;
+- sub-chain dive-in;
+- pre-earnings brief;
+- post-earnings delta report;
+- filing/news impact report;
+- periodic watchlist brief.
+
+#### Report contract
+
+Every report version contains:
+
+- research scope, universe, taxonomy version, as-of, and freshness policy;
+- input manifest and deterministic engine versions;
+- data coverage and omitted capabilities;
+- market/technical context;
+- financial changes;
+- valuation anchors and method disagreement;
+- score dimensions and confidence;
+- chain position and dependencies;
+- catalysts, risks, invalidation conditions, and unknowns;
+- claims linked to exact evidence;
+- audit verdicts;
+- cost/usage summary;
+- delta from the prior comparable report.
+
+#### Harness levels
+
+| Level | Capability | Publication authority |
+|---:|---|---|
+| 0 | fixed pipeline from a page action | deterministic output only |
+| 1 | question → bounded plan → report draft | operator publishes |
+| 2 | filing/earnings/event-triggered delta draft | operator publishes |
+| 3 | scheduled monitoring and stale-report refresh | operator publishes |
+| 4 | auto-publish audit-clean descriptive reports | explicit policy required |
+| 5 | ranked/recommendation output | separate empirical and approval gate |
+
+The program's first harness target is Levels 1–2. Level 4 is not assumed, and Level 5 is outside the
+descriptive-report entry gate.
+
+## 6. Data-cost and procurement plan
+
+### 6.1 Capability cost classes
+
+| Class | Description | Default behavior |
+|---|---|---|
+| C0 | already persisted or free authoritative data | use first |
+| C1 | existing metered entitlement such as UW | budgeted incremental refresh; cache aggressively |
+| C2 | low-cost research subscription | research-only until license and value gates pass |
+| C3 | quote-based institutional feed | optional capability; never a silent runtime dependency |
+
+Every capability registry entry records:
+
+```text
+provider
+capability
+license_class
+fixed_subscription_cost
+marginal_request_cost
+rate_limit
+refresh_frequency
+retention_rights
+display_rights
+derived-data rights
+LLM-processing permission
+coverage
+freshness
+fallback
+last_contract_reviewed_at
+```
+
+Every research/report run records estimated and actual provider usage, cache hits, paid capabilities
+invoked, and conclusions omitted because of budget or entitlement.
+
+### 6.2 Tier 0/1 — current stack
+
+Use existing UW, Massive, SEC, livewire, Argon technical/options/flow data, and already entitled news
+or event sources. This tier supports:
+
+- descriptive company reports;
+- current valuation anchors;
+- current chain comparison;
+- current analyst target/ratings context;
+- earnings calendar, filings, technicals, options, and market structure.
+
+It does **not** support a claim that historical consensus revisions predict returns. Current analyst
+targets are not a substitute for a daily PIT consensus history.
+
+### 6.3 Tier 2 — Sharadar research track
+
+Purpose:
+
+- build historical active-plus-delisted universes;
+- reduce survivorship bias;
+- obtain permanent security identities, corporate actions, and delisting history;
+- pair PIT fundamentals with correct future-return labels.
+
+SEP/prices alone is insufficient for fundamental-score validation; the test needs prices, security
+master, and PIT fundamentals.
+
+Public personal-use pricing observed on 2026-08-11 was approximately $19/month for fundamentals,
+$9/month for prices, and $29/month for the bundle. This is a planning snapshot, not a procurement
+promise; pricing must be rechecked. More importantly, the personal license restricts professional,
+entity, redistribution, and retention uses. The subscription must not be copied into production
+until the actual Argon use and license rights are confirmed.
+
+Procurement gate:
+
+1. use the free sample to validate fields, PIT semantics, identifiers, adjustments, and ingest size;
+2. classify Argon's use as personal or professional/entity use;
+3. obtain written clarification for internal web display, backend analysis, LLM processing, derived
+   report display, and post-termination retention;
+4. preregister the active-plus-delisted validation before viewing results;
+5. purchase the minimum valid package/license;
+6. run the bounded study and persist its full trace under the permitted terms;
+7. decide whether to retain, upgrade, or reject the dataset.
+
+Sharadar gates ranking claims; it does not gate the deterministic card or descriptive report.
+
+References:
+
+- <https://data.nasdaq.com/databases/SEP>
+- <https://sharadar.com/subscribe>
+- <https://sharadar.com/terms>
+
+### 6.4 Tier 3 — LSEG I/B/E/S or FactSet PIT Consensus
+
+Purpose:
+
+- daily historical consensus snapshots;
+- EPS/revenue and company-specific estimate revisions;
+- revision breadth, acceleration, dispersion, and analyst-count change;
+- actuals and, where licensed, company guidance;
+- validation of whether expectation changes add predictive or explanatory value.
+
+These are quote-based institutional capabilities. They are not P1b dependencies and must not appear
+as required fields in the deterministic v1 card.
+
+Before requesting a trial, freeze a common vendor field contract:
+
+- permanent company and security IDs;
+- snapshot/effective timestamp and local-market cutoff;
+- fiscal period, period type, horizon, and accounting basis;
+- metric, currency, units, mean/median/high/low/dispersion, and analyst count;
+- estimate additions, withdrawals, and revisions;
+- individual broker estimates if the hypothesis requires them;
+- actual value and first-known timestamp;
+- guidance range, metric, period, source, and issue timestamp if included;
+- corporate-action, currency, dilution, restatement, and correction policy;
+- active/delisted coverage;
+- API/bulk/non-display rights;
+- internal Argon display, LLM processing, derived-report, and retention rights.
+
+Pre-register the tests before the bake-off:
+
+- 20/60/90-day EPS and revenue revision;
+- revision breadth and acceleration;
+- dispersion and analyst-count changes;
+- guidance midpoint versus consensus;
+- actual surprise and post-earnings revision drift;
+- upstream/downstream revision diffusion;
+- incremental value after momentum, surprise, industry, size, and existing fundamental controls.
+
+Purchase one provider only if the trial demonstrates adequate coverage, correct PIT behavior,
+incremental out-of-sample value, usable rights, and acceptable total cost. Failure leaves the
+expectation-revision block explicitly unsupported without degrading other reports.
+
+References:
+
+- <https://www.lseg.com/en/data-analytics/financial-data/company-data/ibes-estimates>
+- <https://insight.factset.com/resources/at-a-glance-factset-estimates-point-in-time-consensus>
+
+### 6.5 Runtime cost policy
+
+Provider resolution order:
+
+```text
+persisted compatible result
+→ persisted PIT fact
+→ free/already-entitled incremental refresh
+→ C2 research capability if the run is authorized
+→ C3 institutional capability if the run is authorized
+→ explicit unsupported/omitted block
+```
+
+Each harness/report request has maximum wall time, provider calls, paid units, model tokens, retries,
+and freshness. Exceeding a limit produces a partial, labeled draft; it does not silently exceed the
+budget or fabricate the missing section.
+
+## 7. Milestones and PR sequence
+
+Each PR below is independently reviewable, has one primary responsibility, and includes tests,
+documentation, registry changes, and `[Unreleased]` changelog entry where it changes shipped
+behavior. Research-only PRs persist complete artifacts and reproduce commands.
+
+### M0 — close the method and specification boundary
+
+**Purpose:** prevent known research conclusions and stale design text from being encoded as runtime
+policy.
+
+#### PR M0.1 — valuation-control research
+
+Scope:
+
+- merge the bounded valuation-control experiment and full artifacts;
+- record that controlling for tested valuation ratios does not explain margin inversion;
+- mark profitability direction as withheld;
+- mark valuation direction as metric-specific/withheld rather than generic cheaper-is-better;
+- record single-regime, survivorship, and no-cost limitations;
+- no application code.
+
+Exit checks:
+
+- self-check passes;
+- artifact regenerates deterministically from the stated command;
+- Markdown, JSON, VERDICT, and spec numbers agree;
+- no conclusion implies production valuation anchors have been validated.
+
+#### PR M0.2 — source-precedence/spec errata
+
+Scope:
+
+- reconcile A4, canonical views, P1b, source diagrams, tests, and field contract to the measured UW
+  backbone/Massive cross-check/SEC gap-fill policy;
+- resolve the G2 acceptance wording so core-25 cells cannot be colored by composite ranking;
+- distinguish a descriptive-report harness gate from a ranking/action gate;
+- reconcile A11's proposed refresh URI with Argon's standing mutation boundary: fundamental read
+  endpoints remain on the fundamental router, while enqueue/cancel mutations are owned by
+  `api/routers/jobs.py` under `/api/jobs`;
+- no ingest implementation.
+
+Exit checks:
+
+- one source policy appears everywhere;
+- every acceptance condition can be satisfied simultaneously;
+- the primary spec contains no stale claim that already-landed or parallel research is production
+  capability.
+
+**M0 gate:** P1b is blocked until M0.2 is merged. Other research may continue.
+
+### M1 — immutable PIT fundamentals backbone
+
+#### PR M1.1 — observation schema and repository domain
+
+Scope:
+
+- migrations for statement, segment, segment-revenue, SEC-document, and violation observations;
+- freeze the observation identity/reference contract that later typed result-provenance associations
+  will target; result association tables themselves land with the result tables in M2;
+- dataset-registry entries and generated policy documentation;
+- repository domain module rather than additions to aggregate `repository.py`;
+- immutable identity/content-hash and sighting semantics;
+- fixtures for restatement, invalid accounting identity, and provider conflict.
+
+#### PR M1.2 — UW backfill and incremental ingest
+
+Scope:
+
+- UW statements and revenue breakdown as the backbone;
+- backfill and incremental modes sharing one normalization path;
+- per-row validation verdicts;
+- idempotent unchanged refresh;
+- per-ticker coverage artifact.
+
+#### PR M1.3 — Massive reconciliation and SEC gap fill
+
+Scope:
+
+- Massive filing-date metadata and discrepancy observations;
+- SEC XBRL gap fill with `us-gaap` and `ifrs-full` handling;
+- foreign issuer currency/ADR/NCI contract;
+- canonical PIT views and discrepancy read surface.
+
+M1 exit gate:
+
+- all core names reach their measured source-specific spans;
+- unchanged re-ingest writes no new fact;
+- simulated restatement preserves predecessor;
+- invalid raw values remain inspectable but downstream fields abstain;
+- selected canonical facts reproduce from source observations at an arbitrary as-of;
+- real worker/database path passes against the correct database tier.
+
+### M2 — deterministic derivation, valuation, and score
+
+#### PR M2.1 — pure derivation engine
+
+Scope:
+
+- TTM, YoY growth/acceleration, margins, FCF, leverage, coverage, return/capital efficiency, and
+  concentration primitives;
+- pure functions with unit-normalized inputs;
+- worked examples and property/identity tests;
+- no UI and no model calls.
+
+#### PR M2.2 — company-type and valuation engine
+
+Scope:
+
+- historized company-type registry;
+- method registry and per-type implementations;
+- bear/base/bull assumptions and five price anchors;
+- applicability, abstention, confidence, and sensitivity;
+- typed valuation-result → source-observation provenance associations;
+- immutable method versions and singleton active pointer.
+
+#### PR M2.3 — score dimensions and run ledger
+
+Scope:
+
+- independent score dimensions, confidence, and research priority;
+- explicit missing-dimension/renormalization contract;
+- typed score-result → source-observation provenance associations;
+- `fundamental_runs`, stage state, typed output associations, and active-run uniqueness;
+- cached recompute and external-refresh modes;
+- typed enqueue/cancel job API on `api/routers/jobs.py`, returning `202`; the fundamental router stays
+  read-only.
+
+M2 exit gate:
+
+- three hand-worked companies reproduce derivations, anchors, and dimensions;
+- same inputs/method reuse the same logical result;
+- changing company type or any method input changes `inputs_hash`;
+- old and new method versions coexist;
+- no core-25 endpoint sorts by composite;
+- no model is needed for any output.
+
+### M3 — deterministic single-company product
+
+#### PR M3.1 — fundamental API contract
+
+Scope:
+
+- new read-only fundamental router and Pydantic models;
+- run status, current compatible result, history, coverage, and provenance endpoints;
+- typed fundamental job status linked from the existing jobs surface;
+- generated TypeScript contract;
+- stale/missing/incompatible version behavior.
+
+#### PR M3.2 — stock-page fundamental card
+
+Scope:
+
+- financial trends and data-quality/coverage;
+- independent score dimensions and confidence reasons;
+- valuation anchors, scenarios, and method disagreement;
+- provenance drill-down, unknowns, and explicit `na` reasons;
+- compute/refresh action with queued status;
+- loading, stale, partial, error, and provider-unavailable states.
+
+M3 exit gate:
+
+- every rendered number resolves to a persisted deterministic row and source observations;
+- provider/model disablement leaves the last compatible deterministic result usable;
+- stale result is visibly stale;
+- real enqueue → worker → database → API → browser smoke passes.
+
+At M3, the first useful product exists. Later narrative and harness phases must not delay release of
+this deterministic card.
+
+### M4 — general industry-chain surface
+
+#### PR M4.1 — versioned domain/exposure model
+
+Scope:
+
+- versioned domain/layer/chain definitions;
+- company exposure role, validity, evidence, confidence, and status;
+- migration/import from current `watchlist_chain` without pretending old membership has stronger
+  evidence than it does;
+- additive dual-read parity period: the current watchlist filter continues reading `watchlist_chain`
+  until the versioned model reproduces membership and multi-chain behavior, then the read path flips
+  behind a flag;
+- proposal/review path for inferred relationship changes.
+
+#### PR M4.2 — chain matrix and drill-down
+
+Scope:
+
+- AI as the first content pack;
+- compatible-version rollups;
+- coverage/confidence/valuation-distribution/financial-trend encodings;
+- active-watchlist and broader-research-universe scopes clearly distinguished;
+- cell → company → fundamental-card drill-down.
+
+#### PR M4.3 — semiconductor/optical-communication dive-in
+
+Scope:
+
+- prove extension with a narrow sub-chain spanning switch ASIC, DSP, module, EML/laser, silicon
+  photonics, fiber/connector, system vendor, and cloud demand;
+- add domain metrics through registries/plugins;
+- publish evidence and unknowns for every relationship.
+
+M4 exit gate:
+
+- adding the optical sub-chain does not change central run/report orchestration;
+- small cells are not ranked by composite;
+- every aggregate discloses coverage and version compatibility;
+- a user can move from domain to sub-chain to company evidence without a second scoring path.
+
+### M5 — concentration, filings, and catalyst evidence
+
+#### PR M5.1 — discovery gate
+
+Scope:
+
+- read-only core-universe probe for named customer, segment, country, and relationship evidence;
+- measured yield, false-positive review, 10-K/20-F coverage, and cost;
+- explicit ship/kill recommendation for each extraction class.
+
+#### PR M5.2 — approved SEC/concentration ledger
+
+Scope only for classes that pass M5.1:
+
+- durable filing cache by accession;
+- versioned extraction runs and fact membership/retraction;
+- segment/customer/country concentration with citations;
+- disclosed versus inferred identities;
+- bounded retry/rate behavior.
+
+#### PR M5.3 — catalyst/event ledger
+
+Scope:
+
+- earnings dates, guidance where sourceable, filings, product/industry events, and licensed news
+  references;
+- effective/known-at timestamp, materiality, affected domains/chains/companies, source quality, and
+  expiration/resolution;
+- no historical revision claim without PIT estimate data.
+
+M5 exit gate:
+
+- failed discovery classes are killed, not carried as perpetual empty UI;
+- every shipped concentration/event fact has source and known-at time;
+- inferred identities cannot be rendered as disclosed fact;
+- reprocessing a filing/event is idempotent.
+
+### M6 — constrained narrative and audit
+
+#### PR M6.1 — domain-isolated narrative queue
+
+Scope:
+
+- `fundamental_narrative_analyses` and dedicated repository/worker role;
+- provider-neutral runner interface, with the deployable provider first;
+- add `ai-fundamental` to scheduler role validation/group selection, configuration, compose service,
+  heartbeat, queue-depth health, and operational documentation; it is not implied by the existing
+  `ai-deepseek` role;
+- persisted input payload, prompt, schema, resolved model, raw failure output, and status;
+- structured company narrative only; no general loop planner.
+
+#### PR M6.2 — deterministic and model audit
+
+Scope:
+
+- numeric equality/tolerance checks;
+- evidence existence and source-quality checks;
+- PIT/as-of checks;
+- disclosed/inferred/unsupported-language checks;
+- mandatory unknowns and numeric invalidation conditions;
+- claim-level pass/warn/fail/unverifiable;
+- fail suppression from published narrative.
+
+M6 exit gate:
+
+- real enqueue → dedicated worker → structured outcome → audits → UI passes;
+- model/provider failure leaves M3/M4 surfaces usable;
+- model cannot alter any deterministic value;
+- audit-failed claims do not appear as report facts;
+- fundamental rows never enter the trade-insight outcome ledger.
+
+### M7 — versioned report product
+
+M7 depends on the deterministic M3/M4 products and M5 being resolved. It does **not** depend on a
+successful model narrative. M6 may land before or alongside it, and its audited output becomes an
+optional report block. This preserves the invariant that reports remain useful when the provider is
+disabled.
+
+#### PR M7.1 — report/control ledger
+
+Scope:
+
+- `research_runs`, scopes, task manifests, input manifests, reports/versions, claims, claim-evidence,
+  audits, approvals, and feedback;
+- enforceable evidence associations; avoid an FK-less polymorphic evidence column;
+- company, comparison, chain, sub-chain, earnings, event-delta, and watchlist report types;
+- report compatibility and supersession rules;
+- cost/usage and omitted-capability fields.
+
+#### PR M7.2 — report assembly and UI
+
+Scope:
+
+- deterministic block assembly plus optional audited narrative;
+- previous-version delta;
+- evidence/provenance drill-down;
+- draft, audit-failed, approval-required, published, superseded, and stale states;
+- company and chain report routes in Argon.
+
+M7 exit gate:
+
+- an old report replays from its original manifest after new observations/method versions arrive;
+- a new report explains material changes from the prior comparable report;
+- every published claim has evidence or is explicitly labeled inference;
+- report remains useful with narrative absent;
+- cost, coverage, and unsupported capability disclosures are visible.
+
+### M8 — bounded agent harness
+
+M8 starts only after M7 is live. It does not wait for a validated investment ranking because its
+first authority is descriptive draft generation, not action on score ordering.
+
+#### PR M8.1 — narrow command/read surface
+
+Scope:
+
+- authenticated, least-privilege read APIs for facts, runs, reports, versions, coverage, and audits;
+- typed enqueue commands for already-approved Argon jobs;
+- task budget, idempotency key, status, cancellation, and retry policy;
+- distinct harness service identity, route-scoped authorization, key rotation/revocation, actor ID on
+  every command, and redaction tests proving secrets cannot enter prompts, logs, or report manifests;
+- no raw SQL or method/taxonomy mutation endpoint.
+
+#### PR M8.2 — question-to-draft workflow
+
+Scope:
+
+- resolve report type, domain/chain/tickers, as-of, freshness, and budget;
+- produce bounded task DAG with maximum tasks/calls/time/tokens/retries;
+- prefer compatible cached results;
+- assemble a draft and request operator publication;
+- persist plan, decisions, tool calls, outputs, and termination reason.
+
+#### PR M8.3 — event-triggered delta drafts
+
+Scope:
+
+- filings and earnings first;
+- licensed news and PIT estimate changes only when those capabilities exist;
+- impact resolution from event → affected facts → computations → reports;
+- deduplication, cooldown, grouping, and no-change suppression;
+- drafts only.
+
+#### PR M8.4 — scheduled self-tending mode
+
+Scope:
+
+- stale-report and stale-data monitoring;
+- bounded recompute and delta generation;
+- provider/model/data cost telemetry;
+- operator queue and silence discipline;
+- explicit per-report auto-publish policy remains off by default.
+
+M8 exit gate:
+
+- harness cannot mutate facts, methods, score weights, or approved taxonomy;
+- every mutation travels through a typed gate and persisted run;
+- budget exhaustion terminates cleanly with a labeled partial draft;
+- repeated identical triggers deduplicate;
+- one week of scheduled operation has no runaway loops, hidden spend, or silent audit bypass;
+- all reports remain reproducible without the harness process being present.
+
+### M9 — optional empirical upgrades
+
+These are independent research/procurement tracks. They gate stronger claims, not the descriptive
+product.
+
+#### Research M9.A — Sharadar contract/sample probe
+
+- validate sample fields, PIT semantics, permanent IDs, adjustment policy, delisting, and volume;
+- obtain license determination for the intended Argon use;
+- stop if rights are incompatible.
+
+#### Research M9.B — active-plus-delisted score validation
+
+- construct the historical universe by knowledge date;
+- include delisting returns;
+- rerun score dimensions and composite;
+- test time-series deterioration separately;
+- measure turnover, liquidity, transaction-cost assumptions, and regime stability;
+- update ranking permission from evidence.
+
+#### Research M9.C — PIT estimates vendor bake-off
+
+- issue the same field/licensing contract to LSEG and FactSet;
+- run the preregistered revision studies on the same universe and horizon;
+- compare coverage, corrections, PIT integrity, access, rights, total cost, and incremental value;
+- buy at most one provider, or reject both.
+
+#### Build M9.D — licensed estimates adapter
+
+Only if M9.C passes:
+
+- immutable PIT estimate observations and actual/guidance observations;
+- revision/dispersion/breadth features;
+- company and chain report blocks;
+- event trigger integration;
+- separate method version and data-capability disclosure.
+
+M9 ranking/recommendation gate:
+
+- evidence applies to the exact production universe and feature definition;
+- OOS and active-plus-delisted tests pass;
+- regime and cost limitations are recorded;
+- estimates add incremental value if used;
+- operator explicitly approves any new ranking/recommendation authority.
+
+## 8. Dependency graph
+
+```text
+M0 method/spec closure
+  └── M1 PIT data
+       └── M2 deterministic valuation/score
+            ├── M3 company card
+            └── M4 chain surface
+                 └── M5 concentration/events (discovery-gated)
+
+M3 + M5 resolved
+  └── M6 constrained narrative/audit (optional report block)
+
+M3 + M4 + M5 resolved
+  └── M7 versioned reports (works without M6 output)
+
+M6 + M7
+  └── M8 bounded harness
+
+M9 optional datasets/research run alongside M1–M8
+  ├── never block descriptive M3/M4/M7
+  └── do gate stronger ranking, recommendation, and revision claims
+```
+
+M4 can begin its schema/matrix skeleton alongside M2, but the route cannot ship comparative
+fundamental encodings until compatible M2 results exist. M5 begins with discovery and can be killed
+without blocking M3. M6 waits for M5 to be resolved, not necessarily shipped. M7 may proceed without
+M6, but M8 requires both the report ledger and the narrative/audit boundary.
+
+## 9. Program gates
+
+| Gate | Required evidence | Unlocks |
+|---|---|---|
+| G0 — spec consistent | one source policy, compatible acceptance tests, research limits recorded | P1b implementation |
+| G1 — data trustworthy | PIT replay, restatement preservation, violation handling, measured coverage | deterministic engine |
+| G2 — method fixed | worked examples, version/hash identity, abstention and confidence rules | UI rendering |
+| G3 — deterministic product | worker-path smoke, provenance drill-down, stale/partial behavior | narrative and reports |
+| G4 — chain adds information | compatible rollups, evidence-backed exposure, useful dive-in | chain reports |
+| G5 — evidence extraction useful | discovery yield and false-positive gate | concentration/event features |
+| G6 — narrative constrained | structured output, claim audits, provider-down degradation | publishable narrative |
+| G7 — report reproducible | manifest, versions, claims/evidence, delta, cost disclosure | harness |
+| G8 — harness bounded | permissions, budgets, dedup, termination, unattended soak | scheduled drafts |
+| G9 — ranking supported | broad PIT/OOS, active+delisted, regimes, costs | cross-company ordering |
+| G10 — estimates worth cost | trial adds robust incremental value and rights fit | institutional feed adapter |
+
+No gate may be waived by a visually persuasive UI or fluent model narrative.
+
+## 10. Delivery sizing and risk
+
+Sizes describe engineering/review surface, not calendar commitments. Any `L` milestone must be split
+into the child PRs already listed; no PR inherits the milestone size as one unit.
+
+| Milestone | Size | Primary risk driver | Lower-risk release shape |
+|---|---:|---|---|
+| M0 method/spec | S | encoding contradictory research conclusions | docs/research only, no runtime changes |
+| M1 PIT data | L | immutable identity, backfill, source disagreement, foreign issuers | additive tables → backfill → verify → canonical views |
+| M2 valuation/score | L | method ambiguity and false comparability | pure derivations → anchors → dimensions/runs |
+| M3 company card | M | stale/partial state and provenance trust | hidden tab/flag, deterministic only |
+| M4 chain surface | L | taxonomy migration and persuasive small-sample ranking | dual-read parity, coverage-first encodings |
+| M5 filings/events | M/L | extraction false positives and rate limits | mandatory discovery PR; kill weak classes |
+| M6 narrative/audit | M | fluent fabrication and worker isolation | provider off by default until real smoke/audit |
+| M7 report product | L | durable version/supersession contract | deterministic reports first, narrative optional |
+| M8 harness | L | authority, cost runaway, loops, secret leakage | draft-only, typed commands, bounded soak |
+| M9 paid datasets | research-dependent | licensing and unproven incremental value | sample/trial before adapter or contract |
+
+## 11. Rollout, rollback, and compatibility
+
+Every child implementation plan must state its feature flag, migration direction, rollback behavior,
+and post-deploy smoke. The program defaults are:
+
+### Schema and data
+
+- migrations are additive and idempotent;
+- old read paths remain valid until parity and backfill verification finish;
+- no migration drops or rewrites source history in the feature PR;
+- canonical-view changes are versioned or flag-switched so rollback means selecting the prior rule,
+  not deleting new observations;
+- backfills persist run state and resume; aborting a backfill does not publish partial coverage as
+  complete;
+- new temporal tables join the dataset registry and freshness/gap policy in the same PR.
+
+### Workers and providers
+
+- every new recurring job and provider lane has an off switch defaulting to off until deployed
+  migrations and target credentials are verified;
+- worker-role validation, compose service, heartbeat, queue age/depth, and restart instructions ship
+  together;
+- rolling back a worker disables claiming before removing code; queued rows remain inspectable and
+  recoverable;
+- provider credentials stay in runtime configuration and are never copied to model subprocesses,
+  prompts, logs, or evidence manifests.
+
+### API and web
+
+- API additions are backward-compatible until generated clients and web consumers have shipped;
+- mutation endpoints remain under `/api/jobs`; read routers do not accumulate ad-hoc writes;
+- new routes/tabs stay out of navigation behind a flag until their real worker/data path passes;
+- turning a feature flag off preserves stored evidence and renders a clear unavailable/stale state;
+- chain migration uses dual-read parity before changing the existing watchlist filter source.
+
+### Reports and harness
+
+- the report ledger is append-only/versioned; rollback never overwrites published history;
+- narrative and harness flags can be disabled independently of deterministic reports;
+- auto-publication is off by default and requires a separate policy decision;
+- revoking the harness identity stops new commands without removing report readability;
+- budget, authorization, audit, or task-loop failure ends in a persisted failed/partial draft, not a
+  half-published report.
+
+Post-deploy verification is milestone-specific but always reads from a newly opened connection or
+fresh browser request; in-process success alone is not evidence of durable state.
+
+## 12. Verification strategy by layer
+
+### Research
+
+- preregister hypotheses, universe, horizon, features, controls, and kill conditions;
+- persist every configuration and metric, not only the headline;
+- keep exact reproduce command and data/version manifest;
+- verify realized cross-section width and knowledge-time bucketing;
+- separate factor ordering, investment strategy, and live utility claims.
+
+### Storage and compute
+
+- migration idempotence;
+- immutable observation/restatement tests;
+- repository tests against the correct database tier;
+- pure-function unit/property tests;
+- version/hash identity and result-reuse tests;
+- registry and data-gap policy checks.
+
+### API and workers
+
+- enqueue/idempotency/concurrency/retry/resume tests;
+- provider failure and partial-stage recovery;
+- real worker smoke through persisted rows;
+- OpenAPI and generated TypeScript contract checks;
+- no synchronous multi-provider writes from read routes.
+
+### Web
+
+- deterministic number and provenance rendering;
+- loading, stale, partial, unsupported, audit-failed, and provider-down states;
+- accessibility and responsive behavior;
+- Playwright for company, chain, report, and evidence drill-down paths;
+- screenshots under `output/playwright/` only.
+
+### Harness
+
+- golden research questions with expected scope and task bounds;
+- adversarial prompts attempting fact/method/taxonomy mutation;
+- budget exhaustion and cancellation;
+- repeated-trigger deduplication;
+- provider outage and partial-result behavior;
+- audit bypass attempts;
+- one-week soak before increasing authority.
+
+### Standard child-PR quality gates
+
+Every child implementation plan narrows these commands to its changed surface during development,
+then runs the applicable full gates before review:
+
+```text
+uv run pytest
+uv run ruff check .
+uv run python scripts/check_no_yahoo.py
+cd web && npm run typecheck
+cd web && npm run test
+cd web && npm run lint
+cd web && npm run build
+```
+
+Database work also runs migrations twice to prove idempotence and executes its integration tests on
+the correct test database. API contract changes regenerate `web/lib/types.ts`. User-visible routes
+run the named Playwright flows. Worker changes run the real enqueue → claim → persist → API/UI smoke
+after restarting the worker process.
+
+Pure documentation/research PRs do not claim application validation from these commands. They run
+their reproduce/self-check, link any known baseline failures, and verify the exact diff and artifact
+consistency appropriate to their scope.
+
+## 13. Observability and operating model
+
+Every production stage publishes:
+
+- heartbeat and last successful completion;
+- queue depth and oldest age;
+- run counts by status/stage/provider;
+- data freshness and coverage;
+- provider calls, official counters where available, failures, 429s, and cost estimates;
+- model calls/tokens/latency/failure and audit-fail rates;
+- report staleness and unpublished-draft counts;
+- harness suppression/dedup/cooldown and termination reasons.
+
+Alerts should target conditions requiring action, not ordinary `na` or no-change runs. Provider
+outages, stale facts, audit-fail spikes, budget exhaustion, stuck runs, and report publication
+failures are actionable. A company legitimately lacking a field is a report disclosure, not an ops
+page.
+
+## 14. Program completion criteria
+
+The program is complete at its intended descriptive-research scope when a user can ask:
+
+> Research the US optical-communication chain. Compare switch silicon, DSP, lasers, modules, system
+> vendors, and cloud customers; show where operating momentum, valuation pressure, catalysts, and
+> concentration risk sit; then dive into three companies.
+
+Argon can then:
+
+1. freeze the domain, chain, company universe, as-of, taxonomy version, method version, and budget;
+2. state data coverage and unsupported paid capabilities before making conclusions;
+3. run or reuse deterministic financial, valuation, score, technical, and chain calculations;
+4. generate a versioned draft whose claims link to exact evidence;
+5. distinguish facts, derivations, inferences, disputes, and unknowns;
+6. show price anchors, scenarios, catalysts, risks, and numeric invalidation conditions;
+7. audit numbers, sources, time boundaries, inference language, and coverage;
+8. publish through the Argon UI with prior-version delta and provenance drill-down;
+9. refresh only affected work when a filing, earnings event, or licensed signal changes;
+10. stay within recorded data/model budgets and degrade explicitly when a capability is unavailable;
+11. avoid cross-company ranking where the exact production universe lacks supporting evidence;
+12. remain reproducible even if the model provider or external harness is unavailable.
+
+Completion does not imply automatic investment recommendation or trade execution. Those require a
+new program decision after G9, not a silent extension of this one.
+
+## 15. Plan maintenance protocol
+
+This file is the program-level source of truth. It changes only when evidence, scope, dependency, or
+authority changes.
+
+For every milestone:
+
+1. create a child design/spec if the contract is not already fixed;
+2. create a child implementation plan with exact files, tests, commands, and PR boundary;
+3. record the branch/PR and status here;
+4. update the program gate with actual evidence, not “implemented” prose;
+5. record killed ideas and why;
+6. move completed child plans to `docs/superpowers/archive/plans/` under existing conventions;
+7. keep this program plan active until M8 descriptive harness completion or an explicit stop ruling.
+
+Status vocabulary:
+
+```text
+proposed → researched → specified → planned → in_progress → verified → merged
+                                      └────────→ killed
+```
+
+No phase becomes `verified` from unit tests alone when its exit gate requires a real worker, database,
+provider, or browser path.

--- a/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
+++ b/docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md
@@ -52,8 +52,15 @@ The work remains aligned with Argon's goal ladder:
 
 ## 2. Current state and evidence boundary
 
-The plan branch started from commit `d912d5d`. Repository and PR state below was rechecked on
-2026-08-12; later status changes must be recorded rather than inferred from this snapshot.
+The plan branch started from commit `d912d5d`. Repository and PR state below was **rechecked on
+2026-08-18**; later status changes must be recorded rather than inferred from this snapshot.
+
+> **Snapshot correction (2026-08-18).** The rows for P1b, P2, P3, and the core-25 own-history test
+> previously read `not started` / `blocked`. They were written hours before PR #331 merged on the
+> same day and were never revisited, so this plan spent five days understating its own lane by four
+> milestones. The gate that row 6 named — "awaits the mini" — is also gone: the mini is up and its
+> `option_wizard` carries the seeded lane. Anyone reading a `not started` here should verify against
+> the repository before believing it.
 
 | Area | State | Evidence / constraint |
 |---|---|---|
@@ -61,15 +68,20 @@ The plan branch started from commit `d912d5d`. Repository and PR state below was
 | P1a provider/data probes | **landed** | PR #329 committed coverage, field-contract, UW, and SEC probes |
 | Fundamental method validation | **landed** | PR #329 found the composite informative at broad width but noise at core-25 width |
 | Valuation-control follow-up | **landed** | PR #330 merged with all checks passing; research evidence only, no production scoring capability |
-| Core-25 own-history test | **planned / unblocked** | test whether a name's own deterioration precedes its own drawdown; not a cross-sectional rank test |
-| P1b PIT ingest | **not started / blocked** | M0.2 remains a design gate; data-dependent execution also awaits the mini at this snapshot |
-| P2 valuation/score runtime | **not started** | only design and research artifacts exist |
-| P3 fundamental card | **not started** | no production API or UI surface yet |
-| P4 concentration/edge work | **not started** | must begin with a discovery gate |
+| Core-25 own-history test | **landed** | PR #331; `docs/research/2026-08-12-fundamental-{timeseries-test,valuation-timeseries}/`. Split verdict: own-history **valuation** times a name (`sales_to_ev` IC `+0.0744`, `t=5.77`, survives a reversal control); own-history **quality** does not (within-ticker market-neutral IC `-0.0000`, all 16 tests fail BH). Only the valuation half was productized, as the anchor band |
+| P1b PIT ingest | **landed** | PR #331; migration `114`, `storage/fundamental_obs.py`, `worker/jobs/fundamental_ingest.py`, `scripts/backfill/fundamental_ingest_backfill.py`. Prod `option_wizard` holds 257 universe tickers with statements |
+| P2 valuation/score runtime | **landed** | PR #331; migrations `117`/`118`, `fundamentals/{scoring,valuation}.py`, `worker/jobs/fundamental_{scoring,anchors,refresh}.py`. Prod holds 257 scores and 254 anchor bands |
+| P3 fundamental card | **landed** | PR #331; `api/routers/stock.py` `/fundamentals` + `/fundamentals/statements`, `web/components/stock/tabs/FundamentalsTab.tsx` + eight `Fundamental*` panels, flip-to-components back face |
+| P4 concentration/edge work | **discovery done; descriptive-only** | PR #335 retracted the `0/257` computability verdict as a probe artifact — re-measured segment 184/401, geography 128/401 (`docs/research/2026-08-13-fundamental-concentration-axis/`). Capture and card remain unbuilt (lane-next PR-3); the composite weight in design §896 is **withdrawn**, per lane-next D2 |
 | P5 narrative/audit queue | **not started** | current trade-insight queue is not a legal or semantic parent |
-| General industry research | **taxonomy skeleton only** | current watchlist has layer/chain membership, not a versioned exposure graph |
+| General industry research | **taxonomy skeleton only** | watchlist carries many-to-many chain membership (migration `113`), not a versioned exposure graph |
 | Versioned report object | **not started** | a narrative row is not yet a report control plane |
 | Loop harness | **deliberately deferred** | §10 of the primary design; not a missing task in the current research PR |
+
+Task-level continuation now lives in `docs/superpowers/plans/2026-08-13-fundamental-lane-next.md`
+(three PRs: panel width and freshness, an accrual verification, concentration capture). That plan is
+narrower than this one and supersedes it for the next increment; this document stays the cross-phase
+roadmap. **None of its three PRs has landed.**
 
 The current broad-universe validation supports a descriptive product, not an unrestricted ranking:
 
@@ -92,16 +104,21 @@ The current broad-universe validation supports a descriptive product, not an unr
 No later phase may silently strengthen those statements. Stronger claims require their own recorded
 evidence and gate.
 
-Operational boundary at this snapshot:
+Operational boundary, rechecked 2026-08-18:
 
-- the Mac mini is unavailable and hosts both the `option_wizard` P1b write target and the full lake
-  copy, so P1b migrations, ingest, and real-worker smoke are blocked;
-- `option_wizard_local` is not a substitute write target for P1b; doing so would violate the intended
-  environment contract and create work that must be repeated;
-- the local mirror plus UW API are sufficient for the historical core-25 M0.3 test, but the mirror's
-  stale endpoint makes it unsuitable for claims requiring current data;
-- provider-sensitive and data-current tasks resume only after the target environment is restored and
-  rechecked. A stale historical research run must never be presented as current production coverage.
+- the Mac mini is **up**. Its `option_wizard` carries the seeded lane — `fundamental_universe` 257,
+  `fundamental_statement_obs` 257 tickers, `fundamental_scores` 257, `valuation_anchors` 254 — so the
+  earlier "P1b write target unavailable" blocker is discharged, as is any record that the lane
+  shipped dark;
+- `option_wizard_local` is still not a substitute write target. It currently holds statements for
+  **401** tickers against prod's 257, because the extra 144 arrived through the capex research
+  backfill and were never promoted. A count taken locally is therefore not a production count;
+- **the two lake mirrors are not interchangeable, and the MacBook's is the partial one** — 653 equity
+  symbol directories against the mini's 14,689. Any coverage or depth number measured on the MacBook
+  understates production and must be re-measured against `/lake` before it justifies a decision. This
+  already cost one wrong conclusion; see `docs/research/2026-08-18-fundamental-lake-depth/VERDICT.md`;
+- provider-sensitive and data-current tasks must still name the host they ran on. A stale historical
+  research run must never be presented as current production coverage.
 
 ## 3. Non-negotiable invariants
 

--- a/docs/superpowers/plans/2026-08-13-fundamental-lane-next.md
+++ b/docs/superpowers/plans/2026-08-13-fundamental-lane-next.md
@@ -80,7 +80,10 @@ uncertainty the asymmetry is decisive: capture costs ~401 UW calls per quarter a
 the same argument `CLAUDE.md` already makes for `option_surface_grid_daily`. Storing snapshots
 is itself the discriminating test: watch whether the oldest period moves.
 
-### D5. Widening the universe is worth less than it first appeared
+### D5. ~~Widening the universe is worth less than it first appeared~~ — OVERTURNED 2026-08-18
+
+**This decision was wrong, and the error was measuring the wrong host.** It is kept in full
+below rather than deleted, because the mistake is the reusable part.
 
 The scoring pipeline has **zero failures on its input** — every one of the 257 universe names
 has statements and a score; 144 tickers have statements and no membership. But the valuable
@@ -91,11 +94,40 @@ output is the valuation band, and the band needs unadjusted daily closes from th
 | the 257 universe names | **254/257** (exactly matches `valuation_anchors`' 254 tickers) |
 | the 144 excluded names | **29/144** (measured on the MacBook mirror) |
 
-So widening yields **+144 composite scores (the part that does not pay) and +29 valuation bands
+~~So widening yields **+144 composite scores (the part that does not pay) and +29 valuation bands
 (the part that does)** — 254 → 283, about +11%, not the +56% panel width the raw counts suggest.
-The real gate on the valuable half is **lake price depth**, not universe membership. The 144 are
+The real gate on the valuable half is **lake price depth**, not universe membership.~~ The 144 are
 the capex-research cohort and were never breadth-probe candidates, so their depth was never
-assessed. The mini's mirror may be deeper; apex returned 502 when probed, so this is unverified.
+assessed. ~~The mini's mirror may be deeper; apex returned 502 when probed, so this is unverified.~~
+
+**Re-measured on the mini** — the host that actually computes the bands, whose mirror holds 14,689
+equity symbol directories against the MacBook's 653. Full method and per-ticker trace:
+`docs/research/2026-08-18-fundamental-lake-depth/VERDICT.md`.
+
+| the 144 excluded names | MacBook | mini `/lake` |
+|---|---:|---:|
+| has `1d.parquet` | 29 | **141** |
+| price depth ≥ 12 quarters (`MIN_HISTORY`) | 23 | **132** |
+| price depth ≥ 20 quarters (`WINDOW_QUARTERS`) | 21 | **120** |
+| statement depth ≥ 12 quarters | 143 | 143 |
+
+So widening yields **up to +132 valuation bands, not +29** — 254 → up to 386, about **+52%**. The
+raw panel-width figure this decision dismissed was approximately right, and **the gate is universe
+membership after all, not lake depth**. PR 1 is worth roughly 4.5× what this plan credited it with.
+
+132 is an upper bound: clearing the depth gate is necessary, not sufficient, because the method also
+refuses on non-positive EV, a non-positive numerator, and a stale filing. The universe cohort
+converts at 99.2% (256 clear the gate, 254 bands exist), but that rate must not be transferred — the
+144 carry more unprofitable and negative-EV names, which is exactly what the EV guard catches. **PR 1
+must therefore report the realised band count as its verification rather than assert one up front.**
+
+Two lessons, both already paid for once in this lane:
+
+- **counting files is coverage, not computability** — the identical conflation produced the retracted
+  `0/257` concentration verdict in D1, one round earlier;
+- **name the host in any coverage number.** "Measured on the MacBook mirror" was recorded honestly
+  here and still produced a wrong decision, because the caveat was not treated as a blocker. A
+  measurement whose host makes it wrong is not a measurement with a caveat.
 
 ### D6. The alert pipeline is deprioritised — a recorded deviation
 
@@ -112,7 +144,7 @@ the master plan, recorded here deliberately rather than left implicit.
 | `scripts/seed_fundamental_universe.py` | modify — admit statement-bearing names under a stated reason | 1 |
 | `src/uw_scan/worker/scheduler.py` | modify — wire the quarterly statement ingest | 1 |
 | `src/uw_scan/config.py` | modify — ingest cron + enable flag; PR-3 capture flags | 1, 3 |
-| `src/uw_scan/storage/migrations/120_revenue_breakdown_obs.sql` | create — PIT breakdown observations | 3 |
+| `src/uw_scan/storage/migrations/122_revenue_breakdown_obs.sql` | create — PIT breakdown observations. Was `120`; renumbered 2026-08-18 because `120_freshness_sessions_missing.sql` landed on `main` and the unmerged macro branch already claims `116`/`119`/`121`. A duplicate prefix is a CI gate — re-check the next free number when PR 3 actually starts. | 3 |
 | `src/uw_scan/fundamentals/concentration.py` | create — axis grouping, level selection, annual detection | 3 |
 | `src/uw_scan/storage/fundamental_concentration.py` | create — its own storage module, not `repository.py` | 3 |
 | `src/uw_scan/worker/jobs/fundamental_concentration_capture.py` | create — quarterly capture job | 3 |
@@ -208,9 +240,12 @@ from uw_scan.worker.jobs.fundamental_refresh import fundamental_refresh
 ..."   # or the scheduler's registered job path
 ```
 
-Record **both** numbers separately — scores gained and bands gained. Per D5 the expectation is
-~+144 scores and only **~+29 bands**; a bands number far above that means the mini mirror is
-deeper than the MacBook's and D5 should be revised in this PR, not later.
+Record **both** numbers separately — scores gained and bands gained. Per the revised D5 the
+expectation is ~+144 scores and **up to +132 bands** (132 names clear the 12-quarter price gate on
+the mini; 143 clear it on statements). 132 is a ceiling, not a forecast: the method still refuses on
+non-positive EV, a non-positive numerator, and a stale filing, and this cohort is more exposed to
+those than the universe was. **The realised count measured here is the answer** — record it, and if
+it lands far below 132, the gap is the refusal rate on this cohort and belongs in D5.
 
 - [ ] **Step 7: Commit**
 
@@ -340,7 +375,7 @@ Justified by D4 (accrual optionality), scoped by D2 (descriptive only), and cons
 ### Task 1: PIT observation table
 
 **Files:**
-- Create: `src/uw_scan/storage/migrations/120_revenue_breakdown_obs.sql`
+- Create: `src/uw_scan/storage/migrations/122_revenue_breakdown_obs.sql`
 - Modify: `src/uw_scan/reports/data_gap_healer.py`
 - Test: `tests/storage/test_migrations.py`
 
@@ -476,12 +511,15 @@ share — the failure mode this lane already has a rule about. Default to refusi
 | Rebuilding the composite | It orders names and does not pay. More inputs will not change that. |
 | Chain / cluster work | Closed twice, both nulls. |
 | Alert pipeline v1 | D6 — deprioritised by user direction; recorded as a master-plan deviation. |
-| Lake backfill for the 115 price-less names | Belongs to market-warehouse, not argon. Blocked on the D5 re-measurement — apex was 502 when probed, so the mini's true depth is unknown. |
+| Lake backfill for the price-less names | Belongs to market-warehouse, not argon. The D5 re-measurement shrank this from 115 names to **3** (`CFLT`, `CYBR`, `PSTG` are absent from the mini lake entirely) plus 9 more that have a file but under 12 quarters of history. Worth reporting upstream to livewire; not argon work. |
 
 ## Open questions to resolve during execution
 
-1. **Does the mini's lake mirror hold more than the MacBook's?** Decides whether PR-1 buys ~29
-   valuation bands or many more. Measure in PR-1 Step 6; revise D5 in that PR if it differs.
+1. ~~**Does the mini's lake mirror hold more than the MacBook's?**~~ **Answered 2026-08-18: yes,
+   decisively** — 14,689 equity symbols against 653, and 132 of the 144 clear the band's depth gate
+   rather than 29. D5 is revised above; `docs/research/2026-08-18-fundamental-lake-depth/`. This was
+   listed as a PR-1 execution step, but it gates whether PR-1 is worth doing at all, so it was run
+   first. **What remains open is the refusal rate on this cohort**, which only PR-1's ingest answers.
 2. **Does UW's `rev_breakdown` window roll?** Unanswerable from one snapshot. PR-3's stored
    snapshots answer it within two runs: if the oldest period advances, it rolls, and D4's
    urgency was real.

--- a/scripts/research/fundamental_lake_depth_probe.py
+++ b/scripts/research/fundamental_lake_depth_probe.py
@@ -1,0 +1,193 @@
+"""Measure whether lake price depth — not universe membership — gates the valuation band.
+
+`docs/superpowers/plans/2026-08-13-fundamental-lane-next.md` D5 concluded that widening
+the fundamental universe buys only ~29 extra valuation bands, because the 144 candidate
+names lack unadjusted daily closes. That measurement was taken on the MacBook mirror,
+which is a partial copy. This probe re-measures against an arbitrary lake root so the
+production mirror can answer the same question.
+
+D5 counted `1d.parquet` existence. That is coverage, not computability — the same
+conflation that produced the retracted `0/257` concentration verdict. A band needs
+`MIN_HISTORY` (12) of the trailing `WINDOW_QUARTERS` (20) quarters to carry BOTH a
+statement and a priced knowledge date, so this probe reports depth at both thresholds
+rather than file presence alone.
+
+Reproduce (MacBook mirror, cohorts read from the local DB and embedded in the output):
+
+    D=docs/research/2026-08-18-fundamental-lake-depth
+    UW_SCAN_API_KEY=$(grep -m1 '^UW_SCAN_API_KEY=' .env | cut -d= -f2-) \
+    UW_SCAN_DB_HOST=127.0.0.1 UW_SCAN_DB_USER=chenxi UW_SCAN_DB_PASSWORD= \
+    UW_SCAN_DB_NAME=option_wizard_local \
+    uv run --extra postgres python scripts/research/fundamental_lake_depth_probe.py \
+        --lake-root ~/market-warehouse/data-lake/bronze/asset_class=equity \
+        --label macbook --as-of 2026-08-18 --out $D
+
+Reproduce (mini mirror). Prod holds statements for the 257 universe names only, so the
+144-name cohort is replayed from the MacBook run rather than re-read from the prod DB.
+The lake lives on an external volume mounted read-only into the containers as `/lake`;
+it is NOT under the mini user's home, which holds an empty skeleton of the same tree:
+
+    ssh macmini 'cat > /tmp/probe.py' < scripts/research/fundamental_lake_depth_probe.py
+    ssh macmini 'cat > /tmp/cohorts.json' < $D/depth_macbook.json
+    ssh macmini '/opt/homebrew/bin/docker cp /tmp/probe.py argon-api-1:/tmp/probe.py \
+      && /opt/homebrew/bin/docker cp /tmp/cohorts.json argon-api-1:/tmp/cohorts.json \
+      && /opt/homebrew/bin/docker exec argon-api-1 python /tmp/probe.py \
+           --cohorts-from /tmp/cohorts.json --lake-root /lake/bronze/asset_class=equity \
+           --label mini --as-of 2026-08-18 --out /tmp/out'
+    ssh macmini '/opt/homebrew/bin/docker exec argon-api-1 cat /tmp/out/depth_mini.json' \
+        > $D/depth_mini.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+#: Mirrors `uw_scan.fundamentals.valuation`. Duplicated as plain ints so the probe runs
+#: inside the deployed container against whatever code that image carries, instead of
+#: silently measuring against a different window than production uses.
+WINDOW_QUARTERS = 20
+MIN_HISTORY = 12
+
+#: A quarter is ~91.3 days. The band prices each historical quarter at its own knowledge
+#: date, so covering N quarters needs closes reaching back N quarters — not just a file.
+DAYS_PER_QUARTER = 91.3125
+
+
+def _cutoff(today: date, quarters: int) -> date:
+    return today - timedelta(days=round(DAYS_PER_QUARTER * quarters))
+
+
+def load_cohorts_from_db() -> dict[str, list[str]]:
+    """Universe members, and the statement-bearing names with no membership."""
+    import psycopg
+
+    from uw_scan.config import Settings
+
+    with psycopg.connect(Settings.from_env().db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT ticker FROM uw_scan.fundamental_universe ORDER BY 1"
+        )
+        universe = [r[0] for r in cur.fetchall()]
+        cur.execute(
+            """
+            SELECT DISTINCT s.ticker
+              FROM uw_scan.fundamental_statement_obs s
+              LEFT JOIN uw_scan.fundamental_universe u ON u.ticker = s.ticker
+             WHERE u.ticker IS NULL
+             ORDER BY 1
+            """
+        )
+        excluded = [r[0] for r in cur.fetchall()]
+        # Statement depth is the band's other necessary condition. Measured here so a
+        # price-only result is never read as "these names would produce bands".
+        cur.execute(
+            """
+            SELECT ticker, count(DISTINCT period_end)
+              FROM uw_scan.fundamental_statement_obs
+             WHERE period_type = 'quarterly'
+             GROUP BY 1
+            """
+        )
+        stmt_quarters = {t: n for t, n in cur.fetchall()}
+    return {"universe": universe, "excluded": excluded, "stmt_quarters": stmt_quarters}
+
+
+def measure(root: Path, tickers: list[str], today: date) -> dict:
+    """Per-ticker file presence and the earliest close, at both band thresholds."""
+    import pyarrow.parquet as pq
+
+    c12, c20 = _cutoff(today, MIN_HISTORY), _cutoff(today, WINDOW_QUARTERS)
+    per: dict[str, dict] = {}
+    for t in tickers:
+        path = root / f"symbol={t}" / "1d.parquet"
+        if not path.exists():
+            per[t] = {"file": False}
+            continue
+        col = pq.read_table(str(path), columns=["trade_date"]).column("trade_date")
+        days = [d for d in col.to_pylist() if d is not None]
+        if not days:
+            per[t] = {"file": True, "rows": 0}
+            continue
+        lo, hi = min(days), max(days)
+        per[t] = {
+            "file": True,
+            "rows": len(days),
+            "first": lo.isoformat(),
+            "last": hi.isoformat(),
+            "depth_12q": lo <= c12,
+            "depth_20q": lo <= c20,
+        }
+    return {
+        "cohort_n": len(tickers),
+        "has_file": sum(1 for v in per.values() if v.get("file")),
+        "depth_12q": sum(1 for v in per.values() if v.get("depth_12q")),
+        "depth_20q": sum(1 for v in per.values() if v.get("depth_20q")),
+        "cutoff_12q": c12.isoformat(),
+        "cutoff_20q": c20.isoformat(),
+        "per_ticker": per,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lake-root", required=True, type=Path)
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--out", type=Path, default=Path("."))
+    ap.add_argument(
+        "--cohorts-from",
+        type=Path,
+        help="reuse cohorts from a prior run's JSON instead of the DB "
+        "(prod carries no statements for the excluded cohort)",
+    )
+    ap.add_argument("--as-of", type=date.fromisoformat, default=None)
+    args = ap.parse_args()
+
+    today = args.as_of or date.today()
+    if args.cohorts_from:
+        prior = json.loads(args.cohorts_from.read_text())
+        cohorts = prior["cohorts"]
+    else:
+        cohorts = load_cohorts_from_db()
+
+    root = args.lake_root.expanduser()
+    stmt_q = cohorts["stmt_quarters"]
+    result = {
+        "probe": "fundamental lake price depth vs universe membership",
+        "label": args.label,
+        "lake_root": str(root),
+        "as_of": today.isoformat(),
+        "window_quarters": WINDOW_QUARTERS,
+        "min_history": MIN_HISTORY,
+        "cohorts": cohorts,
+        "universe": measure(root, cohorts["universe"], today),
+        "excluded": measure(root, cohorts["excluded"], today),
+        "excluded_stmt_depth": {
+            "ge_12q": sum(
+                1 for t in cohorts["excluded"] if stmt_q.get(t, 0) >= MIN_HISTORY
+            ),
+            "ge_20q": sum(
+                1 for t in cohorts["excluded"] if stmt_q.get(t, 0) >= WINDOW_QUARTERS
+            ),
+        },
+    }
+    args.out.mkdir(parents=True, exist_ok=True)
+    path = args.out / f"depth_{args.label}.json"
+    path.write_text(json.dumps(result, indent=1, sort_keys=True))
+
+    u, e = result["universe"], result["excluded"]
+    print(f"[{args.label}] root={root}")
+    print(
+        f"  universe {u['cohort_n']}: file={u['has_file']} 12q={u['depth_12q']} 20q={u['depth_20q']}"
+    )
+    print(
+        f"  excluded {e['cohort_n']}: file={e['has_file']} 12q={e['depth_12q']} 20q={e['depth_20q']}"
+    )
+    print(f"  excluded statement depth: {result['excluded_stmt_depth']}")
+    print(f"  wrote {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Documentation and one research probe. **No production code** — zero changes under `src/uw_scan/`, `web/`, `tests/`, or `migrations/`. Nothing here alters runtime behaviour.

This PR exists because a recorded decision was **wrong**, and because the roadmap that decision sits under has been understating its own lane for five days.

## 1 — D5 is overturned: lake depth is not the gate

`docs/superpowers/plans/2026-08-13-fundamental-lane-next.md` D5 concluded that widening the fundamental universe buys only **+29** valuation bands, because the 144 candidate names lack unadjusted daily closes — and therefore that "the real gate on the valuable half is lake price depth, not universe membership."

That was measured on the MacBook mirror. It holds **653** equity symbol directories against the mini's **14,689**. The mini is the host that actually computes the bands.

| the 144 excluded names | MacBook | **mini `/lake`** |
|---|---:|---:|
| has `1d.parquet` | 29 | **141** |
| price depth ≥ 12 quarters (`MIN_HISTORY`) | 23 | **132** |
| price depth ≥ 20 quarters (`WINDOW_QUARTERS`) | 21 | **120** |
| statement depth ≥ 12 quarters | 143 | 143 |

D5's numbers reproduce exactly on the MacBook, so the original measurement was correct — it was taken on the wrong machine. Statements are not the constraint.

**Widening yields up to +132 bands, not +29** — 254 → up to 386, about **+52%**. D5 argued the raw +56% panel-width figure was an illusion and the real gain was ~+11%; on the production host the raw figure was approximately right. PR 1 is worth roughly **4.5×** what the plan credits it with, and the gate is universe membership after all.

**132 is an upper bound, and the PR says so.** Clearing the depth gate is necessary, not sufficient — the method still refuses on non-positive EV, a non-positive numerator, and a stale filing (`fundamentals/valuation.py:406-413`). The universe cohort converts at 99.2% (256 clear the gate, 254 bands exist), but that rate is deliberately **not** transferred: the 144 are the capex research cohort and carry more unprofitable and negative-EV names, which is exactly what the EV guard catches. The realised count becomes PR 1's own verification instead of an assertion made up front.

## 2 — Why it went wrong, kept as the reusable part

D5 is struck through in place rather than deleted. Two lessons, both already paid for once in this lane:

- **Counting files is coverage, not computability.** The probe reports depth at both band thresholds instead of `1d.parquet` existence. The identical conflation produced the retracted `0/257` concentration verdict in D1, one round earlier.
- **A measurement whose host makes it wrong is not a measurement with a caveat.** D5 recorded "measured on the MacBook mirror" honestly and still produced a wrong decision, because the caveat was treated as a footnote rather than a blocker.

## 3 — The program plan lands, with a corrected state table

`docs/superpowers/plans/2026-08-12-fundamental-pm-agent-program.md` (1359 lines, M0–M9 + G0–G10) existed only on two local branches. It arrives here with §2 corrected: four rows read `not started` / `blocked` — the core-25 own-history test, P1b PIT ingest, P2 valuation/score runtime, P3 fundamental card — **all of which PR #331 landed hours after the snapshot was written**. The snapshot was never revisited, so the roadmap understated its own lane by four milestones.

The operational boundary is rewritten too: the mini is up, its `option_wizard` is seeded (universe 257 / statements 257 / scores 257 / anchors 254), and the two lake mirrors are flagged as non-interchangeable with the MacBook's named as the partial one. That discharges both the "P1b write target unavailable" blocker and the record that the lane shipped dark.

## 4 — Incidental findings

- **`CFLT`, `CYBR`, `PSTG` are absent from the mini lake entirely.** Real, liquid US listings, so this is a livewire coverage gap, not a probe artifact. The deferred lake-backfill item shrinks from 115 names to 3 (plus 9 with a file but under 12 quarters).
- **Apex answered 200.** D5 left the mini unverified because apex returned 502 when probed. The band reads parquet directly and does not use apex, but the stated reason for not checking no longer holds.
- **PR 3's planned migration renumbers `120` → `122`.** `120_freshness_sessions_missing.sql` landed on `main`, and the unmerged macro branch already claims `116`/`119`/`121`. A duplicate prefix is a CI gate.

## Reviewer notes

- **No CHANGELOG entry, deliberately.** The standing rule is that the changelog rides the feature PR — but there is no user-facing change here (zero `src/`, zero `web/`), so an entry would be manufactured. Same call as #335.
- **The diff is large because ~7.7k lines are the two JSON traces and the 1359-line plan.** Review `VERDICT.md` and the two plan diffs; the JSON is per-ticker evidence (file presence, row count, first/last close, depth flags at both thresholds, all 401 names).
- **The trace regenerates byte-identically** — verified by re-running and `cmp`. `--as-of` is passed explicitly so re-runs stay comparable rather than drifting with the calendar.
- **Both reproduce commands are in the probe's docstring** and are the ones actually used, including the `docker cp` + `docker exec` path for the mini, since the lake lives on an external volume mounted read-only as `/lake` and not under the mini user's home (which holds an empty skeleton of the same tree).
- **Follow-up:** `misc/fundamental-pm-program-plan` and `misc/macro-topdown-pm-plan` are the same commit and both become redundant once this merges. Deleting them before merge would destroy the only copy of the plan.