### PR TITLE
fix(fundamentals): score only what has actually become public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A composite score dated three weeks in the future froze the Fundamentals card for 363
+  names.** `as_of` is the cross-section's *latest* knowledge date — the earliest moment
+  the ranking could legitimately have been computed. When a filer's real filing date is
+  still unknown, that date is estimated as `period_end + 45d`, and for a fresh quarter the
+  estimate has not arrived yet. Two such names (AMAT and CSCO, `period_end` 2026-07-31)
+  carried an estimate of 2026-09-14, and because `as_of` is the bucket **maximum**, their
+  estimate stamped all 371 rows in the quarter — every 2026Q3 score the table holds. The
+  read path orders `as_of DESC`, so nothing computed later can overtake it: the card
+  serves the 2026-08-16 compute, and each correct recompute for the rest of the quarter
+  carries a lower (because arrived) `as_of`, so it would land in the table and stay
+  invisible until the calendar reached September 14. `_build_buckets` now withholds any
+  period whose knowledge date has not arrived, which also removes the quieter half of the
+  defect — an unpublished name was contributing to every other name's z-score using
+  figures the market had not seen. The cutoff is a parameter defaulting to today, so a
+  replay names its own as-of and tests do not read the wall clock; withheld periods are
+  counted in the job's returned totals rather than dropped silently. Migration `129`
+  evicts the rows already written, which is safe because scores are fully derived and
+  every bucket is rebuilt from the statement panel on each run.
+
 ## [0.12.13] — 2026-08-23
 
 

--- a/docs/research/2026-08-23-scoring-knowledge-cutoff/VERDICT.md
+++ b/docs/research/2026-08-23-scoring-knowledge-cutoff/VERDICT.md
@@ -1,0 +1,88 @@
+# A future knowledge date stamped a whole cross-section
+
+Measured against production `option_wizard` on 2026-08-23. Read-only.
+
+## Finding
+
+`fundamental_scoring` keys each cross-section on a **knowledge quarter** and sets
+`as_of` to the bucket's MAXIMUM knowledge date. When a filer's real filing date is
+unknown, `_knowledge_date` estimates `period_end + FALLBACK_LAG_DAYS` (45d). For a
+fresh quarter that estimate has not arrived, and one such name stamps every row in
+its bucket with a future date.
+
+## The A/B, against the real panel
+
+Both arms run the **fixed** `_build_buckets`; the control disables the cutoff by
+setting it to 2099-01-01, which reproduces the shipped behaviour. If the arms agreed,
+the production panel would not express the defect and the run would prove nothing.
+
+```
+db = option_wizard  (read-only)
+universe(ranked) = 450  panel tickers = 420
+
+withheld  no-cutoff=0   cutoff=2026-08-23: 2
+
+latest bucket = 2026Q3
+  ARM A (no cutoff, = shipped): as_of=2026-09-14  names=363
+  ARM B (cutoff today, = fix): as_of=2026-08-17  names=361
+  names withheld from 2026Q3: ['AMAT', 'CSCO']
+    AMAT: period=2026-07-31 knowledge=2026-09-14 filing_date_known=False
+    CSCO: period=2026-07-31 knowledge=2026-09-14 filing_date_known=False
+
+every unarrived row across ALL buckets: {'AMAT': 2026-09-14, 'CSCO': 2026-09-14}
+
+persisted future-dated rows still in the table: max_as_of=2026-09-14 rows=371
+```
+
+`as_of` moves 2026-09-14 → **2026-08-17** (EXTR's real filing date, the latest that
+had actually arrived) at a cost of two names out of 363.
+
+## Damage, stated precisely
+
+The 371 rows are **every 2026Q3 score the table holds** — the poisoned bucket is the
+latest one, not a bucket sitting on top of fresher rows:
+
+```
+as_of      | rows
+2026-09-14 |  371   <- 2026Q3, poisoned
+2026-06-25 |  412
+2026-06-22 |  253
+2026-03-31 |  406
+```
+
+So the shadowing is **prospective**, not retrospective. `latest_for_ticker` orders
+`as_of DESC`; every correct recompute for the rest of the quarter carries a lower
+(because arrived) `as_of` than 2026-09-14, so it would land in the table and never
+surface until the calendar reached September 14. A re-run under the old code also
+writes nothing new — identical rows hit `ON CONFLICT DO NOTHING` — so the card is
+pinned to the 2026-08-16 compute.
+
+The quieter half: AMAT and CSCO contributed to the other 361 names' z-scores using
+figures the market had not seen.
+
+## Correction
+
+An earlier draft of the PR body claimed rows at `as_of` 2026-08-20 already existed and
+were being shadowed. That was wrong — those were `valuation_anchors` rows, which accrue
+daily on the compute date. `fundamental_scores` buckets by knowledge quarter and has no
+2026-08-20 row. The claim is removed, not softened.
+
+## Reproduce
+
+```bash
+# on the mini; needs the FIXED fundamental_scoring.py, so copy it into a THROWAWAY
+# container — never `docker cp` into a running one (its writable layer survives a
+# restart onto unmerged code).
+scp docs/research/2026-08-23-scoring-knowledge-cutoff/prod_ab_probe.py macmini:/tmp/
+scp src/uw_scan/worker/jobs/fundamental_scoring.py macmini:/tmp/fundamental_scoring_fixed.py
+ssh macmini 'D=/opt/homebrew/bin/docker
+$D create --name argon-probe129 --env-file /opt/argon/.env \
+  --add-host host.docker.internal:host-gateway \
+  -v /Volumes/DATA_LAKE/livewire/data-lake:/lake:ro \
+  ghcr.io/moremeds/argon-app:latest python /probe129.py
+$D cp /tmp/probe129.py argon-probe129:/probe129.py
+$D cp /tmp/fundamental_scoring_fixed.py argon-probe129:/app/src/uw_scan/worker/jobs/fundamental_scoring.py
+$D start -a argon-probe129; $D rm -f argon-probe129'
+```
+
+`TODAY` is pinned in the probe rather than read from the clock, so the run reproduces.

