### PR TITLE
docs(macro): archive the desk port plan and its board-conformance trail

### DIFF
--- a/docs/research/2026-08-28-macro-desk-board-conformance/VERDICT.md
+++ b/docs/research/2026-08-28-macro-desk-board-conformance/VERDICT.md
@@ -1,0 +1,183 @@
+# Macro desk — board conformance audit
+
+**Date:** 2026-08-28
+**Board (the spec):** artifact `dde15f29-728e-43e9-86d5-9ab688df4853` — "Argon Macro Desk", updated 2026-08-27
+**Shipped:** `feat/macro-desk-tab-00` (tab 00) and `feat/macro-desk-tabs-03-05` (tabs 01–05) — both merged since (v0.13.1)
+**Question:** which of the board's designed panels actually reached the desk
+
+## Why this exists
+
+The port plan (`docs/superpowers/archive/plans/2026-08-27-macro-desk-page-port.md`) §1 declares a
+non-goal — _"**No new analytics.** Tabs 00–05 are a presentation merge"_ — and §3 binds tab
+03 to one request (`/api/macro/inflation`) and tab 04 to one (`/api/macro/usd`). One state
+endpoint renders one generic state card. The board's tab 03 specifies four distinct panels.
+The plan and the board disagree, and the plan won by default because it was the document
+being executed.
+
+This audit measures the size of that disagreement before anything is rebuilt.
+
+## Method
+
+- **Board panels** counted as `<h3>` elements inside each `section[role="tabpanel"]`
+  (`#t0`–`#t5`) of the saved artifact HTML. This is a **proxy**: a board panel without an
+  h3 is undercounted. Treat the counts as ±1, not exact.
+- **Shipped panels** read two ways: headings scraped from the live dev instance
+  (`http://127.0.0.1:3002`, local DB, 2026-08-28), and component composition read from
+  source. Tabs 01–05 were rendered; tab 00 was read from source only — it lives on the
+  sibling branch and was not running.
+- Status is `present` (the board's panel exists and answers the same question),
+  `partial` (the data is on the tab but not as the designed panel, or a different cut of
+  it), `absent`, or `misplaced` (present on a different tab than the board assigns).
+
+## Conformance
+
+| Board tab                | Panels | present | partial | absent / misplaced |
+| ------------------------ | -----: | ------: | ------: | -----------------: |
+| t0 Overview · Daily Loop |     16 |       8 |       1 |                  7 |
+| t1 Fed · Policy          |      8 |       7 |       0 |                  1 |
+| t2 Rates · Curve         |      9 |       6 |       1 |        2 misplaced |
+| **t3 Inflation**         |  **4** |   **0** |   **1** |              **3** |
+| **t4 US Dollar**         |  **2** |   **0** |   **0** |              **2** |
+| t5 Gold                  |      8 |       5 |       3 |                  0 |
+| **total**                | **47** |  **26** |   **6** |             **15** |
+
+### t3 Inflation — 0 of 4
+
+Board: _arithmetic of confidence · falsifier window/repair table · realized inflation ·
+inflation expectations_. Shipped: one `DomainStateTab` card (`WELL_ABOVE_TARGET · FLAT ·
+CONFIDENCE 42%`, two metric rows, two contradiction lines, evidence-count disclosure) plus
+a refusal panel. The card's metric rows carry realized-inflation _numbers_, which is why
+this scores one partial — but a two-row strip is not the board's realized-inflation panel,
+and there is no expectations panel, no confidence arithmetic, no repair table.
+
+`ConfidenceArithmetic` **exists** and was lifted out of the rates subtree in P5 — it renders
+on tab 00, not here, where the board puts it ("The arithmetic of confidence · why only 0.37"
+is a t3 heading).
+
+### t4 US Dollar — 0 of 2
+
+Board: _nominal vs real, a dollar pair in reverse · upstream citation, chain integrity_.
+Shipped: the same generic card plus a refusal panel. Neither designed panel exists. This is
+the smallest board tab and the only one at zero with nothing partial.
+
+### t5 Gold — content largely present, arrangement not
+
+Five board panels are genuinely there (three lenses, CB 12M net in three buckets
+STRATEGIC/TACTICAL/DIVERSIFIER, western institutional L1 detail, L2 cyclical, input
+manifest via `DataAuditFooter`). Three are partial:
+
+- **Transmission gauge · correlation collapse** — exists as one tile in the KPI strip
+  (`GAUGE REGIME · SUSPENDED`), not as the panel the board opens the tab with.
+- **Anchor decay · gauge corr_60d, daily** — shipped renders `CORRELATION HISTORY · 252D
+ROLLING`. Different window, different cut.
+- **Expression cost · what the option market charges** — exists as the `UW 25Δ SKEW` card
+  inside lens 1, not as a first-class panel.
+
+So gold's divergence is **framing**, not absence: the board leads with the transmission
+question and organizes around it; the shipped tab is the Gold Compass page moved intact and
+organized by lens.
+
+### t1 / t2 — near-complete, two structural slips
+
+Both tabs carry almost everything the board specifies, plus extras the board does not
+(`Provenance and legacy`, `Source Freshness`). Two real deviations:
+
+- **`/macro/fed` has no refusal panel.** The board gives t1 a "What this tab refuses"; the
+  shipped fed tab has none (measured: 0 occurrences; `/macro/rates` has it, as do 03 and 04).
+- **Supply and auction demand are on the wrong tab.** The board puts `Supply SUB-STATE` and
+  `Auction demand · did anyone show up` on t2 (Rates · Curve). Shipped renders `Supply /
+Recent auctions / Issuance & fiscal` on `/macro/fed`.
+
+### t0 Overview — 8 of 16
+
+Present: the four chain-node state cards, contradiction feed, cross-domain contradictions,
+transmission health, and the daily loop. Absent: market deltas (1 week), anchor letting go
+(corr_60d), four policy paths repeated at desk level, FOMC calendar × market pricing,
+confidence repair table, and both energy blocks. `Boundary · what is NOT on this desk` is
+partial via `ChainRefusal`.
+
+## Two findings outside the panel count
+
+1. **The Q1–Q7 acceptance test did not survive the port.** The board's design notes state
+   the rule plainly: _"The seven questions are the acceptance test: every panel must answer
+   at least one, or it gets deleted."_ Neither the plan nor the code carries it. Nothing
+   maps a shipped panel to a question, so nothing can fail the test.
+2. **Tab 08 ships against the board's instruction.** The board's t8 says _"This tab is for
+   you (the operator) and does not ship on the final page."_ The plan registered it as tab
+   08 and `DESIGN NOTES` is in the live tab bar.
+
+## What I did not verify
+
+- Panel **content** correctness — this audit matches panels by question answered, not by
+  whether each renders the right numbers. A panel counted `present` may still be wrong
+  inside.
+- Tab 00 was read **from source**, not rendered. Its eight present panels are inferred from
+  component composition, one confidence level below the rendered tabs.
+- Board panels lacking an `<h3>` are not counted; the board's own claim is 58 panels across
+  9 tabs, against the 47 this method finds across 6 tabs — the remainder is mostly t6/t7/t8,
+  but some part of the gap may be uncounted panels inside t0–t5.
+- The board's **visual** design (palette, spacing, type scale) was not compared at all.
+  Only panel presence.
+
+## Reproduce
+
+```bash
+# 1. run the desk (API + web only, no workers)
+uv run uvicorn uw_scan.api.server:app --host 127.0.0.1 --port 8400 --reload --reload-dir src &
+cd web && NEXT_INTERNAL_API_BASE=http://127.0.0.1:8400 npx next dev --port 3002 --webpack &
+
+# 2. shipped headings per tab
+node /path/to/audit.mjs        # scratchpad script; renders 01-05, dumps h1-h4
+
+# 3. board panels per tab
+#    read the artifact, then count h3 inside each section[role="tabpanel"]
+```
+
+Artifact read via `Artifact action:"read" url:".../dde15f29-728e-43e9-86d5-9ab688df4853"`.
+
+---
+
+## Closure — what the build changed (same day)
+
+The audit above is the measurement; this section records what was done about it and what
+was deliberately not. Commits `bee947cd`…`c886b55d` on `feat/macro-desk-tabs-03-05`.
+
+| Audit finding                      | Disposition                                                                              |
+| ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| t3 Inflation, 0 of 4               | **Built.** All four render; verified live at `/macro/inflation`.                         |
+| t4 US Dollar, 0 of 2               | **Built.** Both render; verified live at `/macro/usd`.                                   |
+| t1 missing its refusal panel       | **Built.** Four invariants that existed only as code comments and test assertions.       |
+| t2 missing Supply / Auction demand | **Moved** from tab 01. One `SupplySection` covers both board panels.                     |
+| t5 framing                         | **Reordered** to the board's sequence: gauge opens the tab, expression cost gets a band. |
+| Tab 08 ships against the board     | **Unlisted.** Registered and reachable at `/macro/notes`, absent from the strip.         |
+| Q1–Q7 acceptance test absent       | **Enforced.** Non-empty tuple on `BoardPanel`, `data-questions` on gold, e2e over both.  |
+| t0 Overview, 8 of 16               | **Not done here** — see below.                                                           |
+
+### The one thing deliberately left
+
+**Tab 00 is not on this branch.** It lives on the sibling `feat/macro-desk-tab-00`
+(2 commits, unmerged), and `VALID_TABS` here has no overview entry at all. Building its
+panels in this worktree would duplicate that branch and collide on `tabs.ts` and
+`app/macro/[tab]/page.tsx` at merge. Of its 7 absences, 3 are buildable against data that
+already exists — the repeated policy paths, the anchor-letting-go read, and the confidence
+repair table — and the third is now a shared component (`ConfidenceRepairPanel`) that tab
+00 can consume when the branches meet. The other 4 need data the desk does not ingest
+(FOMC calendar, GVZ/VIX/HY-OAS deltas, both energy blocks, which the board itself marks as
+proposals).
+
+### Two deferrals, stated on the page rather than dropped
+
+- **Gold's anchor-decay chart** wants the gauge's 60-day correlation daily; the producer
+  computes that history at `window=252` only (`reports/gold_posture.py`). The heading names
+  the window it has and a note names the one that was asked for.
+- **`T5YIFR`** (the board's 5y5y forward row) is carried by no published domain state. The
+  expectations panel names it as missing rather than sourcing it from somewhere uncited.
+
+### Verification
+
+`npm run typecheck` · `npm run lint` · `node scripts/lint-gold-copy.mjs` all clean.
+940 vitest tests pass (up from 930). 37 Playwright specs across
+`macro-desk`/`macro-replay`/`macro-rates-state`/`macro-chart-scale`/`gold-page`/
+`gold-redirect`/`rates-redirect` pass against the running instance.
+
+Screenshots of the final state: `output/playwright/macro-tab-{fed,rates,inflation,usd,gold}.png`.

--- a/docs/superpowers/archive/plans/2026-08-27-macro-desk-page-port.md
+++ b/docs/superpowers/archive/plans/2026-08-27-macro-desk-page-port.md
@@ -1,0 +1,1343 @@
+# Macro Desk — porting the designed board onto `/macro`
+
+**Status:** SHIPPED — P0–P6 released in v0.13.1; archived 2026-08-31. See "Post-port status" below.
+**Date:** 2026-08-27
+**Spec (binding):** the macro desk board artifact —
+`https://claude.ai/code/artifact/dde15f29-728e-43e9-86d5-9ab688df4853`, frozen into this repo at
+`docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html` (sha256 `b98a32de3041a348…`, 9 tab
+sections `#t0`–`#t8`, 58 panels, every value REAL from the mini). The board is the spec for both
+the **information** (which panels exist and what each answers) and the **design** (tokens,
+layout, copy). **Where this plan and the board disagree, the board wins** — the first revision of
+this plan never cited the artifact at all, which is how the divergence in §1 got through.
+**Phase 1 closure:** `project_macro_phase1_closed` — MC5/MC6 killed; the engine stays descriptive.
+
+---
+
+## Post-port status (added 2026-08-31, archiving this plan)
+
+P0–P6 (§8's slicing table) shipped and released in **v0.13.1**: the 9-tab shell,
+tabs 00–05, desk-wide replay, and the two 308 redirects (`/rates`, `/gold`) are all
+live on `origin/main`, which has since evolved past this plan's own design — `tabs.ts`
+now carries a `replayClock` field this plan never specified, and the shell grew a
+`MacroMasthead`/`MacroFooter`/`macroContextSnapshot` chrome layer this plan did not
+describe (see `docs/superpowers/plans/2026-08-30-macro-release-binding-fixes.md`,
+Task 4).
+
+P7 and P8 did **not** ship as this plan describes them:
+
+- **P7 (§8, §10-D):** no `macro_factor_daily` table was materialised — §10-D deferred
+  the answer to the P7 spec, and that spec (`docs/superpowers/specs/2026-08-30-macro-desk-signal-first-design.md`)
+  took a different shape than "materialise a table". Tab 07 ships reading the existing
+  domain states directly.
+- **P8 (§8, §10-C):** tab 06 ships, but as a static, dated proposal panel, not the "FRED
+  spot series, usable the day it lands" this plan settled on in §10-C. No energy series
+  reaches ingest; `EnergyProposal.tsx`'s own header says so ("the only tab on this desk
+  that ships with no live data path"), and `gold_oil_ratio_percentile`
+  (`models/gold.py`) stays permanently `None` with a comment recording exactly that.
+
+**§10-I is still an open operator ruling** — whether `RatesScorecard` should suppress
+its `BUY`/`SELL`/`NEUTRAL` stance word under the desk's "no composite prescribes a
+trade" invariant. Nothing found while archiving this plan resolves it.
+
+---
+
+## 1. Goal
+
+Collapse `/rates`, `/macro` and `/gold` into one **Macro Analysis** desk at `/macro`,
+organised as 9 sub-tabs following the chain **Fed → inflation expectations → USD →
+gold**, with energy proposed but not built.
+
+Non-goals, restated so they cannot drift:
+
+- **No composite.** Four domains publish independently; averaging them is
+  test-forbidden and hides the contradictions the desk exists to show.
+- **Macro never derives equity.** Equity _consumes_ macro factors
+  (`project_macro_phase2_equity_consumes_factors`); the arrow is equity → reads →
+  factor, never the reverse.
+- **The SPX `vrp_macro_signal` card is not part of this desk** — its "macro" means
+  index-level vol. It stays on `/regime`.
+- **The board binds, and it binds per tab.** _Superseded 2026-08-28: "No new analytics. Tabs
+  00–05 are a presentation merge."_ That line is what turned the board's four inflation panels
+  and two dollar panels into one generic state card each. The conformance audit
+  (`docs/research/2026-08-28-macro-desk-board-conformance/`) measured which half of it was ever
+  true: tabs **01 / 02 / 05 are a presentation merge** (their panels were already built), tabs
+  **00 / 03 / 04 are a build** (0 of 6 board panels reached 03/04; 8 of 16 reached 00). What
+  survives is the narrow sense only — **no new engine and no new derived quantity**: every
+  number a board panel prints must already be extractable from a shipped endpoint, and a panel
+  that would need a new one is deferred with its reason, never invented.
+- **Every panel answers a board question.** The board's own acceptance test binds: _"The seven
+  questions are the acceptance test: every panel must answer at least one, or it gets deleted."_
+  A panel names its Q1–Q7 in its own source; one that names none is a deletion candidate. (The
+  board's Q→panel table numbers tabs 00–04, one short of its own nine sections — re-read the
+  artifact before treating a number inside it as a tab id.)
+- **Tab 08 does not ship.** The board's t8 says so in its first line: _"This tab is for you (the
+  operator) and does not ship on the final page."_ It is currently in the live tab bar.
+
+---
+
+## 2. The headline finding: this is mostly a move, not a build
+
+**CORRECTION (2026-08-28, after the conformance audit): this heading held for the source pages
+and was read as holding for the board.** It does not. Measured against the board, 26 of 47
+panels on tabs t0–t5 are present, 6 partial, 15 absent or misplaced — and the absences are not
+spread evenly, they are concentrated in exactly the tabs §3 bound to a single endpoint. §2's own
+closing paragraph already said the panel count was not move-dominated; the audit is the number
+behind it. Read this section as an inventory of what need not be rebuilt, never as a size
+estimate for the remaining work.
+
+All eight panels the board describes as "carried and built" **already exist as argon
+components**. The board re-presented them; it did not invent them.
+
+| Board panel                         | Existing argon component                                 | L   |
+| ----------------------------------- | -------------------------------------------------------- | --- |
+| SEP dot plot                        | `web/components/rates/SepDotPlot.tsx`                    | 296 |
+| Dealer expectations                 | `web/components/rates/DealerPathChart.tsx`               | 334 |
+| Par yield curve                     | `web/components/rates/RatesCurveChart.tsx`               | 233 |
+| Cleveland 5-term + move attribution | `web/components/rates/sections/DecompositionSection.tsx` | 548 |
+| Fed plumbing                        | `web/components/rates/sections/PolicySection.tsx`        | 104 |
+| Auction demand                      | `web/components/rates/sections/SupplySection.tsx`        | 109 |
+| Gold input manifest                 | `web/components/gold/DataAuditFooter.tsx`                | 94  |
+| Four policy paths                   | `web/components/rates/PolicyPathComparison.tsx`          | 431 |
+
+`SepDotPlot.tsx` already carries a **prior-median rule** — one dashed line per horizon
+at the previous release's median (`SepDotPlot.tsx:224-241`, `data-testid="sep-prior-median"`),
+with the move in bps in its `<title>`. It is **not** an overlay of the prior release's
+dot distribution; only the median crosses over. The central-tendency band is a real
+`<rect className={styles.sepBand}>` at `:191-196`; `.sepBandSwatch`
+(`RatesDesk.module.css:1700-1706`) is the 16×12 **legend swatch**, not band geometry.
+**The dot chart on argon was never oversized** — only the board's redraw of it was (§5).
+
+Genuinely new work, with no existing component:
+
+- tab 00's daily loop, contradiction feed, cross-domain contradictions, transmission health
+- a **shared** confidence-arithmetic strip (today `ConfidenceStrip` is private to
+  `rates/sections/StateSection.tsx:77`)
+- tab 07 factor vector; tab 06 energy proposal; the refusal cards
+
+Existing inventory (recounted 2026-08-27, after this session's gold deletions):
+`components/rates/` 5 333 L (17 files) · `components/gold/` **2 067 L (34 files)** ·
+`components/macro/` 469 L (4 files, zero client components).
+
+### The eight are two populations, not one
+
+§7 treats "reusable" as a single property. It is not, and the split is what makes §7's
+component-home decision consequential:
+
+| Population                                      | Components                                                                  | Shaped by                                              |
+| ----------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ |
+| **Portable** — take a `PolicyPathSlot`          | `SepDotPlot`, `DealerPathChart`, `PolicyPathComparison`                     | `/api/macro/policy`, which every tab can call          |
+| **Rates-shaped** — take `RatesSnapshotResponse` | `RatesCurveChart`, `DecompositionSection`, `PolicySection`, `SupplySection` | `components/rates/types.ts` over `/api/rates/snapshot` |
+| **Neither** — gold                              | `DataAuditFooter`                                                           | `@/lib/types` directly; no rates coupling              |
+
+And **all seven rates components import `RatesDesk.module.css`** (`:1`–`:3` in each).
+So today "reusable" means "reusable inside the rates CSS Module." A tab that wants
+`SepDotPlot` without `RatesDesk.module.css` does not exist yet. See §7.
+
+### The claim, stated honestly
+
+"Mostly a move" is true of the **source pages**, not of the **board**, and the two have
+different denominators:
+
+- Of the **39 panels on `/rates` + `/macro` + `/gold`**, ~28 carry over (8 built · 5
+  available · 15 covered). Against that denominator the merge really is deduplication.
+- Of the **58 panels on the board**, roughly half are new — tab 00 entirely, tab 06,
+  tab 07, and tab 08's ten notes panels.
+
+The new panels are cheap per unit (tab 08 is static prose, tabs 06/07 are proposals
+with no data path) while the reused ones are expensive per unit (`DecompositionSection`
+alone is 548 L). So the _effort_ is move-dominated even though the _panel count_ is not.
+Do not read §2 as "half the work is already done" — read it as "no chart needs to be
+designed twice."
+
+---
+
+## 3. Tab → endpoint binding (verified against production 2026-08-27)
+
+Verified by direct call to the mini, not recall. Every tab that binds anything needs
+**1–3 requests, except tab 00, which needs 5** — the snapshot plus all four domain
+states. Tab 00 is the outlier by construction: it is the only tab whose subject is the
+other tabs.
+
+| Tab                      | Route              | Requests                                                         |
+| ------------------------ | ------------------ | ---------------------------------------------------------------- |
+| 00 Overview · Daily Loop | `/macro/overview`  | `/api/macro/snapshot` + 4× `/api/macro/{domain}`                 |
+| 01 Fed · Policy          | `/macro/fed`       | `/api/macro/policy` + `/api/macro/rates` + `/api/rates/snapshot` |
+| 02 Rates · Curve         | `/macro/rates`     | `/api/rates/snapshot` + `/api/macro/rates`                       |
+| 03 Inflation             | `/macro/inflation` | `/api/macro/inflation`                                           |
+| 04 US Dollar             | `/macro/usd`       | `/api/macro/usd`                                                 |
+| 05 Gold                  | `/macro/gold`      | `/api/gold/state` + `/api/macro/gold`                            |
+| 06 Energy · Proposal     | `/macro/energy`    | none — proposal only, no fabricated data                         |
+| 07 Factor Export         | `/macro/factors`   | none yet — `/api/macro/factors` does not exist (P7)              |
+| 08 Design Notes          | `/macro/notes`     | none                                                             |
+
+**CORRECTION, made while executing P3 (2026-08-28): the `/api/macro/rates` column above is
+wrong for tabs 01 and 02, and neither tab calls it.** `/rates` never called it either. The
+`MacroStateSummary` that `StateSection` renders is the `state` field on
+`RatesSnapshotResponse`, and `routers/rates.py:63-72` attaches it **at read time** by
+calling `fetch_macro_domain_state_as_of("policy_rates", at)` — the same repository read, at
+the same instant `resolve_instant` already resolved, that `/api/macro/rates` performs. So
+the second request would fetch the same row twice per page view and open a window in which
+the two answers disagree. `models/rates.py:253-258` states the reason the field is not
+persisted into the stored snapshot, and it is the same reason one level down: _"copying it
+here would fork one answer into two records that could disagree."_ Tab 01 makes **two**
+requests (`/api/rates/snapshot` + `/api/macro/policy`) and tab 02 makes **one**. A later
+tab that genuinely needs the domain state standalone should read `snapshot.state`, not add
+the call.
+
+**`/api/macro/policy` returns all four policy paths in one call** — verified in prod: all
+four paths present, each with 2 prior vintages; SEP `participant_distribution` as
+`(rate_percent, participant_count)` totalling 18 for 2026; dealer `p25/median/p75`
+with `respondent_count: 26`. IQR bands are server-side; no client math.
+
+**It is not the whole Fed tab, and the table above is the binding to trust.** Tab 01 also
+carries Fed plumbing and auction demand, which are `RatesSnapshotResponse` fields
+(`PolicySection`, `SupplySection` — the rates-shaped population in §2), and the
+policy-rates state itself, which is `/api/macro/rates`. Three requests, not one.
+
+### The one-endpoint bindings for 03/04 were right — §1 alone caused the divergence
+
+Measured 2026-08-28 against a running instance: the single response each of tabs 03 and 04
+already fetches **carries every board panel for that tab**. Nothing is missing from the API;
+what was missing was permission to render it. Field-level map, so the build adds no endpoint:
+
+| Board panel                             | Field on the response already fetched                                                         |
+| --------------------------------------- | --------------------------------------------------------------------------------------------- |
+| t3 · arithmetic of confidence           | `confidence_reasons[]` — 3 `multiplicand` + 2 `penalty` terms, each with a `detail` string    |
+| t3 · realized inflation                 | `factors[]` where `causal_role='realized'` (PCEPILFE et al., with `change_over_window`)       |
+| t3 · inflation expectations             | `factors[]` where `causal_role='expectations_survey'`                                         |
+| t3 · falsifier window / repair table    | `contradictions[]` (`rule` + `detail`) over `evidence[]` (139 rows, each with `available_at`) |
+| t4 · nominal vs real, a pair in reverse | `factors[]` = `broad_dollar` (DTWEXBGS) **and** `broad_dollar_real` (RTWEXBGS)                |
+| t4 · upstream citation, chain integrity | `upstream[]` + the `upstream_policy_rates` `informational` term in `confidence_reasons[]`     |
+
+Two traps this map carries with it:
+
+- **The confidence arithmetic must be computed from the terms, never restated from the board.**
+  The board's heading reads "why only 0.37"; the live inflation state answers 0.4177, which the
+  terms reproduce exactly (1.0 × 0.5968 × 1.0, then the 0.3 contradiction penalty). The board's
+  numbers are frozen at its capture instant — bind to the field, never to the board's value.
+- **`notes[]` is authored copy, not a footnote.** USD's note — _"the dollar is measured against
+  the Fed's H.10 nominal broad index; the real index is reported beside it and is never
+  substituted for it"_ — is the nominal/real panel's own rule, written by the engine that
+  produced the pair. Render it with the panel.
+
+Engine versions differ between the local dev DB (`inflation/1`, `usd/1`) and the versions the
+board names (`inflation/2 · rates/2 · usd/3 · gold/2`). Verify against the mini before binding
+anything to a version string — a local-DB reading is not evidence about production.
+
+### SECOND CORRECTION (2026-08-28, same day): the information bound, the design did not
+
+The first build against this section shipped all six panels and still did not look like the
+board. It answered every board question while inventing its own typography — a 13px sans panel
+heading where the board specifies **10px mono uppercase at 1.5px tracking**, no `.read` accent
+rail at all, a solid footer where the board specifies a dashed `.prov` rule, and the confidence
+arithmetic as stacked text blocks rather than the board's bordered `.term` boxes with `×`
+operators and a teal `= conf` chip. The header of this plan already said the board binds "both
+the **information** … and the **design**"; only the first half was executed.
+
+**Why it was invisible.** A missing panel fails a question-coverage check. A panel that answers
+the right question in the wrong visual language passes every check there was — nothing in the
+repo could compare rendered output to the spec, because the spec's own stylesheet had never been
+brought across. So the desk's design drifted to argon's house defaults by omission, exactly the
+way §1's prose beat the board by default.
+
+**The fix, and the rule it establishes.** The board's class grammar is ported to
+`web/app/macro/board.css` — `.sec-title` / `.sec-sub` / `.panel` / `.panel-h` / `.tag{.real,.comp,.plan,.q}` /
+`.state{.okst,.warnst,.critst,.neust}` / `.read` / `.prov` / `.arith{.term,.op,.res}` /
+`.note-refuse` / `.big` / `.delta-*` and the table rules — copied class for class from the frozen
+artifact so the two can be **diffed**. Argon's tokens turned out to be the board's tokens
+verbatim (`--bg-panel #0f1519`, `--border-dim #1e293b`, `--info #8b5cf6`, …), so no palette
+was added; the port is grammar only. Three deviations, each recorded in the CSS beside the rule:
+
+1. `rgba()` overlays of a token's dark value become `color-mix()` of the same token, because the
+   board is single-theme dark and argon has a light theme.
+2. Everything is scoped under `.board`, because /macro also serves the gold and rates tabs and
+   the board's bare `table {}` / `td:first-child {}` rules would restyle them.
+3. `.arith` wraps instead of `nowrap`. The board's mock never scrolls at its term widths; ours
+   pushed the `= conf` chip off the right edge behind an overflow scroller, hiding the product —
+   which is the only thing that panel exists to show.
+
+**And the design binding does not license the board's values.** The board's mock prints `−0.28pp`
+in the Δ column; `change_over_window` carries no unit and is not in the level's unit, so the
+column stays bare. The board's t4 title says "a dollar pair **in reverse**"; both legs are
+positive today, so the title stops at "a dollar pair" and the sentence is derived from the two
+signs. Design binds; frozen readings never do.
+
+### THIRD CORRECTION (2026-08-29): the board is the whole page, not the tabs I rebuilt
+
+The second correction fixed the design of tabs 03–05 and stopped there, which left the desk in a
+worse state than a uniformly wrong one: tabs 01 and 02 kept the old `/rates` styling, so the same
+desk rendered two visual languages depending on which tab you were standing on. The operator's
+correction was one line — _"THE FULL PAGE! ALL TABS!"_ — and it is the obvious reading of an
+artifact that has nine tabs in it.
+
+**The divergence on 01/02 was almost entirely one stylesheet, and mostly structural rather than
+typographic.** `RatesDesk.module.css` made `.section` a box — `bg-panel` + `border-dim`, 20px
+padding — and then filled it with `.slopeCard` / `.policyCard` / `.kpiTile`, each boxed again.
+The board puts exactly **one** level of boxing on a tab: the surface is flat and only `.panel`
+has a background. A card inside a card is a whole level of chrome the board never draws, and it
+is most of why the two halves of the desk did not look related even where their panels agreed.
+Under that sat the same three slips the domain components had, frozen at different values — six
+selectors spelling the panel heading six ways (13–16px sans, two of them in `--positive`),
+interpretive paragraphs with no accent rail and set 650/800 weight, and tables at 11–13px with a
+full-strength rule.
+
+**The page lockups went.** "FED POLICY DESK." and "GOLD COMPASS" each said the same words as the
+tab bar one line above them, in a different typeface. `BoardSecTitle` and `BoardStatePill` are
+lifted into `components/macro/domain/BoardPanel.tsx` and imported by `components/rates` — §7's
+rule is one-way (macro must never import rates) and its stated remedy for a primitive two
+subtrees need is exactly that lift. A second copy of the section title is how the desk got here.
+
+**Two recorded deviations, both about content the board has not compressed:**
+
+1. **The tier jump-nav stays on tabs 01/02.** The board's t1 is eight panels and its t2 is nine;
+   these tabs are eighteen sections across four tiers, because the `/rates` page they were merged
+   from was never compressed to the board's panel count. The board never has a tab long enough to
+   need a nav, so removing ours would be conforming to a decision the board did not make about a
+   tab this size. It goes when the sections do.
+2. **Tab 05's question strip is `Q1 Q2 Q4 Q5 Q7`, not the board's advertised `Q1 Q3 Q4 Q5 Q7`.**
+   The tab has an expression-cost panel the board files elsewhere (Q2) and nothing answering Q3.
+   Printing the board's strip would advertise a question no panel on the tab answers — precisely
+   what the acceptance test exists to catch — so the strip is the measured union.
+
+**Two of the three missing tabs are now built.** t7 Factor Export is what the board itself calls
+"pure assembly": four `/api/macro/*` states flattened, nothing computed. t6 Energy ships as the
+proposal the board designed, and introduced a panel kind this desk had not had before — one whose
+numbers are a **dated finding rather than a live read**. Everywhere else here a stale number is a
+bug; there the date is the number's meaning, so the panel carries its measurement date and method
+and says outright that the counts are a citation. That distinction is now in `CLAUDE.md`.
+
+**t0 Overview is still not built here, and deliberately.** It lives on `feat/macro-desk-tab-00`
+(2 commits, unmerged) and building it in this worktree would duplicate that branch and collide on
+`tabs.ts` and `app/macro/[tab]/page.tsx` at merge. That is the one part of "all tabs" this branch
+does not deliver, and the reason is a merge conflict rather than a judgement about the tab.
+
+### 3.1 Point-in-time replay
+
+`as_of` / `as_of_ts` is accepted by **every** `/api/macro/*` route (`routers/macro.py`
+`:30/:34`, `:48/:52`, `:62/:66`, `:76/:80`, `:90/:94`, `:121/:125`), all six resolving
+through the shared `resolve_instant` (`routers/macro.py:272-294`).
+
+**`/api/rates/snapshot` now accepts them too** — shipped as P1 on this branch.
+`rates_snapshot` takes `as_of: date | None` and `as_of_ts: datetime | None`
+(`routers/rates.py:30-36`) through the _same_ `resolve_instant`, imported rather than
+re-implemented (`routers/rates.py:10`), and `fetch_latest_rates_snapshot`
+(`storage/rates_repository.py:186-221`) gained a `WHERE computed_at <= %s` predicate.
+The live path is byte-identical to the shipped query: the router passes `None` unless a
+date was actually asked for (`routers/rates.py:51`), so a snapshot whose `computed_at`
+sits a second in the future cannot 404 the page. `_mark_stale_snapshot_sources` was
+re-pointed from the wall clock to the requested instant (`routers/rates.py:86-97`) —
+aged against `now`, every historical replay would have force-marked every source stale
+and appended a scheduler-failure risk to every past date on the desk.
+
+> A replayed tab 01/03/04/05 beside a **live** tab 02, with nothing on screen saying
+> so, is the worst failure mode a point-in-time desk has. P1 fixed it at the API.
+> P4 is still what makes it true on screen.
+
+#### Three different clocks, and they are not twins
+
+The plan's first draft called `/api/gold/replay` "the PIT twin of `/api/gold/state`."
+It is not a twin of anything else on this desk. There are **three** definitions of
+"as of" in the surfaces tab 01–05 will bind, and nothing on screen distinguishes them:
+
+| Surface               | Keys on                                     | Where                                                                                                   |
+| --------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `/api/macro/*`        | an **instant**; naive timestamps → **422**  | `resolve_instant`, `routers/macro.py:272-294`                                                           |
+| `/api/rates/snapshot` | **`computed_at`** — when the answer existed | `rates_repository.py:205` (`WHERE computed_at <= %s`)                                                   |
+| `/api/gold/replay`    | **`obs_date`** — the market day it is about | `routers/gold.py:503-516` → `storage/gold.py:862-880`, `WHERE obs_date = %s` (exact equality, not `<=`) |
+
+A single desk-wide date picker over these would have tab 02 answering _"what the desk
+knew at T"_ and tab 05 answering _"what the market did on day T"_, with one control
+above both. That is §3.1's own worst failure mode one level down — not a live tab beside
+a replayed one, but two replayed tabs replaying different things.
+
+**In scope for P4, decide one:** either give `/api/gold/replay` `computed_at` semantics
+(a second parameter, or a `<=`-on-`computed_at` variant), or label the gold tab's
+control an **obs-date** and not an as-of, and say on screen that it is a different
+question. Do not ship the picker over all five tabs until one of those is done.
+
+#### TAKEN in P4 (2026-08-28): the label, per §10-H — and how the ban is discharged
+
+`/api/gold/replay` is unchanged. The label is `MacroReplayClock`
+(`web/components/macro/replay.ts`), and the discharge is that it is a **required field of
+every `VALID_TABS` entry with no default and no fallback** (`components/macro/tabs.ts`).
+That matters more than the copy it selects:
+
+- `ReplayControl` renders **nothing** for `replayClock: "none"` and renders _different
+  prose_ for `"instant"` and `"obs_date"` — the second says outright that it is **not** a
+  point-in-time replay, that it names the market day, and that it is matched exactly. A
+  unit test asserts the two texts differ and that the obs-date one does not carry the
+  instant one's promise.
+- Tab 05 therefore cannot join the picker by omission. There is no default to inherit, so
+  P6 must _write_ `replayClock: "obs_date"` — a line a reviewer sees — and the control it
+  gets is the honest one. Registering a tab with no clock does not compile.
+
+So §3.1's ban is not discharged by "we labelled it and will remember" but by making the
+unlabelled case unrepresentable. **The ban's remaining half still binds P6:** a tab whose
+declared clock does not match what its endpoint actually keys on is the same failure
+wearing a label, and nothing in the type system can check that — it is a review item.
+
+**One correction to the table above, found while wiring it.** `/api/macro/policy` is listed
+as keying on an instant, and it does; but the response's `as_of` field is
+`as_of=as_of` — **the requested instant echoed straight back**
+(`macro/policy_report.py:128`). It is not an answer clock, so it cannot drive a banner. On
+tab 01 the banner is driven by `RatesSnapshotResponse.computed_at` alone, and the policy
+publisher's own freshness stays where it already was: the per-lane release dates inside
+`PolicyPathComparison`. A future tab that fetches only `/api/macro/*` has **no `computed_at`
+anywhere in its responses** and will need `state_summary`'s own clock, not this one.
+
+---
+
+## 4. Blockers found while verifying
+
+### 4.1 Confidence terms were mislabelled — **FIXED on this branch (P0)**
+
+Kept in full as the record, because the reasoning is what the shared
+`ConfidenceArithmetic` component in P5 inherits.
+
+**The bug as found.** `market_path_is_a_shadow` was built with `value=Decimal(0)` and
+no `kind`, inheriting the dataclass default `kind="multiplicand"`
+(`src/uw_scan/macro/contracts.py:139`). It is not in the product:
+
+```
+inflation  1 × 0.516129 × 1.0 × (1 − 0.30) = 0.36129  = reported 0.36129  ✓
+rates      1 × 1        × 1.0 × (1 − 0.15) = 0.85     = reported 0.850    ✓  ← the 0 is absent
+usd        1 × 1        × 1.0 × (1 − 0.00) = 1        = reported 1        ✓
+gold       1 × 1        × 1.0 × (1 − 0.15) = 0.85     = reported 0.850    ✓
+```
+
+`web/components/rates/sections/StateSection.tsx:80-85` sorts the terms: `penalty`
+with `value > 0` and `multiplicand` with `value < 1` go to the **"Reduced by"** strip
+(`:90-102`), `informational` goes to the notes (`:86`, rendered `:109-114`). So the
+live page rendered `market path is a shadow ×0.00` beside a confidence of 0.850.
+
+**The fix was not one keyword — a second term had the identical defect.**
+`policy_paths_absent` in the same file carries `Decimal(len(missing))` — a **COUNT** of
+absent policy paths — and also inherited `multiplicand`. It never reached the "Reduced
+by" strip only because its value is always ≥ 1, so it failed the `< 1` filter; and it
+was not `informational`, so it failed the notes filter too. It rendered in **neither
+list**. The visible bug and the invisible one were the same bug, and fixing only the
+one an operator could see would have left a count mislabelled as a multiplier in the
+component every domain is about to share.
+
+Both are now `kind="informational"`, with the reasoning recorded at the site:
+`rates.py:532` (`policy_paths_absent`) and `rates.py:549` (`market_path_is_a_shadow`).
+`market_factors_absent` (`rates.py:586`) was already correct and is the shape the other
+two now match.
+
+**Scope of the class.** There are **25 `ConfidenceTerm(` construction sites across 6
+files** — `macro/{rates,rates_sub_states,usd,gold_state,confidence}.py` and
+`storage/macro_domain_state.py` — and `contracts.py:139` defaults **every one** of them
+to `"multiplicand"`. The default is the defect surface; the audit is invariant 10 (§9).
+
+**Test.** `tests/unit/macro/test_confidence_term_kinds.py` (+ `conftest.py`) pins both
+shapes on a real state from each of the four engines: a reconciliation test that refolds
+the terms using **`kind` alone** and requires the reported `confidence` back
+(`:57-71`), and a range test that requires anything not `informational` to be a fraction
+in [0, 1] (`:74-93`). The refold is deliberately blind to term _names_ — a test that
+special-cased `market_path_is_a_shadow` by string would have passed straight through the
+bug it exists to catch. `contracts.py:125-134` documents that `kind` exists precisely so
+consumers need not string-match; the test holds the producer to it.
+
+### 4.2 Never build a panel on these — permanently empty in current code
+
+Hardcoded at the source; identical on every request. **Citations re-verified
+2026-08-27** — every gold line below shifted when the producing sites were annotated
+during the §10-E work, so an earlier copy of this table points at the wrong lines.
+
+| Field                                      | Source                                 | Note                                                                              |
+| ------------------------------------------ | -------------------------------------- | --------------------------------------------------------------------------------- |
+| `rates.events[]`                           | `rates/snapshot.py:131`                | `RatesEventItem` has **zero producers** in `src/`; comment at `:126-130`          |
+| `gold.cyclical.two_force_text`             | `routers/gold.py:345-348`              | both halves an em-dash literal; comment at `:341-344`. Render **already deleted** |
+| `gold.decomposition_rows[]`                | `reports/gold_posture.py:445`          | deliberate — comment at `:435-444`                                                |
+| `gold.valuation.gold_oil_ratio_percentile` | `models/gold.py:101`, never assigned   | always `null` — one hit in `src/`, the declaration itself                         |
+| `gold.structural.xau_cny_premium_pct`      | `gold_posture.py:519`                  | always `null`; comment at `:515-518`                                              |
+| `gold.structural.cb_52w_pct`               | `gold_posture.py:520`                  | always `null`; same comment                                                       |
+| COMEX `vault_oz`                           | `gold_posture.py:280`                  | always `null`; comment at `:276-279`                                              |
+| `gold_spx_ratio_percentile`                | computed from `spx_series=[]` (`:337`) | self-declared via `inputs_used`                                                   |
+
+**Two of the dead renders are already gone.** `components/gold/lens2/TwoForceNarrative.tsx`,
+`components/gold/decomposition/LensDecompositionPanel.tsx` and its
+`decomposition/DecompositionBars.tsx` were deleted on this branch — the whole
+`components/gold/decomposition/` directory no longer exists. §10-E's action is executed;
+what remains of §10-E is the standing rule (don't delete the Pydantic fields) and the
+marking at the producing sites, which the comments cited above now carry.
+
+Misleading rather than dead — carry but keep demoted:
+
+- `rates.cross_market` is two decomposition fields under a borrowed heading, with
+  `status="partial"` a literal (`rates/snapshot.py:107-125`).
+- `rates.scorecard` groups whose `source` is a promise: `"Phase 2 official macro
+feeds"` / `"Phase 2 Treasury FiscalData/QRA"` / `"Phase 2 CFTC/TIC"`
+  (`rates/scorecard.py:100,109,118`).
+
+### 4.3 A code default is not deployed state
+
+`settings.rates_snapshot_state_block_enabled` defaults **`False`** (`config.py:223`),
+but production returns a fully populated `state` block — the flag is **on** on the
+mini. Tab 02 must therefore read state from `/api/macro/rates`, which is
+unconditional, and treat `rates_snapshot.state` as a convenience duplicate.
+(`reference_code_default_is_not_deployed_state`.)
+
+### 4.4 The yield curve carries deltas, not prior levels
+
+`RatesCurvePoint` (`models/rates.py:31-39`) has `value` + `delta_1d/1w/1m_bps` and an
+`obs_date` for the **current** observation only. Anchors are
+`latest_on_or_before(as_of − 7/30 **calendar** days)` (`rates/calculations.py:55-57`)
+and are then discarded. A prior level is recoverable (`value − delta_1w_bps/100`); its
+date is not, and across weekends the true anchor slips by an unrecorded amount that
+can differ per tenor.
+
+Keep the board's wording: _"read the shapes, not the calendar."_ A dated multi-curve
+overlay needs new backend surface — no router exposes `rates_observations`.
+
+### 4.5 `/api/gold/gauge` is expensive
+
+`routers/gold.py:371-401` recomputes a 5-year weekly correlation history in a Python
+loop (`:381-389`) — **262** `compute_correlation_gauge` calls **per request**: the
+cursor starts at `today − 1825 d` and steps 7 days while `cursor <= today`, which is
+⌊1825/7⌋ + 1 = **261** iterations, plus the `current` call at `:378`.
+`correlation_history` already arrives inside `/api/gold/state`; do not bind a page to
+`/gauge`.
+
+### 4.6 `/gold` bypasses `lib/api.ts` — and collapses two failures into one message
+
+`app/gold/page.tsx:6-19` uses a raw `fetch` and re-inlines the base-URL resolution
+(`:9`) that `lib/api.ts:26-40` already owns (the `const API` ternary at `:37-40`, with
+the reasoning at `:26-36`). There is no `api.goldState()`. The port adds one rather
+than copying the raw fetch a third time.
+
+**The same function carries a live invariant-2 violation.** `fetchGoldState` returns
+`null` for a non-2xx (`:14`) _and_ for any thrown error (`:16-18`), and `GoldPage` then
+renders one message for both — `"GOLD COMPASS · Posture not yet computed. First
+scheduled run lands at the next worker tick."` (`:23-41`). A dead API and a
+never-computed posture are the same sight. §9 invariant 2 requires **three states**
+(answered / request failed / never computed), and `app/macro/page.tsx:10-19` already
+does it correctly by carrying an `error` string beside the `value`. Tab 05 must not
+inherit the collapse: fix it in the PR that ships `api.goldState()`, not later.
+
+---
+
+## 5. Chart scale — argon already has the answer
+
+The board's SEP dot plot renders at ~2× the rest of its page. Measured across the
+board at 1440px:
+
+| Chart               | viewBox w | rendered px | k        | label at   |
+| ------------------- | --------- | ----------- | -------- | ---------- |
+| Dealer expectations | 1120      | 1132        | 1.01     | 10.1px     |
+| Par yield curve     | 560       | 547         | 0.98     | 9.3px      |
+| **SEP dot plot**    | **560**   | **1132**    | **2.02** | **20.2px** |
+| Central banks       | 520       | 329         | 0.63     | 6.3px      |
+
+`.chart svg { width:100%; height:auto }` plus a fixed `viewBox` stretches the SVG's
+_internal coordinate system_ to the container — and `font-size` lives inside it. So
+effective type size is `font-size × (container_px ÷ viewBox_width)`.
+
+**This is a solved problem in argon.** `web/components/rates/chartGeometry.ts:1-24`:
+
+> _"these are sized by viewBox and stretched to `width:100%` … everything inside
+> scales by `containerWidth/viewBoxWidth`, **TEXT INCLUDED** … The thing to hold equal
+> is the **SCALE FACTOR**, not the viewBox."_
+
+It ships `WIDE_FRAME` (1200×360, full-width) and `NARROW_FRAME` (760×300, grid cell),
+each sized to its real container so k ≈ 1. `CriHistoryChart.tsx:72-82` reaches k = 1.0
+the other way, with a `ResizeObserver`.
+
+### The rule
+
+> **Hold the scale factor at 1, not the viewBox.** Pick the frame whose width matches
+> the container the chart will actually occupy, then `font-size="10"` means 10px.
+
+**Do not invent a new primitive.** Extend `chartGeometry.ts` with a `MID_FRAME` if the
+desk needs a third column width; reuse `WIDE_FRAME` / `NARROW_FRAME` otherwise.
+
+### The rendered-px target
+
+Argon's apparent 9-vs-11px split is mostly a scale-factor artifact. Rendered:
+
+| Family                                     | declared | k     | **rendered** |
+| ------------------------------------------ | -------- | ----- | ------------ |
+| stock panel cards (400×220, height pinned) | 9        | 1.00  | **9.0px**    |
+| regime strips (880×260)                    | 10       | ~1.00 | **10.0px**   |
+| rates strips (1200×360, `.svgLabel` 11px)  | 11       | ~0.94 | **10.3px**   |
+
+**All of the above are 1440px numbers.** `chartGeometry.ts:17-18` states its own frames
+were measured in a **1512px** viewport — _"the full-width chart panel is ~1200px, the
+curve grid cell ~760px (`.curveGrid` gives it 1.4fr of the 1440px shell)"_ — where
+`WIDE_FRAME` lands at k ≈ 1.00, not 0.94. The two are consistent (a 1440px viewport
+gives a ~1368px shell and a ~1132px panel); the point is that **k is a function of
+viewport width and nothing in the plan said which one**. See the gate below.
+
+So target **~9px rendered on panel cards, ~10px on full-width strips**, and leave the
+rates charts' 11px alone — at their frame they already land at 10.3px.
+
+### Standing traps
+
+- **Never `preserveAspectRatio="none"` on a chart that draws `<text>`** — it distorts
+  labels horizontally. Three existing charts do this (`MarketTideDailyChart.tsx:254`,
+  `TopNetImpactChart.tsx:102`, `GexHistoryChart.tsx:168`); `GrgDivergenceChart.tsx:11`
+  carries the counter-comment. Legitimate only for text-free sparklines.
+- `GoldHoldingsVsPriceChart.tsx:326` uses `fontSize={6.5}` — a scale-compensation hack
+  for a 1040×200 frame, **not a design token**. Do not copy it.
+
+### Acceptance gate
+
+A Playwright assertion that every `svg` under `/macro/*` satisfies
+`getBoundingClientRect().width / viewBox.width ∈ [0.90, 1.10]`, **at a viewport pinned
+in the spec itself** (`test.use({ viewport: { width: 1440, height: 900 } })`). This
+converts a recurring eyeball problem into a test.
+
+**The viewport is part of the gate, not an incidental.** k is `container_px ÷
+viewBox_width`, and `container_px` moves with the viewport: the same `WIDE_FRAME` chart
+is k ≈ 0.94 at 1440px and k ≈ 1.00 at 1512px (`chartGeometry.ts:17-18`). A gate that
+does not pin its viewport measures whatever the runner defaulted to, and the band's
+width becomes an artifact of a number nobody wrote down.
+
+**Why the band is ±10% and not tighter, at 1440px.** A tighter `[0.95, 1.06]` would fail
+the very charts being ported: at 1440px argon's rates strips declare a 1200-unit viewBox
+and render at ~1132px, i.e. **k ≈ 0.94**. The band has to admit the existing, correct
+charts while still catching the real defects — the board's k = 2.02 and k = 0.63 are
+both far outside any sane band. Tighten it later, per-family, if the desk's frames
+converge.
+
+**The port can break the gate the port introduces.** `NARROW_FRAME`'s 760 is sized to a
+`.curveGrid` cell (`RatesDesk.module.css:288`) whose width is 1.4fr of the current
+shell. Moving the content under a new `app/macro/layout.tsx` that adds a tab bar — and
+possibly a replay banner — changes that cell. **Re-measure both frame widths in a real
+browser after the shell lands (P2), before the charts arrive (P3), and update
+`chartGeometry.ts` if they moved.** Do not treat 1200/760 as constants across the port.
+
+---
+
+## 6. Routing and information architecture
+
+Argon has four tab patterns. The two that matter:
+
+- **`/regime` + `/scanner`** — `[[...tab]]` catch-all, client state + `pushState`,
+  instant switching.
+- **stock detail** — `[tab]` segment + `<Link>`, **genuinely per-route**; only the
+  active tab's component is instantiated (`[tab]/page.tsx:46-58`), with the tab bar in
+  the **layout** above it (`[ticker]/layout.tsx:42`).
+
+**Correction to the first draft: `/regime` does NOT pre-render every tab.**
+`components/regime/RegimePanel.tsx` is `"use client"` (`:1`) and renders exactly one
+subtab conditionally (`:94-100`) — nothing is server-rendered for the six tabs you are
+not looking at. The `ScannerPanel.tsx:86-89` citation was a **different page**, and even
+there only three of four slots are pre-rendered server content (`flowContent`,
+`discoverContent`, `valueContent`); the fourth is a client component handed an
+`initial` prop. The comment explaining it is at `ScannerPanel.tsx:84-85`. So
+"pre-rendering all nine is wasteful" was an argument against something argon does not
+do, and it cannot be the reason to choose anything.
+
+**Use the stock-detail pattern anyway**, for the reason that survives: `as_of` replay
+needs a server re-fetch per tab, and nine tabs across ~20 endpoints want per-route code
+splitting. But not with the stock page's prefetch setting.
+
+**`prefetch={false}` on every tab link — this is the load-bearing detail.**
+`TabBar.tsx:34` passes bare `prefetch`, which is `prefetch={true}`, and for a dynamic
+route that prefetches the **full route**, not just the loading boundary. A nine-tab bar
+sits entirely in the viewport, so on the stock page's setting every single page view
+would fire nine full RSC prefetches, each one a `force-dynamic` server component
+awaiting 1–3 API calls — **~20 backend requests per view** for the eight tabs nobody
+opened. That is strictly worse than the pre-rendering the first draft rejected.
+
+Use `prefetch={false}`. The default `'auto'` is acceptable **only** once
+`app/macro/[tab]/loading.tsx` exists, because `'auto'` then prefetches to the loading
+boundary rather than the full payload; ship `false` first and revisit with a measurement.
+
+**Use the `/regime` tab-bar styling.** `.ticker-tabs` / `.ticker-tab`
+(`globals.css:3199-3227`): mono, **11px**, uppercase, letter-spacing 0.05em, padding
+10px 16px, `--text-muted` → `--text-primary` with a 2px active underline. The
+stock `TabBar.tsx` inline style (12px, no uppercase, `:36-44`) is the outlier;
+`globals.css:7226-7227` states `.scanner-tab` and `.ticker-tab` deliberately share
+metrics — _"only the active colour differs here, never the scale."_
+
+### `<Link>` + `.ticker-tab` + `as_of` do not compose. Three mechanical problems
+
+None of these are addressed by "use `<Link>` with `.ticker-tab` classes", and all three
+bite in P2:
+
+1. **A static `href` drops the replay date.** `<Link href="/macro/rates">` does not
+   carry `?as_of=`. Propagating it needs `useSearchParams()` in the tab bar, which (a)
+   forces the bar to `"use client"` and (b) requires a `<Suspense>` boundary around it
+   or the whole route opts out of static rendering. It also multiplies the prefetch set
+   by one entry **per distinct `as_of`** — another reason `prefetch={false}` is not
+   optional here.
+2. **`.ticker-tab` is a `<button>` reset, not a link style.** It sets
+   `background: transparent; border: none` (`globals.css:3212-3213`) and **no
+   `text-decoration`**, because every current consumer is a `<button>`
+   (`RegimePanel.tsx:84-92`). Put it on an `<a>` and it inherits the global anchor
+   styling — underline and link colour. This is exactly why the stock `TabBar.tsx` sets
+   `textDecoration: "none"` explicitly (`:43`): it uses `<Link>`. Either add
+   `text-decoration: none` to `.ticker-tab` or set it on the element.
+3. **`.ticker-tabs` has no `flex-wrap`.** It is `display: flex` with a bottom border and
+   nothing else (`globals.css:3200-3204`). `/regime` already needs an inline
+   `style={{ flexWrap: "wrap" }}` override at **seven** tabs (`RegimePanel.tsx:80`).
+   Nine will overflow on narrow viewports. Decide the responsive behaviour in P2 —
+   wrap, or `overflow-x: auto` like `CockpitTabs.tsx:52` — and put it in the class
+   rather than as a third inline override.
+
+### Accessibility: a nine-tab bar needs ARIA, and neither candidate pattern has it
+
+Both patterns §6 considered ship bare elements: `RegimePanel.tsx:84-92` is a plain
+`<button>` and `TabBar.tsx:31-48` a plain `<Link>` — no `role="tablist"`, no
+`role="tab"`, no `aria-selected`. Nine unlabelled controls in a row is where that stops
+being survivable.
+
+Two components in this repo already do it, and are the model:
+
+- `app/cockpit/[ticker]/CockpitTabs.tsx` — `role="tablist"` + `aria-label` (`:47-48`)
+  on the container, `role="tab"` + `aria-selected` on each button (`:63-64`), and
+  `overflowX: "auto"` (`:52`) for the narrow case.
+- `components/stock/panels/greeks/GreekSubTabs.tsx` — `role="tablist"` (`:46`),
+  `role="tab"` + `aria-selected` (`:57-58`).
+
+**Requirement for P2:** the macro tab bar carries `role="tablist"` with an `aria-label`,
+and `role="tab"` + `aria-selected` per tab, matching those two. Note honestly that
+neither model implements roving `tabIndex` or arrow-key navigation — so if the desk
+wants keyboard tab traversal, that is **new** work, not a copy. A link-based bar is also
+not a true ARIA tablist (the panels are separate documents); if the ARIA roles fight the
+`<Link>` semantics, prefer the honest markup — `<nav aria-label="Macro desk tabs">`
+with `aria-current="page"` — over a tablist that lies. Decide once, in P2.
+
+Layout:
+
+```
+web/app/macro/page.tsx              → redirect("/macro/overview")
+web/app/macro/[tab]/page.tsx        → VALID_TABS, per-tab fetch, notFound() otherwise
+web/app/macro/[tab]/loading.tsx     → per-tab loading boundary
+web/app/macro/[tab]/error.tsx       → a dead publisher costs its tab, not the whole desk
+web/app/macro/error.tsx             → catches throws from layout.tsx (the tab bar itself)
+web/app/macro/layout.tsx            → <MacroTabBar/>
+```
+
+**Correction: those boundaries already exist and the port must carry them, not
+invent them.** `app/gold/loading.tsx`, `app/rates/loading.tsx` and `app/rates/error.tsx`
+are all present today, and the pattern being copied ships both
+(`app/stock/[ticker]/[tab]/{loading,error}.tsx`). §7's move list names none of them, so
+a naive re-home **deletes three live boundaries**. Add them to the move list.
+
+**And correct the justification.** A route `error.tsx` replaces the **entire tab**, not
+a card — "one dead publisher must cost one card, not the page" is what the existing
+`settle()` wrappers do (`app/macro/page.tsx:8-19`, `app/rates/page.tsx:7-17`), and they
+stay the primary mechanism. `error.tsx` is the backstop for a throw those wrappers do
+not catch. Separately, **a segment's own `error.tsx` does not catch throws from that
+segment's `layout.tsx`** — so a tab bar that throws needs `app/macro/error.tsx` one
+level up, which is why it is listed above.
+
+- **Redirects: `next.config.ts` does not exist.** The file is `web/next.config.mjs`; it
+  does have `rewrites()` (`:31-40`), and `redirects()` goes beside it.
+  **Next cannot emit 301.** `redirects()` emits **308** (`permanent: true`) or **307**
+  (`permanent: false`); pick 308 for `/rates` and `/gold`. Good news: Next passes query
+  values through to the destination automatically, so `/rates?as_of=X` →
+  `/macro/rates?as_of=X` works with no extra config.
+- **Trap: `/gold/replay/[date]` is kept**, so a redirect written
+  `source: "/gold/:path*"` would swallow it. Only an **exact** `source: "/gold"` is
+  safe. Same shape for `/rates`, which has no children today but may grow them.
+- **`/gold/replay/[date]` is kept** — the only working PIT surface today, and the
+  prototype for desk-wide replay (with §3.1's obs-date caveat).
+- `Sidebar.tsx:28-30` lists Gold, Rates and Macro as three peers; they collapse to one
+  **Macro** entry. Active state is `pathname.startsWith(href)` (`:47-48`) — already
+  correct for `/macro/*`. **Unstated consequence:** with the Gold entry gone,
+  `/gold/replay/[date]` matches no sidebar `href` and highlights **nothing**. Either
+  accept it as a deliberately unlisted deep surface, or re-home replay under
+  `/macro/gold/replay/[date]` in P4.
+- Keep the `settle()` wrapper from `app/rates/page.tsx:7-17` / `app/macro/page.tsx:10-31`.
+- `as_of` rides as a searchParam so it survives tab switches — see problem 1 above for
+  what that costs.
+
+---
+
+## 7. What moves, what changes, what dies
+
+39 distinct panels across the three source pages, each traced page component →
+`api.ts` call → router → table before judging: **8 carried and built · 5 carried and
+still available · 15 already covered · 8 dropped · 3 dropped as structurally dead.**
+
+The merge is mostly **deduplication** — the three pages already share engines and tables.
+
+Component moves:
+
+- `components/rates/*` → `components/macro/rates/*`, `components/gold/*` →
+  `components/macro/gold/*`, or keep the subtrees and re-home only the page shells.
+  **Prefer the latter** — it keeps the diff reviewable and `RatesDesk.module.css`
+  (1 897 L, one of only two CSS Modules in the app) mostly untouched.
+- `ConfidenceStrip` (`rates/sections/StateSection.tsx:77-117`) is promoted to a shared
+  `components/macro/ConfidenceArithmetic.tsx` used by all four domains — this is the
+  component that makes §4.1 load-bearing.
+- Add `api.goldState()` / `api.goldReplay(date)` to `lib/api.ts` (§4.6), and fix the
+  two-failures-one-message collapse while you are there.
+- **Move the loading/error boundaries with the pages** (§6): `app/gold/loading.tsx`,
+  `app/rates/loading.tsx`, `app/rates/error.tsx` → `app/macro/[tab]/{loading,error}.tsx`
+  (+ `app/macro/error.tsx`). Not listed in the first draft; re-homing without them
+  silently deletes three live boundaries.
+
+### The two bullets above contradict each other. The decision
+
+Bullet 1 wants the subtrees left alone "so `RatesDesk.module.css` is untouched."
+Bullet 2 promotes `ConfidenceStrip` out of `rates/sections/StateSection.tsx` — but
+`StateSection.tsx:1` imports `../RatesDesk.module.css` and `ConfidenceStrip` consumes
+**four classes from it**: `styles.confidenceStrip` (`:89`), `styles.confidenceStripLabel`
+(`:92`, `:104`), `styles.confidenceDrag` (`:94`), `styles.confidenceNote` (`:110`). The
+promotion touches that CSS Module either way. Same shape for `chartGeometry.ts`, which
+lives in `components/rates/` while §5 wants gold, USD and inflation tabs to use it —
+which makes `components/macro/*` depend on `components/rates/*`.
+
+**Decided, once:** the subtrees stay where they are, and **shared primitives are lifted
+out of `components/rates/` into `components/macro/`, taking their CSS with them.** Two
+lifts, both in the PR that first needs them:
+
+| Lift                               | To                                          | CSS                                                                                                 | In PR |
+| ---------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----- |
+| `ConfidenceStrip`                  | `components/macro/ConfidenceArithmetic.tsx` | move the 4 classes into a new `ConfidenceArithmetic.module.css`; delete from `RatesDesk.module.css` | P5    |
+| `chartGeometry.ts` (+ `axisTicks`) | `components/macro/chartGeometry.ts`         | none — it is pure TS, no CSS Module import                                                          | P3    |
+
+So "`RatesDesk.module.css` untouched" is **not** the promise. The promise is: no
+wholesale subtree move, and each lift is a named, reviewable diff that carries its own
+styles. `components/macro/*` must never import from `components/rates/*` — if a third
+tab needs a rates component, lift it, do not cross-import.
+
+### The gold posture linter breaks silently if the gold subtree moves
+
+`web/scripts/lint-gold-copy.mjs` hard-codes its scope:
+`const roots = [path.resolve("components/gold"), path.resolve("app/gold")]` (`:118`).
+For a root that does not exist it **`continue`s** (`:120-125`) and the script exits **0**.
+Its banned list includes `"buy"` (`:11`), `"sell"` (`:12`), `"position size"` (`:16`)
+and `"predicted return"` (`:28`) — the exact vocabulary §9 invariant 7 and
+`gold-page.spec.ts:38-41` exist to keep off this desk.
+
+So **either** §7 option breaks it: moving `components/gold/` → `components/macro/gold/`
+removes both roots, and re-homing only the page shell removes `app/gold` — in both cases
+the build-time posture gate passes **vacuously, forever, with no output**.
+
+**Required in the same PR that moves either root (P2 for the shell, P6 for the subtree):**
+
+1. Update `roots` to the new locations, and extend it to `components/macro` +
+   `app/macro` — the desk is one posture surface now, not a gold one.
+2. Make a missing root **fail**, not `continue`. A lint whose scope can evaporate
+   without a message is not a lint. Replace the `try/catch → continue` with an error
+   that names the missing path and exits non-zero.
+
+Item 2 is the load-bearing half: without it the next re-home reintroduces the same
+silence.
+
+### `RatesDesk.tsx` violates three of the desk's own invariants — **SETTLED 2026-08-27**
+
+The plan said "move, don't rewrite." Moved unchanged, `RatesDesk.tsx` (602 L) would put
+three things on the macro desk that the macro desk forbids:
+
+| What                            | Where                                                                                                     | Which rule it breaks                                                                                                    |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `RatesScorecard`                | `RatesDesk.tsx:560`; reads `scorecard.composite_score` at `RatesScorecard.tsx:36-38`                      | §1 "No composite"; §9 invariant 1                                                                                       |
+| `SummaryStances` → `StanceCard` | `RatesDesk.tsx:440-442`, defined `:241-272` / `:215-239`; renders literal `"BUY"` / `"SELL"` (`:206-207`) | §9 invariant 7 (refusals describe, never prescribe); `gold-page.spec.ts:38-39` bans `\bbuy\b` / `\bsell\b` on this desk |
+| `snapshot.synthesis`            | `RatesDesk.tsx:563-568`                                                                                   | prose generated from the composite (`rates/snapshot.py:132-135` feeds it `scorecard.composite_score`)                   |
+
+**The resolution. Do not re-open this in review — it is decided.**
+
+- **`RatesScorecard` — KEPT.** It is already labelled experimental legacy at the
+  component (`RatesScorecard.tsx:45`, `data-testid="scorecard-legacy-banner"`) and
+  already sits in the lowest tier, "Provenance and legacy" (`RatesDesk.tsx:512`,
+  lede: _"the older rule score kept for comparison only"_). It is **demoted further**:
+  moved inside tab 02's **"what this tab refuses"** panel and explicitly labelled a
+  legacy artifact there.
+  **Invariant 1 is amended accordingly (§9):** no composite in the desk's **own
+  chrome**. A clearly-labelled legacy artifact quarantined inside a refusal panel is not
+  chrome — it is the desk showing its work, which is the whole posture. Deleting it
+  would remove the only thing an operator can compare the new state against.
+- **`SummaryStances` / `StanceCard` — DROPPED.** This is prescription, and it breaks
+  invariant 7 **independently of the composite rule** — a stance card would be
+  forbidden even if it were computed from something the desk endorsed. `"BUY"` and
+  `"SELL"` also trip the runtime ban the gold spec already enforces. Drop the two
+  components and `stanceDescription` (`:195-213`) with them.
+- **`snapshot.synthesis` — DROPPED.** Prose generated from the score we just demoted.
+  Keeping the number quarantined and its narration in the open would be the worst of
+  both. The API field stays (§10-E rule: stop rendering, do not delete).
+
+**Test consequence.** `web/tests/e2e/macro-rates-state.spec.ts:59-82` pins the legacy
+scorecard's rendered contract — the `experimental legacy` banner (`:67-69`), and
+`duration-stance` → `UNKNOWN` + `scorecard-no-score` when there is no composite
+(`:71-81`). It skips when the scorecard is absent (`:63-65`), so it will not fail on the
+move — it will pass **vacuously** if the quarantine hides the testids. It must be
+updated to assert the **quarantined** form: scorecard present, inside the refusal panel,
+still banner-labelled. Budget it in P3.
+
+---
+
+## 8. PR slicing
+
+### P0 and P1 are done — the graph starts one layer up
+
+Both landed in this branch's working tree while the plan was under review, so neither is
+scheduled below:
+
+- **P0** — §4.1's two mislabelled terms now carry `kind="informational"` at their
+  construction sites (`macro/rates.py:520` `policy_paths_absent`, `:538`
+  `market_path_is_a_shadow`), each with its reasoning in a comment beside it. Regression
+  suite: **3 tests** in `tests/unit/macro/test_confidence_term_kinds.py`, over fixtures
+  in the new `tests/unit/macro/conftest.py`.
+- **P1** — `/api/rates/snapshot` accepts `as_of` / `as_of_ts` through the shared
+  `resolve_instant` (`routers/rates.py:30-36`, resolved at `:47`), and
+  `fetch_latest_rates_snapshot` gained `WHERE computed_at <= %s`
+  (`storage/rates_repository.py:205`). Tests went 6 → **13** in
+  `tests/integration/api/test_rates_router.py` and 4 → **7** in
+  `tests/integration/storage/test_rates_repository.py`.
+
+They are **working-tree changes, not merged code**. They ride the first PR cut from this
+branch — P2, below — and nothing here may assume they are on `main` before that merges.
+
+**What that unblocks, plainly:**
+
+- **P4 loses its backend dependency entirely.** Its only remaining predecessor is P3,
+  because it needs tabs to put a date control above. §10-A — land replay before or after
+  the merge — is answered by fact rather than preference.
+- **P5 loses P0.** The shared `ConfidenceArithmetic` is now lifted against terms whose
+  `kind` is already correct, so P5 depends on P3 alone.
+- **Nothing else moves.** P2 never touched a confidence term; P6–P8 never touched
+  `as_of`.
+
+### The slices
+
+| #      | PR                           | Scope                                                                                                                                                                                                                                             | Depends on |
+| ------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **P2** | `feat/macro-desk-shell`      | carries P0+P1; `app/macro/[tab]/` + `VALID_TABS`; the four loading/error boundaries (§7); the **registry-driven tab bar** (renders only registered tabs); `api.goldState()` + the three-state fix (§4.6); tab 08; the chart-scale gate            | —          |
+| **P3** | `feat/macro-desk-tabs-01-02` | re-home the rates desk under tabs 01/02 and register them; the `RatesDesk.tsx` settlement (§7); lift `chartGeometry.ts`; re-measure both frames (§5); **308 `/rates` → `/macro/rates`**; re-point/rewrite the rates specs (§9)                    | P2         |
+| **P4** | `feat/macro-desk-replay`     | `as_of` searchParam over the **registered** tabs, date navigation, the "you are replaying" banner driven by `computed_at`; takes §3.1's gold-clock decision (§10-H), which binds when tab 05 joins the picker in P6 — the UI that **consumes** P1 | P3         |
+| **P5** | `feat/macro-desk-tab-00`     | register tab 00 and flip `app/macro/page.tsx` to `redirect("/macro/overview")`; daily loop, contradiction feed, transmission health; shared `ConfidenceArithmetic`. Scope-bounded below                                                           | P3         |
+| **P6** | `feat/macro-desk-tabs-03-05` | inflation, USD, gold as tabs 03/04/05; **308 `/gold` → `/macro/gold`**; sidebar collapse; the `lint-gold-copy.mjs` fix (§7); re-point `gold-page.spec.ts`                                                                                         | P3         |
+| **P7** | `feat/macro-factor-contract` | tab 07 and its backend, **shape per the spec §8 requires below**; §10-D's default is a materialised table                                                                                                                                         | P6, spec   |
+| **P8** | `feat/macro-energy-p1`       | three FRED series into ingest + tab 06 surface; lights up the gold÷oil anchor (§4.2)                                                                                                                                                              | P6         |
+
+Dependency corrections against the first draft:
+
+- **P0 and P1 are no longer in the graph at all.** The first draft serialised the whole
+  port behind them; both are now done, and P2 simply carries them.
+- **P1 had no consumer.** §10-A recommended landing replay first, but no PR in the first
+  draft ever read `as_of`. Recommending a capability and never scheduling its UI is how
+  a backend parameter ships dead. P4 exists for exactly that.
+- **Tabs 06, 07 and 08 were unscheduled.** Nine tabs, six PRs, three tabs nobody built.
+  Tab 08 folds into the shell (static prose, no data path); tabs 06 and 07 attach to the
+  PRs that create their data.
+
+### No PR may ship a link to a route that does not exist
+
+The first draft's P2 shipped the tab bar, the redirects and the sidebar collapse before
+any tab existed. That is not a cosmetic ordering problem, it is a **live outage in two
+directions**:
+
+- Nine links in the bar, of which eight `notFound()` — including
+  `app/macro/page.tsx`'s `redirect("/macro/overview")`, so `/macro` itself 404s until
+  P5.
+- Worse, the 308s send `/rates` → `/macro/rates` (P3) and `/gold` → `/macro/gold` (P6).
+  Two working pages would 404 for the length of two PRs.
+
+**The fix is a registry, not a schedule.** `VALID_TABS` is the single source of both the
+route guard and the bar: `app/macro/[tab]/page.tsx` `notFound()`s on anything not in it,
+and `<MacroTabBar/>` renders one link per entry. P2 seeds it with tab 08 alone; each
+later PR adds its own entry in the same commit that adds its route. The bar therefore
+grows from one slot to nine, and at no point links anywhere that 404s. A test asserts the
+identity — every rendered tab href resolves, and every `VALID_TABS` entry is rendered.
+
+Consequences to hold to:
+
+- **Redirects ride their destination.** `/rates`'s 308 lands in P3, `/gold`'s in P6.
+  Neither may appear in P2.
+- **The sidebar collapses in P6**, the first moment both destinations exist. Until then
+  Gold, Rates and Macro stay three peers, and Macro's `startsWith` match already covers
+  `/macro/*` (`Sidebar.tsx:47-48`).
+- **`app/macro/page.tsx` is left alone until P5.** It keeps rendering today's four
+  domain cards, so `/macro` never 404s. If P6 lands before P5 those four cards are
+  briefly reachable at both `/macro` and their own tabs — a duplicate, not a break; P5
+  replaces the page with the redirect.
+- **§7's linter parenthetical predates this re-slicing.** `lint-gold-copy.mjs`'s roots
+  are `components/gold` and `app/gold` (`:118`), and neither disappears until P6 — so
+  §7's two required items (re-point the roots, make a missing root fail) attach to **P6**,
+  not P2. P2 may add `components/macro` + `app/macro` to `roots` early; that half is
+  purely additive.
+- **The chart-scale gate is vacuous in P2** — tab 08 is prose and draws no SVG. Give the
+  gate a non-zero-count assertion in the same commit, or it is §7's evaporating-scope
+  defect in a new file. It becomes meaningful in P3, which is also where §5 requires the
+  frames re-measured.
+
+### P3 before P5 — and the move is not mechanical
+
+P3 lands first so tab 00 is built against the real desk rather than against the old
+pages, and so every surprise the move produces surfaces before anything new is stacked on
+it. **That is the reason — not that the move is easy.** It is not:
+
+- Re-homing a component across a route boundary changes **what its server component
+  fetches**. `/rates` is one page making one `settle()`-wrapped fetch
+  (`app/rates/page.tsx:7-17`); tabs 01 and 02 are two routes, and the same
+  `RatesSnapshotResponse` has to be fetched by each — or the split has to be decided
+  deliberately, per §3's binding table.
+- `RatesDesk.tsx` (602 L) **is** the page shell, so it cannot move unchanged, and §7's
+  settlement already requires three behaviour changes inside it: quarantine
+  `RatesScorecard`, drop `SummaryStances`/`StanceCard`/`stanceDescription`, stop
+  rendering `snapshot.synthesis`.
+- §5 requires both `chartGeometry.ts` frame widths re-measured in a real browser once
+  the shell changes, and `chartGeometry.ts` is itself lifted in this PR.
+- `RatesDesk.test.tsx` (17.3 K) breaks by construction and is rewritten, not re-pointed
+  (§9).
+
+P6 branches off P3, not P5 — the domain tabs and the overview share no code.
+
+### Navigation order is not causal order
+
+The tabs run Fed (01) → rates (02) → inflation (03) → USD (04) → gold (05). The engine's
+own chain does not: `CAUSAL_ORDER` is `("inflation", "policy_rates", "usd", "gold")`
+(`macro/snapshot.py:43`) — inflation first, policy second. §1's reading chain, "Fed →
+inflation expectations → USD → gold", disagrees with it on the first two links.
+
+**Keep the Fed-first order, and state on the desk that it is a reading order.** Three
+reasons, recorded so nobody silently re-sorts the strip later:
+
+- **Nothing consumes tab adjacency.** `CAUSAL_ORDER` is consumed by
+  `macro/snapshot_assembly.py:74`, `:84` and `:126`, the last of which writes an explicit
+  ordinal into the stored snapshot — and the comment at `snapshot.py:40-42` says why:
+  _"the snapshot stores an explicit ordinal rather than relying on this tuple at read
+  time, so a stored snapshot keeps the order it was assembled with even if the chain is
+  ever reordered."_ The causal order is versioned in the store. The tab strip is not, and
+  must never pretend to be a second copy of it.
+- **Fed-first is how the operator arrives.** A rate decision is the event; inflation is
+  the input he goes looking for afterwards. Sorting the navigation by causality would put
+  inflation at 01 and the Fed at 02, optimising the strip for a chain nobody browses in.
+- **The causal claim already has a home.** `/api/macro/snapshot`'s chain verdict is where
+  the four are asserted to belong together, and tab 00 renders it (§9 invariant 8). That
+  is asserted, tested and stored; a tab order is none of those.
+
+So: do not reorder, and no tab's copy may imply that tab N causes tab N+1.
+
+### What tab 00 may and may not be
+
+Tab 00 is the one slice with no existing component (§2), which is exactly why it is the
+one that can quietly become new analytics.
+
+**Tab 00 re-presents what the other eight tabs already compute. It computes nothing of
+its own.** Its data is the five requests §3 gives it — `/api/macro/snapshot` plus the four
+domain states — the same responses tabs 02–05 render, arranged for a morning read. The
+daily loop, contradiction feed, cross-domain contradictions and transmission-health panels
+are **layouts over fields that already exist**: the snapshot's status and its
+`SnapshotReason` list (`macro/snapshot.py:34`, `:47`), and each domain's `state`,
+`confidence` and `confidence_reasons`.
+
+It must never:
+
+- average, weight, blend or score the four domains — §1's no-composite rule, §9
+  invariant 1;
+- derive a fifth number from the four (a "macro regime", a risk level, a dial);
+- introduce an endpoint of its own — if tab 00 wants a value no tab publishes, that is a
+  change to the domain that owns it, in that domain's PR, not a new aggregate here;
+- re-rank the contradictions. `SnapshotStatus` is already worst-finding-wins and the
+  four values are deliberately kept distinguishable (`snapshot.py:30-33`: _"'rates never
+  ran' and 'rates ran but USD ignored it' call for different operator actions"_). A
+  second severity ordering invented on the client is a composite wearing a list's
+  clothes.
+
+If a panel cannot be built from a field some other tab already renders, it is out of
+scope for P5 and belongs in a spec.
+
+### The factor contract is named here and specified nowhere
+
+§1 states the direction (equity consumes macro factors, never the reverse), §3 gives tab
+07 a route, the table above gives P7 a branch name, and §10-D asks how to deliver it.
+None of that says **what a factor is**: not its shape (a row per
+`(as_of, factor_name, value)`? a typed column set?), not its identity (which clock — the
+observation's, the state's `available_at`, both?), not who writes it (a nightly job over
+the four domain states, or each domain at its own settle), and not who reads it back or
+on what key.
+
+**Out of scope for this plan, explicitly.** This is a presentation port; the factor
+contract is a data contract, and inventing one in a table cell is how a shape nobody
+agreed to becomes the thing three consumers depend on. Verified 2026-08-27: no design
+exists — `macro_factor_daily` and `/api/macro/factors` appear nowhere in `src/` or
+`docs/` outside this plan, and no router serves `/factors` (the only hits under
+`src/uw_scan/api/routers/` are two `factors_jsonb` field reads, `routers/macro.py:208`
+and `routers/gold.py:340`).
+
+**P7 does not open until a design spec exists** under `docs/superpowers/specs/`, carrying
+at minimum: the row grain and key, which clock(s) travel with a factor, the writer, and
+the first named consumer with its join. The direction it must honour is already on record
+(`project_macro_phase2_equity_consumes_factors`). Until then tab 07 stays what §3 says it
+is — a route with no data path — and §10-D is not answerable.
+
+### Deploy ordering: two images, one Watchtower, no ordering guarantee
+
+The API and the web app are separate images — `ghcr.io/moremeds/argon-app` and
+`ghcr.io/moremeds/argon-web` (`docker-compose.yml:26`, `:97`), both built by the same
+release tag (`.github/workflows/release.yml:184-186`) and both pulled independently by
+the engine-wide Watchtower in `/opt/xenon/compose.yml`. **There is no ordering guarantee
+between them.** A release can be live on one image and not the other for as long as
+Watchtower's poll interval, and they can land in either order.
+
+So the rule is: **the API change ships in a release at or before the web change that
+consumes it, and every web change must still be correct against the previous API image.**
+
+**The intermediate state, measured on the mini 2026-08-27** against the currently
+deployed (pre-P1) `argon-app`:
+
+```
+GET /api/rates/snapshot?as_of=2026-01-01  → 200, as_of "2026-08-25"
+GET /api/rates/snapshot                   → 200, as_of "2026-08-25"
+```
+
+Byte-identical. FastAPI ignores a query parameter the route does not declare, so an old
+API image answers a replay request with the **live** snapshot and a 200 — no 404, no 422,
+nothing to notice. If a web image carrying P4's date control ever deploys ahead of the
+API image carrying P1, an operator who picks 2026-01-01 gets tab 02 rendering today's
+curve **under a replay banner**, beside tabs 01/03/04/05 replaying correctly on
+`/api/macro/*`. That is §3.1's worst failure mode manufactured by a deploy race rather
+than by a missing parameter, and it is invisible.
+
+Two things make it benign:
+
+1. **P2 carries P0+P1 and reads neither.** The parameter is therefore live for several
+   releases before P4's UI asks for it. This is the whole reason to keep them in P2
+   rather than holding them for P4.
+2. **P4's banner is driven by the response, not the request.** `/api/rates/snapshot`
+   returns `computed_at`; a replay to instant T must see `computed_at <= T` or render
+   "this publisher did not answer for that instant" instead of a curve. The check is
+   free, is correct against both API images, and is the only thing that survives a
+   Watchtower race.
+
+Per PR: **P3–P6 are web-only** (the 308s are Next config, i.e. the web image), so no
+ordering applies. **P7 and P8 ship API and web together** — both must be additive, and
+tab 07 against an API image without `/api/macro/factors` must render §9 invariant 2's
+"request failed", never an empty factor list dressed as "no factors today".
+
+### Rollback
+
+P2, P4, P5, P7 and P8 are ordinary reverts. **P3 and P6 are not** — each merges a 308,
+and once `/rates` (P3) or `/gold` (P6) redirects, backing out needs a second deploy to
+remove it. Land each on its own and let it sit a day before the next. P0/P1's API changes
+revert cleanly but are additive, so there is rarely a reason to.
+
+Decisions this section formerly hard-coded now live in §10, reconciled: A, B, C and E are
+recorded there as settled with their reasons; D and F–H remain open.
+
+---
+
+## 9. Tests
+
+### Existing, and what the port does to them
+
+| Spec                                                                          | Effect                                                                                                                                                                                                                                                                 |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `web/tests/e2e/macro-rates-state.spec.ts` (12.3 K, **13 tests**)              | `page.goto("/rates")` at `:18` — **breaks on the redirect.** Re-point to `/macro/rates` in P3. Its **3** replay tests (`:154` a 404 for an unanswered instant, `:166` evidence-bounded replay, `:194` stale-not-current) are the model for the desk-wide replay tests. |
+| `web/tests/e2e/gold-page.spec.ts`                                             | `page.goto("/gold")` `:15` — re-point in P6. Keep the posture-language ban (`:38-41`) and the zero-console-errors assertion (`:44`).                                                                                                                                   |
+| `web/tests/e2e/gold-screenshot.spec.ts`                                       | re-point; artifact-only.                                                                                                                                                                                                                                               |
+| `web/tests/unit/rates/*` (5 specs + a 15.9 K shared fixture)                  | 4 of 5 survive if components stay in place (§7). **`RatesDesk.test.tsx` (17.3 K) is the exception** — `RatesDesk.tsx` (602 L) _is_ the page shell, so re-homing it in P3 breaks that spec by construction. Budget for rewriting it, not for it surviving.              |
+| `web/tests/unit/macroDesk.test.tsx` + `tests/fixtures/macroDomainStates.json` | the invariant home; extend rather than replace.                                                                                                                                                                                                                        |
+| `web/tests/unit/{goldCompassLayout,dataAuditFooter}.test.tsx`                 | survive.                                                                                                                                                                                                                                                               |
+
+**Gap: no e2e spec navigates to `/macro` today** — verified by sweeping every
+`page.goto(` under `web/tests/e2e/`; the closest are `/rates` and `/gold`, and only API
+requests reach `/api/macro/*`. P2 adds one.
+
+### Already shipped with P0/P1 — the Python side
+
+Counted 2026-08-27 with `grep -c "def test_"`, not recalled:
+
+| Spec                                                 | Tests                     | What it holds                                                                                                                                                                                                                                                                                                                                                             |
+| ---------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/unit/macro/test_confidence_term_kinds.py`     | **3** (new), 11 collected | invariant 10, over the four engines **plus a fifth rates scenario**. The four alone could not fail on the count half of the bug: each has exactly one absent policy path, and `Decimal(1)` is both a no-op multiplicand and a legal fraction. The fifth holds two absent paths so the count is 2 and both guards bite. Fixtures in the new `tests/unit/macro/conftest.py` |
+| `tests/integration/api/test_rates_router.py`         | **13** (6 → 13)           | `/api/rates/snapshot` replay: the live path byte-unchanged, `computed_at` selection, and `_mark_stale_snapshot_sources` aged against the requested instant, not the wall clock                                                                                                                                                                                            |
+| `tests/integration/storage/test_rates_repository.py` | **7** (4 → 7)             | the `computed_at <= %s` predicate, on a fixture where the **newer** compute carries the **earlier** market date — so a query filtering the wrong column cannot accidentally pass                                                                                                                                                                                          |
+
+These are P4's model one layer down: the replay assertions the desk needs at the UI
+already exist against the same endpoint.
+
+### Invariants that stay test-enforced
+
+1. No composite anywhere in the desk chrome — no score, allocation, or probability.
+2. Empty slots are **three-state**: answered / request failed / never computed.
+3. The four policy paths are never averaged.
+4. `UNKNOWN` ≠ `NEUTRAL`.
+5. SEP dots stay anonymous — the payload is `(rate_percent, participant_count)`
+   (`PolicyPathParticipantPoint`, `models/macro.py:200-201`, carried at `:236`), and the
+   comment at `:214-215` states why: _"an anonymous SEP dot belongs to no named
+   participant."_ (The first draft cited `:215` alone, which is the reason, not the
+   shape.)
+6. Gold valuation keeps its **⚠ NEVER A SIZING INPUT** marking.
+7. Refusals describe; they never prescribe.
+8. The chain verdict is fetched **beside** the cards, never instead of them; its own
+   failure renders as `macro-chain-unassembled`, never as a clean chain.
+9. _(new, P2 scaffold / P3 real)_ Chart scale k ∈ [0.90, 1.10] on every `/macro/*` SVG,
+   at a viewport pinned in the spec (band justified in §5). It must also assert it found
+   at least one SVG — in P2 there are none, and a gate that can pass on an empty set is
+   §7's evaporating-scope defect in a new file.
+10. _(shipped with P0)_ A domain's reported `confidence` equals what its own
+    `confidence_reasons` fold back to using **`kind` alone** —
+    `tests/unit/macro/test_confidence_term_kinds.py`, 3 tests over all four engines.
+    **Nothing is rendered.** This is a Python-side refold of the contract, not a browser
+    assertion; the earlier wording ("the rendered confidence product") described a test
+    that could not exist where the test actually lives. The web layer inherits the
+    invariant through `ConfidenceArithmetic` (P5), which is why P0 had to land first even
+    though it no longer appears in §8's graph.
+
+### Two frozen artifacts, not one
+
+Any PR here that touches an API surface — P7's `/api/macro/factors`, P8's energy fields,
+and P1 already — moves **two** generated files that must never be regenerated wholesale.
+The first draft named only the first.
+
+**1. `web/lib/types.ts` — measured 2026-08-28: 15 559 lines, 492 K.** `npm run gen:types`
+runs the pinned `openapi-typescript` **7.13.0** (`web/package.json:12`), which emits
+_declaration_ order, while the committed file is in the older _alphabetical_ order. A
+full regen reorders the whole file and buries the real change. **Hand-insert additive
+schema changes in their alphabetical slot** — and write them with a shell redirect, not
+the `Edit` tool, whose prettier hook reflows the 4-space generated file to 2-space.
+Recorded in
+`docs/research/2026-07-14-chanlun-signal-lifecycle/phaseb_backend_patterns.md:306-309`.
+
+**2. `tests/integration/api/openapi.snapshot.json` — measured 2026-08-27: 34 054 lines,
+860 K.** Same hazard, omitted by the first draft entirely. It is dumped with
+`json.dumps(indent=2, ensure_ascii=True, sort_keys=True)` (same doc, `:310-313`) and
+`tests/integration/api/test_openapi_snapshot.py` asserts three things against it:
+the **set** of path keys (`:14`), that every recorded method still exists (`:18-22`), and
+`components.schemas` by **exact equality** (`:23`). So a new route trips the first
+assertion and a new response model trips the third — P7 does both.
+
+**A hand-edit is verifiable without a running server, and P1's first one was wrong.**
+Regenerate from the committed snapshot and compare order-normalized:
+
+```bash
+cd web && npx openapi-typescript ../tests/integration/api/openapi.snapshot.json -o /tmp/t.ts
+diff <(sed 's/[[:space:]]\+/ /g' lib/types.ts | sort) <(sed 's/[[:space:]]\+/ /g' /tmp/t.ts | sort) | grep -c '^[<>]'
+```
+
+Sorting removes the alphabetical-vs-declaration ordering, so what survives is real
+content drift. The floor is **16** — a pre-existing key-order artifact inside a JSDoc
+`@example` block, present at `HEAD` before any of this work. P1's hand-edit first
+measured **25**: it had inserted the two query parameters but dropped the operation's
+`@description` block, so the file was not what a regen would produce. Fixed 2026-08-28;
+back to 16. Run this before review on any PR that hand-edits either artifact.
+
+**Both were exercised by P1 and both held.** The `as_of`/`as_of_ts` parameters went in by
+hand: **+22 lines** in `types.ts` and **+51** in the snapshot, each in place, neither
+regenerated. That is the working proof of §10-E's cost argument — the expensive thing is
+the regen, not the edit. (§12's "451 KB" figure predates P1 and this session's gold
+annotations; 492 K is the measured number.)
+
+---
+
+## 10. Decisions needed from the operator
+
+### Still open
+
+Each carries the plan's own default and the reason for it, so silence ships something
+defensible rather than nothing.
+
+|       | Question                                                                                                         | Default, and why                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ----- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D** | Factor delivery: API-only, or materialise `macro_factor_daily`?                                                  | **Materialise** — the first named consumer is a backtest join, and a join wants a table, not a request per row. **But it is not answerable yet:** §8 records that no factor contract exists (no shape, no clock, no writer, no reader), and P7 is blocked on a spec that supplies them. Answer D _in_ that spec, not here.                                                                                                                                 |
+| **F** | Read-only deep link from tab 00 to the `/regime` vol desk?                                                       | **Yes — one link, clearly marked as leaving the macro desk.** §1 keeps the SPX `vrp_macro_signal` card off this desk because its "macro" means index-level vol; a link is not a card, and the alternative is an operator navigating by memory. One link, no embedded value, no shared chrome.                                                                                                                                                              |
+| **G** | Invest in falsifier-threshold measurement ("what CPI print flips the state")?                                    | **Defer to Phase 2.5.** Phase 1 closed with the engine deliberately descriptive (`project_macro_phase1_closed`), and a falsifier threshold is a claim about what _would_ change the answer — a new analytical surface, which §1 rules out for this port.                                                                                                                                                                                                   |
+| **H** | §3.1's gold clock: give `/api/gold/replay` `computed_at` semantics, or label its control an obs-date and say so? | **Label it, do not change the API.** `fetch_gold_posture_for_obs_date` is `WHERE obs_date = %s` with exact equality (`storage/gold.py:862-880`), so `computed_at` semantics is a new query and a new index question, not a second parameter. Labelling costs one string and is honest; §3.1's ban still holds — do not ship the desk-wide picker over all five tabs until one of the two is done. Taken in P4, binding in P6 when tab 05 joins the picker. |
+
+**I — raised by P3's execution 2026-08-28, needs an operator ruling.** §7 drops
+`SummaryStances` because it "renders literal `BUY` / `SELL`", which "breaks invariant 7
+**independently of the composite rule**". The same sentence is true of `RatesScorecard`,
+which §7 keeps: `RatesDurationStance` is
+`Literal["BUY", "SELL", "NEUTRAL", "UNKNOWN"]` (`models/rates.py:18`),
+`rates/scorecard.py:225-227` returns `"BUY"` / `"SELL"` whenever the composite clears
+±0.25 with coverage ≥ 0.5, and `RatesScorecard.tsx:57-59` prints it verbatim as
+`{duration_stance} duration`. So the section titled **"What this tab refuses"**, whose
+prose says the tab takes no stance, can print `SELL duration`. It does not today — prod's
+composite is 0.11, inside the ±0.25 band — which is exactly why nobody has seen it.
+
+Verified it is the only source: `duration_stance` is the sole producer of those two words
+anywhere on the rates data path.
+
+**P3 shipped the narrow, honest thing and did not resolve this**, because resolving it
+means changing what a component renders and §7 says the scorecard question is decided and
+must not be re-opened. The e2e ban is whole-body on tab 01 and scoped to _outside_
+`#refuses` on tab 02, with a non-vacuity anchor proving the carve-out did not swallow the
+page, and the reasoning written into the test.
+
+The plan's own logic points one way — §7 keeps the scorecard so an operator "can compare
+the new state against the old rule score", and the comparison datum is the **score**, not
+the stance word, which is a derived prescription. Suppressing the word while keeping the
+number would satisfy both §7's purpose and invariant 7. That is a rendered-contract change
+with an e2e test pinned to `duration-stance`, so it is the operator's call, not P3's.
+
+### Settled, with the reason recorded
+
+|       | Question                                                                                                                 | Resolution                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A** | Desk-wide replay: land P1 before or after the presentation merge?                                                        | **SETTLED by fact 2026-08-27 — before.** P1 is done in the working tree and rides P2 (§8), so replay is live at the API several releases before P4's UI asks for it. That ordering is also what makes the Watchtower race benign (§8, deploy ordering).                                                                                                                                                                      |
+| **B** | Component homes: move the `rates`/`gold` subtrees under `components/macro/`, or re-home only the page shells?            | **SETTLED 2026-08-27 in §7 — page shells only, plus two named lifts.** The first draft's "and leaves `RatesDesk.module.css` alone" was wrong and is withdrawn: `ConfidenceStrip` consumes four classes from it and `chartGeometry.ts` lives beside it. The promise is no wholesale subtree move, each lift a reviewable diff carrying its own styles, and `components/macro/*` never importing from `components/rates/*`.    |
+| **C** | Energy ordering: FRED spot series (P1, usable same-day) or lake term structure (more distinctive, more expensive)?       | **SETTLED 2026-08-27 — FRED spot first**, and §8's P8 is scoped to it. Three FRED series are usable the day they land and light up the gold÷oil anchor that §4.2 records as permanently `null` today (`models/gold.py:101`). The lake term structure is a larger build for a more distinctive but unmeasured signal; it is not a prerequisite for tab 06 being honest.                                                       |
+| **E** | The **eight** permanently-empty fields (§4.2): delete the fields from the API, or stop rendering them and mark the rest? | **SETTLED 2026-08-27 — stop rendering, do not delete.** Remove the two dead _renders_ (`TwoForceNarrative`, `LensDecompositionPanel`); leave every Pydantic field in place and mark all eight at their producing site. Deleting fields is a contract change costing an OpenAPI snapshot update and a `types.ts` regen that reorders 15 552 lines, for zero operator benefit — what misleads is the rendering, not the field. |
+
+---
+
+## 11. Reproduce
+
+```bash
+ssh macmini 'curl -s http://127.0.0.1:8400/api/macro/policy'
+ssh macmini 'curl -s http://127.0.0.1:8400/api/rates/snapshot'
+ssh macmini 'for d in inflation rates usd gold; do curl -s "http://127.0.0.1:8400/api/macro/$d"; done'
+```
+
+Values in §3/§4 are from 2026-08-27 07:40 UTC+8, `option_wizard/uw_scan` on the mini.
+No value in this plan is invented.
+
+---
+
+## 12. Observed but out of scope
+
+- `web/tests/e2e/regime-page.spec.ts:3` is titled _"three tabs and GEX default"_ and
+  asserts `regime-tab-gex` is active at `:9`, but both `RegimePanel.tsx:37` and
+  `app/regime/[[...tab]]/page.tsx:26` default to `"tide"`. Observed statically; the
+  suite was **not run**, so this is a discrepancy, not a confirmed failure.
+  **CONFIRMED 2026-08-28 by P4's full e2e run: it fails.** So do the other twelve listed
+  below — and all thirteen fail identically against a build of `main` on the same database,
+  so none of them is this port's doing.
+- **The e2e suite has 13 pre-existing failures, baselined 2026-08-28** (P4's run: 72 passed
+  / 13 failed / 1 skipped; the same 13 by name against a main-checkout build). They are
+  `canary-page` (1), `magnet-view` (4), `regime-page` (3), `technicals-tab` (3) and
+  `volatility-tab` (2). Not an empty-database artifact — `/api/watchlist` and
+  `/api/stock/NVDA/volatility/series` both answer 200 locally. **Every macro, rates and
+  gold spec passes** (29 tests, 1 skipped), the chart-scale gate included. A future slice
+  should not read a red suite as its own regression; diff the failing set, not the count.
+- `web/CLAUDE.md:53` states `lib/types.ts` is 47 KB; it is **492 K** (measured 2026-08-28).
+- **`playwright.config.ts` sets `reuseExistingServer: true` on port 3001, which can silently
+  test the wrong code.** A detached `next-server` from the MAIN checkout was holding 3001
+  during P4's verification; run as-is, the suite would have exercised that build — which has
+  none of this port — and reported it as this branch's result. Verified on an isolated port
+  instead. Worth a `PORT`-aware config, or at least a note in `web/CLAUDE.md`, before
+  another slice trusts a green run.
+
+---
+
+## Revision history
+
+Drafted 2026-08-27 from a direct read of the mini and of the three source pages, then put
+through three review passes before sign-off. **Self-review** re-verified every citation
+against the files and rewrote §2, §5 and §6 around what it found — that `/regime` does
+not pre-render its tabs, that the SEP dot plot was never oversized on argon, and that
+"mostly a move" is true of the source pages but not of the board. The **codex tribunal**
+found the §3 tab→endpoint contradictions, the misplaced P0 test claim, and the
+unspecified factor contract, and forced §7's two contradicting component-home bullets to
+a single decision. The **adversarial pass** produced **12 findings**, all applied here:
+that the first draft's P2 would have 308'd two live pages to routes that did not exist
+yet, that P3 was being sold as "mechanical" when it changes what every moved server
+component fetches, that the two deploy images have no ordering guarantee between them,
+that navigation order was being conflated with the engine's `CAUSAL_ORDER`, that tab 00
+had no scope bound, and that §9's counts and both frozen artifacts had drifted. Neither
+earlier pass recorded its own finding count, so none is claimed for them here.
+
+A fourth pass, **simplicity/optimality**, ran over the shipped code rather than the
+document and produced the finding that mattered most: `test_confidence_term_kinds.py`
+**could not fail on half the defect it was written for**. Reverting `kind` on
+`policy_paths_absent` left all nine cases green, because every shipped scenario is
+missing exactly one required path and a count of 1 is invisible to both guards. A fifth
+fixture with two absent paths closes it — measured green with the fix, two failures
+without it. The same pass found a hand-edit of `web/lib/types.ts` that had dropped the
+operation's `@description` block, two test matchers still accepting a landmark name that
+no longer exists, gold fixtures asserting values production cannot emit, and a `WHERE`
+clause assembled in Python where `COALESCE(…, 'infinity')` removes the branch.
+
+**P0 and P1 shipped in the working tree during the revision** — the confidence-term
+`kind` fix with its three-test regression suite, and `as_of` on `/api/rates/snapshot`
+with ten new tests — along with the §10-E gold-panel cleanup. §8 was rebuilt around that
+fact rather than continuing to schedule work that was already done.

--- a/docs/superpowers/archive/plans/2026-08-29-macro-desk-board-full-binding.md
+++ b/docs/superpowers/archive/plans/2026-08-29-macro-desk-board-full-binding.md
@@ -1,0 +1,403 @@
+# Macro desk — bind every board panel to live data
+
+**Status:** EXECUTED 2026-08-29 — 47/47 board panels live
+**Spec:** `docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html` (sha-pinned board artifact)
+**Predecessor:** `docs/superpowers/archive/plans/2026-08-27-macro-desk-page-port.md`
+**Audit:** `docs/research/2026-08-28-macro-desk-board-conformance/VERDICT.md`
+**Branch:** `feat/macro-desk-tabs-03-05`
+
+The board binds its **design** and its **information**. The port so far has bound
+both on four tabs, one of them on none, and three of them partially. This plan
+closes the remainder. It adds **zero new endpoints** — every unbuilt panel's data
+was verified present on the running API on 2026-08-29.
+
+---
+
+## 1. Measured gap
+
+Board panel counts are from the artifact itself (`<div class="panel-h">` per
+`<section id="tN">`). Tab 08 does not ship, by the board's own instruction.
+
+| Tab          |  Board | Conforming | Kind of work | Gap                                                     |
+| ------------ | -----: | ---------: | ------------ | ------------------------------------------------------- |
+| t0 Overview  |     11 |          0 | **BUILD**    | nothing on this branch (see §5, collision)              |
+| t1 Fed       |      8 |          0 | **RESHAPE**  | data bound; house sections, not board panels; 1 missing |
+| t2 Rates     |      9 |          0 | **RESHAPE**  | data bound; 9 board panels rendered as 5 house sections |
+| t3 Inflation |      4 |          4 | ✅ done      | —                                                       |
+| t4 USD       |      2 |          2 | ✅ done      | —                                                       |
+| t5 Gold      |      8 |          2 | **BIND**     | 3 unconsumed endpoints; 2 panels merged into 1          |
+| t6 Energy    |      2 |          2 | ✅ done      | —                                                       |
+| t7 Factors   |      3 |          3 | ✅ done      | —                                                       |
+| t8 Design    |     11 |          — | ✅ unshipped | board says it does not ship                             |
+| **Total**    | **47** |     **11** |              | **36 panels short of the board**                        |
+
+The three kinds are genuinely different work and must not be planned as one:
+
+- **BIND** — the data is fetched but shown below board resolution. Cheapest, highest fidelity gain.
+- **RESHAPE** — the data is already on screen in house sections. No new fetches; this is the design port finishing its job.
+- **BUILD** — nothing exists.
+
+---
+
+## 2. Endpoint reality — re-verified, and the board is stale in two places
+
+Every endpoint in the board's §⑨ was re-probed against `127.0.0.1:8400` on
+2026-08-29. All EXISTS claims hold. **Two entries have changed since the board
+was captured and the plan must not inherit them:**
+
+| Board §⑨ says                        | Actual now                                                 | Consequence                                                    |
+| ------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| `/api/rates/snapshot?as_of=` MISSING | **EXISTS** — `routers/rates.py` takes `as_of` + `as_of_ts` | Q-A is closed. Desk-wide replay is no longer blocked.          |
+| `/api/macro/factors?as_of=` MISSING  | still absent                                               | No blocker — t7 ships as assembly over the four domain states. |
+
+Verification of the first, since it reverses the board's single loudest warning:
+
+```
+GET /api/rates/snapshot              → as_of 2026-08-18, computed_at 2026-08-20T02:33:48Z
+GET /api/rates/snapshot?as_of=2026-06-01 → as_of 2026-05-28, computed_at 2026-05-29T22:45:00Z
+```
+
+The board's worst-case ("a live tab 02 beside a replayed tab 01/03/04/05 and
+nothing on screen saying so") cannot occur. Any plan step written to work around
+it is dead work.
+
+---
+
+## 3. Per-panel binding table
+
+Every field below was observed in a live 200 response. Nothing here is proposed.
+
+### t5 Gold — BIND (do this first; smallest diff, largest fidelity gain)
+
+| Board panel                                | Source                                                         | State today                                    |
+| ------------------------------------------ | -------------------------------------------------------------- | ---------------------------------------------- |
+| Transmission gauge · correlation collapse  | `/api/gold/state` `.gauge`                                     | ✅ `TransmissionGaugePanel`                    |
+| Three lenses · none composites             | `.structural` / `.cyclical` / `.valuation`                     | ✅ three panels                                |
+| **Anchor decay · gauge corr_60d, daily**   | **`/api/gold/gauge` `.history_252d` — 261 dates, 19 valued**   | ⚠️ **60d cut unavailable; series is sparse — see below** |
+| Expression cost                            | `.structural.uw_25d_skew_sigma`                                | ✅ `ExpressionCostPanel`                       |
+| **Central banks · 12M net, three buckets** | `.structural.cb_{strategic,tactical,diversifier}_12m_sum_t`    | ⚠️ merged into `StructuralPanel`               |
+| **Western institutional flows · L1**       | `.structural.{gld_holdings_t,gld_30d_net_flow_t,lbma_*,cot_*}` | ⚠️ merged into the same panel                  |
+| L2 cyclical readings (dimmed)              | `.cyclical.*`                                                  | ✅ `CyclicalPanel`                             |
+| **Input manifest**                         | `.inputs_used` (16 sources × 8 fields)                         | ⚠️ `DataAuditFooter`, not the board's manifest |
+
+**The anchor-decay panel — corrected 2026-08-29.**
+`goldTab.tsx:43` declines `/api/gold/gauge` citing §4.5 of the port plan
+("recomputing 262 correlation gauges per request"). Re-measured: **50ms**
+(`0.057 / 0.054 / 0.050`), against 29ms for `/api/gold/state`. The perf reason no
+longer holds.
+
+But the substitution is **not** a like-for-like downgrade, and an earlier draft of
+this plan said it was. `GoldGaugeTimeSeriesPoint` is `{obs_date, corr_252d}` —
+**0 of 261 points carry `corr_60d`**, and the span is 2021-08-30 → 2026-08-24, so
+it is neither daily nor the 60-day cut. `CorrelationHistoryPanel`'s own note is
+therefore **accurate and stays**: the producer computes at `window=252` only
+(`gold_posture.py`), so the board's 60-day series does not exist to plot and no
+amount of wiring creates it.
+
+What binding actually buys — **measured on the rendered page, not assumed.** An
+earlier draft of this plan said "261 points instead of 3" twice. That was wrong:
+`history_252d` carries 261 **dates** of which only **19 carry a value** — a
+252-day window produces nothing until it has 252 days behind it, and the sampling
+is sparse thereafter. Against `correlation_history`'s 11 observations (3 + 3 + 5
+across the three pairs), the gauge contributes the densest single series on the
+panel — 19 points spanning five years against the largest pair's 5 — and that is
+the whole of the gain.
+
+Worth keeping the reason this was caught: the panel derives both counts at render
+time, so the page printed **19 vs 11** while the plan still said 261 vs 3. The
+board-value rule ("derive every such sentence at render time") exists for stale
+mock figures; here it caught a stale figure of my own.
+
+**The honest finding is a data gap, not a port gap.** The board's t5 anchor-decay
+panel cannot be built as specified — not at 60 days and not at daily resolution —
+because the desk neither computes nor retains that series. Recorded here so the
+next pass does not re-open the endpoint hunt: the fix lives in
+`reports/gold_posture.py`, not in the web layer.
+
+**The board's §⑩ P2.2 names three unconsumed gold endpoints, not one**, and the
+other two carry the desk's densest series:
+
+| Endpoint                     | Carries                                                      | Consumed |
+| ---------------------------- | ------------------------------------------------------------ | -------- |
+| `/api/gold/gauge`            | `history_252d` — 261 dates, 19 valued, corr_252d, 5 yrs       | ❌ no    |
+| `/api/gold/inputs/{id}`      | per-input daily series — `DFII10` **1293 pts**, `GLD_CLOSE` 344 | ❌ no  |
+| `/api/gold/lenses/{id}`      | `posture` + `detail` per lens — the L1 detail t5 asks for      | ❌ no    |
+
+`/api/gold/inputs/*` is what makes the **Input manifest** panel more than a list:
+each of the 16 entries in `inputs_used` has a real series behind it. Note some are
+empty (`cot_gold_weekly` → 0 pts) — a three-state row, not a hidden one.
+
+### t2 Rates — RESHAPE (no new fetches at all)
+
+`CurveDesk` + `sections/DecompositionSection.tsx` already consume every field.
+The board wants nine named panels where the page renders five house sections.
+
+| Board panel                           | Field (already fetched)                                                                                                                                          |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Par yield curve · current vs 1W vs 1M | `curve.points` (11), `curve.slopes` (4)                                                                                                                          |
+| 10Y nominal decomposition             | `decomposition.{nominal_10y,real_10y,breakeven_10y,forward_inflation_5y5y,term_forward_compensation}`                                                            |
+| Cleveland 5-term decomposition        | `decomposition.{model_real_yield_10y,expected_short_real_rate_10y,expected_short_inflation_10y,real_term_premium_10y,inflation_risk_premium_10y}` — exactly five |
+| 10Y move attribution · per window     | `decomposition.attribution` (4 windows)                                                                                                                          |
+| Supply SUB-STATE                      | `supply.{fiscal,supply_read,status}`                                                                                                                             |
+| Positioning SUB-STATE · 10Y futures   | `positioning.{rows,details}`                                                                                                                                     |
+| Funding SUB-STATE                     | `policy.plumbing` (4 rows)                                                                                                                                       |
+| Auction demand · did anyone show up   | `supply.{auctions,recent_auctions}`                                                                                                                              |
+| What this tab refuses                 | static                                                                                                                                                           |
+
+Drop the house-only panels the board does not carry (`Summary`, `Mechanics`,
+`Cross-Market`, `Provenance and legacy`) or fold their content into the board
+panel that owns it. **The board is the spec: a panel it does not carry does not
+ship on its tab.**
+
+### t1 Fed — RESHAPE + one three-state panel
+
+| Board panel                                  | Field                                                                                          | State                            |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- |
+| Four policy paths · who says what            | `/api/macro/policy` `.actual`/`.committee_projection`/`.dealer_expectations`/`.market_implied` | ⚠️ house `Policy Paths`          |
+| **Per-meeting odds · market-implied**        | `.market_implied` — `path: null`, `missing_reason` set                                         | ❌ **absent entirely**           |
+| Dealer expectations · the 3.63 dot           | `.dealer_expectations.path`                                                                    | ⚠️ house `<h3>`                  |
+| Committee projections · the 3.80 dot         | `.committee_projection.path`                                                                   | ⚠️ house `<h3>`                  |
+| State & confidence · the engine's own proof  | `snapshot.state`                                                                               | ⚠️ **see §4 — currently `null`** |
+| Plumbing · the balance sheet behind the rate | `policy.plumbing`                                                                              | ⚠️ house `Mechanics`             |
+| Next events                                  | `snapshot.events` (currently `n=0`)                                                            | ⚠️ house `Events`                |
+| What this tab refuses                        | static                                                                                         | ✅                               |
+
+`market_implied` arrives with `path: null` and a populated `missing_reason`. The
+board's own invariant is three-state slots — so this panel ships **rendering the
+refusal**, never omitted. An absent panel says "we don't cover this"; the field
+says "we cover it and the publisher had nothing." Those are different claims.
+
+### t0 Overview — BUILD, 11 panels, all bindable
+
+| Board panel                               | Source                                                          |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| State flips × confidence moves            | `/api/macro/{inflation,rates,usd,gold}` `.state` + confidence   |
+| Market deltas · 1 week                    | `/api/rates/snapshot` live **and** `?as_of=` −7d (now possible) |
+| Anchor letting go · gauge corr_60d        | `/api/gold/gauge` `.history_252d`                               |
+| Four policy paths · who says what         | `/api/macro/policy`                                             |
+| Contradiction feed · engine-reported      | domain `.contradictions`                                        |
+| Cross-domain contradictions               | `/api/macro/snapshot` `.reasons` (n=2), `.domains` (n=3)        |
+| Transmission health                       | gold gauge + `.correlation_history`                             |
+| FOMC calendar × what the market prices    | `policy.market_implied` + `snapshot.events`                     |
+| Confidence repair · what each event fixes | domain confidence terms                                         |
+| Off-chain dimension · Energy              | static; links t6                                                |
+| Boundary · what is NOT on this desk       | static refusal                                                  |
+
+Note `/api/macro/snapshot` returns `domains: n=3` against four domain tabs. The
+overview must render that as a three-state coverage fact, not silently show three.
+
+---
+
+## 4. Two decisions — TAKEN 2026-08-29 by the operator
+
+**D1 — `rates_snapshot_state_block_enabled` defaults `False`.**
+`src/uw_scan/config.py:223`. The live probe returns `state: null`, so board t1
+panel 5 ("State & confidence · the engine's own proof") has no data to bind.
+`page.tsx:60-66` deliberately does _not_ call `/api/macro/rates`, reasoning that
+a second fetch "forks one answer into two requests that could disagree" — sound,
+but it assumes the flag is on. The board names the fallback explicitly: _"if that
+flag is off the same state is still reachable via `/api/macro/rates`."_
+→ **DECIDED: take the board's named fallback** — cite `/api/macro/rates` beside
+the snapshot. The operator's instruction was to get the board's data and
+information onto the page rather than gate a panel behind a deployment flag. The
+fallback binds real data on every environment with no config change, and it is
+not a new pattern: tab 03 already cites the rates domain state beside its own for
+the market-implied leg (`page.tsx:167-172`), settled separately so an outage in
+the cited publisher costs one panel and not the tab. `page.tsx:60-66`'s
+single-fetch argument holds only while the flag is on; with it off there is no
+answer to fork.
+
+**D2 — tab 00 collides with the sibling branch.**
+`feat/macro-desk-tab-00` holds 2 unmerged commits and would conflict on
+`web/components/macro/tabs.ts` and `web/app/macro/[tab]/page.tsx`.
+→ **DECIDED: build t0 on this branch, absorbing the sibling's 2 commits.** The
+board is the whole page and the desk ships it whole. The registry conflict is
+resolved once, here, rather than twice.
+
+---
+
+## 5. Sequence
+
+Each step is independently revertible and leaves the desk green.
+
+| PR  | Scope                                                                                     | Panels | New endpoints                 |
+| --- | ----------------------------------------------------------------------------------------- | -----: | ----------------------------- |
+| 1   | t5 gold: bind `/api/gold/gauge`, split CB / western flows, input manifest                 |     +6 | 0 (`api.goldGauge()` wrapper) |
+| 2   | t2 rates: nine board panels on `BoardPanel`, retire house sections                        |     +9 | 0                             |
+| 3   | t1 fed: 8 board panels, `market_implied` three-state, state cited from `/api/macro/rates` |     +8 | 0                             |
+| 4   | t0 overview — **here**, absorbing `feat/macro-desk-tab-00`                                |    +11 | 0                             |
+
+PR 1 first because it is the only one that recovers information currently lost
+(11 points where 19 exist, plus three unconsumed endpoints); PRs 2 and 3 move
+information already on screen into the right
+shape.
+
+---
+
+## 6. Acceptance
+
+The board's own test, which reached neither the previous plan nor the code:
+
+> every panel must answer at least one of Q1–Q7, or it gets deleted
+
+- Every new panel is a `BoardPanel` with a non-empty `questions` tuple — a
+  compile error otherwise.
+- **A panel count test per tab**, asserting the board's number: t1=8, t2=9,
+  t5=8, t0=11. This is the check that was missing; a missing panel currently
+  fails nothing.
+- Extend the existing e2e (`web/tests/e2e/macro-desk.spec.ts`) to assert
+  presence of each board panel title per tab, not just HTTP 200.
+- **The board's VALUES never bind.** Its figures froze at its capture instant.
+  Every sentence carrying one is derived at render time and tested in both
+  branches — as already done for `dollar-pair-read` / `gold-gauge-read`.
+- `npm run typecheck`, `lint`, vitest, the posture lint, and the e2e suite green.
+
+---
+
+## 7. Recorded deviations from the board
+
+| Board                                   | Here                                       | Why                                                   |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| §⑨ `/api/rates/snapshot?as_of=` MISSING | exists                                     | Added after capture; verified live 2026-08-29         |
+| §4.5 skip `/api/gold/gauge` (perf)      | bind it                                    | Re-measured 50ms, not expensive; buys 19 pts over 11  |
+| t5 "corr_60d, daily"                    | plot corr_252d, labelled                   | Producer computes `window=252` only; the 60d cut does not exist |
+| t8 ships as a tab                       | reachable at `/macro/notes`, off the strip | The board's own t8 says it does not ship              |
+| t0 built on this branch                 | built on `feat/macro-desk-tab-00`          | Registry collision; D2                                |
+
+
+---
+
+## 8. Outcome — measured 2026-08-29
+
+All 47 shippable board panels render on the live desk. Verified by fetching each
+tab from the running dev server and matching the board's own panel titles, not by
+reading the diff.
+
+| Tab            | Board | Before | After | Commit     |
+| -------------- | ----: | -----: | ----: | ---------- |
+| t0 Overview    |    11 |      0 |    11 | `4fa16ccf` + `46617a7c` |
+| t1 Fed         |     8 |      0 |     8 | `b4fca2c4` |
+| t2 Rates       |     9 |      0 |     9 | `9b73f2f9` |
+| t3 Inflation   |     4 |      4 |     4 | (already conformant) |
+| t4 USD         |     2 |      2 |     2 | (already conformant) |
+| t5 Gold        |     8 |      2 |     8 | `11088f1a` |
+| t6 Energy      |     2 |      2 |     2 | (already conformant) |
+| t7 Factors     |     3 |      3 |     3 | (already conformant) |
+| **Total**      |**47** | **11** |**47** |            |
+
+Zero new endpoints, as predicted. Three previously-unconsumed data paths are now
+bound: `/api/gold/gauge`, `/api/macro/rates` `sub_states`, and `/api/macro/policy`
+`market_implied`.
+
+Gates at the final commit: typecheck clean, **984 unit tests pass**, posture lint
+clean, eslint clean, all 9 routes HTTP 200.
+
+### What is NOT done
+
+- **`/api/gold/lenses/*` and `/api/gold/inputs/*` remain unconsumed.** The board's
+  §⑩ P2.2 names three unconsumed gold routes; one is now bound. `inputs/{id}`
+  carries real depth (`DFII10` 1293 points) and would turn the input manifest from
+  a list into a set of inspectable series. Deferred, not forgotten.
+- **The board's t5 anchor-decay panel cannot be built as specified.** Not a port
+  gap — the desk neither computes nor retains a 60-day correlation series. The fix
+  is in `reports/gold_posture.py`.
+- **No e2e run against a production build.** Unit and route-level checks only.
+- **Everything verified against `option_wizard_local`, never the mini.**
+
+### Three corrections this plan made to itself
+
+Recorded because each was wrong in a way that would have shipped:
+
+1. `/api/rates/snapshot?as_of=` was called MISSING by the board and **exists**;
+   any work sequenced around that blocker was dead work.
+2. "261 points instead of 3" was stated twice and is **19 vs 11** — the gauge's
+   261 dates carry 19 values. The page printed the right numbers while the plan
+   carried the wrong ones, because the panel derives them at render time.
+3. The gold perf deviation (§4.5, "262 correlation gauges per request") measured
+   **50ms** on re-test. Real when written, stale when inherited.
+
+---
+
+## §9 The design port — 2026-08-29, second pass
+
+§8 above closed on **panel inventory**: 47/47 board panels present, every one bound
+to live data. That was the wrong finish line. The operator's words:
+
+> "the 1 to 1 same design and data and binding as the artifact"
+
+Binding the information and not the design is invisible to every check that was
+run, which is why it survived a pass that reported 47/47. Measured rather than
+argued: `web/scripts/board-pixel-compare.mjs`.
+
+### What the second pass found
+
+| Tab | Before | Now |
+| --- | --- | --- |
+| t0 Overview | house inline styles, **0** board classes, no zones, no chain rail | 4 zones, 11 `.panel`s, `.chain` rail |
+| t5 Gold | 9 full-width hairline bands, house panel idiom | board grid: g2/g2/g3 + manifest, 8 `BoardPanel`s |
+| t1 Fed | **0** grids — every panel full-width | 3 × `grid g2`, zone banners |
+| t2 Rates | **0** grids — 7839px against the board's 3982 | `g3` + `g3` + `g2`, 6764px |
+| desk-wide | no provenance key, no Q1–Q7 strip | `BoardLegend` in the layout |
+
+**Note (added 2026-08-31, archiving this plan):** `BoardLegend` did not survive to
+`origin/main`. The shipped shell (`web/app/macro/layout.tsx`) carries `MacroMasthead` /
+`MacroFooter` / `macroContextSnapshot` instead — a later rework, not this table going
+stale. See `docs/superpowers/plans/2026-08-30-macro-release-binding-fixes.md`, Task 4.
+
+`board.css` gained the half of the grammar the first port skipped — `.zone`,
+`.chain`/`.node`/`.arrow`/`.edge-note`, `.contra`, `.conf`, `.meter`, `.meet`/`.pbar`,
+`.chart`, `.cap`, `.lgd`, `.ghost`, `.g4`, `.dir`, `ul.tight`, `.chip`/`.mast-meta`,
+`.legend-strip`/`.pmq`.
+
+### Why the comparison is not a bitmap diff
+
+The board's panels carry mock values frozen at its capture instant; the desk derives
+its own at render time, which is a rule of this port. A pixel subtraction is therefore
+dominated by digits and prose and says nothing about whether the design was ported —
+two pages can differ in every pixel and share a design. The script compares grammar
+coverage, computed style per selector, and full-page screenshots.
+
+### What it caught that reading the code did not
+
+- **The body type scale.** Board 13.5px/1.55, argon 13px/1.5, inherited by everything.
+  The single largest source of drift, and invisible in any per-component review.
+- **Every board table cell was rendering in mono.** `globals.css` styles bare `td` at
+  mono/12px; the board declares neither and inherits sans/12.5px — and an inherited
+  value always loses to a declaration however weak its specificity.
+- **Tabs 01/02 had no grid at all.** The class-coverage check missed this because
+  `.grid.g2` *did* render on the desk — on other tabs. Coverage must be per-tab.
+- **The desk had no key.** Sixty-odd `REAL`/`COMPUTED`/`PLANNED` and `Q1`–`Q7` chips
+  with nothing on the page defining them, while `BoardPanel` encodes those same
+  questions as a required type.
+
+### Result
+
+- Grammar coverage: **40 of 41** probed board elements render.
+- Computed-style diffs: **65 → 15**, all remaining traced to mock-vs-live data or to
+  the two pages opening with a different first instance of a class.
+- Height ratio (live ÷ board): gold 1.03, usd 1.08, overview 1.13, inflation 1.14,
+  energy 1.27, fed 1.34, factors 1.43, rates 1.70. The two outliers are content the
+  board's mock does not carry.
+
+### The one element that does not render, verified
+
+`.pbar`, the per-meeting probability bar. Not an oversight and not deferred:
+`/api/macro/policy` carries `probability_distribution` on **0 of its 21 points across
+all four lanes**, the market-implied lane publishes `missing_reason` instead of a path,
+and `/api/rates/snapshot` has no `market_implied` block. There is no probability on
+this desk to split a bar with, so t0 and t1 state the refusal in the publisher's own
+words. The CSS stays so the bar's return is a markup change.
+
+### Deliberate departures from the board's markup
+
+Both are element choices, not visual ones, and both are recorded beside the code:
+a zone label is an `<h2 class="zl">` and a rates panel is a `<section class="panel">`.
+The class carries every pixel; the element carries a landmark a screen reader can jump
+between.
+
+### Reproduce
+
+```bash
+cd web && node scripts/board-pixel-compare.mjs   # needs the dev server on :3002
+# report.json + 16 screenshots -> output/playwright/board-compare/
+```

--- a/docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html
+++ b/docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html
@@ -1,0 +1,6891 @@
+<!doctype html><html><head><!-- frame-runtime --><base href="/_f/1787798012-44b8/"><script>window.__FRAME_PREAMBLE={"v":1,"capabilities":{"artifact":"artifact.DvsaCnS7.js","assets":"assets.8Gk803W0.js","comments":"comments.GLuHR3zP.js","db":"db.h-3sndFg.js","downloads":"downloads.C3GSvEDP.js","embed":"embed.CxGAyc-v.js","mcp":"mcp.Bvma3qD7.js","network":"network.B5UA9Su4.js","permissions":"permissions.BNySkLV5.js","room":"room.BMMoe2BY.js","sample":"sample.BW2Uysoh.js","self":"artifact.DvsaCnS7.js","user":"user.BpKav-Rf.js"},"transforms":"_transforms.CQm3TZ9K.js","comments":"_comments.DELvYLUh.js","translate":"_translate.5HCW4BJh.js"}</script><script>(function(){"use strict";var J=["light","dark","system"],Q=/^[A-Za-z0-9_-]{1,64}$/,H=/^[a-zA-Z_:][a-zA-Z0-9_:.-]{0,127}$/,ee=new Set(["class","hidden","value","checked"]);function te(e){const t=e.toLowerCase();return t.startsWith("data-")||t.startsWith("aria-")||ee.has(t)}var Me="http://www.w3.org/1999/xhtml",re="http://www.w3.org/2000/svg",ne=new Set(["script","style","iframe","noscript","noframes","noembed","xmp","plaintext","template","title","textarea","object","embed"]),oe=new Set(["script","style"]);function se(e){const t=e.localName.toLowerCase();return e.namespaceURI==="http://www.w3.org/1999/xhtml"?!ne.has(t):e.namespaceURI===re?!oe.has(t):!1}var ae=new Set(["html","head","body","frameset"]);function ie(e){return e.namespaceURI==="http://www.w3.org/1999/xhtml"&&ae.has(e.localName)}function ce(e){if(e===null||typeof e!="object")return!1;const t=e;if(typeof t.target!="string"||!Q.test(t.target)||t.text!==void 0&&typeof t.text!="string")return!1;if(t.attrsSet!==void 0){if(t.attrsSet===null||typeof t.attrsSet!="object")return!1;for(const[r,n]of Object.entries(t.attrsSet))if(!H.test(r)||typeof n!="string")return!1}if(t.attrsRemoved!==void 0){if(!Array.isArray(t.attrsRemoved))return!1;for(const r of t.attrsRemoved)if(typeof r!="string"||!H.test(r))return!1}return!0}function le(e,t){if(e===null||typeof e!="object")return!1;const{seq:r,elements:n}=e;if(typeof r!="number"||!Number.isSafeInteger(r)||!Array.isArray(n)||n.length===0||n.length>64)return!1;for(let s=0;s<n.length;s++)if(!t(n[s]))return!1;return!0}function ue(e){return e===null||typeof e!="object"?!1:le(e.__frame_patch,ce)}function fe(e){if(e===null||typeof e!="object")return!1;const t=e.__frame_init;return t!==null&&typeof t=="object"}function pe(e){return e!==null&&typeof e=="object"&&e.__frame_size_poke===!0}function de(e){if(e===null||typeof e!="object")return!1;const t=e.__frame_theme;if(t===null||typeof t!="object")return!1;const r=t.theme;return typeof r=="string"&&J.includes(r)}var A=/^[\w.-]+\.js$/;function me(e,t,r){return r?"inert":typeof t=="string"&&A.test(t)?e?[t]:"inert":e?"inert":"framed"}function he(){return{post(e,t){parent.postMessage(e,t)},on(e){const t=r=>{r.source===parent&&e(r.data,r.origin)};return addEventListener("message",t),()=>removeEventListener("message",t)}}}function _e(){return{post:()=>{},on:()=>()=>{}}}var O="__frame_scroll",ve=150,ye=310,we=160,be=3e4;function Ee(){let e=0,t=!1,r=!1,n=!1,s=0,a=null;const l=i=>{try{sessionStorage.setItem(O,JSON.stringify({y:i}))}catch{}},d=()=>{if(clearTimeout(e),a===null)return;const i=a;a=null,l(i)},v=()=>{if(t){t=!1;return}r=!0,a=scrollY,clearTimeout(e),e=setTimeout(d,ve)};try{addEventListener("scroll",v,{passive:!0}),addEventListener("pagehide",d)}catch{}const y=()=>{let i;try{i=sessionStorage.getItem(O)}catch{return null}if(i===null)return null;let m;try{m=JSON.parse(i)}catch{m=null}const u=m?.y;if(!(typeof u=="number"&&Number.isFinite(u)&&u>=0)){try{sessionStorage.removeItem(O)}catch{}return null}return u};let S=!1;const h=i=>{try{const m=scrollY;scrollTo({top:i,left:0,behavior:"instant"}),s=i,n=!0,clearTimeout(e),a=null,l(i);const u=scrollY;u!==m&&(t=!0),u!==i&&!S&&(S=!0,addEventListener("load",()=>{try{if(scrollY===u){const k=y();h(k!==null?k:s)}}catch{}},{once:!0}))}catch{}},w=()=>{try{return!!location.hash}catch{return!0}};let o=!1;const f=()=>{try{if(o||innerWidth>ye||innerHeight>we)return;o=!0;const i=Date.now(),m=()=>{try{removeEventListener("resize",m)}catch{}if(Date.now()-i>be||r||w())return;const u=y();h(u!==null?u:s)};addEventListener("resize",m)}catch{}};let _=!1,b=!1;return{restore(){if(_||(_=!0,w()))return;const i=y();i!==null&&(h(i),f())},promoted(){if(b||(b=!0,w()))return;const i=y();i!==null?(h(i),f()):n&&h(s)}}}function ge(e,t,r,n){let s=null;try{s=window.trustedTypes?.createPolicy("frame-runtime",{createScriptURL:v=>v})??null}catch{}const a=window.Worker,l=a?.prototype,d=Object.freeze({Worker:a,workerOn:l?.addEventListener,workerPost:l?.postMessage,workerTerminate:l?.terminate,fetch:window.fetch.bind(window),preventDefault:Event.prototype.preventDefault,policy:s,origins:t});r(e).then(v=>v?.bootTopLevel?v.bootTopLevel(d,n):n.settle()).catch(()=>n.settle())}var Oe="modulepreload",Ce=function(e){return"/"+e},je={},Ae=function(t,r,n){let s=Promise.resolve();function a(l){const d=new Event("vite:preloadError",{cancelable:!0});if(d.payload=l,window.dispatchEvent(d),!d.defaultPrevented)throw l}return s.then(l=>{for(const d of l||[])d.status==="rejected"&&a(d.reason);return t().catch(a)})},Re=window===top,q=Object.getOwnPropertyDescriptor(window,"claude"),T=me(Re,window.__FRAME_PREAMBLE?.topLevel,q?.writable===!1),C=typeof T=="object"&&T[0],p=C?_e():he();(function(){const e=Object.defineProperty,t=globalThis,r=["RTCPeerConnection","webkitRTCPeerConnection","RTCDataChannel","RTCIceCandidate","RTCSessionDescription","RTCRtpSender","RTCRtpReceiver"];let n=0;for(let s=0;s<r.length;s++){const a=r[s];try{e(t,a,{value:void 0,writable:!1,configurable:!1})}catch{try{delete t[a]}catch{}try{e(t,a,{value:void 0,writable:!1,configurable:!0})}catch{}}typeof t[a]=="function"&&n++}if(n&&T==="framed")try{p.post({__frame_rtc_lockdown_failed:n},"*")}catch{}})();var Se=1e4,W=Object.freeze([...window.__FRAME_PREAMBLE?.origins??["https://claude.ai","https://preview.claude.ai"]]);function $(e){for(const t of W)if(t.endsWith(":*"))try{const r=new URL(e);if(`${r.protocol}//${r.hostname}:*`===t)return!0}catch{}else if(e===t)return!0;return!1}var L=Object.freeze({...window.__FRAME_PREAMBLE?.capabilities}),j=window.__FRAME_PREAMBLE?.transforms,N=window.__FRAME_PREAMBLE?.comments,I=window.__FRAME_PREAMBLE?.translate;function R(e){return Ae(()=>import("/_runtime/"+e),void 0)}function K(e,t){return{contract:e.contract,changes:new Set(e.changes??[]),flags:new Set(e.flags??[]),capabilities:e.capabilities??{},capBudgets:e.capBudgets??{},transforms:new Map,shellOrigin:t,mount:D,pipe:()=>({wrap:(r,n)=>(...s)=>{try{return n(...s)}catch(a){return Promise.reject(a)}}})}}var P=null,E=null;function Y(e,t,r){try{Object.defineProperty(e,t,{value:r,writable:!1,configurable:!1,enumerable:!0})}catch{try{Object.defineProperty(e,t,{value:r,writable:!1,configurable:!0,enumerable:!0})}catch{}}}var B=!1;function ke(e,t){const r=[];for(const n of e.elements){const s=document.querySelector(`[data-id="${n.target}"]`);if(!s){p.post({__frame_patch_miss:{seq:e.seq}},t);return}if([...Object.keys(n.attrsSet??{}),...n.attrsRemoved??[]].some(a=>!te(a))){p.post({__frame_patch_miss:{seq:e.seq}},t);return}if(n.text!==void 0&&(!se(s)||ie(s))){p.post({__frame_patch_miss:{seq:e.seq}},t);return}for(const[a,l]of Object.entries(n.attrsSet??{}))if(!G(s,a)){try{s.setAttribute(a,l)}catch{}X(s,a,l)}for(const a of n.attrsRemoved??[])G(s,a)||(s.removeAttribute(a),X(s,a,null));typeof n.text=="string"&&(s.textContent=n.text),r.push(n.target)}try{document.dispatchEvent(new CustomEvent("claude:edit",{detail:{seq:e.seq,targets:r}}))}catch{}}function X(e,t,r){if(!(e instanceof HTMLInputElement))return;const n=t.toLowerCase();n==="checked"?e.checked=r!==null:n==="value"&&e.type!=="file"&&(e.value=r??"")}function G(e,t){const r=t.toLowerCase(),n=e;return r==="data-id"||(r==="value"||r==="checked")&&(n.__artifactSecret===!0||/^(password|hidden|file)$/.test(n.type??"")||/(^|\s)(cc-|one-time-code|current-password|new-password)/i.test(`${e.getAttribute("autocomplete")??""} ${n.autocomplete??""}`))}function V(e){const t=document.documentElement;e==="light"||e==="dark"?(t.dataset.theme=e,t.style.colorScheme=e,B=!0):B&&(delete t.dataset.theme,t.style.colorScheme="",B=!1)}var M=new Map;function Te(){let e;const t={u:new Promise(r=>{e=r}),r:r=>{t.done=!0,e(r)},done:!1,nulled:!1};return t}function U(){for(const e of M.values())e.done||(e.nulled=!0,e.r(null))}var Le=Object.freeze(Object.assign(Object.create(null),{call:Function.prototype.call,apply:Function.prototype.apply,bind:Function.prototype.bind})),D=(e,t)=>{const r=M.get(e);if(!r||r.done){r?.nulled&&E&&p.post({__frame_cap_telemetry:{kind:"cap-load-error",cap:e}},E);return}const n=typeof t=="function"?Object.setPrototypeOf(t,Le):Object.assign(Object.create(null),t);typeof n.then=="function"&&delete n.then,r.r(Object.freeze(n))};function Z(){const e=q?.value??{};Y(window,"claude",e);for(const t of Object.keys(L)){if(e[t]!==void 0){Y(e,t,e[t]);continue}M.set(t,Te())}if(e.use===void 0){const t=r=>{if(typeof r!="string"||!Object.hasOwn(L,r))return Promise.resolve(null);const n=M.get(r);return n?n.u:Promise.resolve(e[r]??null)};try{Object.defineProperty(e,"use",{value:t,writable:!0,configurable:!0,enumerable:!1})}catch{}}}if(T==="framed"){const e=j&&A.test(j)?R(j).catch(()=>{}):Promise.resolve(void 0),t=o=>{if(o.type==="auxclick"&&o.button!==1)return;const f=o.target,_=f&&f.closest?f.closest("a[href],area[href]"):null;if(!_)return;const b=_.getAttribute("href");if(!b)return;let i;try{i=new URL(b,document.baseURI)}catch{return}if((i.protocol==="http:"||i.protocol==="https:")&&i.origin!==location.origin){o.preventDefault();const m=(_.getAttribute("target")??"").toLowerCase(),u=o.type==="auxclick"||o.metaKey||o.ctrlKey||o.shiftKey||o.altKey||!["","_self","_top","_parent"].includes(m);p.post({__frame_nav:!0,url:i.href,newTab:u},"*")}};addEventListener("click",t,!0),addEventListener("auxclick",t,!0);const r={},n=o=>{o.isTrusted&&(r.pointer=!0)},s=o=>{o.isTrusted&&(r.click=!0)};addEventListener("pointermove",n,{capture:!0,passive:!0}),addEventListener("click",s,{capture:!0,passive:!0}),e.then(o=>{o?.wireNav&&(o.wireNav(),removeEventListener("click",t,!0),removeEventListener("auxclick",t,!0),removeEventListener("pointermove",n,!0),removeEventListener("click",s,!0),o.wireEngagement?.(r))});let a=null;try{a=Ee()}catch{}Z();let l=null,d=null,v=0;const y=p.on((o,f)=>{$(f)&&fe(o)&&(l=o.__frame_init,E=f,y(),clearTimeout(v),d?.())});p.post({__frame_connect:!0},"*");const S=new Promise(o=>{d=o,v=setTimeout(()=>{y(),o()},Se)}),h=document.readyState==="loading"?new Promise(o=>document.addEventListener("DOMContentLoaded",()=>o(),{once:!0})):Promise.resolve();h.then(()=>{try{a?.restore()}catch{}});const w={cb:null};p.on((o,f)=>{if($(f)&&pe(o)){try{a?.promoted()}catch{}w.cb?.()}}),S.then(async()=>{if(!l||!E){U();return}V(l.theme);const o=E;let f=!1,_=!1;p.on((c,x)=>{if(x!==o)return;de(c)&&V(c.__frame_theme.theme),ue(c)&&ke(c.__frame_patch,o);const g=c?.__fc_mode;g&&typeof g=="object"&&!f&&N&&A.test(N)&&(f=!0,R(N).then(z=>z.install?.(o,g.on===!0)).catch(()=>{}));const F=c?.__ft_cmd;F&&typeof F=="object"&&!_&&I&&A.test(I)&&(_=!0,R(I).then(z=>z.install?.(o,F)).catch(()=>{}))});const b=Object.keys(l.capabilities??{}).filter(c=>Object.hasOwn(L,c)).map(c=>[c,L[c]]).filter(c=>typeof c[1]=="string"&&A.test(c[1])),i=await Promise.allSettled(b.map(([,c])=>R(c))),m=await e,u=E;if(m?.buildBoot||p.post({__frame_cap_telemetry:{kind:"cap-load-error",cap:"_transforms"}},u),m?.buildBoot)try{P=m.buildBoot(l,m.TRANSFORMS??{},{shellOrigin:u,mount:D},c=>p.post({__frame_cap_telemetry:c},u))}catch{p.post({__frame_cap_telemetry:{kind:"cap-load-error",cap:"_transforms"}},u),P=K(l,u)}else P=K(l,u);const k=c=>p.post({__frame_cap_telemetry:{kind:"cap-load-error",cap:c}},u),Pe=P;i.forEach((c,x)=>{const g=b[x][0];if(c.status!=="fulfilled"){k(g);return}try{c.value?.install?.(Pe)}catch{k(g)}}),U(),await h,p.post({__frame_ready:!0},E),e.then(c=>c?.installSizeReporter?.(u,w))})}else C&&(Z(),ge(C,W,R,{settle:U,mount:D}))})();</script><!-- /frame-runtime --><meta charset=utf8><meta name=viewport content="width=device-width,initial-scale=1"><style>:root{color-scheme:light}body{margin:0;padding:0;font:14px -apple-system,BlinkMacSystemFont,sans-serif;background:#faf9f5;color:#141413}img{max-width:100%}</style></head><body>
+<title>Argon Macro Desk</title>
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap"
+/>
+<style>
+  /* ── Argon Macro Desk · argon design system, single-theme dark ── */
+  :root {
+    --bg-base: #0a0f14;
+    --bg-panel: #0f1519;
+    --bg-panel-raised: #151c22;
+    --border-dim: #1e293b;
+    --text-primary: #e2e8f0;
+    --text-secondary: #94a3b8;
+    --text-muted: #475569;
+    --accent-bg: #05ad98;
+    --accent-text: #0a0f14;
+    --accent-deep: #048a7a;
+    --positive: #05ad98;
+    --negative: #e85d6c;
+    --warning: #f5a623;
+    --info: #8b5cf6;
+    --neutral: #94a3b8;
+    --accent-cool: #38bdf8;
+    --accent-warm: #f5a623;
+    --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sans: "Inter", -apple-system, system-ui, sans-serif;
+  }
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  body {
+    background: var(--bg-base);
+    color: var(--text-primary);
+    font-family: var(--sans);
+    font-size: 13.5px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection {
+    background: rgba(5, 173, 152, 0.25);
+  }
+
+  .wrap {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--sans);
+    text-wrap: balance;
+  }
+  a {
+    color: var(--accent-cool);
+  }
+  .num {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── 48px app bar ── */
+  .appbar {
+    height: 48px;
+    border-bottom: 1px solid var(--border-dim);
+    background: var(--bg-base);
+  }
+  .appbar-inner {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  .brand {
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--text-primary);
+  }
+  .brand em {
+    font-style: normal;
+    color: var(--accent-bg);
+  }
+  .mast-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--mono);
+    font-size: 10px;
+    padding: 3px 9px;
+    border-radius: 3px;
+    border: 1px solid var(--border-dim);
+    color: var(--text-secondary);
+    background: var(--bg-panel);
+  }
+  .chip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+  }
+  .chip.ok {
+    border-color: rgba(5, 173, 152, 0.4);
+  }
+  .chip.ok .dot {
+    background: var(--positive);
+  }
+  .chip.gold {
+    border-color: rgba(5, 173, 152, 0.45);
+    color: var(--accent-bg);
+  }
+
+  /* ── intro band ── */
+  .intro {
+    border-bottom: 1px solid var(--border-dim);
+    background: linear-gradient(180deg, #0d1318 0%, var(--bg-base) 100%);
+  }
+  .kicker {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 1.5px;
+    color: var(--accent-bg);
+    text-transform: uppercase;
+    padding-top: 18px;
+    margin-bottom: 6px;
+  }
+  .intro h1 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
+  }
+  .intro h1 .thin {
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+  .legend-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    padding: 10px 0 14px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+  }
+  .legend-strip b {
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+  .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 2px;
+    vertical-align: 1px;
+    letter-spacing: 0.03em;
+  }
+  .tag.real {
+    background: rgba(5, 173, 152, 0.12);
+    color: var(--positive);
+    border: 1px solid rgba(5, 173, 152, 0.35);
+  }
+  .tag.comp {
+    background: rgba(56, 189, 248, 0.1);
+    color: var(--accent-cool);
+    border: 1px solid rgba(56, 189, 248, 0.35);
+  }
+  .tag.plan {
+    background: rgba(71, 85, 105, 0.15);
+    color: var(--text-secondary);
+    border: 1px dashed var(--text-muted);
+  }
+  .tag.q {
+    background: rgba(139, 92, 246, 0.1);
+    color: var(--info);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+  }
+
+  /* ── PM question strip ── */
+  .pmq {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 8px;
+    padding: 4px 0 18px;
+  }
+  .pmq .q {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    border-radius: 4px;
+    padding: 9px 10px;
+    cursor: default;
+  }
+  .pmq .q b {
+    display: block;
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--accent-bg);
+    letter-spacing: 1.2px;
+    margin-bottom: 3px;
+  }
+  .pmq .q span {
+    font-size: 11.5px;
+    color: var(--text-secondary);
+    line-height: 1.35;
+    display: block;
+  }
+  @media (max-width: 980px) {
+    .pmq {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  }
+  @media (max-width: 640px) {
+    .pmq {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  /* ── tab nav ── */
+  .tabbar {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(10, 15, 20, 0.94);
+    backdrop-filter: blur(6px);
+    border-bottom: 1px solid var(--border-dim);
+  }
+  .tabs {
+    display: flex;
+    gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+  .tab {
+    appearance: none;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    font-family: var(--mono);
+    font-weight: 500;
+    font-size: 11px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 13px 13px 11px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .tab:hover {
+    color: var(--text-secondary);
+  }
+  .tab:focus-visible {
+    outline: 2px solid var(--accent-bg);
+    outline-offset: -2px;
+  }
+  .tab[aria-selected="true"] {
+    color: var(--accent-bg);
+    border-bottom-color: var(--accent-bg);
+  }
+  .tab .n {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-right: 5px;
+  }
+
+  /* ── panels ── */
+  main {
+    padding: 26px 0 80px;
+  }
+  section[role="tabpanel"] {
+    display: none;
+  }
+  section[role="tabpanel"].on {
+    display: block;
+  }
+  .sec-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 12px;
+    margin: 6px 0 4px;
+  }
+  .sec-title h2 {
+    font-size: 17px;
+    font-weight: 700;
+  }
+  .sec-sub {
+    color: var(--text-muted);
+    font-size: 12.5px;
+    margin-bottom: 18px;
+    max-width: 72ch;
+  }
+  .sec-sub b {
+    color: var(--text-secondary);
+  }
+
+  .grid {
+    display: grid;
+    gap: 12px;
+  }
+  .g2 {
+    grid-template-columns: 1fr 1fr;
+  }
+  .g3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .g4 {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  @media (max-width: 980px) {
+    .g3,
+    .g4 {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+  @media (max-width: 640px) {
+    .g2,
+    .g3,
+    .g4 {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .panel {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    border-radius: 6px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .panel.dim {
+    opacity: 0.68;
+  }
+  .panel-h {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .panel-h h3 {
+    font-size: 10px;
+    font-family: var(--mono);
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+  }
+  .panel-h .qs {
+    display: flex;
+    gap: 4px;
+  }
+  .read {
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    border-left: 2px solid var(--accent-deep);
+    padding-left: 9px;
+    line-height: 1.5;
+  }
+  .read b {
+    color: var(--text-primary);
+  }
+  .prov {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    border-top: 1px dashed var(--border-dim);
+    padding-top: 7px;
+    line-height: 1.6;
+  }
+  .prov b {
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  .big {
+    font-family: var(--mono);
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1.1;
+  }
+  .big small {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+  .delta-up {
+    color: var(--positive);
+  }
+  .delta-dn {
+    color: var(--negative);
+  }
+  .delta-flat {
+    color: var(--text-muted);
+  }
+
+  /* state pills */
+  .state {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-family: var(--mono);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 3px;
+    letter-spacing: 0.03em;
+  }
+  .state.warnst {
+    background: rgba(245, 166, 35, 0.12);
+    color: var(--warning);
+    border: 1px solid rgba(245, 166, 35, 0.4);
+  }
+  .state.okst {
+    background: rgba(5, 173, 152, 0.12);
+    color: var(--positive);
+    border: 1px solid rgba(5, 173, 152, 0.38);
+  }
+  .state.critst {
+    background: rgba(232, 93, 108, 0.12);
+    color: var(--negative);
+    border: 1px solid rgba(232, 93, 108, 0.4);
+  }
+  .state.neust {
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--neutral);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+  }
+  .dir {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+  }
+
+  /* confidence bar */
+  .conf {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .conf .track {
+    flex: 1;
+    height: 5px;
+    background: var(--bg-panel-raised);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .conf .fill {
+    height: 100%;
+    background: var(--accent-bg);
+    border-radius: 3px;
+  }
+  .conf .fill.low {
+    background: var(--warning);
+  }
+
+  /* zone headers (tab 00 daily loop) */
+  .zone {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin: 30px 0 12px;
+  }
+  .zone.z1 {
+    margin-top: 12px;
+  }
+  .zone .zk {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--accent-bg);
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .zone .zl {
+    font-family: var(--sans);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 0.05em;
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
+  .zone .rule {
+    flex: 1;
+    height: 1px;
+    background: var(--border-dim);
+    align-self: center;
+  }
+
+  /* meeting probability bars */
+  .meet {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+  .meet-h {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .meet-h b {
+    font-family: var(--sans);
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .meet-h .num {
+    font-size: 11px;
+    color: var(--text-secondary);
+  }
+  .pbar {
+    display: flex;
+    gap: 2px;
+    height: 18px;
+  }
+  .pbar span {
+    display: flex;
+    align-items: center;
+    padding: 0 7px;
+    border-radius: 2px;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--accent-text);
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .pbar .hk {
+    background: var(--warning);
+  }
+  .pbar .hd {
+    background: var(--accent-cool);
+    justify-content: flex-end;
+  }
+
+  /* chain rail */
+  .chain {
+    display: grid;
+    grid-template-columns: 1fr 28px 1fr 28px 1fr 28px 1fr;
+    gap: 0;
+    align-items: stretch;
+    margin: 8px 0 14px;
+  }
+  .chain .arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-deep);
+    font-size: 18px;
+    font-family: var(--mono);
+  }
+  .node {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    border-radius: 6px;
+    padding: 13px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+  .node h3 {
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .node h3 .dom {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+  .node .kv {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-secondary);
+    gap: 8px;
+  }
+  .node .kv .num {
+    color: var(--text-primary);
+  }
+  @media (max-width: 980px) {
+    .chain {
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+    .chain .arrow {
+      transform: rotate(90deg);
+      padding: 2px 0;
+    }
+  }
+  .edge-note {
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 2px 4px;
+  }
+
+  /* tables */
+  .tbl-wrap {
+    overflow-x: auto;
+  }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 12.5px;
+  }
+  th {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: 500;
+    text-align: left;
+    padding: 7px 10px;
+    border-bottom: 1px solid var(--border-dim);
+  }
+  td {
+    padding: 7px 10px;
+    border-bottom: 1px solid rgba(30, 41, 59, 0.6);
+    color: var(--text-secondary);
+    vertical-align: top;
+  }
+  td.num,
+  th.num {
+    text-align: right;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  td:first-child {
+    color: var(--text-primary);
+  }
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  /* meters */
+  .meter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+  }
+  .meter .lbl {
+    width: 150px;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+  }
+  .meter .track {
+    flex: 1;
+    height: 6px;
+    background: var(--bg-panel-raised);
+    border-radius: 3px;
+    position: relative;
+  }
+  .meter .pin {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--accent-bg);
+    border: 2px solid var(--bg-base);
+  }
+  .meter .pin.blue {
+    background: var(--accent-cool);
+  }
+  .meter .pin.crit {
+    background: var(--negative);
+  }
+  .meter .val {
+    font-family: var(--mono);
+    width: 52px;
+    text-align: right;
+    color: var(--text-primary);
+  }
+  .meter .track .mid {
+    position: absolute;
+    left: 50%;
+    top: -2px;
+    bottom: -2px;
+    width: 1px;
+    background: var(--text-muted);
+    opacity: 0.5;
+  }
+
+  /* contradiction feed — argon idiom: warning left border on raised panel */
+  .contra {
+    border-left: 2px solid var(--warning);
+    background: var(--bg-panel-raised);
+    border-radius: 0 4px 4px 0;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .contra b {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--warning);
+    letter-spacing: 0.06em;
+  }
+  .contra span {
+    font-size: 12.5px;
+    color: var(--text-secondary);
+  }
+  .contra .why {
+    font-size: 11.5px;
+    color: var(--text-muted);
+  }
+
+  /* arithmetic chain */
+  .arith {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 5px;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+  .arith .term {
+    background: var(--bg-panel-raised);
+    border: 1px solid var(--border-dim);
+    border-radius: 4px;
+    padding: 5px 7px;
+    text-align: center;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .arith .term small {
+    display: block;
+    font-size: 8.5px;
+    color: var(--text-muted);
+    letter-spacing: 0.02em;
+    margin-top: 2px;
+    white-space: nowrap;
+  }
+  .arith .op {
+    color: var(--text-muted);
+    flex: 0 0 auto;
+    align-self: center;
+  }
+  .arith .res {
+    background: rgba(5, 173, 152, 0.1);
+    border: 1px solid rgba(5, 173, 152, 0.4);
+    color: var(--accent-bg);
+    border-radius: 4px;
+    padding: 5px 10px;
+    font-weight: 600;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+
+  /* charts */
+  .chart {
+    background: var(--bg-panel-raised);
+    border: 1px solid var(--border-dim);
+    border-radius: 5px;
+    padding: 10px 12px;
+  }
+  .chart svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+  .cap {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: var(--text-muted);
+    margin-top: 6px;
+  }
+  .lgd {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    font-size: 11.5px;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+  }
+  .lgd i {
+    display: inline-block;
+    width: 10px;
+    height: 3px;
+    border-radius: 2px;
+    margin-right: 5px;
+    vertical-align: 2px;
+  }
+  text {
+    font-family: "IBM Plex Mono", monospace;
+  }
+
+  .note-refuse {
+    border: 1px dashed var(--border-dim);
+    border-radius: 5px;
+    padding: 11px 13px;
+    font-size: 12.5px;
+    color: var(--text-muted);
+  }
+  .note-refuse b {
+    color: var(--warning);
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.07em;
+  }
+
+  .ghost {
+    border: 1px dashed var(--text-muted);
+    border-radius: 6px;
+    padding: 13px 14px;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: transparent;
+  }
+  .ghost h3 {
+    font-size: 10.5px;
+    font-family: var(--mono);
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  .ghost span {
+    font-size: 12px;
+  }
+  .ghost b {
+    color: var(--text-secondary);
+  }
+
+  ul.tight {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+  ul.tight li {
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    padding-left: 14px;
+    position: relative;
+  }
+  ul.tight li::before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    color: var(--accent-deep);
+  }
+  ul.tight li b {
+    color: var(--text-primary);
+  }
+
+  footer {
+    border-top: 1px solid var(--border-dim);
+    padding: 20px 0 40px;
+    color: var(--text-muted);
+    font-family: var(--mono);
+    font-size: 10.5px;
+    line-height: 1.8;
+  }
+  footer code {
+    color: var(--text-secondary);
+  }
+
+  .tooltip {
+    position: fixed;
+    pointer-events: none;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-dim);
+    border-radius: 4px;
+    padding: 6px 9px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--text-primary);
+    z-index: 99;
+    display: none;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .tab,
+    .chip {
+      transition:
+        color 0.15s,
+        border-color 0.15s;
+    }
+  }
+</style>
+
+<!-- ══════════════════ APP BAR ══════════════════ -->
+<header class="appbar">
+  <div class="wrap">
+    <div class="appbar-inner">
+      <span class="brand">ARGON <em>—</em> MACRO</span>
+      <div class="mast-meta">
+        <span class="chip ok"
+          ><span class="dot"></span>chain snapshot: complete</span
+        >
+        <span class="chip"
+          >as_of <span class="num">2026-08-26 07:40 UTC+8</span></span
+        >
+        <span class="chip gold"
+          >macmini · option_wizard production snapshot</span
+        >
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- ══════════════════ INTRO ══════════════════ -->
+<div class="intro">
+  <div class="wrap">
+    <div class="kicker">Macro Phase 2 Integration Proposal · Review Draft</div>
+    <h1>Macro Desk <span class="thin">/ Fed → Inflation → USD → Gold</span></h1>
+    <div class="legend-strip">
+      <span><b>Provenance:</b></span>
+      <span
+        ><span class="tag real">REAL</span> production DB / API value,
+        verbatim</span
+      >
+      <span
+        ><span class="tag comp">COMPUTED</span> arithmetic on REAL values
+        (formula shown)</span
+      >
+      <span
+        ><span class="tag plan">PLANNED</span> proposed panel, data not yet
+        ingested</span
+      >
+      <span
+        ><span class="tag q">Q1–Q7</span> which PM question a panel
+        answers</span
+      >
+    </div>
+    <div class="pmq">
+      <div class="q">
+        <b>Q1 STATE</b><span>Which macro world am I in?</span>
+      </div>
+      <div class="q">
+        <b>Q2 PRICING</b><span>What gap vs. the official path?</span>
+      </div>
+      <div class="q">
+        <b>Q3 DISAGREEMENT</b><span>Which evidence contradicts itself?</span>
+      </div>
+      <div class="q">
+        <b>Q4 TRANSMISSION</b><span>Is the textbook chain intact?</span>
+      </div>
+      <div class="q">
+        <b>Q5 POSITIONING</b><span>Who is on which side, how crowded?</span>
+      </div>
+      <div class="q">
+        <b>Q6 FALSIFIERS</b><span>What event flips the call?</span>
+      </div>
+      <div class="q">
+        <b>Q7 TRUST</b><span>How fresh? What does the board refuse?</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════ TABS ══════════════════ -->
+<nav class="tabbar">
+  <div class="wrap">
+    <div class="tabs" role="tablist" aria-label="Macro desk tabs">
+      <button class="tab" role="tab" aria-selected="true" data-t="t0">
+        <span class="n">00</span>Overview · Daily Loop
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t1">
+        <span class="n">01</span>Fed · Policy
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t2">
+        <span class="n">02</span>Rates · Curve
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t3">
+        <span class="n">03</span>Inflation
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t4">
+        <span class="n">04</span>US Dollar
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t5">
+        <span class="n">05</span>Gold
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t6">
+        <span class="n">06</span>Energy · Proposal
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t7">
+        <span class="n">07</span>Factor Export
+      </button>
+      <button class="tab" role="tab" aria-selected="false" data-t="t8">
+        <span class="n">08</span>Design Notes
+      </button>
+    </div>
+  </div>
+</nav>
+
+<main class="wrap">
+  <!-- ══════════════════ 00 OVERVIEW · DAILY LOOP ══════════════════ -->
+  <section id="t0" role="tabpanel" class="on">
+    <div class="sec-title">
+      <h2>The Daily Loop</h2>
+      <span class="tag q">Q1 Q2 Q3 Q4 Q6</span>
+    </div>
+    <p class="sec-sub">
+      The desk opens on the loop a macro PM actually runs every morning:
+      <b>what changed · what disagrees · what's next</b>. The transmission chain
+      (inflation → policy → USD → gold) anchors the bottom of this tab; each
+      node is an independent engine's output, and downstream cites the upstream
+      <em>published state identity</em>, never raw data.
+      <b>There is not, and will never be, a composite score.</b>
+    </p>
+
+    <!-- ── ZONE 1 · WHAT CHANGED ── -->
+    <div class="zone z1">
+      <span class="zk">ZONE 1</span><span class="zl">WHAT CHANGED</span>
+      <span class="rule"></span>
+      <span class="zk">week 08-19 → 08-26</span>
+    </div>
+    <div class="grid g3">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>State flips × confidence moves</h3>
+          <span class="tag q">Q1</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Domain</th>
+              <th>State 08-20 → 08-26</th>
+              <th>Confidence path</th>
+            </tr>
+            <tr>
+              <td>Inflation</td>
+              <td>WELL_ABOVE_TARGET · no flip</td>
+              <td class="num" style="color: var(--warning)">0.429 → 0.373</td>
+            </tr>
+            <tr>
+              <td>Policy rates</td>
+              <td>ON_HOLD · no flip</td>
+              <td class="num">1.00 → 0.85 → 1.00</td>
+            </tr>
+            <tr>
+              <td>US dollar</td>
+              <td>RANGEBOUND · no flip</td>
+              <td class="num">1.00 · unchanged</td>
+            </tr>
+            <tr>
+              <td>Gold (gate)</td>
+              <td>SUSPENDED · no flip</td>
+              <td class="num">0.85 · unchanged</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          A week of zero state flips is not a week of zero information —
+          confidence is where the change lives. Inflation's decay is pure
+          freshness (no new evidence; the Michigan input aging toward its
+          staleness penalty). Rates dipped to 0.85 and repaired within the week.
+        </p>
+        <div class="prov">
+          <b>Source</b> macro domain-state history, 28 rows 08-20 → 08-26
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Market deltas · 1 week</h3>
+          <span class="tag q">Q2</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Series</th>
+              <th class="num">start → end</th>
+              <th class="num">Δ 1w</th>
+            </tr>
+            <tr>
+              <td>DGS10 · nominal 10y</td>
+              <td class="num">4.68 → 4.70</td>
+              <td class="num">+2bp</td>
+            </tr>
+            <tr>
+              <td>DFII10 · real 10y</td>
+              <td class="num">2.41 → 2.38</td>
+              <td class="num">−3bp</td>
+            </tr>
+            <tr>
+              <td>T10YIE · breakeven</td>
+              <td class="num">2.27 → 2.32</td>
+              <td class="num">+5bp</td>
+            </tr>
+            <tr>
+              <td>DTWEXBGS · broad USD</td>
+              <td class="num">118.90 → 118.06</td>
+              <td class="num">−0.71%</td>
+            </tr>
+            <tr>
+              <td>SOFR − EFFR</td>
+              <td class="num">−1bp → +2bp</td>
+              <td class="num">+3bp</td>
+            </tr>
+            <tr>
+              <td>GVZ · gold vol</td>
+              <td class="num">23.92 → 28.28</td>
+              <td class="num">+4.4 pts</td>
+            </tr>
+            <tr>
+              <td>VIX</td>
+              <td class="num">14.25 → 15.85</td>
+              <td class="num">+1.6 pts</td>
+            </tr>
+            <tr>
+              <td>HY OAS</td>
+              <td class="num">2.67 → 2.69</td>
+              <td class="num">+2bp</td>
+            </tr>
+            <tr>
+              <td>GLD</td>
+              <td class="num">401.48 → 428.07</td>
+              <td class="num">+6.6%*</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          This week's 10y move is <b>breakeven-led</b> (+5bp BEI vs −3bp real)
+          while the trailing 60d move (+31bp) was real-yield-led — the driver
+          rotated. Vol is bid across the board, with gold vol leading.
+        </p>
+        <div class="prov">
+          <b>Source</b> daily closes, latest obs per series (08-24/25) · *GLD
+          window since 08-14 as stored <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Anchor letting go · gauge corr_60d</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="chart">
+          <svg
+            viewBox="0 0 318 96"
+            role="img"
+            aria-label="Gold vs real-yield 60-day correlation, daily: minus 0.79 on Aug 7 decaying to minus 0.17 on Aug 25"
+          >
+            <g stroke="#1e293b">
+              <line x1="24.5" y1="10" x2="305.8" y2="10" />
+              <line x1="24.5" y1="45" x2="305.8" y2="45" />
+              <line x1="24.5" y1="80" x2="305.8" y2="80" />
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="19.6" y="13" text-anchor="end">0</text>
+              <text x="19.6" y="83" text-anchor="end">−1</text>
+            </g>
+            <polyline
+              points="24.5,65.3 64.7,58.5 104.8,46.2 145.1,42.2 185.2,40.1 225.4,37.0 265.5,33.0 305.8,21.6"
+              fill="none"
+              stroke="#f5a623"
+              stroke-width="2"
+            />
+            <g fill="#f5a623">
+              <circle
+                cx="24.5"
+                cy="65.3"
+                r="4"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-07 · −0.79</title>
+              </circle>
+              <circle cx="64.7" cy="58.5" r="3"><title>−0.69</title></circle>
+              <circle cx="104.8" cy="46.2" r="3"><title>−0.52</title></circle>
+              <circle cx="145.1" cy="42.2" r="3"><title>−0.46</title></circle>
+              <circle cx="185.2" cy="40.1" r="3"><title>−0.43</title></circle>
+              <circle cx="225.4" cy="37.0" r="3"><title>−0.39</title></circle>
+              <circle cx="265.5" cy="33.0" r="3"><title>−0.33</title></circle>
+              <circle
+                cx="305.8"
+                cy="21.6"
+                r="4"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-25 · −0.17</title>
+              </circle>
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="24.5" y="93">08-07</text>
+              <text x="305.8" y="93" text-anchor="end">08-25</text>
+            </g>
+          </svg>
+          <div class="cap">
+            gold ↔ real-yield corr, 60d window, daily
+            <span class="tag real">REAL</span>
+          </div>
+        </div>
+        <p class="read">
+          The 60d link collapsed <span class="num">−0.79 → −0.17</span> in
+          twelve sessions while the 126d window barely moved (<span class="num"
+            >−0.93 → −0.85</span
+          >). Short-window decorrelation during a spot rally: the rally is not a
+          discount-rate trade. Full chart in tab 05.
+        </p>
+        <div class="prov">
+          <b>Source</b> gold gauge corr_60d, 8 daily rows 08-07 → 08-25
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── ZONE 2 · WHAT DISAGREES ── -->
+    <div class="zone">
+      <span class="zk">ZONE 2</span><span class="zl">WHAT DISAGREES</span>
+      <span class="rule"></span>
+      <span class="zk">the raw material of trades</span>
+    </div>
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Four policy paths · who says what</h3>
+          <span class="tag q">Q2 Q3</span>
+        </div>
+        <div class="chart">
+          <svg
+            viewBox="0 0 560 190"
+            role="img"
+            aria-label="Four policy paths compared: actual 3.625, dealer 3.63, committee 3.80, market-implied 3.88 percent"
+          >
+            <!-- axis 3.5 → 4.0 mapped to x 120→520 -->
+            <line x1="120" y1="20" x2="120" y2="160" stroke="#1e293b" />
+            <g stroke="#1e293b">
+              <line x1="220" y1="20" x2="220" y2="160" />
+              <line x1="320" y1="20" x2="320" y2="160" />
+              <line x1="420" y1="20" x2="420" y2="160" />
+              <line x1="520" y1="20" x2="520" y2="160" />
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="112" y="176" text-anchor="middle">3.50</text>
+              <text x="220" y="176" text-anchor="middle">3.625</text>
+              <text x="320" y="176" text-anchor="middle">3.75</text>
+              <text x="420" y="176" text-anchor="middle">3.875</text>
+              <text x="512" y="176" text-anchor="middle">4.00%</text>
+            </g>
+            <!-- lanes: actual 3.625→x220 ; dealer 3.63→x224 ; committee 3.80→x360 ; market 3.88→x424 -->
+            <g font-size="10" fill="#94a3b8">
+              <text x="8" y="39">Actual (07-29 FOMC)</text>
+              <text x="8" y="74">Dealer (NY Fed SME)</text>
+              <text x="8" y="109">SEP median (end-26)</text>
+              <text x="8" y="144">Market (Dec-09 mtg)</text>
+            </g>
+            <g stroke="#1e293b" stroke-dasharray="2 3">
+              <line x1="120" y1="35" x2="520" y2="35" />
+              <line x1="120" y1="70" x2="520" y2="70" />
+              <line x1="120" y1="105" x2="520" y2="105" />
+              <line x1="120" y1="140" x2="520" y2="140" />
+            </g>
+            <line
+              x1="220"
+              y1="24"
+              x2="220"
+              y2="156"
+              stroke="#05ad98"
+              stroke-dasharray="3 3"
+              opacity=".6"
+            />
+            <circle
+              cx="220"
+              cy="35"
+              r="6"
+              fill="#e2e8f0"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Actual 3.625%</title>
+            </circle>
+            <circle
+              cx="224"
+              cy="70"
+              r="6"
+              fill="#38bdf8"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Dealer 3.63% (+0.5bp)</title>
+            </circle>
+            <circle
+              cx="360"
+              cy="105"
+              r="6"
+              fill="#8b5cf6"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Committee 3.80% (+17.5bp)</title>
+            </circle>
+            <circle
+              cx="424"
+              cy="140"
+              r="6"
+              fill="#f5a623"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Market-implied ≈3.88% (+25.5bp)</title>
+            </circle>
+            <g font-size="11" font-weight="600" fill="#e2e8f0">
+              <text x="232" y="39">3.625</text>
+              <text x="236" y="74">
+                3.63
+                <tspan fill="#94a3b8" font-weight="400">+0.5bp</tspan>
+              </text>
+              <text x="372" y="109">
+                3.80
+                <tspan fill="#94a3b8" font-weight="400">+17.5bp</tspan>
+              </text>
+              <text x="436" y="144">
+                ≈3.88
+                <tspan fill="#94a3b8" font-weight="400">+25.5bp</tspan>
+              </text>
+            </g>
+          </svg>
+          <div class="cap">
+            Spreads vs actual are API velocity values
+            <span class="tag real">REAL</span> · market-implied level = 3.625 +
+            25.5bp <span class="tag comp">COMPUTED</span> · lane horizons:
+            dealer survey 07-29 cycle · SEP end-2026 median (published 06-17) ·
+            market = Dec-09 meeting implied
+          </div>
+        </div>
+        <p class="read">
+          The dealer hugs the current rate (+0.5bp); the committee and the
+          market both sit above — what's priced is
+          <b>hawkish repricing / a hiking tail</b>, not cuts. The market prices
+          MORE hiking than the SEP median and far more than the dealer path.
+          Which pole the three converge toward is the next leg; watching that
+          convergence is this panel's daily read. <br /><br />
+          <b
+            >They disagree on the level and agree on the direction of
+            revision.</b
+          >
+          The market has removed cuts, the dealer survey has pushed the first
+          cut out 18 months across three releases, and the committee lifted its
+          own median path 30–50bp between March and June. Three independent
+          respondent sets, one direction — unrolled on <b>tab 01</b>.
+          <span class="tag comp">COMPUTED</span>
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> /api/macro/policy ← macro_observations (4
+          POLICY_PATH_* series) ← macro_market_layer_ingest 19:00–19:15 ET · SEP
+          is the 2026-06-17 official release, dealer survey 07-29 cycle
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Contradiction feed · engine-reported</h3>
+          <span class="tag q">Q3</span>
+        </div>
+        <div class="contra">
+          <b>inflation · cpi_pce_divergence</b>
+          <span
+            >core CPI +2.47pp vs core PCE +3.29pp — beyond the +0.30pp tolerance
+            wedge at <span class="num">−1.12pp</span></span
+          >
+          <span class="why"
+            >The two indexes weight shelter/medical differently; the wider the
+            wedge, the less reliable any single "inflation" label → confidence
+            is penalized, never averaged away</span
+          >
+        </div>
+        <div class="contra">
+          <b>inflation · breadth_contradicts_core</b>
+          <span
+            >median CPI 3m move <span class="num">−1.82pp</span> while core PCE
+            moved just <span class="num">+0.03pp</span></span
+          >
+          <span class="why"
+            >Breadth is falling while the core holds: stickiness is concentrated
+            in a few components — the WELL_ABOVE_TARGET label is being
+            challenged by breadth evidence</span
+          >
+        </div>
+        <div class="contra">
+          <b>gold · gold_against_real_yields_post_2022</b>
+          <span
+            >gold <span class="num">+13.45%</span> in 3 months alongside a
+            <span class="num">+0.10pp</span> rise in 10y real yields</span
+          >
+          <span class="why"
+            >The textbook link (real yields ↑ = carry cost of a zero-coupon
+            asset ↑ = gold ↓) is not currently operative — the gate reports, it
+            does not force an explanation</span
+          >
+        </div>
+        <div class="prov">
+          <b>Source</b> /api/macro/{inflation,gold} contradictions[] ·
+          recomputed nightly by the 19:40 ET macro_state_compute
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Cross-domain contradictions · this week</h3>
+          <span class="tag q">Q3</span>
+        </div>
+        <div class="contra">
+          <b>gold · spot vs anchor</b>
+          <span
+            >GLD <span class="num">+6.6%</span> since 08-14 while the 60d
+            real-yield anchor decayed
+            <span class="num">−0.79 → −0.17</span></span
+          >
+          <span class="why"
+            >Either a new marginal driver is pricing gold or the regime is
+            breaking — flagged, deliberately unresolved. Juxtaposition of two
+            REAL series <span class="tag comp">COMPUTED</span></span
+          >
+        </div>
+        <div class="contra">
+          <b>rates · this week vs the 60d trend</b>
+          <span
+            >week's 10y move breakeven-led (<span class="num">+5bp</span> BEI,
+            <span class="num">−3bp</span> real) — the 60d move (<span
+              class="num"
+              >+31bp</span
+            >) was real-led</span
+          >
+          <span class="why"
+            >The driver rotated. A hedge chosen for a real-yield regime
+            (duration) is not the hedge for a breakeven regime (breakevens /
+            TIPS) — see the 10Y decomposition in tab 02</span
+          >
+        </div>
+        <div class="prov">
+          <b>Basis</b> zone-1 delta tables · both legs REAL, the juxtaposition
+          is ours <span class="tag comp">COMPUTED</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Transmission health · measured link strength</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Link</th>
+              <th>Measure</th>
+              <th class="num">Now</th>
+              <th>Verdict</th>
+            </tr>
+            <tr>
+              <td>Rates → Gold</td>
+              <td>gold↔DFII10 corr 60d (gauge)</td>
+              <td class="num">−0.17</td>
+              <td><span style="color: var(--warning)">letting go</span></td>
+            </tr>
+            <tr>
+              <td>Rates → Gold</td>
+              <td>same · 126d window (gauge)</td>
+              <td class="num">−0.85</td>
+              <td><span style="color: var(--warning)">still holds</span></td>
+            </tr>
+            <tr>
+              <td>Rates → Gold</td>
+              <td>same · 252d window (gauge)</td>
+              <td class="num">−0.04</td>
+              <td><span style="color: var(--negative)">SUSPENDED</span></td>
+            </tr>
+            <tr>
+              <td>USD → Gold</td>
+              <td>gold↔DXY rolling corr (history 08-18)</td>
+              <td class="num">−0.68</td>
+              <td><span style="color: var(--positive)">operative</span></td>
+            </tr>
+            <tr>
+              <td>Geopolitics → Gold</td>
+              <td>gold↔GPR rolling corr (history 08-14)</td>
+              <td class="num">+0.41</td>
+              <td><span style="color: var(--positive)">strengthening</span></td>
+            </tr>
+            <tr>
+              <td>Rates → USD</td>
+              <td>upstream state citation</td>
+              <td class="num">d731eef1 ✓</td>
+              <td><span style="color: var(--positive)">intact</span></td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          The marginal pricer changed: the discount-rate channel (real yields)
+          is failing while the currency-hedge and geopolitical channels take
+          over. This row is the one-line summary of the entire gold tab.
+        </p>
+        <div class="prov">
+          <b>Source</b> gold_posture_daily gauge + correlation_history · full
+          charts in tab 05 <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── ZONE 3 · WHAT'S NEXT ── -->
+    <div class="zone">
+      <span class="zk">ZONE 3</span><span class="zl">WHAT'S NEXT</span>
+      <span class="rule"></span>
+      <span class="zk">dated events that confirm or falsify</span>
+    </div>
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>FOMC calendar × what the market prices</h3>
+          <span class="tag q">Q2 Q6</span>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Sep 15–16</b><span class="num">implied 3.7264%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 38.57%">Hike 25 · 38.6%</span>
+            <span class="hd" style="width: 61.43%">Hold · 61.4%</span>
+          </div>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Oct 27–28</b><span class="num">implied 3.7750%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 19.43%">Hike · 19.4%</span>
+            <span class="hd" style="width: 80.57%">Hold · 80.6%</span>
+          </div>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Dec 8–9</b><span class="num">implied 3.8800%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 42%">Hike · 42.0%</span>
+            <span class="hd" style="width: 58%">Hold · 58.0%</span>
+          </div>
+        </div>
+        <p class="read">
+          <b>Cuts are priced at 0% at every listed horizon</b> — the market is
+          pricing hikes, not cuts. These are the market's numbers (Q2), not a
+          synthesized probability of ours.
+        </p>
+        <div class="prov">
+          <b>Source</b> meeting dates: rates_policy_events (calendar through
+          2027-12) <span class="tag real">REAL</span> · odds: market-implied,
+          CME-style, stored payload 08-26 <span class="tag real">REAL</span> ·
+          cumulative-path check in tab 01
+          <span class="tag comp">COMPUTED</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Confidence repair · what each event fixes</h3>
+          <span class="tag q">Q6</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Event</th>
+              <th>Path</th>
+              <th>Computable consequence</th>
+            </tr>
+            <tr>
+              <td>Next Michigan release (monthly cadence)</td>
+              <td>inflation freshness 0.53 → 1</td>
+              <td class="num">
+                conf 0.37 → 0.70 <span class="tag comp">COMPUTED</span>
+              </td>
+            </tr>
+            <tr>
+              <td>CPI/PCE wedge converges &lt; 0.30pp</td>
+              <td>contradiction penalty (−0.30) lifts</td>
+              <td class="num">
+                conf 0.37 → 0.53 <span class="tag comp">COMPUTED</span>
+              </td>
+            </tr>
+            <tr>
+              <td>Both</td>
+              <td>full repair</td>
+              <td class="num">→ 1.00 <span class="tag comp">COMPUTED</span></td>
+            </tr>
+            <tr>
+              <td>FOMC 2026-09-15/16</td>
+              <td>policy_actual updates → downstream recompute</td>
+              <td>rates → usd → gold cascade</td>
+            </tr>
+            <tr>
+              <td>gold corr252 back below threshold</td>
+              <td>gauge SUSPENDED → operative</td>
+              <td>L2 cyclical lens relights</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          Confidence is multiplication (completeness × freshness × quality ×
+          (1−penalty)), so what each event repairs can be
+          <em>computed in advance</em> — a capability none of the four reference
+          monitors has: their confidence numbers carry no provenance; ours are
+          falsifiable.
+        </p>
+        <div class="prov">
+          <b>Worked check</b> 0.532 × (1−0.30) = 0.372 ✓ matches the API · event
+          calendar rates_policy_events, 24 rows incl. future FOMC → 2027-12-07
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── THE CHAIN ── -->
+    <div class="zone">
+      <span class="zk">ANCHOR</span><span class="zl">THE CHAIN · TODAY</span>
+      <span class="rule"></span>
+      <span class="zk">Q1 Q4 · tabs 01–04 unfold each node</span>
+    </div>
+    <div class="chain">
+      <div class="node">
+        <h3>Inflation <span class="dom">inflation/2</span></h3>
+        <span class="state warnst">WELL_ABOVE_TARGET</span>
+        <span class="dir"
+          >direction FLAT <span class="tag real">REAL</span></span
+        >
+        <div class="conf">
+          <span>conf</span>
+          <div class="track">
+            <div class="fill low" style="width: 37%"></div>
+          </div>
+          <span class="num">0.37</span>
+        </div>
+        <div class="kv">
+          <span>core PCE 3m annualized</span><span class="num">2.89%</span>
+        </div>
+        <div class="kv">
+          <span>core CPI Δ3m</span><span class="num delta-dn">−0.28pp ↓</span>
+        </div>
+        <div class="kv">
+          <span>contradiction penalty</span
+          ><span class="num delta-dn">−0.30 ×2 rules</span>
+        </div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="node">
+        <h3>Policy rates <span class="dom">rates/2</span></h3>
+        <span class="state neust">ON_HOLD</span>
+        <span class="dir"
+          >direction UNKNOWN <span class="tag real">REAL</span></span
+        >
+        <div class="conf">
+          <span>conf</span>
+          <div class="track"><div class="fill" style="width: 100%"></div></div>
+          <span class="num">1.00</span>
+        </div>
+        <div class="kv">
+          <span>FFR target mid</span><span class="num">3.625%</span>
+        </div>
+        <div class="kv">
+          <span>market-implied − actual</span
+          ><span class="num delta-up">+25.5bp</span>
+        </div>
+        <div class="kv">
+          <span>SOFR − EFFR</span><span class="num">+2bp · AMPLE</span>
+        </div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="node">
+        <h3>US dollar <span class="dom">usd/3</span></h3>
+        <span class="state neust">RANGEBOUND</span>
+        <span class="dir"
+          >direction FLAT <span class="tag real">REAL</span></span
+        >
+        <div class="conf">
+          <span>conf</span>
+          <div class="track"><div class="fill" style="width: 100%"></div></div>
+          <span class="num">1.00</span>
+        </div>
+        <div class="kv">
+          <span>nominal broad USD Δ3m</span
+          ><span class="num delta-dn">−1.09%</span>
+        </div>
+        <div class="kv">
+          <span>real broad USD Δ3m</span
+          ><span class="num delta-up">+1.16%</span>
+        </div>
+        <div class="kv">
+          <span>sign divergence</span
+          ><span class="num delta-dn">nominal↓ real↑</span>
+        </div>
+      </div>
+      <div class="arrow">→</div>
+      <div class="node">
+        <h3>Gold <span class="dom">gold/2</span></h3>
+        <span class="state critst">SUSPENDED</span>
+        <span class="dir"
+          >direction RISING <span class="tag real">REAL</span></span
+        >
+        <div class="conf">
+          <span>conf</span>
+          <div class="track"><div class="fill" style="width: 85%"></div></div>
+          <span class="num">0.85</span>
+        </div>
+        <div class="kv">
+          <span>GLD Δ3m</span><span class="num delta-up">+13.45%</span>
+        </div>
+        <div class="kv">
+          <span>gold↔real-yield corr126</span><span class="num">−0.85</span>
+        </div>
+        <div class="kv">
+          <span>corr252</span><span class="num delta-dn">−0.04 · broken</span>
+        </div>
+      </div>
+    </div>
+    <div class="edge-note">
+      Upstream citation integrity: usd cites policy_rates state
+      <span class="num">d731eef12319</span> ✓ · gold cites the
+      inflation/policy_rates/usd state ids ✓ · snapshot verdict
+      <b style="color: var(--positive)">complete</b> — all four cards belong to
+      the same instant, the same world <span class="tag real">REAL</span>
+    </div>
+
+    <div class="grid g2" style="margin-top: 14px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Off-chain dimension · Energy (proposal)</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="ghost">
+          <h3>ENERGY → the inflation node · fifth dimension</h3>
+          <span
+            >WTI / Brent / natural gas (with seasonality). The macro store
+            currently holds <b class="num">0 energy series</b>; but the livewire
+            lake is already landing raw CL (WTI) 5 contract months and BZ
+            (Brent) 4 contract months — the data path is half built. Details in
+            tab 06. <span class="tag real">REAL</span></span
+          >
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Boundary · what is NOT on this desk</h3>
+          <span class="tag q">Q7</span>
+        </div>
+        <div class="note-refuse">
+          <b>BOUNDARY</b> The SPX short-vol card (vrp_macro_signal) is
+          <b>not</b> on this desk: the "macro" in its name means index-level vol
+          (as opposed to single-name), it consumes no state from this chain, and
+          it is a trading-action surface (strikes/credit/Capture) — in conflict
+          with this desk's analysis-only, no-position discipline. It stays on
+          /regime and deserves its own deep link.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 01 FED · POLICY ══════════════════ -->
+  <section id="t1" role="tabpanel">
+    <div class="sec-title">
+      <h2>Fed · Policy</h2>
+      <span class="tag q">Q1 Q2 Q3 Q5 Q7</span
+      ><span class="state neust">ON_HOLD · conf 1.00</span>
+    </div>
+    <p class="sec-sub">
+      Merged from the existing /rates desk (5 tiers, 18 sections) and the
+      policy_rates card on /macro — the two already share one state engine and
+      one table, so the merge is deduplication, not new construction. This tab
+      answers <b>what the committee intends</b>; the term structure it produces
+      lives next door in <b>02 Rates · Curve</b>. The spine of this tab:
+      <b>four policy paths shown separately, never averaged</b> (a blended "Fed
+      path" would be a number no committee voted on, no dealer forecast, and no
+      market traded).
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Four policy paths · who says what</h3>
+          <span class="tag q">Q2</span>
+        </div>
+        <div class="chart">
+          <svg
+            viewBox="0 0 560 190"
+            role="img"
+            aria-label="Four policy paths compared: actual 3.625, dealer 3.63, committee 3.80, market-implied 3.88 percent"
+          >
+            <line x1="120" y1="20" x2="120" y2="160" stroke="#1e293b" />
+            <g stroke="#1e293b">
+              <line x1="220" y1="20" x2="220" y2="160" />
+              <line x1="320" y1="20" x2="320" y2="160" />
+              <line x1="420" y1="20" x2="420" y2="160" />
+              <line x1="520" y1="20" x2="520" y2="160" />
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="112" y="176" text-anchor="middle">3.50</text>
+              <text x="220" y="176" text-anchor="middle">3.625</text>
+              <text x="320" y="176" text-anchor="middle">3.75</text>
+              <text x="420" y="176" text-anchor="middle">3.875</text>
+              <text x="512" y="176" text-anchor="middle">4.00%</text>
+            </g>
+            <g font-size="10" fill="#94a3b8">
+              <text x="8" y="39">Actual (07-29 FOMC)</text>
+              <text x="8" y="74">Dealer (NY Fed SME)</text>
+              <text x="8" y="109">SEP median (end-26)</text>
+              <text x="8" y="144">Market (Dec-09 mtg)</text>
+            </g>
+            <g stroke="#1e293b" stroke-dasharray="2 3">
+              <line x1="120" y1="35" x2="520" y2="35" />
+              <line x1="120" y1="70" x2="520" y2="70" />
+              <line x1="120" y1="105" x2="520" y2="105" />
+              <line x1="120" y1="140" x2="520" y2="140" />
+            </g>
+            <line
+              x1="220"
+              y1="24"
+              x2="220"
+              y2="156"
+              stroke="#05ad98"
+              stroke-dasharray="3 3"
+              opacity=".6"
+            />
+            <circle
+              cx="220"
+              cy="35"
+              r="6"
+              fill="#e2e8f0"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Actual 3.625%</title>
+            </circle>
+            <circle
+              cx="224"
+              cy="70"
+              r="6"
+              fill="#38bdf8"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Dealer 3.63% (+0.5bp)</title>
+            </circle>
+            <circle
+              cx="360"
+              cy="105"
+              r="6"
+              fill="#8b5cf6"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Committee 3.80% (+17.5bp)</title>
+            </circle>
+            <circle
+              cx="424"
+              cy="140"
+              r="6"
+              fill="#f5a623"
+              stroke="#0a0f14"
+              stroke-width="2"
+            >
+              <title>Market-implied ≈3.88% (+25.5bp)</title>
+            </circle>
+            <g font-size="11" font-weight="600" fill="#e2e8f0">
+              <text x="232" y="39">3.625</text>
+              <text x="236" y="74">
+                3.63
+                <tspan fill="#94a3b8" font-weight="400">+0.5bp</tspan>
+              </text>
+              <text x="372" y="109">
+                3.80
+                <tspan fill="#94a3b8" font-weight="400">+17.5bp</tspan>
+              </text>
+              <text x="436" y="144">
+                ≈3.88
+                <tspan fill="#94a3b8" font-weight="400">+25.5bp</tspan>
+              </text>
+            </g>
+          </svg>
+          <div class="cap">
+            Spreads vs actual are API velocity values
+            <span class="tag real">REAL</span>; market-implied level = 3.625 +
+            25.5bp <span class="tag comp">COMPUTED</span> · widest forward-path
+            spread 25bp
+          </div>
+        </div>
+        <p class="read">
+          The dealer hugs the current rate (+0.5bp); the committee and the
+          market both sit above — what's priced is
+          <b>hawkish repricing / a hiking tail</b>, not cuts. Which pole the
+          three converge toward is the next leg; this convergence watch is the
+          panel's daily read. <br /><br />
+          <b
+            >They disagree on the level and agree on the direction of
+            revision.</b
+          >
+          The two panels below unroll the dealer dot and the committee dot into
+          their full distributions, and both show the same thing the market path
+          shows: cuts moving away, not closer.
+          <span class="tag comp">COMPUTED</span>
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> /api/macro/policy ← macro_observations (4
+          POLICY_PATH_* series) ← macro_market_layer_ingest 19:00–19:15 ET · SEP
+          published 2026-06-17, dealer survey 07-29 cycle
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Per-meeting odds · market-implied</h3>
+          <span class="tag q">Q2 Q6</span>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Sep 15–16</b><span class="num">implied 3.7264%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 38.57%">Hike 25 · 38.6%</span>
+            <span class="hd" style="width: 61.43%">Hold · 61.4%</span>
+          </div>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Oct 27–28</b><span class="num">implied 3.7750%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 19.43%">Hike · 19.4%</span>
+            <span class="hd" style="width: 80.57%">Hold · 80.6%</span>
+          </div>
+        </div>
+        <div class="meet">
+          <div class="meet-h">
+            <b>Dec 8–9</b><span class="num">implied 3.8800%</span>
+          </div>
+          <div class="pbar">
+            <span class="hk" style="width: 42%">Hike · 42.0%</span>
+            <span class="hd" style="width: 58%">Hold · 58.0%</span>
+          </div>
+        </div>
+        <p class="read">
+          Cuts priced at 0% at every horizon. The stored payload is internally a
+          <b>cumulative path</b>, which is the strongest sign it is genuine
+          market pricing rather than a display artifact — see the check below.
+        </p>
+        <div class="prov">
+          <b>Check</b> 3.63 (EFFR) + 38.57% × 25bp = 3.7264 ✓ · 3.7264 + 19.43%
+          × 25bp = 3.7750 ✓ · 3.7750 + 42.0% × 25bp = 3.8800 ✓
+          <span class="tag comp">COMPUTED</span> · payload: market-implied,
+          CME-style, stored jsonb 08-26 <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>Dealer expectations · the 3.63 dot, unrolled</h3>
+        <span class="tag q">Q2 Q3 Q6</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        The four-path chart above renders the dealer panel as a
+        <b>single dot at 3.63</b>. That dot is only the near horizon of a
+        16-point term structure — this is the whole curve, and three survey
+        vintages of it, because what the dealers have been <b>doing</b> carries
+        more information than where they currently sit.
+      </p>
+      <div class="chart">
+        <div class="lgd">
+          <span
+            ><i style="background: #f5a623"></i>2026-07-20 survey · latest</span
+          >
+          <span><i style="background: #38bdf8"></i>2026-06-08 survey</span>
+          <span><i style="background: #8b5cf6"></i>2026-04-20 survey</span>
+          <span
+            ><i style="background: rgba(245, 166, 35, 0.35)"></i>IQR p25–p75 ·
+            latest only</span
+          >
+          <span><i style="background: #e2e8f0"></i>EFFR 3.63 · actual</span>
+        </div>
+        <svg
+          viewBox="0 0 1120 262"
+          role="img"
+          aria-label="Expected policy rate by meeting date. Three New York Fed SME survey vintages overlaid, with the interquartile range of the latest vintage only. The first horizon priced below 3.63 moves out from September 2026 in the April survey, to 2027 Q2 in the June survey, to 2028 Q1 in the July survey."
+        >
+          <g stroke="#1e293b">
+            <line x1="70" y1="20" x2="70" y2="230" />
+            <line x1="70" y1="230" x2="1090" y2="230" />
+          </g>
+          <g stroke="#1e293b" stroke-dasharray="2 3">
+            <line x1="70" y1="24.7" x2="1090" y2="24.7" />
+            <line x1="70" y1="83" x2="1090" y2="83" />
+            <line x1="70" y1="141.3" x2="1090" y2="141.3" />
+            <line x1="70" y1="199.7" x2="1090" y2="199.7" />
+            <line x1="217" y1="20" x2="217" y2="230" />
+            <line x1="435.1" y1="20" x2="435.1" y2="230" />
+            <line x1="653.8" y1="20" x2="653.8" y2="230" />
+            <line x1="871.9" y1="20" x2="871.9" y2="230" />
+          </g>
+          <g fill="#94a3b8" font-size="10" text-anchor="end">
+            <text x="62" y="28">3.88</text>
+            <text x="62" y="86">3.63</text>
+            <text x="62" y="145">3.38</text>
+            <text x="62" y="203">3.13</text>
+          </g>
+          <text x="62" y="98" text-anchor="end" font-size="8.5" fill="#e2e8f0">
+            = EFFR
+          </text>
+          <g fill="#94a3b8" font-size="10" text-anchor="middle">
+            <text x="72" y="248" text-anchor="start">2026</text>
+            <text x="217" y="248">2027</text>
+            <text x="435.1" y="248">2028</text>
+            <text x="653.8" y="248">2029</text>
+            <text x="871.9" y="248">2030</text>
+          </g>
+          <polygon
+            points="124.4,83 153.7,83 178.8,83 203.8,83 233.1,83 262.4,83 287.5,83 325.2,83 380.1,41 435.1,41 489.5,83 543.8,83 598.8,83 653.8,83 871.9,99.3 1090,83 1090,199.7 871.9,199.7 653.8,199.7 598.8,199.7 543.8,199.7 489.5,199.7 435.1,199.7 380.1,199.7 325.2,199.7 287.5,141.3 262.4,141.3 233.1,83 203.8,83 178.8,83 153.7,83 124.4,83"
+            fill="rgba(245,166,35,0.07)"
+            stroke="rgba(245,166,35,0.25)"
+            stroke-width="1"
+            stroke-dasharray="2 3"
+          >
+            <title>
+              Latest vintage IQR (p25–p75). Zero width through Jan-2027; widest
+              68bp at 2027 Q3–Q4 (3.13–3.81).
+            </title>
+          </polygon>
+          <polyline
+            points="70,83 99.3,83 124.4,83 153.7,141.3 178.8,141.3 203.8,199.7 233.1,199.7 270.8,199.7 325.2,199.7 380.1,199.7 435.1,199.7 489.5,199.7 543.8,199.7 598.8,199.7 653.8,199.7 871.9,199.7 1090,199.7"
+            fill="none"
+            stroke="#8b5cf6"
+            stroke-width="1.8"
+            stroke-dasharray="5 4"
+          >
+            <title>
+              2026-04-20 survey · 17 horizons · first below 3.63 at the Sep
+              15–16 2026 meeting
+            </title>
+          </polyline>
+          <polyline
+            points="99.3,83 124.4,83 153.7,83 178.8,83 203.8,83 233.1,83 262.4,83 325.2,141.3 380.1,171.7 435.1,199.7 489.5,199.7 543.8,199.7 598.8,199.7 653.8,199.7 871.9,141.3 1090,141.3"
+            fill="none"
+            stroke="#38bdf8"
+            stroke-width="1.8"
+            stroke-dasharray="5 4"
+          >
+            <title>
+              2026-06-08 survey · 16 horizons · first below 3.63 at 2027 Q2
+            </title>
+          </polyline>
+          <polyline
+            points="124.4,83 153.7,83 178.8,83 203.8,83 233.1,83 262.4,83 287.5,83 325.2,83 380.1,83 435.1,83 489.5,141.3 543.8,171.7 598.8,199.7 653.8,199.7 871.9,199.7 1090,185.7"
+            fill="none"
+            stroke="#f5a623"
+            stroke-width="2.2"
+          >
+            <title>
+              2026-07-20 survey · latest · 16 horizons · first below 3.63 at
+              2028 Q1
+            </title>
+          </polyline>
+          <line
+            x1="70"
+            y1="83"
+            x2="1090"
+            y2="83"
+            stroke="#e2e8f0"
+            stroke-width="1.4"
+            stroke-dasharray="1 6"
+            opacity="0.9"
+          >
+            <title>
+              EFFR 3.63% — the actual policy rate the survey is measured against
+            </title>
+          </line>
+          <g fill="#f5a623">
+            <circle cx="124.4" cy="83" r="2.6">
+              <title>Jul. 28-29 2026 · 3.63 · n 26</title>
+            </circle>
+            <circle cx="153.7" cy="83" r="2.6">
+              <title>Sep. 15-16 2026 · 3.63 · n 26</title>
+            </circle>
+            <circle cx="178.8" cy="83" r="2.6">
+              <title>Oct. 27-28 2026 · 3.63 · n 26</title>
+            </circle>
+            <circle cx="203.8" cy="83" r="2.6">
+              <title>Dec. 8-9 2026 · 3.63 · n 26</title>
+            </circle>
+            <circle cx="233.1" cy="83" r="2.6">
+              <title>
+                Jan. 26-27 2027 · 3.63 · n 26 · last zero-width IQR horizon
+              </title>
+            </circle>
+            <circle cx="262.4" cy="83" r="2.6">
+              <title>
+                Mar. 16-17 2027 · 3.63 · IQR opens to 3.38–3.63 · n 26
+              </title>
+            </circle>
+            <circle cx="287.5" cy="83" r="2.6">
+              <title>Apr. 27-28 2027 · 3.63 · IQR 3.38–3.63 · n 26</title>
+            </circle>
+            <circle cx="325.2" cy="83" r="2.6">
+              <title>2027 Q2 · 3.63 · IQR 3.13–3.63 · n 26</title>
+            </circle>
+            <circle cx="380.1" cy="83" r="2.6">
+              <title>
+                2027 Q3 · 3.63 · IQR 3.13–3.81 (68bp, widest) · n 26
+              </title>
+            </circle>
+            <circle cx="435.1" cy="83" r="2.6">
+              <title>2027 Q4 · 3.63 · IQR 3.13–3.81 · n 26</title>
+            </circle>
+            <circle cx="543.8" cy="171.7" r="2.6">
+              <title>2028 Q2 · 3.25 · n 22</title>
+            </circle>
+            <circle cx="598.8" cy="199.7" r="2.6">
+              <title>2028 Q3 · 3.13 · n 22</title>
+            </circle>
+            <circle cx="653.8" cy="199.7" r="2.6">
+              <title>2028 Q4 · 3.13 · n 22</title>
+            </circle>
+            <circle cx="871.9" cy="199.7" r="2.6">
+              <title>2029 · 3.13 · n 22</title>
+            </circle>
+            <circle cx="1090" cy="185.7" r="2.6">
+              <title>2030 · 3.19 · n 22</title>
+            </circle>
+          </g>
+          <g stroke="#0a0f14" stroke-width="2">
+            <circle cx="153.7" cy="141.3" r="4.5" fill="#8b5cf6">
+              <title>
+                Apr-20 survey · first horizon below 3.63 · Sep. 15-16 2026 ·
+                3.38
+              </title>
+            </circle>
+            <circle cx="325.2" cy="141.3" r="4.5" fill="#38bdf8">
+              <title>
+                Jun-08 survey · first horizon below 3.63 · 2027 Q2 · 3.38
+              </title>
+            </circle>
+            <circle cx="489.5" cy="141.3" r="4.5" fill="#f5a623">
+              <title>
+                Jul-20 survey · first horizon below 3.63 · 2028 Q1 · 3.38 · n 22
+              </title>
+            </circle>
+          </g>
+          <g font-size="10" font-weight="600" text-anchor="end">
+            <text x="140.7" y="137" fill="#8b5cf6">APR ▸ Sep-26</text>
+            <text x="312.2" y="137" fill="#38bdf8">JUN ▸ 2027 Q2</text>
+            <text x="476.5" y="137" fill="#f5a623">JUL ▸ 2028 Q1</text>
+          </g>
+        </svg>
+        <div class="cap">
+          Ringed markers are each vintage's
+          <b>first horizon priced below 3.63</b> — all three step to exactly
+          3.38, a single 25bp cut <span class="tag comp">COMPUTED</span> ·
+          medians, IQR and n are payload values
+          <span class="tag real">REAL</span> · the latest vintage is solid with
+          markers, priors dashed without, as on /rates
+        </div>
+      </div>
+      <div class="grid g2" style="margin-top: 11px">
+        <p class="read">
+          Read the three lines by where each one first prices a rate below 3.63
+          — the first cut.
+          <b
+            >Apr-20 survey: Sep-2026. Jun-08 survey: 2027 Q2. Jul-20 survey:
+            2028 Q1.</b
+          >
+          Ninety-one days of calendar (Apr 20 → Jul 20) pushed that horizon out
+          by 562 days — <b>6.2 days of delay bought per day elapsed</b>. Every
+          vintage's first move is the same single 25bp step to 3.38; the only
+          thing being revised is <i>when</i>. This is the same repricing the
+          market-implied path shows, arriving from a different instrument and a
+          different respondent set — 22–26 surveyed dealers against traded
+          fed-funds pricing. Two independent measurements agreeing on
+          <b>hawkish repricing, not cuts</b> is worth more than either alone.
+          The caveat is dating: this survey is 37 days old, so it corroborates
+          the direction <b>through 20 July</b> and is silent on the five weeks
+          since — that stretch is the market path's evidence alone.
+        </p>
+        <p class="read">
+          The band is the second piece of information, and it is the one the
+          original /rates page draws but never states.
+          <b>p25 = p75 = 3.63 through Jan-2027</b> — five consecutive meeting
+          horizons at zero dealer disagreement — and it fans open at
+          <b>the Mar 16–17 2027 meeting</b>, reaching 68bp by 2027 Q3
+          (3.13–3.81). So the panel dates the end of consensus precisely:
+          dealers agree about everything up to January 2027 and about nothing
+          after March 2027. A PM reads that as the horizon where the dealer
+          median stops being a forecast and starts being an average of
+          disagreements — and it is the natural expiry boundary for anything
+          traded off this path.
+        </p>
+      </div>
+      <div class="prov">
+        <b>Pipeline</b> /api/macro/policy → <code>.dealer_expectations</code> ←
+        router <code>src/uw_scan/api/routers/macro.py:28</code> · source
+        <code>new_york_fed_sme</code>, parser <code>nyfed_sme.v1</code>,
+        cost_class free_official <span class="tag real">REAL</span> · endpoint
+        EXISTS in production
+      </div>
+      <div class="prov">
+        <b>Honesty</b> release_date 2026-07-20 = <b>37 days old</b> at the 08-26
+        pull · <code>published_at</code> is null on all three vintages, so these
+        are labelled by <b>release date only</b> — never call it a publication
+        instant · <code>quality_status: "partial"</code> on all three · n varies
+        by horizon, <b>22–26</b> on the latest, the far horizons answered by
+        fewer dealers · the two earlier vintages are separate releases shown for
+        movement, <b>never merged into the latest</b> · and this survey is never
+        merged with, or averaged against, the committee's own projection — they
+        are different questions put to different people
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>Committee projections · the 3.80 dot, unrolled</h3>
+        <span class="tag q">Q1 Q3</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        The four-path chart above shows the committee as a single dot at 3.80.
+        This is that dot's distribution — every participant's own projection,
+        anonymous, one circle each.
+        <b>The count is the fact; the identity is never guessed.</b>
+      </p>
+      <div class="chart">
+        <div class="lgd">
+          <span
+            ><i style="background: #f5a623"></i>Median · SEP released
+            2026-06-17</span
+          >
+          <span
+            ><i style="background: #38bdf8"></i>Prior median · released
+            2026-03-18</span
+          >
+          <span
+            ><i style="background: rgba(245, 166, 35, 0.3)"></i>Central
+            tendency</span
+          >
+          <span
+            ><i style="background: #e2e8f0; border-radius: 50%"></i>One
+            participant</span
+          >
+        </div>
+        <svg
+          viewBox="0 0 1120 300"
+          role="img"
+          aria-label="Federal Reserve Summary of Economic Projections dot plot for 2026, 2027, 2028 and the longer run. Each circle is one anonymous participant projection. The median path was revised up between the March and June releases at every horizon except the longer run."
+        >
+          <line
+            x1="56"
+            y1="24"
+            x2="1060"
+            y2="24"
+            stroke="#1e293b"
+            stroke-dasharray="3 4"
+          />
+          <text
+            x="50"
+            y="27.5"
+            fill="var(--text-muted)"
+            font-size="10"
+            text-anchor="end"
+            font-family="var(--mono)"
+          >
+            4.50
+          </text>
+          <line
+            x1="56"
+            y1="88"
+            x2="1060"
+            y2="88"
+            stroke="#1e293b"
+            stroke-dasharray="3 4"
+          />
+          <text
+            x="50"
+            y="91.5"
+            fill="var(--text-muted)"
+            font-size="10"
+            text-anchor="end"
+            font-family="var(--mono)"
+          >
+            4.00
+          </text>
+          <line
+            x1="56"
+            y1="152.1"
+            x2="1060"
+            y2="152.1"
+            stroke="#1e293b"
+            stroke-dasharray="3 4"
+          />
+          <text
+            x="50"
+            y="155.6"
+            fill="var(--text-muted)"
+            font-size="10"
+            text-anchor="end"
+            font-family="var(--mono)"
+          >
+            3.50
+          </text>
+          <line
+            x1="56"
+            y1="216"
+            x2="1060"
+            y2="216"
+            stroke="#1e293b"
+            stroke-dasharray="3 4"
+          />
+          <text
+            x="50"
+            y="219.5"
+            fill="var(--text-muted)"
+            font-size="10"
+            text-anchor="end"
+            font-family="var(--mono)"
+          >
+            3.00
+          </text>
+          <g stroke="#1e293b">
+            <line x1="56" y1="18" x2="56" y2="246" />
+            <line x1="56" y1="246" x2="1060" y2="246" />
+          </g>
+          <rect
+            x="81.5"
+            y="75.2"
+            width="200"
+            height="64"
+            fill="rgba(245,166,35,0.07)"
+            rx="2"
+          >
+            <title>2026 central tendency 3.6–4.1%</title>
+          </rect>
+          <rect
+            x="332.5"
+            y="100.9"
+            width="200"
+            height="102.4"
+            fill="rgba(245,166,35,0.07)"
+            rx="2"
+          >
+            <title>2027 central tendency 3.1–3.9%</title>
+          </rect>
+          <rect
+            x="583.5"
+            y="139.2"
+            width="200"
+            height="64.1"
+            fill="rgba(245,166,35,0.07)"
+            rx="2"
+          >
+            <title>2028 central tendency 3.1–3.6%</title>
+          </rect>
+          <rect
+            x="834.5"
+            y="152.1"
+            width="200"
+            height="63.9"
+            fill="rgba(245,166,35,0.07)"
+            rx="2"
+          >
+            <title>Longer run central tendency 3.0–3.5%</title>
+          </rect>
+          <line
+            x1="181.5"
+            y1="36.8"
+            x2="181.5"
+            y2="164.8"
+            stroke="#1e293b"
+            stroke-width="1"
+          />
+          <line
+            x1="432.5"
+            y1="36.8"
+            x2="432.5"
+            y2="228.8"
+            stroke="#1e293b"
+            stroke-width="1"
+          />
+          <line
+            x1="683.5"
+            y1="100.9"
+            x2="683.5"
+            y2="228.8"
+            stroke="#1e293b"
+            stroke-width="1"
+          />
+          <line
+            x1="934.5"
+            y1="100.9"
+            x2="934.5"
+            y2="228.8"
+            stroke="#1e293b"
+            stroke-width="1"
+          />
+          <polyline
+            points="181.5,164.8 432.5,203.3 683.5,203.3 934.5,203.3"
+            fill="none"
+            stroke="#38bdf8"
+            stroke-width="2.5"
+            stroke-dasharray="7 5"
+            opacity="0.9"
+          />
+          <circle cx="181.5" cy="164.8" r="4.5" fill="#38bdf8" />
+          <circle cx="432.5" cy="203.3" r="4.5" fill="#38bdf8" />
+          <circle cx="683.5" cy="203.3" r="4.5" fill="#38bdf8" />
+          <circle cx="934.5" cy="203.3" r="4.5" fill="#38bdf8" />
+          <circle
+            cx="181.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.375% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="111.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="131.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="151.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="171.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="191.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="211.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="231.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="251.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.625% · 8 participants at this rate</title>
+          </circle>
+          <circle
+            cx="161.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="181.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="201.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="141.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.125% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="161.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.125% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="181.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.125% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="201.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.125% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="221.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.125% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="181.5"
+            cy="40"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2026 · 4.375% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="432.5"
+            cy="232"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 2.875% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="402.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.125% · 4 participants at this rate</title>
+          </circle>
+          <circle
+            cx="422.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.125% · 4 participants at this rate</title>
+          </circle>
+          <circle
+            cx="442.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.125% · 4 participants at this rate</title>
+          </circle>
+          <circle
+            cx="462.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.125% · 4 participants at this rate</title>
+          </circle>
+          <circle
+            cx="412.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.375% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="432.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.375% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="452.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.375% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="422.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.625% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="442.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.625% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="392.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.875% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="412.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.875% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="432.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.875% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="452.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.875% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="472.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 3.875% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="422.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 4.125% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="442.5"
+            cy="72"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 4.125% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="432.5"
+            cy="40"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2027 · 4.375% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="683.5"
+            cy="232"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 2.875% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="633.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="653.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="673.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="693.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="713.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="733.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.125% · 6 participants at this rate</title>
+          </circle>
+          <circle
+            cx="673.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.375% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="693.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.375% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="643.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.625% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="663.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.625% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="683.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.625% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="703.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.625% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="723.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.625% · 5 participants at this rate</title>
+          </circle>
+          <circle
+            cx="663.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="683.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="703.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>2028 · 3.875% · 3 participants at this rate</title>
+          </circle>
+          <circle
+            cx="924.5"
+            cy="232"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 2.875% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="944.5"
+            cy="232"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 2.875% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="874.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="894.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="914.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="954.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="974.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="994.5"
+            cy="216"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.000% · 7 participants at this rate</title>
+          </circle>
+          <circle
+            cx="924.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.125% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="944.5"
+            cy="200"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.125% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="184"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.250% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="924.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.375% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="944.5"
+            cy="168"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.375% · 2 participants at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="152"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.500% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="136"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.625% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="120"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.750% · 1 participant at this rate</title>
+          </circle>
+          <circle
+            cx="934.5"
+            cy="104"
+            r="5"
+            fill="none"
+            stroke="#e2e8f0"
+            stroke-width="1.5"
+            opacity="0.85"
+          >
+            <title>Longer run · 3.875% · 1 participant at this rate</title>
+          </circle>
+          <line
+            x1="73.5"
+            y1="113.6"
+            x2="289.5"
+            y2="113.6"
+            stroke="#f5a623"
+            stroke-width="3"
+          />
+          <text
+            x="293.5"
+            y="117.5"
+            fill="#f5a623"
+            font-size="11"
+            font-family="var(--mono)"
+          >
+            3.8
+          </text>
+          <line
+            x1="324.5"
+            y1="139.2"
+            x2="540.5"
+            y2="139.2"
+            stroke="#f5a623"
+            stroke-width="3"
+          />
+          <text
+            x="544.5"
+            y="143.1"
+            fill="#f5a623"
+            font-size="11"
+            font-family="var(--mono)"
+          >
+            3.6
+          </text>
+          <line
+            x1="575.5"
+            y1="164.8"
+            x2="791.5"
+            y2="164.8"
+            stroke="#f5a623"
+            stroke-width="3"
+          />
+          <text
+            x="795.5"
+            y="168.7"
+            fill="#f5a623"
+            font-size="11"
+            font-family="var(--mono)"
+          >
+            3.4
+          </text>
+          <line
+            x1="826.5"
+            y1="203.3"
+            x2="1042.5"
+            y2="203.3"
+            stroke="#f5a623"
+            stroke-width="3"
+          />
+          <text
+            x="1046.5"
+            y="207.2"
+            fill="#f5a623"
+            font-size="11"
+            font-family="var(--mono)"
+          >
+            3.1
+          </text>
+          <text
+            x="181.5"
+            y="265"
+            fill="var(--text-secondary)"
+            font-size="11"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            2026
+          </text>
+          <text
+            x="181.5"
+            y="280"
+            fill="var(--text-muted)"
+            font-size="9.5"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            n=18
+          </text>
+          <text
+            x="432.5"
+            y="265"
+            fill="var(--text-secondary)"
+            font-size="11"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            2027
+          </text>
+          <text
+            x="432.5"
+            y="280"
+            fill="var(--text-muted)"
+            font-size="9.5"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            n=18
+          </text>
+          <text
+            x="683.5"
+            y="265"
+            fill="var(--text-secondary)"
+            font-size="11"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            2028
+          </text>
+          <text
+            x="683.5"
+            y="280"
+            fill="var(--warning)"
+            font-size="9.5"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            n=17
+          </text>
+          <text
+            x="934.5"
+            y="265"
+            fill="var(--text-secondary)"
+            font-size="11"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            Longer run
+          </text>
+          <text
+            x="934.5"
+            y="280"
+            fill="var(--text-muted)"
+            font-size="9.5"
+            text-anchor="middle"
+            font-family="var(--mono)"
+          >
+            n=18
+          </text>
+        </svg>
+        <div class="cap">
+          federal_reserve_sep · release 2026-06-17 · prior release overlaid,
+          never merged
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+
+      <div class="grid g2" style="margin-top: 11px; align-items: start">
+        <div>
+          <div class="tbl-wrap">
+            <table>
+              <tr>
+                <th>Horizon</th>
+                <th class="num">Jun-17 median</th>
+                <th class="num">Mar-18 median</th>
+                <th class="num">Revision</th>
+              </tr>
+              <tr>
+                <td>2026</td>
+                <td class="num">3.8</td>
+                <td class="num">3.4</td>
+                <td class="num" style="color: var(--warning)">+40 bp</td>
+              </tr>
+              <tr>
+                <td>2027</td>
+                <td class="num">3.6</td>
+                <td class="num">3.1</td>
+                <td class="num" style="color: var(--warning)">+50 bp</td>
+              </tr>
+              <tr>
+                <td>2028</td>
+                <td class="num">3.4</td>
+                <td class="num">3.1</td>
+                <td class="num" style="color: var(--warning)">+30 bp</td>
+              </tr>
+              <tr>
+                <td><b>Longer run</b></td>
+                <td class="num">3.1</td>
+                <td class="num">3.1</td>
+                <td class="num" style="color: var(--text-secondary)">
+                  unchanged
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class="cap" style="margin-top: 8px">
+            revision = Jun-17 median − Mar-18 median
+            <span class="tag comp">COMPUTED</span>
+          </div>
+        </div>
+        <p class="read" style="margin: 0">
+          <b>The committee raised the path without moving the destination.</b>
+          Every dated horizon was revised up 30–50bp between March and June,
+          while the longer-run dot did not move at all. That is a statement
+          about the journey, not the terminal rate — and it is the reason a
+          single "Fed dot" summary would destroy the information.
+          <br /><br />
+          <b>Read across the three sources and the pattern is exact:</b> they
+          disagree on the <b>level</b> — 3.625 actual · 3.63 dealer · 3.80 SEP ·
+          ≈3.88 market-implied — and agree on the <b>direction of revision</b>.
+          Market pricing has removed cuts, dealers have pushed the first cut out
+          18 months, and the committee has lifted its own path. Three
+          independent respondent sets, one direction.
+          <span class="tag comp">COMPUTED</span>
+        </p>
+      </div>
+
+      <div class="note-refuse" style="margin-top: 11px">
+        <b>2028 carries 17 dots, not 18.</b> One participant is absent from that
+        column in the published table. The count is printed as it is and never
+        normalised to the other horizons — a synthetic eighteenth dot would be a
+        projection nobody made. <b>Longer run has no date</b>: its
+        <span class="num">horizon_date</span> is null, so it is labelled, never
+        placed on a date axis.
+      </div>
+
+      <div class="prov">
+        <b>Pipeline</b> /api/macro/policy → .committee_projection ←
+        <span class="num">src/uw_scan/api/routers/macro.py:28</span> ·
+        source_record_id
+        <span class="num">fed-sep:fomcprojtabl20260617:html</span> · published
+        2026-06-18T02:00+08:00 · quality_status <b>partial</b> · parser_version
+        fed_sep.v2
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>State &amp; confidence · the engine's own proof</h3>
+          <span class="tag q">Q1 Q7</span>
+        </div>
+        <div class="arith">
+          <span class="term">1.00<small>completeness 3/3</small></span
+          ><span class="op">×</span>
+          <span class="term">1.00<small>freshness · stalest 26d</small></span
+          ><span class="op">×</span>
+          <span class="term">1.00<small>quality · official</small></span
+          ><span class="op">×</span>
+          <span class="term">(1−0)<small>no contradiction penalty</small></span
+          ><span class="op">=</span>
+          <span class="res">conf 1.00</span>
+        </div>
+        <p class="read">
+          Direction reports UNKNOWN deliberately: with the three forward paths
+          disagreeing (widest spread 25bp), the engine refuses to invent a
+          "direction" out of them. UNKNOWN ≠ NEUTRAL — an absent view is not a
+          neutral view. Week path: 1.00 → 0.85 → 1.00, dipped and repaired
+          within the week <span class="tag real">REAL</span>.
+        </p>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>velocity metric</th>
+              <th class="num">value</th>
+            </tr>
+            <tr>
+              <td>committee_projection_vs_actual</td>
+              <td class="num">+17.5bp</td>
+            </tr>
+            <tr>
+              <td>dealer_expectations_vs_actual</td>
+              <td class="num">+0.5bp</td>
+            </tr>
+            <tr>
+              <td>market_implied_vs_actual</td>
+              <td class="num">+25.5bp</td>
+            </tr>
+            <tr>
+              <td>widest_forward_path_spread</td>
+              <td class="num">25.0bp</td>
+            </tr>
+            <tr>
+              <td>real_share_of_nominal_change</td>
+              <td class="num">−5 (ratio)</td>
+            </tr>
+          </table>
+        </div>
+        <div class="prov">
+          <b>Note</b> API notes verbatim: curve steepness is reported as
+          steepness; the domain's only term-premium number comes from the
+          Cleveland Fed's estimated model — slope never impersonates term
+          premium <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Plumbing · the balance sheet behind the rate</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Aggregate</th>
+              <th class="num">Level</th>
+              <th>Qualifier (verbatim)</th>
+            </tr>
+            <tr>
+              <td>Fed assets · WALCL</td>
+              <td class="num">6.75 $T</td>
+              <td>Balance sheet expanding</td>
+            </tr>
+            <tr>
+              <td>Reserves · WRESBAL</td>
+              <td class="num">2.94 $T</td>
+              <td>reserve buffer lower</td>
+            </tr>
+            <tr>
+              <td>ON RRP</td>
+              <td class="num">0.00 $T</td>
+              <td>near-zero ON RRP</td>
+            </tr>
+            <tr>
+              <td>TGA · WTREGEN</td>
+              <td class="num">0.95 $T</td>
+              <td>high TGA liquidity drag</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          The target range is <b>3.50–3.75%</b> with EFFR at 3.63 and SOFR at
+          3.65 — the rate is where the committee put it. This table is the other
+          half:
+          <b>how much cash is in the system that the rate is being charged on</b
+          >. Reserves falling while the TGA holds ~$0.95T is drain the policy
+          rate does not show, and ON RRP at zero means the shock absorber that
+          used to sit between them is gone.
+        </p>
+        <div class="note-refuse">
+          <b>Five days behind the rest of this tab.</b> WALCL, WRESBAL and
+          WTREGEN all report <span class="num">status: partial</span> at
+          <span class="num">latest_obs_date 2026-08-19</span> against the
+          snapshot's 2026-08-24 as_of. The levels are real; they are simply
+          older than everything beside them, and a reserve number five days
+          stale is not the same evidence as a rate five minutes old.
+        </div>
+        <div class="prov">
+          <b>Pipeline</b> /api/rates/snapshot → .policy.plumbing ←
+          <span class="num">src/uw_scan/api/routers/rates.py:28</span> ·
+          plumbing_read verbatim: "Balance sheet expanding; reserve buffer
+          lower; near-zero ON RRP; high TGA liquidity drag"
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Next events</h3>
+          <span class="tag q">Q6</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Date</th>
+              <th>Event</th>
+              <th>What it can move</th>
+            </tr>
+            <tr>
+              <td class="num">2026-09-15/16</td>
+              <td>FOMC — 38.6% hike priced</td>
+              <td>policy_actual → full downstream recompute</td>
+            </tr>
+            <tr>
+              <td class="num">2026-10-27/28</td>
+              <td>FOMC — 19.4% hike priced</td>
+              <td>same</td>
+            </tr>
+            <tr>
+              <td class="num">2026-12-08/09</td>
+              <td>FOMC — 42.0% hike priced</td>
+              <td>same · SEP refresh cycle</td>
+            </tr>
+          </table>
+        </div>
+        <div class="prov">
+          <b>Source</b> rates_policy_events, calendar through 2027-12-07
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>What this tab refuses</h3>
+          <span class="tag q">Q7</span>
+        </div>
+        <ul class="tight">
+          <li>
+            <b>No averaging of the four paths</b> — PolicyPathComparison
+            component comment, verbatim: "a blended 'Fed path' would be a number
+            no committee voted on, no dealer forecast, and no market traded"
+          </li>
+          <li>
+            <b>SEP dots stay anonymous</b> — the FOMC does not publish
+            attribution and we do not guess ("never /chair|powell/i", hardened
+            by an e2e test)
+          </li>
+          <li>
+            <b>17 dots stay 17</b> — the 2028 SEP column is one participant
+            short and is printed that way; normalising it to 18 would invent a
+            projection nobody made
+          </li>
+          <li>
+            <b>A stale survey corroborates only its own window</b> — the dealer
+            path is 37 days old, so it confirms the direction through 20 July
+            and says nothing about the five weeks since
+          </li>
+        </ul>
+        <div class="cap" style="margin-top: 8px">
+          The curve-side refusals (slope ≠ term premium, the demoted legacy
+          scorecard) moved with their evidence to <b>02 Rates · Curve</b>
+        </div>
+        <div class="prov">
+          <b>Source</b> web/components/rates/*.tsx code comments and tests ·
+          these invariants migrate wholesale with the merge
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 02 RATES · CURVE ══════════════════ -->
+  <section id="t2" role="tabpanel">
+    <div class="sec-title">
+      <h2>Rates · Curve</h2>
+      <span class="tag q">Q2 Q4 Q5</span>
+    </div>
+    <p class="sec-sub">
+      Split out of the Fed tab deliberately:
+      <b
+        >what the committee intends and what the term structure is pricing are
+        two different questions</b
+      >, and the original /rates page — five tiers, eighteen sections — answered
+      them in one scroll. This tab is the market's side. The curve prints the
+      level, the decompositions say what is inside it, the attribution says who
+      moved it, and the auction table says whether anyone absorbed it.
+    </p>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>Par yield curve · current vs 1W vs 1M</h3>
+        <span class="tag q">Q2 Q4</span>
+      </div>
+      <div class="grid g2" style="align-items: start">
+        <div class="chart">
+          <div class="lgd">
+            <span><i style="background: #f5a623"></i>Current · 2026-08-24</span>
+            <span><i style="background: #38bdf8"></i>1W ago</span>
+            <span><i style="background: #8b5cf6"></i>1M ago</span>
+          </div>
+          <svg
+            viewBox="0 0 560 232"
+            role="img"
+            aria-label="Par yield curve across eleven tenors from one month to thirty years, with the curve one week ago and one month ago overlaid. The front end fell over the month while the long end rose."
+          >
+            <g stroke="#1e293b">
+              <line x1="40" y1="18" x2="40" y2="195" />
+              <line x1="40" y1="195" x2="535" y2="195" />
+            </g>
+            <g stroke="#1e293b" stroke-dasharray="2 3">
+              <line x1="40" y1="18" x2="535" y2="18" />
+              <line x1="40" y1="59.6" x2="535" y2="59.6" />
+              <line x1="40" y1="101.3" x2="535" y2="101.3" />
+              <line x1="40" y1="143" x2="535" y2="143" />
+              <line x1="40" y1="184.6" x2="535" y2="184.6" />
+            </g>
+            <g fill="#94a3b8" font-size="9.5" text-anchor="end">
+              <text x="34" y="21">5.40</text>
+              <text x="34" y="63">5.00</text>
+              <text x="34" y="105">4.60</text>
+              <text x="34" y="146">4.20</text>
+              <text x="34" y="188">3.80</text>
+            </g>
+            <g fill="#94a3b8" font-size="9.5" text-anchor="middle">
+              <text x="40" y="212">1M</text>
+              <text x="89.5" y="212">3M</text>
+              <text x="139" y="212">6M</text>
+              <text x="188.5" y="212">1Y</text>
+              <text x="238" y="212">2Y</text>
+              <text x="287.5" y="212">3Y</text>
+              <text x="337" y="212">5Y</text>
+              <text x="386.5" y="212">7Y</text>
+              <text x="436" y="212">10Y</text>
+              <text x="485.5" y="212">20Y</text>
+              <text x="535" y="212">30Y</text>
+            </g>
+            <polyline
+              points="40,184.6 89.5,167.9 139,155.4 188.5,149.2 238,129.4 287.5,126.3 337,119 386.5,106.5 436,91.9 485.5,40.9 535,43"
+              fill="none"
+              stroke="#8b5cf6"
+              stroke-width="1.8"
+              stroke-dasharray="4 3"
+            >
+              <title>
+                1M ago — reconstructed as value − 1M delta; anchor date not
+                carried in the payload
+              </title>
+            </polyline>
+            <polyline
+              points="40,185.6 89.5,177.3 139,168.9 188.5,163.8 238,144 287.5,137.8 337,124.2 386.5,107.5 436,88.8 485.5,28.4 535,27.4"
+              fill="none"
+              stroke="#38bdf8"
+              stroke-width="1.8"
+              stroke-dasharray="4 3"
+            >
+              <title>
+                1W ago — reconstructed as value − 1W delta; anchor date not
+                carried in the payload
+              </title>
+            </polyline>
+            <polyline
+              points="40,185.6 89.5,177.3 139,167.9 188.5,159.6 238,138.8 287.5,131.5 337,121.1 386.5,106.5 436,90.9 485.5,37.8 535,35.7"
+              fill="none"
+              stroke="#f5a623"
+              stroke-width="2.2"
+            >
+              <title>Current par curve, obs_date 2026-08-24</title>
+            </polyline>
+            <g fill="#f5a623" stroke="#0a0f14" stroke-width="1.4">
+              <circle cx="40" cy="185.6" r="3">
+                <title>
+                  1M (DGS1MO) 3.79% · 1D −1.0 · 1W 0.0 · 1M −1.0 bps
+                </title>
+              </circle>
+              <circle cx="89.5" cy="177.3" r="3">
+                <title>
+                  3M (DGS3MO) 3.87% · 1D −1.0 · 1W 0.0 · 1M −9.0 bps
+                </title>
+              </circle>
+              <circle cx="139" cy="167.9" r="3">
+                <title>
+                  6M (DGS6MO) 3.96% · 1D +1.0 · 1W +1.0 · 1M −12.0 bps
+                </title>
+              </circle>
+              <circle cx="188.5" cy="159.6" r="3">
+                <title>
+                  1Y (DGS1) 4.04% · 1D +1.0 · 1W +4.0 · 1M −10.0 bps
+                </title>
+              </circle>
+              <circle cx="238" cy="138.8" r="3">
+                <title>2Y (DGS2) 4.24% · 1D 0.0 · 1W +5.0 · 1M −9.0 bps</title>
+              </circle>
+              <circle cx="287.5" cy="131.5" r="3">
+                <title>3Y (DGS3) 4.31% · 1D 0.0 · 1W +6.0 · 1M −5.0 bps</title>
+              </circle>
+              <circle cx="337" cy="121.1" r="3">
+                <title>5Y (DGS5) 4.41% · 1D −2.0 · 1W +3.0 · 1M −2.0 bps</title>
+              </circle>
+              <circle cx="386.5" cy="106.5" r="3">
+                <title>7Y (DGS7) 4.55% · 1D −2.0 · 1W +1.0 · 1M 0.0 bps</title>
+              </circle>
+              <circle cx="436" cy="90.9" r="3">
+                <title>
+                  10Y (DGS10) 4.70% · 1D −4.0 · 1W −2.0 · 1M +1.0 bps
+                </title>
+              </circle>
+              <circle cx="485.5" cy="37.8" r="3">
+                <title>
+                  20Y (DGS20) 5.21% · 1D −4.0 · 1W −9.0 · 1M +3.0 bps
+                </title>
+              </circle>
+              <circle cx="535" cy="35.7" r="3">
+                <title>
+                  30Y (DGS30) 5.23% · 1D −4.0 · 1W −8.0 · 1M +7.0 bps
+                </title>
+              </circle>
+            </g>
+          </svg>
+          <div class="cap">
+            Current curve + deltas are stored values
+            <span class="tag real">REAL</span>; the 1W and 1M curves are
+            <b>reconstructed</b>, not stored
+            <span class="tag comp">COMPUTED</span> — see the provenance note
+          </div>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>tenor</th>
+              <th class="num">yield</th>
+              <th class="num">1D</th>
+              <th class="num">1W</th>
+              <th class="num">1M</th>
+            </tr>
+            <tr>
+              <td>1M</td>
+              <td class="num">3.79 %</td>
+              <td class="num delta-up">−1.0</td>
+              <td class="num delta-flat">0.0</td>
+              <td class="num delta-up">−1.0</td>
+            </tr>
+            <tr>
+              <td>3M</td>
+              <td class="num">3.87 %</td>
+              <td class="num delta-up">−1.0</td>
+              <td class="num delta-flat">0.0</td>
+              <td class="num delta-up">−9.0</td>
+            </tr>
+            <tr>
+              <td>6M</td>
+              <td class="num">3.96 %</td>
+              <td class="num delta-dn">+1.0</td>
+              <td class="num delta-dn">+1.0</td>
+              <td class="num delta-up">−12.0</td>
+            </tr>
+            <tr>
+              <td>1Y</td>
+              <td class="num">4.04 %</td>
+              <td class="num delta-dn">+1.0</td>
+              <td class="num delta-dn">+4.0</td>
+              <td class="num delta-up">−10.0</td>
+            </tr>
+            <tr>
+              <td>2Y</td>
+              <td class="num">4.24 %</td>
+              <td class="num delta-flat">0.0</td>
+              <td class="num delta-dn">+5.0</td>
+              <td class="num delta-up">−9.0</td>
+            </tr>
+            <tr>
+              <td>3Y</td>
+              <td class="num">4.31 %</td>
+              <td class="num delta-flat">0.0</td>
+              <td class="num delta-dn">+6.0</td>
+              <td class="num delta-up">−5.0</td>
+            </tr>
+            <tr>
+              <td>5Y</td>
+              <td class="num">4.41 %</td>
+              <td class="num delta-up">−2.0</td>
+              <td class="num delta-dn">+3.0</td>
+              <td class="num delta-up">−2.0</td>
+            </tr>
+            <tr>
+              <td>7Y</td>
+              <td class="num">4.55 %</td>
+              <td class="num delta-up">−2.0</td>
+              <td class="num delta-dn">+1.0</td>
+              <td class="num delta-flat">0.0</td>
+            </tr>
+            <tr>
+              <td>10Y</td>
+              <td class="num">4.70 %</td>
+              <td class="num delta-up">−4.0</td>
+              <td class="num delta-up">−2.0</td>
+              <td class="num delta-dn">+1.0</td>
+            </tr>
+            <tr>
+              <td>20Y</td>
+              <td class="num">5.21 %</td>
+              <td class="num delta-up">−4.0</td>
+              <td class="num delta-up">−9.0</td>
+              <td class="num delta-dn">+3.0</td>
+            </tr>
+            <tr>
+              <td>30Y</td>
+              <td class="num">5.23 %</td>
+              <td class="num delta-up">−4.0</td>
+              <td class="num delta-up">−8.0</td>
+              <td class="num delta-dn">+7.0</td>
+            </tr>
+          </table>
+          <div class="cap" style="margin-top: 8px">
+            bps. Colour follows the <b>bond convention</b>, as on /rates: teal =
+            yield fell, red = yield rose — the opposite sense of an equity price
+            delta. The sign carries the direction on its own
+          </div>
+        </div>
+      </div>
+      <div class="grid g4" style="margin-top: 12px">
+        <div class="chart">
+          <div
+            style="
+              font-family: var(--mono);
+              font-size: 10px;
+              letter-spacing: 1.2px;
+              text-transform: uppercase;
+              color: var(--text-muted);
+            "
+          >
+            2s10s
+          </div>
+          <div class="big">+46.0<small> bps</small></div>
+          <div class="cap">
+            1W <b>−7.0</b> flatter · 1M <b>+10.0</b> steeper
+          </div>
+        </div>
+        <div class="chart">
+          <div
+            style="
+              font-family: var(--mono);
+              font-size: 10px;
+              letter-spacing: 1.2px;
+              text-transform: uppercase;
+              color: var(--text-muted);
+            "
+          >
+            5s30s
+          </div>
+          <div class="big">+82.0<small> bps</small></div>
+          <div class="cap">
+            1W <b>−11.0</b> flatter · 1M <b>+9.0</b> steeper
+          </div>
+        </div>
+        <div class="chart">
+          <div
+            style="
+              font-family: var(--mono);
+              font-size: 10px;
+              letter-spacing: 1.2px;
+              text-transform: uppercase;
+              color: var(--text-muted);
+            "
+          >
+            3m10y
+          </div>
+          <div class="big">+83.0<small> bps</small></div>
+          <div class="cap">
+            1W <b>−2.0</b> flatter · 1M <b>+10.0</b> steeper
+          </div>
+        </div>
+        <div class="chart">
+          <div
+            style="
+              font-family: var(--mono);
+              font-size: 10px;
+              letter-spacing: 1.2px;
+              text-transform: uppercase;
+              color: var(--text-muted);
+            "
+          >
+            2s5s10s butterfly
+          </div>
+          <div class="big">−12.0<small> bps</small></div>
+          <div class="cap">
+            1W <b>+3.0</b> · 1M <b>+4.0</b> — belly cheapening
+          </div>
+        </div>
+      </div>
+      <div class="grid g2" style="margin-top: 11px">
+        <p class="read">
+          <b
+            >10Y prints 4.70 here; the decomposition panel directly below says
+            what is inside that number</b
+          >
+          — 2.38 real + 2.32 breakeven. One figure, two questions: the curve
+          asks where 10Y sits against the rest of the curve, the decomposition
+          asks which half of it moved. Over the month the curve
+          <b>bull-steepened</b> — front end down (3M −9, 6M −12, 1Y −10, 2Y −9
+          bps) while the long end rose (20Y +3, 30Y +7). Over the past week that
+          partly <b>reversed into a bear-flattening</b>: 1Y +4, 2Y +5, 3Y +6
+          against 10Y −2, 20Y −9, 30Y −8. The original /rates page answers this
+          panel with a fixed sentence — "normal positive slope; long-end yield
+          pickup is meaningful" — which is true of every day this year and
+          therefore tells a PM nothing. What is worth reading is the two-speed
+          reversal, and it is only visible as a Δ.
+        </p>
+        <div>
+          <div class="arith">
+            <span class="term">−2.0<small>Δ10Y 1W</small></span
+            ><span class="op">−</span>
+            <span class="term">+5.0<small>Δ2Y 1W</small></span
+            ><span class="op">=</span>
+            <span class="res">2s10s −7.0bp</span>
+          </div>
+          <div class="arith" style="margin-top: 6px">
+            <span class="term">+1.0<small>Δ10Y 1M</small></span
+            ><span class="op">−</span>
+            <span class="term">−9.0<small>Δ2Y 1M</small></span
+            ><span class="op">=</span>
+            <span class="res">2s10s +10.0bp</span>
+          </div>
+          <p class="read" style="margin-top: 9px">
+            Every spread change is a <b>difference of two stored deltas</b>, so
+            the reconstruction cancels out of it entirely and the number is as
+            real as the deltas are. Same construction for the rest: 5s30s = Δ30Y
+            − Δ5Y (1W −8.0 − +3.0 = −11.0; 1M +7.0 − −2.0 = +9.0) · 3m10y = Δ10Y
+            − Δ3M (1W −2.0 − 0.0 = −2.0; 1M +1.0 − −9.0 = +10.0) · butterfly =
+            2·Δ5Y − Δ2Y − Δ10Y (1W +3.0; 1M +4.0)
+            <span class="tag comp">COMPUTED</span>
+          </p>
+        </div>
+      </div>
+      <div class="prov">
+        <b>Pipeline</b> /api/rates/snapshot → <code>.curve</code> ← router
+        <code>src/uw_scan/api/routers/rates.py:28</code> ← FRED
+        <code>DGS*</code> · rounding is the API's own: 2dp percent, 1dp bps ·
+        as_of <b>2026-08-24</b>, computed_at 2026-08-25T22:45Z —
+        <b>two sessions behind</b> the 08-26 pull
+        <span class="tag real">REAL</span> · endpoint EXISTS in production
+      </div>
+      <div class="prov">
+        <b>What is reconstructed</b> the 1W and 1M curves are
+        <b>not stored series</b>. /api/rates/snapshot serves only the current
+        level plus three deltas; the prior curves are rebuilt as
+        <code>value − delta_bps/100</code>, exactly as
+        <code>web/components/rates/RatesCurveChart.tsx:17</code> does it. The
+        arithmetic is exact and self-checking — the current curve reproduces all
+        four API spreads to the decimal (4.70 − 4.24 = +46.0 ✓ · 5.23 − 4.41 =
+        +82.0 ✓ · 4.70 − 3.87 = +83.0 ✓ · 2×4.41 − 4.24 − 4.70 = −12.0 ✓). What
+        is <b>not</b> exact is the dating: the payload carries no anchor date
+        for the prior curves, so "1W ago" and "1M ago" are labels it cannot
+        confirm — the builder takes the latest observation on or before as_of −
+        7d / − 30d, which need not be 08-17 / 07-25. Read the shapes, not the
+        calendar <span class="tag comp">COMPUTED</span>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>10Y nominal decomposition · who is moving</h3>
+          <span class="tag q">Q2</span>
+        </div>
+        <div class="arith">
+          <span class="term">2.38%<small>real (DFII10)</small></span
+          ><span class="op">+</span>
+          <span class="term">2.32%<small>breakeven (T10YIE)</small></span
+          ><span class="op">=</span>
+          <span class="res">4.70% nominal 10Y</span>
+        </div>
+        <p class="read">
+          Real yields +31bp over 60 days (see the gold tab's cyclical lens) with
+          breakevens flat — the trailing rise in nominals was a
+          <b>real-yield problem, not an inflation-expectations problem</b>.
+          <b>This week inverted that</b>: +5bp breakeven, −3bp real. The
+          sentence decides whether the hedge is duration or breakevens, and it
+          is the single most valuable line this tab gives a PM. Per-window
+          move-attribution is <b>no longer a planned slot</b> — it is the table
+          two panels below, built from the same stored
+          <span class="num">rates_snapshots</span> decomposition.
+        </p>
+        <div class="prov">
+          <b>Formula</b> T10YIE is defined as DGS10 − DFII10, so nominal = 2.38
+          + 2.32 <span class="tag comp">COMPUTED</span> · reference-site lesson:
+          usd-monitor passes 10Y−2Y slope off as term premium and its stack sums
+          to 5.16% ≠ the 4.70% nominal — we do not repeat that mistake
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Cleveland 5-term decomposition · the other cut</h3>
+          <span class="tag q">Q2 Q4</span>
+        </div>
+        <div class="arith">
+          <span class="term">0.86<small>E[short real]</small></span
+          ><span class="op">+</span>
+          <span class="term">2.49<small>E[short infl]</small></span
+          ><span class="op">+</span>
+          <span class="term">1.34<small>real term prem</small></span
+          ><span class="op">+</span>
+          <span class="term">0.44<small>infl risk prem</small></span
+          ><span class="op">=</span>
+          <span class="res">5.13 model</span>
+        </div>
+        <div class="arith" style="margin-top: 6px">
+          <span class="term">5.13<small>model nominal</small></span
+          ><span class="op">+</span>
+          <span class="term" style="border-color: rgba(232, 93, 108, 0.5)"
+            >(−0.43)<small>residual vs market</small></span
+          ><span class="op">=</span>
+          <span class="res">4.70% FRED 10Y</span>
+        </div>
+        <p class="read">
+          <b>The model prints 43bp rich to the market.</b> Four estimated terms
+          sum to 5.13; the traded 10Y is 4.70; the gap is carried openly as a
+          residual instead of being distributed into the terms that would hide
+          it. Sub-identity holds too: model real yield 2.20 − real term premium
+          1.34 = 0.86 <span class="tag comp">COMPUTED</span>. <br /><br />
+          This is the <b>same 4.70 cut a different way</b> from the panel beside
+          it, and the two answer different questions. Real + breakeven answers
+          <b>which instrument hedges this</b> — duration or TIPS. The five-term
+          cut answers
+          <b
+            >whether the long end is being paid for risk or for expected
+            policy</b
+          >: a 1.34 real term premium is the compensation number, and no slope
+          can produce it.
+        </p>
+        <div class="note-refuse">
+          <b>Monthly model, daily market.</b> clarida_model_date is
+          <span class="num">2026-08-01</span> and all four Cleveland series
+          report <span class="num">status: partial</span> at obs 2026-08-01 —
+          the decomposition is a month-old estimate sitting beside a
+          two-session-old market price. It diagnoses; it does not track.
+        </div>
+        <div class="prov">
+          <b>Pipeline</b> /api/rates/snapshot → .decomposition ←
+          <span class="num">src/uw_scan/api/routers/rates.py:28</span> ·
+          arithmetic verified digit-for-digit against the payload
+          <span class="tag real">REAL</span>
+          <span class="tag comp">COMPUTED</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>10Y move attribution · who moved it, per window</h3>
+        <span class="tag q">Q1 Q4</span>
+      </div>
+      <div
+        class="note-refuse"
+        style="margin-bottom: 11px; border-color: rgba(245, 166, 35, 0.45)"
+      >
+        <b>Read only the 1M and YTD rows.</b> The Cleveland model is monthly, so
+        at 1D and 1W both ends of the lookback read the same model vintage —
+        every model component is <b>exactly 0.0 by construction</b> and the
+        residual absorbs the entire move. Those two rows are not a finding that
+        nothing moved the components; they are the frequency limit of the model
+        showing through. Unlabelled, a table of zeros reads as fabricated data,
+        which is why the rows are dimmed and marked
+        <span style="color: var(--warning)">◦</span> rather than hidden.
+      </div>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Window</th>
+            <th class="num">10Y nominal</th>
+            <th class="num">Model nominal</th>
+            <th class="num">E[short real]</th>
+            <th class="num">E[short infl]</th>
+            <th class="num">Real term prem</th>
+            <th class="num">Infl risk prem</th>
+            <th class="num">Residual</th>
+            <th>Driver</th>
+          </tr>
+          <tr style="opacity: 0.55">
+            <td><b>1D</b> <span style="color: var(--warning)">◦</span></td>
+            <td class="num" style="color: var(--positive)">−4.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--positive)">−4.0</td>
+            <td>Real rate</td>
+          </tr>
+          <tr style="opacity: 0.55">
+            <td><b>1W</b> <span style="color: var(--warning)">◦</span></td>
+            <td class="num" style="color: var(--positive)">−2.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--text-muted)">0.0</td>
+            <td class="num" style="color: var(--positive)">−2.0</td>
+            <td>Real rate</td>
+          </tr>
+          <tr style="">
+            <td><b>1M</b></td>
+            <td class="num" style="color: var(--negative)">+1.0</td>
+            <td class="num" style="color: var(--negative)">+21.0</td>
+            <td class="num" style="color: var(--negative)">+10.0</td>
+            <td class="num" style="color: var(--negative)">+5.0</td>
+            <td class="num" style="color: var(--negative)">+3.0</td>
+            <td class="num" style="color: var(--negative)">+3.0</td>
+            <td class="num" style="color: var(--positive)">−20.0</td>
+            <td>Expected short real</td>
+          </tr>
+          <tr style="">
+            <td><b>YTD</b></td>
+            <td class="num" style="color: var(--negative)">+52.0</td>
+            <td class="num" style="color: var(--negative)">+68.0</td>
+            <td class="num" style="color: var(--negative)">+44.0</td>
+            <td class="num" style="color: var(--negative)">+16.0</td>
+            <td class="num" style="color: var(--negative)">+9.0</td>
+            <td class="num" style="color: var(--positive)">−1.0</td>
+            <td class="num" style="color: var(--positive)">−16.0</td>
+            <td>Expected short real</td>
+          </tr>
+        </table>
+      </div>
+      <p class="read">
+        <b>Over the month the 10Y barely moved — and that is the finding.</b>
+        Nominal +1.0bp against a model nominal of +21.0bp: expected short real
+        did +10.0, expected short inflation +5.0, and the two premia +3.0 each,
+        while the residual ran −20.0 the other way. The components moved; the
+        price did not. Year to date the same driver dominates — +44.0bp of the
+        +68.0bp model move is <b>expected short real rates</b>, not term premium
+        (+9.0) and not inflation risk (−1.0).
+        <b>This is a policy-expectations selloff wearing a long-end costume.</b>
+      </p>
+      <div class="prov">
+        <b>Check</b> residual = nominal − model nominal, on every row: −4.0−0.0
+        ✓ · −2.0−0.0 ✓ · 1.0−21.0=−20.0 ✓ · 52.0−68.0=−16.0 ✓
+        <span class="tag comp">COMPUTED</span> · windows are calendar-day
+        lookbacks from as_of 2026-08-24 resolved by
+        <span class="num">latest_on_or_before</span>, so a "1W" endpoint is the
+        latest observation on or before 08-17, not a fixed session
+        <span class="tag real">REAL</span>
+      </div>
+      <div class="prov">
+        <b>Pipeline</b> /api/rates/snapshot → .decomposition.attribution ←
+        <span class="num">src/uw_scan/api/routers/rates.py:28</span> · bps, 1dp
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="grid g3" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Supply SUB-STATE</h3>
+          <span class="state neust">IN_RANGE · FLAT</span>
+        </div>
+        <div class="big">
+          0<small> of 7 tenors at 4-quarter issuance highs</small>
+        </div>
+        <p class="read">
+          All 7 coupon tenors (2Y→30Y) sit inside their issuance ranges; gross
+          issuance 3m change is 0. The supply side is not currently a duration
+          pressure source.
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> rates_treasury_auctions (39,361 rows → 2026-08-25) ·
+          conf 1.00 <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Positioning SUB-STATE · 10Y futures</h3>
+          <span class="state neust">IN_RANGE · FALLING</span>
+        </div>
+        <div class="meter">
+          <span class="lbl">Asset Mgr net %OI</span>
+          <div class="track">
+            <span class="mid"></span><span class="pin" style="left: 62%"></span>
+          </div>
+          <span class="val">p62</span>
+        </div>
+        <div class="meter">
+          <span class="lbl">Dealer net %OI</span>
+          <div class="track">
+            <span class="mid"></span
+            ><span class="pin blue" style="left: 31%"></span>
+          </div>
+          <span class="val">p31</span>
+        </div>
+        <div class="meter">
+          <span class="lbl">Lev Money net %OI</span>
+          <div class="track">
+            <span class="mid"></span
+            ><span class="pin crit" style="left: 12%"></span>
+          </div>
+          <span class="val">p12</span>
+        </div>
+        <p class="read">
+          4-week change: asset managers −1.92pp / dealers +1.05pp / leveraged
+          −0.67pp. All three sides are inside their historical percentile bands
+          — no extreme crowding; a squeeze narrative has no evidence right now.
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> rates_cftc_tff_weekly (weekly, obs 2026-08-18) ·
+          contract 043602 = 10Y T-Note futures
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Funding SUB-STATE</h3>
+          <span class="state okst">AMPLE · FLAT</span>
+        </div>
+        <div class="big num">+2bp<small> SOFR − EFFR (08-24)</small></div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <td>Alert thresholds</td>
+              <td class="num">tightening +6bp · stressed +25bp</td>
+            </tr>
+            <tr>
+              <td>Δ1w / Δ4w / Δ13w</td>
+              <td class="num">+3bp / +1bp / +14bp</td>
+            </tr>
+            <tr>
+              <td>ON RRP balance</td>
+              <td class="num">$0.405B · near-drained</td>
+            </tr>
+            <tr>
+              <td>SOFR / EFFR</td>
+              <td class="num">3.65 / 3.63</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          The spread hugs zero but the 13-week slope of +14bp is worth watching:
+          the RRP buffer is empty, so the next drain hits reserves directly.
+          This is the "AMPLE, but the buffer is spent" combination. The spread
+          flipped sign this week (−1bp → +2bp).
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> FRED SOFR/EFFR/RRPONTSYD daily
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>Auction demand · did anyone show up</h3>
+        <span class="tag q">Q4 Q5</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        The Supply sub-state above is
+        <b>issuance size — supply with no demand side</b>. Bid-to-cover and
+        indirect share are the absorption evidence, and they are the difference
+        between "the Treasury sold a lot of duration" and "the market wanted
+        it".
+      </p>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Auction</th>
+            <th>Date</th>
+            <th class="num">Size</th>
+            <th class="num">High rate</th>
+            <th class="num">Bid-to-cover</th>
+            <th class="num">Indirect</th>
+          </tr>
+          <tr>
+            <td>
+              29-Year 6-Month Bond<br /><span
+                style="color: var(--text-muted); font-size: 10.5px"
+                >912810US5</span
+              >
+            </td>
+            <td>08-20</td>
+            <td class="num">8.0 $bn</td>
+            <td class="num">
+              2.973% <span style="color: var(--warning)">real</span>
+            </td>
+            <td class="num">2.82 ×</td>
+            <td class="num" style="color: var(--positive)"><b>74.3%</b></td>
+          </tr>
+          <tr>
+            <td>
+              10-Year Note<br /><span
+                style="color: var(--text-muted); font-size: 10.5px"
+                >91282CRF0</span
+              >
+            </td>
+            <td>08-12</td>
+            <td class="num">42.0 $bn</td>
+            <td class="num">4.683%</td>
+            <td class="num">2.53 ×</td>
+            <td class="num">61.0%</td>
+          </tr>
+          <tr>
+            <td>
+              2-Year Note<br /><span
+                style="color: var(--text-muted); font-size: 10.5px"
+                >91282CRH6</span
+              >
+            </td>
+            <td>08-25</td>
+            <td class="num">69.0 $bn</td>
+            <td class="num">4.204%</td>
+            <td class="num">2.60 ×</td>
+            <td class="num">57.7%</td>
+          </tr>
+          <tr>
+            <td>
+              6-Week Bill<br /><span
+                style="color: var(--text-muted); font-size: 10.5px"
+                >912797UJ4</span
+              >
+            </td>
+            <td>08-25</td>
+            <td class="num">95.0 $bn</td>
+            <td class="num">3.650%</td>
+            <td class="num">2.71 ×</td>
+            <td class="num">60.2%</td>
+          </tr>
+        </table>
+      </div>
+      <div class="note-refuse" style="margin-top: 10px">
+        <b>The 2.973% is a real rate, not a nominal.</b> That row is a
+        TIPS-style long bond, so its high rate is not comparable to the 4.683%
+        beside it and the column must never be read as a curve. It is flagged in
+        place rather than dropped, because dropping the row would silently
+        remove the strongest demand reading on the table.
+      </div>
+      <p class="read">
+        <b>74.3% indirect at the long end is the headline.</b> Indirect bidders
+        are the closest public proxy for foreign and central-bank demand, and
+        three quarters of an 8 $bn long bond going to them — at a bid-to-cover
+        of 2.82, the firmest on the table — says the long end is being absorbed,
+        not forced. Read it against the curve panel above: the long end
+        <b>rose</b> over the month (20Y +3, 30Y +7bp) while demand held. Supply
+        pressure and demand failure are different diagnoses, and only one of
+        them is showing here.
+      </p>
+      <div class="prov">
+        <b>Source</b> supply_read verbatim: "TreasuryDirect auction results show
+        29-Year 6-Month Bond demand is firm; FiscalData public debt is $32.27T;
+        TGA is $0.95T." · one row per tenor bucket, latest each · 2026-08-12 →
+        2026-08-25 <span class="tag real">REAL</span>
+      </div>
+      <div class="prov">
+        <b>Pipeline</b> /api/rates/snapshot → .supply.recent_auctions ←
+        <span class="num">src/uw_scan/api/routers/rates.py:28</span> · size in
+        $bn 1dp, rates in percent, bid-to-cover a ratio
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>What this tab refuses</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <ul class="tight">
+        <li>
+          <b>Slope ≠ term premium</b> — naming is a stance; only a model
+          produces an estimate of compensation for duration risk. The 1.34 above
+          comes from the Cleveland model and says so; 2s10s at +46.0bp is a
+          slope and stays one
+        </li>
+        <li>
+          <b>The model does not overrule the market</b> — model nominal 5.13 vs
+          traded 4.70 is carried as a −0.43 residual, not smoothed into the four
+          terms. A decomposition that always reconciles is a decomposition that
+          has stopped measuring
+        </li>
+        <li>
+          <b>Attribution is not published where it cannot speak</b> — the 1D and
+          1W rows are dimmed because a monthly model cannot resolve a daily
+          move, not because the numbers are missing
+        </li>
+        <li>
+          <b>Legacy scorecard kept, demoted</b> — the old rule-weighted duration
+          stance stays in a collapsed section labeled Experimental legacy; when
+          absent it renders UNKNOWN, never NEUTRAL
+        </li>
+        <li>
+          <b>Reconstructed curves are dated by convention, not by payload</b> —
+          the 1W and 1M overlays carry no anchor date of their own; read the
+          shapes, not the calendar
+        </li>
+      </ul>
+      <div class="prov">
+        <b>Source</b> web/components/rates/*.tsx code comments and tests · these
+        invariants migrate wholesale with the merge
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 03 INFLATION ══════════════════ -->
+  <section id="t3" role="tabpanel">
+    <div class="sec-title">
+      <h2>Inflation</h2>
+      <span class="tag q">Q1 Q3 Q6 Q7</span
+      ><span class="state warnst">WELL_ABOVE_TARGET · FLAT · conf 0.37</span>
+    </div>
+    <p class="sec-sub">
+      First link in the chain, and today's most instructive card:
+      <b>the label says WELL_ABOVE_TARGET while confidence is only 0.37</b> —
+      low confidence is not a defect, it IS information: two contradiction rules
+      are firing and one expectations input is 60 days stale. On the existing
+      /macro page inflation is a single card; this tab unfolds its factors /
+      contradictions / falsifier arithmetic into a full page.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>The arithmetic of confidence · why only 0.37</h3>
+          <span class="tag q">Q7</span>
+        </div>
+        <div class="arith">
+          <span class="term">1.00<small>completeness 8/8</small></span
+          ><span class="op">×</span>
+          <span class="term" style="border-color: rgba(245, 166, 35, 0.5)"
+            >0.53<small>freshness · MICH 60d</small></span
+          ><span class="op">×</span>
+          <span class="term">1.00<small>quality</small></span
+          ><span class="op">×</span>
+          <span class="term" style="border-color: rgba(232, 93, 108, 0.5)"
+            >(1−0.30)<small>contradiction penalty ×2</small></span
+          ><span class="op">=</span>
+          <span class="res">conf 0.37</span>
+        </div>
+        <p class="read">
+          0.532 × 0.70 = 0.372, digit-for-digit what the API returns. Confidence
+          is not a black-box score, it is auditable multiplication — every term
+          names its evidence (it is MICH that is stale; it is these two rules
+          that fire).
+          <b
+            >Week over week the same arithmetic decayed 0.429 → 0.373 with no
+            state change</b
+          >
+          — pure freshness decay as the Michigan input ages
+          <span class="tag real">REAL</span>.
+        </p>
+        <div class="prov">
+          <b>Source</b> /api/macro/inflation confidence_reasons[] · domain-state
+          history 08-20 → 08-26
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Falsifier window · confidence repair table</h3>
+          <span class="tag q">Q6</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Event</th>
+              <th class="num">conf consequence</th>
+            </tr>
+            <tr>
+              <td>Next Michigan survey release (freshness → 1)</td>
+              <td class="num">0.37 → 0.70</td>
+            </tr>
+            <tr>
+              <td>CPI/PCE wedge converges back inside ±0.30pp</td>
+              <td class="num">0.37 → 0.53</td>
+            </tr>
+            <tr>
+              <td>Breadth contradiction clears (median moves with core)</td>
+              <td class="num">one penalty notch lifts</td>
+            </tr>
+            <tr>
+              <td>All clear</td>
+              <td class="num">→ 1.00</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          Borrowed from inflation-monitor's "event intercept" pattern, but we
+          pre-register only <b>state/conf sensitivity</b> (computable), never
+          hike probabilities (those would be invented). The precise release-day
+          threshold — "what CPI/PCE print flips the state label" — is a Phase
+          2.5 measurement slot <span class="tag plan">PLANNED</span>.
+        </p>
+        <div class="prov">
+          <b>Formula</b> see the multiplication chain at left
+          <span class="tag comp">COMPUTED</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Realized inflation</h3>
+          <span class="tag q">Q1</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Metric</th>
+              <th class="num">Level</th>
+              <th class="num">Δ window</th>
+              <th>Direction</th>
+              <th>Period</th>
+            </tr>
+            <tr>
+              <td>core PCE 3m annualized</td>
+              <td class="num">2.89%</td>
+              <td class="num">+0.03pp</td>
+              <td><span class="delta-flat">FLAT</span></td>
+              <td class="num">2026-06</td>
+            </tr>
+            <tr>
+              <td>PCE headline (index)</td>
+              <td class="num">131.39</td>
+              <td class="num">+0.13</td>
+              <td><span class="delta-flat">FLAT</span></td>
+              <td class="num">2026-06</td>
+            </tr>
+            <tr>
+              <td>core CPI (index)</td>
+              <td class="num">336.79</td>
+              <td class="num">−0.28pp</td>
+              <td><span class="delta-up">FALLING</span></td>
+              <td class="num">2026-07</td>
+            </tr>
+            <tr>
+              <td>Cleveland trimmed-mean</td>
+              <td class="num">2.71%</td>
+              <td class="num">−2.52pp</td>
+              <td><span class="delta-up">FALLING</span></td>
+              <td class="num">2026-07</td>
+            </tr>
+            <tr>
+              <td>Atlanta sticky-price</td>
+              <td class="num">2.72%</td>
+              <td class="num">−0.32pp</td>
+              <td><span class="delta-up">FALLING</span></td>
+              <td class="num">2026-07</td>
+            </tr>
+            <tr>
+              <td>Cleveland median CPI Δ</td>
+              <td class="num">—</td>
+              <td class="num">−1.82pp</td>
+              <td><span class="delta-up">FALLING</span></td>
+              <td class="num">2026-07</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          Core PCE (the Fed's anchor) sits flat at ~2.9 while the CPI family
+          falls across the board — exactly the wedge in the contradiction feed.
+          Who is right? Until the next PCE lands, that is this domain's biggest
+          open question. Direction color: falling inflation = green (an
+          improvement to a PM), independent of asset up/down colors.
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> FRED
+          CPIAUCSL/CPILFESL/PCEPI/PCEPILFE/TRMMEAN/MEDCPI/CORESTICK ·
+          macro_series_ingest daily · PIT: available_at ≤ as_of
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Inflation expectations</h3>
+          <span class="tag q">Q1 Q3</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Metric</th>
+              <th class="num">Level</th>
+              <th>Note</th>
+            </tr>
+            <tr>
+              <td>Michigan 1y survey</td>
+              <td class="num">4.6% <span class="delta-dn">↑+0.8</span></td>
+              <td>
+                <span style="color: var(--warning)"
+                  >60d stale — main freshness penalty</span
+                >
+              </td>
+            </tr>
+            <tr>
+              <td>10y breakeven (T10YIE)</td>
+              <td class="num">2.32%</td>
+              <td>borrowed from the rates domain (single owner)</td>
+            </tr>
+            <tr>
+              <td>5y5y forward (T5YIFR)</td>
+              <td class="num">2.32% · 52w p92</td>
+              <td>same FRED reading as gold's L2</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          Survey (4.6, still rising) and market (2.3, anchored) are split by
+          2.3pp — household inflation and bond-market inflation are different
+          worlds. The market's 5y5y sits at the 92nd 52-week percentile: the
+          anchor holds, but at the top of its band.
+          <b>The label says WELL_ABOVE_TARGET; the market prices anchored</b> —
+          that wedge is the tradable context, and this week's breakeven-led +5bp
+          says the market took one step toward the survey, not away from it.
+        </p>
+        <div class="note-refuse">
+          <b>REFUSAL</b> No IPS-style 0–100 composite. Reference lesson:
+          inflation-monitor's N (narrative) component carries 20% weight with 4
+          of its 5 sub-factors hardcoded constants, lifting the regime label
+          from "moderate" to "sticky" — a composite averages away exactly the
+          split above.
+        </div>
+        <div class="prov">
+          <b>Pipeline</b> MICH/T10YIE/T5YIFR (FRED)
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 04 USD ══════════════════ -->
+  <section id="t4" role="tabpanel">
+    <div class="sec-title">
+      <h2>US Dollar</h2>
+      <span class="tag q">Q1 Q4 Q7</span
+      ><span class="state neust">RANGEBOUND · FLAT · conf 1.00</span>
+    </div>
+    <p class="sec-sub">
+      Third link: the dollar transmits the rate differential to gold and
+      commodities. On /macro the dollar is likewise a single card; this tab
+      unfolds its most informative pair —
+      <b
+        >the nominal and real broad-dollar indexes are moving in opposite
+        directions</b
+      >.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Nominal vs real · a dollar pair in reverse</h3>
+          <span class="tag q">Q1</span>
+        </div>
+        <div class="grid g2">
+          <div>
+            <div class="big num">
+              118.06<small> H.10 nominal broad USD (08-21)</small>
+            </div>
+            <div class="num delta-dn" style="font-size: 14px">
+              Δ3m −1.09% · Δ1w −0.71% (118.90 → 118.06)
+            </div>
+          </div>
+          <div>
+            <div class="big num">
+              115.44<small> real broad USD (2026-07)</small>
+            </div>
+            <div class="num delta-up" style="font-size: 14px">Δ3m +1.16%</div>
+          </div>
+        </div>
+        <p class="read">
+          Nominal falling, real rising: the US inflation differential vs trading
+          partners is eating the nominal depreciation. The read on export
+          competitiveness / EM dollar-debt stress is the
+          <b>opposite</b> of what DXY alone would say. API notes verbatim: "the
+          real index is reported beside it and is never substituted for it" —
+          both are shown, neither is chosen. The broad-dollar Δ is the
+          continuous factor exported to tab 07.
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> DTWEXBGS daily (weekly release) / RTWEXBGS monthly ·
+          FRED H.10 · 60d z (gold page fx-basket reading): −1.62 → DXY in its
+          60-day low zone <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Upstream citation · chain integrity</h3>
+          <span class="tag q">Q4 Q7</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Upstream</th>
+              <th>state</th>
+              <th>Citation mode</th>
+            </tr>
+            <tr>
+              <td>policy_rates</td>
+              <td>
+                <span
+                  class="state neust"
+                  style="font-size: 11px; padding: 2px 7px"
+                  >ON_HOLD</span
+                >
+              </td>
+              <td class="num">state id d731eef12319 · never recomputed</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          The USD engine consumes only the rates domain's
+          <em>published state</em>; handing it an upstream raw observation
+          raises immediately. That is what makes the snapshot's incompatible
+          detection meaningful: if rates recomputes overnight while USD still
+          cites the old identity, the chain reports "not the same world" instead
+          of pretending coherence. Next repricing event: FOMC 09-15/16, via the
+          rates state this engine cites.
+        </p>
+        <div class="note-refuse">
+          <b>HONEST BOUNDARY</b> The engine has 1 load-bearing input (DTWEXBGS)
+          + 1 observational input (RTWEXBGS). Bilateral series (JPY/CNY/INR) are
+          stored but not wired into the engine; CIP basis / FX swap curves are
+          outside our data tier; Fed vs ECB/BOJ path differentials need a new
+          foreign-central-bank path ingest. The expansion slots below queue by
+          measurement priority, no coefficients pre-assigned.
+        </div>
+        <div class="prov">
+          <b>Phase 2.5 candidates</b> ① bilateral panel (data already in
+          macro_series_daily) ② VIX×term-premium 2×2 risk taxonomy
+          (usd-monitor's best idea: distinguishing "risk-off buys dollars" from
+          "the risk IS the dollar" — measure first, then ship) ③ policy path
+          differential <span class="tag plan">PLANNED</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 05 GOLD ══════════════════ -->
+  <section id="t5" role="tabpanel">
+    <div class="sec-title">
+      <h2>Gold</h2>
+      <span class="tag q">Q1 Q3 Q4 Q5 Q7</span
+      ><span class="state critst">SUSPENDED · RISING · conf 0.85</span>
+    </div>
+    <p class="sec-sub">
+      Final link, merged with the Gold Compass. The domain state is a
+      <b>gate</b> (is the gold↔real-yield relationship operative), not a view on
+      price; the three lenses publish independently and are never composited.
+      Today's core fact:
+      <b>the gate is SUSPENDED while gold is +13.45% in 3 months</b> — the rally
+      is driven by structural flows (western institutional return +
+      geopolitics), not by discount rates. This week the anchor kept letting go
+      (corr_60d −0.79 → −0.17) while gold optionality repriced +4.4 vol pts.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Transmission gauge · correlation collapse</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="lgd">
+          <span
+            ><i style="background: #f5a623"></i>gold ↔ real yield (DFII10)</span
+          >
+          <span><i style="background: #38bdf8"></i>gold ↔ dollar (DXY)</span>
+          <span
+            ><i style="background: #8b5cf6"></i>gold ↔ geopolitical risk
+            (GPR)</span
+          >
+        </div>
+        <div class="chart">
+          <svg
+            id="corrChart"
+            viewBox="0 0 560 240"
+            role="img"
+            aria-label="Rolling correlation history, monthly sampled: gold vs real yields converging from minus 0.44 to minus 0.05, gold vs DXY stable between minus 0.61 and minus 0.68, gold vs GPR rising from 0.27 to 0.41"
+          >
+            <!-- y: +0.6 → -1.0 maps 20→220 ; zero at y=95 ; x: 5 points 80,190,300,410,520 -->
+            <g stroke="#1e293b">
+              <line x1="60" y1="20" x2="540" y2="20" />
+              <line x1="60" y1="95" x2="540" y2="95" />
+              <line x1="60" y1="170" x2="540" y2="170" />
+              <line x1="60" y1="220" x2="540" y2="220" />
+            </g>
+            <line
+              x1="60"
+              y1="95"
+              x2="540"
+              y2="95"
+              stroke="#475569"
+              stroke-width="1"
+            />
+            <g fill="#94a3b8" font-size="10">
+              <text x="54" y="24" text-anchor="end">+0.6</text>
+              <text x="54" y="99" text-anchor="end">0</text>
+              <text x="54" y="174" text-anchor="end">−0.6</text>
+              <text x="54" y="224" text-anchor="end">−1.0</text>
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="80" y="236" text-anchor="middle">04-17</text>
+              <text x="190" y="236" text-anchor="middle">05-18</text>
+              <text x="300" y="236" text-anchor="middle">06-17</text>
+              <text x="410" y="236" text-anchor="middle">07-20</text>
+              <text x="520" y="236" text-anchor="middle">08-18</text>
+            </g>
+            <polyline
+              points="80,149.9 190,135.0 300,102.1 410,95.6 520,101.6"
+              fill="none"
+              stroke="#f5a623"
+              stroke-width="2"
+            />
+            <polyline
+              points="80,179.4 190,177.9 300,171.5 410,177.8 520,179.9"
+              fill="none"
+              stroke="#38bdf8"
+              stroke-width="2"
+            />
+            <polyline
+              points="80,61.8 190,58.2 300,54.9 410,42.3 520,43.5"
+              fill="none"
+              stroke="#8b5cf6"
+              stroke-width="2"
+            />
+            <g class="pt" fill="#f5a623">
+              <circle cx="80" cy="149.9" r="4">
+                <title>04-17 · −0.44</title>
+              </circle>
+              <circle cx="190" cy="135" r="4">
+                <title>05-18 · −0.32</title>
+              </circle>
+              <circle cx="300" cy="102.1" r="4">
+                <title>06-17 · −0.06</title>
+              </circle>
+              <circle cx="410" cy="95.6" r="4">
+                <title>07-20 · −0.005</title>
+              </circle>
+              <circle
+                cx="520"
+                cy="101.6"
+                r="5"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-18 · −0.05</title>
+              </circle>
+            </g>
+            <g class="pt" fill="#38bdf8">
+              <circle cx="80" cy="179.4" r="4">
+                <title>04-17 · −0.68</title>
+              </circle>
+              <circle cx="190" cy="177.9" r="4">
+                <title>05-18 · −0.66</title>
+              </circle>
+              <circle cx="300" cy="171.5" r="4">
+                <title>06-17 · −0.61</title>
+              </circle>
+              <circle cx="410" cy="177.8" r="4">
+                <title>07-20 · −0.66</title>
+              </circle>
+              <circle
+                cx="520"
+                cy="179.9"
+                r="5"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-18 · −0.68</title>
+              </circle>
+            </g>
+            <g class="pt" fill="#8b5cf6">
+              <circle cx="80" cy="61.8" r="4">
+                <title>04-15 · +0.27</title>
+              </circle>
+              <circle cx="190" cy="58.2" r="4">
+                <title>05-14 · +0.29</title>
+              </circle>
+              <circle cx="300" cy="54.9" r="4">
+                <title>06-15 · +0.32</title>
+              </circle>
+              <circle cx="410" cy="42.3" r="4">
+                <title>07-16 · +0.42</title>
+              </circle>
+              <circle
+                cx="520"
+                cy="43.5"
+                r="5"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-14 · +0.41</title>
+              </circle>
+            </g>
+            <g font-size="10.5" font-weight="600">
+              <text x="440" y="90" fill="#f5a623">real yield −0.05</text>
+              <text x="446" y="196" fill="#38bdf8">DXY −0.68</text>
+              <text x="452" y="34" fill="#8b5cf6">GPR +0.41</text>
+            </g>
+          </svg>
+          <div class="cap">
+            <b>252-day rolling correlation, sampled every 21 trading days</b>,
+            computed on <b>levels, not returns</b>, over a 5-year input window
+            (gold_posture_daily.correlation_history, full series)
+            <span class="tag real">REAL</span> · window resolved from the single
+            call site
+            <span class="num">reports/gold_posture.py:381-383</span> (literal
+            <span class="num">252</span>, all three pairs), stride
+            <span class="num">:102,:114,:125</span> · hover for values
+          </div>
+        </div>
+        <p class="read">
+          Over four months the discount-rate link converged from −0.44 to zero,
+          the dollar link never moved, and the geopolitical link kept
+          strengthening. The gauge's window triplet tells the same story: corr60
+          −0.17 / corr126 −0.85 / corr252 −0.04 — signs cancel inside the long
+          window; the break happened within the year.
+        </p>
+        <div class="note-refuse">
+          <b>No pre-2022 ±1σ reference band, and there never can be one.</b>
+          The band would answer the question this chart most wants answered —
+          how far outside its own history the real-yield link now sits — and
+          <span class="num">correlation_history.pre_2022_band</span> is
+          <span class="num">null</span> in production. Not a fetch failure:
+          <span class="num">GLD_CLOSE</span> holds 343 rows, so
+          <span class="num">range(252, 343, 21)</span> yields exactly the five
+          sample points plotted above and every one of them is post-2022, while
+          <span class="num">_pre_2022_band</span>
+          (<span class="num">gold_posture.py:129-140</span>) requires ≥20 points
+          dated before 2022. The live /gold page draws this band whenever it is
+          present; <b>it has never been present</b>. <br /><br />
+          The <span class="num">{"mean": "-0.84", "std": "0.04"}</span> that
+          looks like a real reading is a test fixture (<span class="num"
+            >tests/integration/api/test_gold_router_state.py:108</span
+          >) and must never reach a screen. A plotted band is a claim about
+          history; this one would be a claim about a fixture.
+        </div>
+        <div class="prov">
+          <b>New slot</b> /api/gold/gauge's history_252d (the gauge's own
+          operative/suspended flip timeline) exists and has never been consumed
+          by any page — first hookup in Phase 2
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Three lenses · each publishes, none composites</h3>
+          <span class="tag q">Q1 Q5</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Lens</th>
+              <th>Reading</th>
+              <th>posture</th>
+            </tr>
+            <tr>
+              <td>L1 Structural flows</td>
+              <td>western-institutional-return</td>
+              <td>
+                <span
+                  class="state warnst"
+                  style="font-size: 11px; padding: 2px 7px"
+                  >DEGRADED</span
+                >
+                <span style="font-size: 11px; color: var(--text-muted)"
+                  >COMEX missing</span
+                >
+              </td>
+            </tr>
+            <tr>
+              <td>L2 Cyclical (discount rate)</td>
+              <td>moderate-trap</td>
+              <td>
+                <span
+                  class="state critst"
+                  style="font-size: 11px; padding: 2px 7px"
+                  >SUSPENDED</span
+                >
+                <span style="font-size: 11px; color: var(--text-muted)"
+                  >dimmed 0.7 with the gate</span
+                >
+              </td>
+            </tr>
+            <tr>
+              <td>L3 Valuation</td>
+              <td>High flag</td>
+              <td>
+                <span
+                  class="state warnst"
+                  style="font-size: 11px; padding: 2px 7px"
+                  >STRETCHED</span
+                >
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div
+          style="
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-top: 2px;
+          "
+        >
+          <div class="meter">
+            <span class="lbl">real gold own-history</span>
+            <div class="track"><span class="pin" style="left: 79%"></span></div>
+            <span class="val">p79</span>
+          </div>
+          <div class="meter">
+            <span class="lbl">gold ÷ M2</span>
+            <div class="track">
+              <span class="pin" style="left: 77.3%"></span>
+            </div>
+            <span class="val">p77</span>
+          </div>
+          <div class="meter">
+            <span class="lbl">gold ÷ oil</span>
+            <div class="track"></div>
+            <span class="val" style="color: var(--text-muted)">n/a</span>
+          </div>
+        </div>
+        <p class="read">
+          The gold÷oil anchor is currently null —
+          <b>it lights up automatically once the energy dimension lands</b>, the
+          first cross-domain deliverable of tab 06. The L3 panel keeps its
+          original warning header: <b>⚠ NEVER A SIZING INPUT</b> (valuation is
+          tail-risk context, never a position input).
+        </p>
+        <div class="prov">
+          <b>Pipeline</b> gold_posture_daily · nightly 19:10 ET (deliberately
+          before the 19:40 domain-state compute, so the gold domain reads
+          tonight's gauge) <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Anchor decay · gauge corr_60d, daily</h3>
+          <span class="tag q">Q4</span>
+        </div>
+        <div class="chart">
+          <svg
+            viewBox="0 0 560 178"
+            role="img"
+            aria-label="Gold vs real-yield 60-day correlation, daily from Aug 7 to Aug 25: minus 0.79 decaying to minus 0.17, while the 126-day window holds near minus 0.85"
+          >
+            <g stroke="#1e293b">
+              <line x1="60" y1="20" x2="540" y2="20" />
+              <line x1="60" y1="85" x2="540" y2="85" />
+              <line x1="60" y1="150" x2="540" y2="150" />
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="54" y="24" text-anchor="end">0</text>
+              <text x="54" y="89" text-anchor="end">−0.5</text>
+              <text x="54" y="154" text-anchor="end">−1.0</text>
+            </g>
+            <line
+              x1="60"
+              y1="130.5"
+              x2="540"
+              y2="130.5"
+              stroke="#475569"
+              stroke-dasharray="4 4"
+            />
+            <text
+              x="536"
+              y="127"
+              text-anchor="end"
+              fill="#94a3b8"
+              font-size="10"
+            >
+              126d gauge −0.85
+            </text>
+            <polyline
+              points="60,122.7 128.6,110.0 197.1,87.2 265.7,79.8 334.3,75.9 402.9,70.2 471.4,62.8 540,41.6"
+              fill="none"
+              stroke="#f5a623"
+              stroke-width="2"
+            />
+            <g fill="#f5a623">
+              <circle
+                cx="60"
+                cy="122.7"
+                r="5"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-07 · −0.79</title>
+              </circle>
+              <circle cx="128.6" cy="110.0" r="3.5">
+                <title>−0.69</title>
+              </circle>
+              <circle cx="197.1" cy="87.2" r="3.5"><title>−0.52</title></circle>
+              <circle cx="265.7" cy="79.8" r="3.5"><title>−0.46</title></circle>
+              <circle cx="334.3" cy="75.9" r="3.5"><title>−0.43</title></circle>
+              <circle cx="402.9" cy="70.2" r="3.5"><title>−0.39</title></circle>
+              <circle cx="471.4" cy="62.8" r="3.5"><title>−0.33</title></circle>
+              <circle
+                cx="540"
+                cy="41.6"
+                r="5"
+                stroke="#0a0f14"
+                stroke-width="2"
+              >
+                <title>08-25 · −0.17</title>
+              </circle>
+            </g>
+            <g fill="#94a3b8" font-size="10">
+              <text x="60" y="168">08-07</text>
+              <text x="540" y="168" text-anchor="end">08-25</text>
+            </g>
+          </svg>
+          <div class="cap">
+            gold ↔ real-yield corr, 60d window, 8 daily rows
+            <span class="tag real">REAL</span> · dashed reference: corr_126d
+            −0.85
+          </div>
+        </div>
+        <p class="read">
+          Twelve sessions took the 60d link from −0.79 to −0.17 while the 126d
+          window barely moved (−0.93 → −0.85 on the week). Short-window
+          decorrelation during a spot rally means the marginal buyer is not
+          trading discount rates. Either a new driver is pricing gold or the
+          regime is breaking — flagged in the 00 disagreement zone, deliberately
+          unresolved.
+        </p>
+        <div class="prov">
+          <b>Source</b> gold_posture_daily gauge corr_60d, daily rows 08-07 →
+          08-25 <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Expression cost · what the option market charges</h3>
+          <span class="tag q">Q2 Q7</span>
+        </div>
+        <div class="big num">
+          28.28<small> GVZ gold vol (08-25) · +4.4 pts w/w</small>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Series</th>
+              <th class="num">1w ago → now</th>
+              <th class="num">Δ</th>
+            </tr>
+            <tr>
+              <td>GVZ · gold vol</td>
+              <td class="num">23.92 → 28.28</td>
+              <td class="num">+18.2%</td>
+            </tr>
+            <tr>
+              <td>VIX</td>
+              <td class="num">14.25 → 15.85</td>
+              <td class="num">+1.6 pts</td>
+            </tr>
+            <tr>
+              <td>GLD spot</td>
+              <td class="num">401.48 → 428.07</td>
+              <td class="num">+6.6% since 08-14</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          Gold optionality repriced ~18% higher in vol terms in a week while
+          spot rallied — long-gold expressed through options got materially more
+          expensive, and the vol market is treating this rally as unstable
+          rather than grinding. A PM weighing gold here prices GVZ, not just the
+          state. The gate says SUSPENDED; the option market is paying up — the
+          same disagreement as the anchor-decay chart, seen from the pricing
+          side.
+        </p>
+        <div class="prov">
+          <b>Source</b> GVZ/VIX daily closes, latest obs in the 08-26 pull
+          (nominally 08-25) · GLD window since 08-14 as stored
+          <span class="tag real">REAL</span> · Δ% 28.28/23.92
+          <span class="tag comp">COMPUTED</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g3" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Central banks · 12M net, three buckets</h3>
+          <span class="tag q">Q5</span>
+        </div>
+        <div class="chart">
+          <svg
+            viewBox="0 0 330 150"
+            role="img"
+            aria-label="Central bank 12-month net gold purchases: strategic accumulators net minus 91 tonnes, tactical defenders plus 29.9 tonnes, reserve diversifiers plus 93.4 tonnes"
+          >
+            <!-- zero x=140; scale 1t = 1.45px; category label above each bar -->
+            <line x1="140" y1="16" x2="140" y2="142" stroke="#475569" />
+            <g font-size="10" fill="#94a3b8">
+              <text x="8" y="18">Strategic accumulators</text>
+              <text x="8" y="66">Tactical defenders</text>
+              <text x="8" y="114">Reserve diversifiers</text>
+            </g>
+            <rect
+              x="8.1"
+              y="24"
+              width="131.9"
+              height="18"
+              rx="3"
+              fill="#e85d6c"
+            >
+              <title>strategic 12m −91.0t</title>
+            </rect>
+            <rect x="142" y="72" width="43.4" height="18" rx="3" fill="#05ad98">
+              <title>tactical 12m +29.9t</title>
+            </rect>
+            <rect
+              x="142"
+              y="120"
+              width="135.4"
+              height="18"
+              rx="3"
+              fill="#05ad98"
+            >
+              <title>diversifier 12m +93.4t</title>
+            </rect>
+            <g font-size="9.5" font-weight="600" fill="#e2e8f0">
+              <text
+                x="134"
+                y="36.4"
+                text-anchor="end"
+                fill="#0a0f14"
+                font-weight="700"
+              >
+                −91.0t
+              </text>
+              <text x="189.4" y="84.4">+29.9t</text>
+              <text x="281.4" y="132.4">+93.4t</text>
+            </g>
+          </svg>
+          <div class="cap">
+            WGC central-bank reserves · obs → 2026-03-31 (quarterly cadence,
+            147d-old data is normal) <span class="tag real">REAL</span>
+          </div>
+        </div>
+        <p class="read">
+          The "central banks are buying gold" narrative needs unbundling: the
+          strategic accumulators (protagonists of the de-dollarization story)
+          were net <b>sellers</b> over 12 months; the buying came from the
+          diversifier bucket — rebalancing, not narrative escalation.
+        </p>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Western institutional flows · L1 detail</h3>
+          <span class="tag q">Q5</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <td>GLD holdings</td>
+              <td class="num">1,049.5t · 30d +45.0t</td>
+            </tr>
+            <tr>
+              <td>LBMA 30d momentum</td>
+              <td class="num">+72.1t</td>
+            </tr>
+            <tr>
+              <td>COT managed-money net long</td>
+              <td class="num">p84 · 4w +0.86σ</td>
+            </tr>
+            <tr>
+              <td>UW 25Δ skew</td>
+              <td class="num">−0.03σ · neutral</td>
+            </tr>
+            <tr>
+              <td>COMEX registered stocks</td>
+              <td class="num" style="color: var(--negative)">
+                missing (self-reported)
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          ETF and LBMA doubly confirm the western institutional return; the
+          options plane (skew) has not followed — the rally is spot/ETF driven,
+          not option speculation. Managed money at p84 is crowded-ish but not
+          extreme.
+        </p>
+        <div class="prov">
+          <b>Honest gap</b> exchange_inventory_daily has never received a COMEX
+          row (table exists, pipeline marks it required); the lens degrades to
+          DEGRADED by rule instead of borrowing neighbor data
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>L2 cyclical readings (dimmed display)</h3>
+          <span class="tag q">Q1</span>
+        </div>
+        <div
+          class="panel dim"
+          style="border: none; padding: 0; background: none"
+        >
+          <div class="tbl-wrap">
+            <table>
+              <tr>
+                <td>CPI YoY</td>
+                <td class="num">2.95%</td>
+              </tr>
+              <tr>
+                <td>5y5y inflation expectations</td>
+                <td class="num">2.32 · 52w p92</td>
+              </tr>
+              <tr>
+                <td>10y real yield</td>
+                <td class="num">2.38 · 60d +31bp</td>
+              </tr>
+              <tr>
+                <td>DXY 60d σ</td>
+                <td class="num">+0.84</td>
+              </tr>
+              <tr>
+                <td>GPR geopolitical index</td>
+                <td class="num">165.2 · 52w p42</td>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <p class="read">
+          The readings stay on display, dimmed to 0.7 — while the gate is
+          SUSPENDED, cyclical views derived from a failed relationship rate as
+          "informational", never "actionable". The dimming is the UI enforcing
+          discipline.
+        </p>
+        <div class="prov">
+          <b>Original detail</b> GoldCompassLayout's L2 opacity treatment,
+          preserved as-is <span class="tag real">REAL</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>Input manifest · what the lenses actually read</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <div class="grid g2" style="align-items: start">
+        <div>
+          <div class="arith">
+            <span class="term">13<small>read</small></span
+            ><span class="op">of</span>
+            <span class="term">16<small>declared</small></span
+            ><span class="op">=</span>
+            <span class="res">81% coverage</span>
+          </div>
+          <p class="read" style="margin-top: 10px">
+            Every gold reading on this tab is produced from 13 inputs. Three
+            more were <b>declared and not read</b>, and the manifest names them
+            with their reasons rather than letting the output look complete.
+            <b>Only one of the three is a gap.</b>
+          </p>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Stale read</th>
+              <th class="num">obs</th>
+              <th class="num">Age</th>
+            </tr>
+            <tr>
+              <td>lbma_inventory_daily</td>
+              <td class="num">2026-06-01</td>
+              <td class="num" style="color: var(--warning)">~86 d</td>
+            </tr>
+            <tr>
+              <td>cb_gold_reserves_monthly</td>
+              <td class="num">2026-03-31</td>
+              <td class="num" style="color: var(--warning)">~100 d</td>
+            </tr>
+          </table>
+          <div class="cap" style="margin-top: 8px">
+            cb_gold_reserves as_of 2026-05-18 — ~100 days since the last capture
+            <i>attempt</i>, not merely since the last new observation
+            <span class="tag real">REAL</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="contra" style="margin-top: 11px">
+        <b>exchange_inventory_daily · comex · required</b>
+        <span
+          >"no rows in comex for exchange_inventory_daily at or before as_of;
+          the lens degrades rather than substituting a neighbour" — the one
+          genuine gap. L1 reports DEGRADED because of this row.</span
+        >
+      </div>
+      <div class="note-refuse" style="margin-top: 9px">
+        <b>fx · L1 · not required</b> — "compute_structural_posture is called
+        with fx_rows=[]. No FX leg is ingested for the gold complex, so the
+        structural lens sees no currency effect at all — recorded because
+        <b
+          >an empty list reaching a lens is indistinguishable in the output from
+          a currency that did not move</b
+        >." <br /><br />
+        <b>spx · L3 · not required</b> — "compute_valuation_overlay is called
+        with spx_series=[]. The gold/equity ratio anchor is therefore never
+        computed, and the overlay reports on the CPI and M2 anchors alone."
+      </div>
+      <p class="read">
+        The sentence inside the fx reason is the principle the whole desk runs
+        on. A lens handed an empty list produces the same clean output as a lens
+        handed a variable that genuinely did not move —
+        <b
+          >silence and zero are identical downstream unless something records
+          the difference</b
+        >. This manifest is that record, and it is why "13 of 16" appears on the
+        screen instead of a coverage number nobody can audit.
+      </p>
+      <div class="prov">
+        <b>Pipeline</b> /api/gold/state → .inputs_used ←
+        <span class="num">src/uw_scan/api/routers/gold.py:422</span> ·
+        omission_reason quoted verbatim, never paraphrased · rendered by
+        DataAuditFooter.tsx:40 on the live page
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 06 ENERGY ══════════════════ -->
+  <section id="t6" role="tabpanel">
+    <div class="sec-title">
+      <h2>Energy · Proposal</h2>
+      <span class="tag plan">PLANNED · data not yet ingested</span>
+    </div>
+    <p class="sec-sub">
+      Fifth dimension on the chain: energy is the supply-side driver of
+      inflation (WTI YoY carries the largest weight in inflation-monitor's D
+      component), the denominator of the gold÷oil anchor, and the OVX factor in
+      usd-monitor's σ panel. Positioning:
+      <b
+        >feed the inflation node + the gold valuation anchor; becoming a fifth
+        domain state requires its own spec and measurement</b
+      >
+      — inherits the MC5/MC6 non-goals, no predictive claims.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h"><h3>Data inventory · findings</h3></div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Source</th>
+              <th>Status</th>
+              <th>Verdict</th>
+            </tr>
+            <tr>
+              <td>macro store (all 97 series enumerated)</td>
+              <td class="num">0 energy series</td>
+              <td><span style="color: var(--negative)">greenfield</span></td>
+            </tr>
+            <tr>
+              <td>livewire lake · WTI (CL)</td>
+              <td class="num">5 contract months landing raw</td>
+              <td>
+                <span style="color: var(--positive)">already collecting</span>
+              </td>
+            </tr>
+            <tr>
+              <td>livewire lake · Brent (BZ)</td>
+              <td class="num">4 contract months landing raw</td>
+              <td>
+                <span style="color: var(--positive)">already collecting</span>
+              </td>
+            </tr>
+            <tr>
+              <td>livewire lake · natural gas (NG)</td>
+              <td class="num">none</td>
+              <td><span style="color: var(--negative)">missing</span></td>
+            </tr>
+            <tr>
+              <td>argon code scaffolding</td>
+              <td class="num">grep: zero hits</td>
+              <td>no legacy baggage</td>
+            </tr>
+          </table>
+        </div>
+        <div class="prov">
+          <b>Method</b> full distinct-series enumeration over
+          macro_observations/macro_series_daily/monthly +
+          bronze/asset_class={cmdty,futures} directory inventory · 2026-08-26
+          <span class="tag real">REAL</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>Onboarding route · three steps, each standalone</h3>
+        </div>
+        <ul class="tight">
+          <li>
+            <b>P1 · FRED series</b> (DCOILWTICO / DCOILBRENTEU / DHHNGSP →
+            macro_series_daily): reuses the existing macro_series_ingest
+            channel, zero new infrastructure. Unlocked same-day: WTI/Brent
+            levels and YoY, the Brent−WTI spread, the
+            <b>gold÷oil valuation anchor</b> (L3's null cell lights up), and WTI
+            YoY ↔ breakeven rolling corr (transmission measurement, reusing the
+            gold gauge methodology)
+          </li>
+          <li>
+            <b>P2 · lake futures</b> (CL/BZ contract months → term-structure
+            panel): contango/backwardation and roll structure — something the
+            FRED spot series cannot give, and none of the four reference
+            monitors has
+          </li>
+          <li>
+            <b>P3 · natural gas + seasonality</b>: once the NG series lands, the
+            seasonal panel = current month's price percentile inside its 10-year
+            same-month distribution (heating/injection season structure).
+            Describe first, research later — seasonality is NG's first-class
+            property; copying the oil panel wholesale would be wrong
+          </li>
+        </ul>
+        <div class="prov">
+          <b>Discipline</b> an energy domain state (e.g. SUPPLY_TIGHT/GLUT)
+          needs its own spec + threshold measurement; until then this tab shows
+          only levels/spreads/percentiles, no labels
+          <span class="tag plan">PLANNED</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g3" style="margin-top: 12px">
+      <div class="ghost">
+        <h3>WTI / Brent levels + spread</h3>
+        <span
+          >Two lines + a Brent−WTI spread bar. Lights up after P1. The
+          transport/quality spread itself carries geopolitical information (cf.
+          Hormuz sensitivity).</span
+        >
+      </div>
+      <div class="ghost">
+        <h3>Futures term structure</h3>
+        <span
+          >CL/BZ contract months connected, contango/backwardation annotated.
+          Lights up after P2; the lake is already collecting.</span
+        >
+      </div>
+      <div class="ghost">
+        <h3>NG seasonal band</h3>
+        <span
+          >Current month vs the 10-year same-month p10–p90 band. Lights up after
+          P3. A seasonal percentile is the correct "52w percentile" analog for
+          NG.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 07 FACTORS ══════════════════ -->
+  <section id="t7" role="tabpanel">
+    <div class="sec-title">
+      <h2>Factor Export · Equity Consumes Macro</h2>
+      <span class="tag q">Q1 Q7</span>
+    </div>
+    <p class="sec-sub">
+      <b
+        >Direction contract (this phase's architecture decision): equity → reads
+        → macro factor, never the reverse.</b
+      >
+      The macro desk derives no equity exposure (MC5 was measured shut); it
+      guarantees the factor is <b>point-in-time correct</b> (available_at ≤
+      as_of + the invalidation clause), and the burden of proving predictive
+      power sits in each consumer's own backtest — the only honest division of
+      labor after MC6 returned descriptive_only.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel" style="grid-column: 1/-1">
+        <div class="panel-h">
+          <h3>Macro factor vector · today's snapshot</h3>
+          <span class="tag q">Q1</span>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Factor</th>
+              <th class="num">Current</th>
+              <th class="num">Δ</th>
+              <th class="num">Data as-of</th>
+              <th>Type</th>
+            </tr>
+            <tr>
+              <td>real_10y (DFII10)</td>
+              <td class="num">2.38%</td>
+              <td class="num">60d +31bp · 1w −3bp</td>
+              <td class="num">08-24</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>breakeven_10y (T10YIE)</td>
+              <td class="num">2.32%</td>
+              <td class="num">1w +5bp</td>
+              <td class="num">08-25</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>nominal_10y <span class="tag comp">COMPUTED</span></td>
+              <td class="num">4.70%</td>
+              <td class="num">1w +2bp</td>
+              <td class="num">08-24</td>
+              <td>identity real+BEI</td>
+            </tr>
+            <tr>
+              <td>policy_rate_mid</td>
+              <td class="num">3.625%</td>
+              <td class="num">—</td>
+              <td class="num">07-29 FOMC</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>market_implied_vs_actual</td>
+              <td class="num">+25.5bp</td>
+              <td class="num">—</td>
+              <td class="num">08-26</td>
+              <td>continuous · pricing gap</td>
+            </tr>
+            <tr>
+              <td>funding_spread (SOFR−EFFR)</td>
+              <td class="num">+2bp</td>
+              <td class="num">1w +3bp · 13w +14bp</td>
+              <td class="num">08-24</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>core_pce_3m_annualized</td>
+              <td class="num">2.89%</td>
+              <td class="num">3m +0.03pp</td>
+              <td class="num">period 06-01 · avail 07-30</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>broad_usd_3m / real_usd_3m</td>
+              <td class="num">−1.09% / +1.16%</td>
+              <td class="num">opposite signs</td>
+              <td class="num">08-21 / 07-01</td>
+              <td>continuous · tier 1</td>
+            </tr>
+            <tr>
+              <td>gold_3m / gold_realyield_corr126</td>
+              <td class="num">+13.45% / −0.85</td>
+              <td class="num">corr60 −0.17 · corr252 −0.04</td>
+              <td class="num">08-25</td>
+              <td>continuous · transmission</td>
+            </tr>
+            <tr>
+              <td>gld_flow_30d / cot_mm_pctile</td>
+              <td class="num">+45.0t / p84</td>
+              <td class="num">4w +0.86σ</td>
+              <td class="num">08-24 / 08-21</td>
+              <td>continuous · positioning</td>
+            </tr>
+            <tr>
+              <td>tff_asset_mgr_pctile (10Y fut)</td>
+              <td class="num">p62</td>
+              <td class="num">4w −1.92pp</td>
+              <td class="num">08-18</td>
+              <td>continuous · positioning</td>
+            </tr>
+            <tr>
+              <td>gvz_gold_vol</td>
+              <td class="num">28.28</td>
+              <td class="num">1w +4.4 pts</td>
+              <td class="num">08-25</td>
+              <td>continuous · expression cost</td>
+            </tr>
+            <tr>
+              <td>vix</td>
+              <td class="num">15.85</td>
+              <td class="num">1w +1.6 pts</td>
+              <td class="num">08-25</td>
+              <td>continuous · expression cost</td>
+            </tr>
+            <tr>
+              <td>hy_oas</td>
+              <td class="num">2.69%</td>
+              <td class="num">1w +2bp</td>
+              <td class="num">08-25</td>
+              <td>continuous · credit risk</td>
+            </tr>
+            <tr>
+              <td style="color: var(--text-muted)">
+                state labels ×4 (inflation/rates/usd/gold)
+              </td>
+              <td class="num" style="color: var(--text-muted)">see tab 00</td>
+              <td class="num">—</td>
+              <td class="num">08-26 07:40</td>
+              <td style="color: var(--warning)">labels · context only</td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          <b
+            >Continuous variables are the first-class factor payload; discrete
+            labels are human context only.</b
+          >
+          Measured reason: state labels chatter (inflation flipped 4× in 68
+          months; a classifier boundary at the median chatters maximally, and
+          hysteresis made it worse). An equity backtest that joins a chattering
+          label gets boundary noise, not macro information. The three risk rows
+          (GVZ/VIX/HY OAS) are exported because expression cost is itself a
+          factor an equity consumer prices.
+        </p>
+        <div class="prov">
+          <b>Contract</b> PIT double clause (available_at ≤ as_of AND
+          invalidated_at not ≤ as_of) · engine-versioned (inflation/2 · rates/2
+          · usd/3 · gold/2) · inputs_hash reproduces the same vector
+          <span class="tag real">REAL</span> · vol/credit rows: latest obs in
+          the 08-26 07:40 pull (nominally 08-25; FRED dailies can lag a session)
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h"><h3>Delivery form · proposal</h3></div>
+        <ul class="tight">
+          <li>
+            <b>API</b>: GET /api/macro/factors?as_of=… (flat JSON, one row per
+            factor: name/value/available_at/engine_version/inputs_hash)
+          </li>
+          <li>
+            <b>Materialized table</b> (for backtest joins):
+            uw_scan.macro_factor_daily, written nightly 19:41 ET (after the
+            snapshot) — one daily factor-vector row; backtests join by date and
+            never cross available_at
+          </li>
+          <li>
+            <b>Consumption precedent</b>: any apex/argon equity-side strategy
+            takes factors as conditioning columns; significance tested and
+            reported by each consumer separately
+          </li>
+        </ul>
+        <div class="prov">
+          <b>Build size</b> read side is pure assembly (every number above is
+          already extractable from existing tables — this page is the proof);
+          write side is one table + one job
+          <span class="tag plan">PLANNED</span>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>What this export does not promise</h3>
+          <span class="tag q">Q7</span>
+        </div>
+        <div class="note-refuse">
+          <b>NO PREDICTIVE CLAIM</b> MC6's pre-test verdict: descriptive_only.
+          The factor vector describes "what the macro world looks like now"; it
+          claims no information about any asset's forward return — that claim
+          must be earned in the consumer's own out-of-sample tests.
+          Reference-site counterexample: inflation-monitor's four-asset signal
+          tower shows confidences 74/72/60/51, all without provenance — we do
+          not produce such numbers.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ══════════════════ 08 DESIGN NOTES ══════════════════ -->
+  <section id="t8" role="tabpanel">
+    <div class="sec-title"><h2>Design Notes · For Review</h2></div>
+    <p class="sec-sub">
+      This tab is for you (the operator) and does not ship on the final page.
+      Ten blocks: ① the first-principles derivation and the Q1–Q7 → panel
+      mapping ② the deep-review verdict (before → after) ③ the reference-monitor
+      benchmark ④ data-quality findings from this build ⑤ the full extraction
+      inventory across /rates, /macro and /gold ⑥ four dead elements found on
+      the live pages ⑦ two freshness-reporting holes ⑧ the palette decision
+      record ⑨ the endpoint reality check ⑩ routing / implementation split +
+      open questions.
+    </p>
+
+    <div class="grid g2">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>① First principles · why the board is shaped like this</h3>
+        </div>
+        <p class="read">
+          A macro PM's P&amp;L is Σ (position × price move). They are paid on
+          <b>the gap between their state assessment and what is priced</b> —
+          nothing on a screen matters unless it feeds direction, size, timing,
+          or risk. So the desk opens on the loop the PM actually runs each
+          morning: <b>WHAT CHANGED</b> (Δ in state, confidence, market) ·
+          <b>WHAT DISAGREES</b> (where the evidence or the pricing contradicts
+          itself — the raw material of trades) · <b>WHAT'S NEXT</b> (dated
+          events that will confirm or falsify). The seven questions are the
+          acceptance test: every panel must answer at least one, or it gets
+          deleted.
+        </p>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Question</th>
+              <th>Answered by</th>
+            </tr>
+            <tr>
+              <td>Q1 State</td>
+              <td>00 chain nodes · 01–04 state cards</td>
+            </tr>
+            <tr>
+              <td>Q2 Pricing</td>
+              <td>
+                00/01 four-path chart · per-meeting odds · 10Y decomposition ·
+                04 expression cost
+              </td>
+            </tr>
+            <tr>
+              <td>Q3 Disagreement</td>
+              <td>
+                00 zone 2 (engine feed + cross-domain rows) · 02 wedge/breadth ·
+                03 nominal/real divergence
+              </td>
+            </tr>
+            <tr>
+              <td>Q4 Transmission</td>
+              <td>
+                00 link-strength table · 04 correlation + decay charts ·
+                citation integrity
+              </td>
+            </tr>
+            <tr>
+              <td>Q5 Positioning</td>
+              <td>01 TFF percentiles · 04 CB buckets / ETF / COT / skew</td>
+            </tr>
+            <tr>
+              <td>Q6 Falsifiers</td>
+              <td>
+                00 zone 3 (calendar + repair table) · 01 next events · 02 repair
+                table
+              </td>
+            </tr>
+            <tr>
+              <td>Q7 Trust</td>
+              <td>
+                confidence arithmetic · provenance rows · refusal cards ·
+                REAL/COMPUTED tags
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>② Deep-review verdict · before → after</h3>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Gap found in the review</th>
+              <th>Resolution on this board</th>
+            </tr>
+            <tr>
+              <td>
+                <b>No Δ layer</b> — the board answered "where am I" but not
+                "what changed since yesterday"; the PM's first question every
+                morning was entirely missing
+              </td>
+              <td>
+                Zone 1: state-flip × confidence-move table · 1-week market
+                deltas · anchor-decay sparkline
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <b>Calendar half-missing</b> — falsifiers named events but not
+                dates; nothing said "the next FOMC is Sep 15–16 and here is
+                what's priced into it"
+              </td>
+              <td>
+                Zone 3: REAL FOMC calendar + market-implied per-meeting odds ·
+                dated repair table · tab 01 next-events panel
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <b>Expression cost absent</b> — a PM prices the trade, not just
+                the state; the board said nothing about what expressing a view
+                costs
+              </td>
+              <td>
+                GVZ/VIX/HY-OAS rows in zone 1 and tab 07 · the gold
+                expression-cost panel in tab 05
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <b>Strength confirmed</b> — auditable confidence multiplication
+                + citation integrity + honest refusals
+              </td>
+              <td>Unchanged. It is the moat; every new panel inherits it</td>
+            </tr>
+            <tr>
+              <td>
+                <b>Extraction from /rates</b> — the operator selected two panels
+                off the existing /rates desk for carry-over: dealer
+                expectations, and the par yield curve with its tenor deltas and
+                spread tiles. Both earn the place for the same structural
+                reason:
+                <b
+                  >each shows a level against its own recent history in one
+                  glance</b
+                >
+                — the Δ layer this review found missing. They are also the two
+                panels the review would have had to invent from scratch
+                otherwise
+              </td>
+              <td>
+                <b>Tab 01</b>: "Dealer expectations · the 3.63 dot, unrolled"
+                (three survey vintages + IQR, deepened with the first-cut
+                horizon shift and the date consensus ends). <b>Tab 02</b>: "Par
+                yield curve · current vs 1W vs 1M" (deepened by replacing the
+                source page's fixed interpretation sentences with computed
+                spread changes) — it moved to the curve tab in the split, next
+                to the decomposition that explains the 4.70 it prints. Both
+                endpoints verified to EXIST in production
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h">
+          <h3>③ Reference benchmark · four Vercel monitors</h3>
+        </div>
+        <div class="tbl-wrap">
+          <table>
+            <tr>
+              <th>Adopted (visible on this board)</th>
+              <th>From</th>
+            </tr>
+            <tr>
+              <td>52w / own-history percentile on every factor</td>
+              <td>gold-monitor</td>
+            </tr>
+            <tr>
+              <td>
+                Event intercepts → recast as computable conf/state sensitivity
+              </td>
+              <td>inflation-monitor</td>
+            </tr>
+            <tr>
+              <td>
+                Nominal 10Y decomposition + per-component attribution (2.5)
+              </td>
+              <td>ust-monitor (its ACM version is the correct one)</td>
+            </tr>
+            <tr>
+              <td>Path divergence as the signal ("which pole converges")</td>
+              <td>ust-monitor</td>
+            </tr>
+            <tr>
+              <td>VIX×TP 2×2 risk taxonomy (measure first, 2.5)</td>
+              <td>usd-monitor</td>
+            </tr>
+            <tr>
+              <th style="padding-top: 10px">Dropped</th>
+              <th style="padding-top: 10px">Why</th>
+            </tr>
+            <tr>
+              <td>0–100 composites (IPS/γ)</td>
+              <td>
+                usd-monitor's homepage γ=38 contradicts the 23 its own formula
+                produces; a composite averages away the contradictions, and
+                collides head-on with the no-composite test
+              </td>
+            </tr>
+            <tr>
+              <td>Editable scorecard</td>
+              <td>
+                good interaction, wrong philosophy: argon's answer is an
+                evidence-grounded state, not a hand-tuned weighted average;
+                /rates' legacy scorecard is kept, demoted, as-is
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Toy backtest account / sentiment word clouds / unsourced
+                confidences
+              </td>
+              <td>
+                a Sharpe 2.66 on 7 trades, a narrative component with 4 of 5
+                factors hardcoded — statistical noise mixed into a decision
+                surface
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p class="read">
+          The four monitors' biggest lesson is structural: they cannot even
+          agree on when the next FOMC is (07-29 vs 09-17), on dot medians, on
+          gold prices, or on the inflation regime —
+          <b>four silos wearing the costume of a chain</b>, which four
+          independent state stores guarantee. Argon's single evidence store +
+          state citation + snapshot verdict is immune to that disease by
+          construction.
+          <b
+            >Our completeness target = their information density + our
+            auditability.</b
+          >
+        </p>
+      </div>
+      <div class="panel">
+        <div class="panel-h">
+          <h3>④ Data-quality findings · from this build</h3>
+        </div>
+        <ul class="tight">
+          <li>
+            <b>macro_series_daily carries ~25× row duplication</b> per (series,
+            obs_date) — every reader must dedup by latest as_of per obs_date, or
+            averages and counts silently inflate
+            <span class="tag real">REAL</span>
+          </li>
+          <li>
+            <b>gold_posture_daily triple-writes per run</b> — read with DISTINCT
+            ON (obs_date) + row_status='active' or three rows answer for one day
+            <span class="tag real">REAL</span>
+          </li>
+          <li>
+            <b>GPRD (daily geopolitical risk) is extremely choppy</b> — use the
+            monthly GPR for display; the daily series is for research only
+            <span class="tag real">REAL</span>
+          </li>
+          <li>
+            <b>correlation_history's window — RESOLVED</b>, and the label on the
+            live page is misleading. It is <b>252-day</b>, from the single call
+            site
+            <span class="num">reports/gold_posture.py:381-383</span> (literal
+            <span class="num">252</span> for all three pairs) — which is why its
+            real-yield endpoint (−0.05) matched the 252d gauge (−0.04) and not
+            the 126d (−0.85). But three qualifiers make "252D ROLLING" wrong as
+            written: the stride is <b>21 trading days, not 1</b> (<span
+              class="num"
+              >:102,:114,:125</span
+            >), the input is trimmed to 5 years, and it correlates
+            <b>levels, not returns</b>. The two "252D" strings on the live page
+            (<span class="num">CorrelationHistoryPanel.tsx:20</span>,
+            <span class="num">CorrelationGaugeCard.tsx:23</span>) are
+            independent literals in separate modules with no shared constant
+            tying either to the code
+            <span class="tag real">RESOLVED</span>
+          </li>
+          <li>
+            <b>The prior yield curves are reconstructions, not stored series</b>
+            — /api/rates/snapshot serves the current level plus 1D/1W/1M deltas
+            and nothing else, so "1W ago" and "1M ago" are rebuilt as
+            <code>value − delta_bps/100</code> and the payload carries
+            <b>no anchor date</b> for either. The values are exact (they
+            reproduce all four API spreads to the decimal) but the calendar
+            labels are the builder's convention — latest observation on or
+            before as_of − 7d / − 30d — not a payload fact. Any future panel
+            that dates those curves is asserting something the API never said
+            <span class="tag real">REAL</span>
+          </li>
+          <li>
+            <b
+              >dealer_expectations.freshness reports zero discovery counters
+              while status is "ok"</b
+            >
+            — <code>releases_discovered / succeeded / failed</code> are all 0 on
+            the SME lane even though <code>last_success_at</code> is today and
+            <code>consecutive_failures</code> is 0. So the payload offers no
+            discovery evidence for this source: nothing in it would distinguish
+            a healthy poll from a lane that has silently stopped finding new
+            releases. Recorded as <b>observed, not diagnosed</b> — it was not
+            investigated in this build <span class="tag real">REAL</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>⑤ Extraction inventory · every panel on the three source pages</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        39 distinct panels across /rates, /macro and /gold, each traced to its
+        endpoint and table before judging.
+        <b
+          >8 carried and built · 5 carried and still available · 15 already
+          covered · 8 dropped · 3 dropped because they are structurally dead</b
+        >
+        (⑥). The merge is mostly deduplication: the three pages already share
+        engines and tables, so most rows are COVERED rather than new work.
+      </p>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Page</th>
+            <th>Panel</th>
+            <th class="num">Verdict</th>
+            <th>Reason / destination</th>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Policy / Rates State</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>01 · State &amp; confidence — same engine, same table</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Policy Paths — four lanes</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>00 + 01 · Four policy paths</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Committee projection (SEP) dot plot</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>01 · the 3.80 dot unrolled, + the Mar→Jun revision</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Dealer expectations by meeting date</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>01 · + first-cut shift and the date consensus ends</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Yield Curve (overlay + tenors + 4 spreads)</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>02 · + computed 1W/1M spread changes</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Decomposition · Cleveland 5-term</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>02 · term premium split out; model 43bp rich</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Decomposition · Move attribution</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>02 · retires the PLANNED slot on the 2-term panel</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Policy · Plumbing (WALCL/WRESBAL/TGA/RRP)</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>01 · the cash the rate is charged on</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Supply · Recent auctions</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>02 · bid-to-cover + indirect = the demand side</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Policy · Policy Rate card (target range, vote split)</td>
+            <td class="num" style="color: var(--warning)">
+              <b>CARRY · open</b>
+            </td>
+            <td>last_meeting.status is <i>partial</i>; vote split 9-3</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Positioning across tenor buckets</td>
+            <td class="num" style="color: var(--warning)">
+              <b>CARRY · open</b>
+            </td>
+            <td>desk carries 10Y only (contract 043602)</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Source Freshness (35 FRED series)</td>
+            <td class="num" style="color: var(--warning)">
+              <b>CARRY · open</b>
+            </td>
+            <td>see ⑦ — two series would render wrong</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Summary KPI tiles</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>identical numbers to the carried curve panel</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Legacy stance grid</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>kept demoted in 02 · What this tab refuses</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Decomposition · Fundamental / Policy view</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>
+              restates the formula; “10Y − EFFR” is a slope named as a premium
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Decomposition · Expectations sources</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>5y5y already on 03; the rest repeats the formula cards</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Policy · Market-Implied Path</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>01 · Per-meeting odds</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Supply · Issuance &amp; fiscal tiles</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>02 · Supply SUB-STATE</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Cross-Market</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>
+              holds no cross-market data — two decomposition fields, borrowed
+              heading
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Events</td>
+            <td class="num" style="color: var(--negative)">
+              <b>DROP · DEAD</b>
+            </td>
+            <td>
+              <span class="num">rates/snapshot.py:126</span> hardcodes
+              <span class="num">events=[]</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Scorecard</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>kept, demoted, as-is</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/rates</td>
+            <td>Synthesis</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>reprints sentences generated from the demoted legacy score</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/macro</td>
+            <td>Chain verdict banner</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>00 · Transmission health — all three states preserved</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/macro</td>
+            <td>Domain state card ×4</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>01/03/04/05 each open with this header</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/macro</td>
+            <td>“what this stood on” drawer</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>the confidence arithmetic strips</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/macro</td>
+            <td>Causal-order arrows</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>00 · transmission chain rail</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/macro</td>
+            <td>Header + lede</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>page chrome</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>REPLAY date picker</td>
+            <td class="num" style="color: var(--warning)">
+              <b>CARRY · open</b>
+            </td>
+            <td>the capability the whole desk wants — see Q-A</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>Data audit footer (inputs read vs declared)</td>
+            <td class="num" style="color: var(--positive)">
+              <b>CARRY · BUILT</b>
+            </td>
+            <td>05 · Input manifest, 13/16 with verbatim reasons</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L1 · GLD price × holdings × per-country CB</td>
+            <td class="num" style="color: var(--warning)">
+              <b>CARRY · open</b>
+            </td>
+            <td>desk has bucket-level only, no price overlay</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>Correlation history · 3 rolling series</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>05 · Anchor decay — window now resolved, band refused</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>KPI ×5 (spot, corr gauge, regime, lens, freshness)</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>spread across 00 and 05</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L1 cards ×5 (CB, ETF flow, COMEX, COT, skew, FX)</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>05 · L1 flows table</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L2 four reading cards + article zone</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>05 · L2 cyclical readings (dimmed)</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L3 valuation flag</td>
+            <td class="num" style="color: var(--text-muted)"><b>COVERED</b></td>
+            <td>05 · Three lenses — keeps ⚠ NEVER A SIZING INPUT</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L1/L2/L3 posture narrative ×3</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>the desk writes its own read line per panel</td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L2 · Two-force narrative</td>
+            <td class="num" style="color: var(--negative)">
+              <b>DROP · DEAD</b>
+            </td>
+            <td>
+              <span class="num">routers/gold.py:341-344</span> hardcodes “—” /
+              “—”
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>Lens decomposition · heuristic z</td>
+            <td class="num" style="color: var(--negative)">
+              <b>DROP · DEAD</b>
+            </td>
+            <td>
+              <span class="num">gold_posture.py:441</span> hardcodes
+              <span class="num">decomposition_rows = []</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--text-muted)">/gold</td>
+            <td>L3 “mean-reversion risk” box</td>
+            <td class="num" style="color: var(--text-muted)"><b>DROP</b></td>
+            <td>static prose, no data</td>
+          </tr>
+        </table>
+      </div>
+      <div class="prov">
+        <b>Method</b> every row traced page component → api.ts call → FastAPI
+        router → Postgres table before a verdict was assigned; verdicts are
+        about information value to a macro PM, not about code quality
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>
+          ⑥ Four dead elements on the live pages — and two misleading ones
+        </h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        These are not stale and not broken by an outage. They are
+        <b>hardcoded empty at the source</b> and render the same way on every
+        request, forever. Found while tracing data paths for the extraction
+        inventory; reported as observed, not diagnosed.
+      </p>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Page · panel</th>
+            <th>Cause</th>
+            <th>What it renders</th>
+          </tr>
+          <tr>
+            <td>/rates · Events</td>
+            <td>
+              <span class="num">rates/snapshot.py:126</span> —
+              <span class="num">events=[]</span> is a literal
+            </td>
+            <td>“Official events/news source not wired in Phase 1.”</td>
+          </tr>
+          <tr>
+            <td>/gold · Two-force narrative</td>
+            <td>
+              <span class="num">routers/gold.py:341-344</span> — returns “—” /
+              “—”
+            </td>
+            <td>two em-dashes under two headings</td>
+          </tr>
+          <tr>
+            <td>/gold · Lens decomposition</td>
+            <td>
+              <span class="num">reports/gold_posture.py:441</span> —
+              <span class="num">decomposition_rows = []</span>
+            </td>
+            <td>“No decomposition data”</td>
+          </tr>
+          <tr>
+            <td>/gold · pre-2022 ±1σ correlation band</td>
+            <td>
+              structurally unreachable — 343 rows, 5 sample points, all
+              post-2022 (<span class="num">gold_posture.py:129-140</span>)
+            </td>
+            <td>nothing — the chart silently omits it</td>
+          </tr>
+        </table>
+      </div>
+      <div class="note-refuse" style="margin-top: 10px">
+        <b>Two more are misleading rather than dead.</b> /rates
+        <b>“Cross-Market”</b> contains no cross-market data — it is two
+        decomposition fields (real 10Y, breakeven 10Y) under a borrowed heading.
+        /rates <b>“Synthesis”</b> prints duration and curve view sentences
+        generated from the legacy rule scorecard — the same score the page
+        elsewhere labels Experimental legacy, so reprinting it as a conclusion
+        re-promotes what the desk deliberately demoted.
+      </div>
+      <div class="prov">
+        <b>Why it matters for this merge</b> a dead panel that is ported forward
+        looks identical to a panel awaiting data. Each of these was dropped with
+        the reason recorded, so nobody re-adds it in Phase 3 expecting it to
+        fill in
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>⑦ Two freshness-reporting holes · observed, not diagnosed</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <ul class="tight">
+        <li>
+          <b
+            ><span class="num">FED_FUNDS_FUTURES_PATH</span> reports
+            <span class="num">latest_obs_date: null</span> with
+            <span class="num">status: ok</span></b
+          >
+          — a freshness strip that sorts or thresholds on obs date would place
+          it anywhere, or drop it, while calling it healthy
+        </li>
+        <li>
+          <b
+            ><span class="num">FED_FOMC</span> reports
+            <span class="num">latest_obs_date 2027-12-08</span></b
+          >
+          — a forward calendar date, not stale data. Any “age = today −
+          latest_obs” computation returns a large negative number for it
+        </li>
+        <li>
+          Both are why the <b>Source Freshness</b> panel is marked CARRY ·
+          <i>open</i> in ⑤ rather than built: a naive port of that strip would
+          publish two wrong rows on day one
+        </li>
+      </ul>
+      <div class="prov">
+        <b>Source</b> /api/rates/snapshot → .source_freshness · 35 series, 28 ok
+        / 7 partial at the 08-26 pull
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>⑧ Palette decision record</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <p class="read">
+        The chart series are argon's own tokens —
+        <span style="color: #f5a623">■</span>
+        <span class="num">--warning #f5a623</span> (most recent) ·
+        <span style="color: #38bdf8">■</span>
+        <span class="num">--accent-cool #38bdf8</span> (one step back) ·
+        <span style="color: #8b5cf6">■</span>
+        <span class="num">--info #8b5cf6</span> (two steps back), with
+        <span class="num">--text-primary #e2e8f0</span> reserved for
+        actual-level reference marks and never used as a series.
+      </p>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Check</th>
+            <th class="num">Result</th>
+            <th>Detail</th>
+          </tr>
+          <tr>
+            <td>CVD separation</td>
+            <td class="num" style="color: var(--positive)">PASS</td>
+            <td>worst adjacent pair ΔE 17.5 deutan / 20.9 tritan</td>
+          </tr>
+          <tr>
+            <td>Normal-vision floor</td>
+            <td class="num" style="color: var(--positive)">PASS</td>
+            <td>24.2 against a floor of 15</td>
+          </tr>
+          <tr>
+            <td>Contrast vs surface</td>
+            <td class="num" style="color: var(--positive)">PASS</td>
+            <td>all ≥ 3:1 on <span class="num">#0f1519</span></td>
+          </tr>
+          <tr>
+            <td>Chroma floor</td>
+            <td class="num" style="color: var(--positive)">PASS</td>
+            <td>all three series</td>
+          </tr>
+          <tr>
+            <td>Lightness band</td>
+            <td class="num" style="color: var(--warning)">FAIL</td>
+            <td>
+              amber L 0.784, sky L 0.754 sit outside the validator's dark band
+              [0.48, 0.67]
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="note-refuse" style="margin-top: 10px">
+        <b>The lightness FAIL was not fixed, deliberately.</b> Re-stepping would
+        have produced colours that are not argon's, to satisfy a within-palette
+        uniformity heuristic, while every check that protects readability
+        already passes. Brand fidelity was an explicit instruction and the band
+        check is not a readability gate. Recorded here so the decision is not
+        silently re-litigated — and so that if the brand tokens ever change, the
+        trade-off is visible rather than inherited. <br /><br />
+        One earlier candidate <b>was</b> re-stepped on this evidence: a teal +
+        sky pairing failed the <b>normal-vision floor at 14.3</b>, which is a
+        readability gate, so teal was dropped as a series colour even though it
+        is argon's primary accent.
+      </div>
+    </div>
+
+    <div class="panel" style="margin-top: 12px">
+      <div class="panel-h">
+        <h3>⑨ Endpoint reality check · every panel on this desk</h3>
+        <span class="tag q">Q7</span>
+      </div>
+      <p class="read" style="margin-bottom: 10px">
+        This board is a specification, so every panel on it is a claim that a
+        data path exists. Each was verified against the running API on the mini
+        and against the router source.
+      </p>
+      <div class="tbl-wrap">
+        <table>
+          <tr>
+            <th>Endpoint</th>
+            <th class="num">Status</th>
+            <th>Router / note</th>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/rates/snapshot</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/rates.py:28</span> — curve, spreads,
+              decomposition, attribution, supply, auctions, plumbing,
+              positioning
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/macro/policy</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/macro.py:28</span> — four paths,
+              per-meeting odds, dealer survey, SEP dots · accepts
+              <span class="num">as_of</span>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <span class="num">GET /api/macro/{inflation,rates,usd,gold}</span>
+            </td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/macro.py:46,60,74,88</span> — the four
+              domain state cards · accept <span class="num">as_of</span>
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/macro/snapshot</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/macro.py:119</span> — the chain verdict
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/gold/state</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/gold.py:422</span> — lenses, correlation
+              history, input manifest · <b>no api.ts wrapper today</b>, both
+              gold pages fetch it raw
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/gold/replay?as_of=</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td><span class="num">routers/gold.py:499</span></td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/gold/gauge</span></td>
+            <td class="num" style="color: var(--positive)">EXISTS</td>
+            <td>
+              <span class="num">routers/gold.py:367</span> —
+              <b>never consumed by any page</b>; carries
+              <span class="num">history_252d</span>
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/rates/snapshot?as_of=</span></td>
+            <td class="num" style="color: var(--negative)">MISSING</td>
+            <td>
+              no date param at <span class="num">routers/rates.py:29-32</span>;
+              blocks desk-wide replay — see Q-A
+            </td>
+          </tr>
+          <tr>
+            <td><span class="num">GET /api/macro/factors?as_of=</span></td>
+            <td class="num" style="color: var(--negative)">MISSING</td>
+            <td>proposed only, in 07 Factor Export — no route exists</td>
+          </tr>
+        </table>
+      </div>
+      <div class="prov">
+        <b>Two build-time facts</b> /api/gold/state has no typed
+        <span class="num">api.ts</span> wrapper — porting gold panels should add
+        <span class="num">api.goldState()</span> rather than copy the raw fetch
+        · and <span class="num">RatesSnapshotResponse.state</span> is gated by
+        <span class="num">settings.rates_snapshot_state_block_enabled</span>
+        (<span class="num">routers/rates.py:39</span>); if that flag is off the
+        same state is still reachable via
+        <span class="num">/api/macro/rates</span>
+        <span class="tag real">REAL</span>
+      </div>
+    </div>
+    <div class="grid g2" style="margin-top: 12px">
+      <div class="panel">
+        <div class="panel-h"><h3>⑩ Routing &amp; implementation split</h3></div>
+        <ul class="tight">
+          <li>
+            <b>Routing</b>: /macro becomes the umbrella, sub-tab routes
+            /macro/[tab] (chain·rates·inflation·usd·gold·energy·factors); /rates
+            and /gold 301 → their tabs; /gold/replay/[date] kept
+          </li>
+          <li>
+            <b>P2.1 presentation merge</b>: umbrella routes + 00 daily loop +
+            contradiction feed. Zero new APIs, zero new tables — every REAL
+            number on this page proves the existing endpoints suffice
+          </li>
+          <li>
+            <b>P2.2 deep pages</b>: unfold inflation/usd from cards into tabs;
+            wire up the three existing-but-unconsumed endpoints (/api/gold/gauge
+            history_252d, /api/gold/lenses/*, /api/gold/inputs/*)
+          </li>
+          <li>
+            <b>P2.3 factor contract</b>: macro_factor_daily table +
+            /api/macro/factors + the 19:41 job
+          </li>
+          <li>
+            <b>P2.4 energy P1</b>: three FRED series into ingest; the gold÷oil
+            anchor lights up
+          </li>
+          <li>
+            Each step is an independent small PR, independently revertible; the
+            invariant tests (no-composite, three-state slots, UNKNOWN≠NEUTRAL,
+            anonymous dots) migrate wholesale and stay green
+          </li>
+        </ul>
+      </div>
+      <div class="panel">
+        <div class="panel-h"><h3>Open questions · for the operator</h3></div>
+        <ul class="tight">
+          <li>
+            <b
+              >Q-A full-desk replay — no longer an open question, it is one
+              missing parameter.</b
+            >
+            <span class="num"
+              >/api/macro/{policy,inflation,rates,usd,gold,snapshot}</span
+            >
+            and <span class="num">/api/gold/{state,replay}</span> all accept
+            <span class="num">as_of</span> today.
+            <span class="num">/api/rates/snapshot</span> accepts none (<span
+              class="num"
+              >routers/rates.py:29-32</span
+            >, and <span class="num">fetch_latest_rates_snapshot</span> has no
+            <span class="num">as_of</span> clause at
+            <span class="num">storage/rates_repository.py:186-195</span>). Until
+            that is added, a desk-wide replay would render a <b>live</b> tab 02
+            beside a replayed tab 01, 03, 04 and 05 — the single worst failure
+            mode for a point-in-time desk, because nothing on screen would say
+            so.
+            <span style="color: var(--accent-bg)"
+              >Recommended: add the parameter first, then promote date
+              navigation. Whole-desk any-date replay is the one capability none
+              of the four reference monitors could ever build</span
+            >
+          </li>
+          <li>
+            <b>Q-B energy ordering</b>: P1 first (FRED spot series, usable
+            same-day) or lake term structure first (more distinctive, more
+            expensive)? Recommended: P1 first
+          </li>
+          <li>
+            <b>Q-C factor delivery</b>: API-only to start, or materialize
+            directly? Recommended: materialize (backtest join is the first
+            consumer)
+          </li>
+          <li>
+            <b>Q-D falsifier thresholds</b>: invest in the Phase 2.5 measurement
+            of "what CPI/PCE print flips the state" (the full event-intercept)?
+          </li>
+          <li>
+            <b>Q-E /regime cross-link</b>: put a read-only deep link to the vol
+            desk (the vrp card) on the 00 overview?
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div>
+      Data snapshot 2026-08-26 07:40 UTC+8 · all REAL values verbatim from the
+      macmini production DB (option_wizard/uw_scan) and production API:
+      <code
+        >ssh macmini 'curl -s
+        http://127.0.0.1:8400/api/macro/{inflation,rates,usd,gold,snapshot}'</code
+      >
+      · <code>/api/gold/state</code> · psql inventory commands live in the
+      research notes (use a tab field separator — series ids embed a literal
+      "|"). COMPUTED values show their formula in place; PLANNED panels contain
+      no fabricated data.
+    </div>
+    <div style="margin-top: 6px">
+      Invariants: no composite (test-enforced) · four paths never averaged ·
+      UNKNOWN ≠ NEUTRAL · three-state empty slots · valuation never a sizing
+      input · equity consumes macro factors, the reverse is forbidden.
+    </div>
+  </div>
+</footer>
+
+<div class="tooltip" id="tt"></div>
+
+<script>
+  // tabs
+  const tabs = [...document.querySelectorAll(".tab")];
+  const panels = [...document.querySelectorAll('section[role="tabpanel"]')];
+  function go(id) {
+    tabs.forEach((t) =>
+      t.setAttribute("aria-selected", t.dataset.t === id ? "true" : "false"),
+    );
+    panels.forEach((p) => p.classList.toggle("on", p.id === id));
+    try {
+      history.replaceState(null, "", "#" + id);
+    } catch (e) {}
+    window.scrollTo({ top: 0 });
+  }
+  tabs.forEach((t) => t.addEventListener("click", () => go(t.dataset.t)));
+  if (location.hash && panels.some((p) => "#" + p.id === location.hash))
+    go(location.hash.slice(1));
+
+  // lightweight hover tooltip mirroring the <title> content (desktop nicety; native title still works)
+  const tt = document.getElementById("tt");
+  document.querySelectorAll("svg circle, svg rect").forEach((el) => {
+    const t = el.querySelector("title");
+    if (!t) return;
+    el.addEventListener("mousemove", (e) => {
+      tt.textContent = t.textContent;
+      tt.style.display = "block";
+      tt.style.left = e.clientX + 14 + "px";
+      tt.style.top = e.clientY + 10 + "px";
+    });
+    el.addEventListener("mouseleave", () => {
+      tt.style.display = "none";
+    });
+  });
+</script>
+
+</body></html>

--- a/web/scripts/board-pixel-compare.mjs
+++ b/web/scripts/board-pixel-compare.mjs
@@ -1,0 +1,347 @@
+/**
+ * Board-vs-live design conformance check.
+ *
+ * ## Why this is not a raw pixel diff
+ *
+ * The obvious reading of "pixel comparison" is `board.png XOR live.png`, and it would
+ * report almost nothing useful. The board's panels carry MOCK values frozen at its capture
+ * instant and the live desk derives its own at render time — that is a rule of this port,
+ * not a defect — so a bitmap subtraction is dominated by digits and prose and says nothing
+ * about whether the design was ported. Two pages can differ in every pixel and share a
+ * design; two can be pixel-close and disagree on every token.
+ *
+ * So the comparison is made where the design actually lives:
+ *
+ *   1. GRAMMAR COVERAGE — every class the board's stylesheet defines and uses, against
+ *      whether the live desk uses it. A class the board renders and the live page never
+ *      does is a design element that was not ported.
+ *   2. COMPUTED STYLE — for each selector present on both sides, the resolved values the
+ *      browser actually paints. This is the pixel-level check, one layer above pixels:
+ *      it compares what would be painted rather than what the stylesheet claims.
+ *   3. SCREENSHOTS — full-page, both sides, for the eye to catch what neither can:
+ *      proportion, rhythm, whether a grid reads as a grid.
+ *
+ * ## Two normalisations, both load-bearing
+ *
+ * Without them the report is 300 lines of noise and nobody reads it twice.
+ *
+ *   - SELECTORS, NOT CLASSES. `.tag` matches `.tag.real` (teal) and `.tag.q` (violet), and
+ *     a bare `querySelector` picks whichever comes first in each document — so the probe
+ *     reports a colour difference that is really "the two pages open with a different kind
+ *     of tag". Every entry below is specific enough to name ONE thing.
+ *   - COLOUR SPACE. argon renders the board's `rgba()` overlays as `color-mix()`, a
+ *     recorded deviation (the board is single-theme dark; argon has a light theme). Chrome
+ *     serialises the result as `color(srgb …)`, which is the same paint in a different
+ *     notation. Both sides are normalised to 8-bit rgba before comparison, so a real
+ *     colour change still shows and a notation change does not.
+ *
+ * Run: node scripts/board-pixel-compare.mjs
+ * Output: output/playwright/board-compare/
+ */
+import { chromium } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const BOARD =
+  process.env.BOARD_HTML ??
+  resolve("../docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html");
+const LIVE = process.env.LIVE_BASE ?? "http://127.0.0.1:3002";
+const OUT = resolve("../output/playwright/board-compare");
+
+/** Board tab id -> the live route that ports it. t8 does not ship on the strip. */
+const TABS = [
+  ["t0", "overview"],
+  ["t1", "fed"],
+  ["t2", "rates"],
+  ["t3", "inflation"],
+  ["t4", "usd"],
+  ["t5", "gold"],
+  ["t6", "energy"],
+  ["t7", "factors"],
+];
+
+/** The properties that decide whether an element looks like itself. */
+const PROPS = [
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "letterSpacing",
+  "lineHeight",
+  "textTransform",
+  "color",
+  "backgroundColor",
+  "borderTopWidth",
+  "borderLeftWidth",
+  "borderTopColor",
+  "borderLeftColor",
+  "borderTopLeftRadius",
+  "paddingTop",
+  "paddingLeft",
+  "gap",
+  "display",
+  "opacity",
+];
+
+/**
+ * What to compare. Each entry names ONE visual thing.
+ *
+ * The board's own shell (`.appbar`, `.tabbar`, `.wrap`, `.pmq`, `.intro`) is excluded:
+ * argon supplies its own chrome around the desk and the board's masthead is not what was
+ * being ported. What is here is the CONTENT grammar — the part that has to match.
+ */
+const SELECTORS = [
+  ["section-title", ".sec-title h2"],
+  ["section-standfirst", "p.sec-sub"],
+  ["panel", ".panel"],
+  ["panel-heading", ".panel-h h3"],
+  ["read-rail", "p.read, div.read"],
+  ["provenance", ".prov"],
+  ["tag-real", ".tag.real"],
+  ["tag-question", ".tag.q"],
+  ["table-header-cell", "th"],
+  ["table-cell", "td"],
+  ["table-numeric-cell", "td.num"],
+  ["big-number", ".big"],
+  ["state-pill", ".state"],
+  ["grid-2up", ".grid.g2"],
+  ["grid-3up", ".grid.g3"],
+  ["refusal-note", ".note-refuse"],
+  ["arith-term", ".arith .term"],
+  ["arith-result", ".arith .res"],
+  ["zone-banner", ".zone"],
+  ["zone-kicker", ".zone .zk"],
+  ["zone-label", ".zone .zl"],
+  ["chain-node", ".node"],
+  ["chain-node-heading", ".node h3"],
+  ["chain-kv", ".node .kv"],
+  ["confidence-bar", ".conf"],
+  ["confidence-track", ".conf .track"],
+  ["meter-label", ".meter .lbl"],
+  ["meter-track", ".meter .track"],
+  ["meter-value", ".meter .val"],
+  ["contradiction", ".contra"],
+  ["contradiction-heading", ".contra b"],
+  ["chart-frame", ".chart"],
+  ["caption", ".cap"],
+  ["legend", ".lgd"],
+  ["ghost-panel", ".ghost"],
+  ["chip", ".chip"],
+  ["edge-note", ".edge-note"],
+  ["meeting-row", ".meet"],
+  ["probability-bar", ".pbar"],
+  ["direction-label", ".dir"],
+  ["tight-list-item", "ul.tight li"],
+];
+
+const probeSource = `
+window.__probe = (entries, props) => {
+  const norm = (v) => {
+    if (typeof v !== "string") return v;
+    // color(srgb r g b / a) -> rgba(R, G, B, a). argon renders the board's rgba()
+    // overlays through color-mix(), which Chrome serialises in srgb notation. Same
+    // paint, different spelling.
+    const m = v.match(/^color\\(srgb ([\\d.]+) ([\\d.]+) ([\\d.]+)(?: \\/ ([\\d.]+))?\\)$/);
+    if (m) {
+      const to255 = (x) => Math.round(parseFloat(x) * 255);
+      const a = m[4] === undefined ? 1 : Math.round(parseFloat(m[4]) * 100) / 100;
+      return a === 1
+        ? \`rgb(\${to255(m[1])}, \${to255(m[2])}, \${to255(m[3])})\`
+        : \`rgba(\${to255(m[1])}, \${to255(m[2])}, \${to255(m[3])}, \${a})\`;
+    }
+    const r = v.match(/^rgba?\\(([\\d.]+),\\s*([\\d.]+),\\s*([\\d.]+)(?:,\\s*([\\d.]+))?\\)$/);
+    if (r) {
+      const a = r[4] === undefined ? 1 : Math.round(parseFloat(r[4]) * 100) / 100;
+      const c = (x) => Math.round(parseFloat(x));
+      return a === 1
+        ? \`rgb(\${c(r[1])}, \${c(r[2])}, \${c(r[3])})\`
+        : \`rgba(\${c(r[1])}, \${c(r[2])}, \${c(r[3])}, \${a})\`;
+    }
+    return v;
+  };
+  const out = {};
+  for (const [name, sel] of entries) {
+    let el = null;
+    try { el = document.querySelector(sel); } catch { el = null; }
+    if (!el) { out[name] = null; continue; }
+    const cs = getComputedStyle(el);
+    const rec = {};
+    for (const p of props) rec[p] = norm(cs[p]);
+    // The first font family only. The board and argon declare different FALLBACK chains
+    // and both resolve to the same face; a difference after the first entry is invisible
+    // unless that face fails to load, and is reported separately rather than 40 times.
+    rec.fontFamily = (rec.fontFamily || "").split(",")[0].trim().replace(/^"|"$/g, "");
+    out[name] = rec;
+  }
+  return out;
+};
+`;
+
+/** A property whose value cannot mean anything on this element. */
+const MEANINGLESS = (prop, rec) =>
+  (prop.startsWith("borderTop") &&
+    prop !== "borderTopWidth" &&
+    rec.borderTopWidth === "0px") ||
+  (prop.startsWith("borderLeft") &&
+    prop !== "borderLeftWidth" &&
+    rec.borderLeftWidth === "0px") ||
+  (prop === "gap" && !["flex", "grid", "inline-flex"].includes(rec.display));
+
+async function main() {
+  mkdirSync(OUT, { recursive: true });
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    deviceScaleFactor: 1,
+    colorScheme: "dark",
+  });
+  await ctx.addInitScript(probeSource);
+
+  const boardStyles = {};
+  const board = await ctx.newPage();
+  await board.goto(`file://${BOARD}`);
+  await board.waitForTimeout(400);
+  for (const [tid, slug] of TABS) {
+    // Force ONE panel visible. The board hides tabpanels with `display:none`, and a
+    // computed style read off a hidden subtree is the hidden value, not the painted one.
+    await board.evaluate((id) => {
+      document
+        .querySelectorAll('section[role="tabpanel"]')
+        .forEach((s) => s.classList.remove("on"));
+      document.getElementById(id)?.classList.add("on");
+    }, tid);
+    await board.waitForTimeout(120);
+    boardStyles[tid] = await board.evaluate(
+      ([e, p]) => window.__probe(e, p),
+      [SELECTORS, PROPS],
+    );
+    await board.screenshot({
+      path: `${OUT}/board-${tid}-${slug}.png`,
+      fullPage: true,
+    });
+  }
+  await board.close();
+
+  const liveStyles = {};
+  const live = await ctx.newPage();
+  for (const [tid, slug] of TABS) {
+    const res = await live.goto(`${LIVE}/macro/${slug}`, {
+      waitUntil: "networkidle",
+    });
+    if (!res || !res.ok()) {
+      liveStyles[tid] = {};
+      console.error(
+        `live /macro/${slug}: HTTP ${res ? res.status() : "no response"}`,
+      );
+      continue;
+    }
+    await live.waitForTimeout(250);
+    liveStyles[tid] = await live.evaluate(
+      ([e, p]) => window.__probe(e, p),
+      [SELECTORS, PROPS],
+    );
+    // `fullPage` captures the DOCUMENT's scroll height, and argon's AppShell scrolls an
+    // inner `<main>` instead — so every live capture came back exactly viewport-height
+    // while the board's came back 3-4k tall, which makes the pair useless to compare.
+    // Growing the viewport to the desk's own height is what actually gets the whole tab.
+    const tall = await live.evaluate(() => {
+      // The LAST bottom edge across every `.board`, not the first element's height. The
+      // desk renders more than one — the legend in the layout carries the class too,
+      // because it is board-styled content and needs `.board .tag` — so a `querySelector`
+      // measures the legend and reports every tab as 325px tall.
+      const els = [...document.querySelectorAll(".board")];
+      if (els.length === 0) return 1000;
+      const bottom = Math.max(
+        ...els.map((e) => e.getBoundingClientRect().bottom + window.scrollY),
+      );
+      return Math.min(12000, Math.ceil(bottom) + 120);
+    });
+    await live.setViewportSize({ width: 1440, height: tall });
+    await live.waitForTimeout(250);
+    await live.screenshot({ path: `${OUT}/live-${tid}-${slug}.png` });
+    await live.setViewportSize({ width: 1440, height: 1000 });
+  }
+  await live.close();
+  await browser.close();
+
+  const boardUses = new Set();
+  const liveUses = new Set();
+  for (const [tid] of TABS) {
+    for (const [name] of SELECTORS) {
+      if (boardStyles[tid]?.[name]) boardUses.add(name);
+      if (liveStyles[tid]?.[name]) liveUses.add(name);
+    }
+  }
+
+  // One row per (selector, property) where the two sides disagree, with the tabs it was
+  // seen on. Reported once rather than per tab: the same token wrong on eight tabs is one
+  // finding, and printing it eight times buries the other seven.
+  const diffs = new Map();
+  for (const [tid, slug] of TABS) {
+    for (const [name] of SELECTORS) {
+      const b = boardStyles[tid]?.[name];
+      const l = liveStyles[tid]?.[name];
+      if (!b || !l) continue;
+      for (const p of PROPS) {
+        if (MEANINGLESS(p, b) || MEANINGLESS(p, l)) continue;
+        if (b[p] === l[p]) continue;
+        const key = `${name}|${p}|${b[p]}|${l[p]}`;
+        if (!diffs.has(key))
+          diffs.set(key, {
+            sel: name,
+            prop: p,
+            board: b[p],
+            live: l[p],
+            tabs: [],
+          });
+        diffs.get(key).tabs.push(`${tid}/${slug}`);
+      }
+    }
+  }
+
+  const report = {
+    coverage: {
+      renderedOnBoard: [...boardUses].sort(),
+      renderedOnLive: [...liveUses].sort(),
+      notPortedToLive: [...boardUses].filter((c) => !liveUses.has(c)).sort(),
+      onLiveOnly: [...liveUses].filter((c) => !boardUses.has(c)).sort(),
+    },
+    diffs: [...diffs.values()],
+  };
+  writeFileSync(`${OUT}/report.json`, JSON.stringify(report, null, 2));
+
+  console.log("=== 1. GRAMMAR COVERAGE ===");
+  console.log(
+    `board renders ${boardUses.size} of ${SELECTORS.length} probed elements; live renders ${liveUses.size}`,
+  );
+  console.log(
+    "on the board, NOT on live:",
+    report.coverage.notPortedToLive.join(", ") || "(none)",
+  );
+  console.log(
+    "on live, not on the board:",
+    report.coverage.onLiveOnly.join(", ") || "(none)",
+  );
+
+  console.log("\n=== 2. COMPUTED-STYLE DIFFS ===");
+  if (report.diffs.length === 0) {
+    console.log("none");
+  }
+  const bySel = {};
+  for (const d of report.diffs) (bySel[d.sel] ??= []).push(d);
+  for (const [sel, ds] of Object.entries(bySel)) {
+    console.log(
+      `\n${sel}  (${ds[0].tabs.length} tab${ds[0].tabs.length === 1 ? "" : "s"})`,
+    );
+    for (const d of ds)
+      console.log(`   ${d.prop}: board=${d.board}  live=${d.live}`);
+  }
+  console.log(
+    `\n${report.diffs.length} distinct diffs across ${Object.keys(bySel).length} elements`,
+  );
+  console.log(`screenshots + report.json -> ${OUT}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Lands 5 files that only ever existed on since-merged macro-desk feature branches
(`feat/macro-desk-tabs-01-02`, `feat/macro-desk-shell`, `feat/macro-desk-replay`,
`feat/macro-desk-tab-00`, `backup/macro-desk-pre-rebase-20260829`) but never made it
into a PR against `main`:

- `docs/superpowers/archive/plans/2026-08-27-macro-desk-page-port.md` — the desk port plan (P0-P8)
- `docs/superpowers/archive/plans/2026-08-29-macro-desk-board-full-binding.md` — its P9 follow-on, already marked `EXECUTED`
- `docs/research/2026-08-28-macro-desk-board-conformance/VERDICT.md` — the audit that drove the follow-on
- `docs/superpowers/archive/specs/2026-08-27-macro-desk-board.html` — the frozen board spec artifact both docs cite
- `web/scripts/board-pixel-compare.mjs` — the conformance-check script the audit was built on

Pulled from `backup/macro-desk-pre-rebase-20260829`, which git history confirms carries
the latest revision of each doc (later correction commits than any other branch).

## Edits beyond a straight copy

- **page-port.md**: `Status` flips `DRAFT` -> `SHIPPED`; a new "Post-port status" section
  records that P0-P6 shipped in v0.13.1 (and main has since evolved past the plan - a
  `replayClock` field, a `MacroMasthead`/`MacroFooter` chrome layer, neither in this plan),
  while **P7 and P8 shipped differently than planned**: no `macro_factor_daily` table
  materialized (SS10-D deferred to a later spec that took a different shape), and tab 06
  ships as a static, dated proposal panel rather than the live FRED-series plan SS10-C
  settled on. SS10-I (whether `RatesScorecard` should suppress its stance word) is recorded
  as still an open operator ruling - nothing found while archiving this resolves it.
- **board-full-binding.md**: a note flags that its `BoardLegend`-in-the-layout row didn't
  survive to `main` - superseded by the masthead/footer rework, not the table going stale.
- **VERDICT.md**: its "neither merged" note is updated - both source branches are, now.
- Cross-references between the four docs are repointed to their new `archive/` paths, and
  `board-pixel-compare.mjs`'s `BOARD` constant follows the spec to `archive/specs/`.

`BoardLegend.tsx` itself is deliberately **not** in this PR - it has no importer on
`main` (superseded by the masthead/footer chrome), so bringing it over would be dead code.

## Why

No code changes, no schema changes. Housekeeping ahead of deleting the now-fully-merged
branches that carried these docs - verified before this PR that each is a genuine 100%
subject-line match against `main`'s history plus these file-level gaps, not a false read
off ancestry (rebases/squashes make `git merge-base --is-ancestor` unreliable here).
