### PR TITLE
feat(macro): additive, point-in-time evidence invalidation (F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+- **The macro ledger can now say "we accepted this and were wrong"** — additive, point-in-time
+  evidence invalidation (migration `131`, `macro_evidence_invalidations`). F2, the last open item
+  in the macro program.
+  - **The gap it closes.** `macro_observations` is immutable — migration 115's guard rejects every
+    `DELETE` and every `UPDATE` touching anything but `last_seen_at` — so `quality_status` can never
+    be moved to `quarantined` after the fact. The ledger could say *we never accepted this*; it had
+    no way to say *we accepted this and were wrong*. The guard is correct and is untouched; this is
+    an overlay beside it, not a mutation of it.
+  - **One predicate produces both required behaviours.** The invalidation carries its own
+    point-in-time clock — `invalidated_at <= as_of`, deliberately the same shape as the
+    `available_at <= as_of` that already governs every macro read. A replay of 2021 does not yet
+    know about a 2026 discovery and returns the row Argon genuinely stood on; a read today knows and
+    excludes it. There is no "current versus replay" branch for a caller to get wrong.
+  - **`invalidated_at` is when WE DISCOVERED the problem, never when the publisher made it.** Keying
+    it on the publisher's error date would silently rewrite history: every replay between the two
+    dates would stop returning a row Argon believed for those months.
+  - **Four of the five readers take the predicate; `fetch_macro_observation_history` must not.** It
+    is the audit view, and filtering it would answer *what did we discard and why* with a view that
+    had already discarded it. It joins and MARKS instead — the row, the discovery instant, the
+    reason and the reviewer, side by side.
+  - **`vintage_*` bounds the publication, `period_*` bounds the reading**, and the pair is not
+    interchangeable: one says which readings are bad, the other which publications of them are. The
+    FRED rebasing needs exactly that separation — every period, but only the vintages before the
+    republish. A test asserts both directions, because swapping them in the predicate flips both.
+  - **Range columns are `period_from`/`period_to`, never `period_start`/`period_end`.**
+    `macro_observations.period_end` already exists and the join predicate references both tables, so
+    reusing the name would produce a filter that silently compares a row to itself.
+  - **The tests were rewritten once, and the reason is recorded in the plan.** The first version
+    passed 10 of 13 *with the feature not yet built*: it invalidated the pre-rebasing vintage and
+    asserted the post value came back, but the post row already wins on `available_at DESC`. The fix
+    was a second period held only at its pre-rebasing vintage, where exclusion is the difference
+    between a value and `None`. Every test now names the production change that breaks it.
+  - Verified against the frozen FRED rebasing (`WRESBAL` period 2025-06-04 carrying `3294.381` at
+    vintage 2025-06-05 and `3294381.0` at 2025-11-13, both labelled `millions_usd`), **not** against
+    production — production holds zero known-bad macro observations out of 28,941, so there is
+    nothing there to exclude.
+  - **It does not repair a series.** Invalidation removes evidence from consideration; it never
+    rewrites a value. A per-vintage `publisher_transform` is the recovery path and is a different
+    mechanism with its own measurement burden.
+  - Enrolled in the gap-healer registry as unhealable (153 → **154 datasets**). An invented
+    invalidation is the rare fabrication that SUBTRACTS — it would remove real observations from
+    every point-in-time read after its instant.
+
 ### Changed
 - **MC5 and MC6 are closed, and the macro program's authority boundary is now a measured finding.**
   Operator decision 2026-08-26; plan status updated in `2026-08-12-top-down-macro-context-program.md`

--- a/docs/runbooks/data-gap-dataset-policy.md
+++ b/docs/runbooks/data-gap-dataset-policy.md
@@ -6,7 +6,7 @@ Generated from `REGISTRY` in `src/uw_scan/reports/data_gap_healer.py` (one sourc
 uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_policy_markdown as r; open('docs/runbooks/data-gap-dataset-policy.md','w').write(r())"
 ```
 
-**153 datasets** across 11 groups.
+**154 datasets** across 11 groups.
 
 ## core_watchlist
 
@@ -74,6 +74,7 @@ uv run python -c "from uw_scan.reports.data_gap_healer import render_dataset_pol
 | macro_domain_state_dependencies | provenance | none | none |  | none | immutable state-level lineage (migration 128); a synthesized edge would claim one domain consulted another's answer when it never did, which is a worse failure than a missing edge because it reads as provenance |  |
 | macro_domain_state_evidence | provenance | none | none |  | none | immutable observation-level lineage for a state; a synthesized row would claim a state stood on evidence it never saw |  |
 | macro_domain_states | provenance | none | none |  | none | immutable record of a decision at an instant; recomputation belongs to the state job, which stamps its own computed_at, and the write guard rejects any edit to a stored answer |  |
+| macro_evidence_invalidations | provenance | none | none |  | none | a reviewer's judgement that accepted evidence was later found bad; there is no source to re-fetch it from, and an invented row would remove real observations from every point-in-time read after its instant |  |
 | macro_observation_artifacts | provenance | none | none |  | none | immutable lineage linking an observation to the exact artifacts that witness it; synthesizing a link would fabricate evidence |  |
 | macro_observations | provenance | none | none |  | none |  |  |
 | macro_release_ingest_status | operational_state | none | none |  | liveness | latest ingest outcome per individual release; describes our attempts, never what the publisher said, so it is not a substitute for immutable release evidence and must not be backfilled |  |

--- a/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
+++ b/docs/superpowers/plans/2026-08-24-macro-mc4-mc6-sequenced.md
@@ -4,8 +4,8 @@
 task decomposition for MC4 is still good; its ORDER, its migration numbers, and its assumption that
 MC6 can validate state flips are not. Read this file for order and gates, that one for task detail.
 
-**Status:** closed 2026-08-26. Everything this document sequenced is either shipped (F5, MC4) or
-formally closed (MC5, MC6). One item remains open and is deliberately unstarted: **F2 invalidation**.
+**Status:** COMPLETE 2026-08-26. Everything this document sequenced is shipped (F5, MC4, F2) or
+formally closed (MC5, MC6). Nothing here is open.
 
 ## Decisions on the record
 
@@ -39,7 +39,8 @@ P0  MC6 preflight  ───────────> DONE 2026-08-24: descripti
                                  └─> MC5 CLOSED 2026-08-26 (no positive reason to build)
 NEXT  MC4 snapshot ───────────> SHIPPED, PRs #384/#386/#387, v0.12.17
                                  └─> first prod snapshot id 1, complete, 2026-08-25 19:40 ET
-LATER F2 invalidation ────────> STILL OPEN. designed; zero production instances; retrofit is cheap
+LATER F2 invalidation ────────> SHIPPED 2026-08-26, migration 131
+                                 └─> zero production instances; verified on the frozen fixture
 ```
 
 Revised 2026-08-24. F2 was ordered before MC4 on the assumption that snapshots bake in evidence
@@ -114,7 +115,7 @@ The gold-state blocker cited here confused two different claims. The MC6 preflig
 gold cannot **replay** (`GLD_CLOSE` holds 275 periods across 3 availability instants). Computing
 **tonight's** state needs no such history and was never blocked.
 
-## P0-b — F2: additive evidence invalidation
+## P0-b — F2: additive evidence invalidation — **SHIPPED 2026-08-26**
 
 WRESBAL was rejected because FRED republished its history 1,000x on 2025-11-13 while the contract
 still labels every vintage `millions_usd`. The store holds 1,173 WRESBAL rows, all `valid`; period
@@ -149,9 +150,24 @@ stood on, which is the correct answer. The retrofit is cheap at any point.
 
 **Do MC4 first.** MC4 fixes a live defect; this one has zero production instances.
 
-**Exit (when built):** raw bytes survive, current readers exclude and the audit view does not,
-the reason is auditable, migration replay is idempotent, and a test asserts BOTH directions of the
-belief rule — returned by a replay before `invalidated_at`, absent after.
+**Exit — MET 2026-08-26.** Migration `131` + `macro_context.py`; 16 integration tests over the
+frozen WRESBAL rebasing. Raw bytes survive (the artifact row is byte-identical after invalidation
+and the observation keeps `quality_status = 'valid'`), the four state-feeding readers exclude and
+`fetch_macro_observation_history` does not — it joins and MARKS, so the audit view shows the row,
+the discovery instant, the reason and the reviewer side by side. Both directions of the belief rule
+are asserted, one second apart.
+
+**The tests had to be rewritten once, and that is the part worth reading.** The first version
+passed 10 of 13 with the feature not yet built. It invalidated the PRE-rebasing vintage and then
+asserted the POST value came back — but the post row already wins on `available_at DESC`, so the
+assertion held whether or not anything was excluded. The fix was a second period held ONLY at its
+pre-rebasing vintage (566 periods were rebased; nothing guarantees a post row for each), where
+exclusion is the difference between a value and `None`. Every test now names the production change
+that breaks it.
+
+**Enrolled as unhealable** (154 datasets). An invented invalidation is the rare fabrication that
+SUBTRACTS: it would silently remove real observations from every point-in-time read after its
+instant.
 
 ## P0-c — MC6 preflight (parallel; does not touch MC4)
 

--- a/docs/superpowers/specs/2026-08-24-macro-evidence-invalidation-design.md
+++ b/docs/superpowers/specs/2026-08-24-macro-evidence-invalidation-design.md
@@ -1,7 +1,15 @@
 # Macro evidence invalidation — an additive, point-in-time overlay
 
-**Status:** design. Not implemented. Read §7 before scheduling the work — the finding that
-motivated this spec is not where the handover said it was.
+**Status:** IMPLEMENTED 2026-08-26 — migration `131`, `macro_context.py`. §7 stands and is
+why the verification is against the frozen fixture rather than production data: production
+holds zero known-bad macro observations, so there is nothing there to exclude.
+
+**One deviation from §3, found by the tests.** `vintage_to` is INCLUSIVE (`available_at <=
+vintage_to`), matching the `available_at <= as_of` it is modelled on. That means a range
+cannot express *"everything strictly before instant X"* without naming the last bad vintage
+instead of the first good one. Writing `vintage_to = <the republish instant>` condemns the
+republish itself — the row that FIXED the problem. The overlay is correct; the caller must
+name the last bad vintage. The test fixture does, and says so.
 
 ## 1. The gap
 

--- a/src/uw_scan/reports/data_gap_healer.py
+++ b/src/uw_scan/reports/data_gap_healer.py
@@ -569,6 +569,22 @@ REGISTRY: list[DatasetRegistryEntry] = [
             "have no independent existence to heal"
         ),
     ),
+    # The evidence-invalidation overlay (migration 131). It is the record that a HUMAN
+    # reviewed accepted evidence and condemned it. A healer that invented a row here would
+    # be asserting a review nobody performed -- and unlike most fabrications this one
+    # SUBTRACTS: an invented invalidation silently removes real evidence from every state.
+    DatasetRegistryEntry(
+        "macro_evidence_invalidations",
+        "macro_evidence",
+        "provenance",
+        expected_frequency="none",
+        source_system="derived",
+        reason=(
+            "a reviewer's judgement that accepted evidence was later found bad; there is "
+            "no source to re-fetch it from, and an invented row would remove real "
+            "observations from every point-in-time read after its instant"
+        ),
+    ),
     DatasetRegistryEntry(
         "macro_domain_state_evidence",
         "macro_evidence",

--- a/src/uw_scan/storage/macro_context.py
+++ b/src/uw_scan/storage/macro_context.py
@@ -32,6 +32,37 @@ from uw_scan.macro_evidence import (
 #: quarantined artifact takes its observations out of service however it was obtained.
 _ARTIFACT_AVAILABLE = "(a.vintage_bearing OR a.available_at <= %s)"
 
+#: The discovery clock, applied the same way the publication clock already is.
+#:
+#: ``macro_observations`` is immutable by design (migration 115), so an accepted row can
+#: never be re-marked ``quarantined``.  This fragment is how the ledger says "we accepted
+#: this and were wrong" without editing what it accepted: an overlay row carries its own
+#: ``invalidated_at`` -- when WE DISCOVERED the problem, never when the publisher made it --
+#: and every state-feeding read applies ``invalidated_at <= as_of``.
+#:
+#: That single predicate produces BOTH required behaviours, which is why there is no
+#: "current versus replay" branch for a caller to get wrong: replaying 2021 today does not
+#: yet know about a 2026 discovery and returns the row Argon actually stood on, while a read
+#: now knows and excludes it.  Belief at the instant is preserved by arithmetic rather than
+#: by a flag someone has to remember to pass.
+#:
+#: The series_range arm bounds ``period_from``/``period_to`` on the observation's
+#: ``period_end`` and ``vintage_from``/``vintage_to`` on its ``available_at``.  Those two
+#: pairs are not interchangeable: one says WHICH READINGS are bad, the other says WHICH
+#: PUBLICATIONS OF THEM are.  The FRED rebasing needs exactly that separation -- every
+#: period, but only the vintages before the republish.
+_NOT_INVALIDATED = """NOT EXISTS (
+  SELECT 1 FROM {schema}.macro_evidence_invalidations v
+  WHERE v.invalidated_at <= %s
+    AND ( v.obs_id = o.obs_id
+       OR v.artifact_id = o.artifact_id
+       OR ( v.series_id = o.series_id
+        AND (v.period_from  IS NULL OR o.period_end   >= v.period_from)
+        AND (v.period_to    IS NULL OR o.period_end   <= v.period_to)
+        AND (v.vintage_from IS NULL OR o.available_at >= v.vintage_from)
+        AND (v.vintage_to   IS NULL OR o.available_at <= v.vintage_to) ) )
+)"""
+
 
 class _MacroContextMixin:
     _conn: psycopg.Connection
@@ -330,11 +361,12 @@ class _MacroContextMixin:
                   AND o.quality_status IN ('valid', 'partial')
                   AND {_ARTIFACT_AVAILABLE}
                   AND a.quality_status IN ('valid', 'partial')
+                  AND {_NOT_INVALIDATED.format(schema=self._schema)}
                 ORDER BY {rank_sql}, o.available_at DESC,
                          o.first_observed_at DESC, o.obs_id DESC
                 LIMIT 1
                 """,
-                (series_id, period_end, as_of, as_of, *rank_params),
+                (series_id, period_end, as_of, as_of, as_of, *rank_params),
             )
             return cur.fetchone()
 
@@ -353,8 +385,9 @@ class _MacroContextMixin:
             "o.quality_status IN ('valid', 'partial')",
             _ARTIFACT_AVAILABLE,
             "a.quality_status IN ('valid', 'partial')",
+            _NOT_INVALIDATED.format(schema=self._schema),
         ]
-        params: list[Any] = [series_id, as_of, as_of]
+        params: list[Any] = [series_id, as_of, as_of, as_of]
         if from_date is not None:
             clauses.append("o.period_end >= %s")
             params.append(from_date)
@@ -408,12 +441,13 @@ class _MacroContextMixin:
                   AND o.quality_status IN ('valid', 'partial')
                   AND {_ARTIFACT_AVAILABLE}
                   AND a.quality_status IN ('valid', 'partial')
+                  AND {_NOT_INVALIDATED.format(schema=self._schema)}
                 ORDER BY {rank_sql}, o.period_end DESC,
                          o.available_at DESC, o.first_observed_at DESC,
                          o.obs_id DESC
                 LIMIT 1
                 """,
-                (series_id, as_of, as_of, *rank_params),
+                (series_id, as_of, as_of, as_of, *rank_params),
             )
             return cur.fetchone()
 
@@ -455,13 +489,14 @@ class _MacroContextMixin:
                       AND o.quality_status IN ('valid', 'partial')
                       AND {_ARTIFACT_AVAILABLE}
                       AND a.quality_status IN ('valid', 'partial')
+                      AND {_NOT_INVALIDATED.format(schema=self._schema)}
                     ORDER BY o.release_key, {rank_sql}, o.available_at DESC,
                              o.first_observed_at DESC, o.obs_id DESC
                 ) AS releases
                 ORDER BY period_end DESC, available_at DESC, obs_id DESC
                 LIMIT %s
                 """,
-                (series_id, as_of, as_of, *rank_params, limit),
+                (series_id, as_of, as_of, as_of, *rank_params, limit),
             )
             return list(cur.fetchall())
 
@@ -470,13 +505,46 @@ class _MacroContextMixin:
         series_id: str,
         period_end: date,
     ) -> list[dict[str, Any]]:
+        """Every vintage of a period, INCLUDING the ones later found bad.
+
+        The one reader that deliberately does not take ``_NOT_INVALIDATED``.  This is the
+        audit view: filtering it would answer "what did we discard, and why" with a view
+        that had already discarded it, and the reason would be unreachable from anywhere.
+
+        It joins and MARKS instead.  ``invalidated_at`` is NULL for a row nothing condemns;
+        a marked row carries the discovery instant, the reason and the reviewer, so the
+        operator sees the row and the argument against it side by side.
+
+        No ``as_of`` here on purpose: the audit view answers what we know NOW about what we
+        once accepted.  A caller wanting the point-in-time answer wants one of the four
+        readers above, and those apply the clock.
+        """
         with self._conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 f"""
-                SELECT o.*, a.source_url, a.source_kind, a.media_type
+                SELECT o.*, a.source_url, a.source_kind, a.media_type,
+                       v.invalidated_at,
+                       v.reason       AS invalidation_reason,
+                       v.reviewer     AS invalidated_by,
+                       v.evidence_url AS invalidation_evidence_url
                 FROM {self._schema}.macro_observations o
                 JOIN {self._schema}.macro_source_artifacts a
                   ON a.artifact_id = o.artifact_id
+                LEFT JOIN LATERAL (
+                    SELECT i.invalidated_at, i.reason, i.reviewer, i.evidence_url
+                    FROM {self._schema}.macro_evidence_invalidations i
+                    WHERE i.obs_id = o.obs_id
+                       OR i.artifact_id = o.artifact_id
+                       OR ( i.series_id = o.series_id
+                        AND (i.period_from  IS NULL OR o.period_end   >= i.period_from)
+                        AND (i.period_to    IS NULL OR o.period_end   <= i.period_to)
+                        AND (i.vintage_from IS NULL OR o.available_at >= i.vintage_from)
+                        AND (i.vintage_to   IS NULL OR o.available_at <= i.vintage_to) )
+                    -- The EARLIEST discovery, because that is when the row stopped being
+                    -- usable. A later duplicate invalidation does not move that instant.
+                    ORDER BY i.invalidated_at ASC, i.invalidation_id ASC
+                    LIMIT 1
+                ) v ON TRUE
                 WHERE o.series_id = %s AND o.period_end = %s
                 ORDER BY o.available_at DESC, o.first_observed_at DESC,
                          o.source, o.obs_id DESC
@@ -484,6 +552,68 @@ class _MacroContextMixin:
                 (series_id, period_end),
             )
             return list(cur.fetchall())
