### PR TITLE
fix(fundamentals): state what the AI chain desk measures, not money transmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+
+- **The AI chain desk states what it measures instead of claiming money
+  transmission.** `/fundamentals/ai-semi` and its cases page drop the
+  upstream-over-customer "amplification" multiple and the transmission /
+  dollar-flow narrative built on it; each group's own TTM revenue-growth median
+  is shown side by side instead. The five section titles now name the questions
+  the data can answer, and the chain map's growth ranges are reported as
+  descriptions of this sample rather than as explanatory power.
+- **Desk figures carry their unit, time basis and sample everywhere they
+  appear.** Revenue growth is labelled TTM YoY, gross margin as the latest
+  reported quarter, capex in USD bn against the same sample's revenue, and
+  own-history valuation as `P<n> · rich/cheap/mid-range` (P0-P100 axis).
+  Missing values read "TTM growth unavailable" / "growth available n/N" /
+  "unavailable" and are still never coerced to zero. Display-semantics only:
+  no metric, API, schema or stored data was recomputed.
+
 ## [0.13.2] — 2026-08-31
 
 

--- a/docs/plans/2026-09-01-fundamentals-report-claims-and-units.md
+++ b/docs/plans/2026-09-01-fundamentals-report-claims-and-units.md
@@ -1,0 +1,188 @@
+# Fundamentals 报告：传导措辞与指标口径修正计划
+
+> **执行说明：** 本文是待用户确认的计划，不是执行授权。批准后按仓库规定使用 `execute-plan` 单线执行；先建 `.worktrees/fundamentals-report-claims-and-units/`，建议分支 `fix/fundamentals-report-claims-and-units`。本次不提交、不推送、不部署；后续 commit 仍需明确授权。
+
+**Goal:** 让现有 AI Chain Desk 与两个案例准确表达“经营指标对照”，不再声称验证了资金传导；明确数字的单位、时间、样本与缺失含义。
+
+**Architecture:** 仅修正现有前端的标题、解释、数字格式与失去依据的衍生展示，继续使用现有 API 和持久化数据。不改变原始指标算法、数据样本、接口、数据库或图形引擎；直接删除不再使用的前端放大比及相关叙事。
+
+**Tech Stack:** Next.js / React / TypeScript，现有 Canvas 图形；Vitest 与现有 Playwright 用例。
+
+**基线：** 2026-09-01，主目录 HEAD `a01a1cb8`（detached HEAD）；存在用户未提交修改。本计划文档是本轮唯一新增文件。此前已实看 Mac mini 的主页面与 cases 页面，线上显示 v0.13.2；此次以当前代码复核变更边界，不假定线上 SHA 等于本地 HEAD。
+
+## 1. 最小范围与非目标
+
+覆盖两个实际页面：
+
+- `/fundamentals` 跳转后的 `/fundamentals/ai-semi`。
+- `/fundamentals/ai-semi/cases`，含 optical interconnect / datacenter buildout。
+
+本次明确不做：
+
+- 不新增报告、研究首页、分部数据采集、客户关系数据库或传导模型。
+- 不补 META、不移除 IBM、不统一两组研究样本，不重算历史 Capex；先如实标注现有边界。
+- 不把 TTM 增速改为单季增速，不改毛利率或估值算法，不做历史回填。
+- 不把 3D 图重做成 2D，不改旋转、半径映射或共用尺度，不新增图表库。
+- 不改 API 字段、OpenAPI、数据库、worker、个股 fundamentals 页面或雷达。
+- 不补新投资判断、预测、排名、自动证伪阈值；“数据限制”不再冒充经营假设的证伪。
+- 不修改历史研究记录来让它符合新措辞；不全仓替换相关术语。
+
+## 2. 已核实的事实与约束
+
+| 事实 | 代码证据 | 对计划的约束 |
+|---|---|---|
+| 案例放大比只是上游营收增速中位数 / 客户营收增速中位数 | `web/lib/fundamentals/desk.ts:336-362` | 删除该比值及强弱传导叙事，不改名后继续作为主结论 |
+| `rev_yoy` 来自 TTM 收入相对前一年 TTM 的增长；毛利率是单季 | `src/uw_scan/fundamentals/features.py:126-153`；`src/uw_scan/worker/jobs/fundamentals_desk_rollup.py:131-150` | 明确 TTM / latest quarter，禁止统一误标“季度同比” |
+| 案例逐公司取最新记录；同一公司可出现在多个环节 | `src/uw_scan/reports/fundamentals_desk_spine.py:209-239` | 不是共同财季，也不是分部收入；重复成员必须说明 |
+| 案例 API 没有逐行财期、估值方法/历史窗口、缺失原因 | `src/uw_scan/models/fundamentals_desk.py:487-505` | 不伪造日期或原因，不承诺本轮补齐这些元数据 |
+| Capex 来自现金流表的供应商 `capital_expenditures` 字段，按财期结束日归入日历季度 | `src/uw_scan/reports/fundamentals_desk_spine.py:124-184`；`src/uw_scan/storage/fundamentals_desk.py:126-163` | 标明供应商字段与日历归桶，不宣称租赁已统一或全部是 AI 支出 |
+| 现有测试直接要求出现 amplification、4.08 和旧标题 | `web/tests/unit/industryDesk.test.tsx:657-730`；`web/tests/e2e/fundamentals-chain-desk.spec.ts:46-64` | 必须同步改这些断言，不能为保住旧测试而保留错误叙事 |
+
+## 3. 最小文件集
+
+预计 11 个现有前端文件，全部属于这两个页面；没有新增业务文件：
+
+| 用途 | 修改文件 |
+|---|---|
+| 主页面、案例入口、五节标题 | `web/app/fundamentals/ai-semi/page.tsx`；`web/app/fundamentals/ai-semi/cases/page.tsx`；`web/components/fundamentals/DeskMasthead.tsx` |
+| Capex / 链图 / 限制说明 | `web/components/fundamentals/CapexPanel.tsx`；`web/components/fundamentals/ChainMapPanel.tsx`；`web/components/fundamentals/DeskLimits.tsx` |
+| 案例卡、图、表 | `web/components/fundamentals/CaseCards.tsx`；`web/components/fundamentals/CaseFunnels.tsx`；`web/components/fundamentals/CaseStageTables.tsx` |
+| 估值文字与已有格式化 helper | `web/components/fundamentals/ValuationPanel.tsx`；`web/lib/fundamentals/desk.ts` |
+
+配套仅修改 `web/tests/unit/industryDesk.test.tsx`、`web/tests/unit/capexPanel.test.tsx`、`web/tests/e2e/fundamentals-chain-desk.spec.ts`，以及实现分支的 `CHANGELOG.md` `[Unreleased]` 条目。若实际需要更多业务文件，先说明原因，不顺手扩范围。
+
+## 4. 执行步骤
+
+### P1 — 撤掉未经验证的传导主张
+
+**文件：** 上表中的两个页面、DeskMasthead、CapexPanel、ChainMapPanel、DeskLimits、CaseCards、CaseFunnels、desk.ts；相关现有测试。
+
+1. 在隔离 worktree 核对基线、相关目录规则及用户修改；跑两份目标单测记录基线。不要切换或清理当前主目录。
+2. 先调整现有 CaseCards 主路径和页面标题断言，使其要求新表达；确认旧实现因这次需求而失败。
+3. 保持现有五节顺序、路由和页面语言，统一 masthead 与正文标题：
+
+| 当前 | 新标题 |
+|---|---|
+| Is the money still coming? | How is sample capex changing? |
+| Where does it land? | How do industry groups compare? |
+| Does it transmit? | How do case groups compare? |
+| What am I paying for it? | Where is valuation versus own history? |
+| What would falsify this? | What are the data limits? |
+
+4. 开篇替换为事实边界，例如：`Company-level growth, reported margins and own-history valuation across selected AI-related industry groups. This page does not trace payments or establish causal transmission.` 不再写“every revenue dollar is somebody else's capex”“唯一外生输入”“end-to-end dollar tracing”“下游无一幸免”。
+5. 案例卡撤掉 4.08× / 2.25×，改为并列的 `Customer-group TTM revenue growth` 与对应另一组的 `TTM revenue growth`，各自显示原有中位数。不计算替代倍数、差分分数或排名；保持案例顺序与成员数。
+6. 删除 `WhyTwo`、`FunnelFindings` / `barelyOpens` 等以该比值选择强弱案例的叙事；删除 `CaseSummary.amplification` 及其计算。`belowCustomer` 若无剩余调用方一并删除。保留仍有用途的组别排序、成员去重和 Capex 自身历史倍数，不泛化清理。
+7. 图上不再写“美元向下流”“吸收/放大”“same dollar, two transmissions”。保留现有图形，改标题为 `Stage growth comparison`，用组别标签与增长值并列，移除案例标题中的数值传导箭头。说明分类排序不是采购链路；组别之间可能是并行供应关系。
+8. CaseCards 或案例说明只保留一处简短限制：相同公司可跨组，使用公司整体数据，不代表这些业务分部各自增长；两案例与 Capex 面板不是同一个买方样本。
+9. ChainMapPanel 中删除“组间极差之比 = 3.1 倍解释力”的推论，保留原始极差作为描述；把增长/毛利率相关系数解释限定为当前样本，不称经济规律。DeskLimits 保留现有数据限制，不编造商业证伪条件。
+10. 同步修正本次触及前端文件中与新表达冲突的注释，跑目标单测。后端旧 docstring / schema 描述不属于本轮变更；本计划不能被称为“整个 API 的语义也已修复”。
+
+**验收：** 两页及 hover/Canvas 标注不再作资金传导或放大主张；原有公司值、组别中位数、覆盖计数及图形行为保留。旧倍数代码及其专用叙事测试不留死路径。
+
+### P2 — 单位、时间口径、样本和缺失含义一致
+
+**文件：** CapexPanel、ChainMapPanel、CaseCards、CaseFunnels、CaseStageTables、ValuationPanel、DeskLimits、desk.ts；相关现有测试。
+
+1. 在现有用例上补充下面的展示断言后再实现。默认不新建测试文件；确需新增时，总计最多 1 个主路径、1 个关键失败路径。
+2. 表格、图例、hover 和解释使用同一组标签，不只在页尾解释：
+
+| 数据 | 展示规则 |
+|---|---|
+| `rev_yoy` | `Revenue growth (TTM YoY, %)`；四个季度收入和 / 上年前四季度收入和 − 1 |
+| `gross_margin` | `Reported gross margin (latest quarter, %)`；单季毛利 / 单季收入；不把所有公司一律标成 GAAP |
+| 组别 median | 明确是有效公司指标的等权中位数，不是收入加权，也不是该环节市场总体增长 |
+| Capex 金额 | 保留现有数值，图表明确 `USD bn`，解释 1 bn = 10 亿美元；正数表示支出规模 |
+| Capex / revenue | `Sample capex / sample revenue (%)`，分母不是 AI 收入，也不是现金流 |
+| `spot_percentile` | `P20 · rich` / `P80 · cheap` 等；标题和可见说明限定“相对自身历史”；高收益率分位表示历史相对便宜，不是折价 80% |
+| 百分点变化 | 使用 `pp (percentage points)`，不与 `%` 增长率混用 |
+
+3. `desk.ts` 内加一个极小的估值展示函数供 CaseStageTables、CaseFunnels、ValuationPanel 共用（已有三个真实调用方）。使用现有 0.3/0.7 rich/cheap 界线，不改阈值、排序或估值方法。格式如 `P${Number((p * 100).toFixed(1))} · rich/cheap/mid-range`；null 用中性缺失文本。坐标轴也显示 P0–P100，不混用 0–1 裸数字。
+4. Capex 可见说明固定以下边界，成员名单仍动态取 API：样本由当前 taxonomy 决定，并非完整 AI 买家集合，不应假设与案例客户组相同；取供应商现金流表字段，未统一融资租赁等调整；不等于纯 AI 支出。本次核对时不含 META 是现状证据，不写成永久硬编码说明，也不把 META 当作币种排除项。不得将其改写成已经核对所有公司的统一“现金 Capex”。
+5. 财期说明明确：Capex 是按各公司财期结束日归入日历季度；案例/链图取各公司最新可用记录，期间可能不同，不代表同步的同一季度，也不是历史时点回放。不给 API 没有的逐行日期补默认值，不把日历面板 `as_of` 冒充全页数据日期。
+6. `rev_yoy=null` 改为 `TTM growth unavailable`；`reporting/total` 改为 `growth available n/N`；不能再由此推出“没有财报”。继续保留公司、空心标记及缺失排除规则，不改成零。估值无 band 只称不可用，不统一归因为历史不足。
+7. Capex 空序列只表达“本样本没有可用季度数据”，不由空序列推断“所有公司都不是 USD”；保留 API 请求失败与空数据的区别。先复用已有测试形状，若缺口确实存在，仅新增上述 1 个关键失败路径。
+8. 图形半径仍是现有截断映射，不声称面积/体积代表金额；说明 0–80% 的显示区间，负增长、缺失和超范围值应看表格。不要在本轮修改坐标映射或对原值截断。
+9. 删除相关单测里只服务于已移除 amplification / 强弱叙事的断言，更新现有缺失与覆盖测试。混有单季 fixture 的旧测试不改造成数据回填工程；只在本轮所用展示用例中清楚区分测试值与口径验证。
+
+**验收：** 同一数字在卡片、表格、hover 和图例中含义一致；TTM 与单季可直接区分；P 分位方向明确；缺失不变零、不编造原因；计算及 API 保持不变。
+
+### P3 — 验证与交付
+
+**文件：** 三份现有测试、`CHANGELOG.md`；不新增验证基础设施。
+
+以下命令均在实施 worktree 的 `web/` 目录执行，本计划编写时未运行这些测试：
+
+```bash
+npm run test -- tests/unit/industryDesk.test.tsx tests/unit/capexPanel.test.tsx
+npm run typecheck
+npx eslint app/fundamentals/ai-semi components/fundamentals lib/fundamentals/desk.ts tests/unit/industryDesk.test.tsx tests/unit/capexPanel.test.tsx tests/e2e/fundamentals-chain-desk.spec.ts
+```
+
+在现有本地开发数据库和已验证端口可用后，复用原浏览器测试；不得误连生产数据库、重用运行旧代码的页面，或为了过测试新增基础设施：
+
+```bash
+npm run build
+PLAYWRIGHT_WEB_PORT=3011 npm run test:e2e -- tests/e2e/fundamentals-chain-desk.spec.ts
+```
+
+3011 须先确认空闲；配置仍使用 API 8400，该服务须确认连接开发库。若当前配置/数据不能支持该测试，如实记录环境阻塞，使用当前 worktree 的实际页面人工核对，不把未执行说成通过。
+
+人工验收两页，截图放 `output/playwright/`：
+
+- 新五节标题、案例入口和实际页面一致；无传导/放大主张或 4.08× headline。
+- 案例原始增长值、毛利率、成员、等权中位数不变；重复公司仍可见。
+- 表头、hover、Canvas 标签注明 TTM / latest quarter / USD bn / P 分位；长标签不遮挡图表或表格。
+- 缺失仍为空值，公司不消失；Capex 完整/部分季度与错误提示未退化。
+- 现有两个图能绘制、同步拖动、主题切换，无新增控制台错误；不新增估值排序。
+- 仓库根运行 `git diff --check`，检查 diff 不包含 API/schema/worker/数据/依赖或无关文件变化。
+- 在 `[Unreleased]` 记录展示语义修正，明确没有重算数据。报告确切命令与结果，不用“单测全绿”代替浏览器验收。
+
+发布不是这份计划的默认授权：得到 commit/PR/merge/release 授权后再按仓库工作流执行，禁止直推 main。线上未部署前，只能称“本地修正已验证”；发布后另核对 Mac mini 实际镜像/版本与两页显示。无数据库变更，回退只需走正常 PR/发布回退流程。
+
+## 5. 计划校验摘要（plan-validator）
+
+### 1) Context Snapshot
+
+仅校验当前两个页面的展示纠偏；已读对应实现、API 形状与现有测试。数据源正确性、历史研究有效性、生产部署状态不在本次验证范围。
+
+### 2) Executive Verdict
+
+**ready，待用户批准执行。** 所有改动可在现有前端完成；无新增依赖、接口、数据迁移或外部服务。没有必须由用户补充的技术选择。
+
+### 3) Plan Coverage Matrix
+
+| Item | Status / Risk | Files / Evidence | Tests / Gap / Fix |
+|---|---|---|---|
+| P1 撤掉传导结论 | valid / medium | `desk.ts:336`、`CaseCards.tsx:64`、`CaseFunnels.tsx:454` | 改 industryDesk / 现有 e2e 旧标题断言；同时删除专用计算与叙事，避免只改 headline |
+| P2 指标语义 | valid / medium | `features.py:126`、`CaseStageTables.tsx:148`、`ValuationPanel.tsx:183`、`CapexPanel.tsx:362` | 扩现有单位/缺失断言；最多两条新测试，逐行日期与缺失原因不在当前 API 中，不能伪造 |
+| P3 验证交付 | valid / low | `web/playwright.config.ts:3-36`、`web/package.json:7-19` | 两份 Vitest、一份既有 e2e、定向 lint/typecheck、实际页面；部署授权单独处理 |
+
+### 4) Findings By Severity
+
+- **F-1 / medium：** 仅替换“amplification”单词无法修正比值驱动的强弱叙事。P1 已改为删除该展示和专用分支。
+- **F-2 / medium：** `CaseStageMember` 缺少逐行时间和缺失状态，强行补全会扩大 API 范围。P2 已改为真实口径说明和中性不可用标签。
+- **F-3 / low：** 单测 stub 了部分 Canvas，单测通过不能证明标签可读。P3 保留既有真实浏览器检查。
+
+### 5) Improvement Points
+
+| Priority | Improvement | Benefit | Effort |
+|---|---|---|---|
+| P0 | 删除比值而非重命名 | 不留下未经验证的主结论 | S |
+| P0 | 保留现有数据、明确口径 | 避免修文案时隐性改指标 | S |
+| P1 | 更新既有测试并做视觉验收 | 验证真实显示，不补测试体系 | S |
+
+### 6) Suggested Revised Plan
+
+按 P1 → P2 → P3 单线执行；P1/P2 各自更新相关现有断言，P3 做最终联验。不建立平行实现或多 Agent 工作流。
+
+### 7) Test And Validation Plan
+
+见 P3 的确切命令与人工检查清单。现有用例优先；新增最多 1 主路径 + 1 关键失败路径，不增加测试文件/框架。
+
+### 8) Open Questions
+
+无阻塞技术问题；仅等待用户确认计划。commit、推送和发布未获授权。
+
+### 9) Confidence And Assumptions
+
+代码范围与可行性信心高；假设执行时沿用本次核实的指标算法。实施前重新核对基线，若字段实际语义已变先更新计划。逐行财期、统一租赁口径、业务分部和因果传导仍未验证，不能在验收时声称解决。

