### PR TITLE
fix(flash): separate run existence from headline in the week strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,24 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   n/h and the intervals are optimistic — the caveat is carried in the run's
   `notes` column, not just the docstring.
 
-## [0.13.6] — 2026-09-06
+### Fixed
 
+- **Flash week strip: the weekly card follows the run, not the Friday cell** —
+  the week page renders the newest `weekly` run wherever it landed (helium files
+  a week-scoped run under its own `run_day`; W36's outlook landed on Sunday
+  2026-09-06), but the strip above it looked for a weekly on the Friday and
+  decided the card's text from a truthy `headline`. A weekly that was ingested,
+  updated in place and rendering five sections below still read "not generated
+  yet" with its pip dark. The card now reads the same index row the body does
+  (`newestOfKind` moved to `web/lib/flash/kinds.ts`, one copy shared by the page
+  and the strip), lights the pip on the run's existence, and says
+  "no headline recorded" — not "not generated yet" — for a recorded run that
+  carries no headline. The five day cards carried the same conflation: a
+  premarket run ingested with an empty `headline` read "no premarket run" over
+  a run that exists. They now say "no headline recorded" too, and keep
+  "no premarket run" for the day where none was filed.
+
+## [0.13.6] — 2026-09-06
 
 ### Fixed
 
@@ -41,8 +57,8 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   `web/tests/fixtures/heliumBriefViewV2.json` is helium's own producer output,
   copied byte-for-byte, so the consumer test fails when the real document
   stops rendering.
-## [0.13.5] — 2026-09-04
 
+## [0.13.5] — 2026-09-04
 
 ### Added
 
