### PR TITLE
fix(fundamentals): price valuation bands from the corporate-action-adjusted tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,107 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   hardcoded, and migration 119 already allows exactly one `NULL -> value` promotion if a
   real instant is ever verified.
 
+- **The valuation band was priced against the wrong share basis, and it put a
+  dozen names on the buy list that do not belong there — while refusing seven
+  that do.** `valuation_anchors` builds each band from 20 quarters of
+  `fundamental / shares ÷ price`, and the two legs disagreed: UW restates
+  historical share counts onto today's post-split basis, while bronze stores
+  closes unadjusted. So the numerator already sat in today's units and the price
+  did not, and every quarter before a split yielded a number wrong by the split
+  factor. BKNG's 1-for-25 set its `buy_below` at $4,702.64 against a $208.25
+  spot — the name read as cheap. On 2026-08-18, 26 of 335 bands were built
+  across a split inside their own window and 12 of those were showing in the buy
+  zone. The error also ran the other way: a split made a name's own yield history
+  look like it spanned two regimes, so the 4x width gate refused it. NVDA, which
+  split 4-for-1 in 2021 and 10-for-1 in 2024, was refused for an "own 20-quarter
+  valuation range spans 16.9x" that was the splits, not its valuation — it and
+  AVGO, LRCX, ORLY, DECK, SMCI and BKSY all get real bands now.
+
+  Prices now come from livewire's **silver** tier, which publishes fully
+  back-adjusted daily bars, rather than being adjusted here. Silver's close is
+  adjusted for splits AND dividends, so it is divided by
+  `price_adjustment_factor * split_volume_factor` to undo the dividend half:
+  a cash dividend genuinely lowers market cap and nothing restates a share count
+  for it, so leaving it in understates every historical market cap on a payer
+  and biases the whole band cheap. `ANCHOR_RULES_REV` goes to 4 so the corrected
+  rows are actually written — the hashed inputs (`fundamental`, `net_debt`,
+  `shares`, `history_n`) are all unchanged by this fix, so without the bump every
+  correction would collide on `(ticker, as_of, engine_version, inputs_hash)` and
+  `DO NOTHING` would keep the wrong band for the rest of the day.
+
+  The file's own `WHY UNADJUSTED CLOSES` note argued the opposite for a sound
+  reason resting on a premise nobody had checked; it now carries the three
+  measurements that disprove it. Verified against production writing nothing:
+  `docs/research/2026-08-21-lake-price-basis-split-contamination/VERDICT.md`.
+
+- **Bronze's 2021-06-11 basis seam, and the 18 names livewire refuses to
+  adjust at all.** Bronze rows before that date were back-adjusted by a legacy
+  backfill and rows from it forward are raw, concatenated without reconciling
+  (TSLA steps 203.37 → 609.89 that day, WMT 46.63 → 140.75). An earlier fix here
+  clamped every series to that date — but it is livewire's boundary for the
+  *ambiguous* symbols only, and applying it globally cost KLAC, whose bronze
+  basis is clean throughout, forty years of history. Silver carries the
+  per-symbol truth: TSLA/WMT/CTAS start exactly 2021-06-11, KLAC starts 1980.
+
+  Where livewire cannot establish a basis at all (`price_basis='unknown'` on
+  bronze) it publishes no silver series — 18 of 450 universe names on
+  2026-08-21, including HON, CMCSA and MSTR. Those fall back to raw bronze,
+  which is provably equivalent when no split falls inside the window being
+  priced, and are **refused** when one does: CXAI's 50-for-1 on 2026-08-18 had
+  left `buy_below` at $0.107 against a $4.59 spot, and TRI's buyback
+  consolidations put it on the buy list 24% below a band it had not earned. The
+  new `unadjustable_prices` counter tracks them, and falls to zero as livewire
+  resolves those symbols upstream.
+
+  That fallback is only sound while "no split on record" means the ingest looked
+  and found none, and on 2026-08-22 it did not: `corporate_actions` covered 137
+  of the universe's 450 names, so 15 of those 18 — AIG, CMCSA, ECL, HON among
+  them — had zero rows for the plain reason that nobody had asked, and every one
+  was banded off an unverified basis. CMCSA was sitting in the buy zone on it.
+  The guard now requires positive evidence that a name was ingested (any split
+  or dividend row) and refuses otherwise, and the ingest itself widened to the
+  full scoring universe so that evidence exists. Refusals rise from 4 to 10 on
+  the 2026-08-22 store and fall back to 4 after one ingest run (verified by
+  staging that run's splits *and* dividends against production). Three names
+  (CFLT, CYBR, PSTG) have no split and no dividend at massive at all, so they
+  can never satisfy the rule; none of the three carries a band today, so the
+  measured coverage cost is zero, but the ceiling is real — an event table
+  cannot record a non-event.
+
+  A missing silver tier is now a hard failure rather than a silent one. The
+  whole directory absent is a mount or path error, never a data gap, and it was
+  the one fault that would have put all 450 names back on unadjusted bronze —
+  quietly reinstating the bug above. The job refuses to run instead, leaving the
+  previous day's bands standing.
+
+- **Twelve foreign filers were refused a valuation band for want of an FX series
+  the lake was carrying the whole time.** Two independent faults. `lake_fx_root`
+  was added after the container migration and never got a case in
+  `Settings.from_env`, so it fell back to a `$HOME` path — `/root/market-warehouse/…`
+  inside the container — that has never existed in production. Every lake root
+  now falls back under `market_warehouse_lake_root` instead of `$HOME`, so the
+  next one added is correct by default and no `.env` edit is needed.
+
+  Underneath that, `fx_symbol` looked only for `USD<CCY>`, and the mirrors
+  disagree: the mini's lake publishes `EURUSD` (1.16973 on 2026-08-21, USD per
+  EUR) and no `USDEUR`, while the MacBook's publishes `USDEUR` (0.8586) and no
+  `EURUSD`. Both are livewire artifacts and neither is wrong. `load_fx` now reads
+  whichever orientation exists and inverts `<CCY>USD` on read, so `convert`'s
+  single convention holds downstream — rather than keeping a table of which
+  currencies are quoted which way in sync with two mirrors. Verified against real
+  filings: ASML Q2-2026 €9.33B → $10.87B, TSM NT$1,270.38B → $40.45B.
+
+  `no_fx` falls 12 → 1 and ASML, ASX, BABA, CCEP, CCJ, NOK, SONY, SPOT, TSM, UMC
+  and WIT get bands. NVO stays refused and should: it reports DKK and the lake
+  carries no DKK series in either orientation. That is an upstream ask, not
+  something to paper over with an unconverted band.
+
+- **The split store covered 137 of the fundamental universe's 450 names.**
+  `corporate_actions_refresh` ingested the watchlist and the VRP panel only, so
+  the guard above had no evidence for most of the names that need it. The job now
+  covers the fundamental universe as well, at 17:35 ET — 45 minutes before
+  `fundamental_refresh`, so the guard is armed on the first day after a deploy.
+
 ## [0.12.10] — 2026-08-20
 
 

