### PR TITLE
feat(fundamentals): seed the five datacenter chains as chain-analysis nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **Seed the five datacenter build-out chains** (EPC/Construction, Generation/Nuclear,
+  Power/Electrical, Cooling/Thermal, DC-REIT/Colo) with real layer ranks — taxonomy rows only, zero
+  assembler change, zero vendor calls.
+  - **The contract this exercises.** `Optical-Communication` was the first chain analysis node;
+    these five are its siblings, and standing them up cost a `ChainSpec` constant each plus one
+    generic `seed_chain_spec` helper. `assemble_chain_report` is untouched, which is the point —
+    `test_the_catalogue_matches_what_the_assembler_actually_emits` passes unmodified.
+  - **One real layer per chain, ranks 10/20/30/40/50.** The chain IS a layer of the build-out;
+    inventing an intra-chain split would publish a shape nobody measured. Ranks are sparse so a
+    split discovered later slots between two of these without renumbering.
+  - **Every spec declares `domain='ai_infrastructure'`, deliberately.** `research_chains`' primary
+    key is `(taxonomy_version, chain, layer)`, so `domain` is a per-LAYER attribute, not part of a
+    chain's identity. All five names are already mirrored from `watchlist_chain` under
+    `ai_infrastructure`; a spec under a second domain would leave one chain carrying two layers
+    across two domains and `chains(version, domain=...)` would answer with half of it. Nothing in
+    the schema forbids that, so `test_no_chain_carries_two_domains` does.
+  - **Memberships are re-homed by retire-and-reinsert, never `UPDATE ... SET layer`** — open
+    membership identity is the partial unique index `chain_membership_open_uq`, which an in-place
+    update collides with. The rank-0 placeholder interval is closed, not deleted, so "was this name
+    in the chain when that report was written" stays answerable.
 - **The macro ledger can now say "we accepted this and were wrong"** — additive, point-in-time
   evidence invalidation (migration `131`, `macro_evidence_invalidations`). F2, the last open item
   in the macro program.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,24 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
     `ai_infrastructure`; a spec under a second domain would leave one chain carrying two layers
     across two domains and `chains(version, domain=...)` would answer with half of it. Nothing in
     the schema forbids that, so `test_no_chain_carries_two_domains` does.
-  - **Memberships are re-homed by retire-and-reinsert, never `UPDATE ... SET layer`** — open
+  - **Memberships are re-homed by reinsert-then-retire, never `UPDATE ... SET layer`** — open
     membership identity is the partial unique index `chain_membership_open_uq`, which an in-place
-    update collides with. The rank-0 placeholder interval is closed, not deleted, so "was this name
-    in the chain when that report was written" stays answerable.
+    update collides with. The order is the failure mode: retiring first leaves a crash window in
+    which the chain has ZERO open memberships and no re-run can heal it, because the recovery scan
+    looks for a placeholder row that is no longer open. Inserting first cannot collide, and a crash
+    leaves the name open on both layers for the next run to finish. The rank-0 placeholder interval
+    is closed, not deleted, so "was this name in the chain when that report was written" stays
+    answerable — and `evidence_class`/`approved_by` are carried across, never rewritten, so
+    pointing this at a chain of `analyst` placements cannot demote a human's assertion to a copy of
+    the watchlist rail.
+  - **`mirror_watchlist_chain` now skips a name already openly a member of the chain under ANY
+    layer.** Its old guard keyed on the layer, which a seed has just changed — so mirror and seed
+    would have churned an interval pair per ticker on every run, contradicting the healer registry's
+    standing claim that an unchanged placement opens no interval.
+  - **Deploy step (manual, not automatic).** Nothing schedules this: run
+    `uv run python scripts/backfill/research_taxonomy_seed.py` on the mini after deploy, or the five
+    chains stay on their rank-0 `L3` placeholder. Zero provider spend, idempotent — a second run is
+    a measured no-op.
 - **The macro ledger can now say "we accepted this and were wrong"** — additive, point-in-time
   evidence invalidation (migration `131`, `macro_evidence_invalidations`). F2, the last open item
   in the macro program.

--- a/scripts/backfill/research_taxonomy_seed.py
+++ b/scripts/backfill/research_taxonomy_seed.py
@@ -26,6 +26,7 @@ import sys
 import psycopg
 
 from uw_scan.config import Settings