--- a/web/app/fundamentals/ai-semi/cases/page.tsx
+++ b/web/app/fundamentals/ai-semi/cases/page.tsx
@@ -15,15 +15,14 @@ import { SECTION } from "@/lib/fundamentalsSection";
 export const dynamic = "force-dynamic";
 
 /**
- * Question 3 — does the money transmit?
+ * Question 3 — how do case groups compare?
  *
- * BOTH CASES LIVE ON THIS ONE ROUTE, DELIBERATELY. The funnels are drawn on a
- * shared radius scale, and the shared scale IS the finding: one chain flares
- * open and the other stays a cylinder under the same capital expenditure.
- * Split across `/cases/optical` and `/cases/datacenter`, each page would
- * compute a scale from its own population, the two silhouettes would stop
- * being comparable, and nothing on either screen would show it. So there is
- * one request, one scale, and one page.
+ * BOTH CASES LIVE ON THIS ONE ROUTE, DELIBERATELY. The two objects are drawn
+ * on a shared radius scale, and the shared scale is what makes them
+ * comparable. Split across `/cases/optical` and `/cases/datacenter`, each page
+ * would compute a scale from its own population, the two silhouettes would
+ * stop being comparable, and nothing on either screen would show it. So there
+ * is one request, one scale, and one page.
  *
  * This route is a STATIC segment and therefore wins over the sibling
  * `[...node]` catch-all that serves per-chain deep dives. A taxonomy chain
@@ -63,14 +62,14 @@ export default async function AiSemiCasesPage() {
           color: "var(--text-primary)",
         }}
       >
-        Does it transmit?
+        How do case groups compare?
       </h1>
 
       <Lede>
         Level 1 places the chains but draws no arrows between them. Some
-        sub-chains in the taxonomy are different: their stages carry an explicit
-        order, so a dollar&apos;s path through them is structure, not inference.
-        They were not picked for being interesting
+        sub-chains in the taxonomy carry an explicit stage order, so their
+        groups can be compared stage by stage. They were not picked for being
+        interesting
         {cases ? (
           <>
             {" "}
@@ -82,8 +81,11 @@ export default async function AiSemiCasesPage() {
             them is drawn below
           </>
         ) : null}
-        . Where the taxonomy does not rank stages, drawing a flow would invent
-        the arrows the chain map deliberately refuses to draw.
+        . Where the taxonomy does not rank stages, laying stages out in an
+        order would invent the structure the chain map deliberately refuses to
+        draw. The order shown is the taxonomy&apos;s ranking of stages, not a
+        traced path of money, and neighbouring groups may be parallel
+        suppliers rather than buyer and seller.
       </Lede>
 
       {error !== null ? (
@@ -103,17 +105,17 @@ export default async function AiSemiCasesPage() {
               color: "var(--text-primary)",
             }}
           >
-            The funnel
+            Stage growth comparison
           </h2>
           <Lede>
             Each ring is one stage. Its{" "}
             <strong style={{ color: "var(--text-primary)" }}>
-              radius is that stage&apos;s median revenue growth
+              radius is that stage&apos;s equal-weight median revenue growth
+              (TTM YoY)
             </strong>{" "}
             — and both cases are drawn on one shared scale, so the two objects
-            are directly comparable. The customer sits on top; the dollar
-            travels downward. A chain that amplifies flares open toward the
-            bottom. A chain that absorbs stays a cylinder.
+            are directly comparable. The customer group sits on top and the
+            stages descend in the taxonomy&apos;s rank order.
           </Lede>
           <CaseFunnels cases={cases!} />
 

--- a/web/app/fundamentals/ai-semi/page.tsx
+++ b/web/app/fundamentals/ai-semi/page.tsx
@@ -103,16 +103,15 @@ export default async function AiSemiDeskPage() {
 
       <DeskSection
         index={1}
-        title="Is the money still coming?"
+        title="How is sample capex changing?"
         accent={`var(${QUESTION_TOKENS[0]})`}
         testId="desk-capex"
       >
         <Lede>
-          Every revenue dollar in this chain is somebody else&apos;s capital
-          expenditure. That makes hyperscaler capex the one exogenous input —
-          the only number here not derived from another number on the page. It
-          is where the desk opens, and if it rolls over, nothing downstream
-          survives it.
+          Quarterly capital expenditure for the members of this sample that
+          file in USD, in USD bn, beside the same sample&apos;s capex as a share
+          of its own revenue. The sample is a taxonomy chain, not the full set
+          of AI buyers, and it is not the same sample as the case groups below.
         </Lede>
         {capex.error ? (
           <PanelError what="Capex" error={message(capex.error)} />
@@ -123,18 +122,20 @@ export default async function AiSemiDeskPage() {
 
       <DeskSection
         index={2}
-        title="Where does it land?"
+        title="How do industry groups compare?"
         accent={`var(${QUESTION_TOKENS[1]})`}
         testId="desk-chain-map"
       >
         <Lede>
-          The spend lands across the section&apos;s chains. A PM needs three
-          things about each at once — how fast it is growing, how well it is
-          paid, and where it sits in the stack — and any two of those on a flat
-          chart hides the third. So the map is dimensional:{" "}
+          A PM needs three things about each chain at once — how fast it is
+          growing, how well it is paid, and where it sits in the taxonomy — and
+          any two of those on a flat chart hides the third. So the map is
+          dimensional:{" "}
           <strong style={{ color: "var(--text-primary)" }}>drag it.</strong>{" "}
-          Growth runs left-to-right, gross margin runs into the depth, and the
-          taxonomy layers are the stacked planes.
+          Revenue growth (TTM YoY) runs left-to-right, reported gross margin
+          (latest quarter) runs into the depth, and the taxonomy layers are the
+          stacked planes. Each chain figure is the equal-weight median of its
+          members carrying that metric.
         </Lede>
         {matrix.error ? (
           <PanelError what="Chain map" error={message(matrix.error)} />
@@ -145,16 +146,15 @@ export default async function AiSemiDeskPage() {
 
       <DeskSection
         index={3}
-        title="Does it transmit?"
+        title="How do case groups compare?"
         accent={`var(${QUESTION_TOKENS[2]})`}
         testId="desk-cases-link"
       >
         <Lede>
           The map places chains but draws no arrows between them. Some
-          sub-chains in the taxonomy are different: their stages carry an
-          explicit order, so a dollar&apos;s path through them is structure
-          rather than inference. Those get modelled as flows, on their own
-          screen and on one shared scale.
+          sub-chains in the taxonomy carry an explicit stage order, so their
+          groups can be laid out side by side on one shared scale. The order is
+          the taxonomy&apos;s, not a traced procurement chain.
         </Lede>
         <p style={{ marginTop: 14 }}>
           <Link
@@ -170,14 +170,14 @@ export default async function AiSemiDeskPage() {
               textDecoration: "none",
             }}
           >
-            Open the case funnels →
+            Open the case groups →
           </Link>
         </p>
       </DeskSection>
 
       <DeskSection
         index={4}
-        title="What am I paying for it?"
+        title="Where is valuation versus own history?"
         accent={`var(${QUESTION_TOKENS[3]})`}
         testId="desk-valuation"
       >
@@ -208,14 +208,13 @@ export default async function AiSemiDeskPage() {
 
       <DeskSection
         index={5}
-        title="What would falsify this?"
+        title="What are the data limits?"
         accent={`var(${QUESTION_TOKENS[4]})`}
         testId="desk-limits-section"
       >
         <Lede>
-          A research surface that cannot be wrong is not research. These are the
-          things that would break the readings above, each measured rather than
-          asserted.
+          The measured boundaries of the readings above: what the store does
+          not hold, what a median leaves out, and what a percentile is not.
         </Lede>
         {limits.error ? (
           <PanelError what="Limits" error={message(limits.error)} />

--- a/web/components/fundamentals/CapexPanel.tsx
+++ b/web/components/fundamentals/CapexPanel.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 /**
- * Question 1 — is the money still coming?
+ * Question 1 — how is sample capex changing?
  *
- * Every revenue dollar downstream on this desk is somebody else's capital
- * expenditure, which makes this the one number here not derived from another
- * number here. It is the desk's PREMISE, not its edge: the figure is on every
- * sell-side deck in the sector, and nothing on this desk is ranked by it.
+ * The sample is whichever members of the current taxonomy chain file capex in
+ * USD. It is NOT the full set of AI buyers and it is not the same sample as
+ * the case customer groups, so a figure here does not describe them. The
+ * amount is the vendor cash-flow statement's `capital_expenditures` field with
+ * no lease adjustment, and it is total company capex rather than AI spend.
  *
  * THE SIGN WARNING, KEPT FROM THE STRIP THIS PANEL REPLACES. For the names
  * that SPEND the capex it is a cost line, not evidence of demand — it reaches
  * their income statement as depreciation. Rising capex read as bullish for the
  * spender inverts its meaning.
  *
- * The LEVEL is not the story; the INTENSITY is. A chain fed by a third of its
- * customers' revenue is not fed by a budget line, it is fed by a decision that
- * can be revisited in a single quarter — which is the whole reason this is
- * question one rather than an appendix.
+ * The LEVEL is not the story; the INTENSITY is — the sample's capex against
+ * the same sample's revenue, which is why this is question one rather than an
+ * appendix.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -134,9 +134,9 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
   const yearAgo = base ? priorYear(base.quarter) : null;
   /** A growth multiple, or `null` through a zero base.
    *
-   *  The same refusal `summariseCase` makes for amplification: a ratio through
-   *  zero is arithmetic, not growth, and `Infinity×` on the desk's opening
-   *  tile would be the most confident-looking number on the page. */
+   *  A ratio through zero is arithmetic, not growth, and `Infinity×` on the
+   *  desk's opening tile would be the most confident-looking number on the
+   *  page. */
   const times = (now: number | null, then: number | null): string | null =>
     now != null && then != null && then > 0 ? `${(now / then).toFixed(1)}${TIMES}` : null;
   const capexTimes = times(base?.capex_usd ?? null, first?.capex_usd ?? null);
