### PR TITLE
fix(macro): the USD boundary belonged in the tail, not at the median

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+
+- **The USD state's boundary moved out of the middle of its own distribution.**
+  `momentum_threshold_pct` 2.0% → 3.0%; `USD_ENGINE_VERSION` and `UsdParameters.version`
+  both `usd/1` → `usd/2`. The retired 2.0% sat at the **61st percentile** of the broad
+  dollar's own 63-observation moves, and a classifier whose boundary sits near the median
+  of its inputs crosses that boundary maximally often — crossing density peaks where the
+  density does. Replaying the state monthly over the stored evidence (2021-01..2026-08,
+  68 instants) it flipped **29 times with a longest regime of 6 months**, alternating
+  RANGEBOUND↔STRENGTHENING six times through 2022 alone — a year in which the dollar ran
+  monotonically from ~96 to ~114. That is threshold proximity being reported as regime
+  change.
+  - At 3.0% (the **76th** percentile) the state flips **13 times with a longest regime of
+    14 months**. RANGEBOUND is now the ordinary three quarters of the record and a
+    directional call needs a top-quartile quarterly move. Distribution over 12,330
+    momentum points: median 1.45%, p75 2.91%, p90 4.57%.
+  - **Hysteresis was the first hypothesis and the measurement rejected it.** A dual
+    entry/exit band left flips flat or raised them at *every* entry threshold (at 3.0%:
+    none 13, exit 2.25% → 17, exit 1.50% → 23), because a wider band relocates transitions
+    rather than removing them. The lever is where the boundary sits, not how sticky it is.
+  - Stored `usd/1` states keep their own semantics and stay readable — states are keyed
+    `(domain, as_of, engine_version, inputs_hash)` and a reader filtering on
+    `engine_version` gets one engine's semantics. Verified through the real
+    `compute_usd_state`: 0 `inputs_hash` collisions between the two parameter sets.
+  - This does **not** make the USD state testable: 13 transitions in 68 months is still
+    far short of an MC6-grade gate. It makes the label mean what it says.
+  - Sweep `scripts/research/usd_threshold_sweep.py`, replay census
+    `scripts/research/macro_state_replay_census.py`, verdict
+    `docs/research/2026-08-23-macro-state-replay-flip-census.md`.
+
 ### Added
+
+- **A test that every macro domain's engine version and parameter version move together.**
+  `tests/unit/macro/test_engine_versions.py`. Splitting them lets a recalibrated engine keep
+  publishing under the old engine identity, so a reader asking for one semantics silently
+  gets two. Not hypothetical: the USD recalibration above bumped the parameter version,
+  left the engine version behind, and nothing failed.
 
 - **Statement ingest is now calendar-driven and daily.** `fundamental_ingest_daily`
   (04:20 ET, uw-0, `UW_SCAN_FUNDAMENTAL_INGEST_DAILY_ENABLED`) reads UW's earnings