+
+    def insert_macro_evidence_invalidation(
+        self,
+        *,
+        target_kind: str,
+        invalidated_at: datetime,
+        reason: str,
+        reviewer: str,
+        overlay_version: str,
+        artifact_id: int | None = None,
+        obs_id: int | None = None,
+        series_id: str | None = None,
+        period_from: date | None = None,
+        period_to: date | None = None,
+        vintage_from: datetime | None = None,
+        vintage_to: datetime | None = None,
+        evidence_url: str | None = None,
+    ) -> int:
+        """Record that accepted evidence was later found bad.  Never edits the evidence.
+
+        This is an OVERLAY, not a repair.  It removes rows from consideration; it never
+        rewrites a value.  Restating a rebased series is a different mechanism with its own
+        measurement burden (a per-vintage ``publisher_transform``), and conflating the two
+        would let a correction masquerade as a retraction.
+
+        ``invalidated_at`` is the discovery instant and is what every reader compares its
+        own ``as_of`` against, so passing the publisher's error date here would silently
+        rewrite history: replays between the two dates would stop returning a row Argon
+        genuinely believed.
+        """
+        _require_aware("invalidated_at", invalidated_at)
+        _require_aware("vintage_from", vintage_from, optional=True)
+        _require_aware("vintage_to", vintage_to, optional=True)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self._schema}.macro_evidence_invalidations (
+                    target_kind, artifact_id, obs_id, series_id,
+                    period_from, period_to, vintage_from, vintage_to,
+                    invalidated_at, reason, evidence_url, reviewer, overlay_version
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING invalidation_id
+                """,
+                (
+                    target_kind,
+                    artifact_id,
+                    obs_id,
+                    series_id,
+                    period_from,
+                    period_to,
+                    vintage_from,
+                    vintage_to,
+                    invalidated_at,
+                    reason,
+                    evidence_url,
+                    reviewer,
+                    overlay_version,
+                ),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        return int(row[0])
 
     def upsert_macro_source_status(
         self,

--- a/src/uw_scan/storage/migrations/131_macro_evidence_invalidations.sql
+++ b/src/uw_scan/storage/migrations/131_macro_evidence_invalidations.sql
@@ -1,0 +1,69 @@
+-- 131_macro_evidence_invalidations.sql -- saying "we accepted this and were wrong".
+--
+-- macro_observations rows are immutable: migration 115's macro_observation_write_guard
+-- rejects every DELETE and every UPDATE that changes any column but last_seen_at. That is
+-- correct and stays. Its consequence is that quality_status can never be moved to
+-- 'quarantined' after the fact, so the ledger can say "we never accepted this" and cannot
+-- say "we accepted this and were wrong." This table is that second sentence, added as an
+-- overlay rather than as a mutation.
+--
+-- THE OVERLAY HAS ITS OWN POINT-IN-TIME CLOCK. `invalidated_at` is when WE DISCOVERED the
+-- problem -- not when the publisher made the error. The read predicate is
+-- `invalidated_at <= as_of`, the same shape as the `available_at <= as_of` that already
+-- governs every macro read, and it is what makes historical replay preserve belief: a 2021
+-- replay does not yet know about a 2026 discovery, so it returns the row Argon actually
+-- stood on, while a read today excludes it. One predicate produces both behaviours, so no
+-- caller has to choose between a "current" and a "replay" code path.
+--
+-- Append-only by POLICY, with no immutability trigger of its own: a mistaken invalidation is
+-- corrected by a later row that supersedes it, which keeps the audit trail intact. If
+-- supersession is ever needed, add `supersedes_id BIGINT NULL` -- never UPDATE.
+--
+-- Additive only. Nothing in 115, 125, 128 or 130 is altered.
+
+SET search_path TO uw_scan, public;
+
+CREATE TABLE IF NOT EXISTS uw_scan.macro_evidence_invalidations (
+  invalidation_id  BIGSERIAL   PRIMARY KEY,
+  target_kind      TEXT        NOT NULL
+    CHECK (target_kind IN ('artifact', 'observation', 'series_range')),
+  artifact_id      BIGINT      NULL REFERENCES uw_scan.macro_source_artifacts (artifact_id),
+  obs_id           BIGINT      NULL REFERENCES uw_scan.macro_observations (obs_id),
+  series_id        TEXT        NULL,
+  -- NULL-open on each side, so a series_range can say "every vintage of this series before
+  -- 2025-11-13" without inventing a lower bound nobody knows.
+  --
+  -- NAMED period_from/period_to, NOT period_start/period_end: macro_observations.period_end
+  -- already exists and the join predicate references BOTH tables, so reusing that name
+  -- produces a filter that silently compares a row to itself and matches everything.
+  period_from      DATE        NULL,
+  period_to        DATE        NULL,
+  vintage_from     TIMESTAMPTZ NULL,
+  vintage_to       TIMESTAMPTZ NULL,
+  invalidated_at   TIMESTAMPTZ NOT NULL,
+  reason           TEXT        NOT NULL CHECK (btrim(reason) <> ''),
+  evidence_url     TEXT        NULL,
+  -- A human owns every invalidation. This is the column that stops the overlay from
+  -- becoming a place where a job quietly deletes data it did not like.
+  reviewer         TEXT        NOT NULL CHECK (btrim(reviewer) <> ''),
+  overlay_version  TEXT        NOT NULL CHECK (btrim(overlay_version) <> ''),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Exactly one target shape, fully specified. A row that names two targets would be two
+  -- invalidations wearing one id, and the reader would have to guess which one was meant.
+  CHECK (
+    (target_kind = 'artifact'     AND artifact_id IS NOT NULL AND obs_id IS NULL AND series_id IS NULL)
+ OR (target_kind = 'observation'  AND obs_id IS NOT NULL AND artifact_id IS NULL AND series_id IS NULL)
+ OR (target_kind = 'series_range' AND series_id IS NOT NULL AND obs_id IS NULL AND artifact_id IS NULL)
+  ),
+  CHECK (period_from IS NULL OR period_to IS NULL OR period_from <= period_to),
+  CHECK (vintage_from IS NULL OR vintage_to IS NULL OR vintage_from <= vintage_to)
+);
+
+-- The read predicate filters on invalidated_at first and then matches a target, so the
+-- clock leads the index.
+CREATE INDEX IF NOT EXISTS idx_macro_evidence_invalidations_clock
+  ON uw_scan.macro_evidence_invalidations (invalidated_at);
+
+CREATE INDEX IF NOT EXISTS idx_macro_evidence_invalidations_series
+  ON uw_scan.macro_evidence_invalidations (series_id, invalidated_at)
+  WHERE series_id IS NOT NULL;

--- a/tests/integration/storage/test_macro_evidence_invalidation.py
+++ b/tests/integration/storage/test_macro_evidence_invalidation.py
@@ -1,0 +1,433 @@
+"""The overlay that lets the ledger say "we accepted this and were wrong" (migration 131).
+
+``macro_observations`` is immutable -- migration 115's guard rejects every DELETE and every
+UPDATE touching anything but ``last_seen_at`` -- so ``quality_status`` cannot be moved to
+``quarantined`` after the fact. These tests fix the one property that makes an additive
+overlay honest instead of a soft delete: the invalidation carries its OWN point-in-time
+clock, so a replay of an instant before we discovered the problem still returns the row
+Argon genuinely believed, and a read after it does not.
+
+The fixture is the real FRED rebasing, frozen from
+``docs/research/2026-08-21-rates-market-layer-probe/VERDICT.md``: ``WRESBAL`` period
+2025-06-04 carries ``3294.381`` at vintage 2025-06-05 and ``3294381.0`` at vintage
+2025-11-13, both labelled ``millions_usd``. Ratio exactly 1000.0, across 566 periods.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from uw_scan.macro_evidence import (
+    macro_artifact_content_identity,
+    macro_observation_content_hash,
+)
+from uw_scan.storage.repository import Repository
+
+SERIES = "WRESBAL"
+
+#: A period we hold at BOTH vintages. Used where the point is which of two rows survives.
+PERIOD = date(2025, 6, 4)
+
+#: A period we hold ONLY at the pre-rebasing vintage -- 566 of them were rebased and there
+#: is no guarantee we captured a post row for each. This is the period the clock tests use,
+#: because it is the only shape where the two failure modes are distinguishable: with both
+#: vintages present the post row wins on ``available_at DESC`` regardless of the overlay, so
+#: a test asserting "the post value came back" would pass with the feature deleted.
+PERIOD_ONLY_PRE = date(2025, 5, 28)
+
+#: The pre-rebasing publication and the value it carried.
+PRE_VINTAGE = datetime(2025, 6, 5, 16, 30, tzinfo=UTC)
+PRE_VALUE = Decimal("3294.381")
+
+#: The republish that multiplied 566 periods of history by exactly 1000 without changing
+#: the declared unit. Both rows say ``millions_usd``; only one of them can be right.
+POST_VINTAGE = datetime(2025, 11, 13, 16, 30, tzinfo=UTC)
+POST_VALUE = Decimal("3294381.0")
+
+#: When WE found out. Deliberately later than the republish: the overlay's clock is the
+#: discovery, never the publisher's error.
+DISCOVERED = datetime(2026, 8, 24, 12, tzinfo=UTC)
+
+SOURCES = ("FRED",)
+
+
+@pytest.fixture
+def repo(seeded_db_empty_cards) -> Repository:
+    return seeded_db_empty_cards
+
+
+def _artifact(repo: Repository, *, record_id: str, available_at: datetime) -> int:
+    raw = {"series": SERIES, "record": record_id}
+    content_hash, length = macro_artifact_content_identity(raw_json=raw)
+    return repo.insert_macro_artifact(
+        source="FRED",
+        source_kind="official",
+        source_record_id=record_id,
+        source_url="https://fred.stlouisfed.org/series/WRESBAL",
+        published_at=available_at,
+        available_at=available_at,
+        retrieved_at=available_at,
+        content_hash=content_hash,
+        parser_version="fred-v1",
+        quality_status="valid",
+        cost_class="free_official",
+        media_type="application/json",
+        content_length=length,
+        vintage_bearing=False,
+        raw_json=raw,
+    )
+
+
+def _observe(
+    repo: Repository,
+    *,
+    artifact_id: int,
+    record_id: str,
+    available_at: datetime,
+    value: Decimal,
+    period_end: date = PERIOD,
+) -> None:
+    row: dict[str, Any] = {
+        "artifact_id": artifact_id,
+        "domain": "policy_rates",
+        "series_id": SERIES,
+        "period_end": period_end,
+        "frequency": "weekly",
+        "unit": "millions_usd",
+        "value_numeric": value,
+        "value_text": None,
+        "value_json": None,
+        "source": "FRED",
+        "source_record_id": record_id,
+        "published_at": available_at,
+        "available_at": available_at,
+        "parser_version": "fred-v1",
+        "quality_status": "valid",
+        "cost_class": "free_official",
+    }
+    row["content_hash"] = macro_observation_content_hash(row)
+    repo.insert_macro_observations([row], seen_at=available_at)
+
+
+def _seed_both_vintages(repo: Repository) -> None:
+    _observe(
+        repo,
+        artifact_id=_artifact(repo, record_id="wresbal-pre", available_at=PRE_VINTAGE),
+        record_id="wresbal-pre",
+        available_at=PRE_VINTAGE,
+        value=PRE_VALUE,
+    )
+    _observe(
+        repo,
+        artifact_id=_artifact(repo, record_id="wresbal-post", available_at=POST_VINTAGE),
+        record_id="wresbal-post",
+        available_at=POST_VINTAGE,
+        value=POST_VALUE,
+    )
+
+
+def _invalidate_pre_rebase(repo: Repository, *, at: datetime = DISCOVERED) -> int:
+    """Every vintage of WRESBAL up to the last pre-rebasing publication, no lower bound.
+
+    ``vintage_to`` is INCLUSIVE -- the same shape as ``available_at <= as_of`` -- so it
+    names the last bad vintage rather than the instant the good one arrived. Passing
+    ``POST_VINTAGE`` here would condemn the republish itself, which is the row that fixed
+    the problem.
+    """
+    return repo.insert_macro_evidence_invalidation(
+        target_kind="series_range",
+        series_id=SERIES,
+        vintage_to=PRE_VINTAGE,
+        invalidated_at=at,
+        reason=(
+            "FRED republished 566 periods multiplied by 1000 on 2025-11-13 while the "
+            "contract still labels every vintage millions_usd"
+        ),
+        evidence_url="https://fred.stlouisfed.org/series/WRESBAL",
+        reviewer="operator",
+        overlay_version="wresbal-rebase/1",
+    )
+
+
+def _seed_only_pre_vintage(repo: Repository) -> None:
+    _observe(
+        repo,
+        artifact_id=_artifact(repo, record_id="wresbal-pre-only", available_at=PRE_VINTAGE),
+        record_id="wresbal-pre-only",
+        available_at=PRE_VINTAGE,
+        value=PRE_VALUE,
+        period_end=PERIOD_ONLY_PRE,
+    )
+
+
+def _value_at(
+    repo: Repository, as_of: datetime, *, period: date = PERIOD
+) -> Decimal | None:
+    row = repo.fetch_macro_observation_as_of(
+        SERIES, period, as_of, preferred_sources=SOURCES
+    )
+    return None if row is None else row["value_numeric"]
+
+
+class TestTheOverlayHasItsOwnClock:
+    """The period held only at its pre-rebasing vintage, so exclusion is visible.
+
+    Each test below names the production change that breaks it. A test that passes with
+    the predicate deleted is not testing the predicate.
+    """
+
+    def test_a_replay_before_the_discovery_still_believes_the_bad_row(
+        self, repo: Repository
+    ) -> None:
+        # Breaks if the predicate drops `invalidated_at <= as_of` and filters
+        # unconditionally. In June 2025 Argon genuinely stood on 3294.381; a replay that
+        # hid it would make the record a fiction rather than a point-in-time answer.
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        assert _value_at(repo, PRE_VINTAGE, period=PERIOD_ONLY_PRE) == PRE_VALUE
+
+    def test_a_read_after_the_discovery_excludes_it(self, repo: Repository) -> None:
+        # Breaks if the predicate is missing entirely.
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        assert _value_at(repo, DISCOVERED, period=PERIOD_ONLY_PRE) is None
+
+    def test_the_boundary_is_the_discovery_instant_not_the_publishers_error(
+        self, repo: Repository
+    ) -> None:
+        # Breaks if the overlay is keyed on the republish date instead of ours: every
+        # replay between 2025-11-13 and 2026-08-24 would stop returning a row Argon
+        # believed for those nine months.
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        one_second_before = DISCOVERED - timedelta(seconds=1)
+        assert _value_at(repo, one_second_before, period=PERIOD_ONLY_PRE) == PRE_VALUE
+        assert _value_at(repo, DISCOVERED, period=PERIOD_ONLY_PRE) is None
+
+    def test_an_unrelated_series_is_untouched(self, repo: Repository) -> None:
+        # Breaks if the series_range arm forgets `v.series_id = o.series_id` -- a NULL
+        # series_id on an observation-target row would otherwise match everything.
+        _seed_both_vintages(repo)
+        repo.insert_macro_evidence_invalidation(
+            target_kind="observation",
+            obs_id=next(
+                r["obs_id"]
+                for r in repo.fetch_macro_observation_history(SERIES, PERIOD)
+                if r["value_numeric"] == PRE_VALUE
+            ),
+            invalidated_at=DISCOVERED,
+            reason="one row only",
+            reviewer="operator",
+            overlay_version="single/1",
+        )
+        _seed_only_pre_vintage(repo)
+
+        assert _value_at(repo, DISCOVERED, period=PERIOD_ONLY_PRE) == PRE_VALUE
+
+
+class TestTheRangeArmBoundsWhatItSays:
+    def test_an_open_lower_bound_takes_only_the_pre_rebasing_vintages(
+        self, repo: Repository
+    ) -> None:
+        # Breaks if the predicate is missing: the series read returns both periods.
+        _seed_both_vintages(repo)
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        rows = repo.fetch_macro_series_as_of(SERIES, DISCOVERED, preferred_sources=SOURCES)
+        assert [(r["period_end"], r["value_numeric"]) for r in rows] == [
+            (PERIOD, POST_VALUE)
+        ]
+
+    def test_a_vintage_range_takes_the_publication(self, repo: Repository) -> None:
+        # Pairs with the next test. vintage_* bounds `available_at`; period_* bounds
+        # `period_end`. Swapping them in the predicate flips BOTH, which is why neither
+        # assertion alone would catch it.
+        _seed_only_pre_vintage(repo)
+        repo.insert_macro_evidence_invalidation(
+            target_kind="series_range",
+            series_id=SERIES,
+            vintage_from=PRE_VINTAGE,
+            vintage_to=PRE_VINTAGE,
+            invalidated_at=DISCOVERED,
+            reason="the publication instant, which is what vintage_* means",
+            reviewer="operator",
+            overlay_version="bounds-check/1",
+        )
+        assert _value_at(repo, DISCOVERED, period=PERIOD_ONLY_PRE) is None
+
+    def test_a_period_range_over_the_same_instants_matches_nothing(
+        self, repo: Repository
+    ) -> None:
+        # Same numbers, read as PERIODS: 2025-05-28 is not inside 2025-06-05..2025-11-13.
+        _seed_only_pre_vintage(repo)
+        repo.insert_macro_evidence_invalidation(
+            target_kind="series_range",
+            series_id=SERIES,
+            period_from=PRE_VINTAGE.date(),
+            period_to=POST_VINTAGE.date(),
+            invalidated_at=DISCOVERED,
+            reason="period-bounded, must not match a period that precedes the range",
+            reviewer="operator",
+            overlay_version="bounds-check/1",
+        )
+        assert _value_at(repo, DISCOVERED, period=PERIOD_ONLY_PRE) == PRE_VALUE
+
+    def test_a_period_range_covering_the_reading_takes_every_vintage_of_it(
+        self, repo: Repository
+    ) -> None:
+        # Breaks if the predicate is missing: the post row would still answer.
+        _seed_both_vintages(repo)
+        repo.insert_macro_evidence_invalidation(
+            target_kind="series_range",
+            series_id=SERIES,
+            period_from=PERIOD,
+            period_to=PERIOD,
+            invalidated_at=DISCOVERED,
+            reason="the whole reading is unusable, at every vintage",
+            reviewer="operator",
+            overlay_version="bounds-check/1",
+        )
+
+        assert _value_at(repo, DISCOVERED) is None
+
+
+class TestTheOtherStateFeedingReaders:
+    def test_latest_observation_excludes_an_invalidated_row(
+        self, repo: Repository
+    ) -> None:
+        # Only the pre vintage is held, so a working predicate leaves the series with no
+        # answer at all. Breaks if this reader was left off the predicate.
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        assert (
+            repo.fetch_latest_macro_observation_as_of(
+                SERIES, DISCOVERED, preferred_sources=SOURCES
+            )
+            is None
+        )
+
+    def test_recent_releases_exclude_an_invalidated_row(self, repo: Repository) -> None:
+        # Seeded with the pre-vintage period alone, so the assertion is a row versus no
+        # row. Breaks if this reader was left off the predicate.
+        #
+        # Not seeded with both periods on purpose: this reader is DISTINCT ON
+        # (release_key), `insert_macro_observations` never writes that column, and
+        # DISTINCT ON treats two NULLs as equal -- so a two-period fixture collapses to one
+        # row and the test would pass with the predicate deleted.
+        _seed_only_pre_vintage(repo)
+        _invalidate_pre_rebase(repo)
+
+        assert (
+            repo.fetch_recent_macro_observations_as_of(
+                SERIES, DISCOVERED, preferred_sources=SOURCES, limit=10
+            )
+            == []
+        )
+
+    def test_an_observation_target_takes_exactly_one_row(self, repo: Repository) -> None:
+        # Invalidate the row that would otherwise WIN, so the fallback is observable.
+        _seed_both_vintages(repo)
+        post = next(
+            r
+            for r in repo.fetch_macro_observation_history(SERIES, PERIOD)
+            if r["value_numeric"] == POST_VALUE
+        )
+        repo.insert_macro_evidence_invalidation(
+            target_kind="observation",
+            obs_id=post["obs_id"],
+            invalidated_at=DISCOVERED,
+            reason="this single row, nothing else",
+            reviewer="operator",
+            overlay_version="single/1",
+        )
+
+        assert _value_at(repo, DISCOVERED) == PRE_VALUE
+
+    def test_an_artifact_target_takes_the_rows_parsed_out_of_it(
+        self, repo: Repository
+    ) -> None:
+        _seed_both_vintages(repo)
+        post = next(
+            r
+            for r in repo.fetch_macro_observation_history(SERIES, PERIOD)
+            if r["value_numeric"] == POST_VALUE
+        )
+        repo.insert_macro_evidence_invalidation(
+            target_kind="artifact",
+            artifact_id=post["artifact_id"],
+            invalidated_at=DISCOVERED,
+            reason="the whole payload was misparsed",
+            reviewer="operator",
+            overlay_version="artifact/1",
+        )
+
+        assert _value_at(repo, DISCOVERED) == PRE_VALUE
+
+
+
+class TestTheAuditViewMustNotFilterItself:
+    def test_history_still_returns_an_invalidated_row(self, repo: Repository) -> None:
+        # Filtering this view would answer "what did we discard and why" with a view that
+        # had already discarded it.
+        _seed_both_vintages(repo)
+        _invalidate_pre_rebase(repo)
+
+        values = {
+            r["value_numeric"]
+            for r in repo.fetch_macro_observation_history(SERIES, PERIOD)
+        }
+        assert values == {PRE_VALUE, POST_VALUE}
+
+    def test_history_marks_the_invalidated_row_with_its_reason_and_reviewer(
+        self, repo: Repository
+    ) -> None:
+        _seed_both_vintages(repo)
+        _invalidate_pre_rebase(repo)
+
+        rows = repo.fetch_macro_observation_history(SERIES, PERIOD)
+        by_value = {r["value_numeric"]: r for r in rows}
+        assert by_value[POST_VALUE]["invalidated_at"] is None
+        assert by_value[POST_VALUE]["invalidation_reason"] is None
+        assert by_value[PRE_VALUE]["invalidated_at"] == DISCOVERED
+        assert "multiplied by 1000" in by_value[PRE_VALUE]["invalidation_reason"]
+        assert by_value[PRE_VALUE]["invalidated_by"] == "operator"
+
+
+class TestTheEvidenceItselfSurvives:
+    def test_the_raw_artifact_is_byte_identical_after_invalidation(
+        self, repo: Repository
+    ) -> None:
+        # Invalidation removes evidence from consideration. It never rewrites a value, and
+        # it must never be a soft delete of the bytes.
+        _seed_both_vintages(repo)
+        history = repo.fetch_macro_observation_history(SERIES, PERIOD)
+        pre = next(r for r in history if r["value_numeric"] == PRE_VALUE)
+        before = repo.fetch_macro_artifact(pre["artifact_id"])
+
+        _invalidate_pre_rebase(repo)
+
+        after = repo.fetch_macro_artifact(pre["artifact_id"])
+        assert after == before
+        assert after["content_hash"] == before["content_hash"]
+
+    def test_the_observation_row_keeps_its_quality_status(
+        self, repo: Repository
+    ) -> None:
+        _seed_both_vintages(repo)
+        _invalidate_pre_rebase(repo)
+
+        pre = next(
+            r
+            for r in repo.fetch_macro_observation_history(SERIES, PERIOD)
+            if r["value_numeric"] == PRE_VALUE
+        )
+        assert pre["quality_status"] == "valid"


### PR DESCRIPTION
The last open item in the macro program. Migration `131`.

## The gap

`macro_observations` is immutable — migration 115's guard rejects every `DELETE` and every `UPDATE` touching anything but `last_seen_at` — so `quality_status` can never be moved to `quarantined` after the fact. The ledger could say *we never accepted this*; it had no way to say *we accepted this and were wrong*. The guard is correct and is untouched: this is an overlay beside it, not a mutation of it.

## One predicate, both behaviours

`invalidated_at <= as_of`, deliberately the same shape as the `available_at <= as_of` that already governs every macro read.

| read | result |
|---|---|
| replay of 2021 | returns the row — a 2026 discovery is not yet known, and that is what Argon believed |
| read today | excludes it |

No "current versus replay" branch for a caller to get wrong. `invalidated_at` is when **we discovered** the problem, never when the publisher made it — keying it on the publisher's date would silently rewrite history for every replay between the two.

## Four readers take it; the fifth must not

`fetch_macro_observation_history` is the audit view. Filtering it would answer *what did we discard and why* with a view that had already discarded it. It joins and **marks** instead: row, discovery instant, reason, reviewer, side by side.

## The tests were rewritten once, and that is the part worth reading

The first version **passed 10 of 13 with the feature not yet built.** It invalidated the pre-rebasing vintage and asserted the post value came back — but the post row already wins on `available_at DESC`, so the assertion held whether or not anything was excluded.

The fix was a second period held **only** at its pre-rebasing vintage (566 periods were rebased; nothing guarantees a post row for each), where exclusion is the difference between a value and `None`.

Two mutation runs, both after the suite was green:

| mutation | result |
|---|---|
| neutralise the predicate | **9 fail** |
| keep the filter, drop the PIT clock | **2 fail** — the belief-preserving pair |

So the suite catches both failure modes: missing the filter, and over-filtering.

## Two things found while building

- **`vintage_to` is inclusive**, matching `available_at <= as_of`. A range therefore cannot express *"everything strictly before instant X"* — writing the republish instant there condemns the republish itself, the row that fixed the problem. The caller must name the last bad vintage. Recorded as a deviation in the spec.
- **`fetch_recent_macro_observations_as_of` is `DISTINCT ON (release_key)`, and `insert_macro_observations` never writes that column.** Two NULLs compare equal under `DISTINCT ON`, so a two-period fixture collapses to one row — which is why that test seeds one period and asserts a row versus no row. Noted in the test, not changed: it is outside this PR.

## Verification

- 16 new integration tests over the frozen FRED rebasing (`WRESBAL` 2025-06-04: `3294.381` at vintage 2025-06-05, `3294381.0` at 2025-11-13, both labelled `millions_usd`).
- Full integration suite: **1346 passed, 9 skipped**. Unit: **2520 passed**. `ruff check src/ tests/ scripts/` clean.
- Verified against the fixture, **not** production: production holds **zero** known-bad macro observations out of 28,941, so there is nothing there to exclude. The plan's original exit criterion was unsatisfiable for that reason.
- Enrolled in the gap-healer registry as unhealable (153 → **154 datasets**). An invented invalidation is the rare fabrication that *subtracts* — it would remove real observations from every point-in-time read after its instant.

## Scope

It does **not** repair a series. Invalidation removes evidence from consideration; it never rewrites a value. A per-vintage `publisher_transform` is the recovery path and is a different mechanism with its own measurement burden.