### PR TITLE
research(macro): MC6 preflight closes the continuous panel as descriptive_only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **MC6 preflight — verdict `descriptive_only`.**
+  `docs/research/2026-08-24-macro-continuous-feature-preflight/` plus
+  `scripts/research/macro_continuous_feature_preflight.py`. Read-only; it replays the engines at
+  historical instants and never touches `macro_domain_states`.
+  - The 2026-08-23 flip census replayed monthly and got 68 points. That clock was a choice — the
+    engines take weekly without complaint (**294/294 instants, three domains, zero errors**). It
+    did not help.
+  - **Information and sample size run in opposite directions here.** The features with the largest
+    effective sample carry none: `usd term.freshness` scores `eff_n` 298 on **two** distinct
+    values, because a high effective sample comes from being noisy rather than informative. Any
+    harness ranking candidates by sample size would select exactly these.
+  - Every economically meaningful feature lands between `eff_n` 0.9 and 27 after the AR(1)
+    correction. `change.DTWEXBGS` — the momentum the entire USD engine rests on, whose threshold
+    PR #377 moved — is **12.8** over 5.6 years. A non-overlapping cross-check independent of the
+    AR(1) model gives ≈22, the same order.
+  - **Longer history does not rescue it and faster sampling is what the correction measures.**
+    Reaching a merely modest `eff_n` of 100 needs 21–57 years for the best features and centuries
+    for the rate levels. The constraint is that these variables move slower than any window a desk
+    will hold, not that our store is short.
+  - 14 of 71 features are constant across all 294 instants, including `term.quality` and
+    `term.revision_penalty` in **every** domain — an independent corroboration of PR #380, since a
+    term that never varied in 5.6 years cannot fail a test that only exercises it.
+  - **One candidate survives and is not endorsed:** release events replay point-in-time —
+    `federal_reserve_fomc` 55 observations across **55** distinct `available_at`, SEP 25/25, CPI
+    family 145 release instants from 2015. Discrete non-overlapping releases escape the overlap
+    death. n≈55–145 is small, surprise/baseline/horizon are unspecified, and it gets its own
+    preflight or it gets dropped.
+  - Gold remains structurally excluded: `GLD_CLOSE` holds 275 periods across **3** availability
+    instants, `GLD_HOLDINGS_OZ` 274 across **1**.
+
+### Changed
+
+- **MC6 over state features is closed, and MC5's hold is now a finding rather than a procedure.**
+  Do not build the walk-forward harness for this panel; the preregistered sample gate fails before
+  a target is even chosen, which is the right place to stop. The risk-monitoring authority boundary
+  is not the conservative option — it is the only one the measurement supports. MC4 proceeds
+  unchanged, which is why the preflight ran in parallel with it rather than after.
+
 ### Fixed
 
 - **Macro confidence now explains the set it actually measured.** `compute_confidence`

--- a/docs/research/2026-08-24-macro-continuous-feature-preflight/VERDICT.md
+++ b/docs/research/2026-08-24-macro-continuous-feature-preflight/VERDICT.md
@@ -1,0 +1,125 @@
+# MC6 preflight — the continuous panel is `descriptive_only`; the event path survives
+
+**Date:** 2026-08-24
+**Reproduce:** `docker exec argon-worker-massive-0-1 python /tmp/macro_continuous_feature_preflight.py`
+(source: `scripts/research/macro_continuous_feature_preflight.py`; copy in with `docker cp`)
+**Full trace:** `census.json` (71 features, 74 series), `features.md` (same, rendered)
+**Window:** 2021-01-04 → 2026-08-18, weekly, 294 instants
+**Writes:** none. `macro_domain_states` was not touched.
+
+## Verdict
+
+**`descriptive_only` for every continuous state feature sampled as a panel.** No window that
+Argon can obtain makes them testable, and sampling faster does not help — it is the thing the
+correction measures.
+
+**Not a blanket verdict on macro.** Release-event samples have a different structure and are
+NOT killed by this measurement. They need their own preflight before anyone concludes anything
+about them.
+
+## What was measured
+
+The 2026-08-23 flip census replayed monthly and got 68 points. That clock was a choice. The
+evidence store's availability structure permits weekly, and the engines take it: **294/294
+instants computed for all three replayable domains, zero errors.** The machinery is fine.
+
+Two numbers per feature. The second decides:
+
+- `points` — how many PIT instants produced a value
+- `eff_n` — `points × (1−ρ)/(1+ρ)`, the AR(1) correction
+
+A slow-moving level read weekly is not one independent observation per read. Reporting `points`
+alone would restate the overlapping-window error the flip census avoided only by accident of
+having chosen a coarse clock.
+
+## The finding: information and sample size are inversely related here
+
+The features with the **largest** effective sample carry **no economic content**:
+
+| feature | distinct values | eff_n |
+|---|---:|---:|
+| `usd term.freshness` | 2 | 298.1 |
+| `policy_rates term.sub_state_confidence:plumbing` | 2 | 294.0 |
+| `usd term.completeness` | 2 | 294.0 |
+
+These are binaries — *was the publisher on time*. Their effective sample is high **because they
+are noisy**, not because they are informative. Any harness ranking candidates by sample size
+would select exactly these and learn nothing.
+
+Every economically meaningful feature sits between `eff_n` 0.9 and 27:
+
+| feature | distinct | ρ | eff_n | window for eff_n = 100 |
+|---|---:|---:|---:|---:|
+| `inflation change.MEDCPIM158SFRBCLE` | 68 | 0.833 | **26.9** | 21.1 years |
+| `inflation change.TRMMEANCPIM158SFRBCLE` | 68 | 0.839 | 25.7 | 22.0 years |
+| `policy_rates level.T10YIE` | 69 | 0.896 | 16.2 | 34.9 years |
+| `usd change.DTWEXBGS` | 247 | 0.913 | **12.8** | 42.1 years |
+| `inflation level.MEDCPIM158SFRBCLE` | 68 | 0.935 | 9.9 | 57.2 years |
+| `policy_rates level.DGS10` | 169 | 0.984 | 2.3 | 248 years |
+| `policy_rates level.SOFR` | 90 | 0.994 | 0.9 | 645 years |
+
+`change.DTWEXBGS` is the momentum the entire USD engine is built on — the quantity whose
+threshold PR #377 moved from p61 to p76. Its effective sample over 5.6 years is **12.8**.
+
+**Cross-check, independent of the AR(1) model:** that feature is a 63-daily-observation change,
+≈13 weeks. Non-overlapping weekly sampling would give 294/13 ≈ **22** points. Same order as
+`eff_n` 12.8, so the correction is not an artefact of assuming AR(1).
+
+**Longer history does not rescue it.** The column above is `100 × (1+ρ)/(1−ρ)` weeks. Reaching a
+merely modest `eff_n` of 100 needs 21–57 years for the best features and centuries for the rate
+levels. The daily series begin 2021 and the CPI family 2015. The constraint is not our store —
+it is that these variables move slower than any window a desk will ever hold.
+
+## 14 of 71 features are constant across all 294 instants
+
+Zero information, including `term.quality` and `term.revision_penalty` in **every** domain.
+
+`revision_penalty` reading 0 across the entire replayed history is a direct, independent
+corroboration of PR #380: its divisor was drawn from the wrong set and nothing caught it,
+because in 294 weekly replays spanning 5.6 years **no series was ever revised in a way the term
+could see**. A term that is structurally constant cannot fail a test that only exercises it.
+
+## What survives: release events are PIT and not autocorrelation-bound
+
+Measured, not assumed:
+
+| event source | observations | distinct `available_at` | span |
+|---|---:|---:|---|
+| `federal_reserve_fomc` | 55 | **55** | 2020-01-30 → 2026-07-30 |
+| `federal_reserve_sep` | 25 | **25** | 2020-06-11 → 2026-06-18 |
+| CPI family (`CPIAUCSL`/`CPILFESL`) | — | **145** | from 2015-01-01 |
+
+One observation per distinct instant means each release carries its own true publication time —
+these replay point-in-time, unlike gold. Discrete non-overlapping releases do not suffer the
+overlap death above: n≈55 (FOMC) to 145 (CPI) is small, but it is a *sample*, not a rolling read
+of one slow number.
+
+This is the only surviving candidate unit. It is **not** endorsed here — surprise definition,
+baseline, and horizon are all unspecified, and a 55-event study has its own power problem. It
+gets its own preflight or it gets dropped.
+
+## Gold is still structurally excluded
+
+`GLD_CLOSE` holds 275 periods across **3** distinct `available_at`; `GLD_HOLDINGS_OZ` holds 274
+periods across **1**. Every historical vintage carries the retrieval clock, so gold cannot be
+replayed before 2026-08-23 by any method. Unchanged from the 2026-08-23 census; migration 119 is
+still the unused promotion mechanism.
+
+## Consequences
+
+1. **MC6 as "empirical promotion research" over state features is closed.** Do not build the
+   walk-forward harness for this panel. The preregistered sample gate fails before a target is
+   even chosen, which is the correct place to stop.
+2. **MC5 has no empirical basis.** Nothing here justifies putting macro into the Fundamental PM
+   surface. Keep it held.
+3. **The risk-monitoring boundary is not the conservative option — it is the only supported
+   one.** These features describe state. Measured over 5.6 years, they cannot carry a forward
+   claim, and MC4's job of refusing to render an incoherent chain is exactly the right use.
+4. **MC4 proceeds unchanged.** It never depended on this result, which is why the preflight was
+   run in parallel.
+
+## What would overturn this
+
+A feature with `eff_n ≥ 100` measured the same way, or a demonstration that the AR(1) correction
+materially understates the independent content of one of these series. Raw `points` is not an
+answer to this file.

