### PR TITLE
feat(macro): the context snapshot contract, schema and storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **The macro context snapshot — contract, schema and storage** (migration `130`). First of
+  four slices; this one is persistence only, and nothing assembles or reads a snapshot yet.
+  - **What was missing.** The four domain states are each individually honest: they record what
+    they stood on, and `macro_domain_state_dependencies` (migration 128) already records
+    state → state edges. No table said the four belong *together*. So `/macro` composes four
+    independent latest reads, and the nightly worker — which does use one `as_of` and the right
+    causal order — catches each domain's exception and continues. **A failed rates job lets USD
+    read the previous rates state** (still satisfying `available_at <= as_of`), persist a new USD
+    state citing it, and gold consume the mixture. Four cards render fresh and nothing can tell.
+  - **The snapshot exists to refuse, never to repair.** It may not substitute a fresher upstream
+    to make a chain look coherent. Substitution is how a monitoring layer becomes a fabrication
+    layer, and it is the one property that must not be traded for a tidier page.
+  - Status will be decided by **dependency-edge identity** — does the upstream `state_id` a
+    downstream actually cited equal the one this snapshot holds for that domain — never by
+    timestamp proximity. Migration 128 already stores those edges, so the check reads them
+    rather than inferring anything from clocks.
+  - Four statuses stay distinguishable on purpose: `complete`, `partial`, `incompatible`,
+    `stale`. *"Rates never ran"* and *"rates ran but USD ignored it"* are both refusals and call
+    for different operator actions, so collapsing them to one "degraded" would destroy the only
+    thing the status is for.
+  - **Absence is the lack of a row, never a row carrying a null** — `state_id` is `NOT NULL`. A
+    nullable one would make every reader decide again what a null meant, and one of them would
+    decide it meant zero.
+  - `inputs_hash` covers the domain state **identities** plus the assembler's parameters, so a
+    nightly rerun over unchanged states is a no-op rather than a second opinion, and a later
+    evidence revision cannot change a stored snapshot's hash — a revision produces a new state
+    rather than editing one.
+  - `fetch_macro_context_snapshot_as_of` returns `None` before any snapshot existed rather than
+    an empty snapshot: an invented *"we knew nothing"* row is a claim Argon never made, and a
+    reader cannot tell one from a real refusal.
+  - Both tables are enrolled in the gap-healer registry as unhealable (151 → **153 datasets**).
+    A healer that invented a missing snapshot would be asserting that four domains once agreed,
+    which is precisely the claim this table exists to be able to refuse.
+
+### Added
+
 - **Evidence invalidation, designed** —
   `docs/superpowers/specs/2026-08-24-macro-evidence-invalidation-design.md`. Not implemented, and
   deliberately deprioritized behind MC4; see below.

