### PR TITLE
fix(normalize): read UW's `data: null` as absence, not a malformed body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   the GitHub-calibrated baseline plus the new test measurement; a regression guard
   rejects local lock/checkpoint waits masquerading as 60+ second single-test costs.
 
+### Fixed
+
+- **One ticker with no history could fail every dataset in a night's replay.** UW
+  answers `data: null` -- not `data: []` -- for a ticker it has no rows for on the
+  requested date, and both normalizer paths read that as a malformed body and raised.
+  Because `interpolated_iv_snapshots` heals through `pipeline_replay`, the raise
+  killed the whole replay for that ticker/date rather than the one absent dataset:
+  KEEL's 63 dates across 2026-01-02..2026-04-02 failed every night and were retried
+  every night, permanently. Null is now an absence and yields no rows; a wrong type
+  is still a contract violation and still raises.
+
 ## [0.13.1] — 2026-08-30
 
 

--- a/src/uw_scan/normalize.py
+++ b/src/uw_scan/normalize.py
@@ -50,11 +50,18 @@ class NormalizationError(Exception):
 
 
 def _data_list(payload: dict) -> list[dict]:
+    """UW answers `data: null` -- not `data: []` -- for a ticker with no history on
+    the requested date, so null is an absence, not a malformed body. Raising on it
+    fails the whole pipeline replay for that date: KEEL's 63 dates in 2026-01-02..
+    04-02 each killed every dataset in the replay, not just the empty one.
+    """
     if "data" not in payload:
         raise NormalizationError(
             f"payload missing 'data' key; got {list(payload.keys())}"
         )
     raw = payload["data"]
+    if raw is None:
+        return []
     if not isinstance(raw, list):
         raise NormalizationError(
             f"payload['data'] expected list, got {type(raw).__name__}"
@@ -243,6 +250,8 @@ def normalize_volatility_stats(payload: dict) -> list[VolStatsRow]:
             f"payload missing 'data' key; got {list(payload.keys())}"
         )
     raw = payload["data"]
+    if raw is None:
+        return []
     if isinstance(raw, dict):
         return [VolStatsRow(**raw)]
     if isinstance(raw, list):

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -60,6 +60,25 @@ def test_normalize_volatility_stats():
     assert latest.iv_rank is not None
 
 
+def test_null_data_is_absence_not_a_malformed_payload():
+    """UW sends `data: null` for a ticker with no history on the date. Both the
+    list path and volatility_stats' dict-or-list path must read that as empty, or
+    one absent dataset fails the entire pipeline replay for the date (KEEL,
+    2026-01-02..04-02, 63 dates)."""
+    assert normalize.normalize_volatility_stats({"data": None}) == []
+    assert normalize.normalize_interpolated_iv({"data": None}) == []
+
+
+def test_genuinely_malformed_data_still_raises():
+    """Absence is null; a wrong type is still a contract violation."""
+    with pytest.raises(normalize.NormalizationError):
+        normalize.normalize_volatility_stats({"data": "not-a-payload"})
+    with pytest.raises(normalize.NormalizationError):
+        normalize.normalize_interpolated_iv({"data": "not-a-payload"})
+    with pytest.raises(normalize.NormalizationError):
+        normalize.normalize_volatility_stats({})
+
+
 def test_normalize_realized_volatility():
     body = _load("realized_volatility")
     rows = normalize.normalize_realized_volatility(body)


### PR DESCRIPTION
## What

`normalize._data_list` and `normalize_volatility_stats` both raised `NormalizationError` when UW answered `data: null`. Null now yields no rows. A wrong type is still a contract violation and still raises.

## Why it mattered more than one empty dataset

`interpolated_iv_snapshots` heals through `pipeline_replay`, so the raise took down **every** dataset in the replay for that ticker/date — not just the absent one.

Measured on the mini, gap-healer run 113:

| | |
|---|---|
| failed items | 63 |
| distinct tickers | **1 — KEEL** |
| date range | 2026-01-02 → 2026-04-02 |
| error | `NormalizationError("volatility_stats['data'] expected dict/list, got NoneType")` |

UW has no history for KEEL in that window, so it returns `data: null`. Those 63 dates failed every night and were re-queued every night, permanently, on a payload that was correct.

## Verification

- New test fails without the fix with the exact production error, passes with it (checked both directions via `git stash`).
- `uv run pytest tests/unit` — 2769 passed.
- `ruff check` / `ruff format --check` clean.

## Note

The fix touches `_data_list` as well as the volatility_stats path. Same vendor convention, same file, and `interpolated_iv` — the dataset actually named in the gap — reads through `_data_list`; fixing only the path that happened to raise first would have surfaced the identical failure one step later.