### PR TITLE
fix(macro): confidence explains the set it actually measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **`docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md`** — MC4–MC6 re-ordered
+  against what was actually measured, and the two decisions that were open in the handover, now
+  settled: **historical replay preserves what Argon believed at the instant** (invalidation affects
+  current reads; a corrected-history read is a reserved opt-in), and **the authority boundary is
+  risk-monitoring** (report freshness, contradictions, missing domains and dependency
+  incompatibility; never rank, size, recommend, or alter Fundamental PM output).
+  - The MC6 preflight moves earlier and runs **in parallel** with MC4 rather than after it. It reads
+    the evidence store and state records only, so it never needed the snapshot — and it is the item
+    that decides whether MC5/MC6 happen at all. Building MC4 first and then discovering there is
+    nothing to validate is the wrong order.
+  - MC4 is specified as a **refusal layer**: status comes from dependency-edge identity, not
+    timestamp proximity, and a snapshot may never repair an incompatible chain by substituting a
+    fresher upstream. Substitution is how a monitoring layer becomes a fabrication layer.
+  - The older MC4–MC6 plan keeps its task decomposition and carries a banner saying its sequencing
+    is superseded.
+
 - **`docs/handover/2026-08-24-macro-executive-summary-claude-handover.md`** — the
   reviewed executive status of the macro program: deployed truth, seven binding
   findings, the delivery sequence, and the completion gates. It was written against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Macro confidence now explains the set it actually measured.** `compute_confidence`