--- a/docs/research/2026-08-21-lake-price-basis-split-contamination/VERDICT.md
+++ b/docs/research/2026-08-21-lake-price-basis-split-contamination/VERDICT.md
@@ -1,0 +1,386 @@
+# The valuation band was priced against the wrong share basis
+
+**Date:** 2026-08-21 · **Status:** fixed on `fix/anchors-split-adjusted-prices`
+**Scope:** `valuation_anchors`, `GET /api/scanner/value`, the Fundamentals card band
+
+## Finding
+
+`valuation_anchors` builds each name's band from 20 quarters of
+`fundamental / shares ÷ price`. The two legs were on different corporate-action
+bases:
+
+- **UW restates `common_stock_shares_outstanding` onto today's post-split basis**,
+  back to the start of the panel.
+- **Bronze stores closes unadjusted** (`adj_close` is an unpopulated copy of
+  `close`). The job read bronze.
+
+So `fundamental / shares` arrives in today's units while the price does not, and
+every quarter before a split yields a number wrong by the split factor.
+
+Verified against the mini's store, 2026-08-21 — each is the real count times the
+factor of a split that had not yet happened:
+
+| ticker | our 2021-12-31 shares | actual then | split |
+|---|---|---|---|
+| TSLA | 3,100,522,833 | ~1,033M | 3-for-1, 2022-08-25 |
+| KLAC | 1,523,310,000 | ~152M | 10-for-1, 2026-06-12 |
+| BKNG | 1,034,275,000 | ~41M | 25-for-1, 2026-04-06 |
+
+## Damage, measured against each band's own window
+
+Not a fixed cutoff — the 20 most recent quarterly `period_end`s per ticker plus
+the 45-day knowledge lag, which is the window `_history` actually prices.
+
+```
+banded names at as_of 2026-08-18                335
+  split cliff inside the yield window            26   (19 splits, 7 real price moves)
+  of those, rendered IN THE BUY ZONE             12
+```
+
+BKNG is the clearest case: 20 quarters of sales yield 25x too low set
+`buy_below` at **$4,702.64** against a **$208.25** spot, so the name read as
+cheap. A reverse split runs the same error the other way — CXAI's 50-for-1 put
+its band at $0.11–$0.40 against a $4.26 spot.
+
+## The lake already solves this — in a tier argon was not reading
+
+livewire derives a **silver** tier: fully back-adjusted daily bars with
+`price_adjustment_factor` and `split_volume_factor` per session, published only
+after every artifact validates (`scripts/livewire_store.py rebuild-silver`).
+13,240 equity symbols on 2026-08-21. Argon's containers already mount the whole
+lake at `/lake:ro`, so it was reachable the entire time — `lake_resolver.py`
+just addresses `bronze/` and nothing pointed anywhere else.
+
+Silver dominates anything reconstructable from bronze on three counts.
+
+**It repairs the 2021-06-11 basis seam.** Every bronze equity series steps that
+day, `source='legacy'` on both sides, in both directions — TSLA 203.37 → 609.89,
+WMT 46.63 → 140.75. Those are later splits showing through one segment and not
+the other: pre-seam rows were back-adjusted by a legacy backfill, post-seam rows
+are raw, and the two were concatenated without reconciling.
+
+**It is per-symbol, where an argon-side clamp can only be global.** The first
+version of this fix clamped every series to 2021-06-11. That is livewire's
+boundary for the *ambiguous* symbols and nobody else's:
+
+| ticker | bronze `price_basis` | silver spans |
+|---|---|---|
+| TSLA / WMT / CTAS | mixed legacy | 2021-06-11 → 2026-08-20 |
+| KLAC | `raw` throughout (11,044 rows) | **1980-10-08** → 2026-08-20 |
+| BKNG | `raw` throughout | 1999-03-30 → 2026-08-20 |
+
+The global clamp cost KLAC forty years of history to fix a defect KLAC does not
+have.
+
+**Where it cannot establish a basis it publishes nothing** — a refusal argon can
+read, rather than a wrong number argon has to detect. 18 of the 450 universe
+names have no silver artifact on 2026-08-21, and it is exactly the set whose
+bronze `price_basis` is `unknown`:
+
+```
+HON    n=11445  basis={'unknown': 11418, 'raw': 27}   -> no silver
+CMCSA  n=11443  basis={'unknown': 11416, 'raw': 27}   -> no silver
+BKNG   n= 6892  basis={'raw': 6892}                   -> silver
+```
+
+Full list: AIG ALB APLD AXON CCEP CCJ CFLT CMCSA CNC CXAI CYBR ECL HON JNPR
+LOGI MSTR PSTG TRI.
+
+## Column algebra: split-only, not total-return
+
+Silver's `close` is adjusted for splits **and** dividends. Only the split half
+belongs in a valuation yield:
+
+```
+market_cap(t) = shares_actual(t)   x price_actual(t)
+              = shares_restated(t) x [price_actual(t) / split_factor(t)]
+              = shares_restated(t) x split_only_close(t)
+```
+
+Nothing restates a share count for a cash dividend — the dividend genuinely
+lowered market cap — so leaving silver's dividend adjustment in understates every
+historical market cap on a payer, inflates its historical yields, and biases the
+whole band cheap against an unadjusted spot. So:
+
+```
+split_only_close = close / (price_adjustment_factor x split_volume_factor)
+```
+
+Verified exact against raw bronze, 2026-08-21:
+
+| ticker | date | silver `close` | split_only | raw bronze | svf |
+|---|---|---|---|---|---|
+| BKNG | 2026-04-02 | 167.3493 | **167.7700** | 4194.25 | 25.0 |
+| BKNG | 2026-04-06 | 175.7482 | **176.1900** | 176.19 | 1.0 |
+| TSLA | 2022-08-19 | 296.6667 | 296.6667 | 890.00 | 3.0 |
+
+BKNG pays a dividend, so `split_only` ≠ `close`; TSLA does not, so its factors
+are exact reciprocals and nothing is divided out. `176.19` matching raw exactly
+at `svf=1` is the identity check.
+
+### apex serves the fully-adjusted close, so it cannot source this
+
+apex's `GET /bars/{ticker}` is the desk's normal price/bar read and it is indeed
+silver-grade — its BKNG close for 2026-04-02 is `167.349`, which is silver's
+`close` **verbatim**. That is exactly why it cannot source a valuation band: the
+number it serves is the total-return one, dividends divided out and all, and the
+endpoint exposes no adjustment parameter and neither factor column. Split-only is
+not derivable from what apex returns.
+
+Two names isolate each half cleanly, measured 2026-08-22:
+
+| ticker | event | `pf x svf` | silver `close` | split_only | raw bronze |
+|---|---|---|---|---|---|
+| CRWD | 4-for-1 split, **no dividend** | **1.000000** | 99.7800 | 99.7800 | 399.12 |
+| ETR | **dividend**, no split | 0.988670 | 113.5982 | **114.9000** | **114.9000** |
+| BKNG | both | 0.997492 | 167.3493 | 167.7700 | 4194.25 |
+
+CRWD's factors cancel to exactly 1.0, so silver's close already IS the split-only
+close and apex would be correct for it. ETR never split, so its whole factor is
+dividend: apex serves 113.5982 where the market-cap-correct price is 114.90. That
+1.13% error would enter every one of ETR's 20 quarters, compounding backwards,
+and it biases the band **cheap** — the direction that puts a name on the buy
+list. It is the same bug class this document is about, entering by another door.
+
+The pair also verifies the arithmetic in both degenerate directions: pure-split
+reproduces bronze/`svf` exactly, pure-dividend reproduces raw bronze exactly.
+
+## Fix
+
+1. `fundamental_anchors` reads **silver**, dividing out the dividend factor.
+2. Names with no silver artifact fall back to raw bronze — provably equivalent
+   when no split falls inside the window being priced, since an
+   unknown-but-consistent basis IS today's basis when nothing has restated the
+   shares since. `_bronze_basis_refusal` decides this per ticker.
+3. A name with no silver **and** an in-window split is **refused**, not banded.
+   So is a name with **no corporate-action record at all** — see below.
+4. `corporate_actions_refresh_once` covers the fundamental universe (it held
+   137 of 450), because that store is the evidence step 2 runs on. It fires at
+   17:35 ET, 45 minutes before `fundamental_refresh`.
+5. `ANCHOR_RULES_REV` 3 → 4, so corrected rows are not dropped by
+   `ON CONFLICT DO NOTHING` — no hashed input changes when only prices do.
+
+### The guard read missing data as clean data
+
+Step 2 is only sound while "no split on record" means the ingest looked and
+found none. Measured on the mini, 2026-08-22:
+
+| | |
+|---|---|
+| fundamental universe | 450 |
+| with **zero** `corporate_actions` rows | **313** |
+| of the 18 silver-less names, zero rows | **15** |
+| ingested names (188) with zero rows | **0** |
+
+313 is exactly 450 − 137, the universe minus what the deployed ingest covered.
+So for 15 of the 18 names that must be priced from bronze — AIG, ALB, AXON,
+CCEP, CFLT, CMCSA, CNC, CXAI, CYBR, ECL, HON, JNPR, LOGI, PSTG, TRI — the guard
+returned "no split in window" because **nobody had asked**, not because none
+happened. CMCSA and ECL have both split inside a 20-quarter window historically.
+CMCSA was showing IN THE BUY ZONE on that basis, `buy_below` 35.27 vs a 26.42
+spot.
+
+`_bronze_basis_refusal` now requires positive evidence — any split or dividend
+row for the ticker — and refuses without it. Zero rows is a sound proxy for
+never-asked because a 12-split/24-dividend lookback catches nearly every
+established name: of the 188 tickers the ingest did cover, not one had zero rows.
+
+Its three known false positives are named rather than assumed. Probing massive
+directly for all 18 silver-less names, only **CFLT, CYBR and PSTG** return no
+split *and* no dividend, so no amount of ingesting will ever make them
+verifiable. None of the three carries a band in either measured state, so the
+coverage cost today is zero — but the ceiling is real, and an event table cannot
+record a non-event. The upgrade path, if it ever matters, is a per-ticker ingest
+coverage row written by `corporate_actions_refresh_once`, not a sentinel event.
+
+Effect on the 2026-08-22 store, run against production writing nothing
+(`STAGE_SPLITS=0`): refusals rise 4 → 10, and the six added are exactly the
+never-ingested names that had bands (ALB, AXON, CMCSA, CNC, ECL, LOGI). With the
+widened ingest simulated faithfully — its splits **and** its dividends —
+(`STAGE_SPLITS=1`) it returns to 4: CXAI, HON, MSTR, TRI, the four with a real
+in-window split. CCEP is the case that proves dividends belong in the evidence:
+0 splits, 22 dividends, and it comes back with a band.
+
+### A missing silver tier failed silently
+
+`load_closes` skips a symbol whose parquet is absent, so an absent *tier* — a
+bad mount, a livewire path change — yielded an empty dict, put all 450 names on
+the bronze fallback, and reinstated the original bug without a single error.
+The job now refuses to start unless `silver_root` is a directory. The previous
+day's bands stand, which beats minting a universe of wrong ones.
+
+### Why not adjust bronze in argon
+
+The first attempt did, using massive's `/v3/reference/splits`. It worked for
+forward splits and then made KLAC *worse* (9.47 → 9.98), because the legacy
+segment already contains whatever splits were known at backfill time — CTAS's
+2024 4-for-1 is baked in, KLAC's 2026 10-for-1 is not — and that date is
+undocumented. The attempt before that scored price gaps with a volume
+level-shift confirmation: ~1.0 recall on real splits, and it still called DOCU's
+42% crash on 2021-12-03 a split. Any threshold loose enough to catch a 2-for-1
+(gap 2.00) sits inside the range real crashes occupy. Neither is needed once the
+producer's own adjusted tier is read.
+
+## Result, verified against production writing nothing
+
+`insert_anchors` swapped for a collector, splits for the 18 silver-less names
+staged inside the transaction, `conn.rollback()` at exit.
+
+```
+considered 420 · banded 321 · refused 53 · unadjustable_prices 5 · written 416
+```
+
+Bands that moved more than 10%, and where the name sat relative to its band:
+
+```
+BKNG   spot   209.87   buy_below  4702.64 ->  190.13    IN -> --
+KLAC   spot   185.86   buy_below   570.25 ->   62.82    IN -> --
+CRWD   spot   190.34   buy_below   362.53 ->   90.07    IN -> --
+NOW    spot   129.75   buy_below   861.91 ->  169.06    IN -> IN
+CTAS   spot   203.52   buy_below   222.00 ->  156.50    IN -> --
+FAST   spot    50.66   buy_below    51.45 ->   34.25    IN -> --
+ETR    spot   107.34   buy_below    81.17 ->   32.79    -- -> --
+APH    spot   153.11   buy_below   149.80 ->   84.48    -- -> --
+WMT    spot   103.84   buy_below    98.79 ->   59.26    -- -> --
+```
+
+**Refused, correctly** — no silver series and a split inside the window:
+
+```
+CXAI   spot     3.94   was buy_below     0.11   (50-for-1, 2026-08-18)
+TRI    spot   105.88   was buy_below   137.82   IN ZONE (buyback consolidations)
+MSTR   spot   112.39   was buy_below   101.23   (1-for-10, 2024-08-08)
+HON    spot   218.32   was buy_below   167.04   (1000-for-1061, 2025-10-30)
+```
+
+### The error also ran the other way
+
+A split inside the window makes a name's own yield history look like it spans
+two regimes, so the 4x width gate refused it. Seven names gain a real band, and
+every one of them split in-window:
+
+```
+NVDA   spot   216.85   buy_below   245.33   IN ZONE   (1-for-4 2021, 1-for-10 2024)
+AVGO   spot   364.03   buy_below   131.88             (1-for-10, 2024-07-15)
+LRCX   spot   310.53   buy_below    79.32             (1-for-10, 2024-10-03)
+ORLY   spot    89.08   buy_below    75.47             (1-for-15, 2025-06-10)
+DECK   spot    88.86   buy_below   106.71   IN ZONE   (1-for-6,  2024-09-17)
+SMCI   spot    36.50   buy_below    39.94   IN ZONE   (1-for-10, 2024-10-01)
+BKSY   spot    26.73   buy_below     6.37             (8-for-1,  2024-09-09)
+```
+
+NVDA was refused in production for an *"own 20-quarter valuation range spans
+16.9x, wider than the 4x limit"*. That span was its two splits — 4x in 2021 and
+10x in 2024, 40x combined — not its valuation. **A previous session diagnosed
+that refusal as a genuine two-regime yield window and concluded the 20-quarter
+window was the cause. That was wrong**; the window is fine and the prices were
+not.
+
+## Verified in the production container, 2026-08-22
+
+Each check ran in a throwaway container against `/opt/argon/.env` and the real
+lake mount, never the running worker.
+
+| Question | Answer |
+|---|---|
+| Does `/lake/silver/asset_class=equity` exist on the mini? | **yes** — the new hard fail will not self-inflict an outage |
+| Does the SHIPPED image resolve `lake_fx_root`? | **no** — `/root/market-warehouse/.../fx`, `exists=False`. The bug is live in production right now |
+| Does the FIXED config resolve it? | **yes** — `/lake/bronze/asset_class=fx`, `exists=True`, 21 symbols |
+| Does `load_fx` orient an inverted pair correctly? | **yes** — EUR returns 0.85490 per USD, the reciprocal of the lake's `EURUSD` 1.16973. TWD 31.82, JPY 158.795, GBP 0.73251 |
+| Does an absent currency return empty? | **yes** — DKK is EMPTY, so NVO is refused rather than banded unconverted |
+| Does massive return splits newest-first? | **yes** — AAPL `2020-08-31 ... 1987-06-16` descending, so `split_limit=12` truncates away only pre-window history |
+| Can the widened ingest finish inside its 45-minute gap? | **yes** — 20 tickers x 2 calls in 9.2s = 0.458 s/ticker, projecting **3.4 min** for 450 names |
+| Does bumping `ANCHOR_RULES_REV` change `inputs_hash`? | **yes** — `rules.rev` is in the hash payload (`valuation.py`), and `test_anchor_reachability.py` monkeypatches the rev and asserts the hash moves |
+
+Reproduce: `apex_vs_silver_check.py` in this directory carries the throwaway-
+container pattern; the other probes used the same shape with
+`--env-file /opt/argon/.env`.
+
+## Residual, not fixed
+
+**COHR** keeps a 5.42x cliff on 2022-07-01: II-VI acquired Coherent and took its
+ticker, so the series concatenates two companies. massive correctly reports no
+split. A ticker-identity seam is a different defect class and no discriminator
+separates it from a real move, so it is recorded here rather than guessed at in
+code. (CXAI had the same seam from its 2023 SPAC; it is now refused for the
+unrelated reason that it has no adjustable series at all.)
+
+**Upstream, for livewire:** the 18 `price_basis='unknown'` symbols are the
+remaining gap. Every one that gets resolved returns a band automatically and
+`unadjustable_prices` falls. That counter is the metric to watch.
+
+**Found while measuring this, fixed in the same change:** 12 foreign filers were
+refused for want of an FX series the lake was carrying. Two faults stacked.
+`lake_fx_root` had no case in `Settings.from_env` at all, so it fell back to
+`$HOME` — `/root/market-warehouse/…` in the container, which has never existed;
+every lake root now falls back under `market_warehouse_lake_root`. And
+`fx_symbol` looked only for `USD<CCY>` while the mini's lake publishes `EURUSD`
+(1.16973, USD per EUR) and no `USDEUR`; `load_fx` now reads either orientation
+and inverts `<CCY>USD`. `no_fx` 12 → 1, `converted` 0 → 11.
+
+Direction verified against real filings rather than inferred from the bands
+looking plausible — a 35% EUR error prints a perfectly plausible band:
+
+```
+ASML 2026-06-30   reported     9.33 B EUR  @ 0.85490 EUR/USD  ->    10.87 B USD
+TSM  2026-06-30   reported  1270.38 B TWD  @ 31.82   TWD/USD  ->    40.45 B USD
+```
+
+TSM's figure is not `1270.38 / 31.82 = 39.92` because a flow takes the TTM
+AVERAGE rate, not the closing one — the two-rate rule, working.
+
+**NVO stays refused, correctly.** It reports DKK and the lake carries no DKK
+series in either orientation. Upstream ask for livewire, not something to paper
+over with an unconverted band.
+
+## Reproduce
+
+`STAGE_SPLITS=0` reads the split store exactly as production has it — the state
+the job meets if it deploys between the 17:35 ingest and the 18:20 band run.
+`STAGE_SPLITS=1` stages the silver-less names' splits inside the transaction to
+simulate the post-deploy store. Both roll back and write nothing.
+
+colima shares no arbitrary host paths, so the patched tree goes in with
+`docker cp` into a *throwaway* container — never into the running worker, whose
+writable layer would then survive a restart onto unmerged code.
+
+```bash
+tar czf /tmp/argonpatch.tgz \
+  src/uw_scan/worker/jobs/fundamental_anchors.py \
+  src/uw_scan/worker/jobs/fundamental_refresh.py \
+  src/uw_scan/storage/corporate_actions.py \
+  src/uw_scan/fundamentals/fx.py src/uw_scan/fundamentals/valuation.py \
+  src/uw_scan/config.py \
+  docs/research/2026-08-21-lake-price-basis-split-contamination/prod_validation.py
+scp /tmp/argonpatch.tgz macmini:/tmp/argonpatch.tgz
+
+ssh macmini 'D=/opt/homebrew/bin/docker
+T=$($D create --network argon_default --add-host=host.docker.internal:host-gateway \
+  -v /Volumes/DATA_LAKE/livewire/data-lake:/lake:ro \
+  --env-file /opt/argon/.env \
+  -e UW_SCAN_DB_HOST=host.docker.internal -e MARKET_WAREHOUSE_LAKE=/lake \
+  -e LAKE_CREDIT_ETF_ROOT=/lake/bronze/asset_class=equity \
+  -e LAKE_VOL_INDEX_ROOT=/lake/bronze/asset_class=volatility \
+  -e STAGE_SPLITS=0 --entrypoint sh ghcr.io/moremeds/argon-app:latest \
+  -c "cd /app && tar xzf /tmp/p.tgz && python docs/research/2026-08-21-lake-price-basis-split-contamination/prod_validation.py")
+$D cp /tmp/argonpatch.tgz $T:/tmp/p.tgz; $D start -a $T; $D rm -f $T'
+```
+
+The split-contamination count before the fix:
+
+```bash
+ssh macmini "/opt/homebrew/bin/docker exec -i argon-worker-massive-0-1 python -" \
+  < scripts/research/valuation_split_contamination_probe.py
+```
+
+Coverage of `corporate_actions` over the universe, and the three names that stay
+unverifiable, are read straight from the mini:
+
+```sql
+-- zero-row share of the universe (313 of 450 on 2026-08-22)
+WITH u AS (SELECT DISTINCT ticker FROM uw_scan.fundamental_universe)
+SELECT count(*) FILTER (WHERE NOT EXISTS (
+         SELECT 1 FROM uw_scan.corporate_actions c WHERE c.ticker = u.ticker)) AS zero_rows,
+       count(*) AS universe
+FROM u;
+```

