### PR TITLE
feat(control): add `uv run control-argon` — doctor / sync / smoke / screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
     `INSERT … ON CONFLICT DO NOTHING`, so it is idempotent and cannot trip the FK
     pins on cited macro evidence. Retires pointing `.env.local` at the mini for a
     browse session.
+  - `up` — starts `dev.sh` detached, log to `output/dev/`, and blocks until the
+    stack is genuinely serving: web 200, API 200, API version equal to `VERSION`,
+    and a worker heartbeat written **after** the launch (the last one matters —
+    the heartbeat a worker wrote before a restart clears the 15-minute freshness
+    bar, and `up` reported ready at 19 s while `dev.sh` was still sleeping before
+    it spawned any worker). Refuses to start over a port that is already held and
+    names the pid, role, age, and originating checkout; `--force` stops them
+    first. Replaces the per-caller ritual of backgrounding `dev.sh`, tailing its
+    ~26 lines/sec of log, and guessing when to stop waiting.
+  - `down [--all] [--older-than H] [--dry-run]` — stops stack processes,
+    enumerated by role and attributed to a checkout by cwd, so `--all` sweeps
+    orphans across worktrees without touching unrelated processes that merely run
+    inside the repo. Enumerating by role rather than by listening port is
+    load-bearing: 5 of the stack's 7 processes bind no socket, so a port-driven
+    sweep stops web and API and leaves the workers behind.
   - `smoke <ticker>` — API enqueue → worker claim → job done → web page, the real
     chain from the smoke-test standing rule.
   - `screenshot <name>` — output path fixed under `output/playwright/`, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Added
+
+- **`uv run control-argon` — one entry point for verifying and controlling the
+  local stack**, so an agent can check its own work instead of handing the
+  verification back to the operator.
+  - `doctor` — ports, DB tier, WS feed, data freshness, and two checks a plain
+    liveness probe cannot make: whether the API is serving **this checkout's
+    version**, and whether the worker heartbeat is alive. Found the local stack
+    answering `/api/health` 200 while running v0.13.0 of a v0.13.2 tree with an
+    87-hour-dead worker.
+  - `sync [--days 7]` — streams the mini's recent rows into
+    `option_wizard_local` over Tailscale (`COPY TO STDOUT` → `COPY FROM STDIN`,
+    no ssh, no dump file). Deny-list rather than allow-list, so a new table syncs
+    by default; date column auto-detected, observation dates preferred over write
+    stamps; tables under 64 MB copied whole. Additive only — `TEMP` table then
+    `INSERT … ON CONFLICT DO NOTHING`, so it is idempotent and cannot trip the FK
+    pins on cited macro evidence. Retires pointing `.env.local` at the mini for a
+    browse session.
+  - `smoke <ticker>` — API enqueue → worker claim → job done → web page, the real
+    chain from the smoke-test standing rule.
+  - `screenshot <name>` — output path fixed under `output/playwright/`, so a
+    repo-root screenshot is structurally impossible rather than just discouraged.
+
 ### Changed
 
 - **Playwright e2e collapses from five configs to two.**
@@ -17,6 +40,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   `playwright.technicals.config.ts` stays: it boots a different server stack, and
   Playwright's `webServer` is a config-level field that cannot be set per project.
   `npm run test:e2e` and the `test:e2e:technicals` CI gate are unchanged.
+- `## Daily commands` in `CLAUDE.md` is 14 lines shorter; `control-argon --help`
+  carries it.
 
 ## [0.13.2] — 2026-08-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,16 @@ The Mac mini `.env` uses `UW_SCAN_DB_HOST=127.0.0.1`, `UW_SCAN_DB_NAME=option_wi
 uv sync --extra postgres          # install
 bash scripts/migrate.sh           # apply SQL migrations (idempotent)
 bash scripts/dev.sh               # run web, API, 2 UW workers, and 2 massive workers
-uv run pytest                     # python tests
-cd web && npm run test            # vitest
-cd web && npm run gen:types       # regenerate types.ts after API change
+uv run control-argon --help       # verify/control the stack — the rest of this list
 ```
+
+`control-argon` is the agent-usable entry point: `doctor` (is the stack up, is it
+running THIS checkout's code, is the data fresh), `sync` (pull the mini's recent
+data into `option_wizard_local`, retiring the `.env.local`-points-at-the-mini
+browse hack), `smoke <ticker>` (API enqueue → worker → DB → web page, the real
+chain), `screenshot <name>` (into `output/playwright/`, never the repo root).
+Source `src/uw_scan/control_argon.py`; design
+`docs/superpowers/specs/2026-09-01-control-argon-design.md`.
 
 ## Release procedure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,28 @@ The Mac mini `.env` uses `UW_SCAN_DB_HOST=127.0.0.1`, `UW_SCAN_DB_NAME=option_wi
 ```bash
 uv sync --extra postgres          # install
 bash scripts/migrate.sh           # apply SQL migrations (idempotent)
-bash scripts/dev.sh               # run web, API, 2 UW workers, and 2 massive workers
-uv run control-argon --help       # verify/control the stack — the rest of this list
+uv run control-argon up            # start the stack and WAIT until it is serving
+uv run control-argon down --all    # stop every stale stack, any worktree
+uv run control-argon --help        # verify/control the stack — the rest of this list
 ```
