### PR TITLE
feat(macro): the desk reads one snapshot, and renders its refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **The macro desk reads one snapshot, and renders its refusal.** Slices 3 and 4 of MC4,
+  which completes it.
+  - **Option A, deliberately: the banner reports, it does not withhold.** A broken chain
+    shows the verdict AND keeps all four cards. The authority boundary for this layer is
+    risk-monitoring — it may say the chain is broken and where, and it may not decide for
+    the reader that the individual answers have stopped being worth seeing.
+  - The offending domain is flagged on its own card as well as in the banner, prefixed
+    with the domain name: the flag sits between two cards, and without a name it reads as
+    belonging to the one above it.
+  - **A missing snapshot renders as "chain never assembled", never as a clean chain.**
+    Absence of a check is not a passed check, and the four cards below it are then four
+    independent reads with nothing having compared them.
+  - **Verified against real stored data, and it caught a real incompatibility.** In the
+    local store, USD state 22 cites `policy_rates` state **21** while the latest rates
+    answer is state **23** — states 20/21/22 came from one pass at 00:45:14 and state 23
+    from a rates-only rerun at 01:15:44 with no matching USD recompute. Every one of those
+    rows is individually current and individually honest; the four-request page reads 22
+    and 23 side by side as a chain and nothing about a timestamp gives it away. Path
+    exercised end to end: job → `macro_context_snapshots` → `GET /api/macro/snapshot`
+    (`status: incompatible`) → `/macro` rendering the banner, both flags and all four
+    cards. Screenshot: `output/playwright/macro-chain-incompatible-2026-08-25.png`
+    (gitignored by policy).
+  - Caveat recorded rather than buried: that instance is from `option_wizard_local`, where
+    a single-domain rerun is exactly what ad-hoc dev work produces. Whether production
+    carries the same shape is **unverified** — the point it proves is that the detector
+    works on real stored edges, not that production is broken.
+  - `web/lib/types.ts` regenerated. Generated from the live unsorted spec, not from
+    `openapi.snapshot.json`: the snapshot is stored `sort_keys=True`, and generating from
+    it reorders every schema — a 5,005-line diff carrying the same 156 lines of content.
+
 - **The macro context snapshot — assembler, nightly job and `/api/macro/snapshot`.**
   Second of four slices; the snapshot is now assembled, persisted and served, and the
   page still reads four independent states until slice 3.

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -163,10 +163,21 @@ and a later evidence revision cannot change an old snapshot's hash.
 
 Four independently reviewable PRs:
 
-1. contract + migration `130` + repository — **DONE 2026-08-24**, PR pending
-2. assembler + worker job + API (current and `?as_of_ts=` replay)
-3. UI reads one snapshot; replay / delta / lazy evidence drawer
-4. real persisted verification: worker → DB → API → browser
+1. contract + migration `130` + repository — **DONE 2026-08-24**, PR #384
+2. assembler + worker job + API (current and `?as_of_ts=` replay) — **DONE 2026-08-25**, PR #386
+3. UI reads one snapshot and renders its refusal — **DONE 2026-08-25**
+4. real persisted verification: worker → DB → API → browser — **DONE 2026-08-25**
+
+Slices 3 and 4 shipped together: the verification exists to prove the UI, so splitting them
+would have opened a PR whose only content was evidence for the previous one. The operator
+chose **option A** for a broken chain — banner plus all four cards, never withholding.
+
+The verification caught a real incompatibility rather than a constructed one: USD state 22
+cites `policy_rates` 21 while the latest rates answer is 23, because a rates-only rerun at
+01:15:44 followed a full pass at 00:45:14 with no matching USD recompute. Local store, so
+production is unverified — what it proves is that the detector fires on real stored edges.
+
+**MC4 is complete.** The remaining open items are F5 (gold schedule) and F2 (invalidation).
 
 **Exit:** a partial domain failure can never render as a coherent fresh chain; a later evidence
 revision does not change an old snapshot hash; the page no longer fetches four latest states.

