### PR TITLE
fix(budget): stop yesterday's UW counter from disabling today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A UW budget day that closed above the account guard silently disabled the
+  entire next day.** UW's `official_daily_count` resets a beat *after* 00:00 UTC,
+  so the first requests of a new budget day still carry the previous day's tail —
+  on 2026-08-18 twelve rows recorded 110204..110214 before the counter dropped to
+  1 at `00:00:04.227Z`. `read_snapshot` took `MAX(official_daily_count)` over the
+  UTC day, which pinned 110214 for the next 24 hours, and `may_spend` halts
+  **every** pool once the account counter reaches `total_guard` (105000). The
+  result was a full-day outage that looked like ordinary budget pressure:
+  `full_scan` made **zero** UW calls all of 08-18, `regime_gex_scan` logged
+  "research UW budget exhausted" from open to close, and `/api/health` reported
+  `ok: false` with "16 expected full scans missed". It also self-obscured — the
+  starved day then closed far below the guard, so the following day recovered on
+  its own and the fault read as intermittent rather than as a stuck gate. The
+  account counter is now the **latest** reading rather than the day's maximum:
+  it is monotone within a budget day, so the newest row is the only maximum that
+  means anything, and it cannot inherit the carry-over. A stale-low read costs at
+  most one extra call before the next snapshot, where the old behaviour cost a
+  trading day.
+
 ## [0.12.7] — 2026-08-19
 
 

--- a/src/uw_scan/sources/uw_budget.py
+++ b/src/uw_scan/sources/uw_budget.py
@@ -91,7 +91,14 @@ def may_spend(pool: Pool, snap: BudgetSnapshot, limits: BudgetLimits) -> bool:
 
 
 def bucket_spend(rows: Iterable[tuple[str | None, int, int | None]]) -> BudgetSnapshot:
-    """Fold (job_name, call_count, account_count) rows into a pool snapshot."""
+    """Fold (job_name, call_count, account_count) rows into a pool snapshot.
+
+    Every row is expected to carry the SAME account counter — `read_snapshot`
+    selects the latest reading once and repeats it per group, so the max-fold
+    below is just a null-tolerant pick. Do not "simplify" that back into a
+    `MAX(official_daily_count)` in SQL: see `read_snapshot` for the day-boundary
+    carry-over that cost a full trading day of scans.
+    """
     live = 0
     research = 0
     account: int | None = None
@@ -118,18 +125,34 @@ def _utc_day_start(now_utc: datetime) -> datetime:
 def read_snapshot(
     conn, schema: str, *, now_utc: datetime | None = None
 ) -> BudgetSnapshot:
-    """Read today's (UTC-day) UW spend grouped into pools from telemetry."""
+    """Read today's (UTC-day) UW spend grouped into pools from telemetry.
+
+    The account counter is the LATEST reading, never `MAX()` over the day. UW's
+    counter resets a beat after 00:00 UTC, so the first requests of a new budget
+    day still carry the previous day's tail — 2026-08-18 recorded twelve rows at
+    110204..110214 before dropping to 1 at 00:00:04.227Z. A `MAX()` pins those
+    for the next 24h, and since `may_spend` halts EVERY pool at `total_guard`,
+    one day closing above the guard silently disabled the whole next day (08-18
+    lost all 16 of its full scans). The counter is monotone inside a day, so the
+    latest reading is the max that matters and is immune to the carry-over; a
+    stale-low read merely costs one extra call before the next snapshot.
+    """
     day_start = _utc_day_start(now_utc or datetime.now(timezone.utc))
     with conn.cursor() as cur:
         cur.execute(
             f"""
             SELECT job_name, COUNT(*)::bigint AS n,
-                   MAX(official_daily_count) AS acct
+                   (SELECT official_daily_count
+                      FROM {schema}.external_api_requests
+                     WHERE provider = 'uw' AND request_started_at >= %s
+                       AND official_daily_count IS NOT NULL
+                     ORDER BY request_started_at DESC
+                     LIMIT 1) AS acct
             FROM {schema}.external_api_requests
             WHERE provider = 'uw' AND request_started_at >= %s
             GROUP BY job_name
             """,
-            (day_start,),
+            (day_start, day_start),
         )
         rows = [(r[0], int(r[1]), r[2]) for r in cur.fetchall()]
     return bucket_spend(rows)