--- a/docs/research/2026-08-24-macro-continuous-feature-preflight/census.json
+++ b/docs/research/2026-08-24-macro-continuous-feature-preflight/census.json
@@ -1,0 +1,1401 @@
+{
+  "window": {
+    "start": "2021-01-04T00:00:00+00:00",
+    "end": "2026-08-18T00:00:00+00:00",
+    "step_days": 7
+  },
+  "instants_attempted": 294,
+  "instants_covered": {
+    "inflation": 294,
+    "policy_rates": 294,
+    "usd": 294
+  },
+  "errors": {
+    "inflation": {},
+    "policy_rates": {},
+    "usd": {}
+  },
+  "availability": [
+    {
+      "domain": "gold",
+      "series_id": "GLD_CLOSE",
+      "frequency": "daily",
+      "rows": 825,
+      "periods": 275,
+      "avail_instants": 3,
+      "first_period": "2025-07-21",
+      "last_period": "2026-08-21"
+    },
+    {
+      "domain": "gold",
+      "series_id": "GLD_HOLDINGS_OZ",
+      "frequency": "daily",
+      "rows": 274,
+      "periods": 274,
+      "avail_instants": 1,
+      "first_period": "2025-07-21",
+      "last_period": "2026-08-20"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "T10YIE",
+      "frequency": "daily",
+      "rows": 1412,
+      "periods": 1410,
+      "avail_instants": 1401,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-21"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "CPILFESL",
+      "frequency": "monthly",
+      "rows": 676,
+      "periods": 138,
+      "avail_instants": 145,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "CPIAUCSL",
+      "frequency": "monthly",
+      "rows": 680,
+      "periods": 138,
+      "avail_instants": 145,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "MEDCPIM158SFRBCLE",
+      "frequency": "monthly",
+      "rows": 1029,
+      "periods": 139,
+      "avail_instants": 138,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "TRMMEANCPIM158SFRBCLE",
+      "frequency": "monthly",
+      "rows": 1152,
+      "periods": 139,
+      "avail_instants": 138,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "PCEPI",
+      "frequency": "monthly",
+      "rows": 1097,
+      "periods": 138,
+      "avail_instants": 137,
+      "first_period": "2015-01-01",
+      "last_period": "2026-06-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "MICH",
+      "frequency": "monthly",
+      "rows": 142,
+      "periods": 138,
+      "avail_instants": 137,
+      "first_period": "2015-01-01",
+      "last_period": "2026-06-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "PCEPILFE",
+      "frequency": "monthly",
+      "rows": 1092,
+      "periods": 138,
+      "avail_instants": 137,
+      "first_period": "2015-01-01",
+      "last_period": "2026-06-01"
+    },
+    {
+      "domain": "inflation",
+      "series_id": "CORESTICKM159SFRBATL",
+      "frequency": "monthly",
+      "rows": 858,
+      "periods": 139,
+      "avail_instants": 137,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "EFFR",
+      "frequency": "daily",
+      "rows": 1414,
+      "periods": 1414,
+      "avail_instants": 1412,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-20"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "SOFR",
+      "frequency": "daily",
+      "rows": 1406,
+      "periods": 1406,
+      "avail_instants": 1405,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-20"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "RRPONTSYD",
+      "frequency": "daily",
+      "rows": 1407,
+      "periods": 1407,
+      "avail_instants": 1402,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-21"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "DFII10",
+      "frequency": "daily",
+      "rows": 1409,
+      "periods": 1409,
+      "avail_instants": 1398,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-20"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "DGS10",
+      "frequency": "daily",
+      "rows": 1411,
+      "periods": 1409,
+      "avail_instants": 1398,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-20"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "7-Year|Note",
+      "frequency": "irregular",
+      "rows": 65,
+      "periods": 65,
+      "avail_instants": 65,
+      "first_period": "2021-03-25",
+      "last_period": "2026-07-28"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "5-Year|Note",
+      "frequency": "irregular",
+      "rows": 58,
+      "periods": 58,
+      "avail_instants": 58,
+      "first_period": "2021-08-25",
+      "last_period": "2026-07-27"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "30-Year|Bond",
+      "frequency": "irregular",
+      "rows": 58,
+      "periods": 58,
+      "avail_instants": 58,
+      "first_period": "2012-05-10",
+      "last_period": "2026-08-13"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "3-Year|Note",
+      "frequency": "irregular",
+      "rows": 36,
+      "periods": 36,
+      "avail_instants": 36,
+      "first_period": "2023-09-11",
+      "last_period": "2026-08-11"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "20-Year|Bond",
+      "frequency": "irregular",
+      "rows": 26,
+      "periods": 26,
+      "avail_instants": 26,
+      "first_period": "2020-05-20",
+      "last_period": "2026-08-19"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "2-Year|Note",
+      "frequency": "irregular",
+      "rows": 23,
+      "periods": 23,
+      "avail_instants": 23,
+      "first_period": "2024-08-27",
+      "last_period": "2026-07-27"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "10-Year|Note",
+      "frequency": "irregular",
+      "rows": 22,
+      "periods": 22,
+      "avail_instants": 22,
+      "first_period": "2021-05-12",
+      "last_period": "2026-08-12"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043607|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020601|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "020604|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "044601|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "042601|open_interest",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|dealer_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "043602|lev_money_net",
+      "frequency": "weekly",
+      "rows": 17,
+      "periods": 17,
+      "avail_instants": 17,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|dealer_net",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|lev_money_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|dealer_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|lev_money_net",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|asset_mgr_net",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|open_interest",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "policy_rates",
+      "series_id": "04360Y|asset_mgr_net_pct_oi",
+      "frequency": "weekly",
+      "rows": 11,
+      "periods": 11,
+      "avail_instants": 11,
+      "first_period": "2026-04-28",
+      "last_period": "2026-08-18"
+    },
+    {
+      "domain": "usd",
+      "series_id": "DTWEXBGS",
+      "frequency": "daily",
+      "rows": 4241,
+      "periods": 1405,
+      "avail_instants": 293,
+      "first_period": "2021-01-04",
+      "last_period": "2026-08-14"
+    },
+    {
+      "domain": "usd",
+      "series_id": "RTWEXBGS",
+      "frequency": "monthly",
+      "rows": 7237,
+      "periods": 139,
+      "avail_instants": 90,
+      "first_period": "2015-01-01",
+      "last_period": "2026-07-01"
+    }
+  ],
+  "features": [
+    {
+      "domain": "inflation",
+      "feature": "change.CORESTICKM159SFRBATL",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9741,
+      "eff_n": 3.9,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.CPIAUCSL",
+      "points": 290,
+      "distinct_values": 70,
+      "rho_lag1": 0.9672,
+      "eff_n": 4.8,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.CPILFESL",
+      "points": 290,
+      "distinct_values": 70,
+      "rho_lag1": 0.9558,
+      "eff_n": 6.5,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.MEDCPIM158SFRBCLE",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.8326,
+      "eff_n": 26.9,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.MICH",
+      "points": 294,
+      "distinct_values": 31,
+      "rho_lag1": 0.9289,
+      "eff_n": 10.8,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.PCEPI",
+      "points": 290,
+      "distinct_values": 68,
+      "rho_lag1": 0.9682,
+      "eff_n": 4.7,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.PCEPILFE",
+      "points": 290,
+      "distinct_values": 68,
+      "rho_lag1": 0.9605,
+      "eff_n": 5.8,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "change.TRMMEANCPIM158SFRBCLE",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.839,
+      "eff_n": 25.7,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "confidence",
+      "points": 294,
+      "distinct_values": 22,
+      "rho_lag1": 0.863,
+      "eff_n": 21.6,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "contradiction_count",
+      "points": 294,
+      "distinct_values": 6,
+      "rho_lag1": 0.865,
+      "eff_n": 21.3,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.CORESTICKM159SFRBATL",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9912,
+      "eff_n": 1.3,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.CPIAUCSL",
+      "points": 294,
+      "distinct_values": 71,
+      "rho_lag1": 0.9883,
+      "eff_n": 1.7,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.CPILFESL",
+      "points": 294,
+      "distinct_values": 71,
+      "rho_lag1": 0.99,
+      "eff_n": 1.5,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.MEDCPIM158SFRBCLE",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.935,
+      "eff_n": 9.9,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.MICH",
+      "points": 294,
+      "distinct_values": 30,
+      "rho_lag1": 0.9599,
+      "eff_n": 6.0,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.PCEPI",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9817,
+      "eff_n": 2.7,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.PCEPILFE",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9779,
+      "eff_n": 3.3,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "level.TRMMEANCPIM158SFRBCLE",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9178,
+      "eff_n": 12.6,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "term.completeness",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "inflation",
+      "feature": "term.contradiction_penalty",
+      "points": 294,
+      "distinct_values": 5,
+      "rho_lag1": 0.8686,
+      "eff_n": 20.7,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "term.freshness",
+      "points": 294,
+      "distinct_values": 9,
+      "rho_lag1": 0.737,
+      "eff_n": 44.5,
+      "constant": false
+    },
+    {
+      "domain": "inflation",
+      "feature": "term.quality",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "inflation",
+      "feature": "term.revision_penalty",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "confidence",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.5498,
+      "eff_n": 85.4,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "contradiction_count",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.5498,
+      "eff_n": 85.4,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|asset_mgr_net",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.7408,
+      "eff_n": 2.4,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|asset_mgr_net_pct_oi",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.6874,
+      "eff_n": 3.0,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|dealer_net",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.3442,
+      "eff_n": 7.8,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|dealer_net_pct_oi",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.538,
+      "eff_n": 4.8,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|lev_money_net",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.7229,
+      "eff_n": 2.6,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|lev_money_net_pct_oi",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.6909,
+      "eff_n": 2.9,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.043602|open_interest",
+      "points": 16,
+      "distinct_values": 14,
+      "rho_lag1": 0.4674,
+      "eff_n": 5.8,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.10-Year|Note",
+      "points": 276,
+      "distinct_values": 8,
+      "rho_lag1": 0.9922,
+      "eff_n": 1.1,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.2-Year|Note",
+      "points": 104,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.20-Year|Bond",
+      "points": 294,
+      "distinct_values": 6,
+      "rho_lag1": 0.9876,
+      "eff_n": 1.8,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.3-Year|Note",
+      "points": 154,
+      "distinct_values": 8,
+      "rho_lag1": 0.9533,
+      "eff_n": 3.7,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.30-Year|Bond",
+      "points": 294,
+      "distinct_values": 6,
+      "rho_lag1": 0.9887,
+      "eff_n": 1.7,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.5-Year|Note",
+      "points": 261,
+      "distinct_values": 18,
+      "rho_lag1": 0.9965,
+      "eff_n": 0.5,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.7-Year|Note",
+      "points": 283,
+      "distinct_values": 16,
+      "rho_lag1": 0.9898,
+      "eff_n": 1.5,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.DFII10",
+      "points": 293,
+      "distinct_values": 160,
+      "rho_lag1": 0.9881,
+      "eff_n": 1.8,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.DGS10",
+      "points": 293,
+      "distinct_values": 169,
+      "rho_lag1": 0.9844,
+      "eff_n": 2.3,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.EFFR",
+      "points": 293,
+      "distinct_values": 31,
+      "rho_lag1": 0.994,
+      "eff_n": 0.9,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.FOMC_TARGET_RANGE",
+      "points": 294,
+      "distinct_values": 14,
+      "rho_lag1": 0.9941,
+      "eff_n": 0.9,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.RRPONTSYD",
+      "points": 294,
+      "distinct_values": 290,
+      "rho_lag1": 0.9923,
+      "eff_n": 1.1,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.SEP_FEDERAL_FUNDS_RATE",
+      "points": 294,
+      "distinct_values": 11,
+      "rho_lag1": 0.9905,
+      "eff_n": 1.4,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.SOFR",
+      "points": 293,
+      "distinct_values": 90,
+      "rho_lag1": 0.994,
+      "eff_n": 0.9,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "level.T10YIE",
+      "points": 294,
+      "distinct_values": 69,
+      "rho_lag1": 0.8956,
+      "eff_n": 16.2,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.completeness",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.contradiction_penalty",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.5498,
+      "eff_n": 85.4,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.freshness",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.market_factors_absent",
+      "points": 294,
+      "distinct_values": 3,
+      "rho_lag1": 0.8766,
+      "eff_n": 19.3,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.policy_paths_absent",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.quality",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.revision_penalty",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.sub_state_confidence:plumbing",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": -0.0,
+      "eff_n": 294.0,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.sub_state_confidence:positioning",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.8333,
+      "eff_n": 26.7,
+      "constant": false
+    },
+    {
+      "domain": "policy_rates",
+      "feature": "term.sub_state_confidence:supply",
+      "points": 294,
+      "distinct_values": 11,
+      "rho_lag1": 0.9735,
+      "eff_n": 3.9,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "change.DTWEXBGS",
+      "points": 280,
+      "distinct_values": 247,
+      "rho_lag1": 0.9127,
+      "eff_n": 12.8,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "change.RTWEXBGS",
+      "points": 294,
+      "distinct_values": 68,
+      "rho_lag1": 0.9357,
+      "eff_n": 9.8,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "confidence",
+      "points": 294,
+      "distinct_values": 5,
+      "rho_lag1": 0.2402,
+      "eff_n": 180.1,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "contradiction_count",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.8814,
+      "eff_n": 18.5,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "level.DTWEXBGS",
+      "points": 293,
+      "distinct_values": 258,
+      "rho_lag1": 0.9751,
+      "eff_n": 3.7,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "level.RTWEXBGS",
+      "points": 294,
+      "distinct_values": 66,
+      "rho_lag1": 0.9823,
+      "eff_n": 2.6,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "term.completeness",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": -0.0,
+      "eff_n": 294.0,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "term.contradiction_penalty",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": 0.8814,
+      "eff_n": 18.5,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "term.freshness",
+      "points": 294,
+      "distinct_values": 2,
+      "rho_lag1": -0.0069,
+      "eff_n": 298.1,
+      "constant": false
+    },
+    {
+      "domain": "usd",
+      "feature": "term.quality",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "usd",
+      "feature": "term.real_index_not_substituted",
+      "points": 1,
+      "distinct_values": 1,
+      "rho_lag1": null,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "usd",
+      "feature": "term.required_period_absent_at_as_of",
+      "points": 1,
+      "distinct_values": 1,
+      "rho_lag1": null,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "usd",
+      "feature": "term.revision_penalty",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    },
+    {
+      "domain": "usd",
+      "feature": "term.upstream_policy_rates",
+      "points": 294,
+      "distinct_values": 1,
+      "rho_lag1": 1.0,
+      "eff_n": 1.0,
+      "constant": true
+    }
+  ]
+}