--- a/web/app/macro/page.tsx
+++ b/web/app/macro/page.tsx
@@ -18,17 +18,31 @@ async function settle(
   }
 }
 
+/** The chain verdict is fetched BESIDE the four cards, not instead of them. It answers a
+ *  question none of them can: whether the four belong together. A failure to reach it must
+ *  not blank the desk, so it settles to null -- which the desk renders as "never
+ *  assembled" rather than as a clean chain. */
+async function settleSnapshot() {
+  try {
+    return await api.macroContextSnapshot();
+  } catch {
+    return null;
+  }
+}
+
 export default async function MacroPage() {
-  const [inflation, rates, usd, gold] = await Promise.all([
+  const [inflation, rates, usd, gold, snapshot] = await Promise.all([
     settle("inflation"),
     settle("rates"),
     settle("usd"),
     settle("gold"),
+    settleSnapshot(),
   ]);
 
   return (
     <MacroDesk
       domains={{ inflation, policy_rates: rates, usd, gold }}
+      snapshot={snapshot}
     />
   );
 }

--- a/web/components/macro/ChainRefusal.tsx
+++ b/web/components/macro/ChainRefusal.tsx
@@ -1,0 +1,82 @@
+import type { MacroContextSnapshot, MacroSnapshotReason } from "./types";
+import { STATUS_LEDE } from "./types";
+
+/**
+ * The chain-level verdict, rendered beside the cards rather than instead of them.
+ *
+ * Four individually-fresh cards cannot show that USD stood on last night's rates — every
+ * row they fetch is current and individually honest, and nothing about a timestamp gives
+ * it away. Only the snapshot carries the claim that the four belong together, and it
+ * decides that from dependency-edge identity: does the upstream state id a domain
+ * actually cited equal the one the snapshot holds for that domain.
+ *
+ * It reports and does not withhold. The authority boundary for this layer is
+ * risk-monitoring: it may say the chain is broken and where, and it may not decide for
+ * the reader that the individual answers are no longer worth seeing.
+ */
+export function ChainRefusal({
+  snapshot,
+}: {
+  snapshot: MacroContextSnapshot | null;
+}) {
+  if (snapshot === null) {
+    return (
+      <div
+        data-testid="macro-chain-unassembled"
+        style={{ ...BOX, borderColor: "var(--border-subtle)" }}
+      >
+        <strong style={LABEL}>Chain never assembled</strong>
+        <p style={BODY}>
+          No context snapshot has been assembled for this instant, so the four cards below
+          are four independent reads. That is not the same as a coherent chain — nothing
+          has checked whether they belong together.
+        </p>
+      </div>
+    );
+  }
+
+  if (snapshot.status === "complete") return null;
+
+  return (
+    <div
+      data-testid="macro-chain-refusal"
+      data-status={snapshot.status}
+      style={{ ...BOX, borderColor: "var(--danger, #a33)" }}
+    >
+      <strong style={LABEL}>
+        Chain {snapshot.status} — read the cards below separately, not as a chain
+      </strong>
+      <p style={BODY}>{STATUS_LEDE[snapshot.status]}</p>
+      <ul style={{ margin: "8px 0 0", paddingLeft: 18, fontSize: 12.5 }}>
+        {(snapshot.reasons ?? []).map((reason: MacroSnapshotReason) => (
+          <li key={`${reason.domain}-${reason.kind}`} style={{ marginBottom: 3 }}>
+            <code style={{ color: "var(--text-primary)" }}>{reason.domain}</code>{" "}
+            <span style={{ color: "var(--text-muted)" }}>({reason.kind})</span> —{" "}
+            {reason.detail}
+          </li>
+        ))}
+      </ul>
+      <p style={{ ...BODY, marginTop: 8, color: "var(--text-muted)" }}>
+        Assembled {snapshot.assembled_at} by {snapshot.assembler_version}. The snapshot
+        holds what each domain actually cited; it never swaps in a fresher upstream to make
+        the chain look coherent.
+      </p>
+    </div>
+  );
+}
+
+const BOX = {
+  border: "1px solid",
+  borderRadius: 6,
+  padding: "10px 12px",
+  marginBottom: 14,
+  background: "var(--bg-elevated, rgba(255,255,255,0.02))",
+} as const;
+
+const LABEL = { fontSize: 13, display: "block" } as const;
+
+const BODY = {
+  margin: "4px 0 0",
+  fontSize: 12.5,
+  color: "var(--text-secondary)",
+} as const;

--- a/web/components/macro/MacroDesk.tsx
+++ b/web/components/macro/MacroDesk.tsx
@@ -1,6 +1,11 @@
+import { ChainRefusal } from "./ChainRefusal";
 import { DomainStateCard } from "./DomainStateCard";
-import type { MacroDomainKey, MacroDomainSlot } from "./types";
-import { CAUSAL_ORDER } from "./types";
+import type {
+  MacroContextSnapshot,
+  MacroDomainKey,
+  MacroDomainSlot,
+} from "./types";
+import { CAUSAL_ORDER, DOMAIN_LABEL } from "./types";
 
 /**
  * The four macro domain states, rendered as a chain rather than a scoreboard.
@@ -12,9 +17,16 @@ import { CAUSAL_ORDER } from "./types";
  */
 export function MacroDesk({
   domains,
+  snapshot = null,
 }: {
   domains: Record<string, MacroDomainSlot>;
+  /** The chain-level verdict. ``null`` means none was ever assembled, which is NOT the
+   *  same as a coherent chain and must never render as one. */
+  snapshot?: MacroContextSnapshot | null;
 }) {
+  const refusedBy = new Map(
+    (snapshot?.reasons ?? []).map((reason) => [reason.domain, reason]),
+  );
   return (
     <div
       style={{
@@ -40,13 +52,32 @@ export function MacroDesk({
         </p>
       </header>
 
+      <ChainRefusal snapshot={snapshot} />
+
       <div style={{ display: "grid", gap: 10 }}>
         {CAUSAL_ORDER.map((domain: MacroDomainKey, i) => (
           <div key={domain} style={{ display: "grid", gap: 10 }}>
-            <DomainStateCard
-              domain={domain}
-              slot={domains[domain] ?? { value: null }}
-            />
+            <div style={{ display: "grid", gap: 6 }}>
+              {refusedBy.has(domain) ? (
+                <div
+                  data-testid={`macro-chain-flag-${domain}`}
+                  style={{
+                    fontSize: 12,
+                    color: "var(--danger, #a33)",
+                    padding: "2px 2px 0",
+                  }}
+                >
+                  {/* Prefixed with the domain: the flag sits between two cards, and
+                      without a name it reads as belonging to the one above it. */}
+                  <strong>{DOMAIN_LABEL[domain]}:</strong>{" "}
+                  {refusedBy.get(domain)?.detail}
+                </div>
+              ) : null}
+              <DomainStateCard
+                domain={domain}
+                slot={domains[domain] ?? { value: null }}
+              />
+            </div>
             {i < CAUSAL_ORDER.length - 1 ? (
               <div
                 aria-hidden

--- a/web/components/macro/types.ts
+++ b/web/components/macro/types.ts
@@ -40,3 +40,24 @@ export const DOMAIN_LEDE: Record<MacroDomainKey, string> = {
   usd: "How policy transmits into the broad dollar.",
   gold: "Whether gold's measured relationships are holding at all.",
 };
+
+export type MacroContextSnapshot =
+  components["schemas"]["MacroContextSnapshotResponse"];
+
+// ``reasons`` and ``domains`` carry Pydantic defaults, so the generated schema marks
+// them optional. Unwrapped here once rather than at every use site.
+export type MacroSnapshotReason =
+  NonNullable<MacroContextSnapshot["reasons"]>[number];
+
+/** What each non-complete status means, in the operator's terms. The two refusals stay
+ *  apart on purpose: "rates never ran" sends you to the scheduler, "rates ran but USD
+ *  ignored it" sends you to the data, and one merged "degraded" would point you at the
+ *  wrong one. */
+export const STATUS_LEDE: Record<string, string> = {
+  partial:
+    "A domain is missing — its job failed or never ran. The domains that did answer are still their own honest answers.",
+  incompatible:
+    "A domain present below stood on an upstream answer that is not the one this snapshot holds. Every card can look current and the chain still be wrong.",
+  stale:
+    "The newest snapshot is older than the expected cadence, so this chain describes an earlier instant than the one you asked about.",
+};

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -116,6 +116,7 @@ type RatesSnapshotResponse = Json<"/api/rates/snapshot", "get">;
 type MacroPolicyComparison = Json<"/api/macro/policy", "get">;
 // All four domain states share one response model, so one alias covers the set.
 type MacroDomainStateResponse = Json<"/api/macro/usd", "get">;
+type MacroContextSnapshotResponse = Json<"/api/macro/snapshot", "get">;
 type PositioningSnapshot = Json<"/api/positioning/{ticker}", "get">;
 type PositioningScreenerResponse = Json<"/api/positioning/screener", "get">;
 
@@ -312,6 +313,19 @@ export const api = {
     _fetch<MacroDomainStateResponse | null>(`/api/macro/${domain}`, undefined, {
       allow404: true,
     }),
+  // `allow404` again, and for a sharper reason than the domain reads: a 404 here means no
+  // snapshot was ever assembled for the instant, which the desk must render as "nothing
+  // checked whether these four belong together" -- never as a coherent chain.
+  macroContextSnapshot: (
+    asOfTs?: string,
+  ): Promise<MacroContextSnapshotResponse | null> =>
+    _fetch<MacroContextSnapshotResponse | null>(
+      asOfTs
+        ? `/api/macro/snapshot?as_of_ts=${encodeURIComponent(asOfTs)}`
+        : "/api/macro/snapshot",
+      undefined,
+      { allow404: true },
+    ),
   tradeInsights: (ticker: string): Promise<TradeInsightsResponse> =>
     _fetch<TradeInsightsResponse>(`/api/stock/${ticker}/trade-insights`),
   tradeInsightsAiAnalysis: (

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1772,6 +1772,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/macro/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Macro Context Snapshot
+         * @description The four domains as one answer, with whatever refusal the assembler recorded.
+         *
+         *     This is the route the desk should read instead of four independent latest states. The
+         *     four-request shape cannot notice that USD stood on last night's rates, because every
+         *     row it fetches is individually current and individually honest; only the snapshot
+         *     holds the claim that they belong together.
+         *
+         *     A ``complete`` status is not a claim that the macro picture is right -- only that the
+         *     chain is internally coherent. The states remain descriptive.
+         */
+        get: operations["macro_context_snapshot_api_macro_snapshot_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/scanner": {
         parameters: {
             query?: never;
@@ -5091,6 +5119,45 @@ export interface components {
              */
             kind: "multiplicand" | "penalty" | "informational";
         };
+        /**
+         * MacroContextSnapshotResponse
+         * @description The four domains as ONE answer, with its refusal intact.
+         *
+         *     The snapshot never repairs an incompatible chain by substituting a fresher upstream:
+         *     ``domains`` holds exactly what each downstream stood on. Substitution is how a
+         *     monitoring layer becomes a fabrication layer, so a caller reading this must expect
+         *     ``status`` to disagree with how fresh the individual rows look.
+         */
+        MacroContextSnapshotResponse: {
+            /**
+             * Requested As Of
+             * Format: date-time
+             */
+            requested_as_of: string;
+            /**
+             * As Of
+             * Format: date-time
+             */
+            as_of: string;
+            /**
+             * Assembled At
+             * Format: date-time
+             */
+            assembled_at: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "complete" | "partial" | "incompatible" | "stale";
+            /** Assembler Version */
+            assembler_version: string;
+            /** Inputs Hash */
+            inputs_hash: string;
+            /** Domains */
+            domains?: components["schemas"]["MacroSnapshotDomainItem"][];
+            /** Reasons */
+            reasons?: components["schemas"]["MacroSnapshotReasonItem"][];
+        };
         /** MacroContradiction */
         MacroContradiction: {
             /** Rule */
@@ -5265,6 +5332,61 @@ export interface components {
              * @enum {string}
              */
             source_kind: "official" | "first_party_publisher" | "entitled_provider" | "third_party_shadow" | "mock" | "static" | "demo";
+        };
+        /**
+         * MacroSnapshotDomainItem
+         * @description One domain's answer as the snapshot holds it.
+         *
+         *     ``state_id`` travels with the answer because the snapshot's claim is about identity:
+         *     it asserts that THIS state, not merely some state of that domain, is the one the
+         *     chain was assembled from.
+         */
+        MacroSnapshotDomainItem: {
+            /**
+             * Domain
+             * @enum {string}
+             */
+            domain: "inflation" | "policy_rates" | "usd" | "gold" | "cross_domain";
+            /** Ordinal */
+            ordinal: number;
+            /** State Id */
+            state_id: number;
+            /** State */
+            state: string;
+            /**
+             * Direction
+             * @enum {string}
+             */
+            direction: "RISING" | "FALLING" | "FLAT" | "UNKNOWN";
+            /** Confidence */
+            confidence: string;
+            /**
+             * As Of
+             * Format: date-time
+             */
+            as_of: string;
+            /** Engine Version */
+            engine_version: string;
+            /** Inputs Hash */
+            inputs_hash: string;
+        };
+        /**
+         * MacroSnapshotReasonItem
+         * @description One domain's refusal, named rather than summarised into the status alone.
+         */
+        MacroSnapshotReasonItem: {
+            /**
+             * Domain
+             * @enum {string}
+             */
+            domain: "inflation" | "policy_rates" | "usd" | "gold" | "cross_domain";
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "absent" | "incompatible" | "stale";
+            /** Detail */
+            detail: string;
         };
         /**
          * MacroStateEvidenceItem
@@ -13829,6 +13951,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MacroDomainStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    macro_context_snapshot_api_macro_snapshot_get: {
+        parameters: {
+            query?: {
+                /** @description UTC calendar date; returns the snapshot answering for that day-end. */
+                as_of?: string | null;
+                /** @description Timezone-aware instant to replay. */
+                as_of_ts?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MacroContextSnapshotResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/tests/unit/macroDesk.test.tsx
+++ b/web/tests/unit/macroDesk.test.tsx
@@ -113,3 +113,121 @@ describe("MacroDesk", () => {
     expect(within(usd).getByText(/usd\/\d/)).toBeTruthy();
   });
 });
+
+// --- The chain-level refusal -------------------------------------------------
+//
+// Four individually-fresh cards cannot show that USD stood on last night's rates: every
+// row they fetch is current and honest. Only the snapshot carries the claim that the four
+// belong together, so the desk renders its verdict WITHOUT hiding the cards -- an operator
+// still needs to see what each engine said while being told not to read them as a chain.
+
+type Snapshot = NonNullable<Parameters<typeof MacroDesk>[0]["snapshot"]>;
+
+function snapshot(over: Partial<Snapshot> = {}): Snapshot {
+  return {
+    requested_as_of: "2026-08-24T07:40:00Z",
+    as_of: "2026-08-24T07:40:00Z",
+    assembled_at: "2026-08-24T07:41:00Z",
+    status: "complete",
+    assembler_version: "snapshot/1",
+    inputs_hash: "f".repeat(64),
+    domains: [
+      { domain: "inflation", ordinal: 0, state_id: 1, state: "ABOVE_TARGET", direction: "FALLING", confidence: "0.71", as_of: "2026-08-24T07:40:00Z", engine_version: "inflation/2", inputs_hash: "a".repeat(64) },
+      { domain: "policy_rates", ordinal: 1, state_id: 2, state: "ON_HOLD", direction: "FLAT", confidence: "0.66", as_of: "2026-08-24T07:40:00Z", engine_version: "rates/2", inputs_hash: "b".repeat(64) },
+      { domain: "usd", ordinal: 2, state_id: 3, state: "RANGEBOUND", direction: "FLAT", confidence: "0.58", as_of: "2026-08-24T07:40:00Z", engine_version: "usd/3", inputs_hash: "c".repeat(64) },
+      { domain: "gold", ordinal: 3, state_id: 4, state: "OPERATIVE", direction: "FLAT", confidence: "0.44", as_of: "2026-08-24T07:40:00Z", engine_version: "gold/2", inputs_hash: "d".repeat(64) },
+    ],
+    reasons: [],
+    ...over,
+  } as Snapshot;
+}
+
+describe("MacroDesk chain coherence", () => {
+  it("says nothing when the chain is coherent", () => {
+    render(<MacroDesk domains={slots()} snapshot={snapshot()} />);
+    expect(screen.queryByTestId("macro-chain-refusal")).toBeNull();
+  });
+
+  it("names an absent domain without hiding the three that answered", () => {
+    render(
+      <MacroDesk
+        domains={slots()}
+        snapshot={snapshot({
+          status: "partial",
+          domains: (snapshot().domains ?? []).filter((d) => d.domain !== "policy_rates"),
+          reasons: [
+            { domain: "policy_rates", kind: "absent", detail: "no policy_rates state at or before this instant" },
+          ],
+        })}
+      />,
+    );
+    const banner = screen.getByTestId("macro-chain-refusal");
+    expect(banner.textContent).toMatch(/policy_rates/);
+    // Option A: the cards stay. Reporting is the authority here, not withholding.
+    expect(screen.getAllByTestId(/^macro-domain-/)).toHaveLength(4);
+    expect(
+      within(screen.getByTestId("macro-domain-usd")).getByText("RANGEBOUND"),
+    ).toBeTruthy();
+  });
+
+  it("distinguishes a broken chain from a merely incomplete one", () => {
+    render(
+      <MacroDesk
+        domains={slots()}
+        snapshot={snapshot({
+          status: "incompatible",
+          reasons: [
+            { domain: "usd", kind: "incompatible", detail: "usd cited policy_rates state 41, the snapshot holds 47" },
+          ],
+        })}
+      />,
+    );
+    const banner = screen.getByTestId("macro-chain-refusal");
+    expect(banner.getAttribute("data-status")).toBe("incompatible");
+    expect(within(banner).getByText(/cited policy_rates state 41/)).toBeTruthy();
+  });
+
+  it("marks the offending card, so the banner is not the only place to look", () => {
+    render(
+      <MacroDesk
+        domains={slots()}
+        snapshot={snapshot({
+          status: "incompatible",
+          reasons: [
+            { domain: "usd", kind: "incompatible", detail: "usd cited a superseded policy_rates state" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByTestId("macro-chain-flag-usd")).toBeTruthy();
+    expect(screen.queryByTestId("macro-chain-flag-gold")).toBeNull();
+  });
+
+  it("says a snapshot was never assembled rather than implying coherence", () => {
+    render(<MacroDesk domains={slots()} snapshot={null} />);
+    const note = screen.getByTestId("macro-chain-unassembled");
+    expect(note.textContent).toMatch(/never/i);
+    // Absence of a snapshot must never read as a clean chain.
+    expect(screen.queryByTestId("macro-chain-refusal")).toBeNull();
+  });
+
+  // Scoped to the BANNER, not the whole render -- the same trap the desk-chrome test
+  // above documents. Gold's own note says the valuation lens "never becomes a price
+  // target, an allocation, or a size", and a container-wide /allocat/i would flag that
+  // disclaimer as if it were the recommendation it exists to refuse.
+  it("reports the breakage without telling anyone what to do about it", () => {
+    render(
+      <MacroDesk
+        domains={slots()}
+        snapshot={snapshot({
+          status: "incompatible",
+          reasons: [{ domain: "usd", kind: "incompatible", detail: "usd cited a superseded policy_rates state" }],
+        })}
+      />,
+    );
+    const text = screen.getByTestId("macro-chain-refusal").textContent ?? "";
+    for (const banned of [/reduce/i, /hedge/i, /position/i, /allocat/i, /recommend/i, /you should/i]) {
+      expect(text).not.toMatch(banned);
+    }
+  });
+});


### PR DESCRIPTION
**Completes MC4.** Slices 3 and 4, shipped together — the verification exists to prove the UI, so splitting them would have opened a PR whose only content was evidence for the previous one.

Slice 1 = #384 (contract, migration `130`, storage). Slice 2 = #386 (assembler, worker, API).

## What changes on the page

The desk composed four independent latest reads. A chain in which USD stood on last night's rates rendered as four fresh cards, because **every row it fetched was individually current and individually honest**.

**Option A, chosen by the operator: the banner reports, it does not withhold.** A broken chain shows the verdict *and* keeps all four cards. The authority boundary for this layer is risk-monitoring — it may say the chain is broken and where, and it may not decide for the reader that the individual answers have stopped being worth seeing.

Also:
- The offending domain is flagged on its own card, **prefixed with the domain name** — the flag sits between two cards and without a name it reads as belonging to the one above it.
- **A missing snapshot renders as "chain never assembled", never as a clean chain.** Absence of a check is not a passed check.

## The verification caught a real one

Not a constructed case. Against the real local store:

| state_id | domain | as_of |
|---|---|---|
| 20 | inflation | 00:45:14 |
| 21 | policy_rates | 00:45:14 |
| 22 | usd | 00:45:14 → **cites 21** |
| 23 | policy_rates | **01:15:44** |

A rates-only rerun followed a full pass with no matching USD recompute. "Latest rates" is 23, "latest usd" is 22 — the four-request page reads them side by side as a chain, and **nothing about a timestamp gives it away.**

Path exercised end to end: job → `macro_context_snapshots` → `GET /api/macro/snapshot` (`status: incompatible`) → `/macro` rendering the banner, both flags, and all four cards. Screenshot at `output/playwright/macro-chain-incompatible-2026-08-25.png` (gitignored by policy).

**Caveat, recorded rather than buried:** that instance is from `option_wizard_local`, where an ad-hoc single-domain rerun is exactly what dev work produces. Whether production carries the same shape is **unverified**. What it proves is that the detector fires on real stored edges.

## Two notes for review

- `web/lib/types.ts` is generated from the **live unsorted** spec, not from `openapi.snapshot.json`. The snapshot is stored `sort_keys=True`; generating from it reorders every schema into a 5,005-line diff carrying the same 156 lines of content.
- The banned-phrase test on the refusal banner is scoped to the **banner**, not the container — the same trap the existing desk-chrome test documents, since gold's own note says the valuation lens "never becomes a price target, an allocation, or a size".

## Tests

`web/tests/unit/macroDesk.test.tsx` — 6 new (15 total in file). Full web suite **828 passed**, typecheck and eslint clean; `ruff check src/ tests/ scripts/` clean.

Local DB note: migrations were blocked at `113` by 23 tables and 47 functions owned by `chenxi` rather than `argon_app`. Reassigned locally; no repo change, but worth knowing if anyone else hits `must be owner of table watchlist_chain`.