### PR TITLE
fix(health): count claimed-but-unfinished gap items as open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Fixed
 
+- **`/api/health` reported the smallest gap backlog exactly when it was largest.**
+  `open_gaps` summed `planned + skipped_budget + failed` -- the three statuses
+  `claim_next_items` will re-claim -- and so answered "what would the healer pick up
+  next", not "what is still undone". Items the healer had already claimed sit in
+  `running`, which it will not re-claim, so a run killed mid-flight strands its whole
+  remainder in the one status the count ignored. When a deploy recreated the worker on
+  2026-08-30, run 113 held **70,206 unprocessed items and health reported 63**, for the
+  45 hours until the next nightly reaped it. `running` now counts toward `open_gaps`
+  and appears in `open_by_dataset`, and is also surfaced on its own so an in-flight
+  run reads apart from an abandoned one.
+
 - **The gap healer now records its own spend and its own progress.** Both were
   invisible, and each blindness hid a different defect.
   - `HealContext` built its UW and massive clients with `job_name=` but no

--- a/src/uw_scan/api/routers/health.py
+++ b/src/uw_scan/api/routers/health.py
@@ -115,7 +115,12 @@ class HealthGapHealer(BaseModel):
     no_data: int = 0
     failed: int = 0
     skipped_budget: int = 0
-    open_gaps: int = 0  # planned + skipped_budget + failed in the latest run
+    running: int = 0
+    # Everything in the latest run not driven to a verdict. Includes 'running':
+    # a run killed mid-flight strands its whole remainder there, so excluding it
+    # made the number smallest exactly when the backlog was largest -- 63 reported
+    # against 70,206 unprocessed after a deploy recreated the worker (2026-08-30).
+    open_gaps: int = 0
     open_by_dataset: dict[str, int] = Field(default_factory=dict)
     last_verified_at: datetime | None = None
 