--- a/docs/research/2026-08-23-scoring-knowledge-cutoff/VERDICT.md
+++ b/docs/research/2026-08-23-scoring-knowledge-cutoff/VERDICT.md
@@ -86,3 +86,73 @@ $D start -a argon-probe129; $D rm -f argon-probe129'
 ```
 
 `TODAY` is pinned in the probe rather than read from the clock, so the run reproduces.
+
+## Manual end-to-end run, 2026-08-23
+
+Production could not be the stage — the fix was not deployed and prod is not a
+scratchpad — and `option_wizard_local` did not reproduce the defect on its own: its
+panel predates the filings that cause it (`withheld no-cutoff=0 today=0`). So the
+seven real observation rows for AMAT and CSCO `period_end` 2026-07-31 were copied
+from prod into local. All seven carry `filing_published_at = NULL`, which is the
+mechanism itself.
+
+The run went through the real job function, the real repository, the real API, and
+the browser — not a helper.
+
+### Arm A — shipped behaviour (`knowledge_cutoff` disabled)
+
+```
+job returned: {'buckets': 84, 'scored': 28807, 'inserted': 326,
+               'skipped_thin': 21, 'withheld_unpublished': 0}
+
+as_of      | rows
+2026-09-14 |  326    <- written into the future
+2026-08-14 |  324
+
+latest_for_ticker(EXTR) -> as_of=2026-09-14  knowledge=2026-08-14
+latest_for_ticker(AMAT) -> as_of=2026-09-14  knowledge=2026-09-14
+GET /api/stock/AAPL/fundamentals -> as_of=2026-09-14 knowledge=2026-08-14
+web: "period 2026-06-30 · cross-section 2026-09-14 · 3 source rows"
+     "0.09   69TH OF 326"
+```
+
+EXTR is the clean demonstration: its own knowledge date is 2026-08-14 and it has
+nothing to do with either unfiled name, yet its row is stamped 2026-09-14.
+
+### Arm B — migration 129, then the fix
+
+```
+future-dated rows: 326 -> 0
+job returned: {'buckets': 84, 'scored': 28805, 'inserted': 0,
+               'skipped_thin': 21, 'withheld_unpublished': 2}
+
+as_of      | rows
+2026-08-14 |  324
+
+latest_for_ticker(EXTR) -> as_of=2026-08-14  knowledge=2026-08-14
+latest_for_ticker(AMAT) -> as_of=2026-06-25  knowledge=2026-06-14
+GET /api/stock/AAPL/fundamentals -> as_of=2026-08-14 knowledge=2026-08-14
+web: "period 2026-06-30 · cross-section 2026-08-14 · 3 source rows"
+     "0.08   68TH OF 324"
+```
+
+`inserted: 0` is the strongest single number here. The fixed run recomputed 2026Q3,
+produced `as_of` 2026-08-14, and hit `ON CONFLICT DO NOTHING` against the bucket that
+was already there — the fix converges on the uncontaminated cross-section the table
+held before the unfiled names arrived, rather than inventing a third answer.
+
+AMAT correctly falls back to its last *published* quarter instead of being scored on
+figures the market has not seen.
+
+### What the browser shows
+
+AAPL's composite moved `0.09 → 0.08` and its rank `69th of 326 → 68th of 324`. Nothing
+about AAPL changed; the panel it is z-scored against lost two names that were not
+public. That is the quieter half of the defect made visible — it was never only a
+date-stamp problem.
+
+The plotted history also starts one quarter earlier (2019-02-14 → 2018-11-14), because
+`series_for_ticker` keeps the newest 40 buckets and the phantom bucket had been
+occupying one of those slots.
+
+Screenshots: `output/playwright/scoring-cutoff-{before,after}.png` (gitignored).

--- a/docs/research/2026-08-23-scoring-knowledge-cutoff/prod_ab_probe.py
+++ b/docs/research/2026-08-23-scoring-knowledge-cutoff/prod_ab_probe.py
@@ -1,0 +1,61 @@
+"""Run the FIXED bucketing against the real production panel. Read-only.
+
+Two arms from the same fixed code: a far-future cutoff reproduces the shipped
+behaviour, today's date is the fix. If the arms agree, the fixture never
+expressed the defect and the run proves nothing.
+"""
+from datetime import date
+
+import psycopg
+
+from uw_scan.config import Settings
+from uw_scan.fundamentals.features import build_features
+from uw_scan.storage.fundamental_obs import FundamentalObsRepository
+from uw_scan.worker.jobs.fundamental_scoring import _build_buckets
+
+TODAY = date(2026, 8, 23)
+NEVER = date(2099, 1, 1)  # "no cutoff" — the shipped behaviour
+
+
+def as_of(bucket):
+    return max(d["knowledge_date"] for d in bucket.values())
+
+
+s = Settings.from_env()
+with psycopg.connect(s.db_dsn()) as conn:
+    print(f"db = {s.db_name}  (read-only)")
+    obs = FundamentalObsRepository(conn, schema="uw_scan")
+    names = obs.list_universe("ranked")
+    panel = obs.statement_panel(names)
+    feats = build_features(panel)
+    print(f"universe(ranked) = {len(names)}  panel tickers = {len(panel)}")
+
+    old, w_old = _build_buckets(feats, panel, knowledge_cutoff=NEVER)
+    new, w_new = _build_buckets(feats, panel, knowledge_cutoff=TODAY)
+
+    print(f"\nwithheld  no-cutoff={w_old}   cutoff={TODAY}: {w_new}")
+
+    latest = max(old)
+    print(f"\nlatest bucket = {latest}")
+    print(f"  ARM A (no cutoff, = shipped): as_of={as_of(old[latest])}  names={len(old[latest])}")
+    if latest in new:
+        print(f"  ARM B (cutoff today, = fix): as_of={as_of(new[latest])}  names={len(new[latest])}")
+    else:
+        print("  ARM B: bucket empty after withholding")
+
+    dropped = set(old[latest]) - set(new.get(latest, {}))
+    print(f"  names withheld from {latest}: {sorted(dropped)}")
+    for t in sorted(dropped):
+        d = old[latest][t]
+        print(f"    {t}: period={d['period'][:10]} knowledge={d['knowledge_date']} "
+              f"filing_date_known={d['filing_date_known']}")
+
+    fut = {t: d["knowledge_date"] for b in old.values() for t, d in b.items()
+           if d["knowledge_date"] > TODAY}
+    print(f"\nevery unarrived row across ALL buckets: {fut}")
+
+    # What the read path currently serves, for contrast.
+    cur = conn.execute(
+        "select max(as_of), count(*) from uw_scan.fundamental_scores where as_of > current_date"
+    ).fetchone()
+    print(f"\npersisted future-dated rows still in the table: max_as_of={cur[0]} rows={cur[1]}")

--- a/src/uw_scan/storage/migrations/129_fundamental_scores_drop_future_as_of.sql
+++ b/src/uw_scan/storage/migrations/129_fundamental_scores_drop_future_as_of.sql
@@ -1,0 +1,22 @@
+-- 129_fundamental_scores_drop_future_as_of.sql — evict score rows dated in the future.
+--
+-- `as_of` is the MAX knowledge date across a cross-section, and until the fix in
+-- `_build_buckets` a name whose filing date was unknown carried an ESTIMATE of
+-- `period_end + 45d`. For a fresh quarter that estimate is a future date, and one
+-- such name stamped every row in its bucket with it.
+--
+-- The damage is on the read path, not the write path: `latest_for_ticker` orders
+-- `as_of DESC`, so a future-dated bucket outranks every later run and the card keeps
+-- serving one stale compute until the calendar reaches that date. On prod 2026-08-23
+-- this was 371 rows across 363 tickers stamped `2026-09-14` (from AMAT and CSCO),
+-- shadowing six days of fresher scores.
+--
+-- Score rows are fully derived — `fundamental_scoring` rebuilds every bucket from the
+-- statement panel on each run — so deleting them loses nothing recomputable. No
+-- guard is needed for idempotency: once the rows are gone the predicate matches
+-- nothing, and if a future-dated row ever reappears, deleting it again is the
+-- correct action rather than a destructive one.
+
+SET search_path TO uw_scan, public;
+
+DELETE FROM uw_scan.fundamental_scores WHERE as_of > CURRENT_DATE;

--- a/src/uw_scan/worker/jobs/fundamental_scoring.py
+++ b/src/uw_scan/worker/jobs/fundamental_scoring.py
@@ -56,41 +56,39 @@ def _knowledge_date(per: dict[str, Any], period: str) -> tuple[date, bool]:
     return (period_end + timedelta(days=FALLBACK_LAG_DAYS), False)
 
 
-def fundamental_scoring(
+def _build_buckets(
+    feats: dict[str, Any],
+    panel_raw: dict[str, Any],
     *,
-    conn: psycopg.Connection,
-    tier: str = "ranked",
-    schema: str = "uw_scan",
-    tickers: list[str] | None = None,
-) -> dict[str, int]:
-    """Score every knowledge-quarter cross-section in the panel. Returns counters."""
-    obs = FundamentalObsRepository(conn, schema=schema)
-    scores = FundamentalScoresRepository(conn, schema=schema)
+    knowledge_cutoff: date,
+) -> tuple[dict[str, dict[str, Any]], int]:
+    """Group one row per (knowledge quarter, ticker). Returns (buckets, withheld).
 
-    engine = scores.active_version()
-    if engine is None:
-        log.error(
-            "fundamental_scoring: no active method version — seed one with "
-            "scripts/seed_fundamental_method.py before scoring"
-        )
-        return {"buckets": 0, "scored": 0, "inserted": 0, "skipped_thin": 0}
+    One name gets ONE vote per cross-section: when a late 10-K and an on-time
+    10-Q land in the same quarter, the fresher period wins rather than both
+    competing.
 
-    names = tickers if tickers is not None else obs.list_universe(tier)
-    if not names:
-        log.info("fundamental_scoring: tier %r is empty — nothing to do", tier)
-        return {"buckets": 0, "scored": 0, "inserted": 0, "skipped_thin": 0}
-
-    panel_raw = obs.statement_panel(names)
-    feats = build_features(panel_raw)
-
-    # bucket -> ticker -> row. One name gets ONE vote per cross-section; when a
-    # late 10-K and an on-time 10-Q land in the same quarter, the fresher period
-    # wins rather than both competing.
+    A period whose knowledge date has not ARRIVED is withheld. When a filer's
+    real filing date is still unknown, `_knowledge_date` estimates `period_end +
+    FALLBACK_LAG_DAYS`, and for a fresh quarter that estimate lands in the
+    future — the name simply is not public yet. Admitting it breaks two things
+    at once: it contributes to every other name's z-score using figures the
+    market has not seen, and because `as_of` is the bucket's MAX knowledge date,
+    one unarrived estimate stamps the entire cross-section with a future date.
+    A future `as_of` then wins `ORDER BY as_of DESC` against every later run,
+    freezing the card on one stale compute until the calendar catches up.
+    Measured on prod 2026-08-23: AMAT and CSCO (period_end 2026-07-31, no filing
+    date) stamped 371 rows `2026-09-14` and shadowed six days of fresher scores.
+    """
     buckets: dict[str, dict[str, Any]] = {}
+    withheld = 0
     for ticker, per_period in feats.items():
         per = panel_raw[ticker]
         for period, values in per_period.items():
             know, known = _knowledge_date(per, period)
+            if know > knowledge_cutoff:
+                withheld += 1
+                continue
             bucket = f"{know.year}Q{(know.month - 1) // 3 + 1}"
             slot = buckets.setdefault(bucket, {})
             prior = slot.get(ticker)
@@ -103,8 +101,64 @@ def fundamental_scoring(
                 "filing_date_known": known,
                 "obs_ids": sorted(per["obs_ids"].get(period, [])),
             }
+    return buckets, withheld
 
-    totals = {"buckets": 0, "scored": 0, "inserted": 0, "skipped_thin": 0}
+
+def fundamental_scoring(
+    *,
+    conn: psycopg.Connection,
+    tier: str = "ranked",
+    schema: str = "uw_scan",
+    tickers: list[str] | None = None,
+    knowledge_cutoff: date | None = None,
+) -> dict[str, int]:
+    """Score every knowledge-quarter cross-section in the panel. Returns counters.
+
+    `knowledge_cutoff` defaults to today and bounds which periods are public
+    enough to score. It is a parameter rather than an inline `date.today()` so a
+    replay names its own as-of, and so a test does not depend on the wall clock.
+    """
+    cutoff = knowledge_cutoff or date.today()
+    obs = FundamentalObsRepository(conn, schema=schema)
+    scores = FundamentalScoresRepository(conn, schema=schema)
+
+    engine = scores.active_version()
+    if engine is None:
+        log.error(
+            "fundamental_scoring: no active method version — seed one with "
+            "scripts/seed_fundamental_method.py before scoring"
+        )
+        return {
+            "buckets": 0,
+            "scored": 0,
+            "inserted": 0,
+            "skipped_thin": 0,
+            "withheld_unpublished": 0,
+        }
+
+    names = tickers if tickers is not None else obs.list_universe(tier)
+    if not names:
+        log.info("fundamental_scoring: tier %r is empty — nothing to do", tier)
+        return {
+            "buckets": 0,
+            "scored": 0,
+            "inserted": 0,
+            "skipped_thin": 0,
+            "withheld_unpublished": 0,
+        }
+
+    panel_raw = obs.statement_panel(names)
+    feats = build_features(panel_raw)
+
+    buckets, withheld = _build_buckets(feats, panel_raw, knowledge_cutoff=cutoff)
+
+    totals = {
+        "buckets": 0,
+        "scored": 0,
+        "inserted": 0,
+        "skipped_thin": 0,
+        "withheld_unpublished": withheld,
+    }
     for bucket in sorted(buckets):
         rows = buckets[bucket]
         if len(rows) < MIN_CROSS_SECTION:
@@ -115,7 +169,9 @@ def fundamental_scoring(
 
         # as_of is the LAST knowledge date in the cross-section: the date by which
         # every name in it was public, and therefore the earliest date this
-        # ranking could legitimately have been computed.
+        # ranking could legitimately have been computed. That sentence is only
+        # true because `_build_buckets` withheld unarrived estimates — a single
+        # one in here would date the ranking's birth in the future.
         as_of = max(d["knowledge_date"] for d in rows.values())
 
         out: list[dict[str, Any]] = []

--- a/tests/unit/worker/test_fundamental_scoring_cutoff.py
+++ b/tests/unit/worker/test_fundamental_scoring_cutoff.py
@@ -1,0 +1,83 @@
+"""A cross-section may only contain information that has actually become public.
+
+Every ticker, period end, and filing date below was read from the production
+`fundamental_scores` table on 2026-08-23 and frozen. EXTR, COHR, TEAM and DMRC
+all filed for period_end 2026-06-30; AMAT and CSCO had not filed for period_end
+2026-07-31, so `_knowledge_date` estimated `period_end + FALLBACK_LAG_DAYS` and
+produced 2026-09-14 — three weeks past the run date. That estimate is what put
+371 rows across 363 tickers into the future and shadowed six days of fresher
+scores behind `ORDER BY as_of DESC`.
+
+Nothing here touches the network, the clock, or a database: `_build_buckets` is
+pure, and the cutoff is passed in.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from uw_scan.worker.jobs.fundamental_scoring import _build_buckets
+
+# The day the production damage was measured.
+RUN_DATE = date(2026, 8, 23)
+
+FILED = {
+    "EXTR": ("2026-06-30", "2026-08-17"),
+    "COHR": ("2026-06-30", "2026-08-14"),
+    "TEAM": ("2026-06-30", "2026-08-14"),
+}
+# Real filings exist for neither, so both fall back to period_end + 45d = 2026-09-14.
+UNFILED = {"AMAT": "2026-07-31", "CSCO": "2026-07-31"}
+
+
+def _panel() -> tuple[dict[str, Any], dict[str, Any]]:
+    feats: dict[str, Any] = {}
+    raw: dict[str, Any] = {}
+    for ticker, (period, filed) in FILED.items():
+        feats[ticker] = {period: {"roe": 0.1}}
+        raw[ticker] = {"filing_dates": {period: filed}, "obs_ids": {period: [1]}}
+    for ticker, period in UNFILED.items():
+        feats[ticker] = {period: {"roe": 0.1}}
+        raw[ticker] = {"filing_dates": {}, "obs_ids": {period: [2]}}
+    return feats, raw
+
+
+def test_an_unarrived_estimate_is_withheld() -> None:
+    buckets, withheld = _build_buckets(*_panel(), knowledge_cutoff=RUN_DATE)
+    assert withheld == 2
+    assert set(buckets["2026Q3"]) == {"EXTR", "COHR", "TEAM"}
+
+
+def test_the_bucket_is_not_stamped_with_a_future_date() -> None:
+    """The regression itself: `as_of` is the bucket max, so one future row poisons it."""
+    buckets, _ = _build_buckets(*_panel(), knowledge_cutoff=RUN_DATE)
+    as_of = max(d["knowledge_date"] for d in buckets["2026Q3"].values())
+    assert as_of == date(2026, 8, 17)  # EXTR, the latest that had actually arrived
+    assert as_of <= RUN_DATE
+
+
+def test_without_the_cutoff_the_future_row_would_win() -> None:
+    """Proves the fixture reproduces the bug — a control, not a tautology."""
+    buckets, withheld = _build_buckets(*_panel(), knowledge_cutoff=date(2027, 1, 1))
+    assert withheld == 0
+    as_of = max(d["knowledge_date"] for d in buckets["2026Q3"].values())
+    assert as_of == date(2026, 9, 14)
+
+
+def test_the_cutoff_is_a_parameter_not_the_wall_clock() -> None:
+    """Backdating withholds names that a later run admits — replay stays honest."""
+    buckets, withheld = _build_buckets(*_panel(), knowledge_cutoff=date(2026, 8, 15))
+    assert withheld == 3  # AMAT, CSCO, and EXTR (filed 08-17, after this cutoff)
+    assert set(buckets["2026Q3"]) == {"COHR", "TEAM"}
+
+
+def test_one_name_still_gets_one_vote_per_quarter() -> None:
+    """Regression guard on the extraction: the fresher period wins, both never run."""
+    feats, raw = _panel()
+    feats["COHR"]["2026-03-31"] = {"roe": 0.2}
+    raw["COHR"]["filing_dates"]["2026-03-31"] = "2026-08-10"
+    raw["COHR"]["obs_ids"]["2026-03-31"] = [3]
+
+    buckets, _ = _build_buckets(feats, raw, knowledge_cutoff=RUN_DATE)
+    assert buckets["2026Q3"]["COHR"]["period"] == "2026-06-30"


### PR DESCRIPTION
## What broke

`as_of` on a `fundamental_scores` row is the cross-section's **latest knowledge date** — the earliest moment that ranking could legitimately have been computed. When a filer's real filing date is still unknown, the knowledge date is estimated as `period_end + FALLBACK_LAG_DAYS` (45d), and for a fresh quarter that estimate has **not arrived yet**.

Because `as_of` is the bucket **maximum**, one unarrived estimate stamps every row in the quarter.

Measured on prod 2026-08-23:

| | |
|---|---|
| `max(as_of)` in `fundamental_scores` | **2026-09-14** — 22 days in the future |
| rows carrying it | **371**, across **363** tickers |
| their `computed_at` | 2026-08-16 → 2026-08-19 |
| tickers with `knowledge_date > today` | **AMAT, CSCO** — `period_end` 2026-07-31, `filing_date_known = false` |

Those 371 rows are **every 2026Q3 score the table holds** — the poisoned bucket is the newest one, not a bucket sitting on top of fresher rows:

```
as_of      | rows
2026-09-14 |  371   <- 2026Q3, poisoned
2026-06-25 |  412
2026-06-22 |  253
2026-03-31 |  406
```

So the shadowing is **prospective**. `latest_for_ticker` orders `as_of DESC`; every correct recompute for the rest of the quarter carries a lower (because arrived) `as_of` than 2026-09-14, so it would land in the table and never surface until the calendar reached September 14. A re-run under the old code writes nothing new either — identical rows hit `ON CONFLICT DO NOTHING` — so the card stays pinned to the 2026-08-16 compute.

The quieter half of the defect: AMAT and CSCO were contributing to the other 361 names' z-scores using figures the market had not seen.

## Evidence — the fixed code against the real production panel

Both arms run the **fixed** `_build_buckets`; the control disables the cutoff by setting it to 2099-01-01, reproducing the shipped behaviour. If the arms agreed, the production panel would not express the defect and the run would prove nothing.

```
db = option_wizard  (read-only)
universe(ranked) = 450  panel tickers = 420

