### PR TITLE
fix(macro): stop pairing period_end with age_days unlabeled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,19 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 - `## Daily commands` in `CLAUDE.md` is 14 lines shorter; `control-argon --help`
   carries it.
 
-## [0.13.2] — 2026-08-31
+### Fixed
 
+- **Macro factor tables read a stale print as fresh.** Every domain-state factor
+  row (`Core PCE`, `Headline PCE`, the inflation survey table, …) printed
+  `{period_end} · {age_days}d` with no label — e.g. `2026-07-01 · 7d`. `age_days`
+  counts days since the print was _published_ (`available_at`), not since
+  `period_end`, so July's PCE — normal to still be the latest reading in early
+  September, since BEA runs about a month behind — read as "7-day-old data from
+  July 1st." `periodLabel()` now renders the reference period as `Jul 2026` and
+  the cell reads `Jul 2026 · pub 7d ago`, with a tooltip carrying both raw
+  timestamps. `web/components/macro/domain/{FactorTable,InflationPanels}.tsx`.
+
+## [0.13.2] — 2026-08-31
 
 ### Changed
 
@@ -96,7 +107,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   invisible, and each blindness hid a different defect.
   - `HealContext` built its UW and massive clients with `job_name=` but no
     `telemetry_recorder`, so `external_api_requests` had never held a single healer
-    row. That table is where `sources/uw_budget.read_snapshot` derives *both* the pool
+    row. That table is where `sources/uw_budget.read_snapshot` derives _both_ the pool
     spend and the account counter from, so an untelemetered healer was not merely
     unobserved by the account governor — it was arithmetically invisible to it, and a
     budget guard wired in ahead of this fix would have read zero and permitted
@@ -105,7 +116,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   - Progress lived only in stdout. Nightly runs 103–106 each stopped 50–88 minutes in
     having touched 1–2 of 23 datasets, with zero failures and their UW cap barely used;
     by the time anyone looked, Watchtower had recreated the worker and the logs were
-    gone, so *where* they stopped had no answer anywhere. Every dispatcher now emits a
+    gone, so _where_ they stopped had no answer anywhere. Every dispatcher now emits a
     per-item stage beat at INFO — the worker runs `basicConfig(level=INFO)`, so a DEBUG
     trace would have produced nothing — and persists the last one to
     `data_gap_runs.summary_jsonb.heartbeat`, which outlives the container. The
@@ -125,8 +136,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   KEEL's 63 dates across 2026-01-02..2026-04-02 failed every night and were retried
   every night, permanently. Null is now an absence and yields no rows; a wrong type
   is still a contract violation and still raises.
-## [0.13.1] — 2026-08-30
 
+## [0.13.1] — 2026-08-30
 
 ### Added
 
@@ -602,6 +613,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
     makes the count 2, and reverting either half of the fix now fails two tests. Measured both ways.
   - The irony is written into the contract itself: `kind` exists so that consumers need not match on
     term strings, and `kind` was the field that was wrong.
+
 ## [0.13.0] — 2026-08-29
 
 ### Added

--- a/web/components/macro/domain/FactorTable.tsx
+++ b/web/components/macro/domain/FactorTable.tsx
@@ -1,5 +1,5 @@
 import type { components } from "@/lib/types";
-import { humanizeIdentifier, seriesLabel } from "../presentation";
+import { humanizeIdentifier, periodLabel, seriesLabel } from "../presentation";
 
 export type MacroFactor = components["schemas"]["MacroFactorState"];
 
@@ -72,7 +72,7 @@ export function FactorTable({
             <th className="num">Level</th>
             <th className="num">Δ window</th>
             <th>Direction</th>
-            <th className="num">Period</th>
+            <th className="num">Period · Published</th>
           </tr>
         </thead>
         <tbody>
@@ -98,8 +98,11 @@ export function FactorTable({
                   {humanizeIdentifier(f.direction)}
                 </span>
               </td>
-              <td className="num">
-                {f.period_end} · {f.age_days}d
+              <td
+                className="num"
+                title={`Covers ${f.period_end}, published ${f.available_at}`}
+              >
+                {periodLabel(f.period_end)} · pub {f.age_days}d ago
               </td>
             </tr>
           ))}

--- a/web/components/macro/domain/InflationPanels.tsx
+++ b/web/components/macro/domain/InflationPanels.tsx
@@ -5,7 +5,7 @@ import {
 } from "./ConfidencePanels";
 import { FactorTable, seriesList, type MacroFactor } from "./FactorTable";
 import type { MacroDomainState } from "../types";
-import { seriesLabel } from "../presentation";
+import { periodLabel, seriesLabel } from "../presentation";
 
 /** What the board's "realized inflation" table carries: the prints themselves plus the
  *  two cuts that say how broad they are. */
@@ -167,9 +167,11 @@ function ExpectationsPanel({
                   {seriesLabel(f.series_id)}
                 </td>
                 <td className="num">{fmtPercent(f.value)}</td>
-                <td>
-                  {f.period_end} · {f.age_days}d old — its age is one of the
-                  freshness terms in the chain at left
+                <td
+                  title={`Covers ${f.period_end}, published ${f.available_at}`}
+                >
+                  {periodLabel(f.period_end)} · published {f.age_days}d ago —
+                  its age is one of the freshness terms in the chain at left
                 </td>
               </tr>
             ))}