--- a/docs/research/2026-08-23-macro-state-replay-flip-census.md
+++ b/docs/research/2026-08-23-macro-state-replay-flip-census.md
@@ -1,0 +1,191 @@
+# Macro state replay: the engines work, the labels are not testable objects
+
+**Date:** 2026-08-23 · **Status:** measured, blocking on MC4/MC5/MC6 sequencing
+**Reproduce:** `docker exec argon-worker-massive-0-1 python /tmp/macro_state_replay_census.py`
+(source: `scripts/research/macro_state_replay_census.py`, read-only, never persists)
+
+## Why this ran
+
+`docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md` sequences
+MC4 (context snapshot) → MC5 (PM overlay) → MC6 (empirical gate). MC6 is where the
+program is supposed to earn the right to influence anything. Before building two
+products on top of the four domain states, one question is worth answering: **is a
+macro state label something MC6 could test?**
+
+Production could not answer it. `macro_domain_states` holds **2 calendar days** of
+history (2026-08-20, 2026-08-23) across 16 rows — the nightly compute only ever runs
+"now", and it was first enabled this week. So the history was reconstructed by replay.
+
+## The engines replay correctly
+
+All four state jobs accept `as_of: datetime | None`. Replayed at six annual instants,
+three of four domains produce a coherent, moving series:
+
+| as_of | inflation | policy_rates | usd |
+|---|---|---|---|
+| 2021-06-30 | WELL_ABOVE_TARGET / RISING / 1.00 | ON_HOLD / FLAT / 0.67 | RANGEBOUND / FLAT / 1.00 |
+| 2022-06-30 | WELL_ABOVE_TARGET / FALLING / 0.40 | TIGHTENING / RISING / 0.67 | STRENGTHENING / RISING / 1.00 |
+| 2023-06-30 | WELL_ABOVE_TARGET / FLAT / 1.00 | ON_HOLD / RISING / 0.67 | RANGEBOUND / FLAT / 1.00 |
+| 2024-06-30 | ABOVE_TARGET / FALLING / 0.85 | ON_HOLD / FALLING / 0.67 | STRENGTHENING / RISING / 1.00 |
+| 2025-06-30 | ABOVE_TARGET / FALLING / 1.00 | ON_HOLD / FALLING / 0.67 | WEAKENING / FALLING / 1.00 |
+| 2026-06-30 | WELL_ABOVE_TARGET / RISING / 0.85 | ON_HOLD / RISING / 0.67 | RANGEBOUND / FLAT / 1.00 |
+
+The rates path catches the actual cycle (ZIRP → the 2022 hiking run → terminal → cuts),
+inflation catches the surge and the disinflation, USD catches the 2022 wrecking ball and
+the 2025 fade. **Nothing here is broken.** The evidence store carries genuine vintages:
+inflation series back to period 2015-01 with ~5–8 vintages each, rates/USD daily back to
+2021-01-04, policy paths back to 2020-01-29.
+
+## The finding: n is either too small to test or too large for the wrong reason
+
+68 monthly replays, 2021-01 through 2026-08:
+
+| domain | state flips | direction flips | labels seen |
+|---|---:|---:|---|
+| inflation | **4** | 22 | BELOW_TARGET, AT_TARGET, ABOVE_TARGET, WELL_ABOVE_TARGET |
+| policy_rates | **8** | 5 | ON_HOLD, TIGHTENING, EASING |
+| usd | **29** | 29 | UNKNOWN, RANGEBOUND, STRENGTHENING, WEAKENING |
+
+### inflation — 4 transitions in 68 months
+
+```
+2021-01  BELOW_TARGET        2024-02  ABOVE_TARGET
+2021-05  AT_TARGET           2026-04  WELL_ABOVE_TARGET
+2021-06  WELL_ABOVE_TARGET
+```
+
+WELL_ABOVE_TARGET held 32 consecutive months; ABOVE_TARGET held 26. This is correct —
+inflation regimes genuinely last years — and it means **no amount of replay makes
+inflation state flips testable.** n=4 does not produce a t-stat.
+
+### policy_rates — 8 transitions, event-driven
+
+```
+2021-01 ON_HOLD    2023-08 TIGHTENING   2025-02 ON_HOLD
+2022-04 TIGHTENING 2023-10 ON_HOLD      2025-10 EASING
+2023-07 ON_HOLD    2024-10 EASING       2026-02 ON_HOLD
+```
+
+The 2023-07 → 08 → 10 round trip is the July 2023 hike, correctly caught. The label
+moves on FOMC meetings, not on a trend, so its n is bounded by the meeting calendar.
+Also note **confidence is pinned at 0.667 at every historical instant** — the dealer and
+market-implied paths only exist from 2026-08-18, so the whole replayable history runs on
+2 of 4 paths. That is honest, but it means any confidence-weighted historical study
+reads uniformly degraded.
+
+### usd — 29 transitions, and this is the bad news
+
+```
+2022-01 RANGEBOUND -> 02 STRENGTHENING -> 03 RANGEBOUND -> 05 STRENGTHENING
+        -> 08 RANGEBOUND -> 09 STRENGTHENING -> 12 RANGEBOUND
+```
+
+2022 was a **monotone** dollar bull run (DXY ~96 → ~114 → ~103). The engine reports it
+as six alternating flips. USD is the only domain with n large enough to test, and its n
+is large **because the classifier chatters, not because the dollar changed regime 29
+times.**
+
+The mechanism is in `macro/usd.py`. `UsdParameters.momentum_threshold_pct = 2.0` is
+calibrated on the *marginal* distribution — its own docstring records that it "leaves
+53.8% of days RANGEBOUND". **A classifier whose boundary sits near the median of its own
+input distribution crosses that boundary maximally often, because crossing density peaks
+where the density does.** Verified: the counts above were produced with
+`prior_state=None`, and `prior_state` reaches `compute_confidence` only
+(`confidence.py:69`, revision detection) and never the state label — so classification is
+memoryless and these are true production flip counts, not a replay artifact.
+
+### What was tried, and what was rejected
+
+The first hypothesis was hysteresis — a dual entry/exit band, so a state is left only on a
+decisive retreat. **Measured and rejected.** Sweeping entry × exit over the same 68 months
+(`scripts/research/usd_threshold_sweep.py`):
+
+| entry | percentile | exit | flips | longest regime |
+|---|---|---|---:|---:|
+| 2.0% | p61 | none | 29 | 6 mo |
+| 2.0% | p61 | 1.00 | 26 | 7 mo |
+| 2.5% | p70 | none | 23 | 8 mo |
+| **3.0%** | **p76** | **none** | **13** | **14 mo** |
+| 3.0% | p76 | 2.25 | 17 | 12 mo |
+| 3.0% | p76 | 1.50 | 23 | 7 mo |
+| 4.0% | p85 | none | 11 | 17 mo |
+| 5.0% | p93 | none | 9 | 22 mo |
+
+At **every** entry threshold the hysteresis variant left flips flat or **raised** them. A
+wider band does not remove transitions, it relocates them — the state stays directional
+longer and then flips straight from STRENGTHENING to WEAKENING. The lever is *where the
+boundary sits*, not *how sticky it is*.
+
+Distribution over 12,330 momentum points: median |63-obs change| 1.45%, p75 2.91%, p90
+4.57%. So 2.0% sat at the **61st** percentile — the middle of the record, which is the
+worst possible place for a boundary. 3.0% sits at the **76th**: RANGEBOUND becomes the
+ordinary three quarters of the record, and a directional call needs a top-quartile
+quarterly move.
+
+Corroboration from an independent source: the preregistered golden scenario
+`usd_strength_against_easing_policy` (`tests/fixtures/macro/usd_gold_golden.json`), authored
+before this analysis, encodes a **+6.34%** move as its example of real STRENGTHENING — far
+out in the tail, not at 2.0%.
+
+**Shipped:** `momentum_threshold_pct` 2.0 → 3.0, `USD_ENGINE_VERSION` and
+`UsdParameters.version` both `usd/1` → `usd/2`. Stored `usd/1` states keep their own
+semantics and stay readable. Verified through the real `compute_usd_state` with parameters
+injected as a kwarg: 29 → 13 flips, longest regime 6 → 14 months, 0 `inputs_hash`
+collisions between the two parameter sets.
+
+**This does not make USD testable.** 13 transitions in 68 months is still far short of what
+an MC6 gate needs. It makes the label mean what it says, which is what item 2 (render it)
+requires.
+
+## gold cannot replay at all
+
+`GLD_CLOSE` holds 275 periods back to 2025-07-21 but `available_at` = 2026-08-23 for
+every row. This is deliberate and documented (`macro/gold_ingest.py:14-24`): neither
+massive nor SPDR stamps a release instant, so `available_at` is the retrieval clock —
+"it never claims we could have known a price before we fetched it". The stated cost:
+"history ingested today is not PIT-replayable before today." Migration 119
+(`macro_artifact_instant_resolution`) is the mechanism to promote a verified instant
+later; until someone does, gold is structurally excluded from every historical study.
+It currently reads SUSPENDED regardless.
+
+## Consequences
+
+1. **MC6 cannot be run on state flips for any domain.** Not for lack of history — the
+   history is there and replays fine — but because of what the labels are. Two are too
+   slow (n=4, n=8), one is too noisy to mean what it says (n=29).
+2. **MC4/MC5 built in plan order would ship two products before this was known.** The
+   "decision surface" MC4 renders would have the chattering domain as its most active
+   panel.
+3. **Macro state flips should not be wired into the Stage-1 alert pipeline as-is.**
+   `CLAUDE.md` names "VRP macro state flips" as one of three alert sources. Inflation
+   would fire 4 times in 6 years; USD would fire every 2.3 months on threshold noise.
+4. **The four domain states currently have zero UI.** `/api/macro/{inflation,rates,usd,gold}`
+   all exist; `web/lib/api.ts` consumes only `/api/macro/policy`, and there is no
+   `web/app/macro/`. The nightly compute writes to a table nothing renders.
+
+## Recommended order (inverted from the plan)
+
+1. ~~**USD hysteresis**~~ → **USD threshold recalibration**. DONE. Hysteresis was the
+   hypothesis and the measurement rejected it; moving the boundary from p61 to p76 cut
+   flips 29 → 13 and extended the longest regime 6 → 14 months. See "What was tried, and
+   what was rejected" above.
+2. **One macro page** rendering the four states + evidence drill-down. This is MC4
+   Task 4 without MC4 Tasks 1–3; the snapshot DAG is not needed to show four states
+   that already exist.
+3. **Hold MC5 and MC6.** MC5 is a PM overlay for a signal that has not been shown to
+   carry information. MC6 needs a testable object, which requires deciding whether the
+   macro layer's unit is the categorical label (untestable) or the continuous features
+   underneath it (1,400+ daily observations, testable).
+
+Do NOT backfill replayed states into `macro_domain_states` to manufacture history:
+those rows are immutable and undeletable (migration 125), the engine version would be
+baked in permanently, and per the census above the resulting series would not be
+testable anyway.
+
+## Related
+
+- `docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md` (program source of truth)
+- `docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md` (the plan this reorders)
+- Precedent for measuring before building: `docs/research/2026-07-28-theta-harvester-weight-sweep.md`
+  (score orders, selected set does not pay) and `docs/research/2026-08-12-fundamental-*/`
+  (composite orders cross-sectionally, cannot time one name).