+from uw_scan.fundamentals.chain_nodes import DATACENTER_CHAINS
 from uw_scan.storage.research_taxonomy import ResearchTaxonomyRepository
 from uw_scan.worker.jobs.research_taxonomy_seed import (
     TAXONOMY_V1,
@@ -33,6 +34,7 @@ from uw_scan.worker.jobs.research_taxonomy_seed import (
     derive_disclosed_exposure,
     mirror_watchlist_chain,
     seed_aliases,
+    seed_chain_spec,
 )
 
 APPROVER = "argon-research"
@@ -104,6 +106,17 @@ def main(argv: list[str] | None = None) -> int:
 
         if not args.measure:
             out["mirror"] = mirror_watchlist_chain(conn, schema=schema)
+
+            # The five datacenter build-out chains, immediately after the mirror
+            # that creates their placeholder layer and before any exposure
+            # derivation reads `chain_membership`. Declared as data in
+            # `chain_nodes`, applied here through the same `define_chains` /
+            # `add_membership` calls every other chain uses — no assembler
+            # change, which is the extension contract those specs exist to test.
+            out["datacenter"] = {
+                spec.chain: seed_chain_spec(conn, spec, schema=schema)
+                for spec in DATACENTER_CHAINS
+            }
 
             # Optical layers + membership through the SAME general calls the
             # mirrored chains use. That symmetry is the extensibility proof.

--- a/src/uw_scan/fundamentals/chain_nodes.py
+++ b/src/uw_scan/fundamentals/chain_nodes.py
@@ -353,3 +353,62 @@ OPTICAL_COMMUNICATION = ChainSpec(
         AliasRule("blueplanetautomation", "integrator"),
     ),
 )
+
+#: The datacenter build-out siblings. Every member is already in the universe;
+#: 42 of 44 carry statements (measured 2026-08-26, DC-REIT/Colo is the gap at
+#: 4 of 6), so these chains cost no incremental UW calls at all.
+#:
+#: ONE REAL LAYER PER CHAIN. The chain IS a layer of the build-out — construction
+#: before generation before distribution before cooling before the operator who
+#: leases the result — and inventing an intra-chain split here would publish a
+#: shape nobody measured. Ranks are sparse, so a split discovered later slots
+#: between two of these without renumbering anything.
+#:
+#: EVERY SPEC IS `ai_infrastructure`, DELIBERATELY. `research_chains`' primary
+#: key is (taxonomy_version, chain, layer), so `domain` is a per-LAYER attribute
+#: and not part of a chain's identity. All five names are already mirrored from
+#: `watchlist_chain` under `ai_infrastructure` with a placeholder layer; a spec
+#: declaring a second domain would leave one chain carrying two layers under two
+#: domains, and `chains(version, domain=...)` would answer with half of it.
+#: `OPTICAL_COMMUNICATION` can carry its own domain only because its spec name
+#: differs from the watchlist's (`Networking/Optical`), so it collides with
+#: nothing. `test_no_chain_carries_two_domains` is the guard.
+DATACENTER_CHAINS: tuple[ChainSpec, ...] = (
+    ChainSpec(
+        domain="ai_infrastructure",
+        chain="EPC/Construction",
+        layers=(
+            Layer(
+                "EPC-Construction",
+                10,
+                "design, engineering, construction of datacenter shells",
+            ),
+        ),
+    ),
+    ChainSpec(
+        domain="ai_infrastructure",
+        chain="Generation/Nuclear",
+        layers=(Layer("Generation", 20, "power generation and nuclear capacity"),),
+    ),
+    ChainSpec(
+        domain="ai_infrastructure",
+        chain="Power/Electrical",
+        layers=(
+            Layer("Power-Electrical", 30, "electrical distribution, switchgear, UPS"),
+        ),
+    ),
+    ChainSpec(
+        domain="ai_infrastructure",
+        chain="Cooling/Thermal",
+        layers=(
+            Layer("Cooling-Thermal", 40, "liquid and air cooling, thermal management"),
+        ),
+    ),
+    ChainSpec(
+        domain="ai_infrastructure",
+        chain="DC-REIT/Colo",
+        layers=(
+            Layer("DC-REIT-Colo", 50, "datacenter REITs and colocation operators"),
+        ),
+    ),
+)

--- a/src/uw_scan/worker/jobs/research_taxonomy_seed.py
+++ b/src/uw_scan/worker/jobs/research_taxonomy_seed.py
@@ -23,7 +23,11 @@ from typing import Any
 
 import psycopg
 
-from uw_scan.storage.research_taxonomy import ResearchTaxonomyRepository
+from uw_scan.fundamentals.chain_nodes import ChainSpec
+from uw_scan.storage.research_taxonomy import (
+    EVIDENCE_MIRRORED,
+    ResearchTaxonomyRepository,
+)
 
 log = logging.getLogger(__name__)
 
@@ -68,9 +72,7 @@ def mirror_watchlist_chain(
         activate=True,
     )
     with conn.cursor() as cur:
-        cur.execute(
-            f"SELECT DISTINCT chain, layer FROM {schema}.watchlist_chain"
-        )
+        cur.execute(f"SELECT DISTINCT chain, layer FROM {schema}.watchlist_chain")
         pairs = cur.fetchall()
         cur.execute(f"SELECT ticker, chain, layer FROM {schema}.watchlist_chain")
         rows = cur.fetchall()
@@ -101,6 +103,84 @@ def mirror_watchlist_chain(
         )
     counters = {"chains": len(pairs), "memberships": len(rows), "opened": added}
     log.info("mirror_watchlist_chain: %s", counters)