--- a/docs/research/2026-08-21-lake-price-basis-split-contamination/apex_vs_silver_check.py
+++ b/docs/research/2026-08-21-lake-price-basis-split-contamination/apex_vs_silver_check.py
@@ -1,0 +1,69 @@
+"""Does apex's /bars close equal silver's close, and is either split-only?
+
+Prints, for one date, each ticker's silver `close`, its two adjustment factors,
+the split-only close reconstructed as `close / (pf * svf)`, and raw bronze.
+CRWD isolates the split half (no dividend, factors cancel to 1.0), ETR the
+dividend half (never split, svf == 1.0), BKNG carries both.
+
+Reproduce (the lake lives on the mini):
+
+  scp docs/research/2026-08-21-lake-price-basis-split-contamination/\
+apex_vs_silver_check.py macmini:/tmp/apexchk.py
+  ssh macmini 'D=/opt/homebrew/bin/docker
+  C=$($D create -v /Volumes/DATA_LAKE/livewire/data-lake:/lake:ro \
+      ghcr.io/moremeds/argon-app:latest python /tmp/apexchk.py)
+  $D cp /tmp/apexchk.py $C:/tmp/apexchk.py; $D start -a $C; $D rm -f $C'
+
+  # and apex's own answer, to compare against the silver `close` column:
+  curl -s "http://100.66.147.98:8322/bars/BKNG?timeframe=1d\
+&start=2026-04-01T00:00:00&end=2026-04-03T00:00:00&limit=0"
+
+Measured 2026-08-22: apex returned 167.349 for BKNG on 2026-04-02, matching
+silver `close` 167.3493 and NOT split_only 167.7700.
+"""
+
+import pyarrow.parquet as pq
+from datetime import date
+
+TARGET = date(2026, 4, 2)
+for sym in ["BKNG", "CRWD", "ETR"]:
+    sp = f"/lake/silver/asset_class=equity/symbol={sym}/1d.parquet"
+    bp = f"/lake/bronze/asset_class=equity/symbol={sym}/1d.parquet"
+    try:
+        t = pq.read_table(
+            sp,
+            columns=["trade_date", "close", "price_adjustment_factor", "split_volume_factor"],
+        ).to_pydict()
+    except Exception as e:
+        print(sym, "silver ERR", repr(e))
+        t = None
+    if t:
+        hit = False
+        for i, d in enumerate(t["trade_date"]):
+            if d == TARGET:
+                c = float(t["close"][i])
+                pf = float(t["price_adjustment_factor"][i])
+                svf = float(t["split_volume_factor"][i])
+                prod = pf * svf
+                print(
+                    f"{sym} SILVER close={c:.4f} pf={pf:.6f} svf={svf:.6f} "
+                    f"pf*svf={prod:.6f} split_only={c / prod:.4f}"
+                )
+                hit = True
+                break
+        if not hit:
+            print(sym, "silver: no row at", TARGET)
+    try:
+        b = pq.read_table(bp, columns=["trade_date", "close"]).to_pydict()
+    except Exception as e:
+        print(sym, "bronze ERR", repr(e))
+        continue
+    hit = False
+    for i, d in enumerate(b["trade_date"]):
+        if d == TARGET:
+            bc = float(b["close"][i])
+            print(f"{sym} BRONZE close={bc:.4f}")
+            hit = True
+            break
+    if not hit:
+        print(sym, "bronze: no row at", TARGET)