--- a/docs/runbooks/data-gap-dataset-policy.md
+++ b/docs/runbooks/data-gap-dataset-policy.md
@@ -6,7 +6,7 @@ Generated from `REGISTRY` in `src/uw_scan/reports/data_gap_healer.py` (one sourc
 uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_policy_markdown as r; open('docs/runbooks/data-gap-dataset-policy.md','w').write(r())"
 ```
 
-**151 datasets** across 11 groups.
+**153 datasets** across 11 groups.
 
 ## core_watchlist
 
@@ -69,6 +69,8 @@ uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_pol
 
 | table | audit_mode | provider | granularity | adapter | freq | reason | verified |
 |---|---|---|---|---|---|---|---|
+| macro_context_snapshot_domains | provenance | none | none |  | none | edges of an immutable snapshot; they are written once with their parent and have no independent existence to heal |  |
+| macro_context_snapshots | provenance | none | none |  | none | immutable record of a four-domain composition at an instant; reassembly belongs to the snapshot job, and inventing one would assert a coherence that was never observed |  |
 | macro_domain_state_dependencies | provenance | none | none |  | none | immutable state-level lineage (migration 128); a synthesized edge would claim one domain consulted another's answer when it never did, which is a worse failure than a missing edge because it reads as provenance |  |
 | macro_domain_state_evidence | provenance | none | none |  | none | immutable observation-level lineage for a state; a synthesized row would claim a state stood on evidence it never saw |  |
 | macro_domain_states | provenance | none | none |  | none | immutable record of a decision at an instant; recomputation belongs to the state job, which stamps its own computed_at, and the write guard rejects any edit to a stored answer |  |

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -163,7 +163,7 @@ and a later evidence revision cannot change an old snapshot's hash.
 
 Four independently reviewable PRs:
 
-1. contract + migration `130` + repository
+1. contract + migration `130` + repository — **DONE 2026-08-24**, PR pending
 2. assembler + worker job + API (current and `?as_of_ts=` replay)
 3. UI reads one snapshot; replay / delta / lazy evidence drawer
 4. real persisted verification: worker → DB → API → browser

--- a/src/uw_scan/macro/snapshot.py
+++ b/src/uw_scan/macro/snapshot.py
@@ -1,0 +1,98 @@
+"""The macro context snapshot: four domain answers held as ONE answer.
+
+The four domain states already exist and already record what they stood on. What did not
+exist is the object that says they belong together. Without it ``/macro`` composes four
+independent latest reads, and the nightly worker -- which does use one ``as_of`` and the
+right causal order -- catches each domain's exception and continues. So a failed rates job
+lets USD read the PREVIOUS rates state (still satisfying ``available_at <= as_of``),
+persist a new USD state citing it, and gold consume the mixture. Four cards render fresh.
+
+**A snapshot's job is to REFUSE, never to repair.** It may not substitute a fresher
+upstream to make a chain look coherent; it names the incompatibility and lets the reader
+see it. Substitution is how a monitoring layer becomes a fabrication layer, and it is the
+one property of this object that must not be traded away for a tidier page.
+
+Status is decided by dependency-edge IDENTITY, not by timestamp proximity: a downstream
+state is compatible when the upstream ``state_id`` it actually cited is the one this
+snapshot holds for that upstream's domain. ``macro_domain_state_dependencies``
+(migration 128) already records those edges, so the check reads them rather than inferring
+anything from clocks.
+
+The assembler that computes the status lives in the next slice; this module is the shape
+it produces and the storage layer consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+#: Worst-finding-wins, in this order. ``complete`` is the only one a reader may treat as a
+#: coherent chain; the other three are refusals of different shapes and must stay
+#: distinguishable, because "rates never ran" and "rates ran but USD ignored it" call for
+#: different operator actions.
+SnapshotStatus = Literal["complete", "partial", "incompatible", "stale"]
+
+#: Why a domain is not contributing a compatible answer.
+ReasonKind = Literal["absent", "incompatible", "stale"]
+
+#: Causal order. The snapshot stores an explicit ordinal rather than relying on this tuple
+#: at read time, so a stored snapshot keeps the order it was assembled with even if the
+#: chain is ever reordered.
+CAUSAL_ORDER: tuple[str, ...] = ("inflation", "policy_rates", "usd", "gold")
+
+
+@dataclass(frozen=True)
+class SnapshotReason:
+    """One named defect, attributed to the domain that carries it.
+
+    ``detail`` is free text for an operator, not a parse target. The pair a consumer
+    branches on is ``(domain, kind)``.
+    """
+
+    domain: str
+    kind: ReasonKind
+    detail: str
+
+    def as_json(self) -> dict[str, str]:
+        return {"domain": self.domain, "kind": self.kind, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class SnapshotDomain:
+    """One domain's answer, pinned by state id.
+
+    Absence is the LACK of one of these, never one carrying a null state. A nullable
+    ``state_id`` would make every reader decide again what a null meant, and one of them
+    would decide it meant zero.
+    """
+
+    domain: str
+    state_id: int
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class MacroContextSnapshot:
+    """Four domain answers, their compatibility verdict, and the identity that reproduces it.
+
+    ``inputs_hash`` covers the state identities and the assembler's parameters, so
+    re-assembling the same instant from the same states is a no-op rather than a second
+    opinion. A later evidence revision cannot change a stored snapshot's hash: the hash is
+    over state IDENTITIES, and a revision produces a new state rather than editing one.
+    """
+
+    as_of: datetime
+    assembled_at: datetime
+    status: SnapshotStatus
+    domains: tuple[SnapshotDomain, ...]
+    inputs_hash: str
+    assembler_version: str
+    reasons: tuple[SnapshotReason, ...] = field(default_factory=tuple)
+
+    def domain_state_id(self, domain: str) -> int | None:
+        return next((d.state_id for d in self.domains if d.domain == domain), None)
+
+    def reason_for(self, domain: str) -> SnapshotReason | None:
+        return next((r for r in self.reasons if r.domain == domain), None)

--- a/src/uw_scan/reports/data_gap_healer.py
+++ b/src/uw_scan/reports/data_gap_healer.py
@@ -541,6 +541,34 @@ REGISTRY: list[DatasetRegistryEntry] = [
             "any edit to a stored answer"
         ),
     ),
+    # The context snapshot and its domain edges (migration 130). A snapshot is the same
+    # kind of object as the states it holds -- an immutable record of what we concluded at
+    # an instant -- so it heals the same way they do, which is not at all. Worse: a healer
+    # that invented a missing snapshot would be asserting that four domains once agreed,
+    # which is precisely the claim this table exists to be able to REFUSE.
+    DatasetRegistryEntry(
+        "macro_context_snapshots",
+        "macro_evidence",
+        "provenance",
+        expected_frequency="none",
+        source_system="derived",
+        reason=(
+            "immutable record of a four-domain composition at an instant; reassembly "
+            "belongs to the snapshot job, and inventing one would assert a coherence "
+            "that was never observed"
+        ),
+    ),
+    DatasetRegistryEntry(
+        "macro_context_snapshot_domains",
+        "macro_evidence",
+        "provenance",
+        expected_frequency="none",
+        source_system="derived",
+        reason=(
+            "edges of an immutable snapshot; they are written once with their parent and "
+            "have no independent existence to heal"
+        ),
+    ),
     DatasetRegistryEntry(
         "macro_domain_state_evidence",
         "macro_evidence",

--- a/src/uw_scan/storage/macro_context_snapshot.py
+++ b/src/uw_scan/storage/macro_context_snapshot.py
@@ -1,0 +1,143 @@
+"""Persistence for the macro context snapshot (migration 130).
+
+Separate module rather than an extension of ``repository.py``: a new domain gets its own
+seam from method one, which is the rule ``repository.py`` exists to demonstrate the cost of
+ignoring.
+
+The write is idempotent on ``(as_of, assembler_version, inputs_hash)``. A nightly rerun
+over unchanged states must return the existing snapshot rather than manufacture a second
+identical answer, and the domain rows are written only when the snapshot row is new -- so a
+rerun cannot append a duplicate edge either.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from uw_scan.macro.snapshot import MacroContextSnapshot
+
+
+def _require_aware(field: str, value: datetime) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+
+
+class _MacroContextSnapshotMixin:
+    _conn: psycopg.Connection
+    _schema: str
+
+    def insert_macro_context_snapshot(self, snapshot: MacroContextSnapshot) -> int:
+        """Persist a snapshot and its domain rows; return the snapshot id.
+
+        Re-inserting the same identity returns the id already stored. The domain rows are
+        inserted only alongside a NEW snapshot row: writing them on the idempotent path
+        would either duplicate the edges or require an upsert whose conflict behaviour is a
+        second place for the two writes to disagree.
+        """
+        _require_aware("as_of", snapshot.as_of)
+        _require_aware("assembled_at", snapshot.assembled_at)
+
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.macro_context_snapshots
+                  (as_of, assembled_at, status, status_reasons_jsonb,
+                   inputs_hash, assembler_version)
+                VALUES (%s, %s, %s, %s::jsonb, %s, %s)
+                ON CONFLICT (as_of, assembler_version, inputs_hash) DO NOTHING
+                RETURNING snapshot_id
+                """,
+                (
+                    snapshot.as_of,
+                    snapshot.assembled_at,
+                    snapshot.status,
+                    json.dumps([r.as_json() for r in snapshot.reasons]),
+                    snapshot.inputs_hash,
+                    snapshot.assembler_version,
+                ),
+            )
+            row = cur.fetchone()
+            if row is None:
+                cur.execute(
+                    f"""
+                    SELECT snapshot_id FROM {self._schema}.macro_context_snapshots
+                    WHERE as_of = %s AND assembler_version = %s AND inputs_hash = %s
+                    """,
+                    (snapshot.as_of, snapshot.assembler_version, snapshot.inputs_hash),
+                )
+                existing = cur.fetchone()
+                if existing is None:  # pragma: no cover - a row that conflicted must exist
+                    raise RuntimeError("snapshot conflicted but could not be read back")
+                return int(existing["snapshot_id"])
+
+            snapshot_id = int(row["snapshot_id"])
+            cur.executemany(
+                f"""
+                INSERT INTO {self._schema}.macro_context_snapshot_domains
+                  (snapshot_id, domain, state_id, ordinal)
+                VALUES (%s, %s, %s, %s)
+                """,
+                [
+                    (snapshot_id, d.domain, d.state_id, d.ordinal)
+                    for d in snapshot.domains
+                ],
+            )
+            return snapshot_id
+
+    def fetch_macro_context_snapshot(self, snapshot_id: int) -> dict[str, Any] | None:
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"SELECT * FROM {self._schema}.macro_context_snapshots WHERE snapshot_id = %s",
+                (snapshot_id,),
+            )
+            return cur.fetchone()
+
+    def fetch_macro_context_snapshot_as_of(
+        self, as_of: datetime
+    ) -> dict[str, Any] | None:
+        """The newest snapshot answering for a time at or before ``as_of``.
+
+        Returns ``None`` before any snapshot existed rather than an empty snapshot. An
+        invented "we knew nothing" row would be a claim Argon never made, and a reader
+        cannot tell one from a real refusal.
+        """
+        _require_aware("as_of", as_of)
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT * FROM {self._schema}.macro_context_snapshots
+                WHERE as_of <= %s
+                ORDER BY as_of DESC, assembled_at DESC, snapshot_id DESC
+                LIMIT 1
+                """,
+                (as_of,),
+            )
+            return cur.fetchone()
+
+    def fetch_macro_context_snapshot_domains(
+        self, snapshot_id: int
+    ) -> list[dict[str, Any]]:
+        """The domain answers a snapshot holds, in the causal order it was assembled with.
+
+        Joins each domain state's own answer, because "the snapshot holds state 41" is not
+        yet useful -- what that state SAID is what a reader is after.
+        """
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                f"""
+                SELECT sd.domain, sd.state_id, sd.ordinal,
+                       s.state, s.direction, s.confidence,
+                       s.as_of AS state_as_of, s.engine_version, s.inputs_hash
+                FROM {self._schema}.macro_context_snapshot_domains sd
+                JOIN {self._schema}.macro_domain_states s ON s.state_id = sd.state_id
+                WHERE sd.snapshot_id = %s
+                ORDER BY sd.ordinal
+                """,
+                (snapshot_id,),
+            )
+            return [dict(row) for row in cur.fetchall()]

--- a/src/uw_scan/storage/migrations/130_macro_context_snapshots.sql
+++ b/src/uw_scan/storage/migrations/130_macro_context_snapshots.sql
@@ -1,0 +1,72 @@
+-- 130_macro_context_snapshots.sql — four domain answers held as ONE answer.
+--
+-- MC2/MC3 landed macro_domain_states (the answer), macro_domain_state_evidence
+-- (state -> observation) and macro_domain_state_dependencies (state -> state). Each domain
+-- is therefore individually honest. What no table said is that four of them belong
+-- together, so /macro composed four independent latest reads and the nightly worker --
+-- which does use one as_of and the right causal order -- catches each domain's exception
+-- and continues. A failed rates job lets USD read the PREVIOUS rates state (still
+-- satisfying available_at <= as_of), persist a new USD state citing it, and gold consume
+-- the mixture. Four cards render fresh and nothing can tell.
+--
+-- The snapshot exists to REFUSE. It never substitutes a fresher upstream to make a chain
+-- look coherent; it records which domain broke the chain and how. Status is decided by
+-- dependency-edge IDENTITY (does the upstream state_id a downstream actually cited equal
+-- the one this snapshot holds for that domain), never by timestamp proximity.
+--
+-- The plan that first specified this reserved 117. The Fundamental lane took 117 and 118
+-- long before it was written, so read the migration tail, never a plan's reservation.
+--
+-- Additive only. Nothing in 125 or 128 is altered.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.macro_context_snapshots (
+  snapshot_id          BIGSERIAL   PRIMARY KEY,
+  as_of                TIMESTAMPTZ NOT NULL,
+  assembled_at         TIMESTAMPTZ NOT NULL,
+  -- Four shapes, deliberately distinguishable. "rates never ran" and "rates ran but USD
+  -- ignored it" are both refusals and call for different operator actions, so collapsing
+  -- them to a single "degraded" would destroy the only thing the status is for.
+  status               TEXT        NOT NULL
+    CHECK (status IN ('complete', 'partial', 'incompatible', 'stale')),
+  -- [{domain, kind, detail}]. A refusal nobody can read is not a refusal.
+  status_reasons_jsonb JSONB       NOT NULL DEFAULT '[]'::JSONB
+    CHECK (jsonb_typeof(status_reasons_jsonb) = 'array'),
+  -- Over the domain state IDENTITIES plus the assembler's parameters. A later evidence
+  -- revision cannot change a stored snapshot's hash, because a revision produces a NEW
+  -- state rather than editing one.
+  inputs_hash          TEXT        NOT NULL
+    CHECK (inputs_hash ~ '^[0-9a-f]{64}$'),
+  assembler_version    TEXT        NOT NULL CHECK (btrim(assembler_version) <> ''),
+  -- A snapshot cannot be assembled before the instant it answers for. The same shape as
+  -- macro_domain_states' own computed_at >= as_of guard.
+  CHECK (assembled_at >= as_of),
+  -- Same question (as_of), same method (assembler_version), same inputs -> one row. A
+  -- nightly rerun over unchanged states is a no-op, not a second opinion.
+  UNIQUE (as_of, assembler_version, inputs_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_macro_context_snapshots_replay
+  ON uw_scan.macro_context_snapshots (as_of DESC, assembled_at DESC);
+
+CREATE TABLE IF NOT EXISTS uw_scan.macro_context_snapshot_domains (
+  snapshot_id BIGINT  NOT NULL
+    REFERENCES uw_scan.macro_context_snapshots (snapshot_id) ON DELETE RESTRICT,
+  domain      TEXT    NOT NULL
+    CHECK (domain IN ('inflation', 'policy_rates', 'usd', 'gold')),
+  -- NOT NULL on purpose. Absence is the LACK of a row, never a row carrying a null: a
+  -- nullable state_id would make every reader decide again what a null meant, and one of
+  -- them would decide it meant zero.
+  state_id    BIGINT  NOT NULL
+    REFERENCES uw_scan.macro_domain_states (state_id) ON DELETE RESTRICT,
+  -- Stored rather than derived from a constant at read time, so a snapshot keeps the
+  -- causal order it was assembled with even if the chain is ever reordered.
+  ordinal     INTEGER NOT NULL CHECK (ordinal >= 0),
+  -- Two answers for one domain in one snapshot is two snapshots.
+  PRIMARY KEY (snapshot_id, domain),
+  UNIQUE (snapshot_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS idx_macro_context_snapshot_domains_state
+  ON uw_scan.macro_context_snapshot_domains (state_id);

--- a/src/uw_scan/storage/repository.py
+++ b/src/uw_scan/storage/repository.py
@@ -34,6 +34,7 @@ from .health import _HealthMixin
 from .jobs import _JobsMixin
 from .market_data import _MarketDataMixin
 from .macro_context import _MacroContextMixin
+from .macro_context_snapshot import _MacroContextSnapshotMixin
 from .macro_domain_state import _MacroDomainStateMixin
 from .macro_series_observations import _MacroSeriesObservationMixin
 from .macro_policy_observations import _MacroPolicyObservationMixin
@@ -124,6 +125,7 @@ class Repository(
     _JobsMixin,
     _MarketDataMixin,
     _MacroContextMixin,
+    _MacroContextSnapshotMixin,
     _MacroDomainStateMixin,
     _MacroPolicyObservationMixin,
     _MacroSeriesObservationMixin,

--- a/tests/integration/storage/test_macro_context_snapshot_repository.py
+++ b/tests/integration/storage/test_macro_context_snapshot_repository.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 
 import psycopg
 import pytest

--- a/tests/integration/storage/test_macro_context_snapshot_repository.py
+++ b/tests/integration/storage/test_macro_context_snapshot_repository.py
@@ -1,0 +1,225 @@
+"""Persistence contract for the macro context snapshot (migration 130).
+
+The four domain states already exist and already record what they stood on. What did not
+exist is a row that says "these four, together, are one answer" -- so the page composed
+four independent latest reads and could render a partially-failed chain as four fresh
+cards. The snapshot is the object that can refuse.
+
+These tests fix the properties that make the refusal trustworthy: a snapshot names states
+that exist, holds each domain at most once, cannot be assembled before the instant it
+answers for, and re-assembling the same identity is a no-op rather than a second opinion.
+
+The states are real: core PCE for June 2023 was 128.311 (2017=100), published 2023-07-28,
+frozen in ``tests/fixtures/macro/inflation_rates_golden.json``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from uw_scan.macro.snapshot import MacroContextSnapshot, SnapshotDomain, SnapshotReason
+from uw_scan.storage.repository import Repository
+
+from .test_macro_domain_state_repository import _insert_observation, _state
+
+AS_OF = datetime(2023, 7, 28, 23, 59, tzinfo=UTC)
+ASSEMBLED_AT = datetime(2023, 7, 29, 3, 0, tzinfo=UTC)
+ASSEMBLER = "snapshot/1"
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
+
+
+def _state_id(repo: Repository, domain: str, *, inputs_hash: str) -> int:
+    """Persist one domain state and return its id.
+
+    Every domain rides the inflation fixture's observation: this file tests the SNAPSHOT's
+    contract, and which series a state stood on is the state's own contract, already
+    covered next door.
+    """
+    obs_id = _insert_observation(repo)
+    state = _state(obs_ids=[obs_id], inputs_hash=inputs_hash)
+    return repo.insert_macro_domain_state(
+        replace(state, domain=domain), computed_at=ASSEMBLED_AT
+    )
+
+
+def _snapshot(
+    *,
+    domains: tuple[SnapshotDomain, ...],
+    status: str = "complete",
+    as_of: datetime = AS_OF,
+    assembled_at: datetime = ASSEMBLED_AT,
+    inputs_hash: str = "c" * 64,
+    reasons: tuple[SnapshotReason, ...] = (),
+) -> MacroContextSnapshot:
+    return MacroContextSnapshot(
+        as_of=as_of,
+        assembled_at=assembled_at,
+        status=status,
+        reasons=reasons,
+        domains=domains,
+        inputs_hash=inputs_hash,
+        assembler_version=ASSEMBLER,
+    )
+
+
+class TestASnapshotIsOneAnswer:
+    def test_it_round_trips_with_its_domain_rows(self, repo: Repository) -> None:
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        rates = _state_id(repo, "policy_rates", inputs_hash="b" * 64)
+        snap_id = repo.insert_macro_context_snapshot(
+            _snapshot(
+                domains=(
+                    SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),
+                    SnapshotDomain(domain="policy_rates", state_id=rates, ordinal=1),
+                )
+            )
+        )
+
+        row = repo.fetch_macro_context_snapshot(snap_id)
+        assert row is not None
+        assert row["status"] == "complete"
+        assert row["as_of"] == AS_OF
+        got = repo.fetch_macro_context_snapshot_domains(snap_id)
+        assert [(d["domain"], d["state_id"]) for d in got] == [
+            ("inflation", infl),
+            ("policy_rates", rates),
+        ]
+
+    def test_the_reasons_survive_the_round_trip(self, repo: Repository) -> None:
+        # A refusal nobody can read is not a refusal.
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        snap_id = repo.insert_macro_context_snapshot(
+            _snapshot(
+                domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),),
+                status="partial",
+                reasons=(
+                    SnapshotReason(
+                        domain="policy_rates", kind="absent", detail="job raised TimeoutError"
+                    ),
+                ),
+            )
+        )
+        row = repo.fetch_macro_context_snapshot(snap_id)
+        assert row["status"] == "partial"
+        assert row["status_reasons_jsonb"] == [
+            {"domain": "policy_rates", "kind": "absent", "detail": "job raised TimeoutError"}
+        ]
+
+    def test_a_partial_snapshot_holds_only_the_domains_that_answered(
+        self, repo: Repository
+    ) -> None:
+        # Absence is the lack of a row, not a row carrying a null. A nullable state_id
+        # would make every reader decide again what a null means.
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        snap_id = repo.insert_macro_context_snapshot(
+            _snapshot(
+                domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),),
+                status="partial",
+            )
+        )
+        assert len(repo.fetch_macro_context_snapshot_domains(snap_id)) == 1
+
+
+class TestTheSnapshotCannotLie:
+    def test_it_cannot_name_a_state_that_does_not_exist(self, repo: Repository) -> None:
+        with pytest.raises(psycopg.errors.ForeignKeyViolation):
+            repo.insert_macro_context_snapshot(
+                _snapshot(
+                    domains=(
+                        SnapshotDomain(domain="inflation", state_id=9_999_999, ordinal=0),
+                    )
+                )
+            )
+
+    def test_one_domain_appears_at_most_once(self, repo: Repository) -> None:
+        # Two answers for one domain in one snapshot is two snapshots.
+        a = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        b = _state_id(repo, "inflation", inputs_hash="b" * 64)
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            repo.insert_macro_context_snapshot(
+                _snapshot(
+                    domains=(
+                        SnapshotDomain(domain="inflation", state_id=a, ordinal=0),
+                        SnapshotDomain(domain="inflation", state_id=b, ordinal=1),
+                    )
+                )
+            )
+
+    def test_an_unknown_status_is_refused(self, repo: Repository) -> None:
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        with pytest.raises(psycopg.errors.CheckViolation):
+            repo.insert_macro_context_snapshot(
+                _snapshot(
+                    domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),),
+                    status="probably_fine",
+                )
+            )
+
+    def test_it_cannot_be_assembled_before_the_instant_it_answers_for(
+        self, repo: Repository
+    ) -> None:
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        with pytest.raises(psycopg.errors.CheckViolation):
+            repo.insert_macro_context_snapshot(
+                _snapshot(
+                    domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),),
+                    assembled_at=AS_OF - timedelta(seconds=1),
+                )
+            )
+
+
+class TestReassemblyIsNotASecondOpinion:
+    def test_the_same_identity_returns_the_same_row(self, repo: Repository) -> None:
+        # Same instant, same assembler, same inputs -> one snapshot. Otherwise every
+        # nightly rerun would manufacture a new "answer" identical to the last.
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        args = _snapshot(
+            domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),)
+        )
+        first = repo.insert_macro_context_snapshot(args)
+        second = repo.insert_macro_context_snapshot(args)
+        assert first == second
+
+    def test_a_different_inputs_hash_is_a_different_snapshot(
+        self, repo: Repository
+    ) -> None:
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        domains = (SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),)
+        first = repo.insert_macro_context_snapshot(_snapshot(domains=domains))
+        second = repo.insert_macro_context_snapshot(
+            _snapshot(domains=domains, inputs_hash="d" * 64)
+        )
+        assert first != second
+
+    def test_the_newest_snapshot_at_or_before_an_instant_is_readable(
+        self, repo: Repository
+    ) -> None:
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        domains = (SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),)
+        older = repo.insert_macro_context_snapshot(
+            _snapshot(domains=domains, as_of=AS_OF - timedelta(days=1))
+        )
+        newer = repo.insert_macro_context_snapshot(_snapshot(domains=domains))
+
+        assert repo.fetch_macro_context_snapshot_as_of(AS_OF)["snapshot_id"] == newer
+        at_older = repo.fetch_macro_context_snapshot_as_of(AS_OF - timedelta(hours=1))
+        assert at_older["snapshot_id"] == older
+
+    def test_replaying_before_any_snapshot_existed_returns_nothing(
+        self, repo: Repository
+    ) -> None:
+        # Not an empty snapshot -- an invented "we knew nothing" row is a claim we never made.
+        infl = _state_id(repo, "inflation", inputs_hash="a" * 64)
+        repo.insert_macro_context_snapshot(
+            _snapshot(domains=(SnapshotDomain(domain="inflation", state_id=infl, ordinal=0),))
+        )
+        assert repo.fetch_macro_context_snapshot_as_of(AS_OF - timedelta(days=365)) is None


### PR DESCRIPTION
First of four MC4 slices, per `docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md`. **Persistence only** — nothing assembles or reads a snapshot yet.

## What was missing

The four domain states are each individually honest. They record what they stood on, and `macro_domain_state_dependencies` (migration 128) **already** records state → state edges — so MC4 does not need to invent lineage, only to *check* it.

No table said the four belong **together**. So `/macro` composes four independent latest reads, and the nightly worker — which *does* use one `as_of` and the right causal order — catches each domain's exception and continues:

> rates job raises → USD runs anyway → USD reads the **previous** rates state (still satisfying `available_at <= as_of`) → persists a new USD state citing it → gold consumes the mixture → **four cards render fresh and nothing can tell**

Production happened to be coherent when checked (all four at `2026-08-24T07:40:00.001360+08:00`, USD citing the current rates state). Nothing enforced or detected that.

## The property that must not be traded away

**A snapshot refuses; it never repairs.** It may not substitute a fresher upstream to make a chain look coherent. Substitution is how a monitoring layer becomes a fabrication layer.

Status will come from **dependency-edge identity** — does the upstream `state_id` a downstream actually cited equal the one this snapshot holds for that domain — never from timestamp proximity.

## Design decisions worth reviewing

| decision | why |
|---|---|
| four statuses, not one "degraded" | *"rates never ran"* and *"rates ran but USD ignored it"* are different refusals calling for different operator actions |
| `state_id` **NOT NULL**; absence = no row | a nullable one makes every reader decide again what null means, and one decides it means zero |
| `ordinal` stored, not derived | a stored snapshot keeps the causal order it was assembled with, even if the chain is reordered later |
| `inputs_hash` over state **identities** | a nightly rerun over unchanged states is a no-op, not a second opinion; a later evidence revision can't change a stored hash, because a revision makes a *new* state |
| `fetch_..._as_of` returns `None`, not an empty snapshot | an invented *"we knew nothing"* row is a claim Argon never made, indistinguishable from a real refusal |
| storage in its own module | `repository.py` gets the mixin for assembly only — new domain, own seam, from method one |

## Migration number

**`130`.** The plan that first specified this reserved `117`; the Fundamental lane took `117` and `118` long before it was written. The migration header says to read the tail, never a plan's reservation.

## Gap-healer registry

Both tables enrolled as unhealable, **151 → 153 datasets**, policy doc regenerated. A healer that invented a missing snapshot would be asserting **that four domains once agreed** — precisely the claim this table exists to be able to refuse.

## Verification

```
uv run pytest tests/unit          -> 2501 passed
uv run pytest tests/integration   -> 1316 passed, 11 skipped
  (new file)                      ->   11 passed
uv run ruff check src/            -> clean
```

Written test-first — the suite failed on `ModuleNotFoundError: uw_scan.macro.snapshot` before any of it existed. Tests cover both directions of idempotency, the FK, the per-domain uniqueness, the status check, the `assembled_at >= as_of` guard, and that replaying before any snapshot existed returns nothing.