+    return counters
+
+
+def seed_chain_spec(
+    conn: psycopg.Connection,
+    spec: ChainSpec,
+    *,
+    schema: str = "uw_scan",
+    version: str = TAXONOMY_V1,
+) -> dict[str, int]:
+    """Give one chain its real layer set and re-home its memberships onto it.
+
+    Standing up a chain analysis node is rows and no assembler logic — the
+    extension contract `chain_nodes` declares. This function is the whole of the
+    "code" half, and it is generic over `ChainSpec`: a sixth chain adds a
+    constant, not a branch.
+
+    Placeholder layers (the rank-0 `L3` the watchlist mirror lays down) are
+    SUPERSEDED, not deleted. The new layer rows land beside them and the
+    memberships move, so "was this name in the chain when that report was
+    written" stays answerable — which is the reason `chain_membership` carries
+    validity intervals instead of a `removed_at`.
+    """
+    repo = ResearchTaxonomyRepository(conn, schema=schema)
+    # Order is load-bearing: `chain_membership` has an FK on
+    # (taxonomy_version, chain, layer) -> `research_chains`, so the target layer
+    # must exist before a membership can name it.
+    repo.define_chains(
+        version,
+        [
+            {
+                "domain": spec.domain,
+                "chain": spec.chain,
+                "layer": layer.layer,
+                "layer_rank": layer.rank,
+                "description": layer.description,
+            }
+            for layer in spec.layers
+        ],
+    )
+    moved = 0
+    if len(spec.layers) == 1:
+        # Retire-and-reinsert, never `UPDATE ... SET layer`: open membership
+        # identity is the partial unique index chain_membership_open_uq
+        # (taxonomy_version, chain, layer, ticker) WHERE valid_to IS NULL, so an
+        # in-place UPDATE collides with a row the same statement has not closed
+        # yet. A multi-layer spec cannot be re-homed automatically at all —
+        # which layer a name belongs to is a research judgement, not a default.
+        target = spec.layers[0].layer
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""SELECT ticker FROM {schema}.chain_membership
+                     WHERE taxonomy_version = %s AND chain = %s
+                       AND layer <> %s AND valid_to IS NULL""",
+                (version, spec.chain, target),
+            )
+            tickers = [t for (t,) in cur.fetchall()]
+            cur.execute(
+                f"""UPDATE {schema}.chain_membership
+                       SET valid_to = now()
+                     WHERE taxonomy_version = %s AND chain = %s
+                       AND layer <> %s AND valid_to IS NULL""",
+                (version, spec.chain, target),
+            )
+        conn.commit()
+        for ticker in tickers:
+            moved += repo.add_membership(
+                version,
+                chain=spec.chain,
+                layer=target,
+                ticker=ticker,
+                evidence_class=EVIDENCE_MIRRORED,
+                approved_by="seed_chain_spec",
+                note=f"re-homed from placeholder layer onto {target}",
+            )
+    conn.commit()
+    counters = {"layers": len(spec.layers), "memberships": moved}
+    log.info("seed_chain_spec %s: %s", spec.chain, counters)
     return counters
 
 

--- a/src/uw_scan/worker/jobs/research_taxonomy_seed.py
+++ b/src/uw_scan/worker/jobs/research_taxonomy_seed.py
@@ -25,6 +25,9 @@ import psycopg
 
 from uw_scan.fundamentals.chain_nodes import ChainSpec
 from uw_scan.storage.research_taxonomy import (
+    EVIDENCE_ANALYST,
+    EVIDENCE_DISCLOSED,
+    EVIDENCE_INFERRED,
     EVIDENCE_MIRRORED,
     ResearchTaxonomyRepository,
 )
@@ -76,6 +79,14 @@ def mirror_watchlist_chain(
         pairs = cur.fetchall()
         cur.execute(f"SELECT ticker, chain, layer FROM {schema}.watchlist_chain")
         rows = cur.fetchall()
+        # A name already openly a member of this CHAIN under any layer is
+        # already mirrored — see the loop below for why the layer is excluded.
+        cur.execute(
+            f"""SELECT DISTINCT chain, ticker FROM {schema}.chain_membership
+                 WHERE taxonomy_version = %s AND valid_to IS NULL""",
+            (version,),
+        )
+        already = {(chain, ticker) for chain, ticker in cur.fetchall()}
 
     repo.define_chains(
         version,
@@ -90,8 +101,20 @@ def mirror_watchlist_chain(
             for chain, layer in pairs
         ],
     )
-    added = 0
+    added = already_member = 0
     for ticker, chain, layer in rows:
+        # The skip is keyed on (chain, ticker) and NOT on the layer, because
+        # `seed_chain_spec` MOVES a mirrored name off the placeholder layer onto
+        # the chain's real one. `add_membership`'s own guard keys on
+        # (version, chain, LAYER, ticker), so after a seed it sees no open row
+        # at the placeholder layer and re-opens one — and the next seed closes
+        # it again. Two intervals per ticker per run, forever, which is exactly
+        # the manufactured history `add_membership` exists to prevent and would
+        # falsify the healer registry's standing claim that a reseed opens no
+        # interval for an unchanged placement.
+        if (chain, ticker.upper()) in already:
+            already_member += 1
+            continue
         added += repo.add_membership(
             version,
             chain=chain,
@@ -101,9 +124,31 @@ def mirror_watchlist_chain(
             approved_by="watchlist_chain",
             note="copied from the shipped chain filter rail",
         )
-    counters = {"chains": len(pairs), "memberships": len(rows), "opened": added}
+    counters = {
+        "chains": len(pairs),
+        "memberships": len(rows),
+        "opened": added,
+        "already_member": already_member,
+    }
     log.info("mirror_watchlist_chain: %s", counters)
     return counters
+
+
+#: Strongest claim first. Used ONLY to pick which of a ticker's several open
+#: placements a re-home carries across — never to rank or filter evidence
+#: anywhere a reader sees it.
+_EVIDENCE_PRECEDENCE = (
+    EVIDENCE_DISCLOSED,
+    EVIDENCE_ANALYST,
+    EVIDENCE_INFERRED,
+    EVIDENCE_MIRRORED,
+)
+
+
+def _rehome_note(note: str | None, from_layer: str, to_layer: str) -> str:
+    """Append the move to the row's own note; provenance is not overwritten."""
+    moved = f"re-homed from layer {from_layer!r} onto {to_layer!r}"
+    return f"{note}; {moved}" if note else moved
 
 
 def seed_chain_spec(
@@ -143,23 +188,59 @@ def seed_chain_spec(
             for layer in spec.layers
         ],
     )
