### PR TITLE
fix(macro): identity is the data, not massive's request envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The gold ingest re-inserted its whole price history every run.** `macro_gold_ingest`
+  hashed massive's OHLC response bytes verbatim, and massive stamps a fresh
+  `request_id` — a 32-hex-character UUID — on every response. Same length every call, so
+  `content_length` matched and only `content_hash` moved: the artifact dedupe missed, and
+  all 275 `GLD_CLOSE` observations hanging off it re-inserted as a new vintage. Measured
+  on the mini the night the job was enabled: a second run over an unchanged 400-day
+  window took the series to 550 rows across 275 distinct periods under 2 artifacts. The
+  SPDR tonnage leg was never affected — its archive carries no per-request stamp.
+  - `macro/gold_ingest.py` now drops `VOLATILE_PRICE_ENVELOPE_FIELDS` from the payload
+    and stores it as `raw_json`, so identity is the DATA rather than the envelope. Parsed
+    JSON rather than edited bytes on purpose: `MacroSourceArtifact` and
+    `storage/macro_context` re-derive the hash through the same canonical serializer, so
+    normalising in one place and hashing in another cannot drift. The stored payload is
+    no longer byte-identical to the wire — acceptable for a query result, and
+    `source_url` plus `retrieved_at` still record what was asked and when.
+  - `worker/jobs/macro_gold_ingest.py` forwards whichever raw representation the artifact
+    chose instead of assuming bytes. The two feeds now differ deliberately: the price
+    payload is JSON, the SPDR archive stays raw because it arrives as CSV or XLSX.
+  - **Why the existing idempotency test was green through all of this:** the price stub
+    returned byte-identical payloads, so it proved that identical bytes deduplicate —
+    never that an unchanged READ does. The stub now varies its `request_id` per call, and
+    a second test asserts row counts directly rather than trusting the job's own tallies,
+    which reported `created=275` while reporting success.
+
+  Existing duplicate rows are left in place; they carry identical values and the
+  newest-vintage read picks correctly, so this is cleanup rather than a correction.
+
 ## [0.12.14] — 2026-08-23
 
 

--- a/src/uw_scan/macro/gold_ingest.py
+++ b/src/uw_scan/macro/gold_ingest.py
@@ -25,6 +25,7 @@ saw this morning, and migration 119 can promote a verified instant later.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -68,10 +69,42 @@ class GoldObservation:
     parser_version: str
 
 
+#: Fields massive stamps per REQUEST rather than per payload. They carry no information
+#: about the bars and change on every call, so hashing them makes a re-read of unchanged
+#: data look like a new artifact -- and the observations hanging off it then re-insert as
+#: a fresh vintage. Measured in production on 2026-08-23: a second run of an unchanged
+#: 400-day window created 275 duplicate ``GLD_CLOSE`` rows under a second artifact,
+#: because ``request_id`` is a 32-hex-character UUID (same LENGTH every call, so
+#: ``content_length`` matched and only the hash moved).
+VOLATILE_PRICE_ENVELOPE_FIELDS: frozenset[str] = frozenset({"request_id"})
+
+
+def _stable_price_payload(raw_bytes: bytes) -> dict[str, Any] | list[Any]:
+    """The massive OHLC payload with its per-request stamps dropped.
+
+    Returned as parsed JSON rather than bytes on purpose. ``MacroSourceArtifact`` hashes
+    a ``raw_json`` through the same canonical serializer the store re-derives with, so
+    identity stays key-order-independent AND the stored payload is queryable JSONB. The
+    alternative -- editing the wire bytes and still storing them as ``raw_bytes`` -- would
+    have to hand-roll a normalizer that ``storage.macro_context`` re-runs byte for byte,
+    which is the invariant most likely to drift.
+
+    The cost, stated plainly: the stored payload is no longer byte-identical to what
+    massive sent. That is acceptable here and would not be for a signed document -- this
+    is a query result, and ``source_url`` plus ``retrieved_at`` still record exactly what
+    was asked and when.
+    """
+    payload = json.loads(raw_bytes)
+    if not isinstance(payload, dict):
+        return payload
+    return {k: v for k, v in payload.items() if k not in VOLATILE_PRICE_ENVELOPE_FIELDS}
+
+
 def gold_price_artifact(
     raw_bytes: bytes, *, source_url: str, retrieved_at: datetime
 ) -> MacroSourceArtifact:
-    content_hash, content_length = macro_artifact_content_identity(raw_bytes=raw_bytes)
+    raw_json = _stable_price_payload(raw_bytes)
+    content_hash, content_length = macro_artifact_content_identity(raw_json=raw_json)
     return MacroSourceArtifact(
         source=GOLD_PRICE_SOURCE,
         source_kind="entitled_provider",
@@ -95,7 +128,7 @@ def gold_price_artifact(
         # The payload carries a bar history, so it reports many periods rather than
         # being one dated release.
         vintage_bearing=True,
-        raw_bytes=raw_bytes,
+        raw_json=raw_json,
     )
 
 

--- a/src/uw_scan/worker/jobs/macro_gold_ingest.py
+++ b/src/uw_scan/worker/jobs/macro_gold_ingest.py
@@ -197,6 +197,12 @@ def _store(
         media_type=artifact.media_type,
         content_length=artifact.content_length,
         vintage_bearing=artifact.vintage_bearing,
+        # Forward whichever representation the artifact chose rather than assuming bytes.
+        # The two feeds differ deliberately: the price payload is stored as parsed JSON so
+        # massive's per-request ``request_id`` can be dropped from its identity, while the
+        # SPDR archive stays raw because it arrives as CSV or XLSX and has no such stamp.
+        raw_json=artifact.raw_json,
+        raw_text=artifact.raw_text,
         raw_bytes=artifact.raw_bytes,
     )
     conn.commit()

--- a/tests/integration/worker/test_macro_gold_state_job.py
+++ b/tests/integration/worker/test_macro_gold_state_job.py
@@ -12,6 +12,7 @@ inventing evidence.  Neither is observable from a function that returns a datacl
 
 from __future__ import annotations
 
+import itertools
 import json
 import os
 from datetime import UTC, date, datetime
@@ -60,6 +61,14 @@ class _HoldingRow:
         self.holdings_oz = holdings_oz
 
 
+#: Incremented per fetch so the stub reproduces the ONE behaviour that broke idempotency
+#: in production: massive stamps a fresh ``request_id`` on every response. A stub that
+#: returns byte-identical payloads makes the re-read test pass no matter what the code
+#: hashes, which is exactly why the original test was green while the real job wrote 275
+#: duplicate rows per run.
+_PRICE_FETCH_COUNT = itertools.count()
+
+
 class _PriceProvider:
     """Replays the frozen GLD closes as the massive payload they came from."""
 
@@ -77,7 +86,13 @@ class _PriceProvider:
             _Bar(date.fromisoformat(r["period_end"]), Decimal(r["value"])) for r in rows
         ]
         payload = json.dumps(
-            {"ticker": ticker, "results": [{"t": 0, "c": str(b.close)} for b in bars]}
+            {
+                "ticker": ticker,
+                "results": [{"t": 0, "c": str(b.close)} for b in bars],
+                # Same shape and same LENGTH every call, different value -- which is what
+                # made ``content_length`` match while the hash moved.
+                "request_id": f"{next(_PRICE_FETCH_COUNT):032x}",
+            }
         ).encode()
         return payload, "https://api.massive.com/v2/aggs/ticker/GLD/range/1/day", bars
 