--- a/scripts/research/macro_state_replay_census.py
+++ b/scripts/research/macro_state_replay_census.py
@@ -1,0 +1,82 @@
+"""Replay the macro domain states over history and census their transitions.
+
+READ-ONLY: computes states at historical ``as_of`` instants and prints them.  It never
+calls ``_persist``, which matters because ``macro_domain_states`` rows are immutable and
+undeletable (migration 125) -- a speculative replay written to prod could never be taken
+back.
+
+Answers one question: is a macro state label a testable object?  A categorical whose
+history holds 4 transitions cannot carry a t-stat no matter how many years you replay.
+
+    docker exec argon-worker-massive-0-1 python /tmp/macro_state_replay_census.py
+
+Verdict for the 2021-01..2026-08 window: docs/research/2026-08-23-macro-state-replay-flip-census.md
+"""
+from datetime import UTC, datetime
+
+from uw_scan.config import Settings
+from uw_scan.macro.evidence_store import (
+    load_inflation_observations, load_rates_observations, load_usd_observations,
+)
+from uw_scan.macro.inflation import compute_inflation_state
+from uw_scan.macro.policy_report import build_policy_comparison
+from uw_scan.macro.rates import compute_rates_state
+from uw_scan.macro.usd import UpstreamState, compute_usd_state
+from uw_scan.worker.jobs.macro_state_jobs import _attribution, _paths
+from uw_scan.worker.scheduler import _repo
+
+
+def months():
+    for y in range(2021, 2027):
+        for m in range(1, 13):
+            if (y, m) > (2026, 8):
+                return
+            yield datetime(y, m, 1, tzinfo=UTC)
+
+
+def main() -> None:
+    s = Settings.from_env()
+    series: dict[str, list[tuple[str, str, str]]] = {"inflation": [], "policy_rates": [], "usd": []}
+    with _repo(s) as repo:
+        for inst in months():
+            tag = inst.strftime("%Y-%m")
+            try:
+                infl = compute_inflation_state(
+                    load_inflation_observations(repo, as_of=inst), as_of=inst, prior_state=None)
+                series["inflation"].append((tag, infl.state, infl.direction))
+            except Exception as exc:
+                series["inflation"].append((tag, f"ERR:{type(exc).__name__}", "-"))
+            rates = None
+            try:
+                obs = load_rates_observations(repo, as_of=inst)
+                rates = compute_rates_state(
+                    _paths(build_policy_comparison(repo, as_of=inst)), as_of=inst,
+                    observations=obs, attribution=_attribution(obs, as_of=inst), prior_state=None)
+                series["policy_rates"].append((tag, rates.state, rates.direction))
+            except Exception as exc:
+                series["policy_rates"].append((tag, f"ERR:{type(exc).__name__}", "-"))
+            try:
+                up = () if rates is None else (UpstreamState(
+                    domain="policy_rates", state=rates.state, direction=rates.direction,
+                    inputs_hash=rates.inputs_hash, as_of=inst),)
+                usd = compute_usd_state(load_usd_observations(repo, as_of=inst), as_of=inst,
+                                        upstream=up, prior_state=None)
+                series["usd"].append((tag, usd.state, usd.direction))
+            except Exception as exc:
+                series["usd"].append((tag, f"ERR:{type(exc).__name__}", "-"))
+
+    for dom, rows in series.items():
+        flips = sum(1 for a, b in zip(rows, rows[1:]) if a[1] != b[1])
+        dflips = sum(1 for a, b in zip(rows, rows[1:]) if a[2] != b[2])
+        labels = sorted({r[1] for r in rows})
+        print(f"\n=== {dom}: {len(rows)} months, {flips} state flips, {dflips} direction flips")
+        print(f"    labels seen: {labels}")
+        prev = None
+        for tag, st, di in rows:
+            if st != prev:
+                print(f"    {tag}  -> {st:<22} {di}")
+                prev = st
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/research/usd_threshold_sweep.py
+++ b/scripts/research/usd_threshold_sweep.py
@@ -1,0 +1,164 @@
+"""Sweep the USD state classifier's entry threshold, and test hysteresis against it.
+
+READ-ONLY.  Never persists: it replays ``compute_usd_state``'s classification over the
+stored evidence at monthly ``as_of`` instants and counts how often the label changes.
+``macro_domain_states`` rows are immutable and undeletable (migration 125), so a sweep
+that wrote its candidates would be permanent.
+
+Two questions, one run:
+
+1. Where should the boundary sit?  A classifier whose boundary sits near the MEDIAN of
+   its own input distribution crosses it maximally often, because crossing density peaks
+   where the density does.  The sweep reports each candidate's percentile alongside its
+   flip count so the choice is calibrated rather than picked.
+2. Does hysteresis help?  For each entry threshold it also runs a dual-threshold
+   (Schmitt) variant that leaves a directional state only below a lower exit band.
+
+Measured 2026-08-23 over 2021-01..2026-08 (68 monthly replays, 12,330 momentum points):
+median |63-obs change| 1.45%, p75 2.91%, p90 4.57%.
+
+    enter  pctile   exit  flips  longest run
+      2.0   60.6%   none     29         6 mo     <- retired
+      3.0   76.2%   none     13        14 mo     <- shipped
+      3.0   76.2%   2.25     17        12 mo
+      3.0   76.2%   1.50     23          7 mo
+      5.0   92.8%   none      9        22 mo
+
+The ``exit_band == enter`` rows reproduce ``compute_usd_state`` exactly; verified against
+the real engine with parameters injected as a kwarg.
+
+Hysteresis was REJECTED on this evidence: at every entry threshold the dual-threshold
+variant left flips flat or RAISED them, because a wider band relocates transitions
+(STRENGTHENING -> WEAKENING directly) rather than removing them.  The lever is where the
+boundary sits, not how sticky it is.
+
+Run inside a worker container, which has the repo and the prod DSN:
+
+    docker cp scripts/research/usd_threshold_sweep.py argon-worker-massive-0-1:/tmp/
+    docker exec argon-worker-massive-0-1 python /tmp/usd_threshold_sweep.py
+
+Verdict: docs/research/2026-08-23-macro-state-replay-flip-census.md
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from statistics import median
+
+from uw_scan.config import Settings
+from uw_scan.macro.evidence_store import load_usd_observations
+from uw_scan.macro.usd import ANCHOR_SERIES, DEFAULT_USD_PARAMETERS
+from uw_scan.worker.scheduler import _repo
+
+WINDOW_OBS = DEFAULT_USD_PARAMETERS.momentum_window_obs
+ENTRY_CANDIDATES = [Decimal(x) for x in ("2.0", "2.5", "3.0", "3.5", "4.0", "4.5", "5.0")]
+START_YEAR, END = 2021, (2026, 8)
+
+
+def momentum_path(values: list[Decimal]) -> list[Decimal]:
+    """Every 63-observation change computable from the window, oldest first."""
+    return [
+        (values[i] - values[i - WINDOW_OBS]) / values[i - WINDOW_OBS] * Decimal(100)
+        for i in range(WINDOW_OBS, len(values))
+        if values[i - WINDOW_OBS] != 0
+    ]
+
+
+def classify(path: list[Decimal], enter: Decimal, exit_band: Decimal) -> str:
+    """Walk the path, seeded RANGEBOUND.  ``exit_band == enter`` is no hysteresis.
+
+    Seeded rather than carried from storage on purpose: the answer at an ``as_of`` stays a
+    pure function of the observations knowable then, which is what makes a replay of a
+    stored row reproduce it.
+
+    A path too short to yield a single momentum point is UNKNOWN, not RANGEBOUND -- the
+    same answer ``_state`` gives, so the ``exit_band == enter`` rows reproduce the shipped
+    classifier exactly instead of silently merging the warm-up months into one long run.
+    """
+    if not path:
+        return "UNKNOWN"
+    state = "RANGEBOUND"
+    for m in path:
+        if state == "STRENGTHENING":
+            if m < exit_band:
+                state = "WEAKENING" if m <= -enter else "RANGEBOUND"
+        elif state == "WEAKENING":
+            if m > -exit_band:
+                state = "STRENGTHENING" if m >= enter else "RANGEBOUND"
+        elif m >= enter:
+            state = "STRENGTHENING"
+        elif m <= -enter:
+            state = "WEAKENING"
+    return state
+
+
+def month_starts():
+    for year in range(START_YEAR, END[0] + 1):
+        for month in range(1, 13):
+            if (year, month) > END:
+                return
+            yield datetime(year, month, 1, tzinfo=UTC)
+
+
+def run_lengths(states: list[str]) -> list[int]:
+    runs, current, n = [], states[0], 1
+    for state in states[1:]:
+        if state == current:
+            n += 1
+        else:
+            runs.append(n)
+            current, n = state, 1
+    runs.append(n)
+    return runs
+
+
+def main() -> None:
+    settings = Settings.from_env()
+    paths: dict[str, list[Decimal]] = {}
+    with _repo(settings) as repo:
+        for instant in month_starts():
+            observations = load_usd_observations(repo, as_of=instant)
+            newest_per_period: dict[object, Decimal] = {}
+            for obs in sorted(
+                (
+                    o
+                    for o in observations
+                    if o.series_id == ANCHOR_SERIES and o.is_known_on(instant)
+                ),
+                key=lambda o: (o.period_end, o.available_at),
+            ):
+                newest_per_period[obs.period_end] = obs.value
+            values = [newest_per_period[k] for k in sorted(newest_per_period)]
+            paths[instant.strftime("%Y-%m")] = momentum_path(values)
+
+    every_move = sorted(abs(m) for path in paths.values() for m in path)
+    if not every_move:
+        raise SystemExit("no momentum points -- is the evidence store populated?")
+
+    def percentile_of(threshold: Decimal) -> float:
+        return 100.0 * sum(1 for m in every_move if m < threshold) / len(every_move)
+
+    print(
+        f"|{WINDOW_OBS}-obs change| over {len(every_move)} points "
+        f"({START_YEAR}-01..{END[0]}-{END[1]:02d}): "
+        f"median={median(every_move):.2f}%  "
+        f"p75={every_move[int(0.75 * len(every_move))]:.2f}%  "
+        f"p90={every_move[int(0.90 * len(every_move))]:.2f}%\n"
+    )
+    print(f"{'enter':>6} {'pctile':>7} {'exit':>6} {'flips':>6} {'longest run':>12}")
+    print("-" * 46)
+    for enter in ENTRY_CANDIDATES:
+        for exit_band in (enter, enter * Decimal("0.75"), enter * Decimal("0.5")):
+            states = [classify(p, enter, exit_band) for p in paths.values()]
+            flips = sum(1 for a, b in zip(states, states[1:]) if a != b)
+            label = "none" if exit_band == enter else f"{exit_band:.2f}"
+            print(
+                f"{enter:>6} {percentile_of(enter):>6.1f}% {label:>6} {flips:>6} "
+                f"{max(run_lengths(states)):>9} mo"
+            )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uw_scan/macro/usd.py
+++ b/src/uw_scan/macro/usd.py
@@ -48,7 +48,10 @@ from .contracts import (
     freshness_for,
 )
 
-USD_ENGINE_VERSION = "usd/1"
+#: Bumped to usd/2 when the momentum threshold moved from the median of the move
+#: distribution (2.0%) to its upper quartile (3.0%).  Stored usd/1 states keep their
+#: own semantics and stay readable; a reader filtering on engine_version gets one.
+USD_ENGINE_VERSION = "usd/2"
 
 UsdStateLabel = Literal["STRENGTHENING", "WEAKENING", "RANGEBOUND", "UNKNOWN"]
 
@@ -95,17 +98,26 @@ class UpstreamState:
 class UsdParameters:
     """Versioned thresholds, hashed with the evidence rather than hidden in constants."""
 
-    version: str = "usd/1"
+    version: str = "usd/2"
     #: Observations, not calendar days.  The H.10 releases weekly carrying the week's
     #: daily values, so 63 observations is about a calendar quarter of prints.
     momentum_window_obs: int = 63
     #: Percent change over that window at which the dollar is doing something.
-    #: Calibrated rather than picked: across 5,169 observations from 2006-01-02 to
-    #: 2026-08-14 the MEDIAN absolute 63-observation change is 1.81% and this threshold
-    #: leaves 53.8% of days RANGEBOUND -- so "rangebound" means the quieter half of the
-    #: record by construction, not a number that felt small. p90 is 4.82%.
-    #: Reproduce: uv run python scripts/research/usd_source_probe.py
-    momentum_threshold_pct: Decimal = Decimal("2.0")
+    #: The boundary belongs in the TAIL of the move distribution, not at its middle.  A
+    #: classifier whose boundary sits near the median of its own inputs crosses that
+    #: boundary maximally often, because crossing density peaks where the density does --
+    #: which is what the retired 2.0 did.  Measured over 12,330 momentum points replayed
+    #: monthly from the stored evidence (2021-01..2026-08): median absolute 63-observation
+    #: change 1.45%, p75 2.91%, p90 4.57%.  3.0 sits at the 76th percentile, so RANGEBOUND
+    #: is the ordinary three quarters of the record and a directional call needs a
+    #: top-quartile quarterly move.
+    #:
+    #: What this buys, same window: the state flips 13 times rather than 29, and its
+    #: longest single regime runs 14 months rather than 6.  Hysteresis was measured as the
+    #: alternative and REJECTED -- a dual entry/exit band left flips flat or raised them
+    #: at every entry threshold, because it relocates transitions rather than removing
+    #: them.  Reproduce: uv run python scripts/research/usd_threshold_sweep.py
+    momentum_threshold_pct: Decimal = Decimal("3.0")
     #: The real index is MONTHLY, so the anchor's 63 observations would be 63 months on
     #: it -- five and a quarter years reported under a label that says three months, and
     #: the two "changes" beside each other would not be comparable at all. Three

--- a/tests/fixtures/macro/usd_rangebound_window.json
+++ b/tests/fixtures/macro/usd_rangebound_window.json
@@ -1,0 +1,648 @@
+{
+  "note": "REAL DTWEXBGS (FRED Broad Dollar Index, daily) observations, frozen 2026-08-23 from the macro evidence store. The 63-observation change over this window is +2.0839% -- above the retired 2.0 threshold but inside the ordinary three quarters of the record, so it is not a directional call.",
+  "series_id": "DTWEXBGS",
+  "frozen_as_of": "2026-08-23",
+  "change_pct_63obs": "2.0839",
+  "rows": [
+    {
+      "period_end": "2026-04-17",
+      "value": "118.0795",
+      "available_at": "2026-04-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-20",
+      "value": "118.2374",
+      "available_at": "2026-04-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-21",
+      "value": "118.4331",
+      "available_at": "2026-04-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-22",
+      "value": "118.6004",
+      "available_at": "2026-04-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-23",
+      "value": "118.7155",
+      "available_at": "2026-04-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-24",
+      "value": "118.7294",
+      "available_at": "2026-04-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-27",
+      "value": "118.5458",
+      "available_at": "2026-05-04T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-28",
+      "value": "118.7717",
+      "available_at": "2026-05-04T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-29",
+      "value": "119.0975",
+      "available_at": "2026-05-04T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-04-30",
+      "value": "118.671",
+      "available_at": "2026-05-04T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-01",
+      "value": "118.3926",
+      "available_at": "2026-05-04T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-04",
+      "value": "118.8264",
+      "available_at": "2026-05-11T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-05",
+      "value": "118.6207",
+      "available_at": "2026-05-11T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-06",
+      "value": "118.0982",
+      "available_at": "2026-05-11T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-07",
+      "value": "118.0116",
+      "available_at": "2026-05-11T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-08",
+      "value": "118.0392",
+      "available_at": "2026-05-11T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-11",
+      "value": "118.0562",
+      "available_at": "2026-05-18T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-12",
+      "value": "118.5238",
+      "available_at": "2026-05-18T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-13",
+      "value": "118.4737",
+      "available_at": "2026-05-18T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-14",
+      "value": "118.6696",
+      "available_at": "2026-05-18T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-15",
+      "value": "119.2825",
+      "available_at": "2026-05-18T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-18",
+      "value": "119.0574",
+      "available_at": "2026-05-26T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-19",
+      "value": "119.451",
+      "available_at": "2026-05-26T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-20",
+      "value": "119.1624",
+      "available_at": "2026-05-26T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-21",
+      "value": "119.369",
+      "available_at": "2026-05-26T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-22",
+      "value": "119.2868",
+      "available_at": "2026-05-26T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-26",
+      "value": "119.1696",
+      "available_at": "2026-06-01T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-27",
+      "value": "119.1829",
+      "available_at": "2026-06-01T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-28",
+      "value": "119.0318",
+      "available_at": "2026-06-01T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-05-29",
+      "value": "118.8783",
+      "available_at": "2026-06-01T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-01",
+      "value": "119.1653",
+      "available_at": "2026-06-08T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-02",
+      "value": "119.0359",
+      "available_at": "2026-06-08T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-03",
+      "value": "119.3848",
+      "available_at": "2026-06-08T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-04",
+      "value": "119.3615",
+      "available_at": "2026-06-08T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-05",
+      "value": "120.0831",
+      "available_at": "2026-06-08T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-08",
+      "value": "120.034",
+      "available_at": "2026-06-15T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-09",
+      "value": "119.9617",
+      "available_at": "2026-06-15T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-10",
+      "value": "119.9134",
+      "available_at": "2026-06-15T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-11",
+      "value": "120.1174",
+      "available_at": "2026-06-15T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-12",
+      "value": "119.5073",
+      "available_at": "2026-06-15T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-15",
+      "value": "119.3158",
+      "available_at": "2026-06-22T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-16",
+      "value": "119.256",
+      "available_at": "2026-06-22T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-17",
+      "value": "119.3871",
+      "available_at": "2026-06-22T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-18",
+      "value": "120.3958",
+      "available_at": "2026-06-22T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-22",
+      "value": "120.5463",
+      "available_at": "2026-06-29T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-23",
+      "value": "121.0552",
+      "available_at": "2026-06-29T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-24",
+      "value": "121.412",
+      "available_at": "2026-06-29T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-25",
+      "value": "121.0559",
+      "available_at": "2026-06-29T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-26",
+      "value": "120.8866",
+      "available_at": "2026-06-29T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-29",
+      "value": "120.9525",
+      "available_at": "2026-07-06T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-06-30",
+      "value": "120.9248",
+      "available_at": "2026-07-06T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-01",
+      "value": "121.1455",
+      "available_at": "2026-07-06T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-02",
+      "value": "120.6902",
+      "available_at": "2026-07-06T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-06",
+      "value": "120.835",
+      "available_at": "2026-07-13T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-07",
+      "value": "120.8145",
+      "available_at": "2026-07-13T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-08",
+      "value": "121.1307",
+      "available_at": "2026-07-13T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-09",
+      "value": "120.753",
+      "available_at": "2026-07-13T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-10",
+      "value": "120.5046",
+      "available_at": "2026-07-13T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-13",
+      "value": "120.7413",
+      "available_at": "2026-07-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-14",
+      "value": "120.4728",
+      "available_at": "2026-07-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-15",
+      "value": "120.3088",
+      "available_at": "2026-07-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-16",
+      "value": "120.331",
+      "available_at": "2026-07-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-17",
+      "value": "120.5315",
+      "available_at": "2026-07-20T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    },
+    {
+      "period_end": "2026-07-20",
+      "value": "120.5401000000",
+      "available_at": "2026-07-27T08:00:00+08:00",
+      "unit": "index_jan_2006_100",
+      "source": "fred",
+      "source_kind": "first_party_publisher",
+      "cost_class": "free_publisher",
+      "causal_role": "curve"
+    }
+  ]
+}

--- a/tests/unit/macro/test_engine_versions.py
+++ b/tests/unit/macro/test_engine_versions.py
@@ -1,0 +1,34 @@
+"""Every macro domain's engine version and parameter version move together.
+
+``engine_version`` is a selector: states are keyed ``(domain, as_of, engine_version,
+inputs_hash)`` and readers filter on it to get one engine's semantics.  ``Parameters.version``
+labels the calibration.  Splitting them lets a recalibrated engine keep publishing under the
+old engine identity, so a reader asking for one semantics silently gets two.
+
+This was not hypothetical: moving USD's momentum threshold bumped the parameter version and
+left the engine version behind, and nothing failed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from uw_scan.macro.gold_state import GOLD_ENGINE_VERSION, DEFAULT_GOLD_PARAMETERS
+from uw_scan.macro.inflation import INFLATION_ENGINE_VERSION, DEFAULT_INFLATION_PARAMETERS
+from uw_scan.macro.rates import RATES_ENGINE_VERSION, DEFAULT_RATES_PARAMETERS
+from uw_scan.macro.usd import USD_ENGINE_VERSION, DEFAULT_USD_PARAMETERS
+
+DOMAINS = [
+    ("gold", GOLD_ENGINE_VERSION, DEFAULT_GOLD_PARAMETERS),
+    ("inflation", INFLATION_ENGINE_VERSION, DEFAULT_INFLATION_PARAMETERS),
+    ("policy_rates", RATES_ENGINE_VERSION, DEFAULT_RATES_PARAMETERS),
+    ("usd", USD_ENGINE_VERSION, DEFAULT_USD_PARAMETERS),
+]
+
+
+@pytest.mark.parametrize("domain,engine_version,parameters", DOMAINS)
+def test_engine_and_parameter_versions_agree(domain, engine_version, parameters) -> None:
+    assert engine_version == parameters.version, (
+        f"{domain}: engine_version {engine_version!r} and parameter version "
+        f"{parameters.version!r} disagree. A recalibration must move BOTH, or readers "
+        f"filtering on engine_version get two different semantics under one label."
+    )