+  drew its terms from two different sets and called all of them *load-bearing*, so USD
+  and Gold each shipped `2/1 load-bearing inputs present` to production — a ratio above
+  its own denominator, because the value counted requirements while the sentence beside
+  it counted every factor consumed. Both states carry one required anchor and one
+  optional input.
+  - **The `revision_penalty` divisor was the real defect, not the sentence.** Its
+    numerator is filtered to the required set by `revised_series`; its divisor counted
+    every factor. A revised USD anchor beside one optional factor therefore scored
+    `1/2` — the term that exists to punish a revision punished it half as hard, and the
+    optional input doing the halving contributes nothing to the state being revised. It
+    read `0` across all four domains only because no series had been revised yet, which
+    is also why no caller-level test could have caught it.
+  - `freshness` and `quality` keep averaging over everything the engine consumed — an
+    optional input the engine read does bear on how reliable the answer is — so what
+    changed there is the claim, not the arithmetic. The quality detail now names the
+    count it averaged and says how many were optional.
+  - **All four engine versions bump** — `inflation/2`, `rates/2`, `usd/3`, `gold/2`.
+    The state *labels* are untouched, but confidence is published on the state record,
+    and a reader comparing it across this change would be comparing two arithmetics.
+    `engine_version` is the selector that keeps them apart; stored states under the old
+    versions stay readable and keep their own semantics.
+  - No current production confidence *value* changes: every affected term is either a
+    sentence or currently `0`.
+  - Two integration tests pinned `"inflation/1"` / `"rates/1"` as literals, which turns
+    a deliberate bump into a failure that reads like a regression. They now assert
+    against the engine constants, which is the thing worth proving — that the API
+    round-trips the engine's identity.
+
+### Changed
+
+- **The macro program plan agrees with the repository again.** It mapped MC1 to PR #359
+  (it was #348), still labelled MC3 `in_progress` after four merged PRs, omitted `usd/2`
+  and `/macro` entirely, and — with its MC4–MC6 child — reserved migrations `117`/`118`,
+  both of which the Fundamental lane had already taken. The tail is `129`, so MC4 starts
+  at `130`. `/macro` is now labelled **MC3.5, a descriptive chain viewer**, not a
+  completed MC4: it composes four independent latest responses and is not an atomic
+  snapshot. MC6's blocked status and the replay census that caused it are recorded
+  inline, so the next reader does not have to rediscover why the sequencing changed.
+
+### Added
+
+- **`docs/handover/2026-08-24-macro-executive-summary-claude-handover.md`** — the
+  reviewed executive status of the macro program: deployed truth, seven binding
+  findings, the delivery sequence, and the completion gates. It was written against
+  `v0.12.16` and had never been committed.
+
 ## [0.12.16] — 2026-08-23
 
 ### Added

--- a/docs/handover/2026-08-24-macro-executive-summary-claude-handover.md
+++ b/docs/handover/2026-08-24-macro-executive-summary-claude-handover.md
@@ -1,0 +1,444 @@
+# Handover: Top-Down Macro Context — executive status and next program
+
+**To:** Claude Code  
+**From:** Codex, after a source/DB/API/browser review on 2026-08-23/24  
+**Repository:** `/Users/chenxi/projects/argon`  
+**Handoff worktree:** `/Users/chenxi/projects/argon/.worktrees/macro-executive-handoff`  
+**Branch:** `misc/macro-executive-handoff`  
+**Base:** `86161f1d` (`v0.12.16`, merged by PR #379)  
+**Status:** documentation handoff only; no macro implementation has been started here  
+
+## Reactivation prompt
+
+> We are continuing the Argon top-down macro program from this handoff. Read this document first,
+> then read the cited plans/research and inspect the current repository and production state. Re-check
+> every time-sensitive fact; do not assume the old chat is available or that this document authorizes
+> implementation, commits, pushes, PM integration, alerts, or signal authority. Preserve the causal
+> order `inflation -> policy/rates -> USD -> gold`. Continue from the ordered next steps and stop at
+> the stated gates.
+
+---
+
+## 1. Executive decision
+
+The macro program has a real, deployed, point-in-time descriptive foundation. MC0 through MC3 are
+substantially implemented: immutable source evidence, FOMC/SEP policy paths, inflation/rates states,
+the rates market layer, USD transmission, Gold's regime gate, worker persistence, API replay, and a
+new `/macro` page all exist.
+
+The program is **not yet a validated decision system**:
+
+- MC4's atomic `MacroContextSnapshot` does not exist. The page composes four independent latest
+  domain responses.
+- MC5 Fundamental PM integration is not implemented and is not authorized by this handoff.
+- MC6 preflight found that categorical state flips are not a statistically viable validation unit.
+  Gold is not historically PIT-replayable before its retrieval-clock evidence began.
+- The evidence ledger cannot mark an already accepted observation as subsequently known-bad.
+- Two concrete truthfulness defects remain visible in current production: `2/1 load-bearing inputs
+  present` for USD and Gold, and Gold state computation occurs before the same day's Gold posture
+  compute.
+
+**Recommended authority boundary:** build the next phase as a **risk-monitoring layer** first. It may
+report freshness, contradictions, missing domains, dependency incompatibility, and measured
+transmission breakdowns. It must not rank, size, recommend, or alter Fundamental PM output.
+
+The user was offered three authority levels — descriptive-only, risk-monitoring, or immediate PM
+input — and did not explicitly choose before requesting this handoff. Do not interpret the handoff
+request as approval for MC5. Confirm the boundary before any implementation whose scope depends on
+that choice.
+
+## 2. Current deployed truth, refreshed 2026-08-24
+
+At handoff time:
+
+- `main` and `origin/main` point to `86161f1d`, tagged `v0.12.16`.
+- GitHub Release workflow run `32647680179` completed successfully.
+- Mac mini health through `http://100.66.147.98:3001/api/health` reports `ok=true`, `db=up`,
+  `version=0.12.16`, and fresh scheduler/worker heartbeats.
+- `http://100.66.147.98:3001/macro` returns HTTP 200.
+- All four current states were computed with the same exact `as_of`:
+  `2026-08-24T07:40:00.001360+08:00`.
+
+| Domain | Engine | State | Direction | Confidence | Evidence rows |
+|---|---|---|---|---:|---:|
+| inflation | `inflation/1` | `WELL_ABOVE_TARGET` | `FLAT` | 0.3952 | 139 |
+| policy_rates | `rates/1` | `ON_HOLD` | `UNKNOWN` | 0.8500 | 580 |
+| usd | `usd/2` | `RANGEBOUND` | `FLAT` | 1.0000 | 328 |
+| gold | `gold/1` | `SUSPENDED` | `RISING` | 0.8500 | 1,091 |
+
+USD references the current `rates/1` state at the same `as_of`. Gold references the current
+inflation, rates, and `usd/2` states at the same `as_of`. This proves the current production row set
+is coherent; it does **not** prove the four-latest API composition is safe under a partial nightly
+failure.
+
+The deployed page response was about 108 KB. The four backing domain API responses totalled about
+673 KB in the review immediately before this handoff, largely because the page fetches full evidence
+arrays but uses them only for counts; factors and confidence reasons are what the UI actually
+renders.
+
+## 3. Milestone status — facts, not plan labels
+
+| Milestone | Current fact | Honest status |
+|---|---|---|
+| MC0 | Immutable macro artifact/observation contract merged in PR #332 | merged, with a known invalidation gap |
+| MC1 | Durable FOMC/SEP paths merged in PR #348; committed verdict is PASS | merged/PASS, with roster residuals |
+| MC2 | Inflation/rates engines, persistence, API, PIT/replay merged in PR #359 | merged and deployed |
+| MC3 | Rates market layer, USD, Gold manifest/state merged through PRs #363/#369/#372/#377 | merged and deployed, semantically bounded |
+| MC4 | `/macro` causal-chain viewer merged in PR #378; snapshot schema/job/API absent | partial: Task 4 shell only |
+| MC5 | Company/chain exposure mapping and removable PM block absent | not started; hold |
+| MC6 | State replay census completed; full preregistered PIT/OOS study absent | blocked on a testable object |
+
+The program source-of-truth plan is stale. It incorrectly maps MC1 to PR #359, still labels MC3
+`in_progress`, omits `usd/2` and `/macro`, and reserves migrations 117/118 although those numbers are
+already used by Fundamentals. Current migration tail is 129. Treat repository/PR history as current
+until the plan is repaired.
+
+### Closed work from PRs #377/#378 — do not reopen it
+
+PR #377 did **not** implement hysteresis. Hysteresis was the initial hypothesis and the measured sweep
+rejected it: at every tested entry threshold, adding an exit band left transition counts flat or made
+them worse. It relocated transitions rather than removing them. The actual lever was the entry
+boundary's position in the dollar's own 63-observation move distribution:
+
+| Entry | Distribution percentile | Exit band | Flips | Longest regime |
+|---:|---:|---:|---:|---:|
+| 2.0% | p61 | none | 29 | 6 months |
+| 2.0% | p61 | 1.00% | 26 | 7 months |
+| 3.0% | p76 | none | 13 | 14 months |
+| 3.0% | p76 | 2.25% | 17 | 12 months |
+| 3.0% | p76 | 1.50% | 23 | 7 months |
+
+The shipped change was deliberately one parameter: 2.0% -> 3.0%. Do not reintroduce hysteresis
+machinery without new, preregistered evidence that overturns this sweep.
+
+The same PR closed an engine-identity defect. `engine_version` is a read selector, not decorative
+metadata: changing only `UsdParameters.version` while leaving `USD_ENGINE_VERSION` unchanged would
+publish changed semantics under the old identity. Tests now assert parameter/engine identity for all
+four domains. Preserve that convention for every future engine change.
+
+PR #378 intentionally shipped only the descriptive four-domain chain. It also exposed a test-design
+lesson: a banned-substring scan for words such as `allocation` flags the Gold disclaimer _"never
+becomes a price target, an allocation, or a size"_ as if it were a recommendation. Test that the desk
+does not synthesize prohibited authority; do not scan the entire rendered payload for words that may
+appear inside an explicit denial.
+
+The original PR-completion note said these commits were not deployed. That statement is now obsolete:
+v0.12.16 is deployed, `/macro` returns 200, and the latest stored USD state uses `usd/2`.
+
+## 4. Required reading, in order
+
+1. `CLAUDE.md` — project rules and live architecture.
+2. `docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md` — intended program, but
+   reconcile its stale status table against this handoff and Git history.
+3. `docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md` — original MC4–MC6
+   design; do not execute its migration numbers or original sequencing literally.
+4. `docs/research/2026-08-23-macro-state-replay-flip-census.md` — the binding empirical preflight
+   that changes MC5/MC6 sequencing.
+5. `docs/research/2026-08-12-fomc-sep-source-probe/VERDICT.md` — current MC1 PASS and its explicit
+   residual limitations.
+6. `docs/research/2026-08-21-rates-market-layer-probe/VERDICT.md` — WRESBAL unit rebase and rates
+   source decisions.
+7. `docs/superpowers/specs/2026-08-12-usd-gold-state-design.md` — USD/Gold scope limits and design
+   deviations.
+8. `src/uw_scan/macro/`, `src/uw_scan/worker/jobs/macro_state_jobs.py`,
+   `src/uw_scan/worker/scheduler.py`, `src/uw_scan/api/routers/macro.py`, and
+   `web/app/macro/page.tsx` — current implementation.
+
+## 5. Binding findings
+
+### F1 — state labels are not a valid MC6 test unit
+
+`docs/research/2026-08-23-macro-state-replay-flip-census.md` replayed 68 monthly instants from
+2021-01 through 2026-08:
+
+- inflation: 4 state flips;
+- policy/rates: 8 state flips;
+- retired `usd/1`: 29 flips, largely threshold chatter;
+- `usd/2`: 13 flips after moving the momentum boundary from 2% to 3%; semantically better, still
+  underpowered;
+- Gold: historical observations have retrieval-time `available_at`, so the domain is structurally
+  unavailable for replay before 2026-08-23.
+
+Do not backfill replayed states into `macro_domain_states`. Those rows are immutable, would bake in
+today's engine version, and would manufacture a sample that remains unsuitable.
+
+**Required correction:** run a separate continuous-feature availability and target preflight before
+building MC5 or the formal MC6 harness. Candidate units may include continuous factor values,
+confidence terms, contradictions, or precisely defined transmission residuals. Fix the target,
+horizon, lag, baseline, sample gate, and kill rule before fitting.
+
+### F2 — known-bad evidence remains `valid`
+
+WRESBAL was rejected because FRED republished its history 1,000x on 2025-11-13 while the single-series
+contract still labels all vintages `millions_usd`. The local evidence store currently holds 1,173
+WRESBAL rows, all 1,173 marked `valid`. For period 2025-06-04 it holds both `3294.381` and
+`3294381.0`, both `millions_usd`, both `valid`.
+
+Current FRED contracts correctly exclude WRESBAL, so today's rates state does not consume it. The
+architectural defect remains: the immutable ledger has no additive mechanism to say an accepted
+artifact/observation/range was later discovered invalid.
+
+**Required correction:** design a versioned invalidation overlay; never mutate or delete raw evidence.
+It should support at least:
+
+- artifact, observation, and bounded series/vintage targets;
+- `invalidated_at`, reason, evidence, reviewer, and version;
+- current/corrected reads that exclude invalidated evidence;
+- an explicit decision on whether historical-belief replay preserves what Argon believed before the
+  invalidation was discovered.
+
+This needs its own design/spec and PR. Do not hide it inside MC4.
+
+### F3 — `/macro` is not MC4's atomic context snapshot
+
+`web/app/macro/page.tsx` runs four independent latest requests with `Promise.all`. The nightly worker
+normally uses one `as_of` and the correct causal order, but each domain job catches its own exception
+and the loop continues. If rates fails, USD can consume an older rates state and still persist a new
+USD state; Gold can then consume a mixture. The page does not compare top-level hashes/timestamps to
+dependency-edge hashes/timestamps.
+
+**Required correction:** implement the actual snapshot DAG from the MC4 plan, using a new migration
+number after 129:
+
+- `macro_context_snapshots`;
+- one domain edge per available compatible state;
+- exact evidence lineage;
+- `complete | partial | incompatible | stale` status with reasons;
+- idempotent `inputs_hash` over state identities and parameters;
+- current/replay APIs;
+- a compact summary response and lazy evidence endpoint;
+- the page reads one stored snapshot, never four latest answers.
+
+### F4 — confidence explanation is false in current production
+
+Both USD and Gold currently render:
+
+```text
+completeness 1 — 2/1 load-bearing inputs present
+```
+
+`src/uw_scan/macro/confidence.py` computes numerical completeness from the required-series
+intersection, but formats the detail with `len(factors)`. Optional factors also enter freshness,
+quality, and revision terms even though they do not enter completeness.
+
+**Required correction:** first freeze semantics in tests:
+
+- the detail count must report required inputs present / required inputs;
+- explicitly decide whether optional factors affect freshness, quality, and revision penalties;
+- removing an optional factor must not silently improve confidence unless that behavior is deliberate
+  and documented.
+
+This is the safest small first implementation PR once the user authorizes coding.
+
+### F5 — Gold reads a posture gauge produced on a later schedule
+
+Scheduler order is:
+
+- 19:30 ET: macro Gold evidence ingest;
+- 19:40 ET: all four macro domain states;
+- 21:00 ET: legacy Gold posture compute.
+
+Gold state calls `fetch_gold_posture_as_of(as_of.date())`, so the same day's posture cannot exist yet.
+The API exposes `gauge_age_days`, which currently reports 2 days across the weekend; the age is
+honest, but the schedule guarantees the state never sees the same day's 21:00 posture during the
+19:40 pass.
+
+**Required correction:** either compute posture before the macro state, rerun only Gold after posture,
+or split Gold snapshot assembly. Add a scheduler-order test and a real persisted smoke that compares
+state `as_of`, gauge observation date, and allowed lag.
+
+### F6 — USD and Gold names must remain semantically bounded
+
+- USD `usd_against_relative_policy` currently observes only the US policy leg; there is no foreign
+  policy differential. Plumbing and positioning are intentionally refused until a stated rule uses
+  them. Do not market this as a complete global relative-policy transmission model.
+- Gold's domain state owns two citable inputs (`GLD_CLOSE`, `GLD_HOLDINGS_OZ`) and borrows real-yield
+  and USD evidence. Central-bank reserves, exchange inventory, COT, and UW options remain on the
+  broader Gold Compass/warm-store path. The state is a narrow relationship gate, not a complete Gold
+  investment view.
+
+### F7 — MC1 PASS is real but not perfect
+
+Do not regress the current PASS to the older worktree handover's PARTIAL. The committed result is
+55/55 statements, 25/25 SEP, real worker -> DB -> API, idempotency, PIT/correction, and offline replay.
+
+Residuals:
+
+- two statements publish a vote tally without a roster;
+- the parser does not capture `Absent and not voting ...` for 2025-07-30;
+- CI's frozen regression corpus is 11 statements and 7 SEP releases, while 55/25 is a dated live
+  measurement;
+- roster/tally checks are not fully independent of the parser that produced them.
+
+Capture the absence format and strengthen reconciliation, but do not block MC4 integrity work on it.
+
+## 6. Recommended delivery sequence
+
+### Step 1 — repair the source-of-truth documents
+
+Update the macro program plan to reflect PRs #332/#348/#359/#363/#369/#372/#377/#378/#379,
+`usd/2`, deployed `/macro`, MC4 partial status, current migration numbers, and the replay census's
+sequencing change. Label the current page **MC3.5 descriptive chain viewer** rather than a completed
+MC4.
+
+**Stop when:** the plan agrees with repository and production state and contains no obsolete migration
+reservation.
+
+### Step 2 — land small truthfulness fixes as separate PRs
+
+Recommended order:
+
+1. confidence semantics/detail;
+2. Gold posture/state schedule ordering;
+3. FOMC absence fixture/reconciliation follow-up.
+
+Do not bundle these with snapshot schema work.
+
+**Stop when:** targeted unit/integration tests and real API/browser smoke show correct explanations,
+the intended Gold gauge lag, and no MC1 regression.
+
+### Step 3 — design and implement evidence invalidation
+
+Write the design first. Preserve raw bytes and observation identities. Specify historical-belief vs
+corrected-history semantics and the query contract before the migration.
+
+**Stop when:** WRESBAL remains physically present, current/corrected readers exclude it, the reason is
+auditable, migration replay is idempotent, and PIT behavior is covered by tests.
+
+### Step 4 — implement the real MC4 snapshot
+
+Split into independently reviewable PRs:
+
+1. snapshot contract + migration + repository;
+2. assembler + worker + API;
+3. UI migration to snapshot + replay/delta/evidence drawer;
+4. real persisted state -> snapshot -> API -> browser verification artifact.
+
+**Stop when:** a partial domain failure can never appear as a coherent fresh chain, a later evidence
+revision does not change an old snapshot hash, and the page no longer fetches four latest states.
+
+### Step 5 — run continuous-feature discovery before MC5
+
+Persist the full availability census and every candidate definition. Decide the testable object before
+building the walk-forward harness. Do not fit if the preregistered minimum sample gate fails.
+
+**Stop when:** there is either a defensible PIT panel and precise target, or a committed
+`descriptive_only` verdict.
+
+### Step 6 — ask for explicit authority before MC5
+
+Only after Steps 1–5 should the user decide whether macro remains descriptive/risk-monitoring or may
+enter the Fundamental PM surface. If MC5 is authorized, keep it removable and prove byte-invariance
+of every fundamental fact, score, valuation anchor, and hash with macro on/off.
+
+**Stop when:** authority is explicit; an empirical result never edits production ranking/sizing by
+itself.
+
+## 7. Completion gates Claude must preserve
+
+Before anyone calls the macro program complete:
+
+1. Known-bad evidence can be invalidated additively without deleting raw evidence.
+2. Confidence reasons and arithmetic refer to the same load-bearing set.
+3. Gold state/gauge timing is deliberate, tested, and exposed.
+4. One persisted context snapshot owns the four-domain composition and exact lineage.
+5. Missing, stale, failed, or incompatible domains produce `partial`/refusal, never a coherent-looking
+   full chain.
+6. Historical replay uses only evidence available by the selected instant; later revisions do not
+   mutate stored answers.
+7. MC6 uses a preregistered, sufficiently sampled target and persists the full trace before exit.
+8. No alert, PM overlay, ranking, sizing, recommendation, or allocation authority is inferred from a
+   descriptive state.
+9. Real smoke follows worker -> DB -> API -> browser. Direct function scripts do not satisfy the
+   production gate.
+10. CHANGELOG, docs, code, tests, and verification evidence ride the same feature PR.
+
+## 8. Worktree and repository boundaries
+
+This handoff worktree was created from clean `main@86161f1d`. The primary checkout at
+`/Users/chenxi/projects/argon` had unrelated user-owned changes when this worktree was created:
+
+- modified `docs/research/2026-08-23-fundamental-filing-date-recovery/VERDICT.md`;
+- modified `docs/superpowers/plans/2026-08-23-fundamental-calendar-ingest-and-filing-dates.md`;
+- untracked `docs/research/2026-08-23-radon-new-features-port-analysis.md`.
+
+Do not copy, revert, commit, or clean those files from this worktree.
+
+Two older macro worktrees are stale and dirty:
+
+- `.worktrees/macro-topdown-pm-plan`;
+- `.worktrees/macro-fomc-sep-policy-paths`.
+
+Do not treat either as current source and do not remove them without first preserving their uncommitted
+contents and receiving user approval.
+
+Standing boundaries:
+
+- no commit without explicit user request;
+- never push directly to `main`;
+- open and merge a PR, then align local main;
+- migrations idempotent;
+- `uv` only;
+- no Yahoo;
+- no naked shorts;
+- no secrets to local model subprocesses;
+- do not extend `storage/repository.py`; use the existing domain mixin/module boundary;
+- do not backfill replayed macro states merely to increase sample size.
+
+## 9. Verification already run
+
+Source review before creating this worktree:
+
+```text
+uv run pytest tests/unit/macro tests/unit/sources/test_fred_macro.py \
+  tests/integration/api/test_macro_state_router.py \
+  tests/integration/worker/test_macro_state_jobs.py \
+  tests/integration/worker/test_macro_gold_state_job.py -q
+-> 295 passed
+
+cd web && npm run test -- tests/unit/macroDesk.test.tsx
+-> 1 file, 9 tests passed
+```
+
+All macro PRs listed above had seven successful CI checks. The v0.12.16 release workflow completed
+successfully. Production health/API/page checks were repeated while writing this handoff and produced
+the deployed truth in section 2.
+
+Baseline verification inside this new worktree is recorded below after the handoff file is written:
+
+```text
+uv sync --extra postgres
+-> success; isolated .venv created and uw-scan 0.12.16 installed
+
+uv run pytest tests/unit/macro tests/unit/sources/test_fred_macro.py \
+  tests/integration/api/test_macro_state_router.py \
+  tests/integration/worker/test_macro_state_jobs.py \
+  tests/integration/worker/test_macro_gold_state_job.py -q
+-> 295 passed
+
+cd web && npm install
+-> dependencies installed; npm reported 13 dependency-audit findings
+   (1 low, 1 moderate, 9 high, 2 critical). This handoff did not run npm audit fixes or alter the
+   dependency graph; package-lock version churn created by npm install was reverted.
+
+cd web && npm run test -- tests/unit/macroDesk.test.tsx
+-> 1 file, 9 tests passed
+
+git diff --check
+-> clean
+```
+
+## 10. First Claude Code actions
+
+1. Run `git status --short --branch` and verify the branch/path/base above. Stop if the worktree has
+   changes other than this handoff that are not explained here.
+2. Read the eight required sources in section 4 and confirm the documented status still matches
+   repository, GitHub, and production.
+3. Ask the user to confirm the next authority boundary if it is still unresolved. Recommend
+   risk-monitoring, not immediate PM authority.
+4. Present a small design for Step 1 plus the first truthfulness PR. Do not start MC4 or MC5 in this
+   documentation branch.
+5. If implementation is approved, create a fresh canonical `.worktrees/<branch-slug>/` worktree for
+   the chosen PR, use TDD, and keep each PR independently reviewable.
+6. Before claiming completion, rerun the relevant unit/integration/web tests and a real deployed-path
+   smoke, then report any drift from this handoff.

--- a/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
@@ -1,5 +1,12 @@
 # Macro MC4–MC6 Context Snapshot, PM Integration, and Validation Implementation Plan
 
+> **Sequencing superseded by** `2026-08-24-macro-mc4-mc6-sequenced.md`. The task decomposition below
+> is still good; the ORDER is not, and neither are the migration numbers. This plan assumed MC6 would
+> validate state transitions — the 2026-08-23 replay census measured 4/8/13 flips over 68 months and
+> killed that unit, so MC6 is now gated on a preflight this plan does not contain. Read the sequenced
+> plan for order, gates, and the two settled decisions (belief-preserving replay; risk-monitoring
+> authority) before executing any task here.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** assemble the four verified macro domains into a reproducible top-down context snapshot,

--- a/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
+++ b/docs/superpowers/plans/2026-08-12-macro-mc4-mc6-context-pm-validation.md
@@ -24,8 +24,10 @@ PM report/card contracts when landed, and `src/uw_scan/backtest/`.
   Re-anchor file paths to the merged PM implementation before coding; do not edit the active P1b
   ingest worktree.
 - MC4, MC5, and MC6 are separate PRs. MC6 failure does not roll back MC4/MC5 descriptive context.
-- Recheck migration numbering; this plan reserves `117_macro_context_snapshots.sql` for MC4 and
-  `118_company_macro_exposures.sql` for MC5.
+- **The reserved migration numbers are void.** This plan reserved `117_macro_context_snapshots.sql`
+  for MC4 and `118_company_macro_exposures.sql` for MC5; the Fundamental lane took both
+  (`117_fundamental_scores.sql`, `118_valuation_anchors.sql`). The tail is `129` as of 2026-08-24, so
+  MC4 starts at `130`. Read the tail from `src/uw_scan/storage/migrations/`, never from this plan.
 
 ## MC4 — versioned context snapshot and macro surface
 

--- a/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
+++ b/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
@@ -192,14 +192,30 @@ Storage boundaries:
 | ID | Status | Child plan | Exit gate |
 |---|---|---|---|
 | MC0 | implementation verified | `2026-08-12-macro-mc0-evidence-contract.md` | two migration replays; immutable hash/time/quality/SQL guards; 19-relation read-only inventory self-check; lint/format/diff gates |
-| MC1 | merged | `2026-08-12-macro-mc1-fomc-sep-policy-paths.md` | official FOMC/SEP evidence and four independent policy paths replay PIT — PR #359, v0.12.10 |
+| MC1 | merged | `2026-08-12-macro-mc1-fomc-sep-policy-paths.md` | official FOMC/SEP evidence and four independent policy paths replay PIT — PR #348. Verdict PASS with residuals: two statements publish a tally without a roster, and the 2025-07-30 `Absent and not voting` form is uncaptured |
 | MC2 | merged | `2026-08-12-macro-mc2-inflation-rates-state.md` | inflation/rates states abstain honestly and reproduce from exact observations — PR #359, v0.12.10 |
-| MC3 | in_progress | `2026-08-12-macro-mc3-usd-gold-state.md` | rates market layer resolves to real evidence; USD/Gold states reuse shared inputs and Gold provenance is complete |
-| MC4–MC6 | planned | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | snapshot, context-only PM integration, then separate PIT/OOS promotion verdict |
+| MC3 | merged | `2026-08-12-macro-mc3-usd-gold-state.md` | rates market layer resolves to real evidence; USD/Gold states reuse shared inputs — PRs #363/#369/#372/#377. **Semantically bounded:** USD observes only the US policy leg (no foreign differential), and Gold's state owns two citable inputs and borrows the rest. Gold provenance is NOT complete; the wider Compass path stays separate |
+| MC3.5 | merged | — | `/macro` renders the four domain states in causal order — PR #378, v0.12.16. Descriptive chain viewer only: it composes four independent latest responses and is **not** MC4's atomic snapshot |
+| MC4 | partial | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | Task 4's page shell shipped as MC3.5 above. Snapshot schema, assembler, job and API absent |
+| MC5 | hold | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | not started, and not authorized. Requires an explicit authority decision plus the MC6 preflight below |
+| MC6 | blocked | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | blocked on a testable object — see the replay census below |
 
 Every child is implemented through its own branch/PR sequence. Status changes only after its stated
 verification evidence exists. Child plans are implementation-ready but do not imply authorization to
 commit or publish.
+
+> **Migration numbers.** This plan's child reserved `117_macro_context_snapshots.sql` for MC4 and
+> `118_company_macro_exposures.sql` for MC5. Both numbers were taken by the Fundamental lane
+> (`117_fundamental_scores.sql`, `118_valuation_anchors.sql`). The tail is `129` as of 2026-08-24, so
+> MC4 starts at `130`. Re-check the tail before writing a migration; do not read a reserved number
+> from either plan.
+
+> **MC6 sequencing changed.** `docs/research/2026-08-23-macro-state-replay-flip-census.md` replayed 68
+> monthly instants (2021-01..2026-08) and found the categorical state label is not a viable validation
+> unit: inflation flips 4 times, rates 8, `usd/2` 13 after the boundary move, and gold cannot replay at
+> all before its retrieval-clock evidence began. A continuous-feature availability and target preflight
+> must run BEFORE MC5 or the MC6 harness. Do not backfill replayed states to manufacture sample size —
+> those rows are immutable and would bake in today's engine version.
 
 ## 7. Dependency and release sequence
 

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -1,0 +1,149 @@
+# MC4–MC6, sequenced against what was actually measured
+
+**Supersedes the sequencing of** `2026-08-12-macro-mc4-mc6-context-pm-validation.md`. That plan's
+task decomposition for MC4 is still good; its ORDER, its migration numbers, and its assumption that
+MC6 can validate state flips are not. Read this file for order and gates, that one for task detail.
+
+**Status:** planned. No implementation authorized by this document.
+
+## Decisions on the record
+
+Both were open in the 2026-08-24 handover and are now settled by the operator:
+
+1. **Historical replay preserves what Argon believed at the instant.** When an accepted observation is
+   later discovered to be bad, replaying a past `as_of` still returns the state as it stood — bad
+   evidence included. That is what point-in-time means: the state genuinely was computed from that
+   evidence, and rewriting it would make the record a fiction. Invalidation affects **current** reads.
+   A corrected-history read is an explicit opt-in parameter, built only when something consumes it.
+
+2. **The authority boundary is risk-monitoring.** The macro layer may report freshness,
+   contradictions, missing domains, dependency incompatibility, and measured transmission breakdowns.
+   It may not rank, size, recommend, or alter any Fundamental PM output. MC4 as specified below sits
+   exactly on this line. MC5 stays held.
+
+## Why the order changed
+
+`docs/research/2026-08-23-macro-state-replay-flip-census.md` replayed 68 monthly instants
+(2021-01..2026-08). The categorical state label is not a viable validation unit: inflation flips 4
+times, rates 8, `usd/2` 13 after the boundary move, and gold cannot replay at all before its
+retrieval-clock evidence began. The original plan assumed MC6 would validate state transitions. It
+cannot. So MC6 is gated on a preflight that the original plan did not contain, and that preflight
+does not depend on MC4 — which is why it moves earlier and runs in parallel.
+
+```text
+P0  F5 gold schedule ────┐
+P0  F2 invalidation  ────┼──> MC4 snapshot ──> (authority already set: risk-monitoring)
+                         │
+P0  MC6 preflight  ──────┘    (parallel; gates MC5/MC6, not MC4)
+```
+
+## P0-a — F5: gold reads a gauge produced on a later schedule
+
+```text
+19:30 ET  macro gold evidence ingest
+19:40 ET  all four macro domain states     (daily)
+21:00 ET  legacy gold posture compute      (Sun-Thu only)
+```
+
+Gold state calls `fetch_gold_posture_as_of(as_of.date())`, so the same day's posture cannot exist at
+19:40. `gauge_age_days` reports the lag honestly, but the schedule guarantees it.
+
+**This cannot be specified until one question is answered:** which market close does each posture row
+cover? The cron is `0 21 * * 0-4`, so Friday evening never runs. Until the covered-close mapping is
+stated, "rerun gold after posture" only relocates an undefined lag. Answer that first, in the spec.
+
+**Exit:** a scheduler-order test, a stated and tested intended lag, and a real persisted smoke
+comparing state `as_of`, gauge observation date, and the allowed lag.
+
+## P0-b — F2: additive evidence invalidation
+
+WRESBAL was rejected because FRED republished its history 1,000x on 2025-11-13 while the contract
+still labels every vintage `millions_usd`. The store holds 1,173 WRESBAL rows, all `valid`; period
+2025-06-04 carries both `3294.381` and `3294381.0`, both `millions_usd`, both `valid`. Current
+contracts exclude the series, so nothing consumes it today. The defect is that the ledger has no way
+to say an accepted artifact was later found bad.
+
+**Design first, in its own spec and PR.** Never mutate or delete raw evidence.
+
+- targets: artifact, observation, and bounded series/vintage ranges
+- fields: `invalidated_at`, reason, evidence, reviewer, version
+- current reads exclude invalidated evidence; **replay does not** (decision 1)
+- a `corrected=true` opt-in on replay is contract-reserved, not implemented
+
+**Exit:** WRESBAL stays physically present, current readers exclude it, the reason is auditable,
+migration replay is idempotent, and belief-preserving replay is covered by a test that would fail if
+a historical `as_of` started excluding it.
+
+## P0-c — MC6 preflight (parallel; does not touch MC4)
+
+Reads the evidence store and state records only. Persists the full census before exit.
+
+- which continuous features exist across the four domains — factor values, confidence terms,
+  contradiction counts, transmission residuals
+- each one's PIT availability and history depth under `available_at <= as_of`
+- gold is structurally excluded until migration 119 promotes a verified instant for `GLD_CLOSE`
+- **preregister before any fitting:** target, horizon, lag, baseline, minimum-sample gate, kill rule
+
+**Exit:** either a defensible PIT panel with a precise target, or a committed `descriptive_only`
+verdict. Do not fit if the preregistered sample gate fails. Do not backfill replayed states into
+`macro_domain_states` to manufacture sample size — those rows are immutable and would bake in
+today's engine version.
+
+## MC4 — the snapshot is a refusal layer
+
+Today the page runs four independent latest requests. The nightly worker uses one `as_of` and the
+correct causal order, but each domain job catches its own exception and the loop continues. If rates
+fails, USD still runs, reads the PREVIOUS rates state (which still satisfies `available_at <= as_of`),
+and persists a new USD state citing it; gold then consumes a mixture. Four cards all render fresh.
+
+Production was coherent when checked on 2026-08-24 — all four states at
+`2026-08-24T07:40:00.001360+08:00`, USD citing the current rates state, gold citing all three. Nothing
+enforces or detects that.
+
+**Migration `130`.** The tail is `129`; the reservations of `117`/`118` in the older plan are void.
+
+Status is decided by **dependency-edge identity**, never by timestamp proximity:
+
+| status | meaning |
+|---|---|
+| `complete` | four domains present, and every downstream's cited upstream state id equals this snapshot's |
+| `partial` | a domain is absent — its job failed or never ran |
+| `incompatible` | a domain is present but cites an upstream that is not this snapshot's |
+| `stale` | the newest snapshot is older than the expected cadence |
+
+**The one constraint that must not break: a snapshot may never repair an incompatible chain by
+substituting a fresher upstream.** Its job is to name the incompatibility. Substitution is how a
+monitoring layer becomes a fabrication layer.
+
+`inputs_hash` covers the four state identities plus snapshot parameters, so re-assembly is idempotent
+and a later evidence revision cannot change an old snapshot's hash.
+
+Four independently reviewable PRs:
+
+1. contract + migration `130` + repository
+2. assembler + worker job + API (current and `?as_of_ts=` replay)
+3. UI reads one snapshot; replay / delta / lazy evidence drawer
+4. real persisted verification: worker → DB → API → browser
+
+**Exit:** a partial domain failure can never render as a coherent fresh chain; a later evidence
+revision does not change an old snapshot hash; the page no longer fetches four latest states.
+
+## MC5 — held
+
+Not started, not authorized. Requires the preflight above to produce something other than
+`descriptive_only`, plus a fresh authority decision. If it ever proceeds, it stays removable and must
+prove byte-invariance of every fundamental fact, score, valuation anchor, and hash with macro on and
+off.
+
+## Gates that survive all of the above
+
+1. Known-bad evidence is invalidated additively; raw evidence is never deleted.
+2. Confidence reasons and confidence arithmetic refer to the same set. *(closed by PR #380)*
+3. Gold state/gauge timing is deliberate, tested, and exposed.
+4. One persisted snapshot owns the four-domain composition and its exact lineage.
+5. Missing, stale, failed or incompatible domains produce refusal, never a coherent-looking chain.
+6. Replay uses only evidence available by the selected instant, and preserves belief.
+7. MC6 uses a preregistered, sufficiently sampled target and persists its full trace before exit.
+8. No alert, PM overlay, ranking, sizing, or allocation authority is inferred from a descriptive state.
+9. Real smoke follows worker → DB → API → browser. A direct function script does not satisfy it.
+10. CHANGELOG, docs, code, tests and verification evidence ride the same feature PR.

--- a/src/uw_scan/macro/confidence.py
+++ b/src/uw_scan/macro/confidence.py
@@ -51,8 +51,11 @@ def compute_confidence(
     # factor that was NOT required, and len()/len() reported 1/1 complete on a state
     # whose one required input was absent: full confidence in a reading built from a
     # substitute. Counting the intersection cannot express that.
+    # Named once, because four terms below need to say WHICH set they measured and the
+    # last defect here was a value and its own explanation drawn from different ones.
+    present_required = required - len(missing)
     completeness = (
-        Decimal(required - len(missing)) / Decimal(required) if required else Decimal(0)
+        Decimal(present_required) / Decimal(required) if required else Decimal(0)
     )
 
     # The minimum, not a mean: one input that has gone quiet past its own cadence
@@ -67,8 +70,14 @@ def compute_confidence(
     )
 
     revised = revised_series(factors, prior_state, required_series=required_series)
+    # Over the REQUIRED present, matching ``revised``, which ``revised_series`` has
+    # already filtered to the required set.  Dividing a required-only count by every
+    # factor let an optional input the state does not stand on halve the penalty for
+    # revising the input it does.
     revision_penalty = (
-        Decimal(len(revised)) / Decimal(present) if present and revised else Decimal(0)
+        Decimal(len(revised)) / Decimal(present_required)
+        if present_required and revised
+        else Decimal(0)
     )
     contradiction_penalty = min(
         contradiction_penalty_each * len(contradictions), contradiction_penalty_cap
@@ -86,7 +95,7 @@ def compute_confidence(
         ConfidenceTerm(
             "completeness",
             completeness,
-            f"{present}/{required} load-bearing inputs present"
+            f"{present_required}/{required} load-bearing inputs present"
             + (f"; missing {', '.join(missing)}" if missing else ""),
         ),
         ConfidenceTerm(
@@ -99,7 +108,12 @@ def compute_confidence(
         ConfidenceTerm(
             "quality",
             quality,
-            "mean publisher quality weight over present load-bearing inputs",
+            f"mean publisher quality weight over {present} consumed input(s)"
+            + (
+                f"; {present - present_required} of them optional"
+                if present > present_required
+                else ""
+            ),
         ),
         ConfidenceTerm(
             "revision_penalty",

--- a/src/uw_scan/macro/gold_state.py
+++ b/src/uw_scan/macro/gold_state.py
@@ -57,7 +57,12 @@ from .contracts import (
 from .evidence_store import INFLATION_EVIDENCE, RATES_EVIDENCE, USD_EVIDENCE
 from .usd import UpstreamState
 
-GOLD_ENGINE_VERSION = "gold/1"
+#: Bumped when the shared confidence engine's revision penalty changed divisor, from
+#: every factor consumed to the required set its numerator was already drawn from.  The
+#: state LABEL is untouched, but confidence is published on the state record and a
+#: reader comparing it across this line would be comparing two arithmetics.  Engine
+#: version is the selector that keeps them apart; stored gold/1 states stay readable.
+GOLD_ENGINE_VERSION = "gold/2"
 
 #: The gate's vocabulary IS the gauge's, uppercased.  Inventing a second set of words for
 #: the same measurement would leave two vocabularies to keep in step, and the one that
@@ -142,7 +147,7 @@ class GoldLensResult:
 class GoldParameters:
     """Versioned thresholds, hashed with the evidence rather than hidden in constants."""
 
-    version: str = "gold/1"
+    version: str = "gold/2"
     #: CALENDAR days, not observation counts, and that distinction is load-bearing.
     #: This engine reads four series off three publication calendars -- GLD trades NYSE
     #: sessions, FRED skips its own holidays, SPDR posts business days -- and over one

--- a/src/uw_scan/macro/inflation.py
+++ b/src/uw_scan/macro/inflation.py
@@ -41,7 +41,12 @@ from .transforms import (
     yoy_from_index,
 )
 
-INFLATION_ENGINE_VERSION = "inflation/1"
+#: Bumped when the shared confidence engine's revision penalty changed divisor, from
+#: every factor consumed to the required set its numerator was already drawn from.  The
+#: state LABEL is untouched, but confidence is published on the state record and a
+#: reader comparing it across this line would be comparing two arithmetics.  Engine
+#: version is the selector that keeps them apart; stored inflation/1 states stay readable.
+INFLATION_ENGINE_VERSION = "inflation/2"
 
 InflationStateLabel = Literal[
     "BELOW_TARGET",
@@ -83,7 +88,7 @@ _INDEX_TRANSFORMS = frozenset({"index", "index_level"})
 class InflationParameters:
     """Versioned thresholds, hashed into ``inputs_hash`` rather than hidden in constants."""
 
-    version: str = "inflation/1"
+    version: str = "inflation/2"
     at_target_lower: Decimal = Decimal("1.75")
     at_target_upper: Decimal = Decimal("2.25")
     above_target_upper: Decimal = Decimal("3.00")

--- a/src/uw_scan/macro/rates.py
+++ b/src/uw_scan/macro/rates.py
@@ -52,7 +52,12 @@ from .rates_rules import (
     year_end_rate,
 )
 
-RATES_ENGINE_VERSION = "rates/1"
+#: Bumped when the shared confidence engine's revision penalty changed divisor, from
+#: every factor consumed to the required set its numerator was already drawn from.  The
+#: state LABEL is untouched, but confidence is published on the state record and a
+#: reader comparing it across this line would be comparing two arithmetics.  Engine
+#: version is the selector that keeps them apart; stored rates/1 states stay readable.
+RATES_ENGINE_VERSION = "rates/2"
 
 RatesStateLabel = Literal["EASING", "ON_HOLD", "TIGHTENING", "INDETERMINATE"]
 
@@ -91,7 +96,7 @@ _ACTION_STATE: dict[str, RatesStateLabel] = {
 class RatesParameters:
     """Versioned thresholds, hashed with the evidence rather than hidden in constants."""
 
-    version: str = "rates/1"
+    version: str = "rates/2"
     #: One eighth of a point -- the finest increment an SEP dot can express, and half
     #: the smallest move the committee actually makes.  Anything coarser would round a
     #: real projected lean to "flat".

--- a/src/uw_scan/macro/usd.py
+++ b/src/uw_scan/macro/usd.py
@@ -51,7 +51,12 @@ from .contracts import (
 #: Bumped to usd/2 when the momentum threshold moved from the median of the move
 #: distribution (2.0%) to its upper quartile (3.0%).  Stored usd/1 states keep their
 #: own semantics and stay readable; a reader filtering on engine_version gets one.
-USD_ENGINE_VERSION = "usd/2"
+#: Bumped when the shared confidence engine's revision penalty changed divisor, from
+#: every factor consumed to the required set its numerator was already drawn from.  The
+#: state LABEL is untouched, but confidence is published on the state record and a
+#: reader comparing it across this line would be comparing two arithmetics.  Engine
+#: version is the selector that keeps them apart; stored usd/2 states stay readable.
+USD_ENGINE_VERSION = "usd/3"
 
 UsdStateLabel = Literal["STRENGTHENING", "WEAKENING", "RANGEBOUND", "UNKNOWN"]
 
@@ -98,7 +103,7 @@ class UpstreamState:
 class UsdParameters:
     """Versioned thresholds, hashed with the evidence rather than hidden in constants."""
 
-    version: str = "usd/2"
+    version: str = "usd/3"
     #: Observations, not calendar days.  The H.10 releases weekly carrying the week's
     #: daily values, so 63 observations is about a calendar quarter of prints.
     momentum_window_obs: int = 63

--- a/tests/integration/api/test_macro_state_router.py
+++ b/tests/integration/api/test_macro_state_router.py
@@ -25,6 +25,7 @@ from tests.integration.worker.test_macro_state_jobs import (
     _ingest_scenario,
 )
 from uw_scan.config import Settings
+from uw_scan.macro.inflation import INFLATION_ENGINE_VERSION
 from uw_scan.storage.repository import Repository
 from uw_scan.worker.jobs.macro_state_jobs import macro_inflation_state_job
 
@@ -64,7 +65,7 @@ class TestReplay:
         assert body["state"] == "WELL_ABOVE_TARGET"
         assert body["direction"] == "FALLING"
         assert body["domain"] == "inflation"
-        assert body["engine_version"] == "inflation/1"
+        assert body["engine_version"] == INFLATION_ENGINE_VERSION
         assert len(body["evidence"]) == 8 * 16
         assert len(body["factors"]) == 8
         first = body["evidence"][0]

--- a/tests/integration/api/test_rates_router.py
+++ b/tests/integration/api/test_rates_router.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from uw_scan.api.routers.rates import _mark_stale_snapshot_sources
 from uw_scan.api.deps import get_repo, get_settings
 from uw_scan.api.server import create_app
+from uw_scan.macro.rates import RATES_ENGINE_VERSION
 from uw_scan.config import Settings
 from uw_scan.models import (
     RatesCurvePoint,
@@ -222,7 +223,7 @@ def test_the_flagged_state_block_carries_its_confidence_and_a_route_to_its_evide
     state = body["state"]
     assert state["domain"] == "policy_rates"
     assert state["state"] == "ON_HOLD"
-    assert state["engine_version"] == "rates/1"
+    assert state["engine_version"] == RATES_ENGINE_VERSION
     assert state["confidence_reasons"], (
         "a confidence with no terms cannot be argued with"
     )

--- a/tests/unit/macro/test_confidence.py
+++ b/tests/unit/macro/test_confidence.py
@@ -11,18 +11,20 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 
 from uw_scan.macro.confidence import compute_confidence
-from uw_scan.macro.contracts import FactorState
+from uw_scan.macro.contracts import FactorState, MacroDomainState
 
 AS_OF = datetime(2026, 8, 21, tzinfo=UTC)
 
 
-def _factor(series_id: str, *, freshness: str = "1.0") -> FactorState:
+def _factor(
+    series_id: str, *, freshness: str = "1.0", value: str = "100"
+) -> FactorState:
     return FactorState(
         name=series_id.lower(),
         causal_role="curve",
         series_id=series_id,
         period_end=date(2026, 8, 14),
-        value=Decimal("100"),
+        value=Decimal(value),
         unit="index_jan_2006_100",
         direction="FLAT",
         change_over_window=Decimal("0"),
@@ -101,3 +103,121 @@ class TestFreshnessTakesTheStalest:
             ("DTWEXBGS", "RTWEXBGS"),
         )
         assert next(r for r in reasons if r.term == "freshness").value == Decimal("0.2")
+
+
+def _prior(factors) -> MacroDomainState:
+    """A prior state carrying ``factors``, for revision detection only.
+
+    Nothing else on the record is read by ``compute_confidence``; the fields exist
+    because the contract is frozen, not because the arithmetic consults them.
+    """
+    return MacroDomainState(
+        domain="usd",
+        state="RANGEBOUND",
+        direction="FLAT",
+        velocity=(),
+        confidence=Decimal(1),
+        confidence_reasons=(),
+        contradictions=(),
+        factors=tuple(factors),
+        evidence_refs=(),
+        engine_version="usd/2",
+        inputs_hash="0" * 12,
+        as_of=AS_OF,
+    )
+
+
+class TestTheDetailNamesTheSetItMeasured:
+    """Completeness counted requirements and reported factors.
+
+    USD and Gold each carry one required anchor beside one optional factor, so both
+    shipped ``2/1 load-bearing inputs present`` to production while the value beneath
+    was a correct 1/1.  A ratio that reads above its own denominator is not a rounding
+    artefact -- it is the numerator and denominator being drawn from different sets,
+    and the half of the pair a reader actually sees was the wrong half.
+    """
+
+    def test_an_optional_factor_does_not_inflate_the_reported_count(self) -> None:
+        _, reasons = _confidence(
+            (_factor("DTWEXBGS"), _factor("RTWEXBGS")), ("DTWEXBGS",)
+        )
+        detail = next(r for r in reasons if r.term == "completeness").detail
+        assert detail.startswith("1/1"), detail
+
+    def test_the_reported_count_never_exceeds_its_own_denominator(self) -> None:
+        _, reasons = _confidence(
+            (_factor("DTWEXBGS"), _factor("RTWEXBGS"), _factor("DTWEXAFEGS")),
+            ("DTWEXBGS",),
+        )
+        detail = next(r for r in reasons if r.term == "completeness").detail
+        assert detail.startswith("1/1"), detail
+
+    def test_the_reported_count_agrees_with_the_value_it_explains(self) -> None:
+        # The pair must never disagree again, whatever the shape of the factor list.
+        _, reasons = _confidence(
+            (_factor("DTWEXBGS"), _factor("DTWEXAFEGS")),
+            ("DTWEXBGS", "RTWEXBGS"),
+        )
+        completeness = next(r for r in reasons if r.term == "completeness")
+        assert completeness.detail.startswith("1/2"), completeness.detail
+        assert completeness.value == Decimal("0.5")
+
+    def test_quality_does_not_report_optional_factors_as_load_bearing(self) -> None:
+        # Quality keeps averaging over everything the engine consumed -- an optional
+        # input the engine read does bear on how reliable the answer is -- so what has
+        # to change is the claim, not the arithmetic.
+        _, reasons = _confidence(
+            (_factor("DTWEXBGS"), _factor("RTWEXBGS")), ("DTWEXBGS",)
+        )
+        detail = next(r for r in reasons if r.term == "quality").detail
+        assert "2" in detail, detail
+        assert "load-bearing" not in detail, detail
+
+
+class TestRevisionPenaltyMeasuresOneSet:
+    """The numerator filtered to required series; the divisor counted every factor.
+
+    A revised anchor beside one optional factor scored 1/2, so the term that exists to
+    punish a revision punished it half as hard -- and the optional factor doing the
+    halving contributed nothing to the state being revised.  It read 0 across all four
+    domains in production only because no series had been revised yet, which is also
+    why no caller-level test could have caught it.
+    """
+
+    def _revision(self, factors, required):
+        return compute_confidence(
+            factors,
+            required_series=required,
+            contradictions=(),
+            contradiction_penalty_each=Decimal("0.15"),
+            contradiction_penalty_cap=Decimal("0.60"),
+            prior_state=_prior((_factor("DTWEXBGS"), _factor("RTWEXBGS"))),
+        )
+
+    def test_a_revised_anchor_beside_an_optional_factor_is_penalised_in_full(
+        self,
+    ) -> None:
+        _, reasons = self._revision(
+            (_factor("DTWEXBGS", value="101"), _factor("RTWEXBGS")), ("DTWEXBGS",)
+        )
+        penalty = next(r for r in reasons if r.term == "revision_penalty")
+        assert penalty.value == Decimal(1), penalty.detail
+
+    def test_an_optional_factors_own_revision_does_not_penalise(self) -> None:
+        # RTWEXBGS is not what the state stands on; a change to it is not a revision
+        # of the answer.
+        _, reasons = self._revision(
+            (_factor("DTWEXBGS"), _factor("RTWEXBGS", value="101")), ("DTWEXBGS",)
+        )
+        assert next(
+            r for r in reasons if r.term == "revision_penalty"
+        ).value == Decimal(0)
+
+    def test_half_a_revised_requirement_set_is_half_a_penalty(self) -> None:
+        _, reasons = self._revision(
+            (_factor("DTWEXBGS", value="101"), _factor("RTWEXBGS")),
+            ("DTWEXBGS", "RTWEXBGS"),
+        )
+        assert next(
+            r for r in reasons if r.term == "revision_penalty"
+        ).value == Decimal("0.5")


### PR DESCRIPTION
## What was wrong

`compute_confidence` drew its terms from two different sets and labelled all of them *load-bearing*. USD and Gold each carry one required anchor beside one optional input, so both shipped this to production:

```
completeness   1   2/1 load-bearing inputs present
```

A ratio above its own denominator. The **value** counted requirements; the **sentence beside it** counted every factor consumed.

| term | numerator | denominator | honest? |
|---|---|---|---|
| `completeness` | required ∩ present | required | arithmetic ✅ / detail ❌ |
| `freshness` | min over all factors | — | ✅ (claims no set) |
| `quality` | all factors | all factors | detail ❌ |
| `revision_penalty` | **required** ∩ revised | **all** factors | **arithmetic ❌** |

## The real defect was `revision_penalty`, not the sentence

Its numerator is filtered to the required set by `revised_series`; its divisor counted every factor. A revised USD anchor beside one optional factor scored `1/2` — **the term that exists to punish a revision punished it half as hard**, and the optional input doing the halving contributes nothing to the state being revised.

It read `0` across all four domains only because no series had been revised yet. That is also why no caller-level test could have caught it: `inflation.py` and `rates.py` pre-filter their factors, so they were correct by accident of their callers — exactly the trap the existing comment at `confidence.py:47` warned about after the *previous* half-fix.

## The decision I made

`freshness` and `quality` keep averaging over everything the engine consumed — an optional input the engine read does bear on how reliable the answer is. A revision is a change to what the state *stood on*, which is the required set by definition. So the arithmetic changed in one place and the claims changed in two.

```
completeness           1     1/1 load-bearing inputs present
quality                1.0   mean publisher quality weight over 2 consumed input(s); 1 of them optional
```

## Why all four engine versions bump

`inflation/2`, `rates/2`, `usd/3`, `gold/2`.

The state *labels* are untouched, but confidence is published on the state record, and a reader comparing it across this line would be comparing two arithmetics. `engine_version` is a read selector — states are keyed `(domain, as_of, engine_version, inputs_hash)`. Publishing changed semantics under an unchanged identity is precisely the defect #377 closed. Stored states under the old versions stay readable with their own semantics.

Two integration tests pinned `"inflation/1"` / `"rates/1"` as literals, which turns a deliberate bump into a failure that reads like a regression. They now assert against the engine constants — that the API round-trips the engine's identity is the thing worth proving.

## Blast radius

**No current production confidence value changes.** Every affected term is either a sentence or currently `0`.

## Docs

The program plan mapped MC1 to PR #359 (it was #348), labelled MC3 `in_progress` after four merged PRs, omitted `usd/2` and `/macro`, and — with its MC4–MC6 child — reserved migrations `117`/`118`, both already taken by the Fundamental lane. Tail is `129`, so **MC4 starts at `130`**. `/macro` is now labelled **MC3.5, a descriptive chain viewer**, not a completed MC4. Also commits the 2026-08-24 executive handover, written against v0.12.16 and never committed.

## Verification

```
uv run pytest tests/unit                 -> 2495 passed
uv run pytest tests/integration          -> 1304 passed, 11 skipped
  (macro subset, uncontended)            -> 77 passed
cd web && npm run test macroDesk         -> 9 passed
uv run ruff check src/ tests/ scripts/   -> clean
```

Written test-first: `test_a_revised_anchor_beside_an_optional_factor_is_penalised_in_full` failed at the predicted `Decimal('0.5')` before the fix.