--- a/tests/integration/sources/test_uw_budget_day_boundary.py
+++ b/tests/integration/sources/test_uw_budget_day_boundary.py
@@ -1,0 +1,93 @@
+"""The account guard must not inherit yesterday's counter across the day boundary.
+
+Reproduces the 2026-08-18 outage: UW's `official_daily_count` resets a beat AFTER
+00:00 UTC, so the first requests of a new budget day still carry the previous
+day's tail. `read_snapshot` used `MAX()` over the UTC day, which pinned that tail
+for the next 24h — and because `may_spend` halts EVERY pool once the account
+counter reaches `total_guard`, one day closing above the guard silently disabled
+the whole next day. full_scan made zero UW calls and health reported "16 expected
+full scans missed".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from uw_scan.sources.uw_budget import BudgetLimits, may_spend, read_snapshot
+from uw_scan.storage.repository import Repository
+
+# The real boundary, to the millisecond: the last pre-reset row landed at
+# 00:00:04.016Z reading 110214, the next at 00:00:04.227Z reading 1.
+_DAY = datetime(2026, 8, 18, tzinfo=UTC)
+_STALE_COUNT = 110_214
+_LIMITS = BudgetLimits(
+    live_ceiling=60_000, research_ceiling=45_000, total_guard=105_000, enabled=True
+)
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
+
+
+def _record(repo: Repository, *, at: datetime, job: str, count: int) -> None:
+    repo.insert_external_api_request(
+        provider="uw",
+        endpoint_key="greek_exposure",
+        method="GET",
+        path_template="/api/stock/{ticker}/greek-exposure",
+        path="/api/stock/SPY/greek-exposure",
+        ticker="SPY",
+        params={},
+        status_code=200,
+        status_family="2xx",
+        started_at=at,
+        finished_at=at,
+        latency_ms=40,
+        official_daily_count=count,
+        official_daily_limit=120_000,
+        job_name=job,
+    )
+
+
+def test_pre_reset_counter_does_not_poison_the_new_budget_day(repo: Repository) -> None:
+    # Four seconds of rows still carrying yesterday's (over-guard) tail...
+    _record(
+        repo,
+        at=_DAY + timedelta(seconds=4.016),
+        job="regime_gex_scan",
+        count=_STALE_COUNT,
+    )
+    # ...then UW's counter resets and the real new day begins.
+    _record(repo, at=_DAY + timedelta(seconds=4.227), job="regime_gex_scan", count=1)
+    _record(repo, at=_DAY + timedelta(minutes=30), job="full_scan", count=812)
+    repo.conn.commit()
+
+    snap = read_snapshot(repo.conn, "uw_scan", now_utc=_DAY + timedelta(hours=6))
+
+    # The guard reads the LATEST counter, not the day's max.
+    assert snap.account_count == 812, (
+        f"account_count={snap.account_count} inherited the pre-reset tail; "
+        "the whole day would be halted"
+    )
+    assert snap.live_spent == 1  # full_scan
+    assert snap.research_spent == 2  # regime_gex_scan x2
+
+    # ...so scans are allowed to run, which is the behaviour that broke.
+    assert may_spend("live", snap, _LIMITS) is True
+    assert may_spend("research", snap, _LIMITS) is True
+
+
+def test_guard_still_halts_when_the_account_is_genuinely_over(repo: Repository) -> None:
+    """The fix must not defang the guard — a real over-guard reading still stops."""
+    _record(repo, at=_DAY + timedelta(hours=1), job="full_scan", count=1_000)
+    _record(repo, at=_DAY + timedelta(hours=9), job="full_scan", count=_STALE_COUNT)
+    repo.conn.commit()
+
+    snap = read_snapshot(repo.conn, "uw_scan", now_utc=_DAY + timedelta(hours=10))
+
+    assert snap.account_count == _STALE_COUNT
+    assert may_spend("live", snap, _LIMITS) is False
+    assert may_spend("research", snap, _LIMITS) is False


### PR DESCRIPTION
## The outage

`/api/health` has been reporting `ok: false` — **"16 expected full scans missed"**. `full_scan` made
**zero** UW calls across all of 2026-08-18, and `regime_gex_scan` logged *"research UW budget
exhausted"* from open to close. Both pools, all day, on an account that had only spent ~51k of its
120k.

## Root cause

UW's `official_daily_count` resets a beat **after** 00:00 UTC. The first requests of a new budget
day still carry the previous day's tail — measured on the real rows, to the millisecond:

```
00:00:04.016251  regime_gex_scan  110214   <- pre-reset
00:00:04.227387  regime_gex_scan       1   <- UW resets
```

`read_snapshot` computed the account counter as `MAX(official_daily_count)` over the **UTC day**.
Those twelve pre-reset rows are inside that day, so `MAX` returned **110214 for all 24 hours**. And
`may_spend` halts **every** pool — live and research alike — once the counter reaches `total_guard`
(105000). The day was dead on arrival.

It only fires when the *previous* day closes ≥ guard, which is exactly what happened: 08-17 ended at
110214.

**It also hid itself.** The starved day then closed far below the guard (~51k), so 08-19 recovered
unaided. That alternation — over-guard day, dead day, clean day — is why this read as intermittent
budget pressure rather than as a stuck gate.

## Fix

The account counter is now the **latest** reading rather than the day's maximum. It is monotone
inside a budget day, so the newest row is the only maximum that means anything, and it cannot
inherit the carry-over. A stale-low read costs at most one extra call before the next snapshot,
where the old behaviour cost a trading day.

`bucket_spend` keeps its max-fold (every row now carries the same scalar) and gained a comment
warning against "simplifying" the `MAX` back into SQL.

## Verification

- New integration test replays the boundary to the millisecond. It **fails on the previous code**
  with `account_count=110214` and passes at `812` — confirmed by reverting the SQL and re-running.
- A second test pins that a genuine over-guard reading still halts both pools: the guard is fixed,
  not defanged. That one passes on both old and new code, which is the point.
- Full CI lint+unit reproduced locally: `ruff check src/ tests/ scripts/`, `_lint_except.py src`,
  `check_no_yahoo.py`, `check_runtime_assets.py`, `check_migration_prefixes.py` all clean;
  **`pytest tests/unit/` 2098 passed**; `pytest tests/integration/{sources,worker}` **201 passed,
  7 skipped**.

`read_snapshot` has exactly two consumers, both in `worker/scheduler.py`, so the fix covers every
call site. `/api/health`'s `uw_today` reads the counter by a different path and was already correct
(19415 while the guard believed 110214) — that disagreement is what exposed this.

## Why it matters now

`DATA_GAP_HEALER_MAX_UW_CALLS` was just raised 24000 → 30000, with a 90000 weekend cap arriving in
v0.12.7. Both make a day closing ≥ 105000 more likely, and under the old behaviour each such day
cost the **next** one entirely. The Saturday-night run bills Sunday, so an over-guard Sunday would
have taken out a full trading Monday.

## Deliberately not in this PR

`HealContext.uw_client()` still builds its `UwClient` without a `telemetry_recorder`, so gap-healer
calls never reach `external_api_requests`. Today's numbers: UW counted 19415, our telemetry recorded
3151, and the healer's own ledger claimed 7328 for 6689 items — three different answers.

That is *not* a drop-in fix, which is why it is not bundled here. Attributing healer calls to the
research pool would make the 45000 research ceiling bind before the healer's own cap, silently
capping the weekend run at 45k instead of 90k. That is a design decision about pool attribution, not
a bug fix, and it deserves its own change.