@@ -189,9 +191,7 @@ function ExpectationsPanel({
               <tr>
                 <td>{seriesLabel(BREAKEVEN_SERIES)}</td>
                 <td className="num">{fmtPercent(breakeven.value)}</td>
-                <td>
-                  rates-owned series · {breakeven.period_end}
-                </td>
+                <td>rates-owned series · {breakeven.period_end}</td>
               </tr>
             ) : (
               <tr>

--- a/web/components/macro/presentation.ts
+++ b/web/components/macro/presentation.ts
@@ -37,11 +37,9 @@ const EXACT_LABELS: Readonly<Record<string, string>> = {
   fx_rows: "Gold FX basket",
   compute_structural_posture: "Structural model",
   compute_valuation_overlay: "Valuation model",
-  asset_mgr_net_pct_oi_change_4w:
-    "Asset managers · 4-week net share change",
+  asset_mgr_net_pct_oi_change_4w: "Asset managers · 4-week net share change",
   dealer_net_pct_oi_change_4w: "Dealers · 4-week net share change",
-  lev_money_net_pct_oi_change_4w:
-    "Leveraged funds · 4-week net share change",
+  lev_money_net_pct_oi_change_4w: "Leveraged funds · 4-week net share change",
   sofr_effr_spread_change_4w: "SOFR–EFFR spread · 4-week change",
   sofr_effr_spread_change_13w: "SOFR–EFFR spread · 13-week change",
 };
@@ -100,7 +98,8 @@ const ACRONYMS = new Set([
 function sentenceWord(word: string, index: number): string {
   const lower = word.toLowerCase();
   if (ACRONYMS.has(lower)) return lower.toUpperCase();
-  if (/^\d+[dwmy]$/.test(lower)) return lower.replace(/[dwmy]$/, (unit) => unit.toUpperCase());
+  if (/^\d+[dwmy]$/.test(lower))
+    return lower.replace(/[dwmy]$/, (unit) => unit.toUpperCase());
   if (index === 0) return lower.charAt(0).toUpperCase() + lower.slice(1);
   return lower;
 }
@@ -138,4 +137,20 @@ export function basisLabel(value: PresentationBasis): string {
   if (value === "COMPUTED") return "Derived";
   if (value === "REFERENCE") return "Reference";
   return "Planned";
+}
+
+/** "2026-07-01" -> "Jul 2026" — the period a monthly/quarterly stat covers.
+ *  Never pair this with `age_days` unlabeled: `age_days` is days since the
+ *  print was PUBLISHED (`available_at`), not since this period ended, and a
+ *  bare "2026-07-01 · 7d" reads as "this is 7-day-old July 1st data" when a
+ *  July print is normally ~4-8 weeks old by the time it is published at all.
+ */
+export function periodLabel(periodEnd: string): string {
+  const d = new Date(`${periodEnd}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return periodEnd;
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  });
 }


### PR DESCRIPTION
## What

Macro domain factor tables (Core PCE, Headline PCE, the inflation survey row)
rendered `{period_end} · {age_days}d` with no label — e.g. `2026-07-01 · 7d`.

`age_days` counts days since the print was **published** (`available_at`),
not since `period_end`. BEA runs PCE about a month behind, so July's print
being the latest available reading in early September is normal — but the
unlabeled pairing reads as "this is 7-day-old data from July 1st," which is
what got flagged as misleading.

## Fix

- `periodLabel()` (new, in `web/components/macro/presentation.ts`) renders
  the reference period as `Jul 2026`.
- The cell now reads `Jul 2026 · pub 7d ago`, with a `title` tooltip carrying
  both raw timestamps (`period_end` + `available_at`).
- Applied to both call sites that had this pairing: `FactorTable.tsx` and the
  inflation survey table in `InflationPanels.tsx`.

Consistent with the Factor Export tab (07), which already prints
`available_at` for this exact reason.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on touched files — clean
- `npx vitest run -t macro` — 13 passed, 0 failed