-    moved = 0
+    moved = opened = 0
     if len(spec.layers) == 1:
-        # Retire-and-reinsert, never `UPDATE ... SET layer`: open membership
+        # Reinsert-THEN-retire, and never `UPDATE ... SET layer`: open membership
         # identity is the partial unique index chain_membership_open_uq
         # (taxonomy_version, chain, layer, ticker) WHERE valid_to IS NULL, so an
         # in-place UPDATE collides with a row the same statement has not closed
         # yet. A multi-layer spec cannot be re-homed automatically at all —
         # which layer a name belongs to is a research judgement, not a default.
+        #
+        # ORDER IS THE FAILURE MODE. Closing first and inserting after leaves a
+        # window in which a crash strands the chain with ZERO open memberships,
+        # and no re-run can heal it: the recovery SELECT looks for
+        # `layer <> target AND valid_to IS NULL`, which by then matches nothing.
+        # Inserting first cannot collide (the layer differs), and a crash in the
+        # window leaves the ticker open on BOTH layers — a state the next run
+        # finds and finishes. Failure-safe rather than failure-lossy.
         target = spec.layers[0].layer
         with conn.cursor() as cur:
             cur.execute(
-                f"""SELECT ticker FROM {schema}.chain_membership
+                f"""SELECT ticker, evidence_class, approved_by, note, layer
+                      FROM {schema}.chain_membership
                      WHERE taxonomy_version = %s AND chain = %s
-                       AND layer <> %s AND valid_to IS NULL""",
-                (version, spec.chain, target),
+                       AND layer <> %s AND valid_to IS NULL
+                     ORDER BY ticker,
+                              array_position(%s::text[], evidence_class),
+                              membership_id""",
+                (version, spec.chain, target, list(_EVIDENCE_PRECEDENCE)),
             )
-            tickers = [t for (t,) in cur.fetchall()]
+            # One re-home per ticker. Ordered strongest-evidence-first above, so
+            # a name openly placed under two layers is carried across by its
+            # STRONGEST claim — a disclosure does not get overwritten by a
+            # mirrored copy just because the copy sorted first.
+            source: dict[str, tuple[str, str, str | None, str]] = {}
+            for ticker, evidence, approver, note, layer in cur.fetchall():
+                source.setdefault(ticker, (evidence, approver, note, layer))
+
+        for ticker, (evidence, approver, note, layer) in source.items():
+            # `evidence_class` and `approved_by` are CARRIED, never rewritten.
+            # Migration 139 says that column exists to keep an analyst's
+            # judgement distinguishable from a copy of the watchlist rail after
+            # the fact; hardcoding `mirrored` here would silently demote every
+            # human assertion this function is ever pointed at — and
+            # `Optical-Communication`'s placements are `analyst`.
+            opened += repo.add_membership(
+                version,
+                chain=spec.chain,
+                layer=target,
+                ticker=ticker,
+                evidence_class=evidence,
+                approved_by=approver,
+                note=_rehome_note(note, layer, target),
+            )
+        with conn.cursor() as cur:
             cur.execute(
                 f"""UPDATE {schema}.chain_membership
                        SET valid_to = now()
@@ -167,19 +248,13 @@ def seed_chain_spec(
                        AND layer <> %s AND valid_to IS NULL""",
                 (version, spec.chain, target),
             )