@@ -64,7 +80,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
     and Frank rows are resolved through the week index, not by date
     arithmetic — helium files a W36 Frank under `run_day 2026-09-07`.
   - Empty states carry the audit they ran (`helium audit — 0 runs for tenant
-    option-wizard, phase premarket, date 2026-08-31`), and an unrenderable
+option-wizard, phase premarket, date 2026-08-31`), and an unrenderable
     `schema_version` names the version that arrived and the one this build
     draws rather than rendering blank.
   - Design spec: `docs/superpowers/specs/2026-09-05-flash-design.md`.
@@ -72,15 +88,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
     `/opt/argon/.env` on the mini followed by `docker-compose up -d api web`
     (Watchtower does not re-read `env_file`). Migration 148 self-applies on
     api boot.
-## [0.13.4] — 2026-09-04
 
+## [0.13.4] — 2026-09-04
 
 ### Changed
 
 - Site meta description is now "Recursive Self-improvement Agent Analytics"
   (`web/app/layout.tsx`).
-## [0.13.3] — 2026-09-03
 
+## [0.13.3] — 2026-09-03
 
 ### Added
 
@@ -144,6 +160,7 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
   July 1st." `periodLabel()` now renders the reference period as `Jul 2026` and
   the cell reads `Jul 2026 · pub 7d ago`, with a tooltip carrying both raw
   timestamps. `web/components/macro/domain/{FactorTable,InflationPanels}.tsx`.
+
 ## [0.13.2] — 2026-08-31
 
 ### Changed

--- a/web/app/flash/[week]/page.tsx
+++ b/web/app/flash/[week]/page.tsx
@@ -1,40 +1,14 @@
 import { api } from "@/lib/api";
 import type {
-  AgentRunIndexRow,
   AgentRunResponse,
   AgentRunWeekListResponse,
   AgentRunWeekResponse,
 } from "@/lib/api";
-import { FLASH_TENANT } from "@/lib/flash/kinds";
+import { FLASH_TENANT, newestOfKind } from "@/lib/flash/kinds";
 
 import { FlashWeekPage } from "@/components/flash/FlashWeekPage";
 
 export const dynamic = "force-dynamic";
-
-/**
- * The newest recorded row of one kind in this week's index.
- *
- * THE WEEK'S RUNS ARE NOT FILED UNDER FRIDAY. helium sends `week_key`
- * explicitly and files each run under its own `run_day` — a Frank 复盘 for
- * W36 carries run_day 2026-09-07, the Monday AFTER the week it reviews. Asking
- * the API for `(frank, friday)` finds nothing and renders "no review attached"
- * over a review that exists. The index is the only authority on which day a
- * week-scoped run actually landed on.
- */
-function newestOfKind(
-  runs: AgentRunIndexRow[],
-  kind: string,
-): AgentRunIndexRow | undefined {
-  return runs
-    .filter((r) => r.kind === kind)
-    .sort((a, b) =>
-      String(a.run_day) === String(b.run_day)
-        ? b.version_no - a.version_no
-        : String(a.run_day) < String(b.run_day)
-          ? 1
-          : -1,
-    )[0];
-}
 
 /**
  * The week view: five days, the weekly summary, and the Frank supplement.

--- a/web/components/flash/WeekStrip.tsx
+++ b/web/components/flash/WeekStrip.tsx
@@ -1,7 +1,13 @@
 import Link from "next/link";
 
 import type { AgentRunIndexRow, AgentRunWeek } from "@/lib/api";
-import { DAY_KINDS, PIP_LABEL, weekDays, weekRange } from "@/lib/flash/kinds";
+import {
+  DAY_KINDS,
+  PIP_LABEL,
+  newestOfKind,
+  weekDays,
+  weekRange,
+} from "@/lib/flash/kinds";
 
 import styles from "./flash.module.css";
 
@@ -37,12 +43,16 @@ export function WeekStrip({
     byDay.get(day)!.add(run.kind);
   }
   const headlineOf = (day: string, kind: string) =>
-    runs.find(
-      (r) => String(r.run_day) === day && r.kind === kind && r.headline,
-    )?.headline ?? "";
+    runs.find((r) => String(r.run_day) === day && r.kind === kind && r.headline)
+      ?.headline ?? "";
 
   const recordedDays = days.filter(({ date }) => byDay.has(date)).length;
-  const weeklyHeadline = headlineOf(last, "weekly");
+  // The weekly card follows the run the week PAGE renders — the newest weekly
+  // in the index, on whatever day it landed — not the Friday cell. Keying the
+  // card on `last` printed "not generated yet" over a rendered outlook, and
+  // keying its text on a truthy headline printed it again for a run that
+  // simply carries no headline. Existence and headline are two facts.
+  const weeklyRun = newestOfKind(runs, "weekly");
 
   // The list arrives newest-first, so the EARLIER week is index + 1.
   const here = weeks.findIndex((w) => w.week_key === weekKey);
@@ -78,6 +88,10 @@ export function WeekStrip({
         {days.map(({ date, dow }) => {
           const kinds = byDay.get(date);
           const headline = headlineOf(date, "premarket");
+          // Same separation as the weekly card: a premarket run that carries
+          // no headline still HAPPENED, so it must not read "no premarket
+          // run" — that sentence is reserved for a day where none was filed.
+          const hasPremarket = kinds?.has("premarket") ?? false;
           return (
             <Link
               key={date}
@@ -90,11 +104,15 @@ export function WeekStrip({
                 <span className={styles.dow}>{dow}</span>
                 <span className={styles.dt}>{date.slice(5)}</span>
               </span>
-              {kinds && headline ? (
+              {headline ? (
                 <span className={styles.one}>{headline}</span>
               ) : (
                 <span className={`${styles.one} ${styles.norun}`}>
-                  {kinds ? "no premarket run" : "no run recorded"}
+                  {hasPremarket
+                    ? "no headline recorded"
+                    : kinds
+                      ? "no premarket run"
+                      : "no run recorded"}
                 </span>
               )}
               <span className={styles.pips}>
@@ -124,18 +142,18 @@ export function WeekStrip({
             <span className={styles.dow}>WEEK</span>
             <span className={styles.dt}>{weekNo}</span>
           </span>
-          {weeklyHeadline ? (
-            <span className={styles.one}>{weeklyHeadline}</span>
+          {weeklyRun?.headline ? (
+            <span className={styles.one}>{weeklyRun.headline}</span>
           ) : (
             <span className={`${styles.one} ${styles.norun}`}>
-              not generated yet
+              {weeklyRun ? "no headline recorded" : "not generated yet"}
             </span>
           )}
           <span className={styles.pips}>
             <span
               className={styles.pip}
               data-testid="pip-weekly"
-              data-on={String(byDay.get(last)?.has("weekly") ?? false)}
+              data-on={String(weeklyRun != null)}
               title="weekly"
             >
               S

--- a/web/lib/flash/kinds.ts
+++ b/web/lib/flash/kinds.ts
@@ -11,6 +11,8 @@
  * into the previous Sunday and silently shifts the whole week strip.
  */
 
+import type { AgentRunIndexRow } from "@/lib/api";
+
 export const FLASH_TENANT = "option-wizard";
 
 /** The three phases of one trading day. `weekly` and `frank` are NOT DayKinds. */
@@ -109,4 +111,32 @@ export function todayEt(now: Date = new Date()): string {
     month: "2-digit",
     day: "2-digit",
   }).format(now);
+}
+
+/**
+ * The newest recorded row of one kind in a week's index.
+ *
+ * THE WEEK'S RUNS ARE NOT FILED UNDER FRIDAY. helium sends `week_key`
+ * explicitly and files each run under its own `run_day` — a Frank 复盘 for
+ * W36 carries run_day 2026-09-07, the Monday AFTER the week it reviews, and
+ * the weekly outlook of W36 landed on Sunday 2026-09-06. Looking for a
+ * week-scoped run on the Friday finds nothing and reports "not generated yet"
+ * over a run that exists. The index is the only authority on which day a
+ * week-scoped run actually landed on, so the strip and the page body must both
+ * read it through here — a second private copy of this rule is how the header
+ * and the body came to disagree in the first place.
+ */
+export function newestOfKind(
+  runs: AgentRunIndexRow[],
+  kind: string,
+): AgentRunIndexRow | undefined {
+  return runs
+    .filter((r) => r.kind === kind)
+    .sort((a, b) =>
+      String(a.run_day) === String(b.run_day)
+        ? b.version_no - a.version_no
+        : String(a.run_day) < String(b.run_day)
+          ? 1
+          : -1,
+    )[0];
 }

--- a/web/tests/components/flashWeekStrip.test.tsx
+++ b/web/tests/components/flashWeekStrip.test.tsx
@@ -35,17 +35,11 @@ const WEEK_36: AgentRunWeek = {
   day_count: 1,
 };
 
-const RUNS = [
-  row("premarket", HEADLINE),
-  row("intraday"),
-  row("close"),
-];
+const RUNS = [row("premarket", HEADLINE), row("intraday"), row("close")];
 
 describe("WeekStrip", () => {
   it("renders five weekdays plus the weekly card", () => {
-    render(
-      <WeekStrip weekKey="2026-W36" runs={RUNS} weeks={[WEEK_36]} />,
-    );
+    render(<WeekStrip weekKey="2026-W36" runs={RUNS} weeks={[WEEK_36]} />);
 
     for (const dow of ["MON", "TUE", "WED", "THU", "FRI"]) {
       expect(screen.getByText(dow)).toBeTruthy();
@@ -85,6 +79,36 @@ describe("WeekStrip", () => {
     expect(
       within(screen.getByTestId("flash-day-2026-09-03")).getByText(HEADLINE),
     ).toBeTruthy();
+  });
+
+  /**
+   * A day card conflated the same two facts the weekly card did: a premarket
+   * run that was recorded with an empty `headline` printed "no premarket run"
+   * over a run that exists. Existence is the pip; the headline is the text.
+   */
+  it("says `no headline recorded` for a headline-less premarket run", () => {
+    render(
+      <WeekStrip
+        weekKey="2026-W36"
+        runs={[
+          row("premarket"),
+          row("close"),
+          { ...row("close"), run_day: "2026-09-02" },
+        ]}
+        weeks={[WEEK_36]}
+      />,
+    );
+
+    const thu = within(screen.getByTestId("flash-day-2026-09-03"));
+    expect(thu.getByText("no headline recorded")).toBeTruthy();
+    expect(thu.queryByText("no premarket run")).toBeNull();
+    expect(thu.getByTestId("pip-premarket").getAttribute("data-on")).toBe(
+      "true",
+    );
+
+    // A day whose only run is a close still says so — that label was right.
+    const wed = within(screen.getByTestId("flash-day-2026-09-02"));
+    expect(wed.getByText("no premarket run")).toBeTruthy();
   });
 
   it("says `no run recorded` on a day that has none", () => {
@@ -133,11 +157,7 @@ describe("WeekStrip", () => {
     };
     // The list arrives newest-first, so "earlier" is index + 1.
     render(
-      <WeekStrip
-        weekKey="2026-W36"
-        runs={RUNS}
-        weeks={[WEEK_36, earlier]}
-      />,
+      <WeekStrip weekKey="2026-W36" runs={RUNS} weeks={[WEEK_36, earlier]} />,
     );
 
     const prev = screen.getByTestId("flash-week-prev");
@@ -154,5 +174,57 @@ describe("WeekStrip", () => {
       screen.getByText("W36 · 1 of 5 days has a recorded run"),
     ).toBeTruthy();
     expect(screen.getByText("2026-08-31 → 2026-09-04")).toBeTruthy();
+  });
+});
+
+/**
+ * The weekly card must follow the run the WEEK PAGE renders.
+ *
+ * Reproduces the option-wizard row of 2026-W36: the weekly landed on Sunday
+ * 2026-09-06 with an empty `headline` and a five-section document. The body
+ * drew the sections while the card above it read "not generated yet".
+ */
+describe("WeekStrip weekly card", () => {
+  const weeklyRow: AgentRunIndexRow = {
+    ...row("weekly"),
+    run_day: "2026-09-06",
+    run_id: "run-735e656b-ca40-4f50-a0d9-63cf25d1c8d2",
+  };
+
+  it("lights the weekly pip for a run filed off the Friday", () => {
+    render(
+      <WeekStrip
+        weekKey="2026-W36"
+        runs={[...RUNS, weeklyRow]}
+        weeks={[WEEK_36]}
+      />,
+    );
+
+    const card = within(screen.getByTestId("flash-day-weekly"));
+    expect(card.getByTestId("pip-weekly").getAttribute("data-on")).toBe("true");
+    expect(card.queryByText("not generated yet")).toBeNull();
+  });
+
+  it("prints the weekly headline when the run carries one", () => {
+    render(
+      <WeekStrip
+        weekKey="2026-W36"
+        runs={[...RUNS, { ...weeklyRow, headline: "Week ahead: payrolls" }]}
+        weeks={[WEEK_36]}
+      />,
+    );
+
+    const card = within(screen.getByTestId("flash-day-weekly"));
+    expect(card.getByText("Week ahead: payrolls")).toBeTruthy();
+  });
+
+  it("still says `not generated yet` when no weekly run exists", () => {
+    render(<WeekStrip weekKey="2026-W36" runs={RUNS} weeks={[WEEK_36]} />);
+
+    const card = within(screen.getByTestId("flash-day-weekly"));
+    expect(card.getByText("not generated yet")).toBeTruthy();
+    expect(card.getByTestId("pip-weekly").getAttribute("data-on")).toBe(
+      "false",
+    );
   });
 });


### PR DESCRIPTION
## Root cause

Two separate facts were collapsed into one in `WeekStrip`.

**Weekly card.** The week page body renders the newest `weekly` run in the index, on whatever day it landed — helium sends `week_key` explicitly and files each run under its own `run_day`. The strip above it instead looked for a weekly on the **Friday cell** (`byDay.get(last)`), and decided the card's text from a **truthy `headline`**. W36's outlook landed on Sunday 2026-09-06 with an empty `headline`: the body drew five sections while the card above it read "not generated yet" with its pip dark.

**Day cards.** Same conflation, different cell: the text branch was `kinds && headline`, so a premarket run that was ingested with an empty `headline` fell through to "no premarket run" — a sentence that should only ever describe a day where no premarket was filed.

## What changed

- `newestOfKind` moved out of `web/app/flash/[week]/page.tsx` into `web/lib/flash/kinds.ts`. One copy of the "a week-scoped run is not filed under Friday" rule, read by both the page body and the strip — a second private copy is how the header and the body came to disagree.
- **Weekly card** now keys its pip on `newestOfKind(runs, "weekly") != null` and its text on that run's `headline`, saying "no headline recorded" for a recorded run with no headline and keeping "not generated yet" for a genuinely absent one.
- **Day cards** get the same separation: pip unchanged (it already keyed on existence), text is the premarket headline if present, else "no headline recorded" when a premarket run exists, else the existing "no premarket run" / "no run recorded" labels.
- CHANGELOG `[Unreleased] → Fixed` entry covers both cards.

No API, schema, or data-path change — this is display logic over the existing `AgentRunIndexRow` index.

## Test evidence

`web/tests/components/flashWeekStrip.test.tsx`, fixtures shaped from the captured option-wizard rows (real `run_day`/`run_id`/headline text, nothing invented):

- weekly: pip lit for a run filed off the Friday · headline printed when carried · "not generated yet" preserved when no weekly exists
- day: `says \`no headline recorded\` for a headline-less premarket run` — asserts the Thursday card drops "no premarket run", lights `pip-premarket`, and that a Wednesday whose only run is a `close` still reads "no premarket run"

Negative control: reverting the day-card branch alone fails exactly that new case (`Unable to find an element with the text: no headline recorded`); restoring it returns 12/12.

```
$ npm run typecheck   # tsc --noEmit — clean
$ npm run lint        # eslint . — clean
$ npm run test -- flashWeekStrip
 Test Files  1 passed (1)
      Tests  12 passed (12)
```