@@ -290,10 +290,11 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
   if (quarters.length === 0) {
     return (
       <Note>
-        No member of <span style={{ fontFamily: MONO }}>{data.chain}</span>{" "}
-        files in USD, so this desk cannot state a combined capital-expenditure
-        figure for it at all. That is an unanswered question, not an answer of
-        zero — a converted total would be this desk inventing an exchange rate.
+        This sample holds no usable quarterly capex data for{" "}
+        <span style={{ fontFamily: MONO }}>{data.chain}</span>, so the desk
+        states no combined figure. That is an unanswered question, not an
+        answer of zero, and it says nothing about which currencies the chain
+        files in.
       </Note>
     );
   }
@@ -351,7 +352,7 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
           }
         />
         <Tile
-          label="share of revenue"
+          label="sample capex / sample revenue (%)"
           value={pct(intensityNow)}
           sub={
             intensityThen == null
@@ -364,8 +365,8 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
       <VizFrame
         caption={
           <>
-            Quarterly capital expenditure {MID} {data.included.length} USD
-            filers, bars {MID} capex as a share of their revenue, line
+            Quarterly capital expenditure, USD bn {MID} {data.included.length}{" "}
+            USD filers, bars {MID} sample capex / sample revenue (%), line
           </>
         }
         readout={<CapexReadout q={shown} prior={shownPrior} />}
@@ -394,7 +395,8 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
         {data.included.length} companies committed{" "}
         <Num>{pct(intensityNow)}</Num> of their combined quarterly revenue to
         capital expenditure in {base ? base.quarter : DASH}, against{" "}
-        <Num>{pct(intensityThen)}</Num> in {first.quarter}.
+        <Num>{pct(intensityThen)}</Num> in {first.quarter}. Amounts are in
+        USD bn (1 bn = 1,000,000,000), positive for spending.
         {capexTimes ? (
           <>
             {" "}
@@ -407,10 +409,7 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
             ) : null}
             .
           </>
-        ) : null}{" "}
-        A chain fed by that share of its customers&apos; revenue is not fed by
-        a budget line. It is fed by a decision that can be revisited in a single
-        quarter, which is why this is question one and not an appendix.
+        ) : null}
       </Finding>
 
       <Note>
@@ -428,11 +427,18 @@ export function CapexPanel({ data }: { data: DeskCapexResponse }) {
           </span>
         ))}
         {Object.keys(data.excluded).length ? ", and " : ""}
-        this desk does not convert currencies. Fiscal quarters are assigned to
-        the calendar quarter containing their end date, which is what lets a
-        May-ending filer sit beside a June-ending one. And read the direction
-        with care: for the names that <em>spend</em> this, rising capex is a
-        cost line arriving as depreciation, not evidence of their own demand.
+        this desk does not convert currencies. That membership is what defines
+        the sample: it is the current taxonomy chain, not the full set of AI
+        buyers, and it should not be assumed to be the same sample as the case
+        customer groups. The amount is the vendor&apos;s cash-flow{" "}
+        <span style={{ fontFamily: MONO }}>capital_expenditures</span> field
+        with no lease or financing adjustment applied here, and it is total
+        company capital expenditure rather than AI spend. Fiscal quarters are
+        assigned to the calendar quarter containing their end date, which is
+        what lets a May-ending filer sit beside a June-ending one. And read the
+        direction with care: for the names that <em>spend</em> this, rising
+        capex is a cost line arriving as depreciation, not evidence of their
+        own demand.
       </Note>
     </>
   );

