### PR TITLE
fix(worker): commit the scheduler's repository transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The scheduler discarded every write from a job that reads before it writes.**
+  `worker/scheduler._repo` opened a connection and closed it in a `finally`, and closing a
+  psycopg connection does not commit — it discards. That is invisible for the many
+  repository methods that call `self._conn.commit()` themselves, and silently fatal for the
+  ones built on `self._conn.transaction()`: that block only emits `COMMIT` when it opened
+  the transaction, and every macro domain-state job loads its observations and its own prior
+  answer *before* it writes, so the connection was already mid-transaction and the write
+  degraded to a savepoint that nothing ever committed. Measured on the mini before the fix:
+  `macro_domain_states` at **8 rows inserted, 2 alive, 0 deleted**, with the nightly job
+  logging `ok` on every run — two nights of inflation and policy-rates states computed
+  correctly and thrown away. The helper is now a `with psycopg.connect(...)` block, which
+  commits on the way out and still rolls back on an exception.
+
+- **Why no test caught it, and what now would.** Every existing test drives its jobs through
+  `with psycopg.connect(...)`, which commits — none of them used the production helper, so a
+  green suite and a silently empty table were compatible. The regression test runs the
+  inflation state job through `scheduler._repo` itself and asserts from a **new** connection;
+  it fails against the old helper. A second case raises inside the block and asserts nothing
+  persisted, because committing on the way out must not become committing on the way down.
+
+
 ## [0.12.11] — 2026-08-23
 
 ### Added

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -86,7 +86,7 @@ its own process by `scripts/dev.sh`). Toggle via `MASSIVE_WS_ENABLED`
 
 ## Rules
 
-- **Every job opens its own conn** via `_repo(settings)` and closes it in `finally`. No long-lived connections — APScheduler runs jobs from a thread pool.
+- **Every job opens its own conn** via `_repo(settings)`, which is a `with psycopg.connect(...)` block — it **commits** on clean exit and rolls back on an exception. Never go back to `connect()` plus `close()` in a `finally`: closing a psycopg connection discards the transaction. That is invisible for the repository methods that call `self._conn.commit()` themselves and silently fatal for the ones built on `self._conn.transaction()`, which only emits `COMMIT` when it opened the transaction — so any job that reads before it writes leaves the connection mid-transaction and its write block degrades to a savepoint nothing commits. That shape threw away every macro domain state for two nights while the job logged `ok`. No long-lived connections — APScheduler runs jobs from a thread pool.
 - **MASSIVE_API_KEY can be unset.** Jobs that need it should no-op + warn (see `_spy_ohlc_refresh`). Never crash the scheduler.
 - **No duplicated provider work.** If a worker role can run in more than one process, loops over watchlist tickers must either use stable shard ownership or atomically claim queued work.
 - **ET timezone everywhere.** `CronTrigger.from_crontab(..., timezone=settings.rth_tz)`. Don't use UTC for trading-hour crons.

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -551,11 +551,26 @@ def _run_rates_fred_ingest(settings: Settings) -> None:
 
 @contextmanager
 def _repo(settings: Settings) -> Iterator[Repository]:
-    conn = psycopg.connect(settings.db_dsn())
-    try:
+    """A repository whose writes are still there after the job returns.
+
+    ``with psycopg.connect(...)`` rather than ``connect()`` plus ``close()`` in a
+    ``finally``: closing a psycopg connection does not commit, it discards.  That is
+    invisible for the many repository methods that call ``self._conn.commit()``
+    themselves, and silently fatal for the ones that rely on ``self._conn.transaction()``
+    -- because ``transaction()`` only emits ``COMMIT`` when it opened the transaction
+    (``psycopg.Transaction._push_savepoint`` sets ``_outer_transaction`` from
+    ``transaction_status == IDLE``).  A job that reads before it writes -- every domain
+    state job does, it loads observations and its own prior answer first -- leaves the
+    connection in a transaction, so the write block degrades to a savepoint and the
+    ``close()`` threw the night's work away.  Measured in production before this fix:
+    ``macro_domain_states`` at 8 rows inserted, 2 alive, 0 deleted, while the job logged
+    ``ok`` every night.
+
+    The block also rolls back on an exception, which the old form did too -- what it adds
+    is the commit on the way out.
+    """
+    with psycopg.connect(settings.db_dsn()) as conn:
         yield Repository(conn, schema=settings.db_schema)
-    finally:
-        conn.close()
 
 
 @contextmanager

--- a/tests/integration/worker/test_macro_state_jobs.py
+++ b/tests/integration/worker/test_macro_state_jobs.py
@@ -32,6 +32,7 @@ from uw_scan.worker.jobs.macro_policy_jobs import (
     macro_sep_ingest_job,
 )
 from uw_scan.worker.jobs.macro_series_ingest import macro_fred_series_ingest_job
+from uw_scan.worker.scheduler import _repo as scheduler_repo
 from uw_scan.worker.jobs.macro_state_jobs import (
     macro_usd_state_job,
     macro_inflation_state_job,
@@ -653,3 +654,72 @@ class TestTheThreeDomainPass:
             c["rule"] == "usd_against_relative_policy"
             for c in row["contradictions_jsonb"]
         )