--- a/docs/research/2026-08-24-macro-continuous-feature-preflight/features.md
+++ b/docs/research/2026-08-24-macro-continuous-feature-preflight/features.md
@@ -1,0 +1,154 @@
+# Full feature census (all 71, every domain)
+
+| domain | feature | points | distinct | rho_lag1 | eff_n |
+|---|---|---:|---:|---:|---:|
+| inflation | `term.freshness` | 294 | 9 | 0.737 | 44.5 |
+| inflation | `change.MEDCPIM158SFRBCLE` | 294 | 68 | 0.8326 | 26.9 |
+| inflation | `change.TRMMEANCPIM158SFRBCLE` | 294 | 68 | 0.839 | 25.7 |
+| inflation | `confidence` | 294 | 22 | 0.863 | 21.6 |
+| inflation | `contradiction_count` | 294 | 6 | 0.865 | 21.3 |
+| inflation | `term.contradiction_penalty` | 294 | 5 | 0.8686 | 20.7 |
+| inflation | `level.TRMMEANCPIM158SFRBCLE` | 294 | 68 | 0.9178 | 12.6 |
+| inflation | `change.MICH` | 294 | 31 | 0.9289 | 10.8 |
+| inflation | `level.MEDCPIM158SFRBCLE` | 294 | 68 | 0.935 | 9.9 |
+| inflation | `change.CPILFESL` | 290 | 70 | 0.9558 | 6.5 |
+| inflation | `level.MICH` | 294 | 30 | 0.9599 | 6.0 |
+| inflation | `change.PCEPILFE` | 290 | 68 | 0.9605 | 5.8 |
+| inflation | `change.CPIAUCSL` | 290 | 70 | 0.9672 | 4.8 |
+| inflation | `change.PCEPI` | 290 | 68 | 0.9682 | 4.7 |
+| inflation | `change.CORESTICKM159SFRBATL` | 294 | 68 | 0.9741 | 3.9 |
+| inflation | `level.PCEPILFE` | 294 | 68 | 0.9779 | 3.3 |
+| inflation | `level.PCEPI` | 294 | 68 | 0.9817 | 2.7 |
+| inflation | `level.CPIAUCSL` | 294 | 71 | 0.9883 | 1.7 |
+| inflation | `level.CPILFESL` | 294 | 71 | 0.99 | 1.5 |
+| inflation | `level.CORESTICKM159SFRBATL` | 294 | 68 | 0.9912 | 1.3 |
+| inflation | `term.completeness` | 294 | 1 | 1.0 | 1.0 |
+| inflation | `term.quality` | 294 | 1 | 1.0 | 1.0 |
+| inflation | `term.revision_penalty` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.sub_state_confidence:plumbing` | 294 | 2 | -0.0 | 294.0 |
+| policy_rates | `confidence` | 294 | 2 | 0.5498 | 85.4 |
+| policy_rates | `contradiction_count` | 294 | 2 | 0.5498 | 85.4 |
+| policy_rates | `term.contradiction_penalty` | 294 | 2 | 0.5498 | 85.4 |
+| policy_rates | `term.sub_state_confidence:positioning` | 294 | 2 | 0.8333 | 26.7 |
+| policy_rates | `term.market_factors_absent` | 294 | 3 | 0.8766 | 19.3 |
+| policy_rates | `level.T10YIE` | 294 | 69 | 0.8956 | 16.2 |
+| policy_rates | `level.043602|dealer_net` | 16 | 14 | 0.3442 | 7.8 |
+| policy_rates | `level.043602|open_interest` | 16 | 14 | 0.4674 | 5.8 |
+| policy_rates | `level.043602|dealer_net_pct_oi` | 16 | 14 | 0.538 | 4.8 |
+| policy_rates | `term.sub_state_confidence:supply` | 294 | 11 | 0.9735 | 3.9 |
+| policy_rates | `level.3-Year|Note` | 154 | 8 | 0.9533 | 3.7 |
+| policy_rates | `level.043602|asset_mgr_net_pct_oi` | 16 | 14 | 0.6874 | 3.0 |
+| policy_rates | `level.043602|lev_money_net_pct_oi` | 16 | 14 | 0.6909 | 2.9 |
+| policy_rates | `level.043602|lev_money_net` | 16 | 14 | 0.7229 | 2.6 |
+| policy_rates | `level.043602|asset_mgr_net` | 16 | 14 | 0.7408 | 2.4 |
+| policy_rates | `level.DGS10` | 293 | 169 | 0.9844 | 2.3 |
+| policy_rates | `level.20-Year|Bond` | 294 | 6 | 0.9876 | 1.8 |
+| policy_rates | `level.DFII10` | 293 | 160 | 0.9881 | 1.8 |
+| policy_rates | `level.30-Year|Bond` | 294 | 6 | 0.9887 | 1.7 |
+| policy_rates | `level.7-Year|Note` | 283 | 16 | 0.9898 | 1.5 |
+| policy_rates | `level.SEP_FEDERAL_FUNDS_RATE` | 294 | 11 | 0.9905 | 1.4 |
+| policy_rates | `level.10-Year|Note` | 276 | 8 | 0.9922 | 1.1 |
+| policy_rates | `level.RRPONTSYD` | 294 | 290 | 0.9923 | 1.1 |
+| policy_rates | `level.2-Year|Note` | 104 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.completeness` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.freshness` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.policy_paths_absent` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.quality` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `term.revision_penalty` | 294 | 1 | 1.0 | 1.0 |
+| policy_rates | `level.EFFR` | 293 | 31 | 0.994 | 0.9 |
+| policy_rates | `level.FOMC_TARGET_RANGE` | 294 | 14 | 0.9941 | 0.9 |
+| policy_rates | `level.SOFR` | 293 | 90 | 0.994 | 0.9 |
+| policy_rates | `level.5-Year|Note` | 261 | 18 | 0.9965 | 0.5 |
+| usd | `term.freshness` | 294 | 2 | -0.0069 | 298.1 |
+| usd | `term.completeness` | 294 | 2 | -0.0 | 294.0 |
+| usd | `confidence` | 294 | 5 | 0.2402 | 180.1 |
+| usd | `contradiction_count` | 294 | 2 | 0.8814 | 18.5 |
+| usd | `term.contradiction_penalty` | 294 | 2 | 0.8814 | 18.5 |
+| usd | `change.DTWEXBGS` | 280 | 247 | 0.9127 | 12.8 |
+| usd | `change.RTWEXBGS` | 294 | 68 | 0.9357 | 9.8 |
+| usd | `level.DTWEXBGS` | 293 | 258 | 0.9751 | 3.7 |
+| usd | `level.RTWEXBGS` | 294 | 66 | 0.9823 | 2.6 |
+| usd | `term.quality` | 294 | 1 | 1.0 | 1.0 |
+| usd | `term.real_index_not_substituted` | 1 | 1 | — | 1.0 |
+| usd | `term.required_period_absent_at_as_of` | 1 | 1 | — | 1.0 |
+| usd | `term.revision_penalty` | 294 | 1 | 1.0 | 1.0 |
+| usd | `term.upstream_policy_rates` | 294 | 1 | 1.0 | 1.0 |
+
+# Evidence availability (all series)
+
+| domain | series | freq | rows | periods | avail_instants | first_period | last_period |
+|---|---|---|---:|---:|---:|---|---|
+| gold | `GLD_CLOSE` | daily | 825 | 275 | 3 | 2025-07-21 | 2026-08-21 |
+| gold | `GLD_HOLDINGS_OZ` | daily | 274 | 274 | 1 | 2025-07-21 | 2026-08-20 |
+| inflation | `T10YIE` | daily | 1412 | 1410 | 1401 | 2021-01-04 | 2026-08-21 |
+| inflation | `CPILFESL` | monthly | 676 | 138 | 145 | 2015-01-01 | 2026-07-01 |
+| inflation | `CPIAUCSL` | monthly | 680 | 138 | 145 | 2015-01-01 | 2026-07-01 |
+| inflation | `MEDCPIM158SFRBCLE` | monthly | 1029 | 139 | 138 | 2015-01-01 | 2026-07-01 |
+| inflation | `TRMMEANCPIM158SFRBCLE` | monthly | 1152 | 139 | 138 | 2015-01-01 | 2026-07-01 |
+| inflation | `PCEPI` | monthly | 1097 | 138 | 137 | 2015-01-01 | 2026-06-01 |
+| inflation | `MICH` | monthly | 142 | 138 | 137 | 2015-01-01 | 2026-06-01 |
+| inflation | `PCEPILFE` | monthly | 1092 | 138 | 137 | 2015-01-01 | 2026-06-01 |
+| inflation | `CORESTICKM159SFRBATL` | monthly | 858 | 139 | 137 | 2015-01-01 | 2026-07-01 |
+| policy_rates | `EFFR` | daily | 1414 | 1414 | 1412 | 2021-01-04 | 2026-08-20 |
+| policy_rates | `SOFR` | daily | 1406 | 1406 | 1405 | 2021-01-04 | 2026-08-20 |
+| policy_rates | `RRPONTSYD` | daily | 1407 | 1407 | 1402 | 2021-01-04 | 2026-08-21 |
+| policy_rates | `DFII10` | daily | 1409 | 1409 | 1398 | 2021-01-04 | 2026-08-20 |
+| policy_rates | `DGS10` | daily | 1411 | 1409 | 1398 | 2021-01-04 | 2026-08-20 |
+| policy_rates | `7-Year|Note` | irregular | 65 | 65 | 65 | 2021-03-25 | 2026-07-28 |
+| policy_rates | `5-Year|Note` | irregular | 58 | 58 | 58 | 2021-08-25 | 2026-07-27 |
+| policy_rates | `30-Year|Bond` | irregular | 58 | 58 | 58 | 2012-05-10 | 2026-08-13 |
+| policy_rates | `3-Year|Note` | irregular | 36 | 36 | 36 | 2023-09-11 | 2026-08-11 |
+| policy_rates | `20-Year|Bond` | irregular | 26 | 26 | 26 | 2020-05-20 | 2026-08-19 |
+| policy_rates | `2-Year|Note` | irregular | 23 | 23 | 23 | 2024-08-27 | 2026-07-27 |
+| policy_rates | `10-Year|Note` | irregular | 22 | 22 | 22 | 2021-05-12 | 2026-08-12 |
+| policy_rates | `043602|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043607|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020601|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `020604|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `044601|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|lev_money_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `042601|open_interest` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|asset_mgr_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|asset_mgr_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|dealer_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|dealer_net_pct_oi` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `043602|lev_money_net` | weekly | 17 | 17 | 17 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|dealer_net` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|lev_money_net_pct_oi` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|dealer_net_pct_oi` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|lev_money_net` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|asset_mgr_net` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|open_interest` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| policy_rates | `04360Y|asset_mgr_net_pct_oi` | weekly | 11 | 11 | 11 | 2026-04-28 | 2026-08-18 |
+| usd | `DTWEXBGS` | daily | 4241 | 1405 | 293 | 2021-01-04 | 2026-08-14 |
+| usd | `RTWEXBGS` | monthly | 7237 | 139 | 90 | 2015-01-01 | 2026-07-01 |

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -84,10 +84,29 @@ Reads the evidence store and state records only. Persists the full census before
 - gold is structurally excluded until migration 119 promotes a verified instant for `GLD_CLOSE`
 - **preregister before any fitting:** target, horizon, lag, baseline, minimum-sample gate, kill rule
 
-**Exit:** either a defensible PIT panel with a precise target, or a committed `descriptive_only`
-verdict. Do not fit if the preregistered sample gate fails. Do not backfill replayed states into
-`macro_domain_states` to manufacture sample size — those rows are immutable and would bake in
-today's engine version.
+**DONE 2026-08-24 — verdict `descriptive_only`.**
+`docs/research/2026-08-24-macro-continuous-feature-preflight/VERDICT.md`
+
+The engines replay weekly without complaint (294/294 instants, three domains, zero errors), so the
+flip census's monthly clock was a choice rather than a limit. It did not help. Every economically
+meaningful feature lands between `eff_n` 0.9 and 27 after the AR(1) correction, and the features
+with the LARGEST effective sample are binaries carrying no economic content — `usd term.freshness`
+scores 298 on two distinct values, because high effective sample comes from being noisy, not from
+being informative. `change.DTWEXBGS`, the momentum the whole USD engine rests on, is `eff_n` **12.8**
+over 5.6 years; reaching a merely modest 100 would take 42 years. Longer history does not rescue
+this and neither does faster sampling — that is what the correction measures.
+
+14 of 71 features are constant across all 294 instants, including `term.quality` and
+`term.revision_penalty` in every domain. The latter independently corroborates PR #380: no series
+was revised in a way the term could see across 5.6 years, which is why its broken divisor survived.
+
+**MC6 over state features is closed. Do not build the walk-forward harness for this panel.**
+
+**One candidate survives and is NOT endorsed:** release events replay point-in-time —
+`federal_reserve_fomc` has 55 observations across 55 distinct `available_at` (2020-01-30 onward),
+SEP 25/25, the CPI family 145 release instants from 2015. Discrete non-overlapping releases do not
+suffer the overlap death. n≈55–145 is small and has its own power problem, and surprise definition,
+baseline and horizon are all unspecified. It gets its own preflight or it gets dropped.
 
 ## MC4 — the snapshot is a refusal layer
 
@@ -128,10 +147,11 @@ Four independently reviewable PRs:
 **Exit:** a partial domain failure can never render as a coherent fresh chain; a later evidence
 revision does not change an old snapshot hash; the page no longer fetches four latest states.
 
-## MC5 — held
+## MC5 — held, and now without an empirical basis
 
-Not started, not authorized. Requires the preflight above to produce something other than
-`descriptive_only`, plus a fresh authority decision. If it ever proceeds, it stays removable and must
+Not started, not authorized. It required the preflight above to produce something other than
+`descriptive_only`. It did not. Nothing measured justifies putting macro into the Fundamental PM
+surface, so the hold is no longer procedural — it is the finding. If it ever proceeds, it stays removable and must
 prove byte-invariance of every fundamental fact, score, valuation anchor, and hash with macro on and
 off.
 

--- a/scripts/research/macro_continuous_feature_preflight.py
+++ b/scripts/research/macro_continuous_feature_preflight.py
@@ -1,0 +1,222 @@
+"""Census the continuous features under the macro domain states, before anything is fitted.
+
+READ-ONLY. Replays the engines at historical instants and harvests the CONTINUOUS values
+they carry -- factor levels, factor changes, confidence terms, contradiction counts. It
+never calls ``_persist``: ``macro_domain_states`` rows are immutable and undeletable
+(migration 125), so a speculative replay written to prod could never be taken back.
+
+Why this exists: the 2026-08-23 flip census killed the categorical state label as a
+validation unit (4/8/13 transitions in 68 monthly instants). That census chose a MONTHLY
+clock. The evidence store's availability structure does not require one, and the honest
+question for MC6 is what sample a continuous feature could actually carry.
+
+Two numbers per feature, and the second is the one that decides:
+
+  points      how many PIT instants produced a value
+  eff_n       points adjusted for AR(1) autocorrelation, N*(1-rho)/(1+rho)
+
+A slow-moving level read weekly is not one independent observation per read. Reporting
+``points`` alone would restate the overlapping-window error that the flip census avoided
+by accident.
+
+    docker exec argon-worker-massive-0-1 python /tmp/macro_continuous_feature_preflight.py
+
+Verdict: docs/research/2026-08-24-macro-continuous-feature-preflight/VERDICT.md
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+
+from uw_scan.config import Settings
+from uw_scan.macro.evidence_store import (
+    load_inflation_observations,
+    load_rates_observations,
+    load_usd_observations,
+)
+from uw_scan.macro.inflation import compute_inflation_state
+from uw_scan.macro.policy_report import build_policy_comparison
+from uw_scan.macro.rates import compute_rates_state
+from uw_scan.macro.usd import UpstreamState, compute_usd_state
+from uw_scan.worker.jobs.macro_state_jobs import _attribution, _paths
+from uw_scan.worker.scheduler import _repo
+
+#: Weekly, because that is what the binding publisher supports. DTWEXBGS carries 1,405
+#: daily periods but only 293 distinct ``available_at`` instants over the window -- it is
+#: a weekly release carrying daily observations, so replaying it daily would resample the
+#: same release five times and inflate every count by 5x while adding no information.
+STEP = timedelta(days=7)
+START = datetime(2021, 1, 4, tzinfo=UTC)
+END = datetime(2026, 8, 18, tzinfo=UTC)
+
+#: Evidence availability, measured directly rather than assumed from a contract's declared
+#: frequency. A series whose vintages were backfilled at retrieval time has one instant no
+#: matter how many periods it holds, and that is invisible from ``frequency``.
+AVAILABILITY_SQL = """
+SELECT domain, series_id, frequency,
+       COUNT(*)                     AS rows,
+       COUNT(DISTINCT period_end)   AS periods,
+       COUNT(DISTINCT available_at) AS avail_instants,
+       MIN(period_end)::text        AS first_period,
+       MAX(period_end)::text        AS last_period
+FROM uw_scan.macro_observations
+WHERE quality_status = 'valid'
+GROUP BY 1, 2, 3
+ORDER BY 1, avail_instants DESC
+"""
+
+
+def instants():
+    inst = START
+    while inst <= END:
+        yield inst
+        inst += STEP
+
+
+def harvest(state) -> dict[str, float]:
+    """Every continuous number a domain state carries, flattened to one row."""
+    out: dict[str, float] = {
+        "confidence": float(state.confidence),
+        "contradiction_count": float(len(state.contradictions)),
+    }
+    for term in state.confidence_reasons:
+        out[f"term.{term.term}"] = float(term.value)
+    for factor in state.factors:
+        out[f"level.{factor.series_id}"] = float(factor.value)
+        if factor.change_over_window is not None:
+            out[f"change.{factor.series_id}"] = float(factor.change_over_window)
+    return out
+
+
+def ar1_effective_n(values: list[float]) -> tuple[float, float]:
+    """Return (lag-1 autocorrelation, effective sample size).
+
+    A level sampled faster than it moves carries far less information than its row count
+    claims. N*(1-rho)/(1+rho) is the standard AR(1) correction; it is a floor on honesty,
+    not a precise variance estimate, and a feature that fails it is not rescued by a
+    better estimator.
+    """
+    n = len(values)
+    if n < 3:
+        return (float("nan"), float(n))
+    mean = sum(values) / n
+    dev = [v - mean for v in values]
+    denom = sum(d * d for d in dev)
+    if denom == 0:
+        return (1.0, 1.0)  # a constant carries one observation, whatever its length
+    rho = sum(dev[i] * dev[i + 1] for i in range(n - 1)) / denom
+    rho = max(-0.999, min(0.999, rho))
+    return (rho, n * (1 - rho) / (1 + rho))
+
+
+def main() -> None:
+    settings = Settings.from_env()
+    panels: dict[str, dict[str, list[float]]] = {
+        d: defaultdict(list) for d in ("inflation", "policy_rates", "usd")
+    }
+    errors: dict[str, dict[str, int]] = {d: defaultdict(int) for d in panels}
+    covered: dict[str, int] = defaultdict(int)
+
+    with _repo(settings) as repo:
+        with repo._conn.cursor() as cur:  # noqa: SLF001 - read-only census
+            cur.execute(AVAILABILITY_SQL)
+            cols = [c.name for c in cur.description]
+            availability = [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+        for inst in instants():
+            rates_state = None
+
+            try:
+                infl = compute_inflation_state(
+                    load_inflation_observations(repo, as_of=inst),
+                    as_of=inst,
+                    prior_state=None,
+                )
+                covered["inflation"] += 1
+                for k, v in harvest(infl).items():
+                    panels["inflation"][k].append(v)
+            except Exception as exc:
+                errors["inflation"][type(exc).__name__] += 1
+
+            try:
+                obs = load_rates_observations(repo, as_of=inst)
+                rates_state = compute_rates_state(
+                    _paths(build_policy_comparison(repo, as_of=inst)),
+                    as_of=inst,
+                    observations=obs,
+                    attribution=_attribution(obs, as_of=inst),
+                    prior_state=None,
+                )
+                covered["policy_rates"] += 1
+                for k, v in harvest(rates_state).items():
+                    panels["policy_rates"][k].append(v)
+            except Exception as exc:
+                errors["policy_rates"][type(exc).__name__] += 1
+
+            try:
+                upstream = (
+                    ()
+                    if rates_state is None
+                    else (
+                        UpstreamState(
+                            domain="policy_rates",
+                            state=rates_state.state,
+                            direction=rates_state.direction,
+                            inputs_hash=rates_state.inputs_hash,
+                            as_of=inst,
+                        ),
+                    )
+                )
+                usd = compute_usd_state(
+                    load_usd_observations(repo, as_of=inst),
+                    as_of=inst,
+                    upstream=upstream,
+                    prior_state=None,
+                )
+                covered["usd"] += 1
+                for k, v in harvest(usd).items():
+                    panels["usd"][k].append(v)
+            except Exception as exc:
+                errors["usd"][type(exc).__name__] += 1
+
+    features = []
+    for domain, cols in panels.items():
+        for name, values in sorted(cols.items()):
+            rho, eff = ar1_effective_n(values)
+            distinct = len(set(values))
+            features.append(
+                {
+                    "domain": domain,
+                    "feature": name,
+                    "points": len(values),
+                    "distinct_values": distinct,
+                    "rho_lag1": None if rho != rho else round(rho, 4),
+                    "eff_n": round(eff, 1),
+                    "constant": distinct <= 1,
+                }
+            )
+
+    print(
+        json.dumps(
+            {
+                "window": {
+                    "start": START.isoformat(),
+                    "end": END.isoformat(),
+                    "step_days": 7,
+                },
+                "instants_attempted": sum(1 for _ in instants()),
+                "instants_covered": dict(covered),
+                "errors": {d: dict(e) for d, e in errors.items()},
+                "availability": availability,
+                "features": features,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_macro_continuous_feature_preflight.py
+++ b/tests/unit/test_macro_continuous_feature_preflight.py
@@ -1,0 +1,57 @@
+"""The AR(1) correction, tested directly — it is the pivot of the MC6 verdict.
+
+`eff_n` is the only number that separates "294 weekly reads" from "12.8 independent
+observations", and the whole `descriptive_only` verdict turns on it. A wrong correction
+would not fail anything else in the repo: the script prints, the doc quotes the print,
+and nobody would know.
+"""
+
+from __future__ import annotations
+
+import math
+
+from scripts.research.macro_continuous_feature_preflight import ar1_effective_n
+
+
+class TestASlowSeriesCarriesFewerObservationsThanItsLength:
+    def test_a_constant_carries_exactly_one(self) -> None:
+        # Not zero: reading the same number 300 times is one observation, not none.
+        rho, eff = ar1_effective_n([5.0] * 300)
+        assert (rho, eff) == (1.0, 1.0)
+
+    def test_a_monotone_ramp_is_worth_a_fraction_of_its_length(self) -> None:
+        rho, eff = ar1_effective_n([float(i) for i in range(300)])
+        assert rho > 0.95
+        assert eff < 10, (
+            f"a 300-point ramp scored {eff}; it is one trend, not 300 draws"
+        )
+
+    def test_an_alternating_series_is_worth_more_than_its_length(self) -> None:
+        # Negative autocorrelation genuinely carries more than N independent draws.
+        rho, eff = ar1_effective_n([1.0, -1.0] * 150)
+        assert rho < -0.95
+        assert eff > 300
+
+    def test_too_short_to_estimate_returns_the_raw_count(self) -> None:
+        rho, eff = ar1_effective_n([1.0, 2.0])
+        assert math.isnan(rho)
+        assert eff == 2.0
+
+
+class TestTheVerdictsCitedNumbersReproduce:
+    """The doc quotes measured values; this pins the arithmetic behind them.
+
+    Measured 2026-08-24 over 294 weekly instants, 2021-01-04..2026-08-18.
+    """
+
+    def test_dtwexbgs_momentum_scores_about_thirteen(self) -> None:
+        # rho as measured for `usd change.DTWEXBGS`, the quantity the USD engine's
+        # threshold sits on. 280 points is what the replay actually produced.
+        eff = 280 * (1 - 0.9127) / (1 + 0.9127)
+        assert 12.5 < eff < 13.0, eff
+
+    def test_reaching_a_modest_effective_hundred_takes_decades(self) -> None:
+        weeks = 100 * (1 + 0.9127) / (1 - 0.9127)
+        assert weeks / 52 > 40, (
+            "the verdict claims 42 years; a shorter answer changes it"
+        )


### PR DESCRIPTION
Runs P0-c of `docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md`, in parallel with MC4 as that plan specifies.

**Verdict: `descriptive_only`.** Read-only — the script never calls `_persist`, because `macro_domain_states` rows are immutable and undeletable and a speculative replay could not be taken back.

## The monthly clock was a choice, and changing it did not help

The 2026-08-23 flip census replayed monthly and got 68 points. The engines take **weekly** without complaint — **294/294 instants, three domains, zero errors**. The machinery was never the problem.

## Information and sample size run in opposite directions here

Features with the **largest** effective sample carry **none**:

| feature | distinct values | eff_n |
|---|---:|---:|
| `usd term.freshness` | **2** | 298.1 |
| `policy_rates term.sub_state_confidence:plumbing` | **2** | 294.0 |
| `usd term.completeness` | **2** | 294.0 |

These are binaries — *was the publisher on time*. Their effective sample is high **because they are noisy**. A harness ranking candidates by sample size would select exactly these.

Every economically meaningful feature lands between `eff_n` 0.9 and 27:

| feature | distinct | ρ | eff_n | window for eff_n=100 |
|---|---:|---:|---:|---:|
| `inflation change.MEDCPIM158SFRBCLE` | 68 | 0.833 | **26.9** | 21.1 y |
| `policy_rates level.T10YIE` | 69 | 0.896 | 16.2 | 34.9 y |
| `usd change.DTWEXBGS` | 247 | 0.913 | **12.8** | 42.1 y |
| `policy_rates level.SOFR` | 90 | 0.994 | 0.9 | 645 y |

`change.DTWEXBGS` is the momentum the entire USD engine rests on — the quantity whose threshold #377 moved from p61 to p76. Over 5.6 years its effective sample is **12.8**.

**Cross-check independent of the AR(1) model:** it is a 63-daily-observation change ≈ 13 weeks, so non-overlapping weekly sampling gives 294/13 ≈ **22**. Same order — the correction is not a modelling artefact.

**Neither more history nor faster sampling rescues it.** Faster sampling is precisely what the correction measures. The constraint is that these variables move slower than any window a desk will hold.

## An independent corroboration of #380

14 of 71 features are constant across all 294 instants, including `term.quality` and `term.revision_penalty` in **every** domain.

`revision_penalty` reading 0 across 5.6 years of replay is why its broken divisor survived — **no series was ever revised in a way the term could see**. A structurally constant term cannot fail a test that only exercises it.

## One candidate survives, and it is not endorsed

Release events replay point-in-time — measured, not assumed:

| source | observations | distinct `available_at` | span |
|---|---:|---:|---|
| `federal_reserve_fomc` | 55 | **55** | 2020-01-30 → 2026-07-30 |
| `federal_reserve_sep` | 25 | **25** | 2020-06-11 → 2026-06-18 |
| CPI family | — | **145** | from 2015-01-01 |

One observation per distinct instant means each release carries its own true publication time. Discrete non-overlapping releases escape the overlap death. n≈55–145 is small, has its own power problem, and surprise/baseline/horizon are all unspecified. **It gets its own preflight or it gets dropped.**

Gold stays structurally excluded: `GLD_CLOSE` 275 periods across **3** availability instants, `GLD_HOLDINGS_OZ` 274 across **1**.

## Consequences

1. **MC6 over state features is closed** — do not build the walk-forward harness for this panel. The sample gate fails before a target is even chosen, which is the right place to stop.
2. **MC5's hold stops being procedural and becomes the finding.**
3. **Risk-monitoring is not the conservative boundary — it is the only supported one.**
4. **MC4 proceeds unchanged**, which is why this ran in parallel rather than after.

## Verification

```
uv run pytest tests/unit                -> 2501 passed
uv run ruff check src/ tests/ scripts/  -> clean
```

`ar1_effective_n` is tested directly: the whole verdict turns on it, and a wrong correction would fail nothing else in the repo — the script prints, the doc quotes the print.

**Full trace persisted:** `census.json` (71 features, 74 series) + `features.md`. Reproduce command in the VERDICT header.