### PR TITLE
fix(macro): compute the gold gauge before the state that reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The gold domain state read yesterday's gauge every single night.** `gold_posture_compute`
+  ran at 21:00 ET; the macro state compute that consumes its row runs at 19:40. The posture
+  row for day D is stamped with the latest `GLD_CLOSE` date, so an evening run on D writes
+  `obs_date = D` — which did not exist yet when the state asked for it 80 minutes earlier.
+  Not a failure mode on a bad night: the schedule guaranteed it on every good one, while
+  `gauge_age_days` honestly reported the lag the schedule itself was creating.
+  - GPR ingest moved 20:00 → **18:35**, posture compute 21:00 → **19:10**, both still Mon–Fri.
+    The whole rest of the daily cascade already finished by 18:30.
+  - **Moving GPR earlier was measured, not assumed.** Its publisher file is a static academic
+    `.xls` already running 2–3 days behind the fetch — an ingest at 19:00 ET on 2026-08-19
+    returned an observation dated 2026-08-17. The fetch clock was never the binding constraint.
+  - The test locks the **order**, not the clock: posture after every ingest it reads, before the
+    state that consumes it. Moving the block stays free; inverting it does not.
+  - Two claims made earlier in this work were wrong and are corrected in the plan doc: `0-4` is
+    Mon–Fri (verified against APScheduler 3.11.2), not Sun–Thu, so "Friday never runs" was false;
+    and the blocking question "which close does a posture row cover" was already answered in code
+    by `_latest_gold_market_date`.
+
 ### Added
 
 - **The macro desk reads one snapshot, and renders its refusal.** Slices 3 and 4 of MC4,

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -41,23 +41,54 @@ LATER F2 invalidation ────────> designed; zero production instan
 Revised 2026-08-24. F2 was ordered before MC4 on the assumption that snapshots bake in evidence
 lineage. They do not, once the overlay is point-in-time — see P0-b.
 
-## P0-a — F5: gold reads a gauge produced on a later schedule
+## P0-a — F5: gold read a gauge produced on a later schedule — **FIXED 2026-08-25**
+
+Before:
 
 ```text
-19:30 ET  macro gold evidence ingest
-19:40 ET  all four macro domain states     (daily)
-21:00 ET  legacy gold posture compute      (Sun-Thu only)
+18:30 ET  gold etf holdings ingest          (Mon-Fri)  <- last daily posture input but GPR
+19:30 ET  macro gold evidence ingest        (daily)
+19:40 ET  all four macro domain states      (daily)     <- reads the posture
+20:00 ET  gold GPR ingest                   (Mon-Fri)
+21:00 ET  legacy gold posture compute       (Mon-Fri)   <- writes the posture
 ```
 
-Gold state calls `fetch_gold_posture_as_of(as_of.date())`, so the same day's posture cannot exist at
-19:40. `gauge_age_days` reports the lag honestly, but the schedule guarantees it.
+Gold state calls `fetch_gold_posture_as_of(as_of.date())` and `gold_posture_compute` stamps its row
+with the latest `GLD_CLOSE` date, so an evening run on day D writes `obs_date = D`. At 21:00 that row
+did not exist when the 19:40 state asked for it. Gold stood on the PREVIOUS day's gauge **every
+night**, structurally. `gauge_age_days` reported the lag honestly while the schedule created it.
 
-**This cannot be specified until one question is answered:** which market close does each posture row
-cover? The cron is `0 21 * * 0-4`, so Friday evening never runs. Until the covered-close mapping is
-stated, "rerun gold after posture" only relocates an undefined lag. Answer that first, in the spec.
+Two corrections to this item as originally written:
 
-**Exit:** a scheduler-order test, a stated and tested intended lag, and a real persisted smoke
-comparing state `as_of`, gauge observation date, and the allowed lag.
+- **`0-4` is Mon–Fri, not Sun–Thu.** Verified empirically against APScheduler 3.11.2. "Friday evening
+  never runs" was wrong; Saturday and Sunday are the skipped days, and there is no gold close then.
+- **The blocking question was already answered in code.** `gold_posture_compute_job` sets
+  `target = as_of or _latest_gold_market_date(repo)`, so a row covers the latest `GLD_CLOSE` in the
+  store and is self-describing. Nothing needed specifying.
+
+After — GPR to 18:35, posture to 19:10:
+
+```text
+18:30 ET  gold etf holdings ingest          (Mon-Fri)
+18:35 ET  gold GPR ingest                   (Mon-Fri)
+19:10 ET  legacy gold posture compute       (Mon-Fri)   <- writes the posture
+19:30 ET  macro gold evidence ingest        (daily)
+19:40 ET  all four macro domain states      (daily)     <- reads TODAY's posture
+```
+
+Moving GPR up costs nothing, and that was measured rather than assumed: the publisher's file is a
+static academic `.xls` already running 2–3 days behind the fetch — an ingest at 19:00 ET on
+2026-08-19 returned an observation dated **2026-08-17**. The fetch clock was never the binding
+constraint.
+
+Mon–Fri is kept on both. The Saturday and Sunday states legitimately read Friday's gauge and say so.
+
+**Exit:** `tests/unit/worker/test_gold_state_reads_todays_gauge.py` locks the ORDER rather than the
+clock times — posture after its whole ingest cascade, before the state that consumes it — so moving
+the block stays free and inverting it does not. The remaining piece is a real persisted smoke
+comparing state `as_of`, gauge `obs_date` and the allowed lag; it cannot run until a gold domain
+state exists (none has ever been computed — see MC6 preflight, gold is structurally excluded until
+migration 119 promotes a verified instant for `GLD_CLOSE`).
 
 ## P0-b — F2: additive evidence invalidation
 

--- a/src/uw_scan/worker/jobs/gold_jobs.py
+++ b/src/uw_scan/worker/jobs/gold_jobs.py
@@ -143,7 +143,7 @@ def gold_fred_ingest_job(
 
 
 def gold_gpr_ingest_job(*, dsn: str, lookback_days: int = 45) -> None:
-    """GPR refresh. Schedule: 20:00 ET daily with the default 45-day window.
+    """GPR refresh. Schedule: 18:35 ET Mon-Fri with the default 45-day window.
 
     Warmup CLI overrides lookback_days for the initial backfill. Idempotent
     via ON CONFLICT."""
@@ -573,8 +573,12 @@ def gold_wgc_cb_ingest_job(
 
 
 def gold_posture_compute_job(*, dsn: str, as_of: date | None = None) -> None:
-    """Compute and persist today's gold_posture_daily row. Schedule: 21:00 ET
-    (after all ingest jobs complete)."""
+    """Compute and persist today's gold_posture_daily row. Schedule: 19:10 ET Mon-Fri.
+
+    After every daily ingest it reads (the last is etf_holdings at 18:30) and BEFORE the
+    19:40 macro state compute, which reads the row this writes. The ordering is the
+    contract, not the clock -- see tests/unit/worker/test_gold_state_reads_todays_gauge.py.
+    """
     with psycopg.connect(dsn) as conn:
         repo = Repository(conn, schema="uw_scan")
         target = as_of or _latest_gold_market_date(repo)

--- a/src/uw_scan/worker/scheduler.py
+++ b/src/uw_scan/worker/scheduler.py
@@ -2546,15 +2546,34 @@ def main() -> int:
                     max_instances=1,
                     coalesce=True,
                 )
+        # 18:35, moved up from 20:00. The posture below must land before the
+        # 19:40 macro state compute, and GPRD is the only daily input that was
+        # scheduled after 18:30. Nothing is lost by fetching earlier: the
+        # publisher's file is a static academic .xls that already runs 2-3 days
+        # behind the fetch (an ingest at 19:00 ET on 2026-08-19 returned an
+        # observation dated 2026-08-17), so the fetch clock was never binding.
         sched.add_job(
             _gold_gpr_ingest,
-            CronTrigger.from_crontab("0 20 * * 0-4", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("35 18 * * 0-4", timezone=settings.rth_tz),
             id="gold_gpr_ingest",
             name="Gold: GPR daily refresh",
         )
+        # 19:10, moved up from 21:00 -- the defect this fixes.
+        #
+        # The gold domain state reads `fetch_gold_posture_as_of(as_of.date())`, and
+        # `gold_posture_compute` stamps its row with the latest GLD_CLOSE date, so an
+        # evening run on day D writes obs_date D. At 21:00 that row did not exist when
+        # the 19:40 state asked for it, so gold stood on the PREVIOUS day's gauge every
+        # night -- not on a bad night, every night. `gauge_age_days` reported the lag
+        # honestly while the schedule itself was creating it.
+        #
+        # 19:10 sits 40 minutes after the last upstream ingest (etf_holdings, 18:30) and
+        # 30 minutes before the state that consumes it. Mon-Fri is kept deliberately:
+        # there is no gold close to compute on a weekend, so the Saturday and Sunday
+        # states legitimately read Friday's gauge and say so.
         sched.add_job(
             _gold_posture_compute,
-            CronTrigger.from_crontab("0 21 * * 0-4", timezone=settings.rth_tz),
+            CronTrigger.from_crontab("10 19 * * 0-4", timezone=settings.rth_tz),
             id="gold_posture_compute",
             name="Gold: posture row compute (post-ingest)",
         )

--- a/tests/unit/worker/test_gold_state_reads_todays_gauge.py
+++ b/tests/unit/worker/test_gold_state_reads_todays_gauge.py
@@ -1,0 +1,134 @@
+"""The gold state must read a gauge computed for the day it answers for.
+
+Gold's domain state calls ``fetch_gold_posture_as_of(as_of.date())`` -- the newest
+posture row at or before the instant. The posture row for day D is written by
+``gold_posture_compute``, whose target date is the latest ``GLD_CLOSE`` in the store,
+so a run on the evening of D stamps ``obs_date = D``.
+
+That makes the ORDER of the two crons the whole contract. If posture runs after the
+state compute, the state can only ever find yesterday's row -- not on a bad night, but
+every night, silently, with ``gauge_age_days`` honestly reporting a lag the schedule
+itself created.
+
+These tests lock the ordering rather than the clock times, so moving the block stays
+free and inverting it does not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import uw_scan.worker.scheduler as scheduler
+
+
+class _StopStart(Exception):
+    """Raised by the fake scheduler's start() to unwind main() after wiring."""
+
+
+class _FakeSignal:
+    SIGTERM = 15
+    SIGINT = 2
+
+    def signal(self, *_a, **_k) -> None:
+        return None
+
+
+def _registered_triggers(monkeypatch, **env) -> dict[str, object]:
+    found: dict[str, object] = {}
+
+    class _FakeSched:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def add_listener(self, *_a, **_k) -> None:
+            pass
+
+        def add_job(self, *args, **kwargs) -> None:
+            job_id = kwargs.get("id")
+            trigger = kwargs.get("trigger") or (args[1] if len(args) > 1 else None)
+            if job_id is not None and trigger is not None:
+                found[job_id] = trigger
+
+        def start(self) -> None:
+            raise _StopStart
+
+        def shutdown(self, *_a, **_k) -> None:
+            pass
+
+    monkeypatch.setattr(scheduler, "BlockingScheduler", _FakeSched)
+    monkeypatch.setattr(scheduler, "signal", _FakeSignal())
+    monkeypatch.setenv("UW_SCAN_DB_HOST", "127.0.0.1")
+    monkeypatch.setenv("UW_SCAN_DB_NAME", "option_wizard_local")
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    with pytest.raises(_StopStart):
+        scheduler.main()
+    return found
+
+
+@pytest.fixture
+def triggers(monkeypatch) -> dict[str, object]:
+    return _registered_triggers(
+        monkeypatch,
+        UW_SCAN_API_KEY="x",
+        UW_SCAN_WORKER_ROLE="all",
+        UW_SCAN_WORKER_INDEX="0",
+        UW_SCAN_WORKER_COUNT="1",
+        UW_SCAN_MACRO_STATE_COMPUTE_ENABLED="true",
+    )
+
+
+def _first_fire_on(trigger, day: datetime) -> datetime | None:
+    """The trigger's first fire within ``day``, or None if it does not run that day."""
+    start = day.replace(hour=0, minute=0, second=0, microsecond=0)
+    nxt = trigger.get_next_fire_time(None, start - timedelta(seconds=1))
+    if nxt is None or nxt >= start + timedelta(days=1):
+        return None
+    return nxt
+
+
+#: A plain Wednesday. Every daily and Mon-Fri cron in the gold cascade fires.
+WEDNESDAY = datetime(2026, 8, 26, tzinfo=ZoneInfo("America/New_York"))
+
+
+def test_the_posture_is_computed_before_the_state_that_reads_it(triggers) -> None:
+    posture = _first_fire_on(triggers["gold_posture_compute"], WEDNESDAY)
+    state = _first_fire_on(triggers["macro_state_compute"], WEDNESDAY)
+
+    assert posture is not None and state is not None
+    assert posture < state, (
+        f"gold_posture_compute fires at {posture:%H:%M} but macro_state_compute "
+        f"reads it at {state:%H:%M}: the gold state can only ever see yesterday's gauge"
+    )
+
+
+def test_the_gpr_ingest_lands_before_the_posture_that_reads_it(triggers) -> None:
+    # GPRD is the posture's only daily input that was scheduled after 18:30.
+    gpr = _first_fire_on(triggers["gold_gpr_ingest"], WEDNESDAY)
+    posture = _first_fire_on(triggers["gold_posture_compute"], WEDNESDAY)
+
+    assert gpr is not None and posture is not None
+    assert gpr < posture
+
+
+def test_the_posture_waits_for_the_whole_daily_ingest_cascade(triggers) -> None:
+    # Every series the posture reads must already be in the store. Naming them
+    # here is the point: a new ingest added after the posture would go unnoticed.
+    upstream = (
+        "gold_fred_ingest",  # DFII10, T5YIFR, DTWEXBGS, CPIAUCSL, M2SL
+        "gold_spot_ingest",  # GLD_CLOSE
+        "gold_uw_options_ingest",
+        "gold_comex_vault_ingest",
+        "gold_etf_holdings_ingest",
+        "gold_gpr_ingest",  # GPRD
+    )
+    posture = _first_fire_on(triggers["gold_posture_compute"], WEDNESDAY)
+
+    for job_id in upstream:
+        fire = _first_fire_on(triggers[job_id], WEDNESDAY)
+        assert fire is not None, f"{job_id} does not run on a weekday"
+        assert fire < posture, f"{job_id} fires at {fire:%H:%M}, after the posture"


### PR DESCRIPTION
## The defect

The gold domain state calls `fetch_gold_posture_as_of(as_of.date())`. `gold_posture_compute` stamps its row with the latest `GLD_CLOSE` date, so an evening run on day D writes `obs_date = D`.

Posture ran at **21:00 ET**. The macro state compute that consumes the row runs at **19:40**.

```
18:30  gold_etf_holdings_ingest   (Mon-Fri)   last daily posture input but GPR
19:30  macro_gold_ingest          (daily)
19:40  macro_state_compute        (daily)     <- reads the posture
20:00  gold_gpr_ingest            (Mon-Fri)
21:00  gold_posture_compute       (Mon-Fri)   <- writes the posture
```

So gold stood on the **previous day's gauge every night** — not a failure mode on a bad night, a guarantee on every good one. `gauge_age_days` reported the lag honestly while the schedule itself was creating it.

## The fix

GPR `20:00 → 18:35`, posture `21:00 → 19:10`. Both stay Mon–Fri. Nothing else moved — the rest of the daily cascade already finished by 18:30.

```
18:30  gold_etf_holdings_ingest   (Mon-Fri)
18:35  gold_gpr_ingest            (Mon-Fri)
19:10  gold_posture_compute       (Mon-Fri)   <- writes the posture
19:30  macro_gold_ingest          (daily)
19:40  macro_state_compute        (daily)     <- reads TODAY's posture
```

**Moving GPR earlier was measured, not assumed.** Its publisher file is a static academic `.xls` already running 2–3 days behind the fetch — an ingest at 19:00 ET on 2026-08-19 returned an observation dated **2026-08-17**. The fetch clock was never the binding constraint.

Mon–Fri kept deliberately: there is no gold close on a weekend, so the Saturday and Sunday states legitimately read Friday's gauge and say so.

## The test

`tests/unit/worker/test_gold_state_reads_todays_gauge.py` locks the **order**, not the clock times — posture after every ingest it reads, before the state that consumes it. Moving the block stays free; inverting it does not. Written first, and it failed with the defect stated in the message:

```
AssertionError: gold_posture_compute fires at 21:00 but macro_state_compute
reads it at 19:40: the gold state can only ever see yesterday's gauge
```

## Two earlier claims corrected rather than quietly dropped

Both are fixed in `docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md`:

- **`0-4` is Mon–Fri, not Sun–Thu** (verified against APScheduler 3.11.2). "Friday evening never runs" was wrong.
- **The question blocking this item was already answered in code.** `gold_posture_compute_job` sets `target = as_of or _latest_gold_market_date(repo)`, so a row covers the latest `GLD_CLOSE` in the store and is self-describing. Nothing needed specifying.

## What is NOT covered

The plan's exit criteria also asked for a real persisted smoke comparing state `as_of`, gauge `obs_date` and the allowed lag. **It cannot run yet**: no gold domain state has ever been computed. Gold is structurally excluded until migration 119 promotes a verified instant for `GLD_CLOSE` (see the MC6 preflight verdict). Recorded in the plan's Exit section rather than marked done.

## Verification

- `uv run ruff check src/ tests/ scripts/` — clean
- `uv run pytest tests/unit/` — 2520 passed