@@ -441,11 +446,13 @@ def health(
         healed=_gh_counts.get("healed", 0),
         no_data=_gh_counts.get("no_data", 0),
         failed=_gh_counts.get("failed", 0),
+        running=_gh_counts.get("running", 0),
         skipped_budget=_gh_counts.get("skipped_budget", 0),
         open_gaps=(
             _gh_counts.get("planned", 0)
             + _gh_counts.get("skipped_budget", 0)
             + _gh_counts.get("failed", 0)
+            + _gh_counts.get("running", 0)
         ),
         open_by_dataset=_gh["open_by_dataset"],
         last_verified_at=_gh["last_verified_at"],

--- a/src/uw_scan/storage/data_gap_healer_repository.py
+++ b/src/uw_scan/storage/data_gap_healer_repository.py
@@ -302,7 +302,12 @@ class DataGapHealerRepository:
                 SELECT dataset, COUNT(*)::int
                   FROM data_gap_items
                  WHERE run_id = %s
-                   AND status IN ('planned', 'skipped_budget', 'failed')
+                   -- 'running' belongs here even though claim_next_items will not
+                   -- re-claim it: these are items the healer took and never drove
+                   -- to a verdict. During a live run that is a small in-flight
+                   -- window; after a killed one it is the entire remainder, which
+                   -- is exactly when this number is read.
+                   AND status IN ('planned', 'skipped_budget', 'failed', 'running')
                  GROUP BY dataset
                  ORDER BY 2 DESC
                 """,

--- a/tests/integration/api/openapi.snapshot.json
+++ b/tests/integration/api/openapi.snapshot.json
@@ -9885,6 +9885,11 @@
             "title": "Open Gaps",
             "type": "integer"
           },
+          "running": {
+            "default": 0,
+            "title": "Running",
+            "type": "integer"
+          },
           "skipped_budget": {
             "default": 0,
             "title": "Skipped Budget",

--- a/tests/integration/api/test_health_gap_healer.py
+++ b/tests/integration/api/test_health_gap_healer.py
@@ -19,8 +19,10 @@ def test_health_includes_gap_healer_block(client):
         "no_data",
         "failed",
         "skipped_budget",
+        "running",
         "last_verified_at",
     } <= set(gh.keys())
     # empty state defaults
     assert gh["open_gaps"] == 0
+    assert gh["running"] == 0
     assert gh["open_by_dataset"] == {}

--- a/tests/integration/storage/test_data_gap_healer_repository.py
+++ b/tests/integration/storage/test_data_gap_healer_repository.py
@@ -153,6 +153,35 @@ def test_gap_healer_health_summary(seeded_db_empty_cards):
     assert h["last_verified_at"] is None
 
 
+def test_gap_healer_health_counts_stranded_claims_as_open(seeded_db_empty_cards):
+    """Items the healer claimed and never finished are open gaps.
+
+    claim_next_items moves 'planned' to 'running' and will not re-claim that
+    status, so a run killed mid-flight strands its whole remainder there. Leaving
+    'running' out of the open count made the number smallest exactly when the
+    backlog was largest: after a deploy recreated the worker on 2026-08-30, run
+    113 held 70,206 unprocessed items and /api/health reported 63.
+    """
+    repo = _repo(seeded_db_empty_cards)
+    run_id = repo.create_run(
+        mode="execute", start_date=None, end_date=None, datasets=["daily_ohlc"]
+    )
+    repo.upsert_items(
+        run_id,
+        [
+            GapItem("daily_ohlc", "2026-06-22|A", date(2026, 6, 22), "A", 1, 0),
+            GapItem("daily_ohlc", "2026-06-23|B", date(2026, 6, 23), "B", 1, 0),
+        ],
+    )
+    assert len(repo.claim_next_items(run_id, limit=2)) == 2  # healer takes them...
+    # ...and dies here, without driving either to a verdict.
+
+    h = repo.gap_healer_health()
+    assert h["counts"].get("planned", 0) == 0
+    assert h["counts"]["running"] == 2
+    assert h["open_by_dataset"]["daily_ohlc"] == 2
+
+
 def test_unregistered_excludes_seeded_tables(seeded_db_empty_cards):
     repo = _repo(seeded_db_empty_cards)
     repo.sync_dataset_registry(REGISTRY)

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5855,6 +5855,11 @@ export interface components {
              */
             skipped_budget: number;
             /**
+             * Running
+             * @default 0
+             */
+            running: number;
+            /**
              * Open Gaps
              * @default 0
              */


### PR DESCRIPTION
## The bug

```python
open_gaps = planned + skipped_budget + failed
```

Those are exactly the statuses `claim_next_items` re-claims, so `open_gaps` answered **"what would the healer pick up next"**, not **"what is still undone"**. Items the healer already claimed sit in `running`, which it will not re-claim — so a run killed mid-flight strands its *entire remainder* in the one status the count ignored.

The status that means "we don't know whether this finished" is the status a crash leaves behind, and it was the one excluded.

## Measured

A Watchtower deploy recreated the argon workers on 2026-08-30 at 11:14:40 +0800. Gap-healer run 113's last item progress was 11:14:36 — four seconds earlier.

| `/api/health` said | reality |
|---|---|
| `open_gaps: 63` | 70,206 items unprocessed |
| `open_by_dataset: {interpolated_iv_snapshots: 63}` | 10 datasets stranded, `uw_dark_lit_flow_prints` alone holding 21,673 |

It held that reading for ~45 h — the run died Saturday evening ET and the healer's cron (`0 20 * * 0-5`) skips Sunday.

## What this does *not* change

The stale run is already handled: `_reap_stale_runs` runs at `data_gap_healer_job:501`, **before** the `_another_run_active` gate at :502, so a corpse has never blocked a later nightly. This PR changes what is reported, not what is done.

## Verification

- New repository test fails without the fix — and fails as `KeyError: 'daily_ohlc'`, because the stranded dataset disappears from `open_by_dataset` entirely rather than merely undercounting. Checked both directions via `git stash`.
- `tests/unit` — 2769 passed. `tests/integration/api` — 348 passed, 1 skipped.
- `ruff check` / `format --check` clean.
- OpenAPI snapshot updated surgically (verified an exact `json.dumps(indent=2, sort_keys=True)` round-trip before editing, so the diff is the 5 added lines and nothing else); `web/lib/types.ts` updated to match.