-        conn.commit()
-        for ticker in tickers:
-            moved += repo.add_membership(
-                version,
-                chain=spec.chain,
-                layer=target,
-                ticker=ticker,
-                evidence_class=EVIDENCE_MIRRORED,
-                approved_by="seed_chain_spec",
-                note=f"re-homed from placeholder layer onto {target}",
-            )
+        # Count the tickers whose placeholder row was CLOSED, not the intervals
+        # opened. A ticker already open on both layers is a real re-home whose
+        # `add_membership` correctly returns False, and reporting that as zero
+        # would tell an operator nothing moved when something did.
+        moved = len(source)
     conn.commit()
-    counters = {"layers": len(spec.layers), "memberships": moved}
+    counters = {"layers": len(spec.layers), "memberships": moved, "opened": opened}
     log.info("seed_chain_spec %s: %s", spec.chain, counters)
     return counters
 

--- a/tests/integration/storage/test_datacenter_chain_seed.py
+++ b/tests/integration/storage/test_datacenter_chain_seed.py
@@ -57,7 +57,37 @@ SEED_ROWS = (
 )
 
 
+def _open_members(conn, schema: str, chain: str | None = None) -> int:
+    where = "taxonomy_version = %s AND valid_to IS NULL"
+    params: list[object] = [TAXONOMY_V1]
+    if chain:
+        where += " AND chain = %s"
+        params.append(chain)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"SELECT count(*) FROM {schema}.chain_membership WHERE {where}", params
+        )
+        return int(cur.fetchone()[0])
+
+
+def _closed_members(conn, schema: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""SELECT count(*) FROM {schema}.chain_membership
+                 WHERE taxonomy_version = %s AND valid_to IS NOT NULL""",
+            (TAXONOMY_V1,),
+        )
+        return int(cur.fetchone()[0])
+
+
 def _lay_the_mirrored_rail(conn, schema: str) -> None:
+    """Seed watchlist_chain, mirror it, and REFUSE to proceed on an empty rail.
+
+    Without the assertion these tests pass vacuously: if `mirror_watchlist_chain`
+    ever stopped mirroring, `seed_chain_spec` would find nothing to move, return
+    `memberships: 0`, and both the rank test and the two-domain test would still
+    go green against an empty table.
+    """
     with conn.cursor() as cur:
         cur.executemany(
             f"""INSERT INTO {schema}.watchlist_chain (ticker, layer, chain)
@@ -67,6 +97,7 @@ def _lay_the_mirrored_rail(conn, schema: str) -> None:
         )
     conn.commit()
     mirror_watchlist_chain(conn, schema=schema)
+    assert _open_members(conn, schema) == len(SEED_ROWS), "the mirrored rail is empty"
 
 
 def test_five_datacenter_chains_declared_in_buildout_order():
@@ -96,6 +127,131 @@ def test_seed_replaces_placeholder_layer_with_real_rank(seeded_db_empty_cards):
         rows = cur.fetchall()
     ranks = {chain: rank for chain, _layer, rank in rows if rank > 0}
     assert ranks == EXPECTED