--- a/web/components/fundamentals/CaseCards.tsx
+++ b/web/components/fundamentals/CaseCards.tsx
@@ -1,19 +1,20 @@
 /**
- * The two cases, summarised — and why there are two rather than one.
+ * The case groups, summarised.
  *
- * They were not picked for being interesting. They were picked because they
- * are the only chains in this section whose stages carry an explicit order,
- * and as it turns out they answer the same question in opposite directions.
- * ONE CASE WOULD HAVE BEEN MISTAKEN FOR A RULE.
+ * They were not picked for being interesting. They are the chains in this
+ * section whose stages carry an explicit order in the taxonomy.
+ *
+ * EACH GROUP'S MEDIAN STANDS ON ITS OWN. The card once headlined the upstream
+ * median divided by the customer median and called it amplification; nothing
+ * in this store traces a payment from one group to the other, so the ratio was
+ * a transmission claim the data does not support. The two medians are printed
+ * side by side instead, and the reader does the comparing.
  */
 
 import type { DeskCase } from "@/lib/api";
 
 import {
   DASH,
-  belowCustomer,
-  MID,
-  TIMES,
   pct,
   sgn,
   caseToken,
@@ -22,7 +23,7 @@ import {
   type CaseSummary,
 } from "@/lib/fundamentals/desk";
 
-import { Finding, MONO, Num, labelStyle, panelStyle } from "./DeskSection";
+import { MONO, Note, labelStyle, panelStyle } from "./DeskSection";
 
 function Row({ term, value }: { term: string; value: string }) {
   return (
@@ -51,6 +52,47 @@ function Row({ term, value }: { term: string; value: string }) {
   );
 }
 
+function Figure({
+  accent,
+  label,
+  value,
+  sub,
+}: {
+  accent: string;
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div style={{ minWidth: 0 }}>
+      <div style={{ ...labelStyle, letterSpacing: 1 }}>{label}</div>
+      <div
+        style={{
+          marginTop: 4,
+          fontFamily: MONO,
+          fontSize: 22,
+          fontWeight: 700,
+          letterSpacing: 0.8,
+          color: accent,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {value}
+      </div>
+      <div
+        style={{
+          marginTop: 2,
+          fontFamily: MONO,
+          fontSize: 10.5,
+          color: "var(--text-muted)",
+        }}
+      >
+        {sub}
+      </div>
+    </div>
+  );
+}
+
 function marginSpan(summary: CaseSummary): string {
   const gms = summary.downstreamFirst
     .map((s) => s.median_gross_margin)
@@ -68,14 +110,6 @@ export function CaseCards({ cases }: { cases: DeskCase[] }) {
     (x): x is { kase: DeskCase; summary: CaseSummary } => x.summary !== null,
   );
   if (usable.length === 0) return null;
-
-  const ranked = usable
-    .filter((x) => x.summary.amplification != null)
-    .sort(
-      (a, b) =>
-        (b.summary.amplification as number) -
-        (a.summary.amplification as number),
-    );
 
   return (
     <div data-testid="case-cards">
@@ -118,21 +152,27 @@ export function CaseCards({ cases }: { cases: DeskCase[] }) {
               </h3>
               <div
                 style={{
-                  marginTop: 10,
-                  fontFamily: MONO,
-                  fontSize: 30,
-                  fontWeight: 700,
-                  letterSpacing: 1,
-                  color: accent,
-                  fontVariantNumeric: "tabular-nums",
+                  marginTop: 12,
+                  display: "grid",
+                  gap: 10,
+                  gridTemplateColumns: "1fr 1fr",
                 }}
               >
-                {summary.amplification == null
-                  ? "na"
-                  : `${summary.amplification.toFixed(2)}${TIMES}`}
+                <Figure
+                  accent={accent}
+                  label="Customer-group revenue growth (TTM YoY, %)"
+                  value={sgn(summary.customer.median_rev_yoy)}
+                  sub={stageLabel(summary.customer.layer)}
+                />
+                <Figure
+                  accent={accent}
+                  label="Upstream-group revenue growth (TTM YoY, %)"
+                  value={sgn(summary.upstream.median_rev_yoy)}
+                  sub={stageLabel(summary.upstream.layer)}
+                />
               </div>
-              <div style={{ ...labelStyle, marginTop: 2 }}>
-                upstream growth divided by customer growth
+              <div style={{ ...labelStyle, marginTop: 6 }}>
+                equal-weight median of the group members carrying a TTM growth
               </div>
               <dl style={{ marginTop: 12 }}>
                 <Row
@@ -143,91 +183,31 @@ export function CaseCards({ cases }: { cases: DeskCase[] }) {
                   term="companies"
                   value={
                     summary.dualListed
-                      ? `${summary.distinctCompanies} (${summary.dualListed} at two stages)`
+                      ? `${summary.distinctCompanies} (${summary.dualListed} in two groups)`
                       : String(summary.distinctCompanies)
                   }
                 />
-                <Row
-                  term="customer stage"
-                  value={`${stageLabel(summary.customer.layer)}  ${sgn(summary.customer.median_rev_yoy)}`}
-                />
                 {fastest ? (
-                  <Row term="fastest stage" value={stageLabel(fastest.layer)} />
+                  <Row term="fastest group" value={stageLabel(fastest.layer)} />
                 ) : null}
-                <Row term="margin span" value={marginSpan(summary)} />
+                <Row
+                  term="reported gross margin (latest quarter, %)"
+                  value={marginSpan(summary)}
+                />
               </dl>
             </div>
           );
         })}
       </div>
 
-      {ranked.length >= 2 ? (
-        <WhyTwo strong={ranked[0]} weak={ranked[ranked.length - 1]} />
-      ) : null}
+      <Note>
+        The same company can sit in more than one group, and it is counted in
+        each group it belongs to. Every figure is company-level: it is the
+        whole company&apos;s reported revenue and margin, not the part of it
+        that serves this chain. And these groups are not the buyer sample the
+        capex panel sums {DASH} the two are built from different memberships,
+        so a figure here does not describe the spenders there.
+      </Note>
     </div>
-  );
-}
-
-function WhyTwo({
-  strong,
-  weak,
-}: {
-  strong: { kase: DeskCase; summary: CaseSummary };
-  weak: { kase: DeskCase; summary: CaseSummary };
-}) {
-  const cm = weak.summary.customer.median_rev_yoy;
-  const supplying = weak.summary.downstreamFirst.slice(1);
-  const below = belowCustomer(weak.summary);
-  // The slowest stage that is ACTUALLY below its customer, not merely the
-  // slowest. The sentence below calls it "slower than the customers it
-  // supplies", and if every supplying stage outgrew the customer that word
-  // would be false while the number beside it stayed correct — the failure
-  // mode this desk is least able to survive.
-  const slowest = [...below]
-    .filter((s) => s.median_rev_yoy != null)
-    .sort(
-      (a, b) => (a.median_rev_yoy as number) - (b.median_rev_yoy as number),
-    )[0];
-
-  // How far apart the two transmissions actually are. The adjective is drawn
-  // from it rather than asserted: two cases that converged would still print
-  // their true amplifications under a sentence claiming they diverge.
-  const gap =
-    (strong.summary.amplification as number) /
-    (weak.summary.amplification as number);
-
-  return (
-    <Finding label="Why one case would not have been enough">
-      One case would have been mistaken for a rule. Both chains are fed by the
-      same capital expenditure and they transmit it{" "}
-      {gap >= 1.5 ? "completely differently" : "at measurably different rates"}:{" "}
-      {strong.kase.label.toLowerCase()}{" "}
-      <Num>
-        {(strong.summary.amplification as number).toFixed(2)}
-        {TIMES}
-      </Num>{" "}
-      against {weak.kase.label.toLowerCase()}&apos;s{" "}
-      <Num>
-        {(weak.summary.amplification as number).toFixed(2)}
-        {TIMES}
-      </Num>
-      .{" "}
-      {slowest ? (
-        <>
-          Worse for the naive version of the thesis,{" "}
-          <strong style={{ color: "var(--text-secondary)" }}>
-            {stageLabel(slowest.layer)}
-          </strong>{" "}
-          grows at <Num>{sgn(slowest.median_rev_yoy)}</Num> {DASH}{" "}
-          <em>slower</em> than the customers it supplies at <Num>{sgn(cm)}</Num>{" "}
-          {DASH} and it is not alone: <Num>{below.length}</Num> of the{" "}
-          {supplying.length} supplying stages sit below their own customer.{" "}
-        </>
-      ) : null}
-      Proximity to the AI dollar does not guarantee participation in it, and no
-      screen sorted on sector or growth would have surfaced that. The two cases
-      are drawn on one shared scale for exactly this reason {MID} see the
-      funnels below.
-    </Finding>
   );
 }

--- a/web/components/fundamentals/CaseFunnels.tsx
+++ b/web/components/fundamentals/CaseFunnels.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 /**
- * The funnels — a dollar's path through the two chains whose stages are ranked.
+ * Stage growth comparison — the chains whose stages the taxonomy ranks.
  *
- * Each ring is one stage, and its RADIUS IS THAT STAGE'S MEDIAN REVENUE
- * GROWTH. Both cases are drawn on ONE SHARED SCALE, so the two objects are
- * directly comparable: a chain that amplifies flares open toward the bottom, a
- * chain that absorbs stays a cylinder. The customer sits on top and the dollar
- * travels downward.
+ * Each ring is one stage, and its RADIUS IS THAT STAGE'S MEDIAN REVENUE GROWTH
+ * (TTM YoY). Both cases are drawn on ONE SHARED SCALE, so the two objects are
+ * directly comparable. The taxonomy's rank order sets the stacking order and
+ * nothing more: it is not a procurement chain, no payment is traced between
+ * stages, and two stages may simply be parallel suppliers.
  *
  * THE SHARED SCALE IS LOAD-BEARING AND SILENT WHEN BROKEN. `radius()` is one
  * function over both cases and `GROWTH_CAP` is a constant, deliberately: a cap
@@ -25,11 +25,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CaseStageMember, DeskCase } from "@/lib/api";
 import {
   DASH,
-  belowCustomer,
   GROWTH_CAP,
   MID,
-  RARR,
-  TIMES,
   alpha,
   onThemeChange,
   pct,
@@ -38,12 +35,13 @@ import {
   caseToken,
   stageLabel,
   summariseCase,
+  valuationPhrase,
   type CaseSummary,
   type DeskPalette,
 } from "@/lib/fundamentals/desk";
 import { createScene, type SceneHandle } from "@/lib/fundamentals/scene";
 
-import { Finding, MONO, VizButton, VizFrame, labelStyle } from "./DeskSection";
+import { MONO, Note, VizButton, VizFrame, labelStyle } from "./DeskSection";
 
 const HEIGHT = 470;
 const RADIUS_MIN = 0.12;
@@ -118,8 +116,9 @@ export function CaseFunnels({ cases }: { cases: DeskCase[] }) {
       <VizFrame
         caption={
           <>
-            Stage funnels {MID} ring = stage median growth {MID} dot = one
-            company at its own growth
+            Stage growth comparison {MID} ring = stage equal-weight median
+            revenue growth (TTM YoY) {MID} dot = one company at its own TTM
+            growth
           </>
         }
         controls={
@@ -137,32 +136,26 @@ export function CaseFunnels({ cases }: { cases: DeskCase[] }) {
               </span>
               <span>{hover.stage}</span>
               <span>
-                revenue growth{" "}
+                revenue growth (TTM YoY, %){" "}
                 <b style={{ color: "var(--text-primary)" }}>
                   {hover.member.rev_yoy == null
-                    ? "no filed quarter"
+                    ? "TTM growth unavailable"
                     : sgn(hover.member.rev_yoy)}
                 </b>
               </span>
               {hover.member.gross_margin != null ? (
                 <span>
-                  gross margin{" "}
+                  reported gross margin (latest quarter, %){" "}
                   <b style={{ color: "var(--text-primary)" }}>
                     {pct(hover.member.gross_margin)}
                   </b>
                 </span>
               ) : null}
               <span>
-                {hover.member.spot_percentile == null ? (
-                  "no valuation band"
-                ) : (
-                  <>
-                    own-history percentile{" "}
-                    <b style={{ color: "var(--text-primary)" }}>
-                      {hover.member.spot_percentile.toFixed(2)}
-                    </b>
-                  </>
-                )}
+                valuation vs own history{" "}
+                <b style={{ color: "var(--text-primary)" }}>
+                  {valuationPhrase(hover.member.spot_percentile)}
+                </b>
               </span>
               {hover.member.reported_currency ? (
                 <span style={{ color: "var(--warning)" }}>
@@ -199,7 +192,15 @@ export function CaseFunnels({ cases }: { cases: DeskCase[] }) {
         </div>
       </VizFrame>
 
-      <FunnelFindings drawable={drawable} />
+      <Note>
+        The radius is a truncated display mapping over 0% to +80% TTM growth:
+        a stage or company outside that range is drawn at the rim, and
+        a company with no TTM growth sits on its stage&apos;s own ring as a
+        hollow mark rather than at the centre. Negative, missing and
+        off-scale values are all in the stage table below. The rings are
+        stacked in the taxonomy&apos;s rank order, which is an ordering of
+        stages and not a traced flow of money between them.
+      </Note>
     </>
   );
 }
@@ -426,16 +427,9 @@ function Funnel({
             color: "var(--text-secondary)",
           }}
         >
-          {summary.amplification == null ? (
-            <>amplification not computable {DASH} no customer median</>
-          ) : (
-            <>
-              {summary.amplification.toFixed(2)}
-              {TIMES} amplification {MID}{" "}
-              {sgn(summary.customer.median_rev_yoy, 0)} at the customer {RARR}{" "}
-              {sgn(summary.upstream.median_rev_yoy, 0)} upstream
-            </>
-          )}
+          customer group {sgn(summary.customer.median_rev_yoy, 0)} {MID}{" "}
+          upstream group {sgn(summary.upstream.median_rev_yoy, 0)} {MID} TTM
+          YoY medians
         </div>
       </div>
       <canvas
@@ -450,121 +444,5 @@ function Funnel({
         }}
       />
     </div>
-  );
-}
-
-/** "Barely opens" needs BOTH a wide gap to the other case and a weak absolute
- *  amplification. On the relative test alone, 20x against 10x would call a
- *  ten-fold amplification "barely" — true of the comparison, false of the
- *  chain, and it is the chain the sentence names. 1.5x is the same threshold
- *  the case card uses for "completely differently"; below it a chain has
- *  passed roughly half its customers' growth upstream, which is not "barely".
- */
-function barelyOpens(strongAmp: number, weakAmp: number): boolean {
-  return strongAmp / weakAmp >= 1.5 && weakAmp < 1.5;
-}
-
-function FunnelFindings({
-  drawable,
-}: {
-  drawable: { kase: DeskCase; s: CaseSummary }[];
-}) {
-  const withAmp = drawable
-    .filter((x) => x.s.amplification != null)
-    .sort(
-      (a, b) => (b.s.amplification as number) - (a.s.amplification as number),
-    );
-  if (withAmp.length < 2) return null;
-  const strong = withAmp[0];
-  const weak = withAmp[withAmp.length - 1];
-  const below = belowCustomer(weak.s);
-
-  // Walk the STRONGER case downstream-to-upstream and find where growth falls
-  // rather than rises. Drawing the dip is the point: a smoothed version
-  // implies "always buy further upstream", which this data does not support.
-  // A dip is a REVERSAL, so it needs a rise before it. Filtering on "lower
-  // than the stage before" alone makes the second stage of a monotonically
-  // falling chain a dip, and the heading — "growth rises and then falls" —
-  // would describe a chain that only ever fell.
-  const dips = strong.s.downstreamFirst
-    .map((stage, i) => ({
-      stage,
-      prev: strong.s.downstreamFirst[i - 1],
-      before: strong.s.downstreamFirst[i - 2],
-    }))
-    .filter(
-      (x) =>
-        x.prev?.median_rev_yoy != null &&
-        x.before?.median_rev_yoy != null &&
-        x.stage.median_rev_yoy != null &&
-        x.prev.median_rev_yoy > x.before.median_rev_yoy &&
-        x.stage.median_rev_yoy < x.prev.median_rev_yoy,
-    );
-
-  return (
-    <>
-      <Finding label="Finding — the same dollar, two transmissions">
-        Both objects use one radius scale, so their shapes are directly
-        comparable.{" "}
-        <strong style={{ color: "var(--text-secondary)" }}>
-          {strong.kase.label}
-        </strong>{" "}
-        flares: its customers grew{" "}
-        <b>{sgn(strong.s.customer.median_rev_yoy)}</b> and the components they
-        ultimately consume grew <b>{sgn(strong.s.upstream.median_rev_yoy)}</b>,
-        an amplification of{" "}
-        <b>
-          {(strong.s.amplification as number).toFixed(2)}
-          {TIMES}
-        </b>
-        .{" "}
-        <strong style={{ color: "var(--text-secondary)" }}>
-          {weak.kase.label}
-        </strong>{" "}
-        {barelyOpens(
-          strong.s.amplification as number,
-          weak.s.amplification as number,
-        )
-          ? "barely opens at all"
-          : "opens less"}{" "}
-        {DASH}{" "}
-        <b>
-          {(weak.s.amplification as number).toFixed(2)}
-          {TIMES}
-        </b>
-        {below.length ? (
-          <>
-            {" "}
-            {DASH} and {below.length} of its {weak.s.downstreamFirst.length - 1}{" "}
-            supplying stages grow more slowly than the customer stage
-          </>
-        ) : null}
-        . Same capital expenditure, measurably different transmissions. This is
-        the reading a sector screen structurally cannot produce, and it is the
-        whole reason the desk models chains at all.
-      </Finding>
-
-      {dips.length ? (
-        <Finding tone="warn" label="Finding — and it is not monotonic">
-          Amplification is not a gradient you can ride stage by stage. Walking{" "}
-          {strong.kase.label.toLowerCase()} down from the customer, growth rises
-          and then <em>falls</em> at{" "}
-          {dips.map((d, i) => (
-            <span key={d.stage.layer}>
-              {i > 0 ? " and " : ""}
-              <strong style={{ color: "var(--text-secondary)" }}>
-                {stageLabel(d.stage.layer)}
-              </strong>{" "}
-              ({sgn(d.stage.median_rev_yoy)}, under the{" "}
-              {stageLabel(d.prev.layer).toLowerCase()} it feeds at{" "}
-              {sgn(d.prev.median_rev_yoy)})
-            </span>
-          ))}
-          . The desk draws the dip rather than smoothing it, because the smooth
-          version implies a trade {DASH} always buy further upstream {DASH} that
-          this data does not support.
-        </Finding>
-      ) : null}
-    </>
   );
 }

--- a/web/components/fundamentals/CaseStageTables.tsx
+++ b/web/components/fundamentals/CaseStageTables.tsx
@@ -1,10 +1,14 @@
 /**
  * Stage detail — every member of every stage, named.
  *
- * A company with no filed quarter is NAMED, flagged, and excluded from the
- * stage median. Never dropped, never imputed to zero: dropping it would make
- * the stage look smaller than it is, and zeroing it would make an absence in
- * Argon read as a collapse at a real business.
+ * A company with no TTM growth in the store is NAMED, flagged, and excluded
+ * from the stage median. Never dropped, never imputed to zero: dropping it
+ * would make the stage look smaller than it is, and zeroing it would make an
+ * absence in Argon read as a collapse at a real business.
+ *
+ * EVERY ROW IS THAT COMPANY'S LATEST AVAILABLE RECORD, so two rows may sit on
+ * different fiscal periods; this is not a synchronised quarter. The API
+ * carries no per-row period, so none is printed rather than defaulted.
  *
  * Ticker cells link to the stock page, which is where a figure's filing date
  * and its raw line items live. The stage median prints its own coverage
@@ -23,6 +27,7 @@ import {
   caseToken,
   stageLabel,
   summariseCase,
+  valuationPhrase,
 } from "@/lib/fundamentals/desk";
 
 import {
@@ -133,8 +138,8 @@ function StageRows({ stage }: { stage: CaseStage }) {
                     color: "var(--text-muted)",
                   }}
                 >
-                  median {sgn(stage.median_rev_yoy)} {MID} {stage.reporting}/
-                  {stage.total} reported
+                  median {sgn(stage.median_rev_yoy)} {MID} growth available{" "}
+                  {stage.reporting}/{stage.total}
                 </span>
               </>
             ) : null}
@@ -149,7 +154,9 @@ function StageRows({ stage }: { stage: CaseStage }) {
           </td>
           <td style={num}>
             {m.rev_yoy == null ? (
-              <span style={{ color: "var(--warning)" }}>no filed quarter</span>
+              <span style={{ color: "var(--warning)" }}>
+                TTM growth unavailable
+              </span>
             ) : (
               sgn(m.rev_yoy)
             )}
@@ -158,7 +165,7 @@ function StageRows({ stage }: { stage: CaseStage }) {
             {m.gross_margin == null ? DASH : pct(m.gross_margin)}
           </td>
           <td style={num}>
-            {m.spot_percentile == null ? DASH : m.spot_percentile.toFixed(2)}
+            {valuationPhrase(m.spot_percentile)}
           </td>
           <td style={td}>{flags(m)}</td>
         </tr>
@@ -181,9 +188,11 @@ export function CaseStageTables({ cases }: { cases: DeskCase[] }) {
   return (
     <div data-testid="case-stage-tables">
       <Note>
-        Each stage lists every member. A company with no filed quarter in the
-        store is flagged and excluded from the stage median {DASH} never
-        dropped, never imputed to zero.
+        Each stage lists every member at its own latest available record, so
+        two rows may sit on different fiscal periods. A company with no TTM
+        growth in the store is flagged and excluded from the stage median{" "}
+        {DASH} never dropped, never imputed to zero. Stage medians are the
+        equal-weight median of the members carrying that metric.
       </Note>
 
       {cases.map((kase, i) => {
@@ -215,9 +224,15 @@ export function CaseStageTables({ cases }: { cases: DeskCase[] }) {
                   <tr>
                     <th style={th}>Stage</th>
                     <th style={th}>Company</th>
-                    <th style={{ ...th, textAlign: "right" }}>Rev growth</th>
-                    <th style={{ ...th, textAlign: "right" }}>Gross margin</th>
-                    <th style={{ ...th, textAlign: "right" }}>Own-hist pct</th>
+                    <th style={{ ...th, textAlign: "right" }}>
+                      Revenue growth (TTM YoY, %)
+                    </th>
+                    <th style={{ ...th, textAlign: "right" }}>
+                      Reported gross margin (latest quarter, %)
+                    </th>
+                    <th style={{ ...th, textAlign: "right" }}>
+                      Valuation vs own history
+                    </th>
                     <th style={th}>Flags</th>
                   </tr>
                 </thead>
@@ -236,7 +251,7 @@ export function CaseStageTables({ cases }: { cases: DeskCase[] }) {
         <Num>{noBand.length}</Num> of the <Num>{members.length}</Num> companies
         across the cases carry no valuation band, so the funnels say where
         growth is and stay deliberately silent on what it costs.{" "}
-        <Num>{absent.length}</Num> have no filed quarter at all
+        <Num>{absent.length}</Num> have no TTM growth available
         {absent.length ? ` (${absent.map((m) => m.ticker).join(", ")})` : ""}:
         they sit in their stage as hollow marks, excluded from the median but
         never removed from the chain.{" "}

--- a/web/components/fundamentals/ChainMapPanel.tsx
+++ b/web/components/fundamentals/ChainMapPanel.tsx
@@ -325,24 +325,24 @@ export function ChainMapPanel({
                 {LAYER_LABELS[hover.layer] ?? hover.layer} ({hover.layer})
               </span>
               <span>
-                growth{" "}
+                revenue growth (TTM YoY, %){" "}
                 <b style={{ color: "var(--text-primary)" }}>
                   {sgn(hover.revYoy)}
                 </b>
               </span>
               <span>
-                gross margin{" "}
+                reported gross margin (latest quarter, %){" "}
                 <b style={{ color: "var(--text-primary)" }}>
                   {pct(hover.grossMargin)}
                 </b>
               </span>
               <span>
+                growth available{" "}
                 <b style={{ color: "var(--text-primary)" }}>
                   {hover.reporting}
-                </b>{" "}
-                of{" "}
-                <b style={{ color: "var(--text-primary)" }}>{hover.members}</b>{" "}
-                reported
+                </b>
+                /
+                <b style={{ color: "var(--text-primary)" }}>{hover.members}</b>
               </span>
             </>
           ) : (
@@ -382,25 +382,21 @@ export function ChainMapPanel({
       inWidest.length > 1 &&
       between > 0 &&
       widest.spread > between ? (
-        <Finding label="Finding — the layer explains less than the chain does">
+        <Finding label="Finding — the ranges overlap across layers">
           Flatten it to <em>Growth {TIMES} layer</em> and the five planes
           overlap heavily. The gap between the fastest and slowest layer median
-          is <Num>{(between * 100).toFixed(1)}pp</Num>. Inside{" "}
+          is <Num>{(between * 100).toFixed(1)}pp</Num> (percentage points).
+          Inside{" "}
           <strong style={{ color: "var(--text-secondary)" }}>
             {widest.layer}
           </strong>{" "}
-          alone it is <Num>{(widest.spread * 100).toFixed(1)}pp</Num> {DASH}{" "}
-          {inWidest[0].chain} at <Num>{sgn(inWidest[0].revYoy)}</Num> down to{" "}
-          {inWidest[inWidest.length - 1].chain} at{" "}
+          alone the range is <Num>{(widest.spread * 100).toFixed(1)}pp</Num>{" "}
+          {DASH} {inWidest[0].chain} at <Num>{sgn(inWidest[0].revYoy)}</Num>{" "}
+          down to {inWidest[inWidest.length - 1].chain} at{" "}
           <Num>{sgn(inWidest[inWidest.length - 1].revYoy)}</Num> {DASH} same
-          layer, each name at its own latest filed quarter. Knowing a company
-          sits upstream tells you roughly{" "}
-          <Num>
-            {(widest.spread / between).toFixed(1)}
-            {TIMES}
-          </Num>{" "}
-          less than knowing which chain it is in. That is the argument for
-          running this desk at chain grain instead of sector grain.
+          layer, each name at its own latest available record. Both figures are
+          descriptions of this sample&apos;s spread; neither measures how much
+          a layer or a chain explains.
         </Finding>
       ) : null}
 
@@ -409,13 +405,14 @@ export function ChainMapPanel({
           tone="warn"
           label={
             Math.abs(corr.t) < 2
-              ? "Finding — growth and margin are close to unrelated"
-              : "Finding — growth and margin move together in this panel"
+              ? "Finding — growth and margin are close to unrelated in this sample"
+              : "Finding — growth and margin move together in this sample"
           }
         >
           Flatten it to <em>Growth {TIMES} margin</em> and the cloud{" "}
           {Math.abs(corr.t) < 2 ? "has no tilt" : "tilts"}:{" "}
-          <Num>r = {corr.r.toFixed(3)}</Num> across {corr.n} chains,{" "}
+          <Num>r = {corr.r.toFixed(3)}</Num> across the {corr.n} chains in
+          this sample,{" "}
           <Num>t = {corr.t.toFixed(2)}</Num> {DASH}{" "}
           {Math.abs(corr.t) < 2
             ? "indistinguishable from none"
@@ -424,9 +421,10 @@ export function ChainMapPanel({
           and grows <Num>{sgn(byMargin[0].revYoy)}</Num>;{" "}
           {byMargin[byMargin.length - 1].chain} earns{" "}
           <Num>{pct(byMargin[byMargin.length - 1].grossMargin)}</Num> and grows{" "}
-          <Num>{sgn(byMargin[byMargin.length - 1].revYoy)}</Num>. Being close to
-          the AI dollar and being paid well for it are separate questions, and
-          the desk refuses to blend them into one score.
+          <Num>{sgn(byMargin[byMargin.length - 1].revYoy)}</Num>. This is a
+          correlation within the chains held here and nothing more {DASH} it is
+          not a rule about the industry, and the desk refuses to blend growth
+          and margin into one score.
         </Finding>
       ) : null}
 

--- a/web/components/fundamentals/DeskLimits.tsx
+++ b/web/components/fundamentals/DeskLimits.tsx
@@ -1,7 +1,7 @@
 /**
- * Question 4 — what would falsify this?
+ * Question 5 — what are the data limits?
  *
- * A research surface that cannot be wrong is not research. Every row here is
+ * Every row here is
  * MEASURED rather than asserted: the numbers come from `/limits`, and the web
  * layer writes captions OVER them, never instead of them.
  *

--- a/web/components/fundamentals/DeskMasthead.tsx
+++ b/web/components/fundamentals/DeskMasthead.tsx
@@ -2,11 +2,9 @@
  * The desk's masthead: what it is for, what it holds, and the question order.
  *
  * The five questions are rendered as a numbered rail because THE ORDER IS THE
- * ARGUMENT. A sector screen sorts companies; a chain desk follows one dollar
- * from the balance sheet that commits it to the companies that book it as
- * revenue, and reports where that transmission breaks. You cannot answer
- * question three before question one, so the page is built in that order and
- * the rail says so before the reader scrolls.
+ * ARGUMENT: the sample's spending first, then how its groups compare, then
+ * what they cost, then what the data cannot say. The rail's titles must match
+ * the section headings below it word for word.
  *
  * The stamp's last cell is `vendor calls: 0`. It is not a boast — it is the
  * property that makes this surface replayable: every number below was
@@ -18,24 +16,24 @@ import { MONO, labelStyle, panelStyle } from "./DeskSection";
 
 export const QUESTIONS: [string, string][] = [
   [
-    "Is the money still coming?",
-    "Hyperscaler capex is the only number here not derived from another number here.",
+    "How is sample capex changing?",
+    "Quarterly capital expenditure, USD bn, for the USD filers in this sample.",
   ],
   [
-    "Where does it land?",
-    "Every chain placed by growth, margin and position at once.",
+    "How do industry groups compare?",
+    "Every chain placed by growth, margin and taxonomy layer at once.",
   ],
   [
-    "Does it transmit?",
-    "A dollar's path through the chains whose stages carry an explicit order.",
+    "How do case groups compare?",
+    "Stage-by-stage growth for the chains whose stages the taxonomy ranks.",
   ],
   [
-    "What am I paying?",
+    "Where is valuation versus own history?",
     "Each name against its own valuation history. Never against its peers.",
   ],
   [
-    "What would falsify it?",
-    "The measured things that would break every reading above.",
+    "What are the data limits?",
+    "The measured boundaries of every reading above.",
   ],
 ];
 
@@ -123,7 +121,7 @@ export function DeskMasthead({
           color: "var(--text-secondary)",
         }}
       >
-        One industry, traced from the dollar that pays for it
+Company-level operating metrics across selected AI-related industry groups
       </p>
 
       <div
@@ -150,15 +148,14 @@ export function DeskMasthead({
           color: "var(--text-secondary)",
         }}
       >
-        A sector screen sorts companies. A chain desk does something a screen
-        cannot: it follows one dollar of spending from the balance sheet that
-        commits it to the companies that book it as revenue — and reports where
-        that transmission breaks. So the scope is narrow on purpose. This is not
-        a coverage universe and it does not rank names against each other. It is{" "}
+        Company-level growth, reported margins and own-history valuation across
+        selected AI-related industry groups.{" "}
         <strong style={{ color: "var(--text-primary)" }}>
-          one industrial chain — AI and semiconductors — modelled end to end
-        </strong>
-        , built in the order a fundamental PM has to ask the questions.
+          This page does not trace payments and does not establish causal
+          transmission between groups.
+        </strong>{" "}
+        The scope is narrow on purpose: it is not a coverage universe and it
+        does not rank names against each other.
       </p>
 
       <ol

--- a/web/components/fundamentals/ValuationPanel.tsx
+++ b/web/components/fundamentals/ValuationPanel.tsx
@@ -28,6 +28,9 @@ import {
   onThemeChange,
   readPalette,
   valuationMarks,
+  valuationPhrase,
+  VALUATION_CHEAP,
+  VALUATION_RICH,
   type DeskPalette,
   type ValuationMark,
 } from "@/lib/fundamentals/desk";
@@ -36,10 +39,11 @@ import { MONO, Note, Num, VizFrame } from "./DeskSection";
 
 const HEIGHT = 176;
 const PAD = { l: 28, r: 28, t: 22, b: 36 };
-/** A name at or above this is cheap against its own past; at or below the
- *  other, rich. Both are label thresholds for reading, never a screen. */
-const CHEAP = 0.7;
-const RICH = 0.3;
+/** Label thresholds for reading, never a screen. Shared with the stage table
+ *  and the funnel readout through `valuationPhrase`, so one surface can never
+ *  call a name rich while another calls it mid-range. */
+const CHEAP = VALUATION_CHEAP;
+const RICH = VALUATION_RICH;
 
 interface Dot {
   x: number;
@@ -91,7 +95,7 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
       ctx.stroke();
       ctx.fillStyle = c.faint;
       ctx.textAlign = "center";
-      ctx.fillText((g / 10).toFixed(1), x, base + 7);
+      ctx.fillText(`P${g * 10}`, x, base + 7);
     }
     // The words, not just the axis. A bare 0.80 reads as expensive to anyone
     // who has met a price percentile before.
@@ -167,10 +171,9 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
     return (
       <Note>
         None of the <Num>{universe}</Num> companies on this desk carries an
-        own-history valuation band. A band needs enough of a name&apos;s own
-        filed history to place today&apos;s yield inside, and this chain has not
-        filed for long enough. The desk says so rather than reaching for a
-        cross-sectional rank, which measured INVERTED in this same universe.
+        own-history valuation band, so the reading is unavailable. The desk
+        says so rather than reaching for a cross-sectional rank, which measured
+        INVERTED in this same universe.
       </Note>
     );
   }
@@ -193,16 +196,10 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
               <span>
                 own-history yield percentile{" "}
                 <b style={{ color: "var(--text-primary)" }}>
-                  {hover.percentile.toFixed(2)}
+                  {valuationPhrase(hover.percentile)}
                 </b>
               </span>
-              <span>
-                {hover.percentile >= CHEAP
-                  ? "cheap against its own past"
-                  : hover.percentile <= RICH
-                    ? "rich against its own past"
-                    : "mid-range against its own past"}
-              </span>
+              <span>relative to its own history, not to its peers</span>
             </>
           ) : (
             <>
@@ -214,7 +211,7 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
               <span>
                 median{" "}
                 <b style={{ color: "var(--text-primary)" }}>
-                  {mid?.toFixed(2)}
+                  {valuationPhrase(mid)}
                 </b>
               </span>
               <span>
@@ -259,10 +256,9 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
           Coverage is the honest headline here.
         </strong>{" "}
         Only <Num>{marks.length}</Num> of <Num>{universe}</Num> companies on the
-        chain map carry a band at all {DASH} a band needs enough own history to
-        place today&apos;s yield inside, and much of this chain has not filed
-        for long enough. Among those that do, the median sits at{" "}
-        <Num>{mid?.toFixed(2)}</Num>:{" "}
+        chain map carry a band at all {DASH} the rest are simply unavailable
+        here, and this panel does not say why. Among those that do, the median
+        sits at <Num>{valuationPhrase(mid)}</Num>:{" "}
         {mid != null && mid < 0.5 ? (
           <>
             the typical covered name is <em>richer</em> than it has usually been
@@ -275,8 +271,9 @@ export function ValuationPanel({ cells }: { cells: ChainMetricCell[] }) {
           </>
         )}
         , <Num>{nRich}</Num> rich against <Num>{nCheap}</Num> cheap. The
-        percentile is a <em>yield</em> percentile {DASH} 0.80 means cheap, not
-        expensive {DASH} which is the most misreadable number on this desk, so
+        percentile is a <em>yield</em> percentile against the name&apos;s own
+        history {DASH} P80 means cheap relative to its own past, not an 80%
+        discount {DASH} which is the most misreadable number on this desk, so
         it never appears as a bare figure without the word beside it. There is
         no way to sort this strip, deliberately.
       </Note>

--- a/web/lib/fundamentals/desk.ts
+++ b/web/lib/fundamentals/desk.ts
@@ -164,6 +164,28 @@ export function sgn(v: number | null | undefined, digits = 1): string {
   return `${v >= 0 ? "+" : ""}${(v * 100).toFixed(digits)}%`;
 }
 
+/**
+ * An own-history valuation percentile, spelled so its direction cannot invert.
+ *
+ * ONE helper for three callers (the stage table, the funnel readout and the
+ * valuation strip). A bare `0.80` reads as expensive to anyone who has met a
+ * price percentile before; this is a YIELD percentile, so 0.80 is CHEAP. Three
+ * private copies is three chances for one surface to say the opposite of
+ * another about the same number.
+ *
+ * `null` is "unavailable" and nothing more: the API does not say WHY a name
+ * carries no band, so neither does this.
+ */
+export function valuationPhrase(p: number | null | undefined): string {
+  if (p == null) return "unavailable";
+  const word = p >= VALUATION_CHEAP ? "cheap" : p <= VALUATION_RICH ? "rich" : "mid-range";
+  return `P${Number((p * 100).toFixed(1))} ${MID} ${word}`;
+}
+
+/** Label thresholds for reading a percentile, never a screen. */
+export const VALUATION_CHEAP = 0.7;
+export const VALUATION_RICH = 0.3;
+
 /** Dollars, in billions. Only ever applied to the USD-filer capex panel. */
 export function usdB(v: number, digits = 1): string {
   return `$${(v / 1e9).toFixed(digits)}B`;
@@ -304,10 +326,6 @@ export interface CaseSummary {
   downstreamFirst: CaseStage[];
   customer: CaseStage;
   upstream: CaseStage;
-  /** Upstream median growth divided by the customer's. Null if either is
-   *  missing or the customer's is not positive — a ratio through zero or a
-   *  negative denominator is arithmetic, not amplification. */
-  amplification: number | null;
   distinctCompanies: number;
   memberships: number;
   /** How many COMPANIES appear at more than one stage of the same case —
@@ -315,28 +333,10 @@ export interface CaseSummary {
   dualListed: number;
 }
 
-/**
- * Supplying stages growing more slowly than the customer they supply.
- *
- * SHARED, because both the case card and the funnel finding print its COUNT —
- * "N of M supplying stages sit below their own customer" — and two copies of
- * the comparison could print different N for the same case with nothing on
- * screen to say which one was right. The customer stage itself is excluded:
- * it does not supply itself, and including it would make N off by one
- * whenever a case's customers happened to be its slowest stage.
- */
-export function belowCustomer(summary: CaseSummary): CaseStage[] {
-  const cm = summary.customer.median_rev_yoy;
-  if (cm == null) return [];
-  return summary.downstreamFirst
-    .slice(1)
-    .filter((s) => s.median_rev_yoy != null && s.median_rev_yoy < cm);
-}
-
 export function summariseCase(stages: CaseStage[]): CaseSummary | null {
   if (stages.length < 2) return null;
-  // The API orders upstream-first (rank ascending); the funnel puts the
-  // customer on top so the dollar travels downward.
+  // The API orders upstream-first (rank ascending); the display puts the
+  // customer group on top. That is a drawing order, not a traced flow.
   const downstreamFirst = [...stages].sort((a, b) => b.rank - a.rank);
   const customer = downstreamFirst[0];
   const upstream = downstreamFirst[downstreamFirst.length - 1];
@@ -353,13 +353,10 @@ export function summariseCase(stages: CaseStage[]): CaseSummary | null {
   }
   const tickers = seenAt;
   const repeated = [...seenAt.values()].filter((n) => n > 1).length;
-  const cm = customer.median_rev_yoy;
-  const um = upstream.median_rev_yoy;
   return {
     downstreamFirst,
     customer,
     upstream,
-    amplification: cm != null && um != null && cm > 0 ? um / cm : null,
     distinctCompanies: tickers.size,
     memberships,
     dualListed: repeated,

--- a/web/tests/e2e/fundamentals-chain-desk.spec.ts
+++ b/web/tests/e2e/fundamentals-chain-desk.spec.ts
@@ -49,11 +49,11 @@ test("the question ladder renders in order, and every scene paints", async ({
     .locator('[data-testid^="desk-"] h2')
     .allInnerTexts();
   expect(headings.slice(0, 5)).toEqual([
-    "IS THE MONEY STILL COMING?",
-    "WHERE DOES IT LAND?",
-    "DOES IT TRANSMIT?",
-    "WHAT AM I PAYING FOR IT?",
-    "WHAT WOULD FALSIFY THIS?",
+    "HOW IS SAMPLE CAPEX CHANGING?",
+    "HOW DO INDUSTRY GROUPS COMPARE?",
+    "HOW DO CASE GROUPS COMPARE?",
+    "WHERE IS VALUATION VERSUS OWN HISTORY?",
+    "WHAT ARE THE DATA LIMITS?",
   ]);
   await expect(
     page.getByTestId("desk-chain-map").locator("canvas"),
@@ -170,6 +170,6 @@ test("the desk never offers a way to sort by valuation", async ({ page }) => {
     expect(label.toLowerCase()).not.toMatch(/\bsort\b|\brank\b|cheapest/);
   }
   await expect(
-    page.getByText(/0\.80 means cheap, not expensive/),
+    page.getByText(/P80 means cheap relative to its own past/),
   ).toBeVisible();
 });

--- a/web/tests/unit/industryDesk.test.tsx
+++ b/web/tests/unit/industryDesk.test.tsx
@@ -10,6 +10,7 @@ import { DeskMasthead } from "@/components/fundamentals/DeskMasthead";
 import { ScopeTable } from "@/components/fundamentals/ScopeTable";
 import {
   chainPoints,
+  sgn,
   summariseCase,
   valuationMarks,
 } from "@/lib/fundamentals/desk";
@@ -663,26 +664,6 @@ describe("summariseCase", () => {
     expect(optical.upstream.layer).toBe("Upstream-Components");
   });
 
-  it("computes amplification as upstream over customer", () => {
-    const optical = summariseCase(CASES[1].stages)!;
-    const expected =
-      (optical.upstream.median_rev_yoy as number) /
-      (optical.customer.median_rev_yoy as number);
-    expect(optical.amplification).toBeCloseTo(expected, 10);
-    // The measured optical reading, reproduced from the full real chain.
-    expect(optical.amplification).toBeCloseTo(4.078, 2);
-  });
-
-  it("refuses a ratio when the customer median is not positive", () => {
-    // Dividing through zero or a negative denominator is arithmetic, not
-    // amplification, and it would print a confident number for nonsense.
-    const flat = summariseCase([
-      stage("Upstream-Components", 10, OPT, [member("AAOI", 0.6, 0.2)]),
-      stage("Customer-Cloud", 70, OPT, [member("AMZN", -0.1, 0.5)]),
-    ])!;
-    expect(flat.amplification).toBeNull();
-  });
-
   it("counts a dual-listed company once, and says how many there are", () => {
     // AAOI, COHR and LITE really sit in BOTH Upstream-Components and
     // Module-Transceiver.
@@ -697,28 +678,30 @@ describe("summariseCase", () => {
 // --- CaseCards --------------------------------------------------------------
 
 describe("CaseCards", () => {
-  it("shows both cases and the amplification each one carries", () => {
+  it("shows each group's own TTM revenue growth, not a ratio between them", () => {
     render(<CaseCards cases={CASES} />);
     const cards = screen.getByTestId("case-cards");
     const text = cards.textContent ?? "";
     expect(text).toContain("Optical interconnect");
     expect(text).toContain("Datacenter buildout");
-    expect(text).toContain("4.08");
+    expect(text).toContain("Customer-group revenue growth (TTM YoY, %)");
+    // The two medians stand side by side, each labelled with its own group.
+    const optical = summariseCase(CASES[1].stages)!;
+    expect(text).toContain(sgn(optical.customer.median_rev_yoy));
+    expect(text).toContain(sgn(optical.upstream.median_rev_yoy));
+    // And the unverified transmission claim is gone: no ratio, no headline
+    // multiple, no "amplification".
+    expect(text).not.toContain("4.08");
+    expect(text).not.toMatch(/amplification/i);
+    expect(text).not.toContain("\u00d7");
   });
 
-  it("says how many supplying stages sit BELOW their own customer", () => {
-    // The finding that no sector screen can produce: proximity to the AI
-    // dollar does not guarantee participation in it.
+  it("states the sample limits the card cannot resolve", () => {
     render(<CaseCards cases={CASES} />);
-    const dc = summariseCase(CASES[0].stages)!;
-    const cm = dc.customer.median_rev_yoy as number;
-    const below = dc.downstreamFirst
-      .slice(1)
-      .filter((s) => (s.median_rev_yoy as number) < cm);
-    expect(below.length).toBeGreaterThan(0);
-    expect(screen.getByTestId("case-cards").textContent ?? "").toContain(
-      `${below.length} of the ${dc.downstreamFirst.length - 1} supplying stages`,
-    );
+    const text = screen.getByTestId("case-cards").textContent ?? "";
+    expect(text).toMatch(/more than one group/i);
+    expect(text).toMatch(/company-level/i);
+    expect(text).toMatch(/capex panel/i);
   });
 });
 
@@ -761,84 +744,14 @@ describe("DeskMasthead", () => {
   });
 });
 
-describe("prose retreats when its condition stops holding", () => {
-  /** Same shape as CASES, but every supplying stage OUTGROWS its customer. */
-  const NO_LAG: DeskCase[] = [
-    {
-      domain: "optical_communication",
-      slug: "optical",
-      label: "Optical interconnect",
-      stages: [
-        stage("Upstream-Components", 10, OPT, [member("AVGO", 0.6, 0.7)]),
-        stage("Module-Transceiver", 30, OPT, [member("COHR", 0.5, 0.4)]),
-        stage("Customer-Cloud", 70, OPT, [member("MSFT", 0.1, 0.7)]),
-      ],
-    },
-    {
-      domain: "dc_buildout",
-      slug: "datacenter",
-      label: "Datacenter buildout",
-      stages: [
-        stage("Power-Electrical", 20, "Power/Electrical", [
-          member("ETN", 0.3, 0.38),
-        ]),
-        stage("DC-REIT-Colo", 50, "DC-REIT/Colo", [member("EQIX", 0.1, 0.5)]),
-      ],
-    },
-  ];
-
-  it("drops the 'slower than the customers it supplies' clause when none is", () => {
-    // The word is an assertion; the number beside it would stay correct while
-    // the word went false. Nothing on screen would show the difference.
-    render(<CaseCards cases={NO_LAG} />);
-    const text = screen.getByTestId("case-cards").textContent ?? "";
-    expect(text).not.toContain("slower than the customers it supplies");
-    expect(text).not.toMatch(/\b0 of the \d+ supplying stages/);
-  });
-
-  it("still prints both amplifications when no stage lags", () => {
-    // Retreating from a claim must not take the measurement with it.
-    render(<CaseCards cases={NO_LAG} />);
-    expect(screen.getByTestId("case-cards").textContent ?? "").toContain(
-      "6.00",
-    );
-  });
-
-  it("stops calling the cases 'completely different' when they converge", () => {
-    const CLOSE: DeskCase[] = [
-      NO_LAG[0],
-      {
-        ...NO_LAG[1],
-        stages: [
-          stage("Power-Electrical", 20, "Power/Electrical", [
-            member("ETN", 0.55, 0.38),
-          ]),
-          stage("DC-REIT-Colo", 50, "DC-REIT/Colo", [member("EQIX", 0.1, 0.5)]),
-        ],
-      },
-    ];
-    render(<CaseCards cases={CLOSE} />);
-    const text = screen.getByTestId("case-cards").textContent ?? "";
-    expect(text).toContain("measurably different rates");
-    expect(text).not.toContain("completely differently");
-  });
-
-  it("keeps 'completely differently' while the gap is real", () => {
-    render(<CaseCards cases={CASES} />);
-    expect(screen.getByTestId("case-cards").textContent ?? "").toContain(
-      "completely differently",
-    );
-  });
-});
-
 // --- CaseStageTables --------------------------------------------------------
 
 describe("CaseStageTables", () => {
-  it("names a company with no filed quarter instead of dropping or zeroing it", () => {
+  it("names a company with no TTM growth instead of dropping or zeroing it", () => {
     render(<CaseStageTables cases={CASES} />);
     const tables = screen.getByTestId("case-stage-tables");
     expect(within(tables).getAllByText("JNPR").length).toBeGreaterThan(0);
-    expect(tables.textContent ?? "").toContain("no filed quarter");
+    expect(tables.textContent ?? "").toContain("TTM growth unavailable");
     // The load-bearing half: it must not have been rendered as +0.0%.
     const row = within(tables).getAllByText("JNPR")[0].closest("tr");
     expect(row?.textContent ?? "").not.toMatch(/\+0\.0%/);
@@ -848,7 +761,7 @@ describe("CaseStageTables", () => {
     render(<CaseStageTables cases={CASES} />);
     // Systems-Networking is 3 of 4 reporting because JNPR abstains.
     expect(screen.getByTestId("case-stage-tables").textContent ?? "").toContain(
-      "3/4 reported",
+      "growth available 3/4",
     );
   });
 


### PR DESCRIPTION
## Why

The AI chain desk claimed a transmission it never measured. `CaseCards` divided the upstream group's median revenue growth by the customer group's and printed the quotient as an **amplification multiple** (4.08× / 2.25×); the page's prose ("every revenue dollar is somebody else's capex", end-to-end dollar tracing) was built on top of it, and the strong/weak case framing was selected by that same ratio.

Nothing in the data traces a payment. The two medians are independent equal-weight medians over different memberships, taken from each company's latest available filing, at the **whole-company** level — not the segment that serves the chain. The quotient of two unrelated medians is not a transmission coefficient.

## What changed

**Claims (P1)** — the ratio is **deleted**, not renamed, along with `CaseSummary.amplification`, `belowCustomer`, `WhyTwo`, `FunnelFindings`/`barelyOpens` and the flow narrative they justified. Each group's own TTM revenue-growth median now prints beside the other's. The five section titles name the questions the data can answer:

| before | after |
|---|---|
| Is the money still coming? | How is sample capex changing? |
| Where does it land? | How do industry groups compare? |
| Does it transmit? | How do case groups compare? |
| What am I paying for it? | Where is valuation versus own history? |
| What would falsify this? | What are the data limits? |

The funnels become "Stage growth comparison" (no arrows, no ratio, plus a note that the stacking is the taxonomy's rank order and not a traced path), and the chain map's growth ranges are reported as descriptions of this sample rather than as explanatory power.

**Units and basis (P2)** — every figure carries its unit, time basis and sample wherever it appears: `Revenue growth (TTM YoY, %)`, `Reported gross margin (latest quarter, %)`, capex in `USD bn` against `Sample capex / sample revenue (%)`, and own-history valuation through one shared `valuationPhrase()` on a P0–P100 axis. Missing values say what is missing (`TTM growth unavailable`, `growth available n/N`, `unavailable`) and are still never coerced to zero. The capex note fixes the sample boundary — a taxonomy chain, not the full set of AI buyers, and not the same membership as the case groups.

**Display semantics only: no metric, API, schema, worker or stored data was recomputed.**

## Verification

| gate | result |
|---|---|
| `npx vitest run tests/unit/industryDesk.test.tsx tests/unit/capexPanel.test.tsx` | 43/43 pass (49 → 43: six narrative-only tests deleted, one added) |
| `npm run typecheck` | clean |
| `npx eslint` on the touched paths | clean |
| `npm run build` | compiled |
| `PLAYWRIGHT_WEB_PORT=3011 npx playwright test tests/e2e/fundamentals-chain-desk.spec.ts` | 6/6 pass, against a real `next start` + local API on `option_wizard_local` |
| both pages in a browser | 0 console errors; no `4.08` / `amplif` in the rendered body; screenshots under `output/playwright/` |

TDD order held — the rewritten assertions failed (4 failed / 34 passed) against the old implementation before any component was touched.

## Known limits, left honest

- `CaseStageMember` carries no per-row fiscal period and no reason for a missing value, so the rows say "each company's latest available record; periods may differ" as prose rather than printing a date, and a missing band says only `unavailable`. No dates or reasons were invented.
- "Funnel" survives in one hover hint and in code comments; it names the canvas shape, not a money-flow claim.

Plan: `docs/plans/2026-09-01-fundamentals-report-claims-and-units.md` (included).