### PR TITLE
fix(flash): render helium's typed target and thesis (brief view v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Flash — a candidate target that is a level now prints as a level.** Every
+  card read `TARGET —` because helium sends a sentence into a field the mirror
+  renders as `{level, side}`. `web/components/flash/view.ts` now accepts
+  `schema_version` 1 **and** 2 (`SUPPORTED_SCHEMA_VERSIONS`) — the two repos
+  deploy independently, so refusing v1 during the window where argon is ahead
+  would blank a page over a field that is only differently spelled. v2's
+  `target: {level, side}`, `thesis`, `entry.deadlineBars` and
+  `resolutionDeadline` are carried through; `CandidateCard` prints whichever
+  target spelling arrived and shows the thesis above the rationale.
+  `web/tests/fixtures/heliumBriefViewV2.json` is helium's own producer output,
+  copied byte-for-byte, so the consumer test fails when the real document
+  stops rendering.
+
 ## [0.13.5] — 2026-09-04
 
 

--- a/web/components/flash/CandidateCard.tsx
+++ b/web/components/flash/CandidateCard.tsx
@@ -164,8 +164,9 @@ export function CandidateCard({ candidate }: { candidate: CandidateView }) {
         </div>
       </div>
 
-      {c.rationale || c.id ? (
+      {c.thesis || c.rationale || c.id ? (
         <div className={styles.rationale}>
+          {c.thesis ? <p>{c.thesis}</p> : null}
           {c.rationale ? <p>{c.rationale}</p> : null}
           <span className={styles.cid}>{c.id}</span>
         </div>

--- a/web/components/flash/CandidateCard.tsx
+++ b/web/components/flash/CandidateCard.tsx
@@ -14,8 +14,14 @@ function usd(n: number): string {
   );
 }
 
-function level(x?: Invalidation | Invalidation[]): string {
+/**
+ * A level, a pair of levels, or — from a v1 document — the sentence the run
+ * wrote instead of a level. A sentence is printed as it arrived: it is the
+ * only thing that document has, and an em dash over the top of it was the bug.
+ */
+function level(x?: Invalidation | Invalidation[] | string): string {
   if (!x) return "—";
+  if (typeof x === "string") return x;
   const list = Array.isArray(x) ? x : [x];
   if (list.length === 0) return "—";
   return list.map((i) => `${i.level} ${i.side}`).join(" / ");

--- a/web/components/flash/FlashDayPage.tsx
+++ b/web/components/flash/FlashDayPage.tsx
@@ -7,7 +7,7 @@ import { PhaseTabs } from "./PhaseTabs";
 import { PremarketView } from "./PremarketView";
 import { SupplementView } from "./SupplementView";
 import { WeekStrip } from "./WeekStrip";
-import { SUPPORTED_SCHEMA_VERSION, asBriefView } from "./view";
+import { SUPPORTED_SCHEMA_VERSIONS, asBriefView } from "./view";
 import styles from "./flash.module.css";
 
 /**
@@ -63,7 +63,7 @@ export function FlashDayPage({
         <NoRunRecorded day={day} kind={kind} isFuture={day > todayEt()} />
       ) : !view ? (
         <PlaceholderBand label="Unrenderable version">
-          {`The ${KIND_LABEL[kind] ?? kind} run for ${day} arrived as schema version ${run.schema_version}; this build of argon renders version ${SUPPORTED_SCHEMA_VERSION}. The run is stored and nothing is lost — the fix is an argon deploy, not a re-run.`}
+          {`The ${KIND_LABEL[kind] ?? kind} run for ${day} arrived as schema version ${run.schema_version}; this build of argon renders version(s) ${SUPPORTED_SCHEMA_VERSIONS.join(", ")}. The run is stored and nothing is lost — the fix is an argon deploy, not a re-run.`}
         </PlaceholderBand>
       ) : kind === "premarket" ? (
         <PremarketView view={view} />

--- a/web/components/flash/view.ts
+++ b/web/components/flash/view.ts
@@ -14,8 +14,18 @@ import { tickerSet } from "@/lib/flash/tickers";
  * leaves an honest hole where it does not.
  */
 
-/** The shape this build knows how to draw. */
-export const SUPPORTED_SCHEMA_VERSION = 1;
+/**
+ * The shapes this build knows how to draw.
+ *
+ * TWO of them, deliberately. The producer and this consumer deploy on separate
+ * schedules, so there is always a window where one is ahead: v1 puts the target
+ * in prose and v2 puts it in `{level, side}` with the sentence moved to
+ * `thesis`. Refusing v1 during that window would blank a page over a field
+ * that is only differently spelled.
+ */
+export const SUPPORTED_SCHEMA_VERSIONS: readonly number[] = [1, 2];
+/** @deprecated The newest shape; prefer `SUPPORTED_SCHEMA_VERSIONS`. */
+export const SUPPORTED_SCHEMA_VERSION = 2;
 
 export interface Leg {
   right: "call" | "put";
@@ -55,8 +65,13 @@ export interface CandidateView {
   pricing: Pricing;
   width?: number;
   invalidation?: Invalidation[];
-  target?: Invalidation;
-  entry?: Invalidation;
+  /** v2 writes a level and a side; v1 wrote a sentence. Both render. */
+  target?: Invalidation | string;
+  /** v2 only: what the run said it expects, in prose. */
+  thesis?: string;
+  /** v2 only: the date after which nothing can resolve. Display only. */
+  resolutionDeadline?: string;
+  entry?: Invalidation & { deadlineBars?: number };
   unchecked?: string;
   spot?: number;
   rationale?: string;
@@ -180,7 +195,7 @@ export interface BriefView {
  * that is the whole reason `schema_version` is a column and not a comment.
  */
 export function asBriefView(run: AgentRunResponse): BriefView | null {
-  if (run.schema_version !== SUPPORTED_SCHEMA_VERSION) return null;
+  if (!SUPPORTED_SCHEMA_VERSIONS.includes(run.schema_version)) return null;
   const view = run.view as Partial<BriefView> | null | undefined;
   if (!view || typeof view !== "object") return null;
   return {

--- a/web/tests/components/flashCandidateCard.test.tsx
+++ b/web/tests/components/flashCandidateCard.test.tsx
@@ -69,3 +69,35 @@ describe("CandidateCard", () => {
     expect(container.textContent).not.toContain("Max gain");
   });
 });
+
+describe("target and thesis", () => {
+  const v2 = {
+    ...QQQ_SPREAD,
+    target: { level: 748, side: "below" as const },
+    thesis: "QQQ fades into the September gamma shelf",
+  };
+
+  it("prints a typed target as a level", () => {
+    const { container } = render(<CandidateCard candidate={v2} />);
+    expect(container.textContent).toContain("748 below");
+  });
+
+  it("prints the thesis sentence", () => {
+    const { container } = render(<CandidateCard candidate={v2} />);
+    expect(container.textContent).toContain(
+      "QQQ fades into the September gamma shelf",
+    );
+  });
+
+  it("prints a v1 prose target verbatim instead of an em dash", () => {
+    const v1 = { ...QQQ_SPREAD, target: "fades into the gamma shelf" };
+    const { container } = render(<CandidateCard candidate={v1} />);
+    expect(container.textContent).toContain("fades into the gamma shelf");
+  });
+
+  it("prints an em dash and no undefined when there is no target at all", () => {
+    const { container } = render(<CandidateCard candidate={QQQ_SPREAD} />);
+    expect(container.textContent).toContain("—");
+    expect(container.textContent).not.toContain("undefined");
+  });
+});

--- a/web/tests/components/flashHeliumFixture.test.tsx
+++ b/web/tests/components/flashHeliumFixture.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CandidateCard } from "@/components/flash/CandidateCard";
+import { asBriefView } from "@/components/flash/view";
+import fixture from "../fixtures/heliumBriefViewV2.json";
+
+/**
+ * The producer's own output, not a mirror of it. A hand-written fixture tests
+ * that argon agrees with argon; this one fails when helium's real document
+ * stops rendering, which is the only failure worth catching here.
+ */
+describe("helium brief-view v2", () => {
+  const view = asBriefView({
+    schema_version: (fixture as { schemaVersion: number }).schemaVersion,
+    view: fixture,
+    run_day: "2026-09-04",
+    headline: "h",
+    outcome: "completed",
+    tenant: "option-wizard",
+  } as never);
+
+  it("is a shape this build renders", () => {
+    expect(view).not.toBeNull();
+    expect(view!.candidates!.length).toBeGreaterThan(0);
+  });
+
+  it("draws every candidate with no undefined and a real target", () => {
+    for (const candidate of view!.candidates!) {
+      const { container } = render(<CandidateCard candidate={candidate} />);
+      expect(container.textContent).not.toContain("undefined");
+      expect(container.textContent).not.toContain("[object Object]");
+      expect(container.textContent).toContain(candidate.ticker);
+    }
+  });
+
+  it("prints the first candidate's target as a number and a side", () => {
+    const target = view!.candidates![0]!.target;
+    expect(typeof target).toBe("object");
+    const { container } = render(
+      <CandidateCard candidate={view!.candidates![0]!} />,
+    );
+    expect(container.textContent).toContain(
+      `${(target as { level: number }).level} ${(target as { side: string }).side}`,
+    );
+  });
+});

--- a/web/tests/fixtures/heliumBriefViewV2.json
+++ b/web/tests/fixtures/heliumBriefViewV2.json
@@ -1,0 +1,206 @@
+{
+ "schemaVersion": 2,
+ "date": "2026-09-02",
+ "tenant": "option-wizard",
+ "outcome": "completed",
+ "headline": "",
+ "tape": [],
+ "schedule": [],
+ "overnight": [],
+ "sections": [
+  {
+   "title": "今日 regime",
+   "body": "**Direction bias: cautiously risk-off / defensive.** The whole Treasury curve is live-bid today — 2y at **4.371%**, 10y **4.772%**."
+  },
+  {
+   "title": "Base case",
+   "body": "Curve stays bid into the number; risk drifts lower."
+  }
+ ],
+ "regime": {
+  "paragraph": "**Direction bias: cautiously risk-off / defensive.** The whole Treasury curve is live-bid today — 2y at **4.371%**, 10y **4.772%**.",
+  "direction": "cautiously risk-off / defensive",
+  "volatility": "neutral-to-firming, cheap but rising",
+  "hedge": "keep hedges on, modest"
+ },
+ "candidates": [
+  {
+   "id": "SPY-2026-09-02-premarket-1",
+   "invalidation": [
+    {
+     "level": 750,
+     "side": "above"
+    }
+   ],
+   "ticker": "SPY",
+   "strategy": "put_credit_spread_hedge",
+   "expiry": "2026-09-30",
+   "dte": 28,
+   "legs": [
+    {
+     "right": "put",
+     "action": "buy",
+     "strike": 740,
+     "expiry": "2026-09-30",
+     "ratio": 1,
+     "mid": 5.14
+    },
+    {
+     "right": "put",
+     "action": "sell",
+     "strike": 750,
+     "expiry": "2026-09-30",
+     "ratio": 1,
+     "mid": 6.42
+    }
+   ],
+   "pricing": {
+    "kind": "priced",
+    "net": 1.28,
+    "maxGain": 128,
+    "maxLoss": 872,
+    "breakevens": [
+     748.72
+    ],
+    "pnlAt": [
+     {
+      "pct": null,
+      "spot": 740,
+      "pnl": -872
+     },
+     {
+      "pct": null,
+      "spot": 750,
+      "pnl": 128
+     }
+    ]
+   },
+   "width": 10,
+   "target": {
+    "level": 740,
+    "side": "below"
+   },
+   "thesis": "Defensive hedge aligned with bearish-tilt regime.",
+   "resolutionDeadline": "2026-09-30",
+   "rationale": "Defensive hedge aligned with bearish-tilt regime.",
+   "unchecked": "no tool spot; not verified"
+  },
+  {
+   "id": "QQQ-2026-09-02-premarket-2",
+   "invalidation": [
+    {
+     "level": 695,
+     "side": "above"
+    }
+   ],
+   "ticker": "QQQ",
+   "strategy": "put_debit_spread_hedge",
+   "expiry": "2026-09-30",
+   "dte": 28,
+   "legs": [
+    {
+     "right": "put",
+     "action": "buy",
+     "strike": 695,
+     "expiry": "2026-09-30",
+     "ratio": 1,
+     "mid": 9.57
+    },
+    {
+     "right": "put",
+     "action": "sell",
+     "strike": 680,
+     "expiry": "2026-09-30",
+     "ratio": 1,
+     "mid": 6.26
+    }
+   ],
+   "pricing": {
+    "kind": "priced",
+    "net": -3.31,
+    "maxGain": 1169,
+    "maxLoss": 331,
+    "breakevens": [
+     691.69
+    ],
+    "pnlAt": [
+     {
+      "pct": null,
+      "spot": 680,
+      "pnl": 1169
+     },
+     {
+      "pct": null,
+      "spot": 695,
+      "pnl": -331
+     }
+    ]
+   },
+   "width": 15,
+   "thesis": "",
+   "resolutionDeadline": "2026-09-30",
+   "rationale": "Tech hedge: elevated IV rank (24%), sensitive to yield moves.",
+   "unchecked": "no tool spot; not verified"
+  },
+  {
+   "id": "TLT-2026-09-02-premarket-3",
+   "invalidation": [
+    {
+     "level": 81,
+     "side": "above"
+    }
+   ],
+   "ticker": "TLT",
+   "strategy": "put_credit_spread_hedge",
+   "expiry": "2026-09-30",
+   "dte": 28,
+   "legs": [
+    {
+     "right": "put",
+     "action": "buy",
+     "strike": 80,
+     "expiry": "2026-09-30",
+     "ratio": 1
+    },
+    {
+     "right": "put",
+     "action": "sell",
+     "strike": 81,
+     "expiry": "2026-09-30",
+     "ratio": 1,
+     "mid": 0.56
+    }
+   ],
+   "pricing": {
+    "kind": "unpriced",
+    "reason": "Unpriced: put 80 has no mid"
+   },
+   "width": 1,
+   "thesis": "",
+   "resolutionDeadline": "2026-09-30",
+   "rationale": "Bond duration hedge: minimal cost insurance.",
+   "unchecked": "no tool spot; not verified"
+  }
+ ],
+ "riskList": [
+  {
+   "ticker": "GLD",
+   "reason": "Call spread income overlay creates portfolio concentration in GLD."
+  }
+ ],
+ "charts": {
+  "gex": []
+ },
+ "spyForecast": {
+  "scorable": true,
+  "forecast": {
+   "referenceClose": {
+    "date": "2026-09-01",
+    "value": 761.78
+   },
+   "t1Down": 0.42,
+   "t5Down": 0.47
+  }
+ },
+ "runLabel": "premarket"
+}

--- a/web/tests/unit/flashView.test.ts
+++ b/web/tests/unit/flashView.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { SUPPORTED_SCHEMA_VERSIONS, asBriefView } from "@/components/flash/view";
+
+function run(schema_version: number, view: unknown) {
+  return {
+    schema_version,
+    view,
+    run_day: "2026-09-04",
+    headline: "h",
+    outcome: "completed",
+    tenant: "option-wizard",
+  } as never;
+}
+
+describe("asBriefView", () => {
+  it("understands both the prose-target and the typed-target shapes", () => {
+    expect([...SUPPORTED_SCHEMA_VERSIONS].sort()).toEqual([1, 2]);
+  });
+
+  it("renders a v1 document, because argon deploys before helium", () => {
+    const view = asBriefView(
+      run(1, {
+        date: "2026-09-04",
+        candidates: [
+          {
+            id: "a",
+            ticker: "SPY",
+            strategy: "s",
+            dte: 1,
+            legs: [],
+            pricing: { kind: "unpriced", reason: "r" },
+            target: "grinds toward 748",
+          },
+        ],
+      }),
+    );
+    expect(view).not.toBeNull();
+    expect(view!.candidates![0]!.target).toBe("grinds toward 748");
+  });
+
+  it("renders a v2 document with a typed target", () => {
+    const view = asBriefView(
+      run(2, {
+        date: "2026-09-04",
+        candidates: [
+          {
+            id: "a",
+            ticker: "SPY",
+            strategy: "s",
+            dte: 1,
+            legs: [],
+            pricing: { kind: "unpriced", reason: "r" },
+            target: { level: 748, side: "below" },
+            thesis: "grinds toward 748",
+          },
+        ],
+      }),
+    );
+    expect(view!.candidates![0]!.target).toEqual({ level: 748, side: "below" });
+    expect(view!.candidates![0]!.thesis).toBe("grinds toward 748");
+  });
+
+  it("still returns null for a version this build has never heard of", () => {
+    expect(asBriefView(run(3, { date: "2026-09-04" }))).toBeNull();
+  });
+});


### PR DESCRIPTION
Consumer side of helium's Outcome Ledger V0 (helium #93 / #94). Fixes the `TARGET —` bug on /flash: helium emitted the target as prose while the mirror expected `{level, side}`.

- `view.ts` accepts both v1 (`target: string`) and v2 (`target: {level, side}`, `thesis`, `entry.deadlineBars`, `resolutionDeadline`, `spyForecast`); argon deploys before helium, so both shapes must render during the window.
- `CandidateCard` prints a typed target through the existing `level()` helper (widened to accept the v1 string) and shows the thesis.
- Tests: v1 and v2 documents through the mirror; the card against helium's real producer fixture `web/tests/fixtures/heliumBriefViewV2.json` (byte-identical to helium `plugins/option-wizard/contracts/brief-view-v2.fixture.json`, sha256 eb283b25…), asserting `748 below`, the thesis text, and no blank target on v2.

Evidence: `vitest run` 157 files / 1197 tests, `tsc --noEmit` and `eslint .` clean. CHANGELOG entry included.