--- a/docs/research/2026-08-21-lake-price-basis-split-contamination/prod_validation.py
+++ b/docs/research/2026-08-21-lake-price-basis-split-contamination/prod_validation.py
@@ -1,0 +1,143 @@
+"""Read-only check of the silver-priced valuation band against production.
+
+Writes NOTHING: insert_anchors is swapped for a collector and the connection is
+rolled back. Splits for the silver-missing names are inserted INSIDE the same
+transaction so the in-window guard runs exactly as it will once the widened
+17:35 corporate-actions ingest has covered the fundamental universe.
+
+Reproduce:
+  ssh macmini 'docker run --rm --env-file /opt/argon/.env \
+    --add-host host.docker.internal:host-gateway \
+    -v /Volumes/DATA_LAKE/livewire/data-lake:/lake:ro \
+    -v /tmp/argonpatch/validate.py:/tmp/validate.py:ro \
+    ghcr.io/moremeds/argon-app:latest python /tmp/validate.py'
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal
+
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.sources.massive_fundamentals import MassiveFundamentalsProvider
+from uw_scan.storage.corporate_actions import CorporateActionsRepository
+from uw_scan.storage.fundamental_anchors import FundamentalAnchorsRepository
+from uw_scan.worker.jobs import fundamental_anchors as mod
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+s = Settings.from_env()
+silver_root = s.market_warehouse_lake_root / "silver/asset_class=equity"
+
+with psycopg.connect(s.db_dsn()) as conn:
+    ca = CorporateActionsRepository(conn, schema=s.db_schema)
+    universe = ca.fetch_fundamental_universe_tickers()
+    missing = [
+        t for t in universe if not (silver_root / f"symbol={t}" / "1d.parquet").exists()
+    ]
+    print(f"universe={len(universe)} no_silver={len(missing)} {missing}")
+
+    # STAGE_SPLITS=1 simulates the post-deploy split store for exactly those
+    # names; STAGE_SPLITS=0 leaves production as it stands, which is the state
+    # the job meets on the first night if it deploys before the widened ingest
+    # has run. Both are worth measuring: the second is what the evidence rule in
+    # `_bronze_basis_refusal` exists for.
+    if os.environ.get("STAGE_SPLITS", "1") == "1":
+        with MassiveFundamentalsProvider(s.massive_api_key.get_secret_value()) as p:
+            added = 0
+            for t in missing:
+                for r in p.fetch_splits(t, limit=50):
+                    if not (r["execution_date"] and r["split_from"] and r["split_to"]):
+                        continue
+                    ca.upsert_corporate_action(
+                        ticker=t,
+                        event_type="split",
+                        event_date=r["execution_date"],
+                        split_ratio=Decimal(r["split_to"]) / Decimal(r["split_from"]),
+                    )
+                    added += 1
+                # Dividends too, or the simulation is not the widened ingest:
+                # they are what makes a never-split name verifiable, and CCEP
+                # carries 22 of them against 0 splits.
+                for r in p.fetch_dividends(t, limit=24):
+                    if not r["ex_dividend_date"]:
+                        continue
+                    ca.upsert_corporate_action(
+                        ticker=t,
+                        event_type="dividend",
+                        event_date=r["ex_dividend_date"],
+                        cash_amount=r.get("cash_amount"),
+                    )
+                    added += 1
+        print(f"staged {added} corporate-action rows (rolled back at exit)")
+    else:
+        print("STAGE_SPLITS=0: reading the split store exactly as production has it")
+
+    before = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT ticker, buy_below, spot FROM (SELECT DISTINCT ON (ticker) * "
+            f"FROM {s.db_schema}.valuation_anchors "
+            "ORDER BY ticker, as_of DESC, result_id DESC) a"
+        )
+        before = {t: (bb, sp) for t, bb, sp in cur.fetchall()}
+
+    collected: list[dict] = []
+    FundamentalAnchorsRepository.insert_anchors = lambda self, rows: (
+        collected.extend(rows) or len(rows)
+    )
+
+    counters = mod.fundamental_anchors(
+        conn=conn,
+        lake_root=s.lake_credit_etf_root,
+        silver_root=silver_root,
+        fx_root=s.lake_fx_root,
+        schema=s.db_schema,
+    )
+    conn.rollback()
+
+print("counters:", counters)
+
+moved, entered, left, refused_now = [], [], [], []
+for row in collected:
+    t = row["ticker"]
+    bb_new, spot = row.get("buy_below"), row.get("spot")
+    bb_old, spot_old = before.get(t, (None, None))
+    if bb_old is None and bb_new is None:
+        continue
+    was_in = bb_old is not None and spot_old is not None and spot_old <= bb_old
+    is_in = bb_new is not None and spot is not None and spot <= bb_new
+    if bb_old is not None and bb_new is None:
+        refused_now.append((t, spot, bb_old, was_in))
+    elif bb_old is not None and bb_new is not None:
+        ratio = float(bb_new) / float(bb_old)
+        if ratio < 0.9 or ratio > 1.1:
+            moved.append((t, spot, bb_old, bb_new, was_in, is_in))
+    if was_in and not is_in:
+        left.append(t)
+    if is_in and not was_in:
+        entered.append(t)
+
+print(f"\n=== bands that moved >10% ({len(moved)}) ===")
+for t, spot, o, n, wi, ii in sorted(moved, key=lambda r: -abs(float(r[3]) / float(r[2]))):
+    print(
+        f"  {t:6s} spot={float(spot or 0):9.2f} buy_below {float(o):10.2f} -> "
+        f"{float(n):9.2f}   {'IN' if wi else '--'} -> {'IN' if ii else '--'}"
+    )
+print(f"\n=== banded before, refused now ({len(refused_now)}) ===")
+for t, spot, o, wi in refused_now:
+    print(f"  {t:6s} spot={float(spot or 0):9.2f} was buy_below {float(o):10.2f} {'IN ZONE' if wi else ''}")
+gained = [
+    (r["ticker"], r.get("spot"), r.get("buy_below"), r.get("history_quarters"))
+    for r in collected
+    if r.get("buy_below") is not None and before.get(r["ticker"], (None, None))[0] is None
+]
+print(f"\n=== refused before, banded now ({len(gained)}) ===")
+for t, spot, bb, hq in sorted(gained):
+    mark = "  IN ZONE" if spot is not None and spot <= bb else ""
+    print(f"  {t:6s} spot={float(spot or 0):9.2f} buy_below {float(bb):9.2f} hist={hq}q{mark}")
+
+print(f"\nleft the buy zone: {sorted(left)}")
+print(f"entered the buy zone: {sorted(entered)}")

--- a/scripts/research/valuation_split_contamination_probe.py
+++ b/scripts/research/valuation_split_contamination_probe.py
@@ -1,0 +1,103 @@
+"""Per-banded-name: does a corporate-action cliff fall inside the yield window
+the band was actually built from?
+
+Read-only. Measures the contamination that `LAKE_BASIS_SEAM` + split adjustment
+in `worker/jobs/fundamental_anchors.py` exist to remove, so it doubles as the
+after-check: re-run once bands have been rebuilt and the count should fall to the
+names whose splits `corporate_actions` still lacks.
+
+Reproduce (on the mini, where the lake and prod DB live):
+
+    ssh macmini "/opt/homebrew/bin/docker exec -i argon-worker-massive-0-1 python -" \
+      < scripts/research/valuation_split_contamination_probe.py
+
+Verdict and the 2026-08-21 numbers:
+`docs/research/2026-08-21-lake-price-basis-split-contamination/VERDICT.md`
+"""
+from datetime import date, timedelta
+from pathlib import Path
+
+import psycopg
+import pyarrow.parquet as pq
+
+from uw_scan.config import Settings
+
+SEAM = date(2021, 6, 11)  # legacy back-adjusted -> raw as-traded
+LAG = timedelta(days=45)
+
+s = Settings.from_env()
+root = Path(s.lake_credit_etf_root)
+
+
+def near_simple_ratio(r):
+    for n in range(1, 51):
+        for m in (1, 2, 3, 4):
+            if m > 1 and n % m == 0:
+                continue
+            for cand, label in ((n / m, f"{n}:{m}"), (m / n, f"{m}:{n}")):
+                if cand > 1.05 and abs(r / cand - 1) < 0.02:
+                    return label
+    return None
+
+
+with psycopg.connect(s.db_dsn()) as conn, conn.cursor() as cur:
+    cur.execute(
+        """SELECT DISTINCT ON (ticker) ticker, spot, buy_below, history_quarters, spot_percentile
+             FROM uw_scan.valuation_anchors
+            WHERE as_of='2026-08-18' AND buy_below IS NOT NULL
+            ORDER BY ticker, result_id DESC"""
+    )
+    banded = {r[0]: r[1:] for r in cur.fetchall()}
+    cur.execute(
+        """SELECT ticker, period_end FROM uw_scan.fundamental_statement_obs
+            WHERE statement='income' AND ticker = ANY(%s)""",
+        (list(banded),),
+    )
+    periods: dict[str, list[date]] = {}
+    for t, p in cur.fetchall():
+        periods.setdefault(t, []).append(p)
+
+rows_out, crosses_seam, clean = [], 0, 0
+for t, (spot, buy_below, hq, pct) in sorted(banded.items()):
+    ps = sorted(set(periods.get(t, [])), reverse=True)[: hq or 20]
+    if not ps:
+        continue
+    start = min(ps) + LAG
+    p = root / f"symbol={t}" / "1d.parquet"
+    if not p.exists():
+        continue
+    tab = pq.read_table(str(p), columns=["trade_date", "close"])
+    ser = sorted(
+        (d, float(c))
+        for d, c in zip(
+            tab.column("trade_date").to_pylist(), tab.column("close").to_pylist()
+        )
+        if d is not None and c is not None and d >= start
+    )
+    if start < SEAM:
+        crosses_seam += 1
+    worst = None
+    for a, b in zip(ser, ser[1:]):
+        if a[1] <= 0:
+            continue
+        gap = max(b[1] / a[1], a[1] / b[1])
+        lab = near_simple_ratio(gap) if gap >= 1.6 else None
+        if lab and (worst is None or gap > worst[0]):
+            worst = (gap, a[0], b[0], lab)
+    if worst is None:
+        clean += 1
+        continue
+    rows_out.append((t, start, worst, float(spot), float(buy_below), float(pct or 0)))
+
+inzone = [r for r in rows_out if r[3] < r[4]]
+print(f"banded names checked: {len(banded)}")
+print(f"  window starts before the 2021-06-11 basis seam: {crosses_seam}")
+print(f"  no split cliff inside the window:               {clean}")
+print(f"  SPLIT CLIFF INSIDE THE WINDOW:                  {len(rows_out)}")
+print(f"    of those, currently rendered IN THE BUY ZONE: {len(inzone)}")
+print()
+print("ticker|window_start|cliff_date|ratio|gap|spot|buy_below|spot_pct|in_buy_zone")
+for t, start, (gap, a, b, lab), spot, bb, pct in sorted(rows_out, key=lambda r: -r[2][0]):
+    print(
+        f"{t}|{start}|{b}|{lab}|{gap:.2f}|{spot:.2f}|{bb:.2f}|{pct:.2f}|{spot < bb}"
+    )

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -617,6 +617,21 @@ class Settings(BaseModel):
         db_name = os.environ.get("UW_SCAN_DB_NAME", "option_wizard_local")
         _enforce_db_isolation(db_host, db_name)
 
+        # Every lake root falls back UNDER the warehouse root, never under $HOME.
+        # In a container $HOME is /root and no lake lives there, so a root with no
+        # env var of its own silently resolves to a path that does not exist. That
+        # is exactly what happened to `lake_fx_root`: it was added after the
+        # container migration, never got a `LAKE_FX_ROOT` case here, and resolved
+        # to /root/market-warehouse/... in production — so 12 foreign filers were
+        # refused for want of an FX series the lake was carrying the whole time.
+        # Deriving the fallback means the next root added is correct by default.
+        _mw_lake = os.environ.get("MARKET_WAREHOUSE_LAKE", "").strip()
+        mw_lake_root = (
+            Path(_mw_lake)
+            if _mw_lake
+            else Path.home() / "market-warehouse" / "data-lake"
+        )
+
         return cls(
             api_key=SecretStr(api_key),
             db_host=db_host,
@@ -954,20 +969,19 @@ class Settings(BaseModel):
             lake_vol_index_root=(
                 Path(_lake_vol)
                 if (_lake_vol := os.environ.get("LAKE_VOL_INDEX_ROOT", "").strip())
-                else Path.home()
-                / "market-warehouse/data-lake/bronze/asset_class=volatility"
+                else mw_lake_root / "bronze/asset_class=volatility"
             ),
             lake_credit_etf_root=(
                 Path(_lake_credit)
                 if (_lake_credit := os.environ.get("LAKE_CREDIT_ETF_ROOT", "").strip())
-                else Path.home()
-                / "market-warehouse/data-lake/bronze/asset_class=equity"
+                else mw_lake_root / "bronze/asset_class=equity"
             ),
-            market_warehouse_lake_root=(
-                Path(_mw_lake)
-                if (_mw_lake := os.environ.get("MARKET_WAREHOUSE_LAKE", "").strip())
-                else Path.home() / "market-warehouse" / "data-lake"
+            lake_fx_root=(
+                Path(_lake_fx)
+                if (_lake_fx := os.environ.get("LAKE_FX_ROOT", "").strip())
+                else mw_lake_root / "bronze/asset_class=fx"
             ),
+            market_warehouse_lake_root=mw_lake_root,
             credit_etf_symbols=_parse_csv_env(
                 "CREDIT_ETF_SYMBOLS", default=["HYG", "JNK", "LQD"]
             ),

--- a/src/uw_scan/fundamentals/fx.py
+++ b/src/uw_scan/fundamentals/fx.py
@@ -34,11 +34,17 @@ at one day's rate.
 
 SYMBOL CONVENTION
 -----------------
-`USD<CCY>` in the lake holds **<CCY> per one USD** (USDEUR closed 0.8586 on
-2026-05-18, i.e. EUR per USD). So `usd = local / rate`. Getting this inverted is
-a ~35% error on EUR that still produces plausible-looking prices, so the
-direction is asserted in the self-check against a real observed level rather than
-left to the reader.
+`USD<CCY>` holds **<CCY> per one USD** (USDEUR closed 0.8586 on 2026-05-18, i.e.
+EUR per USD). So `usd = local / rate`. Getting this inverted is a ~35% error on
+EUR that still produces plausible-looking prices, so the direction is asserted in
+the self-check against a real observed level rather than left to the reader.
+
+The lake does not always use it. The mini's mirror publishes the majors on the
+market's convention instead — `EURUSD` closed 1.16973 on 2026-08-21, USD per EUR
+— and carries no `USDEUR` at all, while the MacBook's mirror carries `USDEUR` and
+no `EURUSD`. `load_fx` reads whichever exists and inverts the second, so this
+module's convention holds downstream regardless. Until it did, `fx_symbol` looked
+for a symbol the production lake has never had.
 """
 
 from __future__ import annotations
@@ -57,19 +63,40 @@ USD_LIKE = frozenset({"USD", None, ""})
 
 
 def fx_symbol(currency: str) -> str:
-    """Lake symbol for a reporting currency. `USD<CCY>` = <CCY> per one USD."""
+    """Lake symbol on THIS module's convention. `USD<CCY>` = <CCY> per one USD."""
     return f"USD{currency.upper()}"
 
 
+def inverse_fx_symbol(currency: str) -> str:
+    """The market's own convention. `<CCY>USD` = USD per one CCY."""
+    return f"{currency.upper()}USD"
+
+
 def load_fx(root: Path, currency: str) -> list[tuple[date, float]]:
-    """Daily rates for one currency, ascending. Empty when the series is absent.
+    """Daily rates for one currency, ascending, as <CCY> per one USD.
+
+    Accepts EITHER orientation from the lake, because the mirrors disagree and
+    neither is wrong: the Mac mini's lake publishes `EURUSD` (1.16973 on
+    2026-08-21, USD per EUR) while the MacBook's publishes `USDEUR` (0.8586,
+    EUR per USD), and both are livewire artifacts. `USD<CCY>` is preferred and
+    used as-is; `<CCY>USD` is inverted on read, so everything downstream sees one
+    convention and `convert`'s `value / rate` stays correct.
+
+    Hardcoding which currencies are quoted which way would be a table to keep in
+    sync with two mirrors; asking the lake what it actually has is both shorter
+    and right when a mirror changes.
 
     Empty is a real answer and callers must refuse the ticker on it rather than
     fall back to an unconverted figure — an unconverted band is the silent wrong
     answer this module exists to prevent.
     """
-    path = root / f"symbol={fx_symbol(currency)}" / BAR_FILENAME
-    if not path.exists():
+    direct = root / f"symbol={fx_symbol(currency)}" / BAR_FILENAME
+    inverse = root / f"symbol={inverse_fx_symbol(currency)}" / BAR_FILENAME
+    if direct.exists():
+        path, invert = direct, False
+    elif inverse.exists():
+        path, invert = inverse, True
+    else:
         return []
     import pyarrow.parquet as pq
 
@@ -79,7 +106,7 @@ def load_fx(root: Path, currency: str) -> list[tuple[date, float]]:
         log.warning("fx: unreadable series for %s: %s", currency, repr(exc))
         return []
     rows = [
-        (d, float(c))
+        (d, 1.0 / float(c) if invert else float(c))
         for d, c in zip(
             tab.column("trade_date").to_pylist(), tab.column("close").to_pylist()
         )

--- a/src/uw_scan/fundamentals/valuation.py
+++ b/src/uw_scan/fundamentals/valuation.py
@@ -222,6 +222,17 @@ MAX_BAND_WIDTH = 4.0
 #: redefined. Threshold moves do not need it: the constants above are hashed
 #: directly, so changing one already produces a new identity.
 #:
+#: rev 4: the yield window is priced from the lake's SILVER tier, on today's
+#: split basis, instead of raw bronze closes. Nothing in this module moved, but
+#: every historical yield the percentiles are drawn from did: the provider
+#: restates share counts onto today's split basis while bronze stores closes
+#: raw, so a quarter before a split was yielding a number wrong by the split
+#: factor. Not bumping this would be the exact failure the
+#: docstring below describes — the corrected band collides with the wrong one on
+#: `(ticker, as_of, engine_version, inputs_hash)` and `DO NOTHING` keeps BKNG's
+#: $4,702.64 `buy_below` against its $208.25 spot. The inputs hashed here
+#: (`fundamental`, `net_debt`, `shares`, `history_n`) are all unchanged by the
+#: fix, so the identity cannot see it any other way.
 #: rev 3: a refusal reports the window it refused ON rather than a hardcoded 0,
 #: and the width refusal describes the window's measured SHAPE instead of
 #: asserting instability it never tested for.
@@ -230,7 +241,7 @@ MAX_BAND_WIDTH = 4.0
 #: `DO NOTHING` would keep the wrong one for the rest of the day.
 #: rev 2: refuse a band with a missing end (`buy_below` / `risk_above` not
 #: invertible). rev 1: the original five-level construction.
-ANCHOR_RULES_REV = 3
+ANCHOR_RULES_REV = 4
 
 
 def anchor_inputs_hash(

--- a/src/uw_scan/storage/corporate_actions.py
+++ b/src/uw_scan/storage/corporate_actions.py
@@ -51,12 +51,117 @@ class _CorporateActionsMixin:
             cols = [d.name for d in cur.description or []]
             return [dict(zip(cols, row, strict=False)) for row in cur.fetchall()]
 
+    def split_factors(
+        self, tickers: list[str]
+    ) -> dict[str, list[tuple[_date, float]]]:
+        """`{ticker: [(execution_date, ratio), ...]}` — the splits on record.
+
+        Bulk because the caller checks a whole universe in one pass and
+        `fetch_corporate_actions` is one round trip per name.
+
+        `ratio` is shares-after per share-before, so a 1-for-25 forward split is
+        25.0 and a 50-for-1 reverse is 0.02. The band job does not adjust prices
+        with these — livewire's silver tier already publishes adjusted closes.
+        It uses them to decide whether a name it CANNOT read from silver may be
+        priced from raw bronze anyway, which is true exactly when no split falls
+        inside the window being priced.
+        """
+        if not tickers:
+            return {}
+        sql = (
+            "SELECT ticker, event_date, split_ratio "
+            f"FROM {self._schema}.corporate_actions "
+            "WHERE event_type = 'split' AND split_ratio IS NOT NULL "
+            "AND split_ratio > 0 AND ticker = ANY(%s) "
+            "ORDER BY ticker, event_date"
+        )
+        out: dict[str, list[tuple[_date, float]]] = {}
+        with self._conn.cursor() as cur:
+            cur.execute(sql, ([t.upper() for t in tickers],))
+            for ticker, event_date, ratio in cur.fetchall():
+                out.setdefault(ticker, []).append((event_date, float(ratio)))
+        return out
+
+    def ingested_tickers(self, tickers: list[str]) -> set[str]:
+        """The subset with at least one row on record — split OR dividend.
+
+        Membership is evidence the ingest ever reached this name, and that is
+        the thing `split_factors` cannot tell you: "never split" and "never
+        asked" both come back as an empty list, so a caller that reads the empty
+        one as clean prices a split name on an unadjusted series. On 2026-08-22
+        that gap covered 15 of the 18 names the band job must price from bronze
+        — AIG, CMCSA, ECL and HON among them, every one silently trusted — for
+        the plain reason that the ingest then covered 137 of the universe's 450.
+
+        Zero rows mostly means not ingested, because a 12-split/24-dividend
+        lookback catches nearly every established name: across the 188 tickers
+        the ingest did cover on 2026-08-22, not one ended with zero rows. It is
+        not a perfect proxy, and the exceptions are known by name — massive
+        returns no split AND no dividend for CFLT, CYBR and PSTG, so those three
+        stay unverifiable however often they are ingested, and lose a band they
+        could in principle carry. Three names against silently mispricing a split
+        one is the trade taken; the caller's refusal text says "indistinguishable
+        from never having asked" rather than asserting the ingest skipped them.
+
+        ponytail: an event table cannot record a non-event. If those three ever
+        matter, the upgrade is a per-ticker ingest-coverage row written by
+        `corporate_actions_refresh_once`, not a sentinel event in here.
+        """
+        if not tickers:
+            return set()
+        sql = (
+            "SELECT DISTINCT ticker "
+            f"FROM {self._schema}.corporate_actions "
+            "WHERE ticker = ANY(%s)"
+        )
+        with self._conn.cursor() as cur:
+            cur.execute(sql, ([t.upper() for t in tickers],))
+            return {row[0] for row in cur.fetchall()}
+
+    def fetch_fundamental_universe_tickers(self) -> list[str]:
+        """Every active name in the fundamental universe, any tier.
+
+        Here rather than on `FundamentalObsRepository` for the reason the
+        module docstring gives for `fetch_distinct_vrp_tickers`: the ingestion
+        job takes one aggregate repo and stays self-contained. `valuation_anchors`
+        prices 20 quarters of history, and for the names livewire cannot
+        publish an adjusted series for, this store is the only evidence of
+        whether their raw closes are on today's share basis. Without coverage
+        here those names are banded across their own splits — CXAI's 50-for-1
+        left buy_below at $0.107 against a $4.59 spot.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"SELECT DISTINCT ticker FROM {self._schema}.fundamental_universe "
+                "WHERE removed_at IS NULL ORDER BY ticker"
+            )
+            return [r[0] for r in cur.fetchall()]
+
     def fetch_distinct_vrp_tickers(self) -> list[str]:
         """The VRP scoring universe — every ticker with a vrp_daily panel. The
-        corporate-action ingestion covers this ∪ active watchlist so every
-        scored ticker has corp-action coverage (research-expansion ISSUE-9)."""
+        corporate-action ingestion covers this ∪ active watchlist ∪ the
+        fundamental universe so every scored ticker has corp-action coverage
+        (research-expansion ISSUE-9)."""
         with self._conn.cursor() as cur:
             cur.execute(
                 f"SELECT DISTINCT ticker FROM {self._schema}.vrp_daily ORDER BY ticker"
             )
             return [r[0] for r in cur.fetchall()]
+
+
+class CorporateActionsRepository(_CorporateActionsMixin):
+    """Standalone handle for callers outside the aggregate `Repository`.
+
+    The mixin is assembled into `Repository` for the ingest job, which already
+    holds one. `fundamental_anchors` does not — it takes a bare connection — and
+    reaching for the aggregate just to read splits would pull in every other
+    domain. Same shape as the other standalone domain repositories.
+    """
+
+    def __init__(self, conn: psycopg.Connection, schema: str = "uw_scan") -> None:
+        self._conn = conn
+        self._schema = schema
+
+    @property
+    def conn(self) -> psycopg.Connection:
+        return self._conn

--- a/src/uw_scan/worker/jobs/corporate_actions_jobs.py
+++ b/src/uw_scan/worker/jobs/corporate_actions_jobs.py
@@ -30,6 +30,12 @@ def corporate_actions_refresh_once(
     split_limit: int = 12,
     dividend_limit: int = 24,
 ) -> int:
+    # Both limits lean on massive returning NEWEST-FIRST, which it does: probed
+    # 2026-08-22, AAPL's 5 splits come back 2020-08-31 ... 1987-06-16 descending.
+    # Ascending would truncate away the RECENT events, the only ones the band's
+    # 20-quarter window can contain. The margin is wide anyway — the widest
+    # lifetime split history in the sample was AAPL's 5 against a limit of 12 —
+    # so this is a note on a dependency, not a live risk.
     if provider is None:
         logger.warning(
             "corporate_actions_refresh: no massive provider (MASSIVE_API_KEY unset); "
@@ -38,8 +44,18 @@ def corporate_actions_refresh_once(
         return 0
     completed = 0
     # ISSUE-9: cover the SCORING universe, not just the active watchlist.
+    # The fundamental universe joined that union on 2026-08-21, when this covered
+    # 137 of its 450 names. The band job prices from livewire's adjusted silver
+    # tier and does not adjust anything with these rows — it reads them to decide
+    # whether a name silver has NO series for may be priced from raw bronze
+    # anyway (see `fetch_fundamental_universe_tickers`). Absent a row it cannot
+    # tell "never split" from "not ingested", and bands the name either way.
     watch = {w.ticker for w in repo.list_active_watchlist()}
-    tickers = sorted(watch | set(repo.fetch_distinct_vrp_tickers()))
+    tickers = sorted(
+        watch
+        | set(repo.fetch_distinct_vrp_tickers())
+        | set(repo.fetch_fundamental_universe_tickers())
+    )
     for ticker in tickers:
         if ticker_filter is not None and not ticker_filter(ticker):
             continue

--- a/src/uw_scan/worker/jobs/fundamental_anchors.py
+++ b/src/uw_scan/worker/jobs/fundamental_anchors.py
@@ -1,17 +1,62 @@
 """Stage-3 anchor job — a price band from each name's own valuation history.
 
-Reads the tier-1 statement panel plus unadjusted daily closes, rebuilds every
-ticker's own valuation-yield history, and persists one band per ticker per
+Reads the tier-1 statement panel plus split-adjusted daily closes, rebuilds
+every ticker's own valuation-yield history, and persists one band per ticker per
 PRICE date under the active method version.
 
-WHY UNADJUSTED CLOSES
----------------------
-`adj_close` is retroactively split-adjusted; `common_stock_shares_outstanding` is
-as-reported at the filing. Multiplying the two mixes reference frames and
-misprices every name across every split it has ever done — NVDA's 10:1 alone
-moves its market cap by an order of magnitude, which would corrupt the whole
-history the band's percentiles are drawn from. Raw close and as-reported shares
-are both point-in-time, so their product is the market cap that was observable.
+WHY PRICES COME FROM SILVER — AND WHY THIS FILE ONCE ARGUED FOR RAW
+-------------------------------------------------------------------
+This section used to argue for RAW closes, on the premise that
+`common_stock_shares_outstanding` is as-reported at the filing, so that raw price
+and as-reported shares are both point-in-time and their product is the market cap
+that was observable. The reasoning is sound. The premise is false for this
+provider, and it was never checked.
+
+UW restates share counts onto TODAY's split basis, back to the beginning of the
+panel. Measured 2026-08-21 against the mini's store:
+
+    TSLA 2021-12-31  3,100,522,833   actual then ~1,033M  (3-for-1, Aug 2022)
+    KLAC 2021-12-31  1,523,310,000   actual then   ~152M  (10-for-1, Jun 2026)
+    BKNG 2021-12-31  1,034,275,000   actual then    ~41M  (25-for-1, Apr 2026)
+
+Each is the real count times the factor of a split that had not happened yet. So
+`fundamental / shares` arrives already in today's units, and pairing it with a
+raw price mixes exactly the two reference frames the old note set out to keep
+apart — in the opposite direction, and unnoticed, because nothing downstream
+compares a band against the price scale it was built from.
+
+The damage was not subtle. On 2026-08-18, 26 of 335 bands were built across a
+split inside their own window, and 12 of those rendered as sitting in the buy
+zone: BKNG at $208.25 against a `buy_below` of $4,702.64 read as cheap, because
+20 quarters of its sales yield were 25x too low. A reverse split runs the same
+error the other way and buries a name under a band it can never reach.
+
+So price has to be put on the same basis the share counts already use, and the
+producer already does it: livewire's SILVER tier publishes fully back-adjusted
+daily bars with `price_adjustment_factor` and `split_volume_factor` per session.
+Argon reads those rather than adjusting bronze itself. Silver is better than
+anything reconstructable here on three counts:
+
+* It repairs a defect argon cannot see around. Bronze's legacy segment was
+  back-adjusted by an old backfill and its newer rows are raw as-traded,
+  concatenated unreconciled — TSLA steps 203.37 -> 609.89 on 2021-06-11, WMT
+  46.63 -> 140.75 the same day, both `source='legacy'`, in opposite directions.
+  Silver starts TSLA/WMT/CTAS exactly at 2021-06-11 and carries KLAC, whose bronze
+  basis is clean throughout, all the way back to 1980.
+* It is per-symbol rather than a global cutoff. An earlier version of this job
+  clamped every series to 2021-06-11, which is livewire's boundary for the
+  ambiguous symbols and nobody else's — it silently cost KLAC forty years.
+* Where livewire cannot establish a basis it publishes NOTHING (18 of 450 on
+  2026-08-21, `price_basis='unknown'` on bronze), which is a refusal argon can
+  read, not a wrong number it has to detect.
+
+`corporate_actions` still earns its keep, in a smaller role: for those 18, it is
+the evidence for whether raw bronze is usable anyway — see
+`_bronze_basis_refusal`.
+Its splits come from massive's `/v3/reference/splits`, an authoritative event
+list, never a price-gap heuristic. That distinction matters: DOCU fell 42% in a
+day on 2021-12-03 and SOUN 48% on 2022-12-30, and any cliff detector wide enough
+to catch a 2-for-1 also eats those, deleting real valuation history.
 
 WHY `as_of` IS THE SPOT DATE, NOT THE FISCAL PERIOD OR THE CLOCK
 ---------------------------------------------------------------