+
+
+class TestTheSchedulerPathPersistsWhatItComputes:
+    """The state the nightly job computes has to still be there after the job returns.
+
+    Every other test in this file opens its connection as ``with psycopg.connect(...)``,
+    which commits on the way out.  The scheduler does not use that form -- it hands jobs
+    a repository from ``scheduler._repo`` -- so no test here could witness a helper that
+    closed the connection without committing.  It closed without committing, and because
+    every state job reads (observations, then its own prior answer) before it writes, the
+    write's ``transaction()`` block was a savepoint rather than the outer transaction and
+    never emitted ``COMMIT``.
+
+    Production evidence before the fix: ``macro_domain_states`` at 8 rows inserted, 2
+    alive, 0 deleted, with the job logging ``ok`` on every run.  A green suite and a
+    silently empty table is exactly the pair this class exists to make impossible.
+    """
+
+    def test_a_state_written_through_the_scheduler_helper_is_still_there(
+        self, seeded_db_empty_cards
+    ) -> None:
+        settings = _settings()
+        _ingest_scenario(settings, _golden_scenario())
+
+        with scheduler_repo(settings) as repo:
+            result = macro_inflation_state_job(repo, as_of=DISINFLATION_AS_OF)
+        assert result.status == "ok", result.error_message
+
+        # A NEW connection: the point is what survived the helper, not what the writing
+        # session could still see inside its own open transaction.
+        with psycopg.connect(settings.db_dsn()) as conn:
+            stored = conn.execute(
+                "SELECT count(*) FROM uw_scan.macro_domain_states WHERE state_id = %s",
+                (result.state_id,),
+            ).fetchone()[0]
+            evidence = conn.execute(
+                """
+                SELECT count(*) FROM uw_scan.macro_domain_state_evidence
+                WHERE state_id = %s
+                """,
+                (result.state_id,),
+            ).fetchone()[0]
+
+        assert stored == 1
+        # The evidence has to survive with it. A state whose lineage was rolled back
+        # separately would be the unfalsifiable claim the store exists to refuse.
+        assert evidence == result.evidence_count
+
+    def test_a_failure_inside_the_block_still_leaves_nothing_behind(
+        self, seeded_db_empty_cards
+    ) -> None:
+        """Committing on the way out must not become committing on the way down.
+
+        The old helper got this right by accident -- it discarded everything -- so the
+        fix has to keep the half that was already correct.
+        """
+        settings = _settings()
+        _ingest_scenario(settings, _golden_scenario())
+
+        with pytest.raises(RuntimeError, match="deliberate"):
+            with scheduler_repo(settings) as repo:
+                macro_inflation_state_job(repo, as_of=DISINFLATION_AS_OF)
+                raise RuntimeError("deliberate failure after the write")
+
+        with psycopg.connect(settings.db_dsn()) as conn:
+            stored = conn.execute(
+                "SELECT count(*) FROM uw_scan.macro_domain_states"
+            ).fetchone()[0]
+        assert stored == 0


### PR DESCRIPTION
## The bug

`worker/scheduler._repo` opened a connection and closed it in a `finally`:

```python
conn = psycopg.connect(settings.db_dsn())
try:
    yield Repository(conn, schema=settings.db_schema)
finally:
    conn.close()
```

Closing a psycopg connection does not commit — it discards.

That is invisible for the many repository methods that call `self._conn.commit()`
themselves, and silently fatal for the six modules built on `self._conn.transaction()`.
`Transaction._push_savepoint` sets `_outer_transaction = (transaction_status == IDLE)`, and
`_get_commit_commands` emits `COMMIT` **only** when `_outer_transaction` is true. Every
macro domain-state job loads its observations and its own prior answer *before* it writes,
so the connection was already mid-transaction — the write block became a savepoint, and
`close()` rolled the whole thing back.

## Measured on the mini before the fix

```
pg_stat_user_tables (option_wizard)
  macro_domain_states          n_tup_ins=8   n_live_tup=2   n_tup_del=0
  macro_domain_state_evidence  n_tup_ins=726 n_live_tup=240 n_tup_del=0
  sequence macro_domain_states_state_id_seq.last_value = 8
```

Inserted 8, alive 2, deleted 0, sequence burned to 8 — a rollback, not a delete. The two
survivors are a manual run. Meanwhile the job logged `ok` every night:

```
2026-08-20 23:40:00  macro state inflation:    ok  WELL_ABOVE_TARGET  conf=0.4290
2026-08-21 23:40:00  macro state inflation:    ok  WELL_ABOVE_TARGET  conf=0.4177
```

Control: `macro_series_ingest` and `macro_policy_jobs` manage their own connections with
`with psycopg.connect(...)` plus explicit `conn.commit()`, and their writes landed on the
same nights (`macro_observations` +4, `macro_source_artifacts` +11 on 08-21).

## Why the suite was green

Every existing test drives its jobs through `with psycopg.connect(...)`, which commits on
exit — none of them used the production helper, so a green suite and a silently empty table
were perfectly compatible.

The regression test runs the inflation state job through `scheduler._repo` itself and
asserts from a **new** connection. Verified to fail against the old helper:

```
>       assert stored == 1
E       assert 0 == 1
```

A second case raises inside the block and asserts nothing persisted — committing on the way
out must not become committing on the way down.

## Blast radius

`_repo` has 59 call sites. The change is net-safe for all of them: jobs that already called
`commit()` themselves see a no-op commit on exit, and the rollback-on-exception behaviour
the old form had is preserved.

## Verification

- `uv run ruff check src/ tests/ scripts/` — clean
- `uv run pytest tests/unit -q` — **2423 passed**
- `uv run pytest tests/integration -q -n 4` — **1241 passed, 9 skipped**
- Regression test verified red against the old helper, green against the new one
- `git diff --check` — clean

## Follow-up (not in this PR)

After deploy, the 19:40 ET run should leave three rows — inflation, policy\_rates and usd —
where it has been leaving none. That is the check that this actually fixed prod, and it
needs a night to observe.