withheld  no-cutoff=0   cutoff=2026-08-23: 2

latest bucket = 2026Q3
  ARM A (no cutoff, = shipped): as_of=2026-09-14  names=363
  ARM B (cutoff today, = fix): as_of=2026-08-17  names=361
  names withheld from 2026Q3: ['AMAT', 'CSCO']
    AMAT: period=2026-07-31 knowledge=2026-09-14 filing_date_known=False
    CSCO: period=2026-07-31 knowledge=2026-09-14 filing_date_known=False

every unarrived row across ALL buckets: {'AMAT': 2026-09-14, 'CSCO': 2026-09-14}
persisted future-dated rows still in the table: max_as_of=2026-09-14 rows=371
```

`as_of` moves 2026-09-14 → **2026-08-17** — EXTR's real filing date, the latest that had actually arrived — at a cost of two names out of 363. The unit tests predicted exactly 2026-08-17 from frozen fixtures before this ran.

Full trace, damage table, and reproduce command: `docs/research/2026-08-23-scoring-knowledge-cutoff/`.

## The fix

`_build_buckets` withholds any period whose knowledge date has not arrived. The cutoff is a parameter defaulting to today rather than an inline `date.today()` — a replay names its own as-of, and the tests never read the wall clock. Withheld periods are counted into the job's returned totals rather than dropped silently.

Migration `129` evicts the rows already written. Scores are fully derived and every bucket is rebuilt from the statement panel on each run, so the delete loses nothing recomputable. It needs no idempotency guard: once the rows are gone the predicate matches nothing, and a future-dated row reappearing is a thing that *should* be deleted again.

## Deploy

The api service self-migrates on boot (`/opt/argon/compose.yml`), so `129` applies with the image that carries the code — the two halves land together rather than needing an ordered manual step.

## Verification

- 5 new tests using real tickers and filing dates frozen from prod, including the control arm above.
- 2428 unit tests, `ruff check src/ tests/ scripts/`, `_lint_except`, `check_no_yahoo`, `check_runtime_assets`, guardrail greps 3/5/9, `check_migration_prefixes`.
- Migration applied against a local DB inside a rolled-back transaction, seeded with the exact shape of the prod damage: future row deleted, arrived row untouched.

## Correction

An earlier draft of this body claimed rows at `as_of` 2026-08-20 already existed and were being shadowed. That was wrong — those were `valuation_anchors` rows, which accrue daily on the compute date; `fundamental_scores` buckets by knowledge quarter and has no 2026-08-20 row. The claim is removed rather than softened, and the correction is recorded in the research trace.