@@ -149,13 +164,46 @@ def test_ingest_lands_both_gold_series_as_citable_evidence(seeded_db_empty_cards
 
 
 def test_ingest_is_idempotent_on_a_second_run(seeded_db_empty_cards):
-    """An unchanged re-read must not mint a phantom revision."""
+    """An unchanged re-read must not mint a phantom revision.
+
+    The price stub deliberately varies its ``request_id`` between calls, so this asserts
+    the property that actually matters -- unchanged DATA deduplicates -- rather than the
+    weaker one a fixed payload can prove.
+    """
     settings = _settings()
     first = _ingest(settings)
     second = _ingest(settings)
 
     assert second.observations_created == 0
     assert second.observations_unchanged == first.observations_created
+
+
+def test_a_fresh_request_id_alone_does_not_mint_a_new_artifact(seeded_db_empty_cards):
+    """Identity is the DATA, not the envelope massive wrapped it in.
+
+    Measured in production on 2026-08-23 before the fix: a second run over an unchanged
+    400-day window created 275 duplicate ``GLD_CLOSE`` rows under a second artifact,
+    because ``request_id`` is a fresh 32-hex UUID per call. Row counts are asserted
+    directly rather than through the job's own tallies -- the tallies are what reported
+    ``created=275`` while claiming success.
+    """
+    settings = _settings()
+    _ingest(settings)
+    _ingest(settings)
+
+    with psycopg.connect(settings.db_dsn()) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*), count(DISTINCT period_end), count(DISTINCT artifact_id)
+            FROM uw_scan.macro_observations
+            WHERE series_id = %s
+            """,
+            (GOLD_PRICE_SERIES,),
+        )
+        rows, periods, artifacts = cur.fetchone()
+
+    assert rows == periods, f"{rows - periods} duplicate rows for {GOLD_PRICE_SERIES}"
+    assert artifacts == 1, f"{artifacts} artifacts for one unchanged payload"
 
 
 def test_state_abstains_before_the_ingest_runs(seeded_db_empty_cards):
@@ -219,9 +267,7 @@ def test_state_persists_with_evidence_after_the_ingest(seeded_db_empty_cards):
             (result.state_id,),
         )
         reasons = cur.fetchone()[0]
-        age = next(
-            r for r in reasons if r["term"] == "anchor_period_age_days"
-        )
+        age = next(r for r in reasons if r["term"] == "anchor_period_age_days")
         assert Decimal(str(age["value"])) > 30, (
             "the fixture's newest gold print is 2025-12-31; a small period age here "
             "would mean the term is reading the retrieval clock too"


### PR DESCRIPTION
## What broke

`macro_gold_ingest` hashed massive's OHLC response bytes verbatim. massive stamps a fresh `request_id` — a 32-hex-character UUID — on every response:

```
"status":"DELAYED","request_id":"fd4d6061b83227af29dab3d3164879fd","count":275}
"status":"DELAYED","request_id":"14cac0133bd8abbb53d5d4a420085f85","count":275}
                                 ^^^^ 29 of 32 chars differ
```

Same **length** every call, so `content_length` matched (30139 both times) and only `content_hash` moved. The artifact dedupe missed, and all 275 `GLD_CLOSE` observations hanging off it re-inserted as a new vintage.

Measured on the mini the night the job was enabled, running the real job twice over an unchanged 400-day window:

| series | rows | distinct periods | artifacts |
|---|---|---|---|
| `GLD_CLOSE` | **550** | 275 | **2** |
| `GLD_HOLDINGS_OZ` | 274 | 274 | 1 |

The SPDR tonnage leg was never affected — its archive carries no per-request stamp.

## Impact

The **state was always correct**: `_rows()` takes the newest vintage per period and the duplicate values are identical. What broke is the point-in-time contract — every night restated the whole 400-day price history as if it had been revised — plus ~275 rows/night of unbounded growth.

## The fix

Store the price payload as `raw_json` with `VOLATILE_PRICE_ENVELOPE_FIELDS` dropped.

Parsed JSON rather than edited bytes on purpose. `storage/macro_context` re-derives the hash from the stored payload and refuses a mismatch (a deliberate integrity check), so "store the full bytes, hash a subset" is not available. Normalising the bytes by hand would mean `macro_context` has to re-run that normaliser byte for byte — the invariant most likely to drift. Routing through `raw_json` reuses the canonical serializer **both** sides already call, and lands the payload as queryable JSONB.

Cost, stated plainly: the stored payload is no longer byte-identical to the wire. Acceptable for a query result — `source_url` and `retrieved_at` still record what was asked and when — and it would not be for a signed document.

`_store` now forwards whichever representation the artifact chose instead of assuming bytes, because the two feeds now differ deliberately: price is JSON, the SPDR archive stays raw (it arrives as CSV or XLSX).

## Why the existing idempotency test was green through all of this

`test_ingest_is_idempotent_on_a_second_run` already existed and passed. Its `_PriceProvider` stub returned **byte-identical** payloads with no `request_id` at all — so it proved that identical bytes deduplicate, never that an unchanged *read* does.

A stub better behaved than the provider it stands in for cannot fail on that provider's misbehaviour.

The stub now varies `request_id` per call. A second test asserts row counts directly rather than trusting the job's own tallies — those reported `created=275` while reporting success.

Both tests were verified to fail on the unfixed source (`assert 64 == 0`, `64 duplicate rows for GLD_CLOSE`) and pass on the fix.

## Verification

- `ruff check src/ tests/ scripts/` — clean
- Guardrails 2 / 3 / 5 / 9, `check_no_yahoo`, `check_runtime_assets`, migration prefixes, version sync — all pass
- `uv run pytest tests/unit` — **2443 passed**
- `uv run pytest tests/integration` — **1245 passed, 11 skipped**
- `git diff --check` — clean

No migration. No API contract change, so no `types.ts` / OpenAPI snapshot regen.

## Not in this PR

Existing duplicate rows on the mini are left in place — identical values, newest-vintage read picks correctly. Cleanup, not a correction.