--- a/tests/unit/macro/test_usd_state.py
+++ b/tests/unit/macro/test_usd_state.py
@@ -314,19 +314,6 @@ class TestMomentumWindow:
         assert velocity.value is None
         assert "different statistic" in velocity.unavailable_reason
 
-    def test_the_threshold_is_the_measured_median_move(self) -> None:
-        """Calibration, asserted so a later edit has to argue with the measurement.
-
-        Across 5,169 observations from 2006-01-02 to 2026-08-14 the median absolute
-        63-observation change is 1.81% and this threshold leaves 53.8% of days
-        RANGEBOUND. A number chosen for feel would drift; this one has a reproduce
-        command behind it.
-        """
-        from uw_scan.macro.usd import DEFAULT_USD_PARAMETERS
-
-        assert DEFAULT_USD_PARAMETERS.momentum_threshold_pct == Decimal("2.0")
-        assert DEFAULT_USD_PARAMETERS.momentum_window_obs == 63
-
     def test_the_anchor_cadence_is_weekly_not_daily(self) -> None:
         """The anchor is REQUIRED, so a wrong cadence deletes the state four days in five."""
         from uw_scan.macro.usd import DEFAULT_USD_PARAMETERS
@@ -458,3 +445,71 @@ class TestTheEngineRefusesAFutureUpstream:
             as_of=as_of,
             upstream=(_upstream(as_of=as_of - timedelta(days=30)),),
         )