@@ -65,11 +110,13 @@ from uw_scan.fundamentals.valuation import (
     METHOD_NUMERATOR,
     TYPE_YIELD,
     UNCLASSIFIED,
+    WINDOW_QUARTERS,
     anchor_inputs_hash,
     build_anchors,
     quarter_inputs,
     yield_at,
 )
+from uw_scan.storage.corporate_actions import CorporateActionsRepository
 from uw_scan.storage.fundamental_anchors import FundamentalAnchorsRepository
 from uw_scan.storage.fundamental_obs import FundamentalObsRepository
 from uw_scan.storage.fundamental_scores import FundamentalScoresRepository
@@ -84,10 +131,22 @@ BAR_FILENAME = "1d.parquet"
 REFUSAL_ALERT_SHARE = 0.30
 
 
-def load_raw_closes(
-    root: Path, tickers: list[str]
+#: Columns the silver tier adds on top of bronze's raw OHLCV. `close` there is
+#: already back-adjusted for BOTH splits and dividends; dividing it back out by
+#: `price_adjustment_factor * split_volume_factor` leaves a SPLIT-ONLY series,
+#: which is the one a valuation yield needs — see `load_closes`.
+_SILVER_COLUMNS = [
+    "trade_date",
+    "close",
+    "price_adjustment_factor",
+    "split_volume_factor",
+]
+
+
+def load_closes(
+    root: Path, tickers: list[str], *, adjusted: bool
 ) -> dict[str, list[tuple[date, float]]]:
-    """Unadjusted daily closes per ticker from the local parquet mirror.
+    """Daily closes per ticker from one tier of the parquet lake.
 
     Points pyarrow at the explicit `1d.parquet` rather than the symbol directory:
     the directory also holds intraday parquets and zero-byte `.lock` markers, and
@@ -96,6 +155,33 @@ def load_raw_closes(
     Rows with a null trade_date are dropped — some symbols carry an
     alternate-schema partition mixed in, and the non-null rows are the clean
     series.
+
+    `adjusted=True` reads livewire's SILVER tier, whose closes are already
+    restated onto today's corporate-action basis, and divides each by
+    `price_adjustment_factor * split_volume_factor` to undo the DIVIDEND half of
+    that restatement. Both halves matter and they pull opposite ways:
+
+    * Splits must be adjusted for. The provider restates historical share counts
+      onto today's post-split basis, so `fundamental/shares` is already in
+      today's units while a raw price is not, and the yield the two form is wrong
+      by the split factor for every quarter before the split. BKNG's 1-for-25 on
+      2026-04-06 put 20 quarters of sales yield 25x too low, which set
+      `buy_below` at $4,702.64 against a $208.25 spot and rendered the name as
+      sitting in its buy zone. 26 of 335 bands carried a split inside their own
+      window on 2026-08-18 and 12 of those were on the buy list.
+    * Dividends must NOT be. A cash dividend genuinely lowers market cap; nothing
+      restates the share count for it. Leaving silver's dividend adjustment in
+      understates every historical market cap on a payer, inflates the historical
+      yields, and biases the whole band cheap against an unadjusted spot.
+
+    `market_cap(t) = shares_restated(t) * split_only_close(t)` is the identity
+    this reconstructs, and it is exact: for BKNG on 2026-04-02 it returns 167.77
+    against a raw close of 4194.25 and a 25.0 split factor.
+
+    `adjusted=False` reads BRONZE closes verbatim. That is only correct for a
+    ticker with no split inside the window being priced — the caller must
+    establish that, because bronze carries no corporate-action treatment of its
+    own and its legacy rows may be on any basis (`price_basis='unknown'`).
     """
     import pyarrow.parquet as pq
 
@@ -105,20 +191,72 @@ def load_raw_closes(
         if not path.exists():
             continue
         try:
-            tab = pq.read_table(str(path), columns=["trade_date", "close"])
-        except (OSError, ValueError) as exc:
+            tab = pq.read_table(
+                str(path),
+                columns=_SILVER_COLUMNS if adjusted else ["trade_date", "close"],
+            ).to_pydict()
+        except (OSError, ValueError, KeyError) as exc:
             log.warning("anchors: unreadable bars for %s: %s", t, repr(exc))
             continue
-        rows = [
-            (d, float(c))
-            for d, c in zip(
-                tab.column("trade_date").to_pylist(), tab.column("close").to_pylist()
-            )
-            if d is not None and c is not None
-        ]
+        if adjusted:
+            rows = [
+                (d, float(c) / (float(pf) * float(svf)))
+                for d, c, pf, svf in zip(
+                    tab["trade_date"],
+                    tab["close"],
+                    tab["price_adjustment_factor"],
+                    tab["split_volume_factor"],
+                )
+                if d is not None and c is not None and pf and svf
+            ]
+        else:
+            rows = [
+                (d, float(c))
+                for d, c in zip(tab["trade_date"], tab["close"])
+                if d is not None and c is not None
+            ]
         if rows:
             out[t] = sorted(rows)
     return out
+
+
+def _bronze_basis_refusal(
+    per: dict[str, Any],
+    periods: list[str],
+    events: list[tuple[date, float]],
+    *,
+    ingested: bool,
+) -> str | None:
+    """Why a bronze-priced name cannot be banded, or None when it may be.
+
+    A split OUTSIDE the window is harmless even on an unknown price basis: the
+    shares restated to today equal the shares as-filed across the whole window,
+    so any consistent basis is today's basis. Inside it, the two disagree by the
+    split factor and the yield series is not on one basis at all.
+
+    That argument only holds while "no split on record" means the ingest looked
+    and found none. Where it never looked, an empty list is an absence of
+    evidence and this refuses instead — see
+    `CorporateActionsRepository.ingested_tickers` for why zero rows is a sound
+    proxy for never-looked, and for the 15 names it silently mispriced before.
+    """
+    if not ingested:
+        return (
+            "no corporate-action history is on record for this name, which is "
+            "indistinguishable from never having asked, so a split inside the "
+            "window being priced cannot be ruled out and the lake has no "
+            "corporate-action-adjusted series to fall back on"
+        )
+    if not periods or not events:
+        return None
+    start = _knowledge_date(per, periods[-WINDOW_QUARTERS:][0])[0]
+    if any(d >= start for d, _ in events):
+        return (
+            "this name split inside the window being priced and the lake has no "
+            "corporate-action-adjusted series for it, so its history and its "
+            "quote are on different share bases"
+        )
+    return None
 
 
 def close_on_or_before(series: list[tuple[date, float]], when: date) -> float | None:
@@ -440,12 +578,24 @@ def fundamental_anchors(
     *,
     conn: psycopg.Connection,
     lake_root: Path,
+    silver_root: Path,
     schema: str = "uw_scan",
     tickers: list[str] | None = None,
     as_of: date | None = None,
     fx_root: Path,
 ) -> dict[str, int]:
     """Compute and persist anchor bands. Returns counters, never raises per ticker."""
+    # First, and before any DB work: the whole tier absent is a mount or a path
+    # error, never a data gap, and it is the one failure that would put every
+    # name back on unadjusted bronze — silently reinstating the bug this job was
+    # fixed for. Refuse the run. The rows already written stay readable and
+    # yesterday's bands stand, which beats minting a universe of wrong ones.
+    if not silver_root.is_dir():
+        raise RuntimeError(
+            f"anchors: no silver tier at {silver_root} — refusing to price the "
+            "universe from unadjusted bronze"
+        )
+
     obs = FundamentalObsRepository(conn, schema=schema)
     scores = FundamentalScoresRepository(conn, schema=schema)
     anchors_repo = FundamentalAnchorsRepository(conn, schema=schema)
@@ -458,7 +608,30 @@ def fundamental_anchors(
     types = anchors_repo.company_types()
     panel = obs.statement_panel(tickers)
     universe = sorted(t for t in panel if t in types)
-    closes = load_raw_closes(lake_root, universe)
+    ca_repo = CorporateActionsRepository(conn, schema=schema)
+    splits = ca_repo.split_factors(universe)
+    ingested = ca_repo.ingested_tickers(universe)
+    closes = load_closes(silver_root, universe, adjusted=True)
+
+    # ponytail: bronze fallback for names livewire cannot yet adjust. Silver is
+    # absent exactly when bronze's own `price_basis` is `unknown`, i.e. the
+    # producer refuses to guess what basis its legacy rows are on — 18 of the
+    # 450-name universe on 2026-08-21, including HON, CMCSA and MSTR. Bronze is
+    # nonetheless provably equivalent for a name with NO split inside the window
+    # being priced, because an unknown-but-consistent basis is today's basis when
+    # nothing has restated the shares since. The per-ticker guard below enforces
+    # that, and once the ingest covers the universe it refuses 4 of the 18 —
+    # CXAI, HON, MSTR, TRI, the four with a real in-window split. Drop this whole
+    # branch when livewire resolves `price_basis` for them.
+    on_bronze = set(universe) - set(closes)
+    if on_bronze:
+        closes |= load_closes(lake_root, sorted(on_bronze), adjusted=False)
+        log.info(
+            "anchors: %d names have no silver series, priced from bronze if a "
+            "clean split record proves the basis (%d of them have one)",
+            len(on_bronze),
+            len(on_bronze & ingested),
+        )
 
     # One FX series per distinct foreign reporting currency, loaded once. Five
     # filers in the measured 257-name panel report non-USD; the rest short-circuit.
@@ -488,6 +661,11 @@ def fundamental_anchors(
         "banded": 0,
         "refused": 0,
         "written": 0,
+        # Names refused because they have no silver series AND a split inside
+        # their own window, so no price series on today's basis exists for them.
+        # Falls to zero as livewire resolves `price_basis`; a RISE means the
+        # producer is losing ground, so it is counted rather than assumed away.
+        "unadjustable_prices": 0,
     }
 
     rows: list[dict[str, Any]] = []
@@ -530,6 +708,37 @@ def fundamental_anchors(
         periods = sorted(per["income-statements"])
         by_statement = currencies.get(ticker) or {}
         spot_date, spot = px[-1]
+
+        # A bronze-priced name whose window spans one of its own splits cannot be
+        # put on a single basis at all: the shares are restated to today and the
+        # price is on whatever basis the legacy backfill left. REFUSE rather than
+        # band it — CXAI's 50-for-1 on 2026-08-18 left `buy_below` at $0.107
+        # against a $4.59 spot, and TRI's buyback consolidations put it on the
+        # buy list 24% below a band it had not earned.
+        unadjustable = (
+            _bronze_basis_refusal(
+                per,
+                periods,
+                splits.get(ticker, ()),
+                ingested=ticker in ingested,
+            )
+            if ticker in on_bronze
+            else None
+        )
+        if unadjustable:
+            counters["unadjustable_prices"] += 1
+            rows.append(
+                _refusal_row(
+                    ticker=ticker,
+                    as_of=as_of or spot_date,
+                    engine=engine,
+                    company_type=company_type,
+                    method=method,
+                    spot=spot,
+                    reasons=[unadjustable],
+                )
+            )
+            continue
 
         # Blocked only by a currency THIS METHOD reads. NBIS's RUB cash-flow
         # statement does not stop `sales_to_ev`, which needs income + balance and

--- a/src/uw_scan/worker/jobs/fundamental_refresh.py
+++ b/src/uw_scan/worker/jobs/fundamental_refresh.py
@@ -67,6 +67,10 @@ def fundamental_refresh(
     anchors = fundamental_anchors(
         conn=conn,
         lake_root=settings.lake_credit_etf_root,
+        # Sibling of the bronze root the other lake readers use. No separate env
+        # var: the mini already sets MARKET_WAREHOUSE_LAKE=/lake and mounts the
+        # whole tree read-only, so silver is reachable there the moment this ships.
+        silver_root=settings.market_warehouse_lake_root / "silver/asset_class=equity",
         fx_root=settings.lake_fx_root,
         schema=settings.db_schema,
     )

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -1695,7 +1695,11 @@ def main() -> int:
                 )
             # Corporate-actions ingestion at 17:35 ET — after the 17:30 OHLC pull,
             # before the research compute. Ingests split/dividend history (massive)
-            # over the vrp_daily ∪ watchlist universe for exact-RV adjustment.
+            # over the vrp_daily ∪ watchlist ∪ fundamental-universe names, for
+            # exact-RV adjustment and for the valuation band's price-basis guard.
+            # The 45-minute gap to `fundamental_refresh` at 18:20 is what arms
+            # that guard on the first day after a deploy rather than leaving it
+            # blind until the next fill.
             sched.add_job(
                 _corporate_actions_refresh,
                 CronTrigger.from_crontab("35 17 * * 0-4", timezone=settings.rth_tz),

--- a/tests/integration/worker/test_corporate_actions_jobs.py
+++ b/tests/integration/worker/test_corporate_actions_jobs.py
@@ -40,3 +40,88 @@ def test_ingest_writes_events(seeded_db_empty_cards, monkeypatch):
 
 def test_null_provider_noops(seeded_db_empty_cards):
     assert corporate_actions_refresh_once(seeded_db_empty_cards, None) == 0
+
+
+def test_ingest_covers_the_fundamental_universe(seeded_db_empty_cards, monkeypatch):
+    """A universe name with no watchlist or VRP row must still get its splits.
+
+    This is the half that was broken in production: the store held 137 of the
+    fundamental universe's 450 names on 2026-08-21, and 9 of the 19 names whose
+    valuation band was priced across an unadjusted split — BKNG, CTAS, CPRT,
+    DXCM, FAST, FTNT, ETR, NVTS, CXAI — had no row at all. `load_raw_closes`
+    cannot adjust for an event nobody fetched, so a band built on a name missing
+    here is silently wrong rather than absent.
+    """
+    repo = seeded_db_empty_cards
+    monkeypatch.setattr(repo, "list_active_watchlist", lambda: [])
+    monkeypatch.setattr(repo, "fetch_distinct_vrp_tickers", lambda: [])
+    with repo.conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO uw_scan.fundamental_universe (ticker, tier, reason) "
+            "VALUES ('BKNG', 'ranked', 'test') ON CONFLICT DO NOTHING"
+        )
+    repo.conn.commit()
+
+    assert corporate_actions_refresh_once(repo, _FakeProvider()) == 1
+    repo.conn.rollback()
+    assert [r["event_type"] for r in repo.fetch_corporate_actions("BKNG")] == [
+        "split",
+        "dividend",
+    ]
+
+
+def test_split_factors_reads_the_universe_in_one_pass(seeded_db_empty_cards):
+    """`split_factors` is what the anchors job reads, so it must agree with the
+    ingest and drop rows that cannot answer the question it is asked.
+
+    A null or non-positive ratio is not evidence that a split happened on a
+    usable basis, so those rows are dropped rather than defaulted — counting one
+    would refuse a band on a row that says nothing.
+    """
+    from decimal import Decimal
+
+    repo = seeded_db_empty_cards
+    for ticker, ratio in (("BKNG", Decimal("25")), ("CTAS", None)):
+        repo.upsert_corporate_action(
+            ticker=ticker,
+            event_type="split",
+            event_date=date(2026, 4, 6),
+            split_ratio=ratio,
+        )
+    repo.upsert_corporate_action(
+        ticker="BKNG",
+        event_type="dividend",
+        event_date=date(2026, 4, 6),
+        cash_amount=Decimal("0.50"),
+    )
+    repo.conn.commit()
+
+    got = repo.split_factors(["bkng", "CTAS"])
+    assert got == {"BKNG": [(date(2026, 4, 6), 25.0)]}
+    assert repo.split_factors([]) == {}
+
+
+def test_ingested_tickers_counts_a_dividend_as_evidence(seeded_db_empty_cards):
+    """The distinction the anchors guard turns on: "never split" vs "never asked".
+
+    A name the ingest reached but that never split has an empty `split_factors`
+    entry and must still be bandable from bronze, so membership here cannot be
+    split-only — a dividend row proves the ingest arrived. A name it never
+    reached has nothing at all, and that is the one the guard must refuse: on
+    2026-08-22 that described 15 of the 18 names with no silver series, back
+    when the ingest covered 137 of the universe's 450.
+    """
+    from decimal import Decimal
+
+    repo = seeded_db_empty_cards
+    repo.upsert_corporate_action(
+        ticker="CTAS",
+        event_type="dividend",
+        event_date=date(2026, 4, 6),
+        cash_amount=Decimal("0.50"),
+    )
+    repo.conn.commit()
+
+    assert repo.split_factors(["CTAS"]) == {}
+    assert repo.ingested_tickers(["ctas", "HON"]) == {"CTAS"}
+    assert repo.ingested_tickers([]) == set()

--- a/tests/unit/fundamentals/test_fx.py
+++ b/tests/unit/fundamentals/test_fx.py
@@ -22,6 +22,8 @@ from uw_scan.fundamentals.fx import (
     average_rate,
     convert,
     fx_symbol,
+    inverse_fx_symbol,
+    load_fx,
     rate_on_or_before,
 )
 
@@ -141,3 +143,63 @@ def test_average_rate_falls_back_to_the_close_on_an_empty_window():
 def test_symbol_convention_is_local_per_usd():
     assert fx_symbol("twd") == "USDTWD"
     assert fx_symbol("EUR") == "USDEUR"
+    assert inverse_fx_symbol("eur") == "EURUSD"
+
+
+def _write_fx(root, symbol, rows):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    d = root / f"symbol={symbol}"
+    d.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {"trade_date": [r[0] for r in rows], "close": [r[1] for r in rows]},
+            schema=pa.schema(
+                [("trade_date", pa.date32()), ("close", pa.float64())]
+            ),
+        ),
+        d / "1d.parquet",
+    )
+
+
+class TestLoadFxAcceptsEitherOrientation:
+    """The two lake mirrors disagree and neither is wrong.
+
+    Real closes, both read 2026-08-21: the mini's lake carries EURUSD at 1.16973
+    (USD per EUR) and no USDEUR; the MacBook's carries USDEUR at 0.8586 (EUR per
+    USD) and no EURUSD. Before this, `fx_symbol` looked only for USDEUR — so in
+    production the series was reported absent and ASML, CCEP, NOK and SPOT were
+    refused a band for want of an FX rate the lake was carrying.
+    """
+
+    MINI = [(date(2026, 8, 20), 1.16805), (date(2026, 8, 21), 1.16973)]
+    MACBOOK = [(date(2026, 5, 18), 0.8585755)]
+
+    def test_usd_ccy_is_read_as_published(self, tmp_path):
+        _write_fx(tmp_path, "USDEUR", self.MACBOOK)
+
+        assert load_fx(tmp_path, "EUR") == [(date(2026, 5, 18), 0.8585755)]
+
+    def test_ccy_usd_is_inverted_on_read(self, tmp_path):
+        """1.16973 USD per EUR is 0.8549 EUR per USD — the module's convention."""
+        _write_fx(tmp_path, "EURUSD", self.MINI)
+
+        got = dict(load_fx(tmp_path, "EUR"))
+
+        assert got[date(2026, 8, 21)] == pytest.approx(1 / 1.16973)
+        assert 0.85 < got[date(2026, 8, 21)] < 0.86
+
+    def test_the_direct_symbol_wins_when_a_lake_has_both(self, tmp_path):
+        """Deterministic rather than filesystem-order dependent."""
+        _write_fx(tmp_path, "USDEUR", self.MACBOOK)
+        _write_fx(tmp_path, "EURUSD", self.MINI)
+
+        assert load_fx(tmp_path, "EUR") == [(date(2026, 5, 18), 0.8585755)]
+
+    def test_a_currency_the_lake_lacks_stays_empty(self, tmp_path):
+        """NVO reports DKK and the mini's lake has neither USDDKK nor DKKUSD, so
+        it must stay refused rather than be banded unconverted."""
+        _write_fx(tmp_path, "EURUSD", self.MINI)
+
+        assert load_fx(tmp_path, "DKK") == []

--- a/tests/unit/worker/test_anchors_split_adjustment.py
+++ b/tests/unit/worker/test_anchors_split_adjustment.py
@@ -1,0 +1,216 @@
+"""The valuation band's price series must be on today's share basis.
+
+Fixtures are REAL rows from livewire's silver tier, read on 2026-08-21 and
+frozen here. BKNG is a dividend payer that ran a 1-for-25 forward split on
+2026-04-06; TSLA pays nothing and ran a 3-for-1 on 2022-08-25. Between them
+they cover both halves of the adjustment and the case where they cancel.
+
+Reproduce the fixtures:
+  ssh macmini '~/market-warehouse/.venv/bin/python -c "
+  import pyarrow.parquet as pq
+  print(pq.read_table(\"/Volumes/DATA_LAKE/livewire/data-lake/silver/\"
+        \"asset_class=equity/symbol=BKNG/1d.parquet\").to_pydict())"'
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from uw_scan.worker.jobs.fundamental_anchors import (
+    _bronze_basis_refusal,
+    fundamental_anchors,
+    load_closes,
+)
+
+# (trade_date, close, price_adjustment_factor, split_volume_factor)
+BKNG_SILVER = [
+    (date(2026, 4, 2), 167.34929786852948, 0.03989969550420921, 25.0),
+    (date(2026, 4, 6), 175.7481837721655, 0.9974923876052302, 1.0),
+    (date(2026, 8, 20), 209.87, 1.0, 1.0),
+]
+TSLA_SILVER = [
+    (date(2021, 6, 11), 203.29666666666665, 0.3333333333333333, 3.0),
+    (date(2022, 8, 19), 296.6666666666667, 0.3333333333333333, 3.0),
+]
+# The raw as-traded closes those silver rows were derived from.
+BKNG_RAW = {date(2026, 4, 2): 4194.25, date(2026, 4, 6): 176.19}
+
+
+def _write(root: Path, ticker: str, rows: list[tuple], columns: list[str]) -> None:
+    d = root / f"symbol={ticker}"
+    d.mkdir(parents=True)
+    pq.write_table(
+        pa.table(
+            {c: [r[i] for r in rows] for i, c in enumerate(columns)},
+            schema=pa.schema(
+                [(columns[0], pa.date32())]
+                + [(c, pa.float64()) for c in columns[1:]]
+            ),
+        ),
+        d / "1d.parquet",
+    )
+
+
+SILVER_COLS = ["trade_date", "close", "price_adjustment_factor", "split_volume_factor"]
+
+
+@pytest.fixture
+def silver(tmp_path: Path) -> Path:
+    root = tmp_path / "silver"
+    _write(root, "BKNG", BKNG_SILVER, SILVER_COLS)
+    _write(root, "TSLA", TSLA_SILVER, SILVER_COLS)
+    return root
+
+
+def test_silver_close_is_divided_back_to_a_split_only_basis(silver: Path) -> None:
+    """Splits stay adjusted; the dividend half is undone.
+
+    Silver's own close on 2026-04-02 is 167.35 — that is the raw 4194.25 put on
+    today's basis by BOTH the 25.0 split and BKNG's dividends since. Only the
+    split belongs in a market cap: nothing restates a share count for a dividend,
+    so leaving it in understates every historical market cap on a payer and
+    biases the whole band cheap. 4194.25 / 25 is the number we want.
+    """
+    got = dict(load_closes(silver, ["BKNG"], adjusted=True)["BKNG"])
+
+    assert got[date(2026, 4, 2)] == pytest.approx(BKNG_RAW[date(2026, 4, 2)] / 25.0)
+    assert got[date(2026, 4, 2)] == pytest.approx(167.77)
+    assert got[date(2026, 4, 2)] > 167.34929786852948  # the dividend, undone
+
+    # Post-split there is no split left to undo, so it is the raw close again.
+    assert got[date(2026, 4, 6)] == pytest.approx(BKNG_RAW[date(2026, 4, 6)])
+
+    # And the series does not cliff across the split the way a raw one does:
+    # 4194.25 -> 176.19 is a 24x drop, 167.77 -> 176.19 is a 5% gain.
+    assert 0.9 < got[date(2026, 4, 6)] / got[date(2026, 4, 2)] < 1.1
+
+
+def test_a_name_that_pays_no_dividend_keeps_silvers_close(silver: Path) -> None:
+    """TSLA's factors are exact reciprocals, so nothing is divided out."""
+    got = dict(load_closes(silver, ["TSLA"], adjusted=True)["TSLA"])
+
+    assert got[date(2021, 6, 11)] == pytest.approx(203.29666666666665)
+    # 609.89 was the raw close that day; 3-for-1 makes it 203.30 on today's basis.
+    assert got[date(2021, 6, 11)] == pytest.approx(609.89 / 3, rel=1e-4)
+
+
+def test_bronze_is_read_verbatim(tmp_path: Path) -> None:
+    """`adjusted=False` applies nothing — the caller owns proving it is safe."""
+    root = tmp_path / "bronze"
+    _write(
+        root,
+        "BKNG",
+        [(d, BKNG_RAW[d]) for d in sorted(BKNG_RAW)],
+        ["trade_date", "close"],
+    )
+
+    got = dict(load_closes(root, ["BKNG"], adjusted=False)["BKNG"])
+
+    assert got == BKNG_RAW
+
+
+def test_a_symbol_with_no_artifact_is_absent(silver: Path) -> None:
+    """Livewire publishes no silver for a symbol whose bronze basis is unknown.
+
+    18 of the 450-name universe on 2026-08-21, HON and MSTR among them. The
+    reader must leave them out rather than invent a series — the caller decides
+    whether bronze is provably equivalent for them.
+    """
+    got = load_closes(silver, ["BKNG", "HON"], adjusted=True)
+
+    assert "HON" not in got
+    assert "BKNG" in got
+
+
+def _panel(period_ends: list[str]) -> dict:
+    return {"filing_dates": {p: f"{p}T00:00:00Z" for p in period_ends}}
+
+
+class TestBronzeBasisRefusal:
+    """The guard deciding whether an unadjustable bronze series may be used."""
+
+    PERIODS = ["2021-12-31", "2022-12-31", "2023-12-31", "2024-12-31", "2025-12-31"]
+
+    def _refuse(self, events, *, ingested=True):
+        return _bronze_basis_refusal(
+            _panel(self.PERIODS), self.PERIODS, events, ingested=ingested
+        )
+
+    def test_a_split_inside_the_window_disqualifies_bronze(self) -> None:
+        """CXAI's 50-for-1 on 2026-08-18 left buy_below at $0.107 vs a $4.59 spot."""
+        assert "split inside the window" in self._refuse([(date(2024, 8, 8), 10.0)])
+
+    def test_a_split_before_the_window_is_harmless(self) -> None:
+        """CMCSA last split in 2017; its window starts 2021, so any consistent
+        basis IS today's basis and bronze prices it correctly."""
+        assert self._refuse([(date(2017, 2, 21), 2.0)]) is None
+
+    def test_the_boundary_date_counts_as_inside(self) -> None:
+        assert self._refuse([(date(2021, 12, 31), 2.0)]) is not None
+
+    def test_a_clean_record_with_no_splits_permits_bronze(self) -> None:
+        """Ingested and empty is evidence of no split — the one case that passes."""
+        assert self._refuse([]) is None
+
+    def test_a_name_never_ingested_is_refused_even_with_no_events(self) -> None:
+        """The 2026-08-22 production state for 15 of the 18 silver-less names:
+        zero rows because the ingest covered 137 of 450, not because they never
+        split. AIG, CMCSA, ECL and HON were all banded off unadjusted bronze."""
+        reason = self._refuse([], ingested=False)
+        assert reason is not None
+        assert "never having asked" in reason
+
+    def test_never_ingested_outranks_a_clean_looking_window(self) -> None:
+        """An out-of-window split must not launder an unverified name into a band."""
+        assert (
+            self._refuse([(date(2017, 2, 21), 2.0)], ingested=False) is not None
+        )
+
+    def test_no_periods_is_safe_for_an_ingested_name(self) -> None:
+        assert (
+            _bronze_basis_refusal(
+                {"filing_dates": {}}, [], [(date.today(), 2.0)], ingested=True
+            )
+            is None
+        )
+
+
+class TestMissingSilverTier:
+    """An absent tier is a mount error, and it must not degrade to bronze.
+
+    `load_closes` skips a symbol whose parquet is missing, so an absent tier
+    used to yield an empty dict, put the whole universe on the bronze fallback,
+    and reinstate the split-basis bug without raising anything. The guard runs
+    before any DB work, which is why `conn=None` reaches it here.
+    """
+
+    def _call(self, silver: Path, tmp_path: Path) -> None:
+        fundamental_anchors(
+            conn=None,  # type: ignore[arg-type]
+            lake_root=tmp_path,
+            silver_root=silver,
+            fx_root=tmp_path,
+        )
+
+    def test_absent_tier_refuses_the_run(self, tmp_path: Path) -> None:
+        with pytest.raises(RuntimeError, match="no silver tier"):
+            self._call(tmp_path / "silver", tmp_path)
+
+    def test_a_file_where_the_tier_should_be_refuses_too(self, tmp_path: Path) -> None:
+        stray = tmp_path / "silver"
+        stray.write_text("")
+        with pytest.raises(RuntimeError, match="no silver tier"):
+            self._call(stray, tmp_path)
+
+    def test_a_present_tier_passes_the_guard(self, tmp_path: Path) -> None:
+        silver = tmp_path / "silver"
+        silver.mkdir()
+        # Past the guard it reaches the DB, and conn=None is what proves it got
+        # there — the guard is the only thing that can raise RuntimeError first.
+        with pytest.raises(AttributeError):
+            self._call(silver, tmp_path)


### PR DESCRIPTION
## The bug

`valuation_anchors` builds each band from 20 quarters of `fundamental / shares ÷ price`, and the two legs were on different share bases. UW restates historical share counts onto today's post-split basis; bronze stores closes unadjusted. Every quarter before a split therefore yielded a number wrong by the split factor.

BKNG's 1-for-25 set `buy_below` at **$4,702.64 against a $208.25 spot** — the name read as cheap. On 2026-08-18, **26 of 335 bands** were built across a split inside their own window and **12 of those were showing in the buy zone**.

The error also ran the other way: a split made a name's own yield history look like it spanned two regimes, so the 4x width gate refused it. NVDA was refused for an "own 20-quarter valuation range spans 16.9x" that was the splits, not its valuation. It, AVGO, LRCX, ORLY, DECK, SMCI and BKSY all get real bands now.

## The fix

Read livewire's **silver** tier — already restated onto today's basis — and divide out the dividend half:

```
split_only_close = close / (price_adjustment_factor × split_volume_factor)
```

A cash dividend genuinely lowers market cap and nothing restates the share count for it, so leaving that adjustment in biases every band **cheap** — the direction that puts names on the buy list.

Two names isolate each half and verify the arithmetic in both degenerate directions:

| ticker | event | `pf × svf` | silver `close` | split_only | raw bronze |
|---|---|---|---|---|---|
| CRWD | 4-for-1 split, **no dividend** | **1.000000** | 99.7800 | 99.7800 | 399.12 |
| ETR | **dividend**, no split | 0.988670 | 113.5982 | **114.9000** | **114.9000** |
| BKNG | both | 0.997492 | 167.3493 | 167.7700 | 4194.25 |

### Why not apex

apex's `GET /bars/{ticker}` is silver-grade — its BKNG close is silver's `close` verbatim (`167.349`). That is exactly why it cannot source this: it serves the total-return number, exposes no adjustment parameter, and returns neither factor column. For ETR apex serves 113.5982 where the market-cap-correct price is 114.90 — a 1.13% error entering all 20 quarters, biased cheap. Split-only is not derivable from what apex returns.

## Two failure directions the first cut got wrong

**The bronze fallback's guard read missing data as clean data.** `split_factors` returns an empty list both for "never split" and "never ingested", and the ingest covered 137 of 450 names — so **15 of the 18 silver-less names passed because nobody had asked**. CMCSA was showing in the buy zone on that basis (`buy_below` 35.27 vs 26.42 spot).

`_bronze_basis_refusal` now requires positive evidence — any split *or* dividend row — and refuses without it. Of the 188 tickers the ingest did cover, **not one** had zero rows. CFLT, CYBR and PSTG are the named, accepted false positives: massive returns neither event for them, so no amount of ingesting makes them verifiable. None carries a band today, so the measured coverage cost is zero.

**An absent silver *tier* failed silently.** `load_closes` skips a symbol whose parquet is missing, so a bad mount yielded an empty dict, put all 450 names on unadjusted bronze, and reinstated this bug without an error. The job now refuses to start, before any DB work.

## Also in this PR

- `corporate_actions_refresh_once` covers the fundamental universe — that store is the evidence the guard runs on. Fires 17:35 ET, 45 min before the band job.
- **FX root fallback derived from `MARKET_WAREHOUSE_LAKE`.** The shipped image resolves `lake_fx_root` to `/root/market-warehouse/.../fx`, `exists=False` — this is live in production, silently refusing foreign filers for want of a series the lake carries.
- `ANCHOR_RULES_REV` 3 → 4, so corrected rows are not dropped by `ON CONFLICT DO NOTHING`.

## Verification

Full dry-run against the mini's production data with `insert_anchors` swapped for a collector and the transaction rolled back. Each check below ran in a **throwaway** container against `/opt/argon/.env` and the real lake mount — never the running worker.

| Question | Answer |
|---|---|
| Silver tier present on the mini? | **yes** — the new hard fail won't self-inflict an outage |
| Does the **shipped** image resolve `lake_fx_root`? | **no** — `exists=False`. Bug is live now |
| Does the **fixed** config? | **yes** — `/lake/bronze/asset_class=fx`, 21 symbols |
| Inverted FX pair handled? | **yes** — EUR 0.85490/USD, the reciprocal of the lake's `EURUSD` 1.16973 |
| Absent currency? | **yes** — DKK EMPTY, so NVO refuses rather than banding unconverted |
| massive split ordering? | **newest-first** — AAPL `2020-08-31 … 1987-06-16`, so `split_limit=12` truncates only pre-window history |
| Widened ingest inside its 45-min gap? | **yes** — 0.458 s/ticker measured → **3.4 min** for 450 names |
| Does a rev bump change `inputs_hash`? | **yes** — `rules.rev` is in the payload, asserted in `test_anchor_reachability.py` |

Tests: **3473 passed, 11 skipped, 0 failed** (`tests/unit tests/integration`). ruff, `_lint_except`, `check_no_yahoo` all clean.

Research trace with reproduce commands: `docs/research/2026-08-21-lake-price-basis-split-contamination/`

## Known, disclosed

- Local runs used `-p no:randomly`. CI randomizes, and the pre-existing dotenv leak (`test_settings_reads_option_surface_flags` — any bare `Settings.from_env()` leaks `XENON_QUERY_API_KEY` from a repo `.env` into `os.environ`) can fail on an unlucky seed. Unrelated to this branch; CI has no `.env`, so the leak has no source there.