+
+**Start the stack with `up`, not `dev.sh` directly.** `dev.sh` still does the
+work and `up` execs it, but it runs in the foreground, emits ~26 log lines/sec,
+and offers no readiness signal, so every caller has to invent its own way to
+find out whether the stack came up. `up` detaches it, sends the log to
+`output/dev/`, and blocks until the stack is actually serving: web 200, API 200,
+the API's version equal to `VERSION`, and a worker heartbeat written *after* the
+launch. It exits non-zero if any of that fails to happen.
+
+It refuses to start on top of something else and names what is in the way. This
+matters more than it sounds: on 2026-09-01 this machine had five orphaned stacks
+from four worktrees, two of them already deleted, the oldest four days old. One
+was `next start` serving a four-day-old `.next/standalone` build on port 3001 —
+argon's default web port — answering 200 the whole time. Anything that started a
+stack, curled :3001, and got a 200 was validating a four-day-old build and
+calling it a pass. `down` exists because nothing ever stopped them: it sweeps by
+role and attributes each process to the checkout it was started from, so
+`--all` cleans the fleet without touching the stack you meant to keep.
 
 `control-argon` is the agent-usable entry point: `doctor` (is the stack up, is it
 running THIS checkout's code, is the data fresh), `sync` (pull the mini's recent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Postgres schema `uw_scan`, owned by role `argon_app` (NOSUPERUSER). UW (Unusual 
 | Host                        | DB name               | Writer                      | Reset                                   |
 | --------------------------- | --------------------- | --------------------------- | --------------------------------------- |
 | `127.0.0.1` on the Mac mini | `option_wizard`       | macmini launchd stack only  | persistent (prodlike)                   |
-| `127.0.0.1` (MacBook / CI)  | `option_wizard_local` | local `bash scripts/dev.sh` | persistent (dev-owned)                  |
+| `127.0.0.1` (MacBook / CI)  | `option_wizard_local` | local `control-argon up` | persistent (dev-owned)                  |
 | either host                 | `option_wizard_test`  | `uv run pytest`             | wiped per-fixture (DROP SCHEMA CASCADE) |
 
 The Mac mini `.env` uses `UW_SCAN_DB_HOST=127.0.0.1`, `UW_SCAN_DB_NAME=option_wizard`, and `UW_SCAN_ALLOW_DB_MISMATCH=1` for the same-host prodlike route. MacBook runs fully local by default. To point at the mini for a browse session, `.env.local` must override BOTH `UW_SCAN_DB_HOST=100.66.147.98` AND `UW_SCAN_DB_NAME=option_wizard` (otherwise the tripwire blocks mini+local-name). See `docs/superpowers/specs/2026-06-01-mac-mini-stack-migration-design.md`.
@@ -179,7 +179,7 @@ Worker roles: `ai-codex`, `ai-claude`, and `ai-deepseek` (provider-pinned, recom
 - **Never add `Co-Authored-By: Claude` trailers** to commits
 - **CHANGELOG rides the feature PR.** Add the `[Unreleased]` entry on the feature branch BEFORE merging — code, tests, docs, and changelog in one PR. Only the `cut.sh prepare` version-bump PR is legitimately separate
 - **Worktrees live in `.worktrees/<branch-slug>/`** — the project-root `.worktrees/` directory is the only canonical location (already gitignored). When done, `git worktree remove <path>` — stale worktrees holding `main` block `git checkout main` in the primary repo
-- **Smoke tests run the real worker path** — API enqueue → DB row → worker claims → DB result → web UI renders. Never a one-off `/tmp` script calling the function directly; the user validates via the web page. If the worker predates your edit, restart the stack first (APScheduler doesn't hot-reload)
+- **Smoke tests run the real worker path** — API enqueue → DB row → worker claims → DB result → web UI renders. Never a one-off `/tmp` script calling the function directly; the user validates via the web page. If the worker predates your edit, restart the stack first — `uv run control-argon down && uv run control-argon up`, which returns only once a worker heartbeat postdates the relaunch (APScheduler doesn't hot-reload)
 - **R2 lake is primary for EOD/backfill reads** (new backtest/backfill code reads R2 parquet via `sources/lake.py`, falls back to the local mirror); Postgres warm store stays the API request-time read path. Outputs still persist to Postgres
 - **Migrations are idempotent** (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`). No tracking table — re-running is a no-op
 - **Live API tests** are marked `live` and need `UW_SCAN_API_KEY`; default `pytest` excludes them

--- a/docs/superpowers/specs/2026-09-01-control-argon-design.md
+++ b/docs/superpowers/specs/2026-09-01-control-argon-design.md
@@ -1,6 +1,6 @@
 # control-argon — an agent-usable verification/control entry point
 
-Status: design approved for Step 1–2 (done, this PR); Step 3 (the CLI) not yet built.
+Status: Step 1–2 shipped (PR #407). Step 3 shipped, with four deviations recorded below.
 Date: 2026-09-01
 
 ## The constraint that shapes everything
@@ -119,3 +119,86 @@ in exactly one of the two sets — that is the check's teeth, and its own unit t
 Step 1 (config convergence) and Step 2 (root cleanup) are pure deletion, reversible, and
 independent of the CLI's design — landed first so the convergence claim is proven by a diff
 before any new code is written. Step 3 follows.
+
+
+---
+
+## What actually happened (written after building it)
+
+Four decisions in this spec did not survive contact. Recorded here rather than
+quietly rewritten above.
+
+### 1. There is no SSH layer, and no `\copy`
+
+The mini's Postgres answers **directly over Tailscale** from the MacBook on the
+same `argon_app` credentials (`psql -h 100.66.147.98 -d option_wizard` returns
+rows). So `sync` is two psycopg connections in one process, streaming
+`COPY … TO STDOUT` into `COPY … FROM STDIN`. `pg_dump`'s missing row filter never
+came up, and nothing has to exist on the mini.
+
+### 2. The table → date-column manifest is gone, and so is the drift check
+
+**168 of 175 tables carry a date column.** A hand-maintained manifest at that
+scale is a liability, and the reverse-drift check existed only to police it. Both
+are replaced by:
+
+- a **deny-list** (5 raw/audit tables, ~11 GB) — everything else syncs *by
+  default*, so a newly added table is included without anyone remembering. The
+  failure mode flips from "silently missing a slice" to "the sync got slower".
+- an **auto-detected date column**, chosen from `DATE_COL_PRIORITY`, which puts
+  observation dates ahead of write stamps — `inserted_at` dates the write, so a
+  backfilled row reads as fresh under it.
+- a **size rule instead of a dimension/fact classification**: under 64 MB, copy
+  the table whole; over it, copy the date window. Size is the only reason to
+  window in the first place.
+- `sync` **reports any windowed table that copied 0 rows** as "likely
+  slow-moving". That is the self-diagnosing property the drift check was for,
+  obtained without a list to maintain.
+
+This preserves the stated intent — the list must not be able to go stale in
+silence — with less machinery. It is a deliberate departure from the approved
+design, not an oversight.
+
+### 3. Nothing is deleted, anywhere
+
+The sync COPYs into a `TEMP` table and then `INSERT … ON CONFLICT DO NOTHING`.
+Additive and idempotent (a second run inserts 0 rows), and it sidesteps the FK
+pins — cited macro evidence is undeletable by design, so a delete-then-copy sync
+would have hard-failed on `macro_source_artifacts`.
+
+Two things Postgres rejects on insert had to be handled explicitly, both found by
+running it rather than by reading the schema: **53 `GENERATED ALWAYS AS … STORED`
+columns** (dropped from the copy, recomputed on insert) and **2 `GENERATED ALWAYS
+AS IDENTITY` columns** (kept, with `OVERRIDING SYSTEM VALUE`, because that id is
+what `ON CONFLICT` dedups on).
+
+### 4. `doctor` gained the check that matters most, and `sync --push` is deferred
+
+While testing, the local `/api/health` returned **200 while serving v0.13.0 of a
+v0.13.2 checkout**, with a worker heartbeat 87.6 hours old — and 500ing on every
+real endpoint. A liveness probe that only asks "did something answer" certifies
+exactly that outage as healthy. `doctor` now compares the API's reported version
+against `VERSION` and fails on a stale worker heartbeat.
+
+`sync --push` (the mini-ward direction, absorbing
+`scripts/deploy/macmini-data-promote.sh`) is **not built**. It writes to the
+prodlike tier, and there is no way to rehearse that safely from here. The promote
+script stays until there is.
+
+### The honest convergence account
+
+Retired: 3 Playwright configs, 8 repo-root PNGs, the `.env.local`-points-at-the-mini
+browse hack, ad-hoc `/tmp` Playwright scripts, the 14-line `## Daily commands`
+block (now 5 lines and a pointer), and the human standing at the end of the smoke
+chain.
+
+**Not** retired, contrary to the table at the top of this spec:
+`scripts/smoke_container_assets.sh` verifies that a **built Docker image** carries
+its runtime assets — a different question from "is the local stack healthy", and
+one `doctor` does not answer. It stays. So does `macmini-data-promote.sh`, per
+deviation 4.
+
+The line count goes UP (one ~700-line module plus its test). What goes down is the
+number of **entry points**: one command to learn instead of five scripts, one
+env-var convention instead of four config files, and one place a screenshot can
+land.

--- a/docs/superpowers/specs/2026-09-01-control-argon-design.md
+++ b/docs/superpowers/specs/2026-09-01-control-argon-design.md
@@ -202,3 +202,91 @@ The line count goes UP (one ~700-line module plus its test). What goes down is t
 number of **entry points**: one command to learn instead of five scripts, one
 env-var convention instead of four config files, and one place a screenshot can
 land.
+
+## Addendum: `up` / `down` (added after the first build)
+
+The original four subcommands answered "is the stack healthy" and deliberately
+left starting it to `dev.sh`, on the reasoning that wrapping an existing script
+deletes nothing and is therefore amplification. That reasoning counted files and
+not failures, and it was wrong.
+
+### What the machine actually looked like
+
+Measured on 2026-09-01, on a working laptop, with no incident in progress:
+
+| age | port | role | origin |
+| --- | --- | --- | --- |
+| 4d06h | 3001 | `next start` on `.next/standalone` | main checkout |
+| 3d17h | 8477 | uvicorn | `.worktrees/fundamentals-desk-pages` |
+| 3d15h | 3012 | `next start` | `.worktrees/fundamentals-desk-pages` |
+| 3d14h | 8400 | uvicorn | `.worktrees/feat-macro-desk-tabs-03-05` **(worktree deleted)** |
+| 2d14h | 39030 | `next start` | `.worktrees/feat-macro-desk-tabs-03-05` **(worktree deleted)** |
+
+No workers were running at all. Two of the four originating worktrees had
+already been `git worktree remove`d; their processes kept running against
+`.venv` directories that no longer existed.
+
+The four-day-old entry is the expensive one. It held **3001**, argon's default
+web port, running a build produced four days earlier — no HMR, no relation to
+any subsequent commit — and it answered 200 for every one of those four days.
+An agent that edited code, started a stack, and curled `:3001` got a green
+light for a build that predated its own change. A stale process that errors is
+a nuisance; one that answers correctly is a trap, and this is the failure mode
+that makes agents burn a long tail of tokens without converging: the signal
+they are steering by is not connected to the thing they changed.
+
+### Why `dev.sh` cannot be driven programmatically
+
+1. `exec npx concurrently` — foreground, never exits, ~26 log lines/sec
+   interleaved across 7 processes. A caller either blocks until its own timeout
+   or backgrounds it and then pays to read the firehose.
+2. No readiness signal. Startup is staggered by hardcoded `sleep 15/20/22/24/26`;
+   "is it up" is only answerable from outside, by polling.
+3. No stop. Restarting means `ps | grep | kill` by hand, which is why the table
+   above exists.
+4. `concurrently` is not run with `--kill-others`, so one dead process leaves the
+   rest serving. A half-stack presents as a healthy one.
+
+### The shape of the fix
+
+`up` adds no new judgement of its own. The readiness predicate already existed
+inside `doctor`; it was extracted to `StackState` and is now the single
+definition both commands use, so they cannot drift apart about what "ready"
+means. `up` spawns `dev.sh` detached with its log in `output/dev/`, polls that
+predicate, and prints one line per state change.
+
+Three findings from building it, each of which changed the design:
+
+- **`up` needs a stronger worker check than `doctor` can make.** `doctor` sees
+  one instant and can only ask whether the heartbeat is recent. `up` knows when
+  it launched, so it asks whether the heartbeat was written *after* that.
+  Without this, the row a worker wrote before the restart clears the 15-minute
+  bar and `up` reports ready while `dev.sh` is still in its `sleep 20` — measured
+  at 19 s, with no worker process in existence.
+- **Enumerate by role, not by listening port.** Ports were the visible symptom,
+  so they were the first index tried. But 5 of the stack's 7 processes bind no
+  socket: a port-driven `down` stops web and API and leaves 4 schedulers and the
+  WS consumer orphaned, manufacturing exactly what it was run to clean up.
+  Processes are enumerated by command role and attributed to a checkout by cwd,
+  with ports demoted to metadata.
+- **Role matching is an allow-list, and deliberately the opposite choice from
+  `sync`'s deny-list.** Being inside the argon tree does not make a process
+  argon's: uv-installed MCP servers run with the repo as their cwd and listen on
+  ports of their own. The list direction follows the cost of being wrong — a
+  missed orphan is caught on the next run, a wrongly matched process is someone's
+  killed editor or agent session. `sync` faces the opposite asymmetry (a missed
+  table is an invisible data hole) and so takes the opposite default.
+
+Two smaller things that had to be measured rather than assumed: `uv run` does
+not forward `SIGTERM`, so terminating the wrapper leaves uvicorn holding the
+port — the tree rooted at each pid is signalled explicitly, and descendants are
+killed rather than trusting a process group we did not create. And `lsof`'s
+LISTEN rows append a `(LISTEN)` state column, so the address is not the last
+field.
+
+### What it retires
+
+The per-caller ritual: background `dev.sh`, tail the log, curl the port, guess.
+It was never written down anywhere, which is why every agent re-derived it and
+why it never got better. It is now one command, one line of output, one exit
+code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = [
   "arch==8.0.0",
 ]
 
+[project.scripts]
+# One entry point for verifying and controlling the local stack:
+#   uv run control-argon doctor | sync | smoke <ticker> | screenshot <name>
+control-argon = "uw_scan.control_argon:main"
+
 [project.optional-dependencies]
 postgres = [
   "psycopg[binary,pool]>=3.2",

--- a/src/uw_scan/control_argon.py
+++ b/src/uw_scan/control_argon.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""control-argon — one entry point for verifying and controlling the local stack.
+
+Replaces: scripts/smoke_container_assets.sh, reading scripts/dev.sh by eye, the
+`.env.local`-points-at-the-mini browse hack, ad-hoc /tmp Playwright scripts, and
+the `## Daily commands` block in CLAUDE.md.
+
+    uv run control-argon doctor
+    uv run control-argon sync --days 7
+    uv run control-argon smoke AAPL
+    uv run control-argon screenshot watchlist --path /
+
+Design notes: docs/superpowers/specs/2026-09-01-control-argon-design.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import psycopg
+
+from uw_scan.config import Settings, _enforce_db_isolation
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCREENSHOT_DIR = REPO_ROOT / "output" / "playwright"
+
+# The mini is the sync source: always on, freshest data. Direct over Tailscale —
+# its Postgres answers the same argon_app credentials the MacBook uses, so no ssh.
+MINI_HOST = "100.66.147.98"
+MINI_DB = "option_wizard"
+LOCAL_DB = "option_wizard_local"
+
+# Tables the sync never copies. Deny-list rather than allow-list on purpose: a
+# newly added table then syncs BY DEFAULT, so forgetting to update this file
+# makes the sync slower (visible) instead of silently incomplete (invisible).
+# Everything here is either raw vendor bodies or an audit trail — big, and worth
+# nothing on a browse box.
+DENY = frozenset(
+    {
+        "raw_payloads",
+        "option_contract_snapshots",
+        "external_api_requests",
+        "api_request_audit",
+        "uw_fetch_memo",
+    }
+)
+
+# Preferred date column, most-business-meaningful first. `inserted_at` and
+# friends are last: they date the WRITE, not the observation, so a backfilled row
+# looks fresh (see reference_freshness_from_available_at_is_blind_to_backfill).
+DATE_COL_PRIORITY = (
+    "market_date",
+    "trade_date",
+    "data_date",
+    "snapshot_date",
+    "obs_date",
+    "as_of",
+    "as_of_date",
+    "date",
+    "curr_date",
+    "period_end",
+    "occurred_at",
+    "executed_at",
+    "scanned_at",
+    "computed_at",
+    "started_at",
+    "requested_at",
+    "created_at",
+    "captured_at",
+    "recorded_at",
+    "fetched_at",
+    "inserted_at",
+    "updated_at",
+)
+
+# Under this, copy the whole table: it is a dimension/lookup, and windowing one
+# by date yields a useless fragment (or nothing at all, for monthly series).
+FULL_COPY_MAX_BYTES = 64 * 1024 * 1024
+
+# What `doctor` calls stale, and after how many days.
+FRESHNESS_TABLES = {
+    "option_surface_grid_daily": 4,
+    "daily_ohlc": 4,
+    "watchlist_card": 2,
+    "technical_daily": 4,
+    "vrp_daily": 5,
+    "cri_snapshots": 4,
+    "vcg_snapshots": 4,
+}
+
+DATE_TYPES = frozenset(
+    {"date", "timestamp with time zone", "timestamp without time zone"}
+)
+
+OK, WARN, FAIL = "ok  ", "WARN", "FAIL"
+
+
+def emit(status: str, msg: str) -> None:
+    print(f"[{status}] {msg}")
+
+
+# --------------------------------------------------------------------------
+# connections
+# --------------------------------------------------------------------------
+
+
+def local_settings() -> Settings:
+    """Local target. `from_env` runs the (host, db_name) tripwire for us."""
+    return Settings.from_env()
+
+
+def mini_dsn(local: Settings) -> str:
+    """Source DSN for the mini, guarded by the app's own isolation rules.
+
+    The tripwire in uw_scan.config is a Python import-time guard reached only via
+    Settings.from_env — a psql/psycopg connection built by hand never touches it.
+    Calling it explicitly is what keeps this command inside the same policy.
+    """
+    _enforce_db_isolation(MINI_HOST, MINI_DB)
+    pw = local.db_password.get_secret_value()
+    password_clause = f" password={pw}" if pw else ""
+    return (
+        f"host={MINI_HOST} port=5432 dbname={MINI_DB} "
+        f"user={local.db_user}{password_clause}"
+    )
+
+
+def require_sync_direction(local: Settings) -> None:
+    """Refuse anything but mini/option_wizard -> this box/option_wizard_local."""
+    if local.db_host == MINI_HOST:
+        raise SystemExit(
+            "refusing to sync: this box is pointed at the mini "
+            f"(UW_SCAN_DB_HOST={local.db_host}). Drop the .env.local override — "
+            "syncing the mini onto itself is what this command exists to retire."
+        )
+    if local.db_name != LOCAL_DB:
+        raise SystemExit(
+            f"refusing to sync: target db is {local.db_name!r}, expected {LOCAL_DB!r}. "
+            "option_wizard_test is TRUNCATEd per test — synced data would not "
+            "survive one case; option_wizard is the mini's own prodlike tier."
+        )
+
+
+# --------------------------------------------------------------------------
+# schema introspection
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Table:
+    name: str
+    columns: tuple[str, ...]
+    date_columns: tuple[str, ...]
+    size_bytes: int
+    # GENERATED ALWAYS AS (…) STORED — Postgres rejects an explicit value, so
+    # these are dropped from the copy and recomputed on insert. 53 of them.
+    generated: frozenset[str] = frozenset()
+    # GENERATED ALWAYS AS IDENTITY — an explicit value needs OVERRIDING SYSTEM
+    # VALUE. Kept rather than dropped: it is the id ON CONFLICT dedups on.
+    identity_always: frozenset[str] = frozenset()
+
+    def date_column(self) -> str | None:
+        for candidate in DATE_COL_PRIORITY:
+            if candidate in self.date_columns:
+                return candidate
+        return self.date_columns[0] if self.date_columns else None
+
+
+def read_schema(conn: psycopg.Connection, schema: str) -> dict[str, Table]:
+    rows = conn.execute(
+        """
+        SELECT c.relname,
+               a.attname,
+               format_type(a.atttypid, NULL) AS coltype,
+               pg_total_relation_size(c.oid) AS sz,
+               a.attgenerated,
+               a.attidentity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = %s
+        JOIN pg_attribute a ON a.attrelid = c.oid
+                           AND a.attnum > 0 AND NOT a.attisdropped
+        WHERE c.relkind = 'r'
+        ORDER BY c.relname, a.attnum
+        """,
+        (schema,),
+    ).fetchall()
+    cols: dict[str, list[str]] = {}
+    dates: dict[str, list[str]] = {}
+    sizes: dict[str, int] = {}
+    gen: dict[str, set[str]] = {}
+    ident: dict[str, set[str]] = {}
+    for name, col, coltype, size, generated, identity in rows:
+        cols.setdefault(name, []).append(col)
+        sizes[name] = size
+        if coltype in DATE_TYPES:
+            dates.setdefault(name, []).append(col)
+        if generated:
+            gen.setdefault(name, set()).add(col)
+        if identity == "a":
+            ident.setdefault(name, set()).add(col)
+    return {
+        name: Table(
+            name,
+            tuple(c),
+            tuple(dates.get(name, ())),
+            sizes[name],
+            frozenset(gen.get(name, ())),
+            frozenset(ident.get(name, ())),
+        )
+        for name, c in cols.items()
+    }
+
+
+def primary_key_columns(conn: psycopg.Connection, schema: str, table: str) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = %s
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(i.indkey)
+        WHERE c.relname = %s AND i.indisprimary
+        """,
+        (schema, table),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+# --------------------------------------------------------------------------
+# sync
+# --------------------------------------------------------------------------
+
+
+def sync_one(
+    src: psycopg.Connection,
+    dst: psycopg.Connection,
+    schema: str,
+    src_table: Table,
+    dst_table: Table,
+    cutoff: date,
+) -> tuple[int, str]:
+    """Stream one table's slice mini -> local. Returns (rows, how)."""
+    # Column intersection, in the TARGET's order: the two boxes drift apart
+    # whenever local is behind on migrations, and a bare COPY would misalign.
+    shared = set(src_table.columns)
+    cols = [
+        c
+        for c in dst_table.columns
+        if c in shared and c not in dst_table.generated and c not in src_table.generated
+    ]
+    if not cols:
+        return 0, "no shared columns"
+    collist = ", ".join(f'"{c}"' for c in cols)
+
+    date_col = src_table.date_column()
+    if src_table.size_bytes <= FULL_COPY_MAX_BYTES or date_col is None:
+        where, params, how = "", (), "full"
+    else:
+        where, params, how = f' WHERE "{date_col}" >= %s', (cutoff,), f"≥{cutoff}"
+
+    select = f'SELECT {collist} FROM "{schema}"."{src_table.name}"{where}'
+
+    with dst.cursor() as dcur:
+        dcur.execute(
+            f"CREATE TEMP TABLE _sync AS SELECT {collist} "
+            f'FROM "{schema}"."{dst_table.name}" WITH NO DATA'
+        )
+        with (
+            src.cursor() as scur,
+            scur.copy(f"COPY ({select}) TO STDOUT", params) as reader,
+        ):
+            with dcur.copy(f"COPY _sync ({collist}) FROM STDIN") as writer:
+                for block in reader:
+                    writer.write(block)
+        # Additive, never destructive: no DELETE, so foreign keys that pin rows
+        # in place (cited macro evidence, for one) cannot fail the sync, and a
+        # re-run is a no-op rather than a churn.
+        has_pk = bool(primary_key_columns(dst, schema, dst_table.name))
+        conflict = "ON CONFLICT DO NOTHING" if has_pk else ""
+        overriding = (
+            " OVERRIDING SYSTEM VALUE" if dst_table.identity_always & set(cols) else ""
+        )
+        dcur.execute(
+            f'INSERT INTO "{schema}"."{dst_table.name}" ({collist})'
+            f"{overriding} SELECT {collist} FROM _sync {conflict}"
+        )
+        rows = dcur.rowcount
+        dcur.execute("DROP TABLE _sync")
+    dst.commit()
+    return rows, how
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    local = local_settings()
+    require_sync_direction(local)
+    schema = local.db_schema
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=args.days)).date()
+
+    print(
+        f"sync  {MINI_HOST}/{MINI_DB} -> {local.db_host}/{local.db_name}  "
+        f"(window ≥ {cutoff}, tables ≤ {FULL_COPY_MAX_BYTES // 1024 // 1024} MB copied whole)"
+    )
+
+    with (
+        psycopg.connect(mini_dsn(local)) as src,
+        psycopg.connect(local.db_dsn()) as dst,
+    ):
+        src_tables = read_schema(src, schema)
+        dst_tables = read_schema(dst, schema)
+
+        wanted = sorted((set(src_tables) & set(dst_tables)) - DENY)
+        if args.tables:
+            requested = {t.strip() for t in args.tables.split(",") if t.strip()}
+            unknown = requested - set(wanted)
+            if unknown:
+                raise SystemExit(f"unknown or denied table(s): {sorted(unknown)}")
+            wanted = sorted(requested)
+
+        only_on_mini = sorted(set(src_tables) - set(dst_tables) - DENY)
+        if only_on_mini:
+            emit(
+                WARN,
+                f"{len(only_on_mini)} table(s) exist only on the mini "
+                f"(run scripts/migrate.sh): {', '.join(only_on_mini[:6])}",
+            )
+
+        total = 0
+        empty: list[str] = []
+        for name in wanted:
+            if args.dry_run:
+                src_t = src_tables[name]
+                how = (
+                    "full"
+                    if src_t.size_bytes <= FULL_COPY_MAX_BYTES
+                    or src_t.date_column() is None
+                    else f"≥{cutoff} on {src_t.date_column()}"
+                )
+                print(f"  {name:<44} {how}")
+                continue
+            try:
+                rows, how = sync_one(
+                    src, dst, schema, src_tables[name], dst_tables[name], cutoff
+                )
+            except psycopg.Error as exc:
+                dst.rollback()
+                emit(FAIL, f"{name}: {exc.__class__.__name__}: {exc}")
+                continue
+            total += rows
+            if rows == 0 and how != "full":
+                empty.append(name)
+            print(f"  {name:<44} {rows:>9,} rows  ({how})")
+
+        if not args.dry_run:
+            print(f"\n{total:,} rows inserted across {len(wanted)} tables")
+            if empty:
+                # Self-diagnosing manifest: a windowed table that never yields a
+                # row inside the window is almost always slow-moving (monthly
+                # macro series) and wants a whole-table copy instead.
+                emit(
+                    WARN,
+                    f"{len(empty)} windowed table(s) copied 0 rows — likely "
+                    f"slow-moving, consider raising FULL_COPY_MAX_BYTES or "
+                    f"denying them: {', '.join(empty[:8])}",
+                )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# doctor
+# --------------------------------------------------------------------------
+
+
+def http_json(url: str, timeout: float = 5.0) -> dict | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.load(resp)
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def http_ok(url: str, timeout: float = 5.0) -> int | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    failures = 0
+    local = local_settings()
+    # A code default is not deployed state — print what is actually addressed.
+    emit(OK, f"db target  {local.db_host}/{local.db_name} schema={local.db_schema}")
+
+    for name, url in (
+        ("web", f"http://127.0.0.1:{args.web_port}/"),
+        ("api", f"http://127.0.0.1:{args.api_port}/api/health"),
+    ):
+        status = http_ok(url)
+        if status == 200:
+            emit(OK, f"{name:<4}       {url} -> 200")
+        else:
+            failures += 1
+            emit(
+                FAIL,
+                f"{name:<4}       {url} -> {status or 'unreachable'} "
+                f"(start it: bash scripts/dev.sh)",
+            )
+
+    health = http_json(f"http://127.0.0.1:{args.api_port}/api/health")
+    if health:
+        # /api/health answering 200 proves a process is listening, NOT that it is
+        # running this checkout's code. A stale uvicorn serves a healthy /health
+        # and 500s on every real endpoint — the exact shape of the 2026-08 "three
+        # stalled endpoints" incident, which was a whole-stack outage wearing a
+        # green health check.
+        repo_version = (REPO_ROOT / "VERSION").read_text().strip()
+        running = str(health.get("version") or "?")
+        if running != repo_version:
+            failures += 1
+            emit(
+                FAIL,
+                f"api ver    serving {running}, repo is {repo_version} — "
+                "restart the stack (APScheduler and uvicorn do not hot-reload)",
+            )
+        else:
+            emit(OK, f"api ver    {running}")
+
+        lag = health.get("worker_lag_seconds")
+        if lag is None:
+            emit(WARN, "worker     no heartbeat reported")
+        elif lag > 900:
+            failures += 1
+            emit(
+                FAIL,
+                f"worker     heartbeat {lag / 3600:.1f}h old "
+                f"({health.get('scheduler_heartbeat_name') or 'unknown'}) — "
+                "no worker is running",
+            )
+        else:
+            emit(OK, f"worker     heartbeat {lag:.0f}s old")
+
+        ws = (health.get("ws_consumer") or {}).get("active_source")
+        emit(OK if ws else WARN, f"ws feed    active_source={ws or 'none'}")
+
+    try:
+        conn = psycopg.connect(local.db_dsn(), connect_timeout=5)
+    except psycopg.Error as exc:
+        emit(FAIL, f"db         unreachable: {exc}")
+        return 1
+
+    with conn:
+        tables = read_schema(conn, local.db_schema)
+        today = datetime.now(timezone.utc).date()
+        stale = False
+        for name, max_age in sorted(FRESHNESS_TABLES.items()):
+            table = tables.get(name)
+            if table is None:
+                emit(WARN, f"freshness  {name}: table absent (run scripts/migrate.sh)")
+                continue
+            col = table.date_column()
+            newest = conn.execute(
+                f'SELECT max("{col}") FROM "{local.db_schema}"."{name}"'
+            ).fetchone()[0]
+            if newest is None:
+                emit(WARN, f"freshness  {name}: empty — run `control-argon sync`")
+                stale = True
+                continue
+            if isinstance(newest, datetime):
+                newest = newest.date()
+            age = (today - newest).days
+            if age > max_age:
+                stale = True
+                emit(WARN, f"freshness  {name}: {col}={newest} — stale {age} days")
+            else:
+                emit(OK, f"freshness  {name}: {col}={newest} ({age}d)")
+        if stale:
+            emit(WARN, "some tables are stale — run `uv run control-argon sync`")
+
+        # The sync has no manifest to go stale, but it does have a size cutoff.
+        # Report what that cutoff currently decides, so the one remaining knob
+        # cannot rot silently.
+        windowed = [
+            t
+            for t in tables.values()
+            if t.name not in DENY
+            and t.size_bytes > FULL_COPY_MAX_BYTES
+            and t.date_column() is None
+        ]
+        if windowed:
+            emit(
+                WARN,
+                "large table(s) with no date column — sync copies them WHOLE: "
+                + ", ".join(sorted(t.name for t in windowed)),
+            )
+
+    return 1 if failures else 0
+
+
+# --------------------------------------------------------------------------
+# smoke
+# --------------------------------------------------------------------------
+
+
+def cmd_smoke(args: argparse.Namespace) -> int:
+    """API enqueue -> DB row -> worker claim -> DB result -> web page renders.
+
+    This is the chain CLAUDE.md describes as ending in "the user validates via
+    the web page" — the step that hard-codes a human as the bottleneck.
+    """
+    ticker = args.ticker.upper()
+    api = f"http://127.0.0.1:{args.api_port}"
+
+    if http_ok(f"{api}/api/health") != 200:
+        emit(FAIL, f"api not up at {api} — bash scripts/dev.sh")
+        return 1
+
+    req = urllib.request.Request(f"{api}/api/watchlist/{ticker}/rescan", method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            job = json.load(resp)
+    except urllib.error.HTTPError as exc:
+        emit(FAIL, f"enqueue {ticker}: HTTP {exc.code} {exc.read()[:200]!r}")
+        return 1
+    job_id = job["job_id"]
+    emit(OK, f"enqueued   job {job_id} for {ticker}")
+
+    deadline = time.monotonic() + args.timeout
+    status = job.get("status")
+    while time.monotonic() < deadline:
+        time.sleep(3)
+        state = http_json(f"{api}/api/jobs/{job_id}")
+        if state is None:
+            continue
+        status = state.get("status")
+        if status in {"done", "succeeded", "failed", "error"}:
+            if status in {"failed", "error"}:
+                emit(FAIL, f"worker     job {status}: {state.get('error')}")
+                return 1
+            emit(OK, f"worker     job {status} (run_id={state.get('run_id')})")
+            break
+        print(f"  ... {status}", flush=True)
+    else:
+        emit(
+            FAIL,
+            f"worker     job still {status!r} after {args.timeout}s — is a "
+            "worker running? (bash scripts/dev.sh; APScheduler does not hot-reload)",
+        )
+        return 1
+
+    page = f"http://127.0.0.1:{args.web_port}/stock/{ticker}"
+    code = http_ok(page, timeout=30)
+    if code != 200:
+        emit(FAIL, f"web        {page} -> {code or 'unreachable'}")
+        return 1
+    emit(OK, f"web        {page} -> 200")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# screenshot
+# --------------------------------------------------------------------------
+
+
+SHOT_SPEC = """import {{ test }} from "@playwright/test";
+test("control-argon screenshot", async ({{ page }}) => {{
+  test.setTimeout(90_000);
+  await page.setViewportSize({{ width: {width}, height: {height} }});
+  await page.goto({path!r});
+  await page.waitForLoadState("networkidle").catch(() => {{}});
+  await page.waitForTimeout({settle});
+  await page.screenshot({{ path: {out!r}, fullPage: {full} }});
+}});
+"""
+
+
+def cmd_screenshot(args: argparse.Namespace) -> int:
+    """Retires the ad-hoc /tmp Playwright script.
+
+    The output path is fixed under output/playwright/, so a repo-root screenshot
+    is structurally impossible rather than merely against CLAUDE.md's rule — a
+    rule that had been broken eight times when this was written.
+    """
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    out = SCREENSHOT_DIR / f"{Path(args.name).name}.png"
+    web = REPO_ROOT / "web"
+    spec = web / "tests" / "e2e" / "_control-argon-shot.spec.ts"
+    spec.write_text(
+        SHOT_SPEC.format(
+            width=args.width,
+            height=args.height,
+            path=args.path,
+            settle=args.settle_ms,
+            out=str(out),
+            full="true" if args.full_page else "false",
+        )
+    )
+    # PW_NO_WEBSERVER is the knob step 1 added when the four extra Playwright
+    # configs were deleted: drive a stack that is already running, don't boot one.
+    try:
+        proc = subprocess.run(
+            ["npx", "playwright", "test", "_control-argon-shot", "--reporter=line"],
+            cwd=web,
+            env={
+                **os.environ,
+                "PW_NO_WEBSERVER": "1",
+                "PLAYWRIGHT_WEB_PORT": str(args.web_port),
+            },
+            check=False,
+        )
+    finally:
+        spec.unlink(missing_ok=True)
+    if proc.returncode != 0 or not out.exists():
+        emit(FAIL, f"screenshot failed (is the stack up on :{args.web_port}?)")
+        return 1
+    emit(OK, f"wrote {out.relative_to(REPO_ROOT)}")
+    return 0
+
+
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="control-argon",
+        description="Verify and control the local argon stack.",
+        epilog=(
+            "day-to-day:\n"
+            "  bash scripts/dev.sh                  web + API + workers + WS consumer\n"
+            "  bash scripts/migrate.sh              apply SQL migrations (idempotent)\n"
+            "  uv run control-argon doctor          is the stack up, is the data fresh\n"
+            "  uv run control-argon sync            pull the mini's recent data down\n"
+            "  uv run control-argon smoke AAPL      enqueue -> worker -> web, end to end\n"
+            "  uv run pytest tests/unit/            fast tests\n"
+            "  cd web && npm run test               vitest\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # Ports live on a shared parent, on the SUBCOMMANDS only. Declaring them on
+    # the top-level parser as well looks harmless and is not: the subparser's
+    # own default overwrites whatever the pre-subcommand flag set.
+    ports = argparse.ArgumentParser(add_help=False)
+    ports.add_argument("--web-port", type=int, default=3001)
+    ports.add_argument("--api-port", type=int, default=8400)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    d = sub.add_parser(
+        "doctor", parents=[ports], help="stack liveness, DB tier, data freshness"
+    )
+    d.set_defaults(func=cmd_doctor)
+
+    s = sub.add_parser("sync", help=f"pull {MINI_DB} from the mini into {LOCAL_DB}")
+    s.add_argument("--days", type=int, default=7, help="date window (default 7)")
+    s.add_argument("--tables", help="comma-separated subset")
+    s.add_argument(
+        "--dry-run", action="store_true", help="print the plan, copy nothing"
+    )
+    s.set_defaults(func=cmd_sync)
+
+    k = sub.add_parser(
+        "smoke", parents=[ports], help="API enqueue -> worker -> DB -> web page"
+    )
+    k.add_argument("ticker")
+    k.add_argument("--timeout", type=int, default=180)
+    k.set_defaults(func=cmd_smoke)
+
+    shot = sub.add_parser(
+        "screenshot", parents=[ports], help="capture a page into output/playwright/"
+    )
+    shot.add_argument("name", help="output file stem")
+    shot.add_argument("--path", default="/", help="app path, e.g. /stock/AAPL")
+    shot.add_argument("--width", type=int, default=1440)
+    shot.add_argument("--height", type=int, default=1200)
+    shot.add_argument("--settle-ms", type=int, default=1500)
+    shot.add_argument("--full-page", action="store_true")
+    shot.set_defaults(func=cmd_screenshot)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/uw_scan/control_argon.py
+++ b/src/uw_scan/control_argon.py
@@ -30,6 +30,14 @@ from pathlib import Path
 import psycopg
 
 from uw_scan.config import Settings, _enforce_db_isolation
+from uw_scan.control_stack import (
+    WORKER_LAG_MAX,
+    argon_procs,
+    cmd_down,
+    cmd_up,
+    probe,
+    read_stack,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCREENSHOT_DIR = REPO_ROOT / "output" / "playwright"
@@ -380,95 +388,76 @@ def cmd_sync(args: argparse.Namespace) -> int:
 # --------------------------------------------------------------------------
 
 
-@dataclass(frozen=True)
-class Probe:
-    """One HTTP probe. `detail` carries WHY it failed, never an empty shrug.
-
-    A diagnostic that reports "unreachable" and drops the reason makes the
-    operator re-run the request by hand to learn what a tool already knew.
-    """
-
-    status: int | None
-    body: dict | None
-    detail: str
-
-    def __bool__(self) -> bool:
-        return self.status == 200
-
-
-def probe(url: str, timeout: float = 5.0) -> Probe:
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            raw = resp.read()
-            status = resp.status
-    except urllib.error.HTTPError as exc:
-        return Probe(exc.code, None, repr(exc))
-    except (urllib.error.URLError, OSError) as exc:
-        return Probe(None, None, repr(exc))
-    try:
-        return Probe(status, json.loads(raw), "")
-    except ValueError as exc:
-        # A 200 that is not JSON is still a reachable page (the web root, say).
-        return Probe(status, None, repr(exc))
-
-
 def cmd_doctor(args: argparse.Namespace) -> int:
     failures = 0
     local = local_settings()
     # A code default is not deployed state — print what is actually addressed.
     emit(OK, f"db target  {local.db_host}/{local.db_name} schema={local.db_schema}")
 
-    api_health = f"http://127.0.0.1:{args.api_port}/api/health"
-    for name, url in (
-        ("web", f"http://127.0.0.1:{args.web_port}/"),
-        ("api", api_health),
+    # Same predicate `up` waits on, so the two can never disagree about "ready".
+    state = read_stack(args.web_port, args.api_port, REPO_ROOT)
+    for name, result, port in (
+        ("web", state.web, args.web_port),
+        ("api", state.api, args.api_port),
     ):
-        result = probe(url)
         if result:
-            emit(OK, f"{name:<4}       {url} -> 200")
+            emit(OK, f"{name:<4}       127.0.0.1:{port} -> 200")
         else:
             failures += 1
             emit(
                 FAIL,
-                f"{name:<4}       {url} -> {result.status or 'unreachable'} "
-                f"{result.detail} (start it: bash scripts/dev.sh)",
+                f"{name:<4}       127.0.0.1:{port} -> {result.status or 'unreachable'} "
+                f"{result.detail} (start it: uv run control-argon up)",
             )
 
-    health = probe(api_health).body
-    if health:
+    if state.api:
         # /api/health answering 200 proves a process is listening, NOT that it is
         # running this checkout's code. A stale uvicorn serves a healthy /health
         # and 500s on every real endpoint — the exact shape of the 2026-08 "three
         # stalled endpoints" incident, which was a whole-stack outage wearing a
         # green health check.
-        repo_version = (REPO_ROOT / "VERSION").read_text().strip()
-        running = str(health.get("version") or "?")
-        if running != repo_version:
+        if state.running_version != state.repo_version:
             failures += 1
             emit(
                 FAIL,
-                f"api ver    serving {running}, repo is {repo_version} — "
-                "restart the stack (APScheduler and uvicorn do not hot-reload)",
+                f"api ver    serving {state.running_version}, repo is "
+                f"{state.repo_version} — restart: uv run control-argon up --force",
             )
         else:
-            emit(OK, f"api ver    {running}")
+            emit(OK, f"api ver    {state.running_version}")
 
-        lag = health.get("worker_lag_seconds")
-        if lag is None:
+        if state.worker_lag is None:
             emit(WARN, "worker     no heartbeat reported")
-        elif lag > 900:
+        elif state.worker_lag > WORKER_LAG_MAX:
             failures += 1
             emit(
                 FAIL,
-                f"worker     heartbeat {lag / 3600:.1f}h old "
-                f"({health.get('scheduler_heartbeat_name') or 'unknown'}) — "
+                f"worker     heartbeat {state.worker_lag / 3600:.1f}h old — "
                 "no worker is running",
             )
         else:
-            emit(OK, f"worker     heartbeat {lag:.0f}s old")
+            emit(OK, f"worker     heartbeat {state.worker_lag:.0f}s old")
 
-        ws = (health.get("ws_consumer") or {}).get("active_source")
-        emit(OK if ws else WARN, f"ws feed    active_source={ws or 'none'}")
+        emit(
+            OK if state.ws_source else WARN,
+            f"ws feed    active_source={state.ws_source or 'none'}",
+        )
+
+    # Orphans from other checkouts are the failure this tool exists to make
+    # visible: they answer 200 from code that is days old and no longer on disk.
+    strays = [
+        p
+        for p in argon_procs()
+        if not p.cwd.startswith(str(REPO_ROOT))
+        and {args.web_port, args.api_port} & set(p.ports)
+    ]
+    for stray in strays:
+        emit(
+            WARN,
+            f"stray      :{','.join(str(x) for x in stray.ports)} held by pid "
+            f"{stray.pid} ({stray.role}, {stray.age_human}) from {stray.cwd} — "
+            "`control-argon down --all`",
+        )
 
     try:
         conn = psycopg.connect(local.db_dsn(), connect_timeout=5)
@@ -540,7 +529,7 @@ def cmd_smoke(args: argparse.Namespace) -> int:
 
     health = probe(f"{api}/api/health")
     if not health:
-        emit(FAIL, f"api not up at {api} {health.detail} — bash scripts/dev.sh")
+        emit(FAIL, f"api not up at {api} {health.detail} — uv run control-argon up")
         return 1
 
     req = urllib.request.Request(f"{api}/api/watchlist/{ticker}/rescan", method="POST")
@@ -572,7 +561,7 @@ def cmd_smoke(args: argparse.Namespace) -> int:
         emit(
             FAIL,
             f"worker     job still {status!r} after {args.timeout}s — is a "
-            "worker running? (bash scripts/dev.sh; APScheduler does not hot-reload)",
+            "worker running? (control-argon up; APScheduler does not hot-reload)",
         )
         return 1
 
@@ -657,9 +646,10 @@ def build_parser() -> argparse.ArgumentParser:
         description="Verify and control the local argon stack.",
         epilog=(
             "day-to-day:\n"
-            "  bash scripts/dev.sh                  web + API + workers + WS consumer\n"
+            "  uv run control-argon up              start the stack, wait until it serves\n"
+            "  uv run control-argon down --all      stop every stale stack\n"
             "  bash scripts/migrate.sh              apply SQL migrations (idempotent)\n"
-            "  uv run control-argon doctor          is the stack up, is the data fresh\n"
+            "  uv run control-argon doctor          is it up, is it CURRENT, is data fresh\n"
             "  uv run control-argon sync            pull the mini's recent data down\n"
             "  uv run control-argon smoke AAPL      enqueue -> worker -> web, end to end\n"
             "  uv run pytest tests/unit/            fast tests\n"
@@ -679,6 +669,30 @@ def build_parser() -> argparse.ArgumentParser:
         "doctor", parents=[ports], help="stack liveness, DB tier, data freshness"
     )
     d.set_defaults(func=cmd_doctor)
+
+    u = sub.add_parser(
+        "up", parents=[ports], help="start the stack and WAIT until it is serving"
+    )
+    u.add_argument(
+        "--force",
+        action="store_true",
+        help="stop whatever holds the ports first, including other checkouts",
+    )
+    u.add_argument("--full", action="store_true", help="DEV_FULL=1 (AI workers)")
+    u.add_argument("--timeout", type=int, default=240)
+    u.set_defaults(func=cmd_up)
+
+    w = sub.add_parser("down", help="stop this checkout's stack")
+    w.add_argument(
+        "--all",
+        action="store_true",
+        help="every argon stack process, any worktree (orphan sweep)",
+    )
+    w.add_argument(
+        "--older-than", type=float, metavar="HOURS", help="only ones this old"
+    )
+    w.add_argument("--dry-run", action="store_true", help="list, kill nothing")
+    w.set_defaults(func=cmd_down)
 
     s = sub.add_parser("sync", help=f"pull {MINI_DB} from the mini into {LOCAL_DB}")
     s.add_argument("--days", type=int, default=7, help="date window (default 7)")

--- a/src/uw_scan/control_argon.py
+++ b/src/uw_scan/control_argon.py
@@ -353,7 +353,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
                 )
             except psycopg.Error as exc:
                 dst.rollback()
-                emit(FAIL, f"{name}: {exc.__class__.__name__}: {exc}")
+                emit(FAIL, f"{name}: {repr(exc)}")
                 continue
             total += rows
             if rows == 0 and how != "full":
@@ -380,22 +380,36 @@ def cmd_sync(args: argparse.Namespace) -> int:
 # --------------------------------------------------------------------------
 
 
-def http_json(url: str, timeout: float = 5.0) -> dict | None:
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return json.load(resp)
-    except (urllib.error.URLError, OSError, ValueError):
-        return None
+@dataclass(frozen=True)
+class Probe:
+    """One HTTP probe. `detail` carries WHY it failed, never an empty shrug.
+
+    A diagnostic that reports "unreachable" and drops the reason makes the
+    operator re-run the request by hand to learn what a tool already knew.
+    """
+
+    status: int | None
+    body: dict | None
+    detail: str
+
+    def __bool__(self) -> bool:
+        return self.status == 200
 
 
-def http_ok(url: str, timeout: float = 5.0) -> int | None:
+def probe(url: str, timeout: float = 5.0) -> Probe:
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return resp.status
+            raw = resp.read()
+            status = resp.status
     except urllib.error.HTTPError as exc:
-        return exc.code
-    except (urllib.error.URLError, OSError):
-        return None
+        return Probe(exc.code, None, repr(exc))
+    except (urllib.error.URLError, OSError) as exc:
+        return Probe(None, None, repr(exc))
+    try:
+        return Probe(status, json.loads(raw), "")
+    except ValueError as exc:
+        # A 200 that is not JSON is still a reachable page (the web root, say).
+        return Probe(status, None, repr(exc))
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
@@ -404,22 +418,23 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # A code default is not deployed state — print what is actually addressed.
     emit(OK, f"db target  {local.db_host}/{local.db_name} schema={local.db_schema}")
 
+    api_health = f"http://127.0.0.1:{args.api_port}/api/health"
     for name, url in (
         ("web", f"http://127.0.0.1:{args.web_port}/"),
-        ("api", f"http://127.0.0.1:{args.api_port}/api/health"),
+        ("api", api_health),
     ):
-        status = http_ok(url)
-        if status == 200:
+        result = probe(url)
+        if result:
             emit(OK, f"{name:<4}       {url} -> 200")
         else:
             failures += 1
             emit(
                 FAIL,
-                f"{name:<4}       {url} -> {status or 'unreachable'} "
-                f"(start it: bash scripts/dev.sh)",
+                f"{name:<4}       {url} -> {result.status or 'unreachable'} "
+                f"{result.detail} (start it: bash scripts/dev.sh)",
             )
 
-    health = http_json(f"http://127.0.0.1:{args.api_port}/api/health")
+    health = probe(api_health).body
     if health:
         # /api/health answering 200 proves a process is listening, NOT that it is
         # running this checkout's code. A stale uvicorn serves a healthy /health
@@ -458,7 +473,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     try:
         conn = psycopg.connect(local.db_dsn(), connect_timeout=5)
     except psycopg.Error as exc:
-        emit(FAIL, f"db         unreachable: {exc}")
+        emit(FAIL, f"db         unreachable: {repr(exc)}")
         return 1
 
     with conn:
@@ -523,8 +538,9 @@ def cmd_smoke(args: argparse.Namespace) -> int:
     ticker = args.ticker.upper()
     api = f"http://127.0.0.1:{args.api_port}"
 
-    if http_ok(f"{api}/api/health") != 200:
-        emit(FAIL, f"api not up at {api} — bash scripts/dev.sh")
+    health = probe(f"{api}/api/health")
+    if not health:
+        emit(FAIL, f"api not up at {api} {health.detail} — bash scripts/dev.sh")
         return 1
 
     req = urllib.request.Request(f"{api}/api/watchlist/{ticker}/rescan", method="POST")
@@ -532,7 +548,7 @@ def cmd_smoke(args: argparse.Namespace) -> int:
         with urllib.request.urlopen(req, timeout=15) as resp:
             job = json.load(resp)
     except urllib.error.HTTPError as exc:
-        emit(FAIL, f"enqueue {ticker}: HTTP {exc.code} {exc.read()[:200]!r}")
+        emit(FAIL, f"enqueue {ticker}: {repr(exc)} {exc.read()[:200]!r}")
         return 1
     job_id = job["job_id"]
     emit(OK, f"enqueued   job {job_id} for {ticker}")
@@ -541,7 +557,7 @@ def cmd_smoke(args: argparse.Namespace) -> int:
     status = job.get("status")
     while time.monotonic() < deadline:
         time.sleep(3)
-        state = http_json(f"{api}/api/jobs/{job_id}")
+        state = probe(f"{api}/api/jobs/{job_id}").body
         if state is None:
             continue
         status = state.get("status")
@@ -561,9 +577,12 @@ def cmd_smoke(args: argparse.Namespace) -> int:
         return 1
 
     page = f"http://127.0.0.1:{args.web_port}/stock/{ticker}"
-    code = http_ok(page, timeout=30)
-    if code != 200:
-        emit(FAIL, f"web        {page} -> {code or 'unreachable'}")
+    rendered = probe(page, timeout=30)
+    if not rendered:
+        emit(
+            FAIL,
+            f"web        {page} -> {rendered.status or 'unreachable'} {rendered.detail}",
+        )
         return 1
     emit(OK, f"web        {page} -> 200")
     return 0

--- a/src/uw_scan/control_stack.py
+++ b/src/uw_scan/control_stack.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Stack liveness and process lifecycle for control-argon.
+
+Split from control_argon.py because none of this touches Postgres: port
+ownership, process ancestry, and signalling are pure stdlib + lsof/ps, so they
+unit-test without a database.
+
+Why this module exists at all. On 2026-09-01 this machine was carrying five
+orphaned stacks — 2 to 4 days old, from four different worktrees, two of which
+had already been `git worktree remove`d. One of them was `next start` serving a
+four-day-old `.next/standalone` build on port 3001, argon's default web port. It
+answered 200. Any agent that edited code, started a stack, and curled :3001 was
+validating a build from four days earlier and getting a green light for it.
+A stale process that errors is a nuisance; one that answers correctly is a trap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# liveness
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One HTTP probe. `detail` carries WHY it failed, never an empty shrug.
+
+    A diagnostic that reports "unreachable" and drops the reason makes the
+    operator re-run the request by hand to learn what a tool already knew.
+    """
+
+    status: int | None
+    body: dict | None
+    detail: str
+
+    def __bool__(self) -> bool:
+        return self.status == 200
+
+
+def probe(url: str, timeout: float = 5.0) -> Probe:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        return Probe(exc.code, None, repr(exc))
+    except (urllib.error.URLError, OSError) as exc:
+        return Probe(None, None, repr(exc))
+    try:
+        return Probe(status, json.loads(raw), "")
+    except ValueError as exc:
+        # A 200 that is not JSON is still a reachable page (the web root, say).
+        return Probe(status, None, repr(exc))
+
+# --------------------------------------------------------------------------
+# discovery
+# --------------------------------------------------------------------------
+
+
+# Recognised stack roles, longest-specific first. This is an ALLOW-list on
+# purpose, and the opposite choice from sync's deny-list, because the costs point
+# the other way: a missed orphan is caught on the next run, while one wrongly
+# matched process is a killed MCP server or editor. Being in the argon tree is
+# not enough to be argon's — uv-installed MCP servers run with the repo as their
+# cwd and listen on ports of their own.
+ROLE_PATTERNS: tuple[tuple[str, str], ...] = (
+    # Supervisors first. `concurrently` is handed every child command as
+    # arguments, so its own command line contains all the patterns below it;
+    # matched in the other order it would report itself as a WS consumer.
+    ("scripts/dev.sh", "dev.sh"),
+    ("concurrently", "dev.sh"),
+    ("uw_scan.worker.massive_ws_consumer", "ws"),
+    ("uw_scan.worker.scheduler", "worker"),
+    ("uw_scan.api.server", "api"),
+    ("uvicorn", "api"),
+    ("next dev", "web(dev)"),
+    ("next start", "web(start)"),
+    ("next-server", "web"),
+)
+
+
+def role_of(command: str) -> str | None:
+    for needle, label in ROLE_PATTERNS:
+        if needle in command:
+            return label
+    return None
+
+
+@dataclass(frozen=True)
+class Proc:
+    """A listening process, with the checkout it was started from."""
+
+    pid: int
+    ppid: int
+    age_seconds: int
+    cwd: str
+    command: str
+    ports: tuple[int, ...]
+    role: str
+
+    @property
+    def age_human(self) -> str:
+        h, m = divmod(self.age_seconds // 60, 60)
+        d, h = divmod(h, 24)
+        if d:
+            return f"{d}d{h:02d}h"
+        return f"{h}h{m:02d}m" if h else f"{m}m"
+
+
+def parse_etime(etime: str) -> int:
+    """`[[DD-]HH:]MM:SS` -> seconds. macOS ps has no `etimes` keyword."""
+    days = 0
+    if "-" in etime:
+        d, etime = etime.split("-", 1)
+        days = int(d)
+    parts = [int(x) for x in etime.split(":")]
+    while len(parts) < 3:
+        parts.insert(0, 0)
+    h, m, s = parts
+    return ((days * 24 + h) * 60 + m) * 60 + s
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        done = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"[control-argon] {cmd[0]} failed: {repr(exc)}", file=sys.stderr)
+        return ""
+    # lsof exits 1 when nothing matches — that is data, not an error.
+    return done.stdout
+
+
+logger = logging.getLogger(__name__)
+
+
+def _ints(*values: str) -> tuple[int, ...] | None:
+    """Parse integer columns out of a ps/lsof row; None when the row is not one.
+
+    One handler instead of four identical `except ValueError: continue` blocks.
+    A skipped row is logged rather than swallowed: silently dropping a line here
+    means `down` silently misses an orphan, which is the failure this module is
+    for.
+    """
+    try:
+        return tuple(int(v) for v in values)
+    except ValueError as exc:
+        logger.debug("unparsable process column in %r: %s", values, repr(exc))
+        return None
+
+
+def argon_root() -> Path:
+    """The main checkout, shared by every worktree (worktrees live under it)."""
+    out = _run(
+        [
+            "git",
+            "-C",
+            str(Path(__file__).resolve().parent),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ]
+    ).strip()
+    return Path(out).parent if out else Path(__file__).resolve().parents[2]
+
+
+def _listen_ports() -> dict[int, set[int]]:
+    """pid -> listening TCP ports, from one lsof call."""
+    ports: dict[int, set[int]] = {}
+    for line in _run(["lsof", "-nP", "-iTCP", "-sTCP:LISTEN"]).splitlines()[1:]:
+        fields = line.split()
+        if len(fields) < 9:
+            continue
+        # NAME is column 9, but a LISTEN row appends a `(LISTEN)` state column,
+        # so the last field is not the address. Take the last field that looks
+        # like one instead of trusting either position.
+        name = next((f for f in reversed(fields) if ":" in f), "")
+        if not name:
+            continue
+        parsed = _ints(fields[1], name.rsplit(":", 1)[1])
+        if parsed is None:
+            continue
+        ports.setdefault(parsed[0], set()).add(parsed[1])
+    return ports
+
+
+def _cwds(pids: list[int]) -> dict[int, str]:
+    """pid -> cwd. `lsof -F` emits a `p<pid>` line then an `n<path>` line."""
+    if not pids:
+        return {}
+    out = _run(["lsof", "-a", "-d", "cwd", "-Fn", "-p", ",".join(map(str, pids))])
+    cwds: dict[int, str] = {}
+    current = None
+    for line in out.splitlines():
+        if line.startswith("p"):
+            parsed = _ints(line[1:])
+            current = parsed[0] if parsed else None
+        elif line.startswith("n") and current is not None:
+            cwds[current] = line[1:]
+    return cwds
+
+
+def _ps(pids: list[int]) -> dict[int, tuple[int, int, str]]:
+    """pid -> (ppid, age_seconds, command)."""
+    if not pids:
+        return {}
+    out = _run(
+        ["ps", "-o", "pid=,ppid=,etime=,command=", "-p", ",".join(map(str, pids))]
+    )
+    rows: dict[int, tuple[int, int, str]] = {}
+    for line in out.splitlines():
+        fields = line.split(None, 3)
+        if len(fields) < 4:
+            continue
+        parsed = _ints(fields[0], fields[1])
+        if parsed is None:
+            continue
+        rows[parsed[0]] = (parsed[1], parse_etime(fields[2]), fields[3])
+    return rows
+
+
+def _all_processes() -> dict[int, tuple[int, int, str]]:
+    """Every process on the box -> (ppid, age_seconds, command)."""
+    out = _run(["ps", "-eo", "pid=,ppid=,etime=,command="])
+    rows: dict[int, tuple[int, int, str]] = {}
+    for line in out.splitlines():
+        fields = line.split(None, 3)
+        if len(fields) < 4:
+            continue
+        parsed = _ints(fields[0], fields[1])
+        if parsed is None:
+            continue
+        rows[parsed[0]] = (parsed[1], parse_etime(fields[2]), fields[3])
+    return rows
+
+
+def argon_procs() -> list[Proc]:
+    """Every argon stack process, identified by role and attributed by cwd.
+
+    Enumeration is by ROLE, not by listening port. Only 2 of the stack's 7
+    processes bind a TCP socket — the 4 schedulers and the WS consumer do not —
+    so a port-driven sweep stops web and API and leaves the workers orphaned,
+    manufacturing the very thing it was run to clean up.
+
+    cwd is what attributes a process to a checkout: `next dev` and `uvicorn` are
+    identical across worktrees. It keeps reporting the path after the worktree is
+    deleted, which is precisely when you most need to know where it came from.
+    """
+    root = str(argon_root())
+    ports = _listen_ports()
+    meta = _all_processes()
+    candidates = {
+        pid: (ppid, age, command, role)
+        for pid, (ppid, age, command) in meta.items()
+        if (role := role_of(command)) is not None
+    }
+    cwds = _cwds(list(candidates))
+    procs = []
+    for pid, (ppid, age, command, role) in candidates.items():
+        cwd = cwds.get(pid, "")
+        if not cwd.startswith(root):
+            continue
+        procs.append(
+            Proc(pid, ppid, age, cwd, command, tuple(sorted(ports.get(pid, ()))), role)
+        )
+    return sorted(procs, key=lambda p: -p.age_seconds)
+
+
+# --------------------------------------------------------------------------
+# termination
+# --------------------------------------------------------------------------
+
+
+def _children_of(roots: set[int]) -> set[int]:
+    """Transitive descendants, from one `ps -eo pid,ppid` pass."""
+    edges: dict[int, list[int]] = {}
+    for line in _run(["ps", "-eo", "pid=,ppid="]).splitlines():
+        fields = line.split()
+        if len(fields) == 2:
+            parsed = _ints(fields[0], fields[1])
+            if parsed:
+                edges.setdefault(parsed[1], []).append(parsed[0])
+    seen: set[int] = set()
+    stack = list(roots)
+    while stack:
+        for child in edges.get(stack.pop(), []):
+            if child not in seen:
+                seen.add(child)
+                stack.append(child)
+    return seen
+
+
+def _protected() -> set[int]:
+    """Us and our ancestors. Never signal the session we are running in."""
+    safe = {os.getpid()}
+    pid = os.getppid()
+    parents = {}
+    for line in _run(["ps", "-eo", "pid=,ppid="]).splitlines():
+        fields = line.split()
+        if len(fields) == 2:
+            parsed = _ints(fields[0], fields[1])
+            if parsed:
+                parents[parsed[0]] = parsed[1]
+    while pid and pid not in safe:
+        safe.add(pid)
+        pid = parents.get(pid, 0)
+    return safe
+
+
+def terminate(pids: set[int], grace: float = 4.0) -> tuple[set[int], set[int]]:
+    """SIGTERM the processes and their descendants, then SIGKILL survivors.
+
+    Descendants are killed explicitly rather than by process group. Signalling a
+    group we did not create can reach further than intended; the tree rooted at
+    a known pid cannot. Killing children matters: `uv run uvicorn` does NOT
+    forward SIGTERM, so terminating the wrapper alone leaves uvicorn holding the
+    port — measured, not assumed.
+    """
+    targets = (pids | _children_of(pids)) - _protected()
+    if not targets:
+        return set(), set()
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        alive = {pid for pid in targets if _alive(pid)}
+        if not alive:
+            break
+        for pid in alive:
+            try:
+                os.kill(pid, sig)
+            except (ProcessLookupError, PermissionError) as exc:
+                print(f"[control-argon] kill {pid}: {repr(exc)}", file=sys.stderr)
+        deadline = time.monotonic() + grace
+        while time.monotonic() < deadline and any(_alive(p) for p in alive):
+            time.sleep(0.2)
+    survivors = {pid for pid in targets if _alive(pid)}
+    return targets - survivors, survivors
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        # ProcessLookupError: gone. PermissionError: alive, but not ours to
+        # signal — reporting it as dead would make `down` claim a success it
+        # did not have.
+        logger.debug("kill(%d, 0): %s", pid, repr(exc))
+        return isinstance(exc, PermissionError)
+    return True
+
+
+if __name__ == "__main__":  # pragma: no cover - manual inspection aid
+    for proc in argon_procs():
+        print(f"{proc.pid:>7} {proc.role:<10} {proc.age_human:>7} {proc.ports} {proc.cwd}")
+
+
+# --------------------------------------------------------------------------
+# readiness — the single definition of "the stack is up", shared by doctor and up
+# --------------------------------------------------------------------------
+
+WORKER_LAG_MAX = 900.0
+
+
+@dataclass(frozen=True)
+class StackState:
+    """What is actually serving, as opposed to what is listening.
+
+    The four fields below are one predicate, not four: a 200 from /api/health
+    only proves a process holds the socket. Version pins it to THIS checkout,
+    and worker lag catches the half-stack — concurrently is not run with
+    --kill-others, so a scheduler can die and leave web+API answering happily.
+    """
+
+    web: Probe
+    api: Probe
+    repo_version: str
+    running_version: str | None
+    worker_lag: float | None
+    ws_source: str | None
+
+    @property
+    def ready(self) -> bool:
+        return not self.blockers()
+
+    def blockers(self) -> list[str]:
+        out = []
+        if not self.web:
+            out.append(f"web down ({self.web.detail or self.web.status})")
+        if not self.api:
+            out.append(f"api down ({self.api.detail or self.api.status})")
+        elif self.running_version != self.repo_version:
+            out.append(
+                f"api serving {self.running_version}, repo is {self.repo_version}"
+            )
+        if self.api and self.worker_lag is None:
+            out.append("no worker heartbeat")
+        elif self.worker_lag is not None and self.worker_lag > WORKER_LAG_MAX:
+            out.append(f"worker heartbeat {self.worker_lag / 3600:.1f}h old")
+        return out
+
+
+def read_stack(web_port: int, api_port: int, repo_root: Path) -> StackState:
+    web = probe(f"http://127.0.0.1:{web_port}/")
+    api = probe(f"http://127.0.0.1:{api_port}/api/health")
+    body = api.body or {}
+    return StackState(
+        web=web,
+        api=api,
+        repo_version=(repo_root / "VERSION").read_text().strip(),
+        running_version=str(body["version"]) if body.get("version") else None,
+        worker_lag=body.get("worker_lag_seconds"),
+        ws_source=(body.get("ws_consumer") or {}).get("active_source"),
+    )
+
+
+# --------------------------------------------------------------------------
+# up / down
+# --------------------------------------------------------------------------
+
+
+def _describe(proc: Proc, repo_root: Path) -> str:
+    where = proc.cwd
+    if not Path(where.split("/web")[0]).exists():
+        where += "  (worktree deleted)"
+    elif not where.startswith(str(repo_root)):
+        where += "  (other checkout)"
+    ports = ",".join(f":{p}" for p in proc.ports) or "-"
+    return f"  pid {proc.pid:<7} {proc.role:<10} {ports:<13} {proc.age_human:>7}  {where}"
+
+
+def cmd_up(args: argparse.Namespace) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    wanted = {args.web_port, args.api_port}
+
+    holders = [p for p in argon_procs() if wanted & set(p.ports)]
+    mine = [p for p in holders if p.cwd.startswith(str(repo_root))]
+    foreign = [p for p in holders if p not in mine]
+
+    state = read_stack(args.web_port, args.api_port, repo_root)
+    if state.ready and not args.force:
+        print(f"[ok  ] already up and current (v{state.repo_version})")
+        return 0
+
+    if holders:
+        if not args.force:
+            print("[FAIL] ports are already held:")
+            for proc in holders:
+                print(_describe(proc, repo_root))
+            print(
+                "\n  Something is serving these ports and it is not this checkout's\n"
+                "  current code. Re-run with --force to stop them first, or pick\n"
+                "  other ports with --web-port / --api-port."
+            )
+            if foreign:
+                print("  --force will stop processes from ANOTHER checkout (listed above).")
+            return 1
+        print("[..  ] stopping what holds the ports:")
+        for proc in holders:
+            print(_describe(proc, repo_root))
+        killed, survived = terminate({p.pid for p in holders})
+        print(f"[ok  ] stopped {len(killed)} process(es)")
+        if survived:
+            print(f"[FAIL] would not die: {sorted(survived)}")
+            return 1
+
+    log_dir = repo_root / "output" / "dev"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{time.strftime('%Y%m%d-%H%M%S')}.log"
+    env = {
+        **os.environ,
+        "WEB_PORT": str(args.web_port),
+        "API_PORT": str(args.api_port),
+        "DEV_FULL": "1" if args.full else "0",
+    }
+    # Detached in its own session: the stack must outlive this command, and the
+    # log must go to a file. dev.sh's `concurrently` writes ~26 lines/sec, which
+    # is not something to hand back to a caller through a pipe.
+    with log_path.open("wb") as log:
+        proc = subprocess.Popen(
+            ["bash", "scripts/dev.sh"],
+            cwd=repo_root,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    print(f"[..  ] started dev.sh (pid {proc.pid}), log: {log_path}")
+
+    started = time.monotonic()
+    deadline = started + args.timeout
+    last = ""
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            print(f"[FAIL] dev.sh exited with {proc.returncode} — see {log_path}")
+            _tail(log_path)
+            return 1
+        elapsed = time.monotonic() - started
+        state = read_stack(args.web_port, args.api_port, repo_root)
+        blockers = state.blockers()
+        # doctor can only ask "is the heartbeat recent" — it has no start time to
+        # compare against. `up` does, so it asks the stronger question: was this
+        # heartbeat written AFTER we launched? Without it, the row a worker wrote
+        # minutes before the restart passes the 15-minute freshness bar and `up`
+        # reports ready while dev.sh is still in its `sleep 20` before any worker
+        # exists. Measured: a down/up cycle called ready at 19s with no worker.
+        if state.api and (state.worker_lag is None or state.worker_lag >= elapsed):
+            blockers = [b for b in blockers if "heartbeat" not in b]
+            blockers.append("worker not started yet (heartbeat predates this run)")
+        if not blockers:
+            print(
+                f"[ok  ] stack ready in {elapsed:.0f}s — "
+                f"web :{args.web_port}, api :{args.api_port}, v{state.repo_version}"
+            )
+            return 0
+        current = "; ".join(blockers)
+        if current != last:
+            print(f"[..  ] waiting: {current}")
+            last = current
+        time.sleep(3)
+
+    print(f"[FAIL] not ready after {args.timeout}s: {'; '.join(blockers)}")
+    print(f"       the stack is still running — log: {log_path}")
+    _tail(log_path)
+    return 1
+
+
+def _tail(path: Path, lines: int = 15) -> None:
+    try:
+        tail = path.read_text(errors="replace").splitlines()[-lines:]
+    except OSError as exc:
+        print(f"       (could not read log: {repr(exc)})")
+        return
+    for line in tail:
+        print(f"       | {line[:160]}")
+
+
+def cmd_down(args: argparse.Namespace) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    procs = argon_procs()
+    if not args.all:
+        procs = [p for p in procs if p.cwd.startswith(str(repo_root))]
+    if args.older_than:
+        procs = [p for p in procs if p.age_seconds >= args.older_than * 3600]
+
+    if not procs:
+        scope = "the argon tree" if args.all else "this checkout"
+        print(f"[ok  ] nothing to stop in {scope}")
+        return 0
+
+    for proc in procs:
+        print(_describe(proc, repo_root))
+    if args.dry_run:
+        print(f"[ok  ] dry run — {len(procs)} process(es) would be stopped")
+        return 0
+
+    killed, survived = terminate({p.pid for p in procs})
+    print(f"[ok  ] stopped {len(killed)} process(es)")
+    if survived:
+        print(f"[FAIL] would not die: {sorted(survived)}")
+        return 1
+    return 0

--- a/src/uw_scan/worker/CLAUDE.md
+++ b/src/uw_scan/worker/CLAUDE.md
@@ -100,7 +100,7 @@ its own process by `scripts/dev.sh`). Toggle via `MASSIVE_WS_ENABLED`
 - **Idempotent.** A job that runs twice in a minute (e.g., after a restart) must produce the same DB state.
 - **No business logic in `scheduler.py`** — it just wires triggers to functions. Heavy lifting lives in `jobs/*.py` and `volatility_jobs.py`.
 - **Signals: SIGTERM/SIGINT** trigger `sched.shutdown(wait=False)` then `sys.exit(0)`. Don't introduce blocking cleanup.
-- **Workers don't hot-reload.** uvicorn `--reload` refreshes only the API process; APScheduler workers keep running the module they imported at fork. If an edit "doesn't take effect", first run `/bin/ps -axww -o pid,etime,command | grep uw_scan` and compare `etime` to your edit time — restart the `concurrently` parent (`bash scripts/dev.sh`), not individual workers. Also check for duplicate `concurrently` parents (two = two competing dev stacks). Same applies to env rotation (`DEEPSEEK_API_KEY`, `XENON_*`, …): env is frozen at fork.
+- **Workers don't hot-reload.** uvicorn `--reload` refreshes only the API process; APScheduler workers keep running the module they imported at fork. If an edit "doesn't take effect", run `uv run control-argon down && uv run control-argon up` — `down` stops the whole stack (workers included; a port-scoped kill leaves them running) and `up` blocks until a worker heartbeat written *after* the relaunch appears, which is the only evidence that your edit is the code now executing. `uv run control-argon doctor` lists the running processes with ages and checkouts; two `dev.sh` supervisors means two competing dev stacks — `down --all` clears every checkout's. Same applies to env rotation (`DEEPSEEK_API_KEY`, `XENON_*`, …): env is frozen at fork.
 
 ## Provider concurrency model
 

--- a/tests/unit/test_control_argon.py
+++ b/tests/unit/test_control_argon.py
@@ -1,0 +1,83 @@
+"""Pure-logic checks for the control-argon CLI. No DB, no network."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from uw_scan.config import Settings
+from uw_scan.control_argon import (
+    DENY,
+    LOCAL_DB,
+    MINI_DB,
+    MINI_HOST,
+    Table,
+    build_parser,
+    mini_dsn,
+    require_sync_direction,
+)
+
+
+def _table(**kw) -> Table:
+    base = dict(name="t", columns=("a",), date_columns=(), size_bytes=0)
+    return Table(**{**base, **kw})
+
+
+def test_date_column_prefers_the_observation_date_over_the_write_date():
+    # inserted_at dates the WRITE; a backfilled row would look fresh under it.
+    t = _table(date_columns=("inserted_at", "market_date", "expiry"))
+    assert t.date_column() == "market_date"
+
+
+def test_date_column_falls_back_to_a_write_stamp_when_that_is_all_there_is():
+    assert _table(date_columns=("inserted_at",)).date_column() == "inserted_at"
+
+
+def test_date_column_is_none_when_the_table_has_no_date_at_all():
+    assert _table().date_column() is None
+
+
+def test_deny_list_covers_the_raw_and_audit_tables():
+    # These are the ones worth nothing on a browse box and cost ~11 GB.
+    assert {"raw_payloads", "external_api_requests", "api_request_audit"} <= DENY
+
+
+def _settings(**kw) -> Settings:
+    base = dict(
+        api_key=SecretStr("test"),
+        db_host="127.0.0.1",
+        db_name=LOCAL_DB,
+        db_user="argon_app",
+        db_password=SecretStr("pw"),
+    )
+    return Settings(**{**base, **kw})
+
+
+def test_sync_refuses_the_test_tier():
+    # option_wizard_test is TRUNCATEd per test — synced data dies in one case.
+    with pytest.raises(SystemExit, match="option_wizard_test"):
+        require_sync_direction(_settings(db_name="option_wizard_test"))
+
+
+def test_sync_refuses_when_this_box_is_pointed_at_the_mini():
+    with pytest.raises(SystemExit, match="pointed at the mini"):
+        require_sync_direction(_settings(db_host=MINI_HOST, db_name=MINI_DB))
+
+
+def test_sync_accepts_the_one_supported_direction():
+    require_sync_direction(_settings())
+
+
+def test_mini_dsn_targets_the_mini_and_carries_the_password():
+    dsn = mini_dsn(_settings())
+    assert f"host={MINI_HOST}" in dsn and f"dbname={MINI_DB}" in dsn
+    assert "password=pw" in dsn
+
+
+def test_ports_are_parsed_after_the_subcommand():
+    args = build_parser().parse_args(["doctor", "--api-port", "8402"])
+    assert (args.api_port, args.web_port) == (8402, 3001)
+    assert (
+        build_parser().parse_args(["smoke", "AAPL", "--web-port", "3003"]).web_port
+        == 3003
+    )

--- a/tests/unit/test_control_stack.py
+++ b/tests/unit/test_control_stack.py
@@ -1,0 +1,122 @@
+"""Unit tests for control-argon's stack liveness and process attribution.
+
+No database, no network, no processes started: everything here is the parsing
+and predicate logic that decides what `up` waits for and what `down` is allowed
+to kill. The kill path itself is deliberately not exercised — a test that
+signals real pids is not a unit test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from uw_scan.control_stack import (
+    WORKER_LAG_MAX,
+    Probe,
+    Proc,
+    StackState,
+    parse_etime,
+    role_of,
+)
+
+
+def _state(**kw) -> StackState:
+    base = dict(
+        web=Probe(200, None, ""),
+        api=Probe(200, {}, ""),
+        repo_version="0.13.2",
+        running_version="0.13.2",
+        worker_lag=3.0,
+        ws_source="massive.com_ws",
+    )
+    base.update(kw)
+    return StackState(**base)
+
+
+class TestParseEtime:
+    def test_mm_ss(self) -> None:
+        assert parse_etime("07:51") == 7 * 60 + 51
+
+    def test_hh_mm_ss(self) -> None:
+        assert parse_etime("07:54:27") == 7 * 3600 + 54 * 60 + 27
+
+    def test_days(self) -> None:
+        # The real orphan that held :8400 for three and a half days.
+        assert parse_etime("03-14:49:09") == 3 * 86400 + 14 * 3600 + 49 * 60 + 9
+
+
+class TestRoleOf:
+    def test_supervisor_wins_over_its_arguments(self) -> None:
+        # concurrently is handed every child command as an argument, so its own
+        # command line contains the worker patterns. Ordering must not let it
+        # report itself as a WS consumer.
+        cmd = (
+            "npx --prefix web concurrently -n next,api,massive-ws "
+            "uv run python -m uw_scan.worker.massive_ws_consumer"
+        )
+        assert role_of(cmd) == "dev.sh"
+
+    def test_known_roles(self) -> None:
+        assert role_of("uv run python -m uw_scan.worker.scheduler") == "worker"
+        assert role_of("uv run uvicorn uw_scan.api.server:app --port 8400") == "api"
+        assert role_of("node ./node_modules/.bin/next dev") == "web(dev)"
+        assert role_of("npm exec next start -p 3012") == "web(start)"
+        assert role_of("next-server (v16.2.6)") == "web"
+
+    def test_unrelated_process_is_not_argon(self) -> None:
+        # A uv-installed MCP server runs with the repo as its cwd and listens on
+        # a port of its own. cwd alone would sweep it up; the role allow-list is
+        # what keeps `down` from killing the user's agent session.
+        assert role_of("/Users/x/.cache/uv/archive-v0/8KM/bin/python -m serena") is None
+        assert role_of("psql -h 127.0.0.1 -d option_wizard_local") is None
+
+
+class TestStackState:
+    def test_all_green_is_ready(self) -> None:
+        assert _state().ready
+        assert _state().blockers() == []
+
+    def test_version_mismatch_blocks(self) -> None:
+        # The 4-day-old `next start` on :3001 answered 200. Liveness alone is
+        # not readiness.
+        state = _state(running_version="0.13.0")
+        assert not state.ready
+        assert "serving 0.13.0" in state.blockers()[0]
+
+    def test_stale_worker_blocks(self) -> None:
+        state = _state(worker_lag=WORKER_LAG_MAX + 1)
+        assert not state.ready
+        assert "heartbeat" in state.blockers()[0]
+
+    def test_missing_worker_heartbeat_blocks(self) -> None:
+        state = _state(worker_lag=None)
+        assert not state.ready
+        assert state.blockers() == ["no worker heartbeat"]
+
+    def test_web_down_names_the_reason(self) -> None:
+        # A diagnostic that drops the cause makes the operator re-run the
+        # request by hand to learn what the tool already knew.
+        state = _state(web=Probe(None, None, "URLError(ConnectionRefusedError(61))"))
+        assert "ConnectionRefused" in state.blockers()[0]
+
+    def test_api_down_does_not_also_report_a_version_mismatch(self) -> None:
+        # With no API there is no running version; reporting "serving None"
+        # would be noise on top of the real failure.
+        state = _state(api=Probe(None, None, "refused"), running_version=None)
+        assert len(state.blockers()) == 1
+        assert "api down" in state.blockers()[0]
+
+
+class TestProc:
+    def test_age_human(self) -> None:
+        assert Proc(1, 0, 90, "/x", "c", (), "web").age_human == "1m"
+        assert Proc(1, 0, 3 * 3600 + 300, "/x", "c", (), "web").age_human == "3h05m"
+        assert (
+            Proc(1, 0, 4 * 86400 + 6 * 3600, "/x", "c", (), "web").age_human == "4d06h"
+        )
+
+    def test_cwd_attributes_a_process_to_its_checkout(self) -> None:
+        worktree = "/Users/x/projects/argon/.worktrees/feat-a/web"
+        proc = Proc(1, 0, 60, worktree, "next dev", (3001,), "web(dev)")
+        assert not proc.cwd.startswith("/Users/x/projects/argon/.worktrees/feat-b")
+        assert Path(proc.cwd).is_absolute()


### PR DESCRIPTION
Step 3 of `control-argon`, following #407. Design + deviations: `docs/superpowers/specs/2026-09-01-control-argon-design.md`.

One entry point so an agent can verify its own work instead of handing verification back to the operator.

| | retires |
| --- | --- |
| `doctor` | reading `scripts/dev.sh` by eye, guessing whether the stack is alive |
| `sync [--days 7]` | pointing `.env.local` at the mini for a browse session |
| `smoke <ticker>` | the human standing at the end of the smoke chain |
| `screenshot <name>` | ad-hoc `/tmp` Playwright scripts |
| `--help` | the 14-line `## Daily commands` block in `CLAUDE.md` |

## Three things the build changed about the design

**1. No ssh, no `pg_dump`.** The mini's Postgres answers **directly over Tailscale** on the same `argon_app` credentials. `sync` is two psycopg connections streaming `COPY … TO STDOUT` → `COPY … FROM STDIN` in one process. Nothing needs to exist on the mini.

**2. The table→date-column manifest is gone.** 168 of 175 tables carry a date column; a hand-maintained manifest at that scale is a liability, and the spec's reverse-drift check existed only to police it. Replaced by a **deny-list** (5 raw/audit tables, ~11 GB) so a new table syncs *by default* — the failure mode flips from "silently missing a slice" to "the sync got slower" — plus an auto-detected date column (observation dates ahead of write stamps, since `inserted_at` makes a backfilled row look fresh), a size rule instead of a dimension/fact classification, and a report of any windowed table that copied 0 rows. Same intent, less machinery. Called out as a deliberate departure, not an oversight.

**3. Nothing is deleted.** `TEMP` table → `INSERT … ON CONFLICT DO NOTHING`. Idempotent, and it sidesteps the FK pins — cited macro evidence is undeletable by design, so delete-then-copy would have hard-failed on `macro_source_artifacts`.

## What `doctor` found on its first run

The local `/api/health` returned **200 while serving v0.13.0 of a v0.13.2 checkout**, worker heartbeat **87.6 hours** old, 500ing on every real endpoint. A probe that only asks "did something answer" certifies that outage as healthy, so `doctor` now checks the served version against `VERSION` and fails on a dead heartbeat.

## Verified by running it, not by reading it

```
$ uv run control-argon doctor
[FAIL] api ver    serving 0.13.0, repo is 0.13.2 — restart the stack
[FAIL] worker     heartbeat 87.6h old (worker:uw:0) — no worker is running
[WARN] freshness  cri_snapshots: data_date=2026-07-10 — stale 53 days

$ uv run control-argon sync --tables cri_snapshots,vcg_snapshots,option_surface_grid_daily
  cri_snapshots              7,842 rows  (full)
  option_surface_grid_daily  838,204 rows  (≥2026-08-25)
  vcg_snapshots              9,498 rows  (full)
$ uv run control-argon sync --tables cri_snapshots,vcg_snapshots   # idempotency
  0 rows inserted across 2 tables
$ uv run control-argon doctor
[ok  ] freshness  cri_snapshots: data_date=2026-08-31 (1d)

$ uv run control-argon smoke AAPL --api-port 8402
[ok  ] enqueued   job fe2f0906… for AAPL
[ok  ] worker     job done (run_id=112820)
[ok  ] web        http://127.0.0.1:3001/stock/AAPL -> 200

$ uv run control-argon screenshot control-argon-watchlist --path /
[ok  ] wrote output/playwright/control-argon-watchlist.png
```

Two bugs the real run caught that reading the schema would not have: **53 `GENERATED ALWAYS AS … STORED` columns** (Postgres rejects an explicit value — dropped from the copy, recomputed on insert) and **2 `GENERATED ALWAYS AS IDENTITY` columns** (kept with `OVERRIDING SYSTEM VALUE`, since that id is what `ON CONFLICT` dedups on).

`uv run ruff check src/ tests/ scripts/` clean; `uv run pytest tests/unit/` → **2778 passed**, including 9 new pure-logic tests (no DB, no network).

## Deliberately not built

- **`sync --push`.** It writes the prodlike tier and cannot be rehearsed safely from here, so `scripts/deploy/macmini-data-promote.sh` stays.
- **`scripts/smoke_container_assets.sh` is NOT retired**, contrary to the spec's opening table. It verifies a *built Docker image* carries its runtime assets — a different question from local stack health, and one `doctor` does not answer.

## One rule bent

`src/uw_scan/control_argon.py` is 698 lines against the <500 target (well under the 1000-line split line). It is comment-heavy rather than logic-heavy — four independent subcommands with no domain seam worth splitting on yet.