+
+
+class TestDirectionalCallRequiresATopQuartileMove:
+    """The boundary belongs in the tail of the move distribution, not at its middle.
+
+    A classifier whose boundary sits near the MEDIAN of its own input distribution
+    crosses that boundary maximally often, because crossing density peaks where the
+    density does.  Measured on the stored evidence: at 2.0% the USD state flipped 29
+    times across 68 monthly replays with a longest regime of 6 months; at 3.0% it flips
+    13 times with a longest regime of 14 months.
+    """
+
+    WINDOW = json.loads(
+        (
+            Path(__file__).parents[2]
+            / "fixtures"
+            / "macro"
+            / "usd_rangebound_window.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    def _rows(self) -> list[DomainObservation]:
+        return [
+            DomainObservation(
+                series_id=self.WINDOW["series_id"],
+                causal_role=row["causal_role"],
+                period_end=date.fromisoformat(row["period_end"]),
+                value=Decimal(row["value"]),
+                unit=row["unit"],
+                publisher_transform="index_level",
+                available_at=datetime.fromisoformat(row["available_at"]),
+                superseded_at=None,
+                source=row["source"],
+                source_kind=row["source_kind"],
+                cost_class=row["cost_class"],
+            )
+            for row in self.WINDOW["rows"]
+        ]
+
+    def test_the_frozen_window_really_is_a_two_percent_move(self) -> None:
+        """Guards the fixture: if this drifts, the test below stops testing the band."""
+        rows = self._rows()
+        first, last = rows[0].value, rows[-1].value
+        change = (last - first) / first * Decimal(100)
+        assert Decimal("2.0") <= change < Decimal("3.0")
+        assert round(change, 4) == Decimal(self.WINDOW["change_pct_63obs"])
+
+    def test_an_ordinary_quarterly_move_is_not_a_directional_call(self) -> None:
+        state = compute_usd_state(self._rows(), as_of=_instant("2026-07-27"))
+        assert state.state == "RANGEBOUND"
+        assert state.direction == "FLAT"
+
+    def test_the_threshold_sits_at_the_upper_quartile_of_the_move_distribution(
+        self,
+    ) -> None:
+        """Calibration, asserted so a later edit has to argue with the measurement.
+
+        Across 12,330 momentum points replayed monthly from the stored evidence
+        (2021-01..2026-08) the median absolute 63-observation change is 1.45% and 3.0%
+        sits at the 76th percentile -- so RANGEBOUND is the ordinary three quarters of
+        the record and a directional call needs a top-quartile quarterly move.
+
+        Reproduce: scripts/research/usd_threshold_sweep.py
+        """
+        from uw_scan.macro.usd import DEFAULT_USD_PARAMETERS
+
+        assert DEFAULT_USD_PARAMETERS.momentum_threshold_pct == Decimal("3.0")
+        assert DEFAULT_USD_PARAMETERS.momentum_window_obs == 63


### PR DESCRIPTION
## What

The USD state's classification boundary moved from the **middle** of its own input
distribution to its **upper quartile**: `momentum_threshold_pct` 2.0% → 3.0%,
`USD_ENGINE_VERSION` and `UsdParameters.version` both `usd/1` → `usd/2`.

## Why

`macro_domain_states` holds 2 calendar days of history in prod, so the state series was
reconstructed by replay (`scripts/research/macro_state_replay_census.py`, read-only —
those rows are immutable and undeletable, so a speculative backfill would be permanent).

Over 68 monthly replays, 2021-01..2026-08:

| domain | state flips |
|---|---:|
| inflation | 4 |
| policy_rates | 8 |
| **usd** | **29** |

USD was the only domain with n large enough to test, and its n was large **because the
classifier chattered** — not because the dollar changed regime 29 times. 2022 alone:

```
2022-01 RANGEBOUND → 02 STRENGTHENING → 03 RANGEBOUND → 05 STRENGTHENING
        → 08 RANGEBOUND → 09 STRENGTHENING → 12 RANGEBOUND
```

That year the broad dollar ran monotonically from ~96 to ~114.

The cause: 2.0% sat at the **61st percentile** of the anchor's own 63-observation moves.
A boundary near the median of its inputs is crossed maximally often, because crossing
density peaks where the density does. `usd.py`'s docstring framed "53.8% of days
RANGEBOUND" as the calibration's virtue; it was the defect.

## What was rejected

**Hysteresis** — a dual entry/exit band — was the first hypothesis. Measured and rejected:

| entry | pctile | exit | flips | longest regime |
|---|---|---|---:|---:|
| 2.0% | p61 | none | 29 | 6 mo |
| 2.5% | p70 | none | 23 | 8 mo |
| **3.0%** | **p76** | **none** | **13** | **14 mo** |
| 3.0% | p76 | 2.25 | 17 | 12 mo |
| 3.0% | p76 | 1.50 | 23 | 7 mo |
| 4.0% | p85 | none | 11 | 17 mo |
| 5.0% | p93 | none | 9 | 22 mo |

At **every** entry threshold the hysteresis variant left flips flat or raised them: a
wider band relocates transitions (STRENGTHENING → WEAKENING directly) rather than
removing them. The lever is where the boundary sits, not how sticky it is.

3.0% is the smallest candidate reaching the knee, so it is the least aggressive change
that fixes the problem.

## Corroboration

The preregistered golden scenario `usd_strength_against_easing_policy`, authored before
this analysis, encodes **+6.34%** as its example of real STRENGTHENING — far out in the
tail. It passes unchanged.

## Verification

- Real `compute_usd_state`, parameters injected as a kwarg (no file in the prod container
  touched): **29 → 13 flips**, longest regime **6 → 14 months**, **0 `inputs_hash`
  collisions** between the two parameter sets.
- Sweep reproduces the shipped classifier exactly on its `exit == entry` rows.
- `ruff check src/ tests/ scripts/` clean · **2479 unit** · **206 macro integration**.

## Also

`tests/unit/macro/test_engine_versions.py` — every domain's engine version and parameter
version must move together. Not hypothetical: this change bumped the parameter version,
left `USD_ENGINE_VERSION` behind, and nothing failed. The other three domains pass it
already.

## Scope

Stored `usd/1` states keep their own semantics and stay readable; states are keyed
`(domain, as_of, engine_version, inputs_hash)` and a reader filtering on `engine_version`
gets one engine's semantics.

**This does not make the USD state testable.** 13 transitions in 68 months is still far
short of an MC6-grade gate. It makes the label mean what it says — which is the
prerequisite for rendering it, the next PR in this line.

Verdict: `docs/research/2026-08-23-macro-state-replay-flip-census.md`