+
+
+def test_mirror_and_seed_stop_churning_after_the_first_cycle(seeded_db_empty_cards):
+    """mirror -> seed -> mirror -> seed opens no further interval.
+
+    `add_membership`'s own guard keys on (version, chain, LAYER, ticker), and a
+    seed leaves no open row at the placeholder layer — so an unguarded mirror
+    re-opens every placeholder and the next seed closes it again, two intervals
+    per ticker per run, forever. That is the manufactured history the guard
+    exists to prevent, and it would falsify the healer registry's standing claim
+    that an unchanged placement opens no interval on a reseed.
+    """
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    for spec in DATACENTER_CHAINS:
+        seed_chain_spec(conn, spec, schema=schema)
+
+    settled_closed = _closed_members(conn, schema)
+    settled_open = _open_members(conn, schema)
+    assert settled_closed == len(SEED_ROWS)  # one retired placeholder per name
+
+    for _ in range(2):
+        counters = mirror_watchlist_chain(conn, schema=schema)
+        assert counters["opened"] == 0
+        assert counters["already_member"] == len(SEED_ROWS)
+        for spec in DATACENTER_CHAINS:
+            assert seed_chain_spec(conn, spec, schema=schema)["memberships"] == 0
+        assert _closed_members(conn, schema) == settled_closed
+        assert _open_members(conn, schema) == settled_open
+
+
+def test_an_analyst_placement_survives_a_re_home_as_analyst(seeded_db_empty_cards):
+    """Provenance is carried, not rewritten.
+
+    `seed_chain_spec` is generic over `ChainSpec`, and `Optical-Communication`'s
+    memberships are `evidence_class='analyst'`. Hardcoding `mirrored` on the
+    reinsert would silently demote a human's assertion to a copy of the
+    watchlist rail — the exact distinction migration 139 says the column exists
+    to preserve.
+    """
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    repo = ResearchTaxonomyRepository(conn, schema=schema)
+    # Replace one mirrored placement with a human one at the same placeholder
+    # layer, the way an analyst override would arrive.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""UPDATE {schema}.chain_membership SET valid_to = now()
+                 WHERE taxonomy_version = %s AND ticker = 'EQIX'
+                   AND valid_to IS NULL""",
+            (TAXONOMY_V1,),
+        )
+    conn.commit()
+    repo.add_membership(
+        TAXONOMY_V1,
+        chain="DC-REIT/Colo",
+        layer="L3",
+        ticker="EQIX",
+        evidence_class="analyst",
+        approved_by="a-human",
+        note="asserted placement; not a disclosure",
+    )
+
+    spec = next(s for s in DATACENTER_CHAINS if s.chain == "DC-REIT/Colo")
+    seed_chain_spec(conn, spec, schema=schema)
+
+    by_ticker = {m["ticker"]: m for m in repo.members(TAXONOMY_V1, "DC-REIT/Colo")}
+    assert by_ticker["EQIX"]["layer"] == "DC-REIT-Colo"
+    assert by_ticker["EQIX"]["evidence_class"] == "analyst"
+    assert by_ticker["EQIX"]["approved_by"] == "a-human"
+    # The row's own note survives; the move is appended to it.
+    assert by_ticker["EQIX"]["note"].startswith("asserted placement; not a disclosure")
+    assert "re-homed from layer 'L3'" in by_ticker["EQIX"]["note"]
+    # DLR came through the mirror and stays a mirrored copy.
+    assert by_ticker["DLR"]["evidence_class"] == "mirrored"
+
+
+def test_an_interrupted_seed_heals_on_the_next_run(seeded_db_empty_cards):
+    """The crash window leaves a name on BOTH layers, never on neither.
+
+    Reinsert-then-retire is the whole point: a crash after the inserts and
+    before the close is recoverable, because the recovery SELECT
+    (`layer <> target AND valid_to IS NULL`) still matches the placeholder row.
+    Closing first would leave zero open memberships and nothing left to find.
+    """
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    repo = ResearchTaxonomyRepository(conn, schema=schema)
+    spec = next(s for s in DATACENTER_CHAINS if s.chain == "DC-REIT/Colo")
+
+    # Reproduce the interrupted state by hand: the target layer exists and both
+    # names are open on it, and the placeholder rows were never closed.
+    repo.define_chains(
+        TAXONOMY_V1,
+        [
+            {
+                "domain": spec.domain,
+                "chain": spec.chain,
+                "layer": spec.layers[0].layer,
+                "layer_rank": spec.layers[0].rank,
+                "description": spec.layers[0].description,
+            }
+        ],
+    )
+    for ticker in ("EQIX", "DLR"):
+        repo.add_membership(
+            TAXONOMY_V1,
+            chain=spec.chain,
+            layer=spec.layers[0].layer,
+            ticker=ticker,
+            evidence_class="mirrored",
+            approved_by="seed_chain_spec",
+            note="interrupted mid-seed",
+        )
+    assert _open_members(conn, schema, spec.chain) == 4  # both layers, both names
+
+    counters = seed_chain_spec(conn, spec, schema=schema)
+    # Two placeholders really were retired — a counter keyed on `add_membership`
+    # would have reported 0 here, telling an operator nothing moved.
+    assert counters["memberships"] == 2
+    assert counters["opened"] == 0
+
+    open_members = repo.members(TAXONOMY_V1, spec.chain)
+    assert len(open_members) == 2
+    assert {m["layer"] for m in open_members} == {spec.layers[0].layer}
 
 
 def test_memberships_move_onto_the_real_layer(seeded_db_empty_cards):

--- a/tests/integration/storage/test_datacenter_chain_seed.py
+++ b/tests/integration/storage/test_datacenter_chain_seed.py
@@ -1,0 +1,168 @@
+"""Standing up a datacenter node is taxonomy rows, not code (spec §2 contract).
+
+The five datacenter build-out chains are `Optical-Communication`'s siblings, and
+the point of this test is what it does NOT touch: no assembler, no schema, no
+scoring fork. If a chain node ever needs one of those, the extension contract is
+broken and this file is where that shows up first.
+
+WHY EVERY SPEC IS `ai_infrastructure` AND NOT A NEW DOMAIN
+---------------------------------------------------------
+`research_chains`' primary key is `(taxonomy_version, chain, layer)` — `domain`
+is NOT in the key, so it is a per-LAYER attribute. All five chain names are
+already mirrored from `watchlist_chain` under `domain='ai_infrastructure'` with a
+placeholder layer, so declaring the specs under a second domain would leave one
+chain carrying two layers under two domains and `chains(version, domain=...)`
+would return half a chain. `test_no_chain_carries_two_domains` is the guard.
+`Optical-Communication` escapes the whole question only because its spec name
+differs from the watchlist's `Networking/Optical`.
+"""
+
+from __future__ import annotations
+
+from uw_scan.fundamentals.chain_nodes import DATACENTER_CHAINS
+from uw_scan.storage.research_taxonomy import ResearchTaxonomyRepository
+from uw_scan.worker.jobs.research_taxonomy_seed import (
+    TAXONOMY_V1,
+    mirror_watchlist_chain,
+    seed_chain_spec,
+)
+
+#: chain -> the rank its single real layer carries. Build-out reading order,
+#: sparse so an intra-chain split discovered later slots between two of these
+#: without renumbering.
+EXPECTED = {
+    "EPC/Construction": 10,
+    "Generation/Nuclear": 20,
+    "Power/Electrical": 30,
+    "Cooling/Thermal": 40,
+    "DC-REIT/Colo": 50,
+}
+
+#: Real members, copied verbatim from `watchlist_taxonomy` L3. The test DB's
+#: baseline carries no `watchlist_chain` rows (that table is seeded at runtime,
+#: not by a migration), so the mirrored rail these specs re-home has to be laid
+#: down here. VRT is Power/Electrical, not Cooling/Thermal — the argon taxonomy
+#: files Vertiv under electrical distribution.
+SEED_ROWS = (
+    ("MTZ", "L3", "EPC/Construction"),
+    ("EME", "L3", "EPC/Construction"),
+    ("OKLO", "L3", "Generation/Nuclear"),
+    ("CEG", "L3", "Generation/Nuclear"),
+    ("VRT", "L3", "Power/Electrical"),
+    ("ETN", "L3", "Power/Electrical"),
+    ("MOD", "L3", "Cooling/Thermal"),
+    ("AAON", "L3", "Cooling/Thermal"),
+    ("EQIX", "L3", "DC-REIT/Colo"),
+    ("DLR", "L3", "DC-REIT/Colo"),
+)
+
+
+def _lay_the_mirrored_rail(conn, schema: str) -> None:
+    with conn.cursor() as cur:
+        cur.executemany(
+            f"""INSERT INTO {schema}.watchlist_chain (ticker, layer, chain)
+                     VALUES (%s, %s, %s)
+                ON CONFLICT (ticker, chain) DO NOTHING""",
+            SEED_ROWS,
+        )
+    conn.commit()
+    mirror_watchlist_chain(conn, schema=schema)
+
+
+def test_five_datacenter_chains_declared_in_buildout_order():
+    assert {c.chain for c in DATACENTER_CHAINS} == set(EXPECTED)
+    for spec in DATACENTER_CHAINS:
+        assert len(spec.layers) == 1
+        assert spec.layers[0].rank == EXPECTED[spec.chain]
+
+
+def test_every_datacenter_spec_declares_the_mirrored_domain():
+    """A second domain would split a chain across two `chains()` answers."""
+    assert {c.domain for c in DATACENTER_CHAINS} == {"ai_infrastructure"}
+
+
+def test_seed_replaces_placeholder_layer_with_real_rank(seeded_db_empty_cards):
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    for spec in DATACENTER_CHAINS:
+        counters = seed_chain_spec(conn, spec, schema=schema)
+        assert counters["layers"] == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""SELECT chain, layer, layer_rank FROM {schema}.research_chains
+                 WHERE taxonomy_version = %s AND chain = ANY(%s)""",
+            (TAXONOMY_V1, list(EXPECTED)),
+        )
+        rows = cur.fetchall()
+    ranks = {chain: rank for chain, _layer, rank in rows if rank > 0}
+    assert ranks == EXPECTED
+
+
+def test_memberships_move_onto_the_real_layer(seeded_db_empty_cards):
+    """Re-home is retire-and-reinsert: the open row is the only current one."""
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    repo = ResearchTaxonomyRepository(conn, schema=schema)
+    for spec in DATACENTER_CHAINS:
+        counters = seed_chain_spec(conn, spec, schema=schema)
+        assert counters["memberships"] == 2
+
+    open_members = repo.members(TAXONOMY_V1, "DC-REIT/Colo")
+    assert {m["ticker"] for m in open_members} == {"EQIX", "DLR"}
+    assert {m["layer"] for m in open_members} == {"DC-REIT-Colo"}
+
+    # The placeholder interval is closed, not deleted: "was EQIX in this chain
+    # when that report was written" has to stay answerable.
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""SELECT count(*) FROM {schema}.chain_membership
+                 WHERE taxonomy_version = %s AND chain = %s
+                   AND layer = 'L3' AND valid_to IS NOT NULL""",
+            (TAXONOMY_V1, "DC-REIT/Colo"),
+        )
+        assert cur.fetchone()[0] == 2
+
+
+def test_seeding_twice_moves_nothing_the_second_time(seeded_db_empty_cards):
+    """A reseed must not manufacture a history of identical intervals."""
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    for spec in DATACENTER_CHAINS:
+        seed_chain_spec(conn, spec, schema=schema)
+    for spec in DATACENTER_CHAINS:
+        assert seed_chain_spec(conn, spec, schema=schema)["memberships"] == 0
+
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""SELECT count(*) FROM {schema}.chain_membership
+                 WHERE taxonomy_version = %s AND valid_to IS NULL""",
+            (TAXONOMY_V1,),
+        )
+        assert cur.fetchone()[0] == len(SEED_ROWS)
+
+
+def test_no_chain_carries_two_domains(seeded_db_empty_cards):
+    """`domain` is a per-layer column; one chain must still mean one domain.
+
+    Nothing in the schema enforces this — the PK is (version, chain, layer) — so
+    a spec declared under a domain the mirror did not use would split the chain
+    silently, and `chains(version, domain=...)` would answer with half of it.
+    """
+    conn, schema = seeded_db_empty_cards.conn, seeded_db_empty_cards._schema
+    _lay_the_mirrored_rail(conn, schema)
+    for spec in DATACENTER_CHAINS:
+        seed_chain_spec(conn, spec, schema=schema)
+
+    repo = ResearchTaxonomyRepository(conn, schema=schema)
+    active = repo.active_version()
+    assert active == TAXONOMY_V1
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""SELECT chain, array_agg(DISTINCT domain ORDER BY domain)
+                  FROM {schema}.research_chains
+                 WHERE taxonomy_version = %s
+                 GROUP BY chain
+                HAVING count(DISTINCT domain) > 1""",
+            (active,),
+        )
+        assert cur.fetchall() == []


### PR DESCRIPTION
Stands up the five datacenter build-out chains — EPC/Construction, Generation/Nuclear, Power/Electrical, Cooling/Thermal, DC-REIT/Colo — as chain-analysis nodes beside `Optical-Communication`.

Implements Task 3 of `docs/superpowers/plans/2026-08-26-fundamentals-industry-desk.md` (spec: `docs/superpowers/specs/2026-08-26-fundamentals-industry-desk-design.md` §2).

## What this is

A node is **data, not code**. The point of this PR is what it does *not* contain: no assembler change, no router, no model, no migration. The untouched `test_the_catalogue_matches_what_the_assembler_actually_emits` passing is the proof — that is the spec's extension contract, made testable.

Each chain gets one real layer (the chain IS a layer of the build-out) at sparse ranks 10/20/30/40/50, and its existing mirrored memberships are re-homed off the rank-0 `L3` placeholder the watchlist mirror lays down. 44 memberships across the five, all already in the universe; zero vendor calls.

## Two corrections to the plan, made during implementation

- **Domain.** The plan said `dc_buildout`. That string exists nowhere; the vocabulary is `{ai_infrastructure, optical_communication}`. Because `research_chains`' PK is `(taxonomy_version, chain, layer)` with `domain` **outside** the key, declaring a new domain for chain names already mirrored under `ai_infrastructure` would have left one chain carrying two layers under two domains, and a domain-filtered read would return half a chain. All five declare `ai_infrastructure`, and `test_no_chain_carries_two_domains` defends it.
- **Fixture.** The plan said VRT is Cooling/Thermal. Argon files Vertiv under Power/Electrical (`watchlist_taxonomy.py:173`). All ten frozen tickers are verified real members of the chains claimed.

## Review findings fixed before this PR opened

- **The seed had no caller** — `seed_chain_spec` was invoked only by its own tests, so the chains would have kept their meaningless rank-0 layer after deploy. Now wired into `scripts/backfill/research_taxonomy_seed.py`, the same route optical's layers took.
- **Interval churn** — `add_membership` keys on `(version, chain, layer, ticker)`, so a seeded chain's closed placeholder rows were re-opened by the next mirror and re-closed by the next seed, forever. The mirror now skips a ticker already openly a member under any layer. This makes the healer registry's standing "a reseed opens no interval" claim true.
- **A lossy crash window** — the retire committed before the reinserts, so an interruption left zero open memberships and a re-run could not heal. Inverted to reinsert-then-retire: a crash now leaves the ticker open on both layers, which the next run cleans up.
- **Silent provenance loss** — the re-home hardcoded `evidence_class`, so pointing this generic function at a chain carrying `analyst` placements would have demoted a human assertion to a copy of the watchlist rail. Provenance is now carried through and the original note preserved with the move appended.

## Deploy

Nothing runs the backfill automatically. After merge, run `scripts/backfill/research_taxonomy_seed.py` on the mini for the rows to land. Re-running is idempotent.

## Tests

25 passing: 9 new in `test_datacenter_chain_seed.py` (including multi-cycle churn, interrupted-seed healing, and analyst-provenance survival) plus the 16 untouched `test_research_reports.py`.