### PR TITLE
docs(macro): close MC5 and MC6, correct the F5 exit blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+- **MC5 and MC6 are closed, and the macro program's authority boundary is now a measured finding.**
+  Operator decision 2026-08-26; plan status updated in `2026-08-12-top-down-macro-context-program.md`
+  and `2026-08-24-macro-mc4-mc6-sequenced.md`. Documentation only — no code, schema or behaviour changes.
+  - **MC6 reached its own designated exit rather than stalling short of it.** `descriptive_only` is one
+    of the three verdicts its Task 12 was written to publish. The preflight that produced it was not in
+    the original plan; it asked a question that plan never asked — is there enough sample to test
+    ANYTHING — and answered it before the expensive walk-forward harness of Task 11 was built.
+  - **Information and sample size run in opposite directions in this panel**, which is why no harness
+    could have been trusted to pick its own target: the three features with the largest effective
+    sample are all two-valued *was the publisher on time* binaries scoring `eff_n` ~294–298, high
+    precisely because they are noisy. Every economically meaningful feature lands at `eff_n` 0.9–27
+    over 5.6 years.
+  - **MC5's closure is a different decision from its verdict, and the distinction is recorded.**
+    `descriptive_only` says *retain MC4/MC5*, written assuming MC5 would already be built when MC6 ran.
+    It never was, so the live question was whether to BUILD it — which that taxonomy does not answer.
+    It is closed for want of a positive reason, not because the verdict forbade it.
+  - Reopening either requires a release-**event** preflight (FOMC 55 observations across 55 distinct
+    `available_at`, SEP 25/25, CPI family 145 release instants) AND a fresh authority decision. That
+    preflight is unauthorized and unstarted; surprise definition, baseline and horizon are all unspecified.
+
+### Fixed
+- **The F5 gold-schedule exit was recorded as blocked by a dev-database artifact.** The plan said the
+  persisted smoke "cannot run until a gold domain state exists (none has ever been computed)". That was
+  measured against `option_wizard_local`. **Production has held gold states since 2026-08-23**, and they
+  carry the defect and its fix directly: state 30 (Mon 2026-08-24 19:40 ET) read a gauge computed for
+  2026-08-21 — three days stale, because the old schedule ran the posture at 21:00, 80 minutes *after*
+  the state that consumes it — and state 34 (Tue 2026-08-25 19:40 ET, first run under the new schedule)
+  reads `obs_date` 2026-08-25, age **0**. The blocker also conflated two claims: the MC6 preflight found
+  gold cannot **replay**, which says nothing about computing tonight's state.
+
 ## [0.12.17] — 2026-08-25
 
 

--- a/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
+++ b/docs/superpowers/plans/2026-08-12-top-down-macro-context-program.md
@@ -1,9 +1,12 @@
 # Top-Down Macro Context — Program Plan
 
-> **Status:** in progress. MC0 implementation is verified on branch
-> `feat/macro-evidence-contract`; repository and PR history are authoritative for merge status. This
-> is the macro program source of truth and child-plan registry. It does not authorize implementation
-> on the active Fundamental PM ingest branch.
+> **Status:** MC0–MC4 shipped (v0.12.17); MC5 and MC6 closed by the operator 2026-08-26. The
+> descriptive chain is complete and the program carries **no** score, ranking, sizing or PM-integration
+> authority — that boundary is now a measured finding, not a pending decision. One designed-but-unbuilt
+> item remains: **F2 additive evidence invalidation** (`2026-08-24-macro-evidence-invalidation-design.md`),
+> zero production instances. The only path that could reopen MC5/MC6 is a release-**event** preflight,
+> which is unauthorized and unstarted. Repository and PR history are authoritative for merge status.
+> This is the macro program source of truth and child-plan registry.
 
 **Goal:** replace four disconnected dashboards with a reproducible top-down research system that
 explains inflation → policy/rates → USD transmission → gold, preserves every source and vintage,
@@ -196,9 +199,9 @@ Storage boundaries:
 | MC2 | merged | `2026-08-12-macro-mc2-inflation-rates-state.md` | inflation/rates states abstain honestly and reproduce from exact observations — PR #359, v0.12.10 |
 | MC3 | merged | `2026-08-12-macro-mc3-usd-gold-state.md` | rates market layer resolves to real evidence; USD/Gold states reuse shared inputs — PRs #363/#369/#372/#377. **Semantically bounded:** USD observes only the US policy leg (no foreign differential), and Gold's state owns two citable inputs and borrows the rest. Gold provenance is NOT complete; the wider Compass path stays separate |
 | MC3.5 | merged | — | `/macro` renders the four domain states in causal order — PR #378, v0.12.16. Descriptive chain viewer only: it composes four independent latest responses and is **not** MC4's atomic snapshot |
-| MC4 | partial | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | Task 4's page shell shipped as MC3.5 above. Snapshot schema, assembler, job and API absent |
-| MC5 | hold | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | not started, and not authorized. Requires an explicit authority decision plus the MC6 preflight below |
-| MC6 | blocked | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | blocked on a testable object — see the replay census below |
+| MC4 | merged | `2026-08-24-macro-mc4-mc6-sequenced.md` | one persisted snapshot owns the four-domain composition and renders its refusal — PRs #384/#386/#387, v0.12.17. Status comes from dependency-edge identity, never timestamp proximity, and a snapshot may never repair an incompatible chain by substituting a fresher upstream. First production snapshot: id 1, `as_of` 2026-08-25 19:40 ET, `complete`, four domains present |
+| MC5 | killed | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | **Closed by the operator 2026-08-26**, never started. It required the MC6 preflight to return something other than `descriptive_only`; it did not, so nothing measured justifies putting macro into the Fundamental PM surface. The hold stopped being procedural and became the finding. Reopening requires the release-event preflight below to produce a testable object AND a fresh authority decision |
+| MC6 | killed | `2026-08-12-macro-mc4-mc6-context-pm-validation.md` | **Closed by the operator 2026-08-26.** The preflight (`docs/research/2026-08-24-macro-continuous-feature-preflight/`) produced `descriptive_only`, which is one of MC6's own three designated verdicts — so MC6 reached its exit without building the walk-forward harness, and the harness must not be built for this panel. Every economically meaningful feature lands at `eff_n` 0.9–27 over 5.6 years; `usd change.DTWEXBGS`, which the whole USD engine rests on, is 12.8 and would need 42 years to reach 100. Neither longer history nor faster sampling rescues it — faster sampling is what the AR(1) correction measures |
 
 Every child is implemented through its own branch/PR sequence. Status changes only after its stated
 verification evidence exists. Child plans are implementation-ready but do not imply authorization to
@@ -210,12 +213,16 @@ commit or publish.
 > MC4 starts at `130`. Re-check the tail before writing a migration; do not read a reserved number
 > from either plan.
 
-> **MC6 sequencing changed.** `docs/research/2026-08-23-macro-state-replay-flip-census.md` replayed 68
-> monthly instants (2021-01..2026-08) and found the categorical state label is not a viable validation
-> unit: inflation flips 4 times, rates 8, `usd/2` 13 after the boundary move, and gold cannot replay at
-> all before its retrieval-clock evidence began. A continuous-feature availability and target preflight
-> must run BEFORE MC5 or the MC6 harness. Do not backfill replayed states to manufacture sample size —
-> those rows are immutable and would bake in today's engine version.
+> **MC6 sequencing changed, then MC6 ended.** `docs/research/2026-08-23-macro-state-replay-flip-census.md`
+> replayed 68 monthly instants (2021-01..2026-08) and found the categorical state label is not a viable
+> validation unit: inflation flips 4 times, rates 8, `usd/2` 13 after the boundary move, and gold cannot
+> replay at all before its retrieval-clock evidence began. That forced a continuous-feature availability
+> and target preflight BEFORE MC5 or the MC6 harness — a step the original child plan did not contain.
+> The preflight ran 2026-08-24 (`docs/research/2026-08-24-macro-continuous-feature-preflight/`) and
+> returned `descriptive_only`, closing both. Do not backfill replayed states to manufacture sample size —
+> those rows are immutable, would bake in today's engine version, and the preflight showed sample size
+> is not the binding constraint anyway: **the features with the largest effective sample are the ones
+> carrying no economic content**, because a high `eff_n` comes from being noisy rather than informative.
 
 ## 7. Dependency and release sequence
 

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -4,7 +4,8 @@
 task decomposition for MC4 is still good; its ORDER, its migration numbers, and its assumption that
 MC6 can validate state flips are not. Read this file for order and gates, that one for task detail.
 
-**Status:** planned. No implementation authorized by this document.
+**Status:** closed 2026-08-26. Everything this document sequenced is either shipped (F5, MC4) or
+formally closed (MC5, MC6). One item remains open and is deliberately unstarted: **F2 invalidation**.
 
 ## Decisions on the record
 
@@ -31,11 +32,14 @@ cannot. So MC6 is gated on a preflight that the original plan did not contain, a
 does not depend on MC4 — which is why it moves earlier and runs in parallel.
 
 ```text
-P0  F5 gold schedule ─────────> (independent; blocked on a question, see below)
+P0  F5 gold schedule ─────────> SHIPPED 2026-08-25, PR #388, v0.12.17
+                                 └─> verified in prod 2026-08-26: gauge age 3d -> 0d
 P0  MC6 preflight  ───────────> DONE 2026-08-24: descriptive_only
-                                 └─> MC5/MC6 closed; MC4 unaffected
-NEXT  MC4 snapshot ───────────> (authority already set: risk-monitoring)
-LATER F2 invalidation ────────> designed; zero production instances; retrofit is cheap
+                                 └─> MC6 CLOSED 2026-08-26 (its own designated verdict)
+                                 └─> MC5 CLOSED 2026-08-26 (no positive reason to build)
+NEXT  MC4 snapshot ───────────> SHIPPED, PRs #384/#386/#387, v0.12.17
+                                 └─> first prod snapshot id 1, complete, 2026-08-25 19:40 ET
+LATER F2 invalidation ────────> STILL OPEN. designed; zero production instances; retrofit is cheap
 ```
 
 Revised 2026-08-24. F2 was ordered before MC4 on the assumption that snapshots bake in evidence
@@ -83,12 +87,32 @@ constraint.
 
 Mon–Fri is kept on both. The Saturday and Sunday states legitimately read Friday's gauge and say so.
 
-**Exit:** `tests/unit/worker/test_gold_state_reads_todays_gauge.py` locks the ORDER rather than the
-clock times — posture after its whole ingest cascade, before the state that consumes it — so moving
-the block stays free and inverting it does not. The remaining piece is a real persisted smoke
-comparing state `as_of`, gauge `obs_date` and the allowed lag; it cannot run until a gold domain
-state exists (none has ever been computed — see MC6 preflight, gold is structurally excluded until
-migration 119 promotes a verified instant for `GLD_CLOSE`).
+**Exit — MET 2026-08-26.** `tests/unit/worker/test_gold_state_reads_todays_gauge.py` locks the ORDER
+rather than the clock times — posture after its whole ingest cascade, before the state that consumes
+it — so moving the block stays free and inverting it does not.
+
+**Correction: the persisted smoke was never blocked.** This section previously said it could not run
+because "no gold domain state has ever been computed". That was measured against `option_wizard_local`,
+a dev database. **Production has held gold states since 2026-08-23**, and they carry the defect and its
+fix directly (`gauge_age_days` term on `macro_domain_states.confidence_reasons_jsonb`, prod
+`option_wizard`, read 2026-08-26):
+
+| state | `as_of` (ET) | engine | gauge age | gauge `obs_date` |
+|---:|---|---|---:|---|
+| 18 | 2026-08-23 Sun 03:41 | `gold/1` | 2 | 2026-08-21 |
+| 22 | 2026-08-23 Sun 04:43 | `gold/1` | 2 | 2026-08-21 |
+| 26 | 2026-08-23 Sun 19:40 | `gold/1` | 2 | 2026-08-21 |
+| 30 | 2026-08-24 Mon 19:40 | `gold/1` | **3** | 2026-08-21 |
+| 34 | 2026-08-25 Tue 19:40 | `gold/2` | **0** | **2026-08-25** |
+
+State 30 is the defect stated in production data rather than inferred from cron strings: a Monday
+19:40 state reading Friday's gauge, because Monday's posture did not run until 21:00 — 80 minutes
+after the state that consumes it. State 34 is the first run under the new schedule: Tuesday 19:10
+wrote the gauge, Tuesday 19:40 read it, age 0.
+
+The gold-state blocker cited here confused two different claims. The MC6 preflight's finding is that
+gold cannot **replay** (`GLD_CLOSE` holds 275 periods across 3 availability instants). Computing
+**tonight's** state needs no such history and was never blocked.
 
 ## P0-b — F2: additive evidence invalidation
 
@@ -156,6 +180,11 @@ this and neither does faster sampling — that is what the correction measures.
 was revised in a way the term could see across 5.6 years, which is why its broken divisor survived.
 
 **MC6 over state features is closed. Do not build the walk-forward harness for this panel.**
+**Formally closed by the operator 2026-08-26.** Note what happened procedurally: `descriptive_only`
+is one of the three verdicts MC6's own Task 12 was designed to publish, so MC6 reached its designated
+exit — it did not stall short of it. The preflight was not in the original plan; it asked a question
+that plan never asked (is there enough sample to test ANYTHING?) and answered it before the expensive
+Task 11 harness was built.
 
 **One candidate survives and is NOT endorsed:** release events replay point-in-time —
 `federal_reserve_fomc` has 55 observations across 55 distinct `available_at` (2020-01-30 onward),
@@ -213,13 +242,23 @@ production is unverified — what it proves is that the detector fires on real s
 **Exit:** a partial domain failure can never render as a coherent fresh chain; a later evidence
 revision does not change an old snapshot hash; the page no longer fetches four latest states.
 
-## MC5 — held, and now without an empirical basis
+## MC5 — CLOSED by the operator 2026-08-26
 
-Not started, not authorized. It required the preflight above to produce something other than
-`descriptive_only`. It did not. Nothing measured justifies putting macro into the Fundamental PM
-surface, so the hold is no longer procedural — it is the finding. If it ever proceeds, it stays removable and must
-prove byte-invariance of every fundamental fact, score, valuation anchor, and hash with macro on and
-off.
+Never started, never authorized, and now closed rather than held. It required the preflight above to
+produce something other than `descriptive_only`. It did not. Nothing measured justifies putting macro
+into the Fundamental PM surface, so the hold stopped being procedural — it is the finding.
+
+**What "closed" means here, precisely.** MC6's own verdict taxonomy defines `descriptive_only` as
+*"retain MC4/MC5; no score/ranking/sizing authority"* — written on the assumption that MC5 would
+already be BUILT by the time MC6 ran, so the sentence means *do not tear out what exists*. MC5 was
+never built, so the live question was **whether to build it**, which that taxonomy does not answer.
+The operator answered it: no. `descriptive_only` does not by itself forbid a context-only MC5 block
+(that block was designed with no scoring authority — the byte-invariance test exists for exactly
+that reason); what closes it is the absence of any positive reason to build it.
+
+If it is ever reopened it stays removable and must prove byte-invariance of every fundamental fact,
+score, valuation anchor, and hash with macro on and off. Its reserved migration `118` is void — the
+Fundamental lane took that number long ago.
 
 ## Gates that survive all of the above
 


### PR DESCRIPTION
Operator closed MC5 and MC6 on 2026-08-26. Documentation only — no code, schema or behaviour changes.

## What changed

- `2026-08-12-top-down-macro-context-program.md` — milestone table: MC4 `partial` → `merged`, MC5 `hold` → `killed`, MC6 `blocked` → `killed`; header status and the MC6-sequencing note rewritten.
- `2026-08-24-macro-mc4-mc6-sequenced.md` — header status, P0 ledger, MC5 and MC6 sections, and the F5 exit.
- `CHANGELOG.md` — `[Unreleased]`.

## Two things worth reading rather than skimming

**MC6 did not stall — it exited.** `descriptive_only` is one of the three verdicts its own Task 12 was written to publish. The preflight that produced it was not in the original plan; it asked a question that plan never asked (is there enough sample to test *anything*) and answered it before Task 11's harness was built.

**MC5's closure is a different decision from MC6's verdict.** `descriptive_only` reads *retain MC4/MC5*, written on the assumption MC5 would already be built when MC6 ran. It never was, so the live question was whether to **build** it — which that taxonomy does not answer. Recorded explicitly so a future reader does not mistake 'closed' for 'forbidden'.

## A correction, not a status update

The F5 exit said its persisted smoke "cannot run until a gold domain state exists (none has ever been computed)". That was measured against `option_wizard_local`, a dev database. Production has held gold states since 2026-08-23:

| state | `as_of` (ET) | engine | gauge age | gauge `obs_date` |
|---:|---|---|---:|---|
| 30 | 2026-08-24 Mon 19:40 | `gold/1` | **3** | 2026-08-21 |
| 34 | 2026-08-25 Tue 19:40 | `gold/2` | **0** | **2026-08-25** |

State 30 is the defect in production data rather than inferred from cron strings. State 34 is the first run under PR #388's schedule. The blocker also conflated two claims: the MC6 preflight found gold cannot **replay**, which says nothing about computing tonight's state.