### PR TITLE
feat(macro): gold domain state — MC3 Part B's last deferred step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **The gold domain state — MC3 Part B's last deferred step, on the condition its own
+  spec named.** Deviation 7 of the USD/gold design deferred
+  `MacroDomainState(domain="gold")` because gold's inputs lived in warm-store tables that
+  carry no `obs_id`, and the store refuses a state whose evidence cannot be pointed at.
+  It also wrote its own overturn condition: *"an ingest that lands the gold sources as
+  `macro_observations`."* `worker/jobs/macro_gold_ingest.py` is that ingest. No migration
+  was required — migration 115 has accepted `domain = 'gold'` since it was written, and so
+  have 125 and 128; the schema was never the blocker, only the ingest.
+  - `macro/gold_state.py` publishes **the gate** — whether the gold/real-yield
+    relationship Lens 2 rests on is currently in force — reading the correlation gauge
+    `cards/regime_gauge.py` already computes rather than recomputing it. The three lenses
+    publish beside it as sub-states with their own confidence, and there is deliberately
+    no precedence rule between them.
+  - `GET /api/macro/gold`, with replay and evidence drill-down, completing
+    inflation → rates → USD → gold. The router previously carried a comment explaining why
+    this endpoint deliberately did not exist; that comment is now the docstring explaining
+    what changed.
+  - Nightly `macro_gold_ingest` at 19:30 ET (massive-0, gated
+    `UW_SCAN_MACRO_GOLD_INGEST_ENABLED`, default **off**), and gold appended to the 19:40
+    state chain **last** — it is the terminal node and reads all three upstreams, so
+    running it earlier would record zero dependency edges every night while looking
+    healthy.
+  - Both preregistered gold scenarios in `tests/fixtures/macro/usd_gold_golden.json` now
+    execute against the engine. They were frozen from live publishers before any of this
+    code existed, and they changed the design twice: the upstream refusal had to invert
+    from causal-role to series-id (gold's own anchor shares `decomposition_component` with
+    two upstream series, so a role-based refusal rejects it), and the measurement window
+    had to become calendar-based (over the fixture's own quarter `GLD_CLOSE` has 64 prints
+    where `DFII10` has 62, so an observation-count window silently mutes the
+    post-2022 contradiction on the shorter leg).
+
+### Fixed
+
+- **The Gold Compass lens-decomposition panel had never rendered a row.**
+  `reports/gold_posture._decomposition_rows_from_lenses` read ten `*_z` attributes off the
+  three lens dataclasses; nine exist nowhere in the tree and the tenth only as a database
+  column, so it returned `[]` on every run since it was written. Deleted rather than
+  repaired: the lenses report native units (tonnes, ounces, percent, basis points) and
+  percentiles, never z-scores, and no model has ever fitted weights over them — summing
+  them into one "contribution" column and sorting by magnitude would rank a reserves flow
+  above a valuation percentile because tonnes are numerically larger than a probability.
+  The API field and the database column are unchanged (`[]` before, `[]` after), so this
+  is not a contract change. A test now fails if any lens grows a real z-score, which is
+  the moment to decide deliberately whether the panel should exist.
+
 ## [0.12.12] — 2026-08-23
 
 

--- a/docs/superpowers/specs/2026-08-12-usd-gold-state-design.md
+++ b/docs/superpowers/specs/2026-08-12-usd-gold-state-design.md
@@ -81,6 +81,40 @@ document's rulings before implementation started.
    deferred. **Overturned by:** an ingest that lands the gold sources as
    `macro_observations`, at which point the state can cite real evidence.
 
+   > **OVERTURNED 2026-08-23**, on exactly the stated condition.
+   > `worker/jobs/macro_gold_ingest.py` lands `GLD_CLOSE` and `GLD_HOLDINGS_OZ` as
+   > `macro_observations`, so `macro/gold_state.py` cites real `obs_id`s and
+   > `MacroDomainState(domain="gold")` persists. No migration was needed — migration 115
+   > has accepted `domain = 'gold'` since it was written, and 125 and 128 likewise; the
+   > schema was never the blocker, only the ingest.
+   >
+   > **Two of sixteen, not ten of ten.** The overturn is narrower than "ingest gold's ten
+   > sources". Only the two the STATE stands on are citable: the price (its required
+   > anchor) and the ETF tonnage (Lens 1). Lens 2's legs are cited too but BORROWED —
+   > gold points at the rows `RATES_EVIDENCE` and `USD_EVIDENCE` already own, which is
+   > the many-readers case and not a second ingest. Central-bank reserves, exchange
+   > inventory, COT and UW options remain warm-store only and stay in the manifest with
+   > their omission reasons. So the domain state is real and its lineage is complete for
+   > what it stands on; the full sixteen-source promotion is still a milestone.
+   >
+   > Two findings the golden fixture forced, both recorded because they generalise:
+   >
+   > - **The refusal had to invert.** USD refuses upstream evidence by causal ROLE. Gold
+   >   cannot: its anchor `GLD_CLOSE` carries `decomposition_component`, the same role
+   >   `DFII10` and `RTWEXBGS` carry upstream, so a role-based refusal rejects gold's own
+   >   anchor. Gold refuses by series id instead, derived from the owning tuples. And it
+   >   refuses far less: Lens 2 is DEFINED on the real yield and the dollar, so refusing
+   >   them would not protect an invariant, it would delete the lens. What protects the
+   >   double-count rule here is the confidence DENOMINATOR — `required_series` is
+   >   gold-owned only, so a quiet upstream degrades a lens and never the gate.
+   > - **The window had to become calendar-based.** The engine reads four series off
+   >   three publication calendars. Over the fixture's own quarter `GLD_CLOSE` has 64
+   >   prints and `DFII10` has 62, so a window of "63 observations" reads one leg and
+   >   returns None for the other — muting the `gold_against_real_yields_post_2022`
+   >   contradiction for a reason that has nothing to do with the market. 63 CALENDAR
+   >   days is set by the fixture rather than chosen: at 91 the real-yield leg inverts
+   >   sign and the preregistered ADVERSE reading reads UNKNOWN.
+
 8. **The `/gold` provenance change is additive, not feature-flagged.** Plan step B6.3
    asks for a flag with the existing response retained during parity. A flag guards a
    NEW block that can be compared against an old one; this milestone completes an

--- a/src/uw_scan/api/routers/macro.py
+++ b/src/uw_scan/api/routers/macro.py
@@ -81,12 +81,35 @@ def macro_usd_state(
     return _domain_state(repo, "usd", _resolve_instant(as_of, as_of_ts))
 
 
-#: There is deliberately no ``/macro/gold``. No gold ``MacroDomainState`` is computed --
-#: gold's inputs live in warm-store tables rather than ``macro_observations``, so the
-#: state could cite no evidence and the store refuses an answer nobody can reconstruct
-#: (design spec, deviation 7). A route that can only ever 404 is not an endpoint, it is
-#: a promise. Gold's provenance is served by ``/api/gold/state`` and ``/api/gold/replay``,
-#: which carry the full sixteen-input manifest.
+@router.get("/gold", response_model=MacroDomainStateResponse)
+def macro_gold_state(
+    as_of: date | None = Query(
+        default=None,
+        description="UTC calendar date; returns the state answering for that day-end.",
+    ),
+    as_of_ts: datetime | None = Query(
+        default=None, description="Timezone-aware instant to replay."
+    ),
+    repo: Repository = Depends(get_repo),
+) -> MacroDomainStateResponse:
+    """The gold GATE, not a view on gold.
+
+    This route did not exist until now, and the reason it did not is worth keeping:
+    gold's inputs lived in warm-store tables rather than ``macro_observations``, so no
+    state could cite evidence and the store refuses an answer nobody can reconstruct
+    (design spec, deviation 7). That deviation names its own overturn condition -- "an
+    ingest that lands the gold sources as macro_observations" -- and
+    ``worker/jobs/macro_gold_ingest`` is it.
+
+    Honest about the scope of that overturn: TWO of the manifest's sixteen inputs are
+    citable, the gold price and the ETF tonnage. They are the two the state stands on,
+    which is what makes it persistable. The rest of the manifest -- central-bank
+    reserves, exchange inventory, COT, UW options -- is still warm-store only and is
+    still served, with its omission reasons, by ``/api/gold/state`` and
+    ``/api/gold/replay``. This endpoint does not replace those; it answers a narrower
+    question they never answered.
+    """
+    return _domain_state(repo, "gold", _resolve_instant(as_of, as_of_ts))
 
 
 def _domain_state(

--- a/src/uw_scan/config.py
+++ b/src/uw_scan/config.py
@@ -211,6 +211,11 @@ class Settings(BaseModel):
     # issues per term before it can call a multi-quarter high, so a first scheduled run
     # on an empty store produces sub-states that correctly say UNKNOWN and nothing else.
     macro_market_layer_ingest_enabled: bool = False
+    # MC3 gold evidence: GLD_CLOSE and GLD_HOLDINGS_OZ promoted from the warm store into
+    # macro_observations.  Off by default like its siblings, and load-bearing rather than
+    # cosmetic: the gold state's REQUIRED anchor is GLD_CLOSE, so with this off the gold
+    # state job abstains every night -- correctly, but silently.
+    macro_gold_ingest_enabled: bool = False
     macro_state_compute_enabled: bool = False
     # Dual-read: attach the policy/rates domain state to the legacy rates snapshot.
     # Separate from the compute flag so the state can accrue a history before the
@@ -746,6 +751,9 @@ class Settings(BaseModel):
             ),
             macro_market_layer_ingest_enabled=_env_bool(
                 "UW_SCAN_MACRO_MARKET_LAYER_INGEST_ENABLED", False
+            ),
+            macro_gold_ingest_enabled=_env_bool(
+                "UW_SCAN_MACRO_GOLD_INGEST_ENABLED", False
             ),
             macro_state_compute_enabled=_env_bool(
                 "UW_SCAN_MACRO_STATE_COMPUTE_ENABLED", False

--- a/src/uw_scan/macro/evidence_store.py
+++ b/src/uw_scan/macro/evidence_store.py
@@ -32,6 +32,14 @@ from uw_scan.sources.fred_macro import SERIES_CONTRACT
 from uw_scan.storage.repository import Repository
 
 from .contracts import CausalRole, DomainObservation
+from .gold_ingest import (
+    GOLD_FLOW_SERIES,
+    GOLD_FLOW_SOURCE,
+    GOLD_FLOW_UNIT,
+    GOLD_PRICE_SERIES,
+    GOLD_PRICE_SOURCE,
+    GOLD_PRICE_UNIT,
+)
 from .inflation import REQUIRED as INFLATION_REQUIRED
 from .rates_market import (
     MARKET_SERIES_CONTRACT,
@@ -87,6 +95,12 @@ USD_HISTORY_DAYS = 400
 #: points, which spans the 2021-2022 tightening and its unwind, the one episode in the
 #: sample where the nominal and real indices moved by materially different amounts.
 USD_REAL_HISTORY_DAYS = 1830
+
+
+#: Gold's window.  Its engine measures over 63 calendar days and the ETF flow leg needs
+#: enough history to reach back that far after holidays and a missed post, so this is
+#: deliberately several times the window rather than exactly it.
+GOLD_HISTORY_DAYS = 400
 
 
 @dataclass(frozen=True)
@@ -226,6 +240,34 @@ USD_EVIDENCE: tuple[SeriesEvidenceContract, ...] = (
 )
 
 
+#: Gold's own two series and ALL of what gold owns.
+#:
+#: The real yield and the broad dollar are Lens 2's legs and are deliberately absent:
+#: they belong to ``RATES_EVIDENCE`` and ``USD_EVIDENCE``, and gold reads the same stored
+#: rows rather than ingesting a second copy.  ``macro/gold_state.py`` derives its
+#: borrowed-series tagging from those tuples, so adding either here would silently move a
+#: series out of "borrowed" and INTO gold's confidence denominator -- the double-count
+#: showing up as false certainty rather than as a duplicate row.
+GOLD_EVIDENCE: tuple[SeriesEvidenceContract, ...] = (
+    SeriesEvidenceContract(
+        series_id=GOLD_PRICE_SERIES,
+        causal_role="decomposition_component",
+        unit=GOLD_PRICE_UNIT,
+        publisher_transform="level",
+        source=GOLD_PRICE_SOURCE,
+        history_days=GOLD_HISTORY_DAYS,
+    ),
+    SeriesEvidenceContract(
+        series_id=GOLD_FLOW_SERIES,
+        causal_role="positioning",
+        unit=GOLD_FLOW_UNIT,
+        publisher_transform="level",
+        source=GOLD_FLOW_SOURCE,
+        history_days=GOLD_HISTORY_DAYS,
+    ),
+)
+
+
 class EvidenceContractError(ValueError):
     """A stored row does not match the contract the engine was built against."""
 
@@ -288,6 +330,52 @@ def load_usd_observations(
     # and the real index reads five years of monthly ones, and one window would either
     # starve the second or drag five years of daily prints into every ``inputs_hash``.
     return load_domain_observations(repo, USD_EVIDENCE, as_of=as_of)
+
+
+def load_gold_observations(
+    repo: Repository, *, as_of: datetime
+) -> tuple[DomainObservation, ...]:
+    """Gold's OWN rows, plus the upstream-owned legs Lens 2 is defined on.
+
+    One call returning both is deliberate.  The alternative -- gold loading only what it
+    owns and the caller stitching the borrowed legs in -- puts the borrowing decision in
+    the job, where the next reader cannot see it beside the contracts that justify it.
+    """
+    return load_domain_observations(
+        repo,
+        (*GOLD_EVIDENCE, *_gold_borrowed_contracts()),
+        as_of=as_of,
+    )
+
+
+def _gold_borrowed_contracts() -> tuple[SeriesEvidenceContract, ...]:
+    """Lens 2's two legs, taken from their OWNERS' contracts rather than re-declared.
+
+    Copying the declarations here would create the second owner the double-count rule
+    forbids, and the copy would drift the first time rates restated ``DFII10``'s unit.
+    Reaching into the owning tuple is what makes "many readers" literal.
+    """
+    wanted = {"DFII10": RATES_EVIDENCE, "DTWEXBGS": USD_EVIDENCE}
+    out: list[SeriesEvidenceContract] = []
+    for series_id, owner in wanted.items():
+        match = next((c for c in owner if c.series_id == series_id), None)
+        if match is None:
+            raise EvidenceContractError(
+                f"{series_id} is no longer declared by its owning domain, so gold cannot "
+                "borrow it. Lens 2 is defined on this series -- re-declaring it under "
+                "gold would create a second owner rather than fix the gap"
+            )
+        out.append(
+            SeriesEvidenceContract(
+                series_id=match.series_id,
+                causal_role=match.causal_role,
+                unit=match.unit,
+                publisher_transform=match.publisher_transform,
+                source=match.source,
+                history_days=GOLD_HISTORY_DAYS,
+            )
+        )
+    return tuple(out)
 
 
 def _window_start(

--- a/src/uw_scan/macro/gold_ingest.py
+++ b/src/uw_scan/macro/gold_ingest.py
@@ -1,0 +1,222 @@
+"""Gold's own two series, promoted from the warm store into the evidence store.
+
+**Why this module has to exist at all.**  The Gold Compass has read gold prices and ETF
+tonnage for a long time, but it read them from ``macro_series_daily`` and
+``etf_holdings_daily`` -- the WARM store, which carries no ``obs_id``.  A
+``MacroDomainState`` whose evidence cannot be pointed at is refused at persist time by
+design, so the gold domain could not produce a state no matter how good its engine was.
+The schema was never the blocker: ``macro_observations`` has accepted
+``domain = 'gold'`` since migration 115.  Only the ingest was missing.
+
+**Two series and no more.**  Gold's Lens 2 also reads the real yield and the broad
+dollar, and those are NOT ingested here -- they are owned by ``RATES_EVIDENCE`` and
+``USD_EVIDENCE`` and gold points at the same stored rows.  Ingesting them again under a
+second owner is precisely the double-count the design spec prohibits, and this module is
+where it would happen.
+
+**Availability follows R1.**  Neither publisher stamps a per-observation release instant:
+massive answers a query and SPDR posts a file.  So ``published_at`` is NULL and
+``available_at`` is our retrieval clock -- conservative in the only direction that
+matters, because it never claims we could have known a price before we fetched it.  The
+cost, stated plainly: history ingested today is not PIT-replayable before today.  That is
+not a limitation this choice introduces, it is the true epistemic state of a row we first
+saw this morning, and migration 119 can promote a verified instant later.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from uw_scan.macro_evidence import macro_artifact_content_identity
+from uw_scan.models.macro import MacroSourceArtifact
+
+DOMAIN = "gold"
+
+GOLD_PRICE_SERIES = "GLD_CLOSE"
+GOLD_PRICE_SOURCE = "massive.com"
+GOLD_PRICE_PARSER_VERSION = "gold_price/1"
+#: GLD closes, in dollars per share. The Compass's canonical gold-price series since the
+#: retired FRED LBMA fix; keeping the same ``series_id`` is what lets the evidence store
+#: and the warm store describe the same thing.
+GOLD_PRICE_UNIT = "usd_per_share"
+
+GOLD_FLOW_SERIES = "GLD_HOLDINGS_OZ"
+GOLD_FLOW_SOURCE = "spdrgoldshares"
+GOLD_FLOW_PARSER_VERSION = "gold_flow/1"
+#: Troy ounces held by the trust. Ounces and never dollars: tonnage counted in ounces
+#: rises only when metal actually enters the trust, so a rally cannot be read as
+#: accumulation. A dollar-denominated holdings series would make Lens 1 a price series
+#: wearing a flow label.
+GOLD_FLOW_UNIT = "troy_oz"
+
+
+@dataclass(frozen=True)
+class GoldObservation:
+    """One published gold value with the instant it became knowable."""
+
+    series_id: str
+    causal_role: str
+    period_end: date
+    value_numeric: Decimal
+    unit: str
+    available_at: datetime
+    source: str
+    parser_version: str
+
+
+def gold_price_artifact(
+    raw_bytes: bytes, *, source_url: str, retrieved_at: datetime
+) -> MacroSourceArtifact:
+    content_hash, content_length = macro_artifact_content_identity(raw_bytes=raw_bytes)
+    return MacroSourceArtifact(
+        source=GOLD_PRICE_SOURCE,
+        source_kind="entitled_provider",
+        source_record_id=f"{GOLD_PRICE_SOURCE}:gld-daily-ohlc",
+        source_url=source_url,
+        # A query result, not a dated release: these bytes became available when we asked.
+        published_at=None,
+        available_at=retrieved_at,
+        retrieved_at=retrieved_at,
+        last_seen_at=retrieved_at,
+        content_hash=content_hash,
+        parser_version=GOLD_PRICE_PARSER_VERSION,
+        quality_status="valid",
+        # ``already_entitled`` and not ``paid_authorized``: the massive subscription is
+        # bought for the OHLC lane and this call rides it, so the marginal cost of gold's
+        # evidence is zero. The distinction is what the cost class is FOR -- it lets a
+        # reader see which evidence would disappear if a budget were cut.
+        cost_class="already_entitled",
+        media_type="application/json",
+        content_length=content_length,
+        # The payload carries a bar history, so it reports many periods rather than
+        # being one dated release.
+        vintage_bearing=True,
+        raw_bytes=raw_bytes,
+    )
+
+
+def gold_flow_artifact(
+    raw_bytes: bytes, *, source_url: str, media_type: str, retrieved_at: datetime
+) -> MacroSourceArtifact:
+    content_hash, content_length = macro_artifact_content_identity(raw_bytes=raw_bytes)
+    return MacroSourceArtifact(
+        source=GOLD_FLOW_SOURCE,
+        source_kind="official",
+        source_record_id=f"{GOLD_FLOW_SOURCE}:gld-holdings-archive",
+        source_url=source_url,
+        published_at=None,
+        available_at=retrieved_at,
+        retrieved_at=retrieved_at,
+        last_seen_at=retrieved_at,
+        content_hash=content_hash,
+        parser_version=GOLD_FLOW_PARSER_VERSION,
+        quality_status="valid",
+        cost_class="free_official",
+        # SPDR serves the same archive as CSV or XLSX depending on the day; the caller
+        # reports which arrived rather than this module assuming one.
+        media_type=media_type,
+        content_length=content_length,
+        vintage_bearing=True,
+        raw_bytes=raw_bytes,
+    )
+
+
+def price_observations(
+    bars: Sequence[Any], *, retrieved_at: datetime
+) -> list[GoldObservation]:
+    """One observation per daily bar close.
+
+    A bar with a non-positive close is DROPPED rather than stored: gold has never traded
+    at or below zero, so such a row is a parse failure or a vendor placeholder, and one
+    of those inside a percent-change window silently produces an enormous move.
+    """
+    out: list[GoldObservation] = []
+    for bar in bars:
+        close = getattr(bar, "close", None)
+        bar_date = getattr(bar, "date", None)
+        if close is None or bar_date is None:
+            continue
+        value = Decimal(str(close))
+        if value <= 0:
+            continue
+        out.append(
+            GoldObservation(
+                series_id=GOLD_PRICE_SERIES,
+                causal_role="decomposition_component",
+                period_end=bar_date,
+                value_numeric=value,
+                unit=GOLD_PRICE_UNIT,
+                available_at=retrieved_at,
+                source=GOLD_PRICE_SOURCE,
+                parser_version=GOLD_PRICE_PARSER_VERSION,
+            )
+        )
+    return out
+
+
+def flow_observations(
+    rows: Sequence[Any], *, retrieved_at: datetime
+) -> list[GoldObservation]:
+    """One observation per published holdings print, in troy ounces."""
+    out: list[GoldObservation] = []
+    for row in rows:
+        holdings = getattr(row, "holdings_oz", None)
+        obs_date = getattr(row, "obs_date", None)
+        if holdings is None or obs_date is None:
+            continue
+        value = Decimal(str(holdings))
+        if value <= 0:
+            continue
+        out.append(
+            GoldObservation(
+                series_id=GOLD_FLOW_SERIES,
+                causal_role="positioning",
+                period_end=obs_date,
+                value_numeric=value,
+                unit=GOLD_FLOW_UNIT,
+                available_at=retrieved_at,
+                source=GOLD_FLOW_SOURCE,
+                parser_version=GOLD_FLOW_PARSER_VERSION,
+            )
+        )
+    return out
+
+
+def observation_row(
+    observation: GoldObservation,
+    *,
+    artifact_id: int,
+    artifact: MacroSourceArtifact,
+    available_at: datetime | None = None,
+) -> dict[str, Any]:
+    """The row shape the observation writer takes.
+
+    ``available_at`` overrides the observation's own when the caller knows the STORED
+    artifact's retrieval instant -- which differs from this run's clock whenever the
+    payload deduped to one we already had. The store enforces that an observation cannot
+    postdate the artifact carrying it, so this is what makes a re-run idempotent instead
+    of a hard failure.
+    """
+    return {
+        "artifact_id": artifact_id,
+        "domain": DOMAIN,
+        "series_id": observation.series_id,
+        "period_end": observation.period_end,
+        "frequency": "daily",
+        "unit": observation.unit,
+        "value_numeric": observation.value_numeric,
+        "source": artifact.source,
+        "source_record_id": artifact.source_record_id,
+        # Always NULL, per R1. Neither publisher stamps a per-observation release
+        # instant, and deriving one by rule would be indistinguishable in the schema
+        # from an observed one.
+        "published_at": None,
+        "available_at": available_at or observation.available_at,
+        "parser_version": observation.parser_version,
+        "quality_status": "valid",
+        "cost_class": artifact.cost_class,
+    }

--- a/src/uw_scan/macro/gold_state.py
+++ b/src/uw_scan/macro/gold_state.py
@@ -1,0 +1,922 @@
+"""The gold domain state: whether the relationship Lens 2 rests on is in force.
+
+Gold keeps its three lenses and this module does not change what they say.  What it adds
+is the one fact belonging to no single lens -- **the gate**: is the gold/real-yield
+relationship the cyclical lens rests on currently holding?  Spec 3.1, verbatim: "The gate
+is the domain's state."
+
+The measurement already exists.  ``cards/regime_gauge.py`` computes rolling correlations
+between the gold price and the 10-year real yield and publishes ``operative`` / ``partial``
+/ ``suspended``.  This module gives that verdict a point-in-time identity, an upstream
+lineage, per-lens sub-states and a confidence.  It does not recompute it.
+
+**An unrecognised gauge label maps to UNKNOWN, never to OPERATIVE.**  Defaulting there
+would assert the pre-2022 relationship holds, which is the single claim the gate exists to
+withhold.
+
+**Gold READS upstream-owned series; it does not OWN them.**  Lens 2 is defined on the real
+yield and the broad dollar, so refusing them -- the way USD refuses ``EFFR`` -- would not
+protect an invariant, it would delete the lens.  The double-count prohibition is "one
+publisher payload, one owner, many readers", and pointing at the same ``obs_id`` the rates
+state points at IS the many-readers case.  What gold must never do is re-derive the
+upstream's CONCLUSION, which is why ``required_series`` for the confidence denominator is
+gold-owned only: a borrowed series going quiet degrades a lens, it does not make gold less
+sure of its own gate.
+
+Contradictions report that evidence disagrees.  They never resolve into a direction and
+never change a state label (spec 4), and there is deliberately no precedence rule between
+Lens 1 and Lens 2 -- collapsing them would throw away the only information the
+disagreement carries.
+
+Design: ``docs/superpowers/specs/2026-08-12-usd-gold-state-design.md`` sections 3, 3.1, 4.
+Golden scenarios: ``tests/fixtures/macro/usd_gold_golden.json``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Literal
+
+from .confidence import compute_confidence
+from .contracts import (
+    ConfidenceTerm,
+    Contradiction,
+    Direction,
+    DomainObservation,
+    EvidenceRef,
+    FactorState,
+    MacroDomainState,
+    MacroSubState,
+    Velocity,
+    compute_inputs_hash,
+    freshness_for,
+)
+from .evidence_store import INFLATION_EVIDENCE, RATES_EVIDENCE, USD_EVIDENCE
+from .usd import UpstreamState
+
+GOLD_ENGINE_VERSION = "gold/1"
+
+#: The gate's vocabulary IS the gauge's, uppercased.  Inventing a second set of words for
+#: the same measurement would leave two vocabularies to keep in step, and the one that
+#: drifted would be the one nobody reads.
+GoldStateLabel = Literal["OPERATIVE", "PARTIAL", "SUSPENDED", "UNKNOWN"]
+
+#: Gold decoupled from real yields after 2022.  A Lens 2 fitted across the break averages
+#: a negative relationship with a broken one and describes neither side, so the break is a
+#: calendar fact this engine gates on -- distinct from ``gauge_state``, which is the
+#: MEASURED correlation.  Both are load-bearing and they are not the same thing.
+REGIME_BREAK_YEAR = 2022
+
+#: Gold's own anchor.  REQUIRED: with it absent the state abstains.
+ANCHOR_SERIES = "GLD_CLOSE"
+#: Lens 1's flow leg, gold-owned.  Counted in ounces, so a rise is real accumulation into
+#: the trust rather than a price effect.
+FLOW_SERIES = "GLD_HOLDINGS_OZ"
+#: Lens 2's two legs, both BORROWED from upstream domains.
+REAL_YIELD_SERIES = "DFII10"
+DOLLAR_SERIES = "DTWEXBGS"
+
+_GAUGE_TO_STATE: dict[str, GoldStateLabel] = {
+    "operative": "OPERATIVE",
+    "partial": "PARTIAL",
+    "suspended": "SUSPENDED",
+}
+
+
+def _series_owner_map() -> dict[str, str]:
+    """Which domain owns each series, DERIVED from the evidence contracts.
+
+    Derived rather than restated so widening ``RATES_EVIDENCE`` re-tags gold's borrowed
+    rows on the same commit.  A hand-maintained copy would keep calling a series gold-owned
+    after somebody else claimed it, and the confidence denominator would silently start
+    counting a series gold does not own.
+    """
+    out: dict[str, str] = {}
+    for domain, contracts in (
+        ("inflation", INFLATION_EVIDENCE),
+        ("policy_rates", RATES_EVIDENCE),
+        ("usd", USD_EVIDENCE),
+    ):
+        for contract in contracts:
+            out.setdefault(contract.series_id, domain)
+    return out
+
+
+SERIES_OWNER: dict[str, str] = _series_owner_map()
+
+#: Everything gold owns outright.  The confidence denominator is drawn from here alone.
+GOLD_OWNED_SERIES: tuple[str, ...] = (ANCHOR_SERIES, FLOW_SERIES)
+
+#: Per-lens vocabularies. Deliberately three separate Literals and not one shared enum:
+#: STRONG is about tonnage into a trust and ADVERSE is about a macro backdrop, and a
+#: common type would invite exactly the cross-lens comparison the no-precedence rule
+#: exists to refuse. Every one includes UNKNOWN and none includes NEUTRAL-as-absence.
+GoldFlowLabel = Literal["STRONG", "NEUTRAL", "WEAK", "UNKNOWN"]
+GoldCyclicalLabel = Literal["SUPPORTIVE", "ADVERSE", "MIXED", "SUSPENDED", "UNKNOWN"]
+GoldValuationLabel = Literal["FAVORABLE", "NEUTRAL", "STRETCHED", "UNKNOWN"]
+
+
+@dataclass(frozen=True)
+class GoldLensResult:
+    """The persisted deterministic gauge this state reads, and nothing more.
+
+    Built from a stored ``gold_posture_daily`` row by the job, never recomputed here and
+    never fetched from a provider.  Carrying the row's own ``obs_date`` rather than
+    inheriting the state's ``as_of`` is the point: the orchestrator runs on its own
+    schedule, and a state that assumed the two instants matched would report a stale gauge
+    as current.
+    """
+
+    obs_date: date | None
+    gauge_state: str | None
+    corr_252d_level: Decimal | None = None
+    corr_60d_level: Decimal | None = None
+    #: Lens 3's flag, carried through as a sub-state.  A warning, never a size.
+    valuation_flag: str | None = None
+
+
+@dataclass(frozen=True)
+class GoldParameters:
+    """Versioned thresholds, hashed with the evidence rather than hidden in constants."""
+
+    version: str = "gold/1"
+    #: CALENDAR days, not observation counts, and that distinction is load-bearing.
+    #: This engine reads four series off three publication calendars -- GLD trades NYSE
+    #: sessions, FRED skips its own holidays, SPDR posts business days -- and over one
+    #: quarter of the golden fixture ``GLD_CLOSE`` has 64 prints where ``DFII10`` has 62.
+    #: A window of "63 observations" is therefore a different span on every series, and
+    #: on the shorter one it silently returns None and mutes the contradiction the window
+    #: exists to detect. Anchoring on the calendar makes the legs comparable.
+    #:
+    #: 63 days -- nine weeks -- is set by the golden fixture rather than chosen. Measured
+    #: across its two preregistered scenarios: at 91 days the real-yield leg INVERTS
+    #: (2024-07-24 2.00 -> 2024-10-23 1.93, -7bp) and the dollar leg falls inside its
+    #: threshold, so the preregistered ADVERSE reading reads UNKNOWN; and the ETF flow
+    #: series carries only 65 days of history, so nothing longer is measurable at all.
+    #: The admissible band is roughly 45-65 days and 63 sits inside it rather than on its
+    #: edge. One window for all four series: the fixture gives no reason for two, and a
+    #: second parameter nothing distinguishes is the one that silently becomes wrong.
+    window_days: int = 63
+    momentum_threshold_pct: Decimal = Decimal("5.0")
+    #: Percent change in ounces held at which accumulation is STRONG rather than drift.
+    flow_strong_pct: Decimal = Decimal("2.0")
+    #: Lens 2's legs. A real yield move in basis points and a dollar move in percent --
+    #: two units, two thresholds, never one number applied to both.
+    real_yield_move_bps: Decimal = Decimal("10")
+    dollar_move_pct: Decimal = Decimal("1.0")
+    contradiction_penalty_each: Decimal = Decimal("0.15")
+    contradiction_penalty_cap: Decimal = Decimal("0.60")
+    freshness_decay_multiple: Decimal = Decimal("3")
+    anchor_cadence_days: int = 1
+    #: SPDR publishes holdings each business day.
+    flow_cadence_days: int = 1
+
+    def as_record(self) -> dict[str, Any]:
+        return {
+            key: (format(value, "f") if isinstance(value, Decimal) else value)
+            for key, value in sorted(asdict(self).items())
+        }
+
+
+DEFAULT_GOLD_PARAMETERS = GoldParameters()
+
+
+def compute_gold_state(
+    observations: Iterable[DomainObservation],
+    *,
+    as_of: datetime,
+    lens: GoldLensResult | None = None,
+    upstream: Sequence[UpstreamState] = (),
+    parameters: GoldParameters = DEFAULT_GOLD_PARAMETERS,
+    prior_state: MacroDomainState | None = None,
+) -> MacroDomainState:
+    """Assemble the gold gate, its three lens sub-states, and their disagreements."""
+    if as_of.tzinfo is None or as_of.utcoffset() is None:
+        raise ValueError("as_of must be timezone-aware")
+    _refuse_future_upstream(upstream, as_of)
+
+    eligible = tuple(
+        sorted(
+            (obs for obs in observations if obs.is_known_on(as_of)),
+            key=lambda obs: (obs.series_id, obs.period_end, obs.available_at),
+        )
+    )
+    price = _rows(eligible, ANCHOR_SERIES)
+    flow = _rows(eligible, FLOW_SERIES)
+    real_yield = _rows(eligible, REAL_YIELD_SERIES)
+    dollar = _rows(eligible, DOLLAR_SERIES)
+
+    # The confidence denominator counts what gold OWNS.  A borrowed series going quiet
+    # degrades the lens that reads it -- reported in that sub-state's own confidence --
+    # and does not make gold less certain about its own gate.
+    factors = tuple(
+        factor
+        for factor in (
+            _factor(
+                price, "gold_price", as_of, parameters.anchor_cadence_days, parameters
+            ),
+            _factor(
+                flow, "gld_holdings", as_of, parameters.flow_cadence_days, parameters
+            ),
+        )
+        if factor is not None
+    )
+
+    state = _state(lens)
+    price_change = _change_pct(price, parameters.window_days)
+    direction = _direction(price_change, parameters)
+
+    sub_states = (
+        _flow_sub_state(flow, as_of, parameters),
+        _cyclical_sub_state(real_yield, dollar, state, as_of, parameters),
+        _valuation_sub_state(lens),
+    )
+    contradictions = _contradictions(
+        price=price,
+        real_yield=real_yield,
+        sub_states=sub_states,
+        as_of=as_of,
+        parameters=parameters,
+    )
+
+    confidence, reasons = compute_confidence(
+        factors,
+        required_series=(ANCHOR_SERIES,),
+        contradictions=contradictions,
+        contradiction_penalty_each=parameters.contradiction_penalty_each,
+        contradiction_penalty_cap=parameters.contradiction_penalty_cap,
+        prior_state=prior_state,
+        absent_reason=_absent_reason(price, lens),
+    )
+    reasons = (
+        reasons
+        + _anchor_period_note(price, as_of)
+        + _lens_note(lens, as_of)
+        + _borrowed_note(eligible)
+        + _upstream_note(upstream)
+    )
+
+    return MacroDomainState(
+        domain="gold",
+        state=state,
+        direction=direction,
+        velocity=_velocity(price_change, lens, parameters),
+        confidence=confidence,
+        confidence_reasons=reasons,
+        contradictions=contradictions,
+        factors=factors,
+        # Every row the state stood on, borrowed rows included, each pointing at the ONE
+        # stored observation its owner also points at.  That shared obs_id is the
+        # many-readers mechanism, not a second copy.
+        evidence_refs=tuple(
+            EvidenceRef(
+                series_id=obs.series_id,
+                period_end=obs.period_end,
+                causal_role=obs.causal_role,
+                available_at=obs.available_at,
+                obs_id=obs.obs_id,
+                artifact_id=obs.artifact_id,
+            )
+            for obs in eligible
+        ),
+        engine_version=GOLD_ENGINE_VERSION,
+        inputs_hash=compute_inputs_hash(
+            engine_version=GOLD_ENGINE_VERSION,
+            parameters={
+                **parameters.as_record(),
+                # The gauge is an input, so it is hashed: an orchestrator that re-ran and
+                # changed its mind must change this identity even when every observation
+                # is byte-identical.
+                "lens": (
+                    None
+                    if lens is None
+                    else f"{lens.obs_date}:{lens.gauge_state}:{lens.corr_252d_level}"
+                ),
+                "upstream": sorted(
+                    f"{item.domain}:{item.inputs_hash}" for item in upstream
+                ),
+            },
+            observations=eligible,
+        ),
+        as_of=as_of,
+        sub_states=sub_states,
+        notes=(
+            "the domain state is the GATE -- whether the gold/real-yield relationship "
+            "Lens 2 rests on is in force -- and not a view on gold. the three lenses "
+            "publish beside it as sub-states with their own confidence, and there is no "
+            "precedence rule between them",
+            "the valuation lens is a warning: it never becomes a price target, an "
+            "allocation, or a size",
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- the gate
+
+
+def _state(lens: GoldLensResult | None) -> GoldStateLabel:
+    """The gauge verdict, with every unrecognised label falling to UNKNOWN.
+
+    Spec 3.1: an unrecognised gauge label maps to UNKNOWN, never to ``operative``.
+    Raising instead would be defensible for a typo and wrong for the case that matters --
+    a gauge that grows a fourth label mid-deploy would take the state job down rather than
+    reporting that it no longer understands the gate.
+    """
+    if lens is None or lens.gauge_state is None:
+        return "UNKNOWN"
+    return _GAUGE_TO_STATE.get(lens.gauge_state, "UNKNOWN")
+
+
+# ------------------------------------------------------------------------- sub-states
+#
+# The three lenses publish BESIDE the gate, each with its own coverage (spec 3.1). Their
+# own coverage is the point: Part A's R2 says a domain's confidence may never stand in
+# for a sub-state's, and the inverse holds too -- the gate can be certain while Lens 2
+# has no legs to read, and Lens 1 can be fully covered while the gate reads UNKNOWN.
+
+
+def _flow_sub_state(
+    flow: Sequence[DomainObservation], as_of: datetime, parameters: GoldParameters
+) -> MacroSubState:
+    """Lens 1 -- structural flow, read off ETF tonnage in ounces.
+
+    Ounces, not dollars: holdings counted in ounces rise only when metal actually enters
+    the trust, so a rally cannot masquerade as accumulation.
+    """
+    change = _change_pct(flow, parameters.window_days)
+    label: GoldFlowLabel
+    if change is None:
+        label = "UNKNOWN"
+    elif change >= parameters.flow_strong_pct:
+        label = "STRONG"
+    elif change <= -parameters.flow_strong_pct:
+        label = "WEAK"
+    else:
+        label = "NEUTRAL"
+    return MacroSubState(
+        role="positioning",
+        state=label,
+        direction=_sign_direction(change, parameters.flow_strong_pct),
+        velocity=(
+            Velocity(
+                metric="gld_holdings_change",
+                value=change,
+                unit="percent",
+                window_months=2,
+                unavailable_reason=(
+                    None
+                    if change is not None
+                    else (
+                        f"{FLOW_SERIES} history does not reach "
+                        f"{parameters.window_days} calendar days before its latest print"
+                    )
+                ),
+            ),
+        ),
+        confidence=_coverage_confidence(
+            flow, as_of, parameters.flow_cadence_days, parameters
+        ),
+        confidence_reasons=(),
+        series_ids=(FLOW_SERIES,),
+        latest_period_end=flow[-1].period_end if flow else None,
+        unavailable_reason=(
+            None if flow else f"no {FLOW_SERIES} observation available at as_of"
+        ),
+    )
+
+
+def _cyclical_sub_state(
+    real_yield: Sequence[DomainObservation],
+    dollar: Sequence[DomainObservation],
+    gate: GoldStateLabel,
+    as_of: datetime,
+    parameters: GoldParameters,
+) -> MacroSubState:
+    """Lens 2 -- the regime-gated cyclical read, on two BORROWED legs.
+
+    Gated on the gate: with the relationship measured suspended, a cyclical reading drawn
+    from it describes a correlation that is not currently holding. Reporting SUSPENDED is
+    not degradation, it is the honest answer.
+    """
+    if gate == "SUSPENDED":
+        return MacroSubState(
+            role="decomposition_component",
+            state="SUSPENDED",
+            direction="UNKNOWN",
+            velocity=(),
+            confidence=Decimal(0),
+            confidence_reasons=(),
+            series_ids=(REAL_YIELD_SERIES, DOLLAR_SERIES),
+            latest_period_end=real_yield[-1].period_end if real_yield else None,
+            unavailable_reason=(
+                "the gold/real-yield relationship reads suspended at as_of, so a "
+                "cyclical view drawn from it would describe a correlation that is not "
+                "currently in force"
+            ),
+        )
+
+    yield_move = _change_abs(real_yield, parameters.window_days)
+    dollar_move = _change_pct(dollar, parameters.window_days)
+    # Adverse for gold: a higher real yield raises the carrying cost of a zero-coupon
+    # asset, and a stronger dollar lowers the price of a dollar-denominated one.
+    legs = [
+        _leg_adverse(yield_move, parameters.real_yield_move_bps / Decimal(100)),
+        _leg_adverse(dollar_move, parameters.dollar_move_pct),
+    ]
+    known = [leg for leg in legs if leg is not None]
+    label: GoldCyclicalLabel
+    if not known:
+        label = "UNKNOWN"
+    elif all(leg is True for leg in known):
+        label = "ADVERSE"
+    elif all(leg is False for leg in known):
+        label = "SUPPORTIVE"
+    else:
+        label = "MIXED"
+    return MacroSubState(
+        role="decomposition_component",
+        state=label,
+        # Deliberately UNKNOWN and never derived from the legs. The golden scenario
+        # preregisters ``lens2_direction_inferred: null``: an adverse backdrop is a
+        # statement about the environment, not a forecast of which way gold goes.
+        direction="UNKNOWN",
+        velocity=(
+            Velocity(
+                metric="real_yield_change",
+                value=yield_move,
+                unit="percent",
+                window_months=2,
+                unavailable_reason=(
+                    None if yield_move is not None else f"no {REAL_YIELD_SERIES} window"
+                ),
+            ),
+            Velocity(
+                metric="broad_dollar_change",
+                value=dollar_move,
+                unit="percent",
+                window_months=2,
+                unavailable_reason=(
+                    None if dollar_move is not None else f"no {DOLLAR_SERIES} window"
+                ),
+            ),
+        ),
+        confidence=_coverage_confidence(real_yield, as_of, 1, parameters),
+        confidence_reasons=(),
+        series_ids=(REAL_YIELD_SERIES, DOLLAR_SERIES),
+        latest_period_end=real_yield[-1].period_end if real_yield else None,
+        unavailable_reason=(
+            None
+            if known
+            else "neither cyclical leg had enough history at as_of to measure a move"
+        ),
+    )
+
+
+def _valuation_sub_state(lens: GoldLensResult | None) -> MacroSubState:
+    """Lens 3 -- the valuation overlay. A warning, never a size."""
+    flag = None if lens is None else lens.valuation_flag
+    label: GoldValuationLabel
+    if flag in {"High", "Severe"}:
+        label = "STRETCHED"
+    elif flag == "Moderate":
+        label = "NEUTRAL"
+    elif flag == "Low":
+        label = "FAVORABLE"
+    else:
+        label = "UNKNOWN"
+    return MacroSubState(
+        role="realized",
+        state=label,
+        direction="UNKNOWN",
+        velocity=(),
+        confidence=Decimal(1) if label != "UNKNOWN" else Decimal(0),
+        confidence_reasons=(
+            ConfidenceTerm(
+                term="valuation_is_a_warning",
+                value=Decimal(0),
+                detail=(
+                    "long-run anchors say where the price sits in its own history; they "
+                    "never become a price target, an allocation or a size"
+                ),
+                kind="informational",
+            ),
+        ),
+        series_ids=(),
+        latest_period_end=None if lens is None else lens.obs_date,
+        unavailable_reason=(
+            None if label != "UNKNOWN" else "no stored valuation flag at as_of"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------- contradictions
+
+
+def _contradictions(
+    *,
+    price: Sequence[DomainObservation],
+    real_yield: Sequence[DomainObservation],
+    sub_states: Sequence[MacroSubState],
+    as_of: datetime,
+    parameters: GoldParameters,
+) -> tuple[Contradiction, ...]:
+    """Spec 4's two gold rules. Neither resolves into a direction or moves a label."""
+    out: list[Contradiction] = []
+
+    gold_move = _change_pct(price, parameters.window_days)
+    yield_move = _change_abs(real_yield, parameters.window_days)
+    # The WINDOW's start year, not ``as_of``'s. A window straddling the break is exactly
+    # what the gate exists to refuse -- calling it post-2022 because the run happened in
+    # January would let one leg of the comparison come from the regime the other says no
+    # longer applies.
+    window = _endpoints(price, parameters.window_days)
+    window_starts_post_break = (
+        window is not None and window[0].period_end.year >= REGIME_BREAK_YEAR
+    )
+    if (
+        window_starts_post_break
+        and gold_move is not None
+        and yield_move is not None
+        and gold_move != 0
+        and yield_move != 0
+        and (gold_move > 0) == (yield_move > 0)
+    ):
+        out.append(
+            Contradiction(
+                rule="gold_against_real_yields_post_2022",
+                detail=(
+                    f"gold {gold_move:+.2f}% and the 10y real yield {yield_move:+.2f}pp "
+                    "moved together over the same window; the pre-2022 relationship is "
+                    "that they oppose, because a higher real rate is a higher carrying "
+                    "cost for a zero-coupon asset. reported, not resolved -- the gate "
+                    "exists so a Lens 2 fitted across the break cannot average a "
+                    "negative relationship with a broken one and describe neither"
+                ),
+            )
+        )
+
+    flow = next((s for s in sub_states if s.role == "positioning"), None)
+    cyclical = next(
+        (s for s in sub_states if s.role == "decomposition_component"), None
+    )
+    if flow is not None and cyclical is not None:
+        if flow.state == "STRONG" and cyclical.state == "ADVERSE":
+            out.append(
+                Contradiction(
+                    rule="gold_flow_against_cyclical",
+                    detail=(
+                        "structural flows read STRONG while the cyclical backdrop reads "
+                        "ADVERSE. both are reported as findings and neither overwrites "
+                        "the other: there is no precedence rule, because collapsing them "
+                        "would throw away the only information the disagreement carries"
+                    ),
+                )
+            )
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------- helpers
+
+
+def _rows(
+    observations: Sequence[DomainObservation], series_id: str
+) -> tuple[DomainObservation, ...]:
+    """This series' point-in-time view: one row per period, newest vintage, oldest first.
+
+    ``is_known_on`` already drops vintages superseded before ``as_of``, but it cannot drop
+    one whose replacement is still in the future -- both are legitimately "known", and the
+    fixture's broad-dollar series carries two vintages for all 205 of its periods. Keeping
+    both would put the same period into the window twice and let a restatement land at an
+    endpoint, so the newest vintage in force wins per period.
+    """
+    by_period: dict[date, DomainObservation] = {}
+    for obs in observations:
+        if obs.series_id != series_id:
+            continue
+        held = by_period.get(obs.period_end)
+        if held is None or obs.available_at >= held.available_at:
+            by_period[obs.period_end] = obs
+    return tuple(by_period[period] for period in sorted(by_period))
+
+
+def _endpoints(
+    rows: Sequence[DomainObservation], window_days: int
+) -> tuple[DomainObservation, DomainObservation] | None:
+    """The newest row and the newest row at least ``window_days`` before it.
+
+    None when the history does not reach back that far, rather than a change measured
+    over whatever happened to exist: a three-week move reported under a quarterly label
+    is a different statistic wearing the same name.
+    """
+    if not rows:
+        return None
+    latest = rows[-1]
+    cutoff = latest.period_end - timedelta(days=window_days)
+    earlier = [row for row in rows if row.period_end <= cutoff]
+    if not earlier:
+        return None
+    return earlier[-1], latest
+
+
+def _change_pct(rows: Sequence[DomainObservation], window_days: int) -> Decimal | None:
+    """Percent change over the calendar window, or None if history is short."""
+    pair = _endpoints(rows, window_days)
+    if pair is None:
+        return None
+    start, end = pair
+    if start.value == 0:
+        return None
+    return (end.value - start.value) / start.value * Decimal(100)
+
+
+def _change_abs(rows: Sequence[DomainObservation], window_days: int) -> Decimal | None:
+    """Absolute change, for a series already quoted in percent.
+
+    A yield's percent CHANGE is meaningless -- 1.77 to 1.93 is "+9%" and nobody in rates
+    says that. The move is 16 basis points, and that is what the threshold is stated in.
+    """
+    pair = _endpoints(rows, window_days)
+    if pair is None:
+        return None
+    start, end = pair
+    return end.value - start.value
+
+
+def _leg_adverse(move: Decimal | None, threshold: Decimal) -> bool | None:
+    """True if this leg is adverse for gold, False if supportive, None if unreadable.
+
+    A move inside the threshold is NOT adverse and not supportive -- returning False for
+    it would let two quiet legs read SUPPORTIVE, which is absence rendered as a view.
+    """
+    if move is None:
+        return None
+    if move >= threshold:
+        return True
+    if move <= -threshold:
+        return False
+    return None
+
+
+def _factor(
+    rows: Sequence[DomainObservation],
+    name: str,
+    as_of: datetime,
+    cadence_days: int,
+    parameters: GoldParameters,
+) -> FactorState | None:
+    if not rows:
+        return None
+    latest = rows[-1]
+    age_days = max(0, (as_of - latest.available_at).days)
+    change = _change_pct(rows, parameters.window_days)
+    return FactorState(
+        name=name,
+        causal_role=latest.causal_role,
+        series_id=latest.series_id,
+        period_end=latest.period_end,
+        value=latest.value,
+        unit=latest.unit,
+        direction=_sign_direction(change, parameters.momentum_threshold_pct),
+        change_over_window=change,
+        available_at=latest.available_at,
+        age_days=age_days,
+        freshness=freshness_for(
+            age_days, cadence_days, parameters.freshness_decay_multiple
+        ),
+        quality_status=latest.quality_status,
+        source=latest.source,
+        source_kind=latest.source_kind,
+    )
+
+
+def _coverage_confidence(
+    rows: Sequence[DomainObservation],
+    as_of: datetime,
+    cadence_days: int,
+    parameters: GoldParameters,
+) -> Decimal:
+    """A sub-state's own confidence: does its series exist and is it on schedule.
+
+    Its OWN, per spec 3.1 and Part A's R2 -- the domain's gate confidence never stands in
+    for a lens's coverage, and a lens's coverage never stands in for the gate's.
+    """
+    if not rows:
+        return Decimal(0)
+    age_days = max(0, (as_of - rows[-1].available_at).days)
+    return freshness_for(age_days, cadence_days, parameters.freshness_decay_multiple)
+
+
+def _direction(change: Decimal | None, parameters: GoldParameters) -> Direction:
+    return _sign_direction(change, parameters.momentum_threshold_pct)
+
+
+def _sign_direction(change: Decimal | None, threshold: Decimal) -> Direction:
+    if change is None:
+        return "UNKNOWN"
+    if change >= threshold:
+        return "RISING"
+    if change <= -threshold:
+        return "FALLING"
+    return "FLAT"
+
+
+def _velocity(
+    price_change: Decimal | None,
+    lens: GoldLensResult | None,
+    parameters: GoldParameters,
+) -> tuple[Velocity, ...]:
+    corr = None if lens is None else lens.corr_252d_level
+    return (
+        Velocity(
+            metric="gold_price_change",
+            value=price_change,
+            unit="percent",
+            window_months=3,
+            unavailable_reason=(
+                None
+                if price_change is not None
+                else (
+                    f"{ANCHOR_SERIES} history does not reach "
+                    f"{parameters.window_days} calendar days before its latest print"
+                )
+            ),
+        ),
+        Velocity(
+            metric="gold_real_yield_corr_252d",
+            value=corr,
+            unit="correlation",
+            window_months=12,
+            unavailable_reason=(
+                None if corr is not None else "no gauge correlation stored at as_of"
+            ),
+        ),
+    )
+
+
+def _absent_reason(
+    price: Sequence[DomainObservation], lens: GoldLensResult | None
+) -> str | None:
+    if not price:
+        return (
+            f"no {ANCHOR_SERIES} observation available at as_of; the state abstains "
+            "rather than reporting a gate with no gold price under it"
+        )
+    if lens is None or lens.gauge_state is None:
+        return (
+            "no stored gauge verdict at as_of, so the gate reads UNKNOWN; defaulting it "
+            "to operative would assert the pre-2022 relationship holds, which is the "
+            "one claim the gate exists to withhold"
+        )
+    return None
+
+
+def _anchor_period_note(
+    price: Sequence[DomainObservation], as_of: datetime
+) -> tuple[ConfidenceTerm, ...]:
+    """How old the newest gold PRICE is, which freshness deliberately does not measure.
+
+    ``freshness_for`` reads ``available_at`` -- when we learned a value -- and that is the
+    right denominator for detecting a publisher that has gone quiet. It is the wrong one
+    for answering "is this price current", and the two come apart hard on this lane: a
+    backfill stamps 400 days of history with today's retrieval clock, so every one of
+    those prints reads perfectly fresh while the newest is over a year old.
+
+    Reported as its own informational term rather than folded into the confidence, for
+    the same reason the rest of them are: a number that silently absorbed two different
+    kinds of staleness could not be argued with.
+    """
+    if not price:
+        return ()
+    age_days = max(0, (as_of.date() - price[-1].period_end).days)
+    return (
+        ConfidenceTerm(
+            term="anchor_period_age_days",
+            value=Decimal(age_days),
+            detail=(
+                f"the newest {ANCHOR_SERIES} print is for {price[-1].period_end} "
+                f"({age_days}d before as_of). freshness measures when we LEARNED a "
+                "value, not how old the value is, so a backfilled history reads fresh "
+                "and this term is the only thing that says otherwise"
+            ),
+            kind="informational",
+        ),
+    )
+
+
+def _lens_note(
+    lens: GoldLensResult | None, as_of: datetime
+) -> tuple[ConfidenceTerm, ...]:
+    """The gauge's own age, which is not the price's age.
+
+    The orchestrator runs nightly on its own schedule. A state computed the morning after
+    a failed orchestrator run stands on a two-day-old gauge, and nothing else in
+    ``confidence_reasons`` would say so -- the price factor would be fresh.
+    """
+    if lens is None or lens.obs_date is None:
+        return ()
+    age_days = max(0, (as_of.date() - lens.obs_date).days)
+    return (
+        ConfidenceTerm(
+            term="gauge_age_days",
+            value=Decimal(age_days),
+            detail=(
+                f"the gauge this gate reads was computed for {lens.obs_date} "
+                f"({age_days}d before as_of); the orchestrator runs on its own schedule "
+                "and its age is not the gold price's age"
+            ),
+            kind="informational",
+        ),
+    )
+
+
+def _borrowed_note(
+    observations: Sequence[DomainObservation],
+) -> tuple[ConfidenceTerm, ...]:
+    """Name the rows gold READ but does not OWN, so the lineage is legible.
+
+    Without this the evidence list looks like sixteen gold-owned series. The distinction
+    is what keeps ``required_series`` honest: a borrowed series going quiet degrades the
+    lens that reads it, and must never move the gate's own confidence.
+    """
+    borrowed = sorted(
+        {
+            f"{obs.series_id}({SERIES_OWNER[obs.series_id]})"
+            for obs in observations
+            if obs.series_id in SERIES_OWNER
+        }
+    )
+    if not borrowed:
+        return ()
+    return (
+        ConfidenceTerm(
+            term="borrowed_evidence",
+            value=Decimal(len(borrowed)),
+            detail=(
+                f"read but not owned: {', '.join(borrowed)}. these point at the same "
+                "stored observations their owning domain points at -- one payload, one "
+                "owner, many readers -- and are excluded from this state's required "
+                "series so a quiet upstream degrades a lens, not the gate"
+            ),
+            kind="informational",
+        ),
+    )
+
+
+def _upstream_note(
+    upstream: Sequence[UpstreamState],
+) -> tuple[ConfidenceTerm, ...]:
+    if not upstream:
+        return ()
+    named = ", ".join(
+        f"{item.domain}={item.state}/{item.direction}"
+        for item in sorted(upstream, key=lambda item: item.domain)
+    )
+    return (
+        ConfidenceTerm(
+            term="upstream_consumed",
+            value=Decimal(len(upstream)),
+            detail=f"consumed {len(upstream)} upstream state(s) by state id: {named}",
+            kind="informational",
+        ),
+    )
+
+
+def _refuse_future_upstream(upstream: Sequence[UpstreamState], as_of: datetime) -> None:
+    """An upstream answering for a later instant could not have been known."""
+    domains = [item.domain for item in upstream]
+    duplicated = sorted({d for d in domains if domains.count(d) > 1})
+    if duplicated:
+        raise ValueError(
+            f"upstream lists {duplicated} more than once; a domain has one answer per "
+            "as_of, and picking the first would make the result depend on argument order"
+        )
+    ahead = [item for item in upstream if item.as_of > as_of]
+    if ahead:
+        named = ", ".join(
+            f"{item.domain}@{item.as_of.isoformat()}"
+            for item in sorted(ahead, key=lambda item: item.domain)
+        )
+        raise ValueError(
+            f"upstream {named} answers for an instant after as_of {as_of.isoformat()}; "
+            "consuming it would be lookahead, and the fact that the future answer is "
+            "about another domain does not make it knowable"
+        )
+
+
+__all__ = [
+    "ANCHOR_SERIES",
+    "DOLLAR_SERIES",
+    "FLOW_SERIES",
+    "GOLD_ENGINE_VERSION",
+    "GOLD_OWNED_SERIES",
+    "REAL_YIELD_SERIES",
+    "REGIME_BREAK_YEAR",
+    "SERIES_OWNER",
+    "DEFAULT_GOLD_PARAMETERS",
+    "GoldLensResult",
+    "GoldParameters",
+    "compute_gold_state",
+]

--- a/src/uw_scan/reports/gold_posture.py
+++ b/src/uw_scan/reports/gold_posture.py
@@ -126,42 +126,6 @@ def _rolling_corr_pairs(
     return out
 
 
-def _decomposition_rows_from_lenses(
-    structural: Any, cyclical: Any, valuation: Any
-) -> list[dict[str, Any]]:
-    """Flatten each lens's headline heuristic z-scores into a decomposition list.
-
-    Values are pulled from already-computed lens snapshots. Where a lens does
-    not yet expose a particular z-score the entry is silently skipped (the v1
-    cards expose only what they can compute). Sorted descending by |contribution|
-    and capped at 12 rows."""
-    rows: list[dict[str, Any]] = []
-    candidates: list[tuple[str, str, Any]] = [
-        ("L1", "CB Δ12M", getattr(structural, "cb_strategic_z", None)),
-        ("L1", "COMEX ROC", getattr(structural, "comex_20d_roc_z", None)),
-        ("L1", "ETF flow", getattr(structural, "etf_flow_z", None)),
-        ("L1", "COT MM", getattr(structural, "cot_mm_z", None)),
-        ("L1", "UW skew", getattr(structural, "uw_skew_z", None)),
-        ("L2", "DFII10", getattr(cyclical, "dfii10_z", None)),
-        ("L2", "GPR", getattr(cyclical, "gpr_z", None)),
-        ("L2", "DXY", getattr(cyclical, "dxy_z", None)),
-        ("L3", "Gold/CPI", getattr(valuation, "real_price_z", None)),
-        ("L3", "Gold/M2", getattr(valuation, "gold_m2_z", None)),
-    ]
-    for lens_id, name, value in candidates:
-        if value is None:
-            continue
-        rows.append(
-            {
-                "lens": lens_id,
-                "factor": name,
-                "contribution": str(Decimal(str(round(float(value), 3)))),
-            }
-        )
-    rows.sort(key=lambda r: abs(float(r["contribution"])), reverse=True)
-    return rows[:12]
-
-
 def _pre_2022_band(
     corr_series: list[tuple[date, Decimal]],
 ) -> dict[str, Any] | None:
@@ -464,9 +428,17 @@ def compute_and_persist_gold_posture(
         if latest_skew is not None:
             uw_25d_skew_sigma = Decimal(str(latest_skew))
 
-    decomposition_rows = _decomposition_rows_from_lenses(
-        structural, cyclical, valuation
-    )
+    # No lens decomposition. The removed builder read ten ``*_z`` attributes off the
+    # three lens dataclasses; nine exist nowhere in the tree and the tenth only as a DB
+    # column, so it returned [] on every run since it was written. Repairing it by
+    # renaming the reads would be worse than the bug: the lenses expose native units
+    # (tonnes, ounces, percent, basis points) and percentiles, never z-scores, and no
+    # model ever fitted weights over them. Summing them into one "contribution" column
+    # and sorting by magnitude would rank a reserves flow above a valuation percentile
+    # because tonnes are numerically larger than a probability -- an allocation-shaped
+    # output backed by nothing, which is what this plan's B6 step 6 says to remove.
+    # The column and the API field stay: both are [] today and [] after.
+    decomposition_rows: list[dict[str, Any]] = []
     gld_history_rows = [
         {
             "obs_date": r["obs_date"].isoformat(),

--- a/src/uw_scan/sources/etf_holdings.py
+++ b/src/uw_scan/sources/etf_holdings.py
@@ -76,13 +76,36 @@ class EtfHoldingsProvider:
         self.close()
 
     def fetch_gld(self, *, start: date | None = None) -> list[EtfHoldingRow]:
+        return self.fetch_gld_payload(start=start)[3]
+
+    def fetch_gld_payload(
+        self, *, start: date | None = None
+    ) -> tuple[bytes, str, str, list[EtfHoldingRow]]:
+        """The rows AND the bytes, media type and URL they came from.
+
+        One fetch, two consumers -- the warm store wants rows, the macro evidence store
+        wants a hashable artifact. The media type is REPORTED rather than assumed because
+        SPDR serves this same archive as CSV or XLSX depending on the day, and an
+        artifact mislabelled ``text/csv`` is one a replay cannot re-parse.
+        """
         response = self._get_with_telemetry(
             self.GLD_URL, self.GLD_PARAMS, endpoint_key="spdr_gld_archive"
         )
         response.raise_for_status()
+        source_url = str(response.request.url)
         if _looks_like_xlsx(response):
-            return self._parse_spdr_archive_xlsx("GLD", response.content, start)
-        return self._parse_spdr_csv("GLD", response.text, start)
+            return (
+                response.content,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                source_url,
+                self._parse_spdr_archive_xlsx("GLD", response.content, start),
+            )
+        return (
+            response.content,
+            "text/csv",
+            source_url,
+            self._parse_spdr_csv("GLD", response.text, start),
+        )
 
     def fetch_gldm(self, *, start: date | None = None) -> list[EtfHoldingRow]:
         response = self._get_with_telemetry(

--- a/src/uw_scan/sources/ohlc.py
+++ b/src/uw_scan/sources/ohlc.py
@@ -73,6 +73,18 @@ class MassiveOhlcProvider:
         self.close()
 
     def fetch_daily(self, ticker: str, start: date, end: date) -> list[OhlcBar]:
+        return self.fetch_daily_payload(ticker, start, end)[2]
+
+    def fetch_daily_payload(
+        self, ticker: str, start: date, end: date
+    ) -> tuple[bytes, str, list[OhlcBar]]:
+        """The bars AND the bytes they were parsed from, plus the URL that served them.
+
+        One fetch, two consumers: the warm store wants the bars and the macro evidence
+        store wants an artifact it can hash and replay from. Fetching twice would cost a
+        second vendor call and -- worse -- could return a different payload, so the
+        stored artifact would not be the bytes the stored observations came from.
+        """
         path = (
             f"/v2/aggs/ticker/{ticker}/range/1/day/"
             f"{start.isoformat()}/{end.isoformat()}"
@@ -84,6 +96,8 @@ class MassiveOhlcProvider:
             ticker=ticker,
         )
         r.raise_for_status()
+        raw_bytes = r.content
+        source_url = str(r.request.url)
         payload = r.json()
         results = payload.get("results") or []
         bars: list[OhlcBar] = []
@@ -103,7 +117,7 @@ class MassiveOhlcProvider:
                     volume=int(row["v"]) if row.get("v") is not None else None,
                 )
             )
-        return bars
+        return raw_bytes, source_url, bars
 
     def _get_with_telemetry(
         self,

--- a/src/uw_scan/storage/gold.py
+++ b/src/uw_scan/storage/gold.py
@@ -829,6 +829,36 @@ class _GoldMixin:
             cols = [c.name for c in cur.description]
             return dict(zip(cols, row, strict=True))
 
+    def fetch_gold_posture_as_of(self, as_of: _date) -> dict[str, Any] | None:
+        """The newest active posture row for a date AT OR BEFORE ``as_of``.
+
+        Neither existing reader answers this. ``fetch_gold_posture_latest`` returns the
+        newest row regardless of the instant being answered for -- fine for the live page,
+        lookahead for a replay -- and ``fetch_gold_posture_for_obs_date`` needs an exact
+        date, so a state computed on a day the orchestrator did not run would find
+        nothing and report UNKNOWN rather than reading the gauge that WAS in force.
+
+        ``computed_at ASC`` within a date matches the replay discipline the exact-date
+        reader already uses: the first non-invalidated computation is the one that stood.
+        """
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM uw_scan.gold_posture_daily
+                WHERE obs_date <= %s
+                  AND row_status = 'active'
+                ORDER BY obs_date DESC, computed_at ASC
+                LIMIT 1
+                """,
+                (as_of,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [c.name for c in cur.description]
+            return dict(zip(cols, row, strict=True))
+
     def fetch_gold_posture_for_obs_date(self, obs_date: _date) -> dict[str, Any] | None:
         """Replay discipline: return the first non-invalidated posture row."""
         with self._conn.cursor() as cur:

--- a/src/uw_scan/worker/jobs/macro_gold_ingest.py
+++ b/src/uw_scan/worker/jobs/macro_gold_ingest.py
@@ -1,0 +1,230 @@
+"""Ingest gold's own two series into the point-in-time evidence store.
+
+Same structural choice as ``macro_market_layer_ingest``, for the same reason: **the
+artifact is written and COMMITTED before anything is parsed out of it**.  A publisher
+schema change then costs this run and leaves the payload that caused it queryable, rather
+than throwing away the bytes that would explain the failure.
+
+What this does NOT ingest is the interesting part.  Lens 2 reads the 10-year real yield
+and the broad dollar, and both stay owned by ``RATES_EVIDENCE`` / ``USD_EVIDENCE``.  Gold
+points at the same stored rows.  Ingesting them here would put one publisher payload
+under two owners, and the copies diverge on the first parser change.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+
+import psycopg
+
+from uw_scan.macro.gold_ingest import (
+    flow_observations,
+    gold_flow_artifact,
+    gold_price_artifact,
+    observation_row,
+    price_observations,
+)
+from uw_scan.sources.etf_holdings import EtfHoldingsProvider
+from uw_scan.sources.ohlc import MassiveOhlcProvider
+from uw_scan.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+#: The GLD ticker massive serves bars for.
+GOLD_SPOT_TICKER = "GLD"
+
+#: How much history each run asks for.  Generous on purpose: these publishers are cheap,
+#: the writer is idempotent on unchanged values, and a short window means a run that fails
+#: for a week leaves a hole the engine's 63-day window would silently read across.
+DEFAULT_LOOKBACK_DAYS = 400
+
+
+@dataclass
+class MacroGoldIngestResult:
+    feeds_attempted: int = 0
+    feeds_succeeded: int = 0
+    artifacts_seen: int = 0
+    observations_created: int = 0
+    observations_unchanged: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def macro_gold_ingest_job(
+    *,
+    dsn: str,
+    massive_api_key: str,
+    schema: str = "uw_scan",
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    price_provider_factory: Callable[[], object] | None = None,
+    flow_provider_factory: Callable[[], object] | None = None,
+) -> MacroGoldIngestResult:
+    """Fetch, store and parse both gold-owned feeds. One failing feed does not stop the other.
+
+    The provider factories exist so a test can drive the REAL job -- artifact write,
+    commit, parse, upsert -- against frozen payloads instead of the network. A test that
+    called the parsing helpers directly would prove the parsers work and nothing about
+    the ordering this module is built around.
+    """
+    result = MacroGoldIngestResult()
+    retrieved_at = datetime.now(UTC)
+    end = retrieved_at.date()
+    start = end - timedelta(days=lookback_days)
+
+    with psycopg.connect(dsn) as conn:
+        repo = Repository(conn, schema=schema)
+        _run_feed(
+            "gold_price",
+            lambda: _price_feed(
+                repo,
+                conn,
+                api_key=massive_api_key,
+                start=start,
+                end=end,
+                retrieved_at=retrieved_at,
+                provider_factory=price_provider_factory,
+            ),
+            result,
+        )
+        _run_feed(
+            "gold_flow",
+            lambda: _flow_feed(
+                repo,
+                conn,
+                start=start,
+                retrieved_at=retrieved_at,
+                provider_factory=flow_provider_factory,
+            ),
+            result,
+        )
+    return result
+
+
+def _run_feed(name, call, result: MacroGoldIngestResult) -> None:
+    result.feeds_attempted += 1
+    try:
+        artifacts, created, unchanged = call()
+    except Exception as exc:
+        # Logged and recorded, never raised: a dead vendor must not stop the other feed,
+        # and the state job's own abstention already reports the consequence honestly.
+        logger.warning("macro gold ingest feed %s failed: %s", name, repr(exc))
+        result.errors.append(f"{name}: {repr(exc)[:400]}")
+        return
+    result.feeds_succeeded += 1
+    result.artifacts_seen += artifacts
+    result.observations_created += created
+    result.observations_unchanged += unchanged
+
+
+def _price_feed(
+    repo: Repository,
+    conn: psycopg.Connection,
+    *,
+    api_key: str,
+    start: date,
+    end: date,
+    retrieved_at: datetime,
+    provider_factory: Callable[[], object] | None = None,
+) -> tuple[int, int, int]:
+    factory = provider_factory or (
+        lambda: MassiveOhlcProvider(api_key=api_key, timeout=60.0)
+    )
+    with factory() as provider:
+        raw_bytes, source_url, bars = provider.fetch_daily_payload(
+            GOLD_SPOT_TICKER, start, end
+        )
+    artifact = gold_price_artifact(
+        raw_bytes, source_url=source_url, retrieved_at=retrieved_at
+    )
+    return _store(
+        repo,
+        conn,
+        artifact,
+        lambda: price_observations(bars, retrieved_at=retrieved_at),
+        retrieved_at,
+    )
+
+
+def _flow_feed(
+    repo: Repository,
+    conn: psycopg.Connection,
+    *,
+    start: date,
+    retrieved_at: datetime,
+    provider_factory: Callable[[], object] | None = None,
+) -> tuple[int, int, int]:
+    factory = provider_factory or EtfHoldingsProvider
+    with factory() as provider:
+        raw_bytes, media_type, source_url, rows = provider.fetch_gld_payload(
+            start=start
+        )
+    artifact = gold_flow_artifact(
+        raw_bytes,
+        source_url=source_url,
+        media_type=media_type,
+        retrieved_at=retrieved_at,
+    )
+    return _store(
+        repo,
+        conn,
+        artifact,
+        lambda: flow_observations(rows, retrieved_at=retrieved_at),
+        retrieved_at,
+    )
+
+
+def _store(
+    repo: Repository,
+    conn: psycopg.Connection,
+    artifact,
+    parse,
+    seen_at: datetime,
+) -> tuple[int, int, int]:
+    artifact_id = repo.insert_macro_artifact(
+        source=artifact.source,
+        source_kind=artifact.source_kind,
+        source_record_id=artifact.source_record_id,
+        source_url=artifact.source_url,
+        published_at=artifact.published_at,
+        available_at=artifact.available_at,
+        retrieved_at=artifact.retrieved_at,
+        content_hash=artifact.content_hash,
+        parser_version=artifact.parser_version,
+        quality_status=artifact.quality_status,
+        cost_class=artifact.cost_class,
+        media_type=artifact.media_type,
+        content_length=artifact.content_length,
+        vintage_bearing=artifact.vintage_bearing,
+        raw_bytes=artifact.raw_bytes,
+    )
+    conn.commit()
+
+    # The STORED artifact's retrieval clock, not this run's.
+    #
+    # ``insert_macro_artifact`` dedupes on content hash, so a re-read of unchanged bytes
+    # returns the ORIGINAL row with its original ``retrieved_at``. Stamping the
+    # observations with this run's wall clock then makes every one of them postdate the
+    # payload that carries it, and the store refuses the batch -- so the second run of an
+    # idempotent job fails outright. Reading the instant back makes "when did we learn
+    # this" a property of the payload rather than of whichever run happened to look.
+    stored = repo.fetch_macro_artifact(artifact_id)
+    available_at = stored["retrieved_at"] if stored else artifact.retrieved_at
+
+    # Only now. The bytes are safe, so a parse failure from here on costs this run and
+    # leaves the payload that caused it queryable.
+    outcome = repo.upsert_macro_series_observations(
+        [
+            observation_row(
+                observation,
+                artifact_id=artifact_id,
+                artifact=artifact,
+                available_at=available_at,
+            )
+            for observation in parse()
+        ],
+        seen_at=seen_at,
+    )
+    conn.commit()
+    return 1, outcome.created, outcome.unchanged

--- a/src/uw_scan/worker/jobs/macro_state_jobs.py
+++ b/src/uw_scan/worker/jobs/macro_state_jobs.py
@@ -21,10 +21,12 @@ from decimal import Decimal
 
 from uw_scan.macro.contracts import DomainObservation, MacroDomainState
 from uw_scan.macro.evidence_store import (
-    load_usd_observations,
+    load_gold_observations,
     load_inflation_observations,
     load_rates_observations,
+    load_usd_observations,
 )
+from uw_scan.macro.gold_state import GoldLensResult, compute_gold_state
 from uw_scan.macro.inflation import compute_inflation_state
 from uw_scan.macro.policy_report import build_policy_comparison
 from uw_scan.macro.rates import compute_rates_state
@@ -147,6 +149,99 @@ def macro_usd_state_job(
     )
     return _persist(
         repo, state, computed_at=computed_at or datetime.now(UTC), upstream=edges
+    )
+
+
+def macro_gold_state_job(
+    repo: Repository,
+    *,
+    as_of: datetime | None = None,
+    computed_at: datetime | None = None,
+) -> MacroStateJobResult:
+    """Gold: the terminal node, standing on three upstream ANSWERS and a stored gauge.
+
+    Two things this job deliberately does not do.  It does not recompute the correlation
+    gauge -- that is the nightly orchestrator's output and recomputing it here would give
+    the desk two gold verdicts that can disagree.  And it does not fetch a provider: every
+    input is read from storage, which is what lets an arbitrary ``as_of`` replay produce
+    the same state without a network.
+
+    A missing upstream is not an error.  Gold's gate is measured from its own price and
+    the stored gauge; the upstream answers add lineage and let the cross-domain
+    contradictions fire.  With none stored, the state is still true and simply carries no
+    edges -- which is honest, where standing on a guessed upstream would not be.
+    """
+    instant = as_of or datetime.now(UTC)
+    try:
+        observations = load_gold_observations(repo, as_of=instant)
+        upstream_rows = _gold_upstream_rows(repo, instant)
+        state = compute_gold_state(
+            observations,
+            as_of=instant,
+            lens=_gold_lens(repo, instant),
+            upstream=tuple(item for item, _role, _row in upstream_rows),
+            prior_state=_prior_state(repo, "gold", instant),
+        )
+    except Exception as exc:
+        logger.warning("macro gold state failed: %s", repr(exc))
+        return _failed("gold", instant, exc)
+    edges = [(int(row["state_id"]), role) for _item, role, row in upstream_rows]
+    return _persist(
+        repo, state, computed_at=computed_at or datetime.now(UTC), upstream=edges
+    )
+
+
+#: What each upstream DOES for gold. Not the roles they play for each other: the same
+#: rates answer is ``policy_actual`` to the dollar and a discount-rate component to gold,
+#: which is exactly why the role lives on the EDGE and not on the upstream state.
+_GOLD_UPSTREAM_ROLES: tuple[tuple[str, str], ...] = (
+    # The real-yield leg Lens 2 is built on.
+    ("policy_rates", "decomposition_component"),
+    # The currency gold is priced in. Migration 128 names this edge verbatim:
+    # "gold consulted usd as curve".
+    ("usd", "curve"),
+    # The denominator behind the valuation lens's real price.
+    ("inflation", "realized"),
+)
+
+
+def _gold_upstream_rows(
+    repo: Repository, as_of: datetime
+) -> list[tuple[UpstreamState, str, dict[str, object]]]:
+    """Each upstream answer available at ``as_of``, with the role it plays for gold."""
+    out: list[tuple[UpstreamState, str, dict[str, object]]] = []
+    for domain, role in _GOLD_UPSTREAM_ROLES:
+        row = repo.fetch_macro_domain_state_as_of(domain, as_of)
+        if row is None:
+            continue
+        out.append(
+            (
+                UpstreamState(
+                    domain=domain,
+                    state=str(row["state"]),
+                    direction=str(row["direction"]),
+                    inputs_hash=str(row["inputs_hash"]),
+                    as_of=row["as_of"],
+                    confidence=row["confidence"],
+                ),
+                role,
+                row,
+            )
+        )
+    return out
+
+
+def _gold_lens(repo: Repository, as_of: datetime) -> GoldLensResult | None:
+    """The gauge that was in force at ``as_of``, read from storage and never recomputed."""
+    row = repo.fetch_gold_posture_as_of(as_of.date())
+    if row is None:
+        return None
+    return GoldLensResult(
+        obs_date=row.get("obs_date"),
+        gauge_state=row.get("gauge_state"),
+        corr_252d_level=row.get("gauge_corr_252d"),
+        corr_60d_level=row.get("gauge_corr_60d"),
+        valuation_flag=row.get("valuation_flag"),
     )
 
 

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -58,7 +58,9 @@ from uw_scan.worker.jobs.macro_market_layer_ingest import (
     macro_market_layer_ingest_job,
 )
 from uw_scan.worker.jobs.macro_series_ingest import macro_fred_series_ingest_job
+from uw_scan.worker.jobs.macro_gold_ingest import macro_gold_ingest_job
 from uw_scan.worker.jobs.macro_state_jobs import (
+    macro_gold_state_job,
     macro_inflation_state_job,
     macro_rates_state_job,
     macro_usd_state_job,
@@ -1529,13 +1531,34 @@ def main() -> int:
             f" failed={','.join(result.failed_feeds)}" if result.failed_feeds else "",
         )
 
+    def _macro_gold_ingest() -> None:
+        if settings.massive_api_key is None:
+            logger.info("macro gold ingest skipped: no massive api key configured")
+            return
+        result = macro_gold_ingest_job(
+            dsn=settings.db_dsn(),
+            massive_api_key=settings.massive_api_key.get_secret_value(),
+            schema=settings.db_schema,
+        )
+        logger.info(
+            "macro gold ingest: %d/%d feeds, %d artifacts, %d created, %d unchanged%s",
+            result.feeds_succeeded,
+            result.feeds_attempted,
+            result.artifacts_seen,
+            result.observations_created,
+            result.observations_unchanged,
+            f", errors={result.errors}" if result.errors else "",
+        )
+
     def _macro_state_compute() -> None:
-        # One connection, all three domains, IN ORDER -- and for USD the order is a
-        # dependency, not a nicety. It reads the stored rates ANSWER, so rates must have
-        # been computed for this instant first or USD runs with no upstream and the
-        # policy contradiction cannot fire.
+        # One connection, all FOUR domains, IN ORDER -- and the order is a dependency,
+        # not a nicety. USD reads the stored rates ANSWER, so rates must have been
+        # computed for this instant first or USD runs with no upstream and the policy
+        # contradiction cannot fire. Gold is the terminal node and reads all three, so it
+        # runs last: put it earlier and it records zero dependency edges every night while
+        # looking perfectly healthy.
         #
-        # ONE as_of for all three, stamped once rather than per job. Letting each call
+        # ONE as_of for all four, stamped once rather than per job. Letting each call
         # now() gives three instants seconds apart, and then "the inflation state and
         # the rates state" are answers to two slightly different questions -- which is
         # exactly the comparison this pass exists to make safe. It also makes USD's
@@ -1547,6 +1570,7 @@ def main() -> int:
                 macro_inflation_state_job,
                 macro_rates_state_job,
                 macro_usd_state_job,
+                macro_gold_state_job,
             ):
                 result = job(repo, as_of=instant)
                 logger.info(
@@ -2437,6 +2461,20 @@ def main() -> int:
                     max_instances=1,
                     coalesce=True,
                 )
+            if settings.macro_gold_ingest_enabled:
+                # 19:30, the last free slot before the 19:40 compute. Ordering matters
+                # the same way the market layer's does: gold's REQUIRED anchor is
+                # GLD_CLOSE, so an ingest scheduled AFTER the compute would leave every
+                # state standing on yesterday's last price -- or, on the first night,
+                # abstaining.
+                sched.add_job(
+                    _macro_gold_ingest,
+                    CronTrigger.from_crontab("30 19 * * *", timezone=settings.rth_tz),
+                    id="macro_gold_ingest",
+                    name="Macro: gold price and ETF tonnage evidence",
+                    max_instances=1,
+                    coalesce=True,
+                )
             if settings.macro_state_compute_enabled:
                 # After every ingest above, and after them by enough that a slow SEP
                 # fetch cannot make tonight's state answer from yesterday's evidence.
@@ -2444,7 +2482,7 @@ def main() -> int:
                     _macro_state_compute,
                     CronTrigger.from_crontab("40 19 * * *", timezone=settings.rth_tz),
                     id="macro_state_compute",
-                    name="Macro: inflation, policy/rates and USD domain states",
+                    name="Macro: inflation, policy/rates, USD and gold domain states",
                     max_instances=1,
                     coalesce=True,
                 )

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -27582,6 +27582,79 @@
         ]
       }
     },
+    "/api/macro/gold": {
+      "get": {
+        "description": "The gold GATE, not a view on gold.\n\nThis route did not exist until now, and the reason it did not is worth keeping:\ngold's inputs lived in warm-store tables rather than ``macro_observations``, so no\nstate could cite evidence and the store refuses an answer nobody can reconstruct\n(design spec, deviation 7). That deviation names its own overturn condition -- \"an\ningest that lands the gold sources as macro_observations\" -- and\n``worker/jobs/macro_gold_ingest`` is it.\n\nHonest about the scope of that overturn: TWO of the manifest's sixteen inputs are\ncitable, the gold price and the ETF tonnage. They are the two the state stands on,\nwhich is what makes it persistable. The rest of the manifest -- central-bank\nreserves, exchange inventory, COT, UW options -- is still warm-store only and is\nstill served, with its omission reasons, by ``/api/gold/state`` and\n``/api/gold/replay``. This endpoint does not replace those; it answers a narrower\nquestion they never answered.",
+        "operationId": "macro_gold_state_api_macro_gold_get",
+        "parameters": [
+          {
+            "description": "UTC calendar date; returns the state answering for that day-end.",
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "UTC calendar date; returns the state answering for that day-end.",
+              "title": "As Of"
+            }
+          },
+          {
+            "description": "Timezone-aware instant to replay.",
+            "in": "query",
+            "name": "as_of_ts",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Timezone-aware instant to replay.",
+              "title": "As Of Ts"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MacroDomainStateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Macro Gold State",
+        "tags": [
+          "macro",
+          "macro"
+        ]
+      }
+    },
     "/api/macro/inflation": {
       "get": {
         "operationId": "macro_inflation_state_api_macro_inflation_get",

--- a/tests/integration/worker/test_macro_gold_state_job.py
+++ b/tests/integration/worker/test_macro_gold_state_job.py
@@ -1,0 +1,312 @@
+"""The gold lane end to end: ingest -> evidence store -> state -> dependency edges.
+
+Every value is real and frozen.  The gold closes and ETF tonnage come from
+``tests/fixtures/macro/usd_gold_golden.json``, fetched from the live publishers before
+any of this code existed; the stub providers replay those bytes so the REAL job runs its
+real ordering -- artifact write, commit, parse, upsert -- without a network.
+
+The point of driving the job rather than the helpers: this lane's whole design is that
+the artifact is committed BEFORE the parse, and that gold's state abstains rather than
+inventing evidence.  Neither is observable from a function that returns a dataclass.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+
+from uw_scan.config import Settings
+from uw_scan.macro.gold_ingest import GOLD_FLOW_SERIES, GOLD_PRICE_SERIES
+from uw_scan.storage.repository import Repository
+from uw_scan.worker.jobs.macro_gold_ingest import macro_gold_ingest_job
+from uw_scan.worker.jobs.macro_state_jobs import macro_gold_state_job
+
+GOLDEN = json.loads(
+    (
+        Path(__file__).parents[1].parent / "fixtures" / "macro" / "usd_gold_golden.json"
+    ).read_text(encoding="utf-8")
+)
+
+
+def _settings() -> Settings:
+    test_db = os.environ.get("UW_SCAN_TEST_DB_NAME")
+    if not test_db:
+        pytest.fail("UW_SCAN_TEST_DB_NAME is not set", pytrace=False)
+    os.environ.setdefault("UW_SCAN_API_KEY", "test-dummy-not-used")
+    return Settings.from_env().model_copy(update={"db_name": test_db})
+
+
+def _rows(scenario_id: str, series_id: str) -> list[dict[str, Any]]:
+    scenario = next(s for s in GOLDEN["scenarios"] if s["id"] == scenario_id)
+    return [r for r in scenario["inputs"] if r["series_id"] == series_id]
+
+
+class _Bar:
+    def __init__(self, bar_date: date, close: Decimal) -> None:
+        self.date = bar_date
+        self.close = close
+
+
+class _HoldingRow:
+    def __init__(self, obs_date: date, holdings_oz: Decimal) -> None:
+        self.obs_date = obs_date
+        self.holdings_oz = holdings_oz
+
+
+class _PriceProvider:
+    """Replays the frozen GLD closes as the massive payload they came from."""
+
+    def __enter__(self) -> "_PriceProvider":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def fetch_daily_payload(
+        self, ticker: str, start: date, end: date
+    ) -> tuple[bytes, str, list[_Bar]]:
+        rows = _rows("gold_and_real_yields_decoupled_post_2022", GOLD_PRICE_SERIES)
+        bars = [
+            _Bar(date.fromisoformat(r["period_end"]), Decimal(r["value"])) for r in rows
+        ]
+        payload = json.dumps(
+            {"ticker": ticker, "results": [{"t": 0, "c": str(b.close)} for b in bars]}
+        ).encode()
+        return payload, "https://api.massive.com/v2/aggs/ticker/GLD/range/1/day", bars
+
+
+class _FlowProvider:
+    """Replays the frozen SPDR tonnage prints as the CSV they came from."""
+
+    def __enter__(self) -> "_FlowProvider":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def fetch_gld_payload(
+        self, *, start: date | None = None
+    ) -> tuple[bytes, str, str, list[_HoldingRow]]:
+        rows = _rows("strong_official_flows_against_adverse_cyclical", GOLD_FLOW_SERIES)
+        parsed = [
+            _HoldingRow(date.fromisoformat(r["period_end"]), Decimal(r["value"]))
+            for r in rows
+        ]
+        csv = "date,ounces\n" + "\n".join(
+            f"{r.obs_date.isoformat()},{r.holdings_oz}" for r in parsed
+        )
+        return (
+            csv.encode(),
+            "text/csv",
+            "https://www.spdrgoldshares.com/archive",
+            parsed,
+        )
+
+
+def _ingest(settings: Settings) -> Any:
+    return macro_gold_ingest_job(
+        dsn=settings.db_dsn(),
+        massive_api_key="unused-by-the-stub",
+        price_provider_factory=_PriceProvider,
+        flow_provider_factory=_FlowProvider,
+    )
+
+
+def _repo(conn: psycopg.Connection) -> Repository:
+    return Repository(conn, schema="uw_scan")
+
+
+def test_ingest_lands_both_gold_series_as_citable_evidence(seeded_db_empty_cards):
+    """The blocker deviation 7 named, closed: gold rows now carry an ``obs_id``."""
+    settings = _settings()
+    result = _ingest(settings)
+
+    assert result.feeds_succeeded == 2, result.errors
+    assert result.artifacts_seen == 2
+    assert result.observations_created > 0
+
+    with psycopg.connect(settings.db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT series_id, count(*), count(obs_id)
+            FROM uw_scan.macro_observations
+            WHERE domain = 'gold'
+            GROUP BY series_id ORDER BY series_id
+            """
+        )
+        found = {r[0]: (r[1], r[2]) for r in cur.fetchall()}
+
+    assert set(found) == {GOLD_PRICE_SERIES, GOLD_FLOW_SERIES}
+    for series, (total, with_id) in found.items():
+        assert total == with_id > 0, f"{series} has rows without an obs_id"
+
+
+def test_ingest_is_idempotent_on_a_second_run(seeded_db_empty_cards):
+    """An unchanged re-read must not mint a phantom revision."""
+    settings = _settings()
+    first = _ingest(settings)
+    second = _ingest(settings)
+
+    assert second.observations_created == 0
+    assert second.observations_unchanged == first.observations_created
+
+
+def test_state_abstains_before_the_ingest_runs(seeded_db_empty_cards):
+    """No anchor, no row -- and that is a correct outcome, not a failure."""
+    settings = _settings()
+    with psycopg.connect(settings.db_dsn()) as conn:
+        result = macro_gold_state_job(_repo(conn), as_of=datetime.now(UTC))
+
+    assert result.status == "abstained"
+    assert result.state_id is None
+
+
+def test_state_persists_with_evidence_after_the_ingest(seeded_db_empty_cards):
+    """The whole lane: ingest, then a state that cites what it stood on."""
+    settings = _settings()
+    _ingest(settings)
+
+    # ``now()``, and NOT the fixture's 2026-01-08. These rows were RETRIEVED just now,
+    # so under R1 that is when they became knowable -- asking for January is asking what
+    # we knew before we fetched, and the store's own guard rejects a state that cites it.
+    # The first draft of this test did exactly that and was refused, which is the guard
+    # doing its job on the code that was supposed to respect it.
+    as_of = datetime.now(UTC)
+    with psycopg.connect(settings.db_dsn()) as conn:
+        result = macro_gold_state_job(_repo(conn), as_of=as_of)
+
+    assert result.status == "ok", result.error_message
+    assert result.state_id is not None
+    assert result.evidence_count > 0
+
+    with psycopg.connect(settings.db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT domain, state FROM uw_scan.macro_domain_states WHERE state_id = %s",
+            (result.state_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "gold"
+        # No stored gauge in this fixture, so the gate must read UNKNOWN. Any other
+        # answer would mean it defaulted -- which is the one thing spec 3.1 forbids.
+        assert row[1] == "UNKNOWN"
+
+        cur.execute(
+            """
+            SELECT count(*) FROM uw_scan.macro_domain_state_evidence
+            WHERE state_id = %s
+            """,
+            (result.state_id,),
+        )
+        assert cur.fetchone()[0] > 0
+
+        # Confidence is deliberately NOT asserted low here. ``freshness_for`` measures
+        # when we LEARNED a value, and we learned all of this a moment ago, so a high
+        # confidence is correct. What must not be invisible is that the newest print is
+        # months old -- and that is what this term exists to say.
+        cur.execute(
+            """
+            SELECT confidence_reasons_jsonb FROM uw_scan.macro_domain_states
+            WHERE state_id = %s
+            """,
+            (result.state_id,),
+        )
+        reasons = cur.fetchone()[0]
+        age = next(
+            r for r in reasons if r["term"] == "anchor_period_age_days"
+        )
+        assert Decimal(str(age["value"])) > 30, (
+            "the fixture's newest gold print is 2025-12-31; a small period age here "
+            "would mean the term is reading the retrieval clock too"
+        )
+
+
+def test_state_records_dependency_edges_on_its_upstreams(seeded_db_empty_cards):
+    """Gold is the terminal node: its edges are what make the chain traversable."""
+    settings = _settings()
+    _ingest(settings)
+    as_of = datetime.now(UTC)
+
+    with psycopg.connect(settings.db_dsn()) as conn:
+        repo = _repo(conn)
+        upstream_id = _seed_upstream_state(repo, conn, "policy_rates", as_of)
+        result = macro_gold_state_job(repo, as_of=as_of)
+
+    assert result.status == "ok", result.error_message
+
+    with psycopg.connect(settings.db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT upstream_state_id, causal_role
+            FROM uw_scan.macro_domain_state_dependencies
+            WHERE downstream_state_id = %s
+            """,
+            (result.state_id,),
+        )
+        edges = cur.fetchall()
+
+    assert (upstream_id, "decomposition_component") in edges
+
+
+def _seed_upstream_state(
+    repo: Repository, conn: psycopg.Connection, domain: str, as_of: datetime
+) -> int:
+    """One real upstream answer, written through the same store the jobs use."""
+    from uw_scan.macro.contracts import (
+        ConfidenceTerm,
+        EvidenceRef,
+        MacroDomainState,
+    )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT obs_id, series_id, period_end, available_at
+            FROM uw_scan.macro_observations
+            WHERE domain = 'gold' LIMIT 1
+            """
+        )
+        obs = cur.fetchone()
+    assert obs is not None, "ingest must have run first"
+
+    state = MacroDomainState(
+        domain=domain,
+        state="ON_HOLD",
+        direction="FLAT",
+        velocity=(),
+        confidence=Decimal("1"),
+        confidence_reasons=(
+            ConfidenceTerm(term="seeded", value=Decimal(1), detail="test upstream"),
+        ),
+        contradictions=(),
+        factors=(),
+        evidence_refs=(
+            EvidenceRef(
+                series_id=obs[1],
+                period_end=obs[2],
+                # macro_observations carries no causal_role: the role is a property of
+                # the CONTRACT that read the row, not of the row, which is what lets
+                # gold and rates cite the same observation in different roles.
+                causal_role="decomposition_component",
+                available_at=obs[3],
+                obs_id=obs[0],
+            ),
+        ),
+        engine_version="test/1",
+        inputs_hash="d" * 64,
+        # The SAME instant, not an earlier one. The evidence guard admits equality
+        # (``available_at <= as_of``) and these observations were retrieved moments ago,
+        # so backdating the upstream by even a minute makes it cite evidence from its
+        # own future -- which the store refuses, correctly.
+        as_of=as_of,
+    )
+    state_id = repo.insert_macro_domain_state(state, computed_at=as_of)
+    conn.commit()
+    return int(state_id)

--- a/tests/unit/macro/test_gold_domain_state.py
+++ b/tests/unit/macro/test_gold_domain_state.py
@@ -1,0 +1,314 @@
+"""Golden-scenario tests for the gold domain state (the gate).
+
+Every input is real, frozen from the live publisher in
+``tests/fixtures/macro/usd_gold_golden.json`` before this engine existed.  The ``expect``
+blocks in that file are preregistered predictions: a test here that disagrees with one is
+a finding about the engine, and the fixture is not the thing to edit.
+
+Sibling of ``test_gold_state.py``, which covers the evidence MANIFEST.  This file covers
+the STATE built on it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from uw_scan.macro.contracts import DomainObservation
+from uw_scan.macro.gold_state import (
+    ANCHOR_SERIES,
+    DOLLAR_SERIES,
+    FLOW_SERIES,
+    GOLD_OWNED_SERIES,
+    REAL_YIELD_SERIES,
+    SERIES_OWNER,
+    GoldLensResult,
+    compute_gold_state,
+)
+from uw_scan.macro.usd import UpstreamState
+
+GOLDEN = json.loads(
+    (
+        Path(__file__).parents[2] / "fixtures" / "macro" / "usd_gold_golden.json"
+    ).read_text(encoding="utf-8")
+)
+SCENARIOS: dict[str, dict[str, Any]] = {s["id"]: s for s in GOLDEN["scenarios"]}
+
+DECOUPLED = "gold_and_real_yields_decoupled_post_2022"
+FLOW_VS_CYCLICAL = "strong_official_flows_against_adverse_cyclical"
+
+
+def _instant(value: str) -> datetime:
+    return datetime.fromisoformat(value).replace(tzinfo=UTC)
+
+
+def _observation(row: dict[str, Any], obs_id: int) -> DomainObservation:
+    return DomainObservation(
+        series_id=row["series_id"],
+        causal_role=row["causal_role"],
+        period_end=date.fromisoformat(row["period_end"]),
+        value=Decimal(row["value"]),
+        unit=row["unit"],
+        publisher_transform="level",
+        available_at=_instant(row["available_at"]),
+        superseded_at=(
+            _instant(row["superseded_at"]) if row.get("superseded_at") else None
+        ),
+        source=row["source"],
+        # The fixture predates the source-kind vocabulary this engine reads; "vendor"
+        # is its word for what the contracts call an entitled provider.
+        source_kind=(
+            "entitled_provider"
+            if row["source_kind"] == "vendor"
+            else row["source_kind"]
+        ),
+        cost_class=row["cost_class"],
+        # A stored row always has one; the persist path refuses a state whose evidence
+        # cannot be pointed at, so a fixture without them would test a shape prod never
+        # sees. Position in the fixture is a fine stand-in for the real identity.
+        obs_id=obs_id,
+    )
+
+
+def _scenario(scenario_id: str) -> tuple[tuple[DomainObservation, ...], datetime]:
+    scenario = SCENARIOS[scenario_id]
+    rows = tuple(
+        _observation(row, obs_id)
+        for obs_id, row in enumerate(scenario["inputs"], start=1)
+    )
+    return rows, _instant(scenario["as_of"])
+
+
+# --------------------------------------------------------------- preregistered scenarios
+
+
+def test_decoupled_scenario_fires_the_post_2022_contradiction() -> None:
+    """Gold and real yields rising together is reportable, not resolvable.
+
+    Preregistered: ``contradictions_include: [gold_against_real_yields_post_2022]`` and
+    ``lens2_direction_inferred: null``.
+    """
+    observations, as_of = _scenario(DECOUPLED)
+    expect = SCENARIOS[DECOUPLED]["expect"]
+
+    state = compute_gold_state(observations, as_of=as_of)
+
+    for rule in expect["contradictions_include"]:
+        assert state.fired(rule), (
+            f"{rule} did not fire; fired={[c.rule for c in state.contradictions]}"
+        )
+
+    # The preregistered null: an adverse or decoupled backdrop is never turned into a
+    # direction for gold.
+    cyclical = state.sub_state("decomposition_component")
+    assert cyclical is not None
+    assert cyclical.direction == "UNKNOWN"
+
+    # The contradiction reports; it does not resolve into a view.
+    assert state.state in {"OPERATIVE", "PARTIAL", "SUSPENDED", "UNKNOWN"}
+
+
+def test_decoupled_scenario_measures_both_legs_despite_unequal_print_counts() -> None:
+    """The trap the calendar window exists to avoid.
+
+    Over this quarter ``GLD_CLOSE`` has 64 prints and ``DFII10`` has 62 -- they run on
+    different publication calendars. A window expressed in OBSERVATIONS would read the
+    gold leg and return None for the real-yield leg, and the contradiction would go
+    quiet for a reason that has nothing to do with the market.
+    """
+    observations, _ = _scenario(DECOUPLED)
+    counts = {
+        series: len({o.period_end for o in observations if o.series_id == series})
+        for series in (ANCHOR_SERIES, REAL_YIELD_SERIES)
+    }
+    assert counts[ANCHOR_SERIES] != counts[REAL_YIELD_SERIES], (
+        "fixture no longer has unequal print counts; this test guards a trap that would "
+        "no longer be reproduced"
+    )
+
+
+def test_flow_against_cyclical_reports_both_without_precedence() -> None:
+    """Preregistered: lens1 STRONG, lens2 ADVERSE, ``lens_precedence: null``."""
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    expect = SCENARIOS[FLOW_VS_CYCLICAL]["expect"]
+
+    state = compute_gold_state(observations, as_of=as_of)
+
+    flow = state.sub_state("positioning")
+    cyclical = state.sub_state("decomposition_component")
+    assert flow is not None and cyclical is not None
+    assert flow.state == expect["lens1_flow"]
+    assert cyclical.state == expect["lens2_cyclical"]
+
+    for rule in expect["contradictions_include"]:
+        assert state.fired(rule), (
+            f"{rule} did not fire; fired={[c.rule for c in state.contradictions]}"
+        )
+
+    # No precedence: BOTH readings survive into the state. A design that let one lens
+    # overwrite the other would leave one of these two assertions unsatisfiable.
+    assert flow.state != cyclical.state
+
+
+def test_the_two_lenses_carry_their_own_confidence() -> None:
+    """R2, applied to gold: the gate's confidence never stands in for a lens's."""
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    state = compute_gold_state(observations, as_of=as_of)
+
+    for role in ("positioning", "decomposition_component", "realized"):
+        sub = state.sub_state(role)
+        assert sub is not None, f"{role} sub-state missing"
+        assert isinstance(sub.confidence, Decimal)
+
+
+# ------------------------------------------------------------------------- invariants
+
+
+def test_unrecognised_gauge_label_is_unknown_never_operative() -> None:
+    """Spec 3.1. Defaulting to operative would assert the very thing the gate withholds."""
+    observations, as_of = _scenario(DECOUPLED)
+    state = compute_gold_state(
+        observations,
+        as_of=as_of,
+        lens=GoldLensResult(
+            obs_date=as_of.date(), gauge_state="a_label_from_the_future"
+        ),
+    )
+    assert state.state == "UNKNOWN"
+
+
+def test_gate_reads_the_stored_gauge_verdict() -> None:
+    observations, as_of = _scenario(DECOUPLED)
+    for gauge, expected in (
+        ("operative", "OPERATIVE"),
+        ("partial", "PARTIAL"),
+        ("suspended", "SUSPENDED"),
+    ):
+        state = compute_gold_state(
+            observations,
+            as_of=as_of,
+            lens=GoldLensResult(obs_date=as_of.date(), gauge_state=gauge),
+        )
+        assert state.state == expected
+
+
+def test_suspended_gate_suspends_the_cyclical_lens() -> None:
+    """A cyclical view drawn from a relationship measured as not holding is not a view."""
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    state = compute_gold_state(
+        observations,
+        as_of=as_of,
+        lens=GoldLensResult(obs_date=as_of.date(), gauge_state="suspended"),
+    )
+    cyclical = state.sub_state("decomposition_component")
+    assert cyclical is not None
+    assert cyclical.state == "SUSPENDED"
+    assert cyclical.unavailable_reason is not None
+    # And with Lens 2 suspended the flow/cyclical contradiction cannot fire: there is no
+    # adverse cyclical reading to disagree with.
+    assert not state.fired("gold_flow_against_cyclical")
+
+
+def test_absent_anchor_abstains_rather_than_answering_from_upstream() -> None:
+    observations, as_of = _scenario(DECOUPLED)
+    without_price = tuple(o for o in observations if o.series_id != ANCHOR_SERIES)
+    state = compute_gold_state(without_price, as_of=as_of)
+    assert state.confidence == Decimal(0)
+    absent = state.reason("absent_reason") or state.reason("completeness")
+    assert absent is not None
+
+
+def test_borrowed_series_are_not_in_the_confidence_denominator() -> None:
+    """The double-count rule's practical edge.
+
+    Gold READS the real yield and the broad dollar -- Lens 2 is defined on them -- but a
+    quiet upstream must degrade the LENS, never the gate's own confidence.
+    """
+    assert SERIES_OWNER[REAL_YIELD_SERIES] == "policy_rates"
+    assert SERIES_OWNER[DOLLAR_SERIES] == "usd"
+    assert REAL_YIELD_SERIES not in GOLD_OWNED_SERIES
+    assert DOLLAR_SERIES not in GOLD_OWNED_SERIES
+    assert set(GOLD_OWNED_SERIES) == {ANCHOR_SERIES, FLOW_SERIES}
+
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    full = compute_gold_state(observations, as_of=as_of)
+    without_dollar = compute_gold_state(
+        tuple(o for o in observations if o.series_id != DOLLAR_SERIES), as_of=as_of
+    )
+    assert without_dollar.confidence == full.confidence
+
+
+def test_borrowed_evidence_is_named_in_the_reasons() -> None:
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    state = compute_gold_state(observations, as_of=as_of)
+    borrowed = state.reason("borrowed_evidence")
+    assert borrowed is not None
+    assert REAL_YIELD_SERIES in borrowed.detail
+    assert "policy_rates" in borrowed.detail
+
+
+def test_evidence_refs_point_at_the_shared_observations() -> None:
+    """Many readers, one row: the borrowed refs carry obs_ids, they are not copies."""
+    observations, as_of = _scenario(FLOW_VS_CYCLICAL)
+    state = compute_gold_state(observations, as_of=as_of)
+    series = {ref.series_id for ref in state.evidence_refs}
+    assert REAL_YIELD_SERIES in series
+    assert ANCHOR_SERIES in series or FLOW_SERIES in series
+    assert all(ref.obs_id is not None for ref in state.evidence_refs)
+
+
+def test_inputs_hash_changes_when_an_upstream_changes_its_mind() -> None:
+    observations, as_of = _scenario(DECOUPLED)
+    base = UpstreamState(
+        domain="policy_rates",
+        state="ON_HOLD",
+        direction="FLAT",
+        inputs_hash="a" * 64,
+        as_of=as_of,
+    )
+    moved = UpstreamState(
+        domain="policy_rates",
+        state="ON_HOLD",
+        direction="FLAT",
+        inputs_hash="b" * 64,
+        as_of=as_of,
+    )
+    first = compute_gold_state(observations, as_of=as_of, upstream=(base,))
+    second = compute_gold_state(observations, as_of=as_of, upstream=(moved,))
+    assert first.inputs_hash != second.inputs_hash
+
+
+def test_upstream_from_the_future_is_refused() -> None:
+    observations, as_of = _scenario(DECOUPLED)
+    ahead = UpstreamState(
+        domain="usd",
+        state="RANGEBOUND",
+        direction="FLAT",
+        inputs_hash="c" * 64,
+        as_of=_instant("2027-01-01"),
+    )
+    with pytest.raises(ValueError, match="lookahead"):
+        compute_gold_state(observations, as_of=as_of, upstream=(ahead,))
+
+
+def test_valuation_lens_is_a_warning_and_says_so() -> None:
+    observations, as_of = _scenario(DECOUPLED)
+    state = compute_gold_state(
+        observations,
+        as_of=as_of,
+        lens=GoldLensResult(
+            obs_date=as_of.date(), gauge_state="operative", valuation_flag="Severe"
+        ),
+    )
+    valuation = state.sub_state("realized")
+    assert valuation is not None
+    assert valuation.state == "STRETCHED"
+    warning = next(
+        r for r in valuation.confidence_reasons if r.term == "valuation_is_a_warning"
+    )
+    assert "never" in warning.detail

--- a/tests/unit/test_gold_models.py
+++ b/tests/unit/test_gold_models.py
@@ -156,3 +156,33 @@ def test_gold_state_response_round_trips():
     assert "FAVORABLE" in dumped
     assert "L1" in dumped
     assert "China" in dumped
+
+
+def test_no_lens_exposes_a_z_score() -> None:
+    """The premise the removed decomposition builder was written against.
+
+    ``_decomposition_rows_from_lenses`` read ten ``*_z`` attributes off these three
+    dataclasses and returned ``[]`` on every run since it was written, because none of
+    them exists. This test pins WHY it was deleted rather than repaired: the lenses
+    report native units and percentiles, and there is no fitted model that would make
+    them summable into one contribution column.
+
+    If a lens ever grows a real z-score, this fails -- which is the moment to decide
+    deliberately whether the decomposition panel should exist, instead of discovering
+    a silently empty one years later.
+    """
+    from uw_scan.cards.cyclical_zones import CyclicalPosture
+    from uw_scan.cards.structural_flow import StructuralPosture
+    from uw_scan.cards.valuation import ValuationOverlay
+
+    for lens in (StructuralPosture, CyclicalPosture, ValuationOverlay):
+        z_fields = sorted(
+            name
+            for name in getattr(lens, "__annotations__", {})
+            if name.endswith("_z")
+        )
+        assert not z_fields, (
+            f"{lens.__name__} now exposes {z_fields}; the lens decomposition panel was "
+            "removed because no lens produced a z-score. Decide whether to rebuild it "
+            "on a fitted model rather than re-adding an unweighted magnitude sort."
+        )

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1737,6 +1737,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/macro/gold": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Macro Gold State
+         * @description The gold GATE, not a view on gold.
+         *
+         *     This route did not exist until now, and the reason it did not is worth keeping:
+         *     gold's inputs lived in warm-store tables rather than ``macro_observations``, so no
+         *     state could cite evidence and the store refuses an answer nobody can reconstruct
+         *     (design spec, deviation 7). That deviation names its own overturn condition -- "an
+         *     ingest that lands the gold sources as macro_observations" -- and
+         *     ``worker/jobs/macro_gold_ingest`` is it.
+         *
+         *     Honest about the scope of that overturn: TWO of the manifest's sixteen inputs are
+         *     citable, the gold price and the ETF tonnage. They are the two the state stands on,
+         *     which is what makes it persistable. The rest of the manifest -- central-bank
+         *     reserves, exchange inventory, COT, UW options -- is still warm-store only and is
+         *     still served, with its omission reasons, by ``/api/gold/state`` and
+         *     ``/api/gold/replay``. This endpoint does not replace those; it answers a narrower
+         *     question they never answered.
+         */
+        get: operations["macro_gold_state_api_macro_gold_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scanner": {
         parameters: {
             query?: never;
@@ -13740,6 +13775,40 @@ export interface operations {
         };
     };
     macro_usd_state_api_macro_usd_get: {
+        parameters: {
+            query?: {
+                /** @description UTC calendar date; returns the state answering for that day-end. */
+                as_of?: string | null;
+                /** @description Timezone-aware instant to replay. */
+                as_of_ts?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MacroDomainStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    macro_gold_state_api_macro_gold_get: {
         parameters: {
             query?: {
                 /** @description UTC calendar date; returns the state answering for that day-end. */


### PR DESCRIPTION
Deviation 7 of the USD/gold design deferred `MacroDomainState(domain="gold")` because gold's inputs lived in warm-store tables carrying no `obs_id`, and the store refuses a state whose evidence cannot be pointed at. It also wrote its own overturn condition — *"an ingest that lands the gold sources as `macro_observations`"*. `worker/jobs/macro_gold_ingest.py` is that ingest.

**No migration was required.** Migration 115 has accepted `domain = 'gold'` since it was written, and so have 125 and 128. The schema was never the blocker, only the ingest.

## What this adds

`macro/gold_state.py` publishes **the gate** — whether the gold/real-yield relationship Lens 2 rests on is currently in force. Spec 3.1, verbatim: *"The gate is the domain's state."* It reads the correlation gauge `cards/regime_gauge.py` already computes rather than recomputing it; two gold verdicts that can disagree is not a feature. The three lenses publish beside it as sub-states with their own confidence, and there is deliberately **no precedence rule** between them.

- `GET /api/macro/gold` with replay and evidence drill-down, completing inflation → rates → USD → gold. The router previously carried a comment explaining why this endpoint deliberately did not exist; that comment is now the docstring explaining what changed.
- Nightly `macro_gold_ingest` at 19:30 ET (massive-0, gated `UW_SCAN_MACRO_GOLD_INGEST_ENABLED`, default **off**).
- Gold appended to the 19:40 state chain **last** — it is the terminal node and reads all three upstreams, so running it earlier would record zero dependency edges every night while looking perfectly healthy.

## Scope, stated honestly

The overturn is narrower than *"ingest gold's ten sources"*. **Two of sixteen** manifest inputs are citable: the price (the required anchor) and the ETF tonnage (Lens 1). Lens 2's legs are cited too but **borrowed** — gold points at the rows `RATES_EVIDENCE` and `USD_EVIDENCE` already own, which is the many-readers case, not a second ingest. Central-bank reserves, exchange inventory, COT and UW options remain warm-store only and stay in the manifest with their omission reasons. Recorded in the spec under deviation 7 rather than claimed as complete.

## The golden fixture changed the design twice

`tests/fixtures/macro/usd_gold_golden.json` carries two **preregistered** gold scenarios, frozen from live publishers before any of this code existed. Both now execute against the engine, and both found something.

**The upstream refusal had to invert.** USD refuses upstream evidence by causal *role*. Gold cannot — its anchor `GLD_CLOSE` carries `decomposition_component`, the same role `DFII10` and `RTWEXBGS` carry upstream, so a role-based refusal rejects gold's own anchor. Gold refuses by series id instead, **derived** from the owning tuples rather than restated. And it refuses far less: Lens 2 is *defined* on the real yield and the broad dollar, so refusing them would not protect an invariant, it would delete the lens. What protects the double-count rule here is the confidence **denominator** — `required_series` is gold-owned only, so a quiet upstream degrades a lens and never the gate.

**The window had to become calendar-based.** Over the fixture's own quarter `GLD_CLOSE` has 64 prints where `DFII10` has 62 — different publication calendars. A window of "63 observations" is a different span on every series and returns `None` on the shorter leg, muting `gold_against_real_yields_post_2022` for a reason that has nothing to do with the market. 63 **calendar** days is set by the fixture rather than chosen: at 91 days the real-yield leg inverts sign (2.00 → 1.93) and the preregistered `ADVERSE` reading resolves to `UNKNOWN`. Same trap CLAUDE.md already records for `DTWEXBGS`/`RTWEXBGS`.

## Two bugs the tests caught

**A deduped artifact keeps its original clock.** `insert_macro_artifact` dedupes on content hash, so a re-read of unchanged bytes returns the *original* row with its *original* `retrieved_at`. Stamping the observations with this run's wall clock made every one of them postdate the payload carrying it, and the store refused the batch — so the second run of an idempotent job failed outright. Run 1 always passes, so a single-run smoke test would never see it. Fixed by reading the instant back from the stored artifact.

**Test lookahead, refused by the guard.** The first draft asked for the state at the fixture's 2026-01-08 while the rows had been retrieved moments ago. `macro_domain_state_evidence_guard` rejected it, correctly — that is the guard doing its job on the code meant to respect it.

Not a bug: months-old evidence reports `confidence 1.0`, because `freshness_for` measures when we *learned* a value, not how old it is. Rather than change that, gold now emits `anchor_period_age_days` as its own informational term — a backfill stamps 400 days of history with today's clock and every print reads fresh, and this is the only thing that says otherwise.

## Also fixed

`reports/gold_posture._decomposition_rows_from_lenses` had **never returned a row**. It read ten `*_z` attributes off the three lens dataclasses; nine exist nowhere in the tree and the tenth only as a database column. Deleted rather than repaired: the lenses report native units (tonnes, ounces, percent, basis points) and percentiles, never z-scores, and no model has ever fitted weights over them — summing them into one "contribution" column and sorting by magnitude would rank a reserves flow above a valuation percentile because tonnes are numerically larger than a probability. API field and DB column unchanged (`[]` before, `[]` after), so this is not a contract change. A test now fails if any lens grows a real z-score.

## Verification

| gate | result |
|---|---|
| `ruff check src/ tests/ scripts/` | pass |
| `_lint_except` / `check_no_yahoo` / `check_runtime_assets` | pass |
| guardrail greps 3, 5, 9 / migration prefixes | pass |
| `pytest tests/unit/` | 2438 passed |
| `pytest tests/integration/` | 1244 passed, 11 skipped (7m08s) |
| `npm run test` | 813 passed (121 files) |
| `npx tsc --noEmit` | clean |
| `git diff --check` | clean |
| OpenAPI snapshot | +1 path, **0** schema drift |
| `web/lib/types.ts` | +69 / −0 |

No migration added, so there is no fresh-DB replay to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
