### PR TITLE
research(density): skewed-t innovation arm (SKEWT) + run 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **SPX density cone asymmetric-innovation arm (`SKEWT`)** — `density/fit.ARMS` gains one
+  argon-added research arm: arm G's configuration (multi-start, retry ladder,
+  `MAX_FAILURE_CARRY_DAYS`) with Hansen (1994)'s **skewed t** (arch's `SkewStudent`,
+  params `eta` = df, `lambda` = skewness) as the GJR likelihood's innovation family,
+  instead of G's Normal or H's symmetric t. Branch-guarded on `family == "skewt"`, so the
+  vendored `normal`/`t` paths and the golden parity test are untouched; production `ARM`
+  stays `G`. `spx_density_arm_h.py --arm SKEWT` persists run 7,
+  `spx-density-calibration-arm-skewt`, and now records the fitted parameter RANGES
+  (min/median/max per parameter, plus how often the skew is pinned on a bound) in
+  `params_grid.fitted_param_ranges` and `notes`. Asymmetry IS identified — `lambda` sits in
+  [-0.1916, -0.1877] on all 82 sessions, never at a bound, never at 0 — but the cone is a
+  block bootstrap over empirical standardized residuals, so a family can only move
+  omega/alpha/gamma/beta, never the simulated innovation shape. Verdict flat, as for H:
+  prospective q95 ratio 0.879 vs G's 0.919 (H 0.888), reconstructed q05 worsens to 1.080 vs
+  G's 1.048. `ARM` stays `G`.
 - **SPX density cone arm counterfactuals** — `scripts/research/spx_density_arm_h.py`
   replays every published `spx_density_forecast` as_of through
   `compute_forecast(..., arm=, seed_offset=)` (two new research-only kwargs; production

--- a/scripts/research/spx_density_arm_h.py
+++ b/scripts/research/spx_density_arm_h.py
@@ -49,8 +49,21 @@ Reproduce (the mini's prod DB is the only tier that carries the 83 as_of rows):
 Reads:  uw_scan.spx_density_forecast (settled rows only), uw_scan.vol_index_daily,
         uw_scan.backtest_sweep_{runs,results} (run 3, for the side-by-side)
 Writes: uw_scan.backtest_sweep_runs / _results ONLY, strategy
-        'spx-density-calibration-arm-H'. NEVER spx_density_forecast — the published log
+        'spx-density-calibration-arm-<arm>' ('-arm-H' by default; a multi-character arm key
+        is lower-cased into the slug, so --arm SKEWT persists as
+        'spx-density-calibration-arm-skewt'). NEVER spx_density_forecast — the published log
         is arm G's by definition and this script has no business rewriting it.
+
+`--arm` generalises the same replay to any row of `density/fit.ARMS`: runs 4-6 used it for
+H, F and a G seed-offset noise floor. `--arm SKEWT` is the argon-added ASYMMETRIC arm — arm
+G's configuration with Hansen (1994)'s skewed t in the GJR likelihood. One thing to hold on
+to when reading its result: `gjr_std_boot_cone` draws its innovations by BLOCK BOOTSTRAP
+from the empirical standardized-residual pool, so no innovation family ever becomes the
+shape of a simulated path. A family can only move omega/alpha/gamma/beta — and through them
+the variance path, v_next and the residuals that get resampled. The run therefore records
+the fitted parameter RANGES (params_grid.fitted_param_ranges): a skew that never moves off
+its symmetric start, or sits on a bound, means the asymmetry was never identified and the
+metric delta belongs to the variance parameters, not to the family.
 """
 
 from __future__ import annotations
@@ -58,6 +71,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import logging
+import statistics
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -99,8 +113,16 @@ STRATEGY_PREFIX = "spx-density-calibration-arm-"
 
 
 def strategy_for(arm: str, seed_offset: int) -> str:
-    """'spx-density-calibration-arm-H'; '-seed1' suffix marks a noise-floor control."""
-    return f"{STRATEGY_PREFIX}{arm}" + (f"-seed{seed_offset}" if seed_offset else "")
+    """'spx-density-calibration-arm-H'; '-seed1' suffix marks a noise-floor control.
+
+    Single-letter arm keys keep their case: runs 4-6 are persisted as '-arm-H', '-arm-F'
+    and '-arm-G-seed1', and those exact strings are the only join key back to them, so the
+    slug rule may not rewrite them. A multi-character key (the argon-added 'SKEWT') is
+    lower-cased into the slug, because a strategy string is a slug and 'SKEWT' shouting
+    inside one would be the only upper-case word in the table.
+    """
+    slug = arm if len(arm) == 1 else arm.lower()
+    return f"{STRATEGY_PREFIX}{slug}" + (f"-seed{seed_offset}" if seed_offset else "")
 
 
 STRATEGY = strategy_for(ARM, 0)
@@ -191,8 +213,15 @@ def replay_arm(
     *,
     arm: str = ARM,
     seed_offset: int = 0,
-) -> dict[tuple[date, int], dict]:
-    """(as_of, h) -> {'anchor_close', 'q05'..'q95', 'density_bins_jsonb', 'fallback_used'}.
+) -> tuple[dict[tuple[date, int], dict], dict[date, dict[str, float] | None]]:
+    """`((as_of, h) -> cell, as_of -> fitted params)`.
+
+    A cell is {'anchor_close', 'q05'..'q95', 'density_bins_jsonb', 'fallback_used'}. The
+    second return value is `ForecastResult.params` per session — the fitted GJR parameters
+    plus whatever the innovation family adds (arm H: `nu`; arm SKEWT: `eta`, `lambda`),
+    or None on a night the fit was rejected and the labelled EWMA fallback ran. It exists
+    so a run can report whether the family's extra parameters were actually IDENTIFIED
+    rather than pinned at a bound.
 
     Uses `compute_forecast`'s own as_of truncation — the same call the backfill script
     makes — so the seed is the v13 panel-index convention and the replay is bit-faithful
@@ -201,6 +230,7 @@ def replay_arm(
     """
     bar_dates = {d for d, _ in bars}
     out: dict[tuple[date, int], dict] = {}
+    fitted: dict[date, dict[str, float] | None] = {}
     for n, as_of in enumerate(as_ofs, start=1):
         if as_of not in bar_dates:
             raise MissingInputError(
@@ -216,6 +246,7 @@ def replay_arm(
             cell["density_bins_jsonb"] = row["density_bins_jsonb"]
             cell["fallback_used"] = result.fallback_used
             out[(as_of, int(row["h"]))] = cell
+        fitted[as_of] = result.params
         log.info(
             "replayed %d/%d as_of=%s arm=%s seed=%d fallback=%s",
             n,
@@ -225,7 +256,7 @@ def replay_arm(
             result.seed,
             result.fallback_used,
         )
-    return out
+    return out, fitted
 
 
 def merge_rows(
@@ -264,6 +295,102 @@ def merge_rows(
             raise MissingInputError(f"published realised_return is NULL at {key}")
         merged.append(row)
     return merged
+
+
+# --------------------------------------------------------------------------------------
+# fitted-parameter spread
+# --------------------------------------------------------------------------------------
+
+#: |lambda| at or above this counts as pinned on Hansen's (-1, 1) bound.
+SKEW_BOUND_EPS = 1e-3
+
+
+def param_ranges(
+    fitted: Mapping[date, dict | None],
+) -> dict[str, dict[str, float | int]]:
+    """param -> {n, min, median, max} across the as_of sessions that produced a fit.
+
+    WHY THIS IS PART OF THE RECORD, not a debug print: an innovation family's extra
+    parameter that never moves carries no information. If the fitted skew is the same
+    number every session, or sits on a bound, then the likelihood never identified an
+    asymmetry and any metric delta must be attributed to the variance parameters it
+    dragged along — not to the family. The range is what lets a reader tell those apart,
+    so it is persisted in params_grid rather than only printed.
+
+    `_sessions` records the fitted/fallback split: a range over 80 of 83 sessions is a
+    different claim from a range over all 83.
+    """
+    ranges: dict[str, dict[str, float | int]] = {}
+    keys = sorted({k for pr in fitted.values() if pr for k in pr})
+    for k in keys:
+        vals = sorted(
+            float(pr[k]) for pr in fitted.values() if pr is not None and k in pr
+        )
+        if not vals:
+            continue
+        entry: dict[str, float | int] = {
+            "n": len(vals),
+            "min": vals[0],
+            "median": statistics.median(vals),
+            "max": vals[-1],
+        }
+        if k == "lambda":
+            entry["n_pinned_at_bound"] = sum(
+                1 for v in vals if abs(v) >= 1.0 - SKEW_BOUND_EPS
+            )
+            entry["n_exactly_symmetric"] = sum(1 for v in vals if v == 0.0)
+            entry["n_negative"] = sum(1 for v in vals if v < 0.0)
+        ranges[k] = entry
+    ranges["_sessions"] = {
+        "n": len(fitted),
+        "fitted": sum(1 for pr in fitted.values() if pr is not None),
+        "fallback": sum(1 for pr in fitted.values() if pr is None),
+    }
+    return ranges
+
+
+def print_param_ranges(ranges: Mapping[str, Mapping[str, float | int]]) -> None:
+    sess = ranges.get("_sessions", {})
+    print()
+    print(
+        f"### Fitted parameters across as_of "
+        f"({sess.get('fitted', 0)} fitted / {sess.get('n', 0)} sessions, "
+        f"{sess.get('fallback', 0)} fallback)"
+    )
+    print()
+    print("| param | n | min | median | max | note |")
+    print("| --- | --- | --- | --- | --- | --- |")
+    for k, e in ranges.items():
+        if k == "_sessions":
+            continue
+        note = ""
+        if k == "lambda":
+            note = (
+                f"pinned at bound: {e.get('n_pinned_at_bound', 0)}, "
+                f"exactly 0: {e.get('n_exactly_symmetric', 0)}, "
+                f"negative: {e.get('n_negative', 0)}"
+            )
+        print(
+            f"| {k} | {e['n']} | {float(e['min']):.6f} | {float(e['median']):.6f} "
+            f"| {float(e['max']):.6f} | {note} |"
+        )
+    print()
+
+
+def fitted_summary_line(ranges: Mapping[str, Mapping[str, float | int]]) -> str:
+    """One sentence for `notes`, so the durable row states the spread without a join."""
+    parts = [
+        f"{k} [{float(e['min']):.4f}, {float(e['median']):.4f}, {float(e['max']):.4f}]"
+        for k, e in ranges.items()
+        if k != "_sessions"
+    ]
+    sess = ranges.get("_sessions", {})
+    return (
+        "FITTED PARAMETER SPREAD (min, median, max) over "
+        f"{sess.get('fitted', 0)}/{sess.get('n', 0)} fitted sessions: "
+        + "; ".join(parts)
+        + ". Full detail in params_grid.fitted_param_ranges."
+    )
 
 
 # --------------------------------------------------------------------------------------
@@ -330,7 +457,7 @@ def print_summary(
     print()
 
 
-def notes_for(arm: str, seed_offset: int) -> str:
+def notes_for(arm: str, seed_offset: int, fitted_line: str = "") -> str:
     spec = ARMS[arm]
     control = (
         f" NOISE-FLOOR CONTROL: same arm as production, every cone seed is "
@@ -366,6 +493,7 @@ def notes_for(arm: str, seed_offset: int) -> str:
         "Arm G was itself selected by signal-lab's v13 run on an earlier window; a win here "
         "is a reason to run a proper selection study, never on its own a reason to switch "
         "the published arm. "
+        f"{fitted_line} "
         "Reads spx_density_forecast (never writes it); writes backtest_sweep_* only."
     )
 
@@ -438,7 +566,10 @@ def main() -> int:
                 "no SPX series in vol_index_daily — the replay has no input"
             )
 
-        replayed = replay_arm(bars, as_ofs, arm=args.arm, seed_offset=args.seed_offset)
+        replayed, fitted = replay_arm(
+            bars, as_ofs, arm=args.arm, seed_offset=args.seed_offset
+        )
+        ranges = param_ranges(fitted)
         merged = merge_rows(published, replayed)
         scored: list[Scored] = [score_row(r) for r in merged]
         n_fallback = sum(1 for c in replayed.values() if c["fallback_used"])
@@ -461,6 +592,9 @@ def main() -> int:
             "quantile_levels": [tau for tau, _ in LEVELS],
             "pit_deciles": 10,
             "aggregations": ["origin_x_h", "h_pooled", "origin_pooled"],
+            # The estimator's own output, not a knob: which parameters the family added and
+            # how far they actually moved across the window. See `param_ranges`.
+            "fitted_param_ranges": ranges,
         }
 
         if args.dry_run:
@@ -490,12 +624,15 @@ def main() -> int:
                 git_sha=sha,
                 data_start=min(r.as_of for r in scored),
                 data_end=max(r.as_of for r in scored),
-                notes=notes_for(args.arm, args.seed_offset),
+                notes=notes_for(
+                    args.arm, args.seed_offset, fitted_line=fitted_summary_line(ranges)
+                ),
             )
             results, run_id = out["results"], out["run_id"]
             log.info("run_id=%s ok=%s error=%s", run_id, out["n_ok"], out["n_error"])
 
     print_tables(results)
+    print_param_ranges(ranges)
     if args.limit_as_of is None:
         print_summary(
             results, baseline, baseline_run_id=args.baseline_run_id, arm=args.arm

--- a/src/uw_scan/density/constants.py
+++ b/src/uw_scan/density/constants.py
@@ -50,6 +50,11 @@ MULTI_STARTS: tuple[tuple[float, float, float, float], ...] = (
 )
 #: §3.2. Student-t carries a trailing `nu` the Normal model does not.
 T_START_NU = 8.0
+#: ARGON-ADDED (not signal-lab, not part of v13): the skewed-t family's start for Hansen's
+#: skewness parameter. 0.0 is the SYMMETRIC point — at lambda = 0 arch's `SkewStudent`
+#: reduces exactly to `StudentsT`, so the skewed arm starts from the symmetric t and any
+#: fitted asymmetry is something the likelihood moved to, never something the start assumed.
+SKEWT_START_LAMBDA = 0.0
 
 CHANNEL_OK = "ok"
 CHANNEL_TOO_SHORT = "too_short"
@@ -59,6 +64,8 @@ CHANNEL_NON_FINITE = "non_finite"
 CHANNEL_INVALID_PARAMS = "invalid_params"
 CHANNEL_NON_STATIONARY = "non_stationary"
 CHANNEL_BAD_NU = "bad_nu"
+#: ARGON-ADDED: Hansen skewness outside (-1, 1), where the skewed-t density is undefined.
+CHANNEL_BAD_SKEW = "bad_skew"
 CHANNEL_NON_FINITE_LL = "non_finite_loglik"
 
 MAX_FAILURE_CARRY_DAYS = 10

--- a/src/uw_scan/density/fit.py
+++ b/src/uw_scan/density/fit.py
@@ -2,9 +2,12 @@
 
 Source: signal-lab @ 0f893513, research/runs/_v8_estimator.py + research/runs/_v8_arms.py
 (+ fit_gjr from scripts/forward_paths.py — dead code on arm G, kept so _fit stays verbatim).
-Only this header and imports differ from source; every body below is byte-identical
-(the sole permitted edits: two function-local `from scripts.forward_paths import ...`
-lines deleted — both names are module-level imports here). Frozen behaviours the parity
+Only this header, the imports, and the ARGON-ADDED "skewt" family differ from source;
+every body below is byte-identical on the vendored `normal`/`t` paths (the sole permitted
+edits: two function-local `from scripts.forward_paths import ...` lines deleted — both
+names are module-level imports here). The skewt additions are branch-guarded on
+`family == "skewt"`, so no vendored code path changes behaviour; the golden parity test
+(arm G, Normal) is the standing proof. Frozen behaviours the parity
 test pins: all 5 starts evaluated unconditionally (no early exit); select_attempt argmax
 over admissible loglik, ties within LOGLIK_TOL -> lowest grid index via min over the
 eligible set; _attempt catches bare Exception around model.fit.
@@ -19,6 +22,7 @@ import numpy as np
 from uw_scan.density.cone import GJR_MIN_OBS, _to_pct_log
 from uw_scan.density.constants import (
     CHANNEL_BAD_NU,
+    CHANNEL_BAD_SKEW,
     CHANNEL_EXCEPTION,
     CHANNEL_INVALID_PARAMS,
     CHANNEL_NON_FINITE,
@@ -30,8 +34,15 @@ from uw_scan.density.constants import (
     LOGLIK_TOL,
     MAX_FAILURE_CARRY_DAYS,
     MULTI_STARTS,
+    SKEWT_START_LAMBDA,
     T_START_NU,
 )
+
+#: ARGON-ADDED. The innovation families `fit_v8` accepts. `normal`/`t` are v13's;
+#: `skewt` is Hansen (1994)'s skewed t (arch's `SkewStudent`), parameterised by `eta`
+#: (degrees of freedom, arch bound [2.05, 300]) and `lambda` (skewness, bound [-1, 1],
+#: SYMMETRIC AT 0 where the density is exactly Student-t with nu = eta).
+FAMILIES = ("normal", "t", "skewt")
 
 @dataclass(frozen=True)
 class Attempt:
@@ -52,11 +63,18 @@ def _guard(p: dict, family: str) -> tuple[bool, str, float]:
     vals = [p["omega"], p["alpha"], p["gamma"], p["beta"]]
     if family == "t":
         vals.append(p.get("nu", float("nan")))
+    if family == "skewt":
+        vals += [p.get("eta", float("nan")), p.get("lambda", float("nan"))]
     if not all(np.isfinite(v) for v in vals):
         return False, CHANNEL_NON_FINITE, float("nan")
     if p["omega"] <= 0.0 or p["alpha"] < 0.0 or p["beta"] < 0.0 or p["alpha"] + p["gamma"] < 0.0:
         return False, CHANNEL_INVALID_PARAMS, float("nan")
     # E[I(r<0)] = 1/2 for a symmetric innovation, so a GJR's persistence is alpha + gamma/2 + beta.
+    # Kept UNCHANGED for skewt, deliberately: under an asymmetric innovation the exact term is
+    # the half second moment E[z^2 * 1{z<0}], which is not 1/2 — but `cone.gjr_var_path` (frozen,
+    # vendored, shared by every arm) seeds its recursion with omega / (1 - alpha - gamma/2 - beta),
+    # so a guard using a DIFFERENT persistence could admit a fit whose simulator seed is negative.
+    # The screen stays consistent with the simulator; the approximation is documented, not hidden.
     pers = p["alpha"] + p["gamma"] / 2.0 + p["beta"]
     if pers >= 1.0:
         return False, CHANNEL_NON_STATIONARY, float(pers)
@@ -65,20 +83,34 @@ def _guard(p: dict, family: str) -> tuple[bool, str, float]:
     # are finite for any nu > 0; the constraint is about the normalisation, not their existence.
     if family == "t" and not (2.0 < p["nu"] < np.inf):
         return False, CHANNEL_BAD_NU, float(pers)
+    # ARGON-ADDED, skewt only. `eta` is the same normalisation constraint as `nu` above.
+    # `lambda` is Hansen's skewness: the density's b = sqrt(1 + 3*lambda^2 - a^2)
+    # normalisation collapses at |lambda| = 1, so the OPEN interval is the admissible set
+    # and a fit pinned on the bound is rejected rather than published.
+    if family == "skewt":
+        if not (2.0 < p["eta"] < np.inf):
+            return False, CHANNEL_BAD_NU, float(pers)
+        if not (-1.0 < p["lambda"] < 1.0):
+            return False, CHANNEL_BAD_SKEW, float(pers)
     return True, CHANNEL_OK, float(pers)
 
 
 def _attempt(hist: np.ndarray, family: str, grid_index: int, starts) -> Attempt:
-    from arch.univariate import GARCH, Normal, StudentsT, ZeroMean
+    from arch.univariate import GARCH, Normal, SkewStudent, StudentsT, ZeroMean
 
     nan = float("nan")
     r_pct = _to_pct_log(hist)
     if r_pct.size < GJR_MIN_OBS:
         return Attempt(grid_index, False, CHANNEL_TOO_SHORT, nan, nan, False, None)
+    dist = Normal()
+    if family == "t":
+        dist = StudentsT()
+    elif family == "skewt":
+        dist = SkewStudent()  # ARGON-ADDED: Hansen (1994), params (eta, lambda)
     model = ZeroMean(
         r_pct,
         volatility=GARCH(p=1, o=1, q=1),
-        distribution=StudentsT() if family == "t" else Normal(),
+        distribution=dist,
     )
     try:
         kw = {} if starts is None else {"starting_values": np.asarray(starts, dtype=float)}
@@ -95,6 +127,12 @@ def _attempt(hist: np.ndarray, family: str, grid_index: int, starts) -> Attempt:
     }
     if family == "t":
         p["nu"] = float(res.params.get("nu", nan))
+    if family == "skewt":
+        # arch names them exactly "eta" and "lambda"; keep its names so the persisted
+        # params_jsonb is readable against the library that produced them. Extra keys are
+        # inert downstream — `gjr_var_path` / `_gjr_simulate` read omega/alpha/gamma/beta only.
+        p["eta"] = float(res.params.get("eta", nan))
+        p["lambda"] = float(res.params.get("lambda", nan))
     loglik = float(getattr(res, "loglikelihood", nan))
     ok, channel, pers = _guard(p, family)
     if not np.isfinite(loglik):
@@ -129,6 +167,20 @@ def select_attempt(attempts: list[Attempt], *, loglik_tol: float = LOGLIK_TOL) -
     return min(eligible, key=lambda a: a.grid_index)
 
 
+def _start_for(family: str, sv: tuple[float, float, float, float]):
+    """The distribution's starting values appended to a variance start (§3.2's grid).
+
+    ARGON-ADDED for `skewt` only; `normal` and `t` return exactly what the vendored
+    comprehension returned. The skew start is the SYMMETRIC point, so multi-start does not
+    seed an asymmetry the data did not ask for.
+    """
+    if family == "t":
+        return (*sv, T_START_NU)
+    if family == "skewt":
+        return (*sv, T_START_NU, SKEWT_START_LAMBDA)
+    return sv
+
+
 def fit_v8(
     hist: np.ndarray,
     *,
@@ -144,12 +196,12 @@ def fit_v8(
 
     Selection is `select_attempt`'s two-step eligible-set rule.
     """
-    if family not in ("normal", "t"):
-        raise ValueError(f"family must be 'normal' or 't', got {family!r}")
+    if family not in FAMILIES:
+        raise ValueError(f"family must be one of {FAMILIES}, got {family!r}")
 
     grid: list = [None]  # index 0 == the arch package's own default starting values
     if multi_start:
-        grid += [(*sv, T_START_NU) if family == "t" else sv for sv in MULTI_STARTS]
+        grid += [_start_for(family, sv) for sv in MULTI_STARTS]
 
     attempts = [_attempt(hist, family, i, sv) for i, sv in enumerate(grid)]
     won = select_attempt(attempts, loglik_tol=loglik_tol)
@@ -217,6 +269,11 @@ ARMS: dict[str, ArmSpec] = {
     "F": ArmSpec("t", True, False, 0),
     "G": ArmSpec("normal", True, True, MAX_FAILURE_CARRY_DAYS),
     "H": ArmSpec("t", True, True, MAX_FAILURE_CARRY_DAYS),
+    # ARGON-ADDED research arm: arm G's configuration with an ASYMMETRIC innovation
+    # (Hansen skewed-t) in the likelihood. Multi-character key on purpose — it is not one
+    # of signal-lab's lettered v8 arms and must not read as one. Research-only; `forecast.ARM`
+    # stays "G".
+    "SKEWT": ArmSpec("skewt", True, True, MAX_FAILURE_CARRY_DAYS),
 }
 
 

--- a/tests/unit/density/test_fit_skewt.py
+++ b/tests/unit/density/test_fit_skewt.py
@@ -1,0 +1,109 @@
+"""The ARGON-ADDED skewed-t arm: reduction to the symmetric t, bounds, determinism.
+
+Every input here is REAL frozen SPX history — `src/uw_scan/density/data/panel.parquet`,
+the same digest-pinned panel the golden parity test fits. No synthetic returns.
+
+What this arm can and cannot move is worth stating where the tests are: the family enters
+the LIKELIHOOD only. `cone.gjr_std_boot_cone` draws its innovations by block bootstrap from
+the empirical standardized residual pool, so the fitted (eta, lambda) never become the
+shape of a simulated path — they move omega/alpha/gamma/beta, and through them the variance
+path, v_next and the residual pool itself. Nothing else.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from uw_scan.density.constants import (
+    CHANNEL_BAD_SKEW,
+    MAX_FAILURE_CARRY_DAYS,
+    SKEWT_START_LAMBDA,
+)
+from uw_scan.density.fit import ARMS, ArmSpec, _guard, fit_v8
+
+PANEL = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "uw_scan"
+    / "density"
+    / "data"
+    / "panel.parquet"
+)
+
+
+@pytest.fixture(scope="module")
+def spx_returns() -> np.ndarray:
+    closes = (
+        pd.read_parquet(PANEL).sort_values("trade_date")["close"].to_numpy(dtype=float)
+    )
+    return closes[1:] / closes[:-1] - 1.0
+
+
+def test_arm_skewt_is_arm_g_with_an_asymmetric_family() -> None:
+    """Same configuration as the production arm; the innovation family is the ONLY change."""
+    assert ARMS["SKEWT"] == ArmSpec("skewt", True, True, MAX_FAILURE_CARRY_DAYS)
+    g = ARMS["G"]
+    assert (ARMS["SKEWT"].multi_start, ARMS["SKEWT"].retry, ARMS["SKEWT"].max_carry) == (
+        g.multi_start,
+        g.retry,
+        g.max_carry,
+    )
+    assert ARMS["SKEWT"].legacy is False
+    assert ARMS["G"].family == "normal"  # production arm untouched
+
+
+def test_skewed_likelihood_reduces_to_student_t_at_the_symmetric_value(
+    spx_returns: np.ndarray,
+) -> None:
+    """lambda = 0 is not "approximately symmetric" — Hansen's density IS the standardized
+    Student-t there, so the two log-likelihoods must agree to floating-point noise on the
+    same real residuals. This is what makes the arm a strict generalisation of arm H."""
+    from arch.univariate import SkewStudent, StudentsT
+
+    resids = 100.0 * np.log1p(spx_returns[-1500:])
+    sigma2 = np.full_like(resids, float(np.var(resids)))
+    for eta in (4.0, 8.0, 30.0):
+        sym = StudentsT().loglikelihood(
+            np.array([eta]), resids, sigma2, individual=False
+        )
+        skew = SkewStudent().loglikelihood(
+            np.array([eta, SKEWT_START_LAMBDA]), resids, sigma2, individual=False
+        )
+        assert float(skew) == pytest.approx(float(sym), rel=0.0, abs=1e-8)
+
+
+def test_fit_returns_skew_and_df_within_bounds(spx_returns: np.ndarray) -> None:
+    """The fit must produce BOTH extra parameters, admissibly: eta > 2 (the unit-variance
+    standardisation) and |lambda| < 1 (Hansen's b-normalisation)."""
+    params, attempts = fit_v8(spx_returns, family="skewt", multi_start=True)
+    assert params is not None
+    assert set(params) == {"omega", "alpha", "gamma", "beta", "eta", "lambda"}
+    assert 2.0 < params["eta"] < np.inf
+    assert -1.0 < params["lambda"] < 1.0
+    assert len(attempts) == 5  # index 0 = arch's own default + the 4 MULTI_STARTS
+    assert all(np.isfinite(a.loglik) for a in attempts)
+
+
+def test_fit_is_deterministic_across_two_calls(spx_returns: np.ndarray) -> None:
+    """No unseeded randomness anywhere in the estimator: same input, byte-identical output."""
+    a, _ = fit_v8(spx_returns, family="skewt", multi_start=True)
+    b, _ = fit_v8(spx_returns, family="skewt", multi_start=True)
+    assert a == b
+
+
+def test_guard_rejects_a_skew_pinned_on_the_bound() -> None:
+    """|lambda| = 1 collapses the density's normalisation — rejected, never published."""
+    base = {"omega": 0.04, "alpha": 0.01, "gamma": 0.24, "beta": 0.83, "eta": 7.0}
+    ok, channel, _ = _guard({**base, "lambda": -0.2}, "skewt")
+    assert ok and channel == "ok"
+    ok, channel, _ = _guard({**base, "lambda": -1.0}, "skewt")
+    assert not ok and channel == CHANNEL_BAD_SKEW
+
+
+def test_unknown_family_still_raises() -> None:
+    with pytest.raises(ValueError, match="family must be one of"):
+        fit_v8(np.zeros(1000), family="laplace")


### PR DESCRIPTION
Stacked on #421 (`research/density-arm-h`). Adds **one** research arm and the run that scores it. Production `ARM` stays `"G"`; no call site changes; nothing merged.

## The innovation family, and where it actually enters

`density/fit.ARMS["SKEWT"] = ArmSpec("skewt", multi_start=True, retry=True, MAX_FAILURE_CARRY_DAYS)` — arm G's configuration exactly, with **Hansen (1994)'s skewed t** (arch's `SkewStudent`) replacing G's Normal / H's symmetric t in the GJR likelihood. Two extra parameters, arch's own names kept: `eta` (degrees of freedom, bounds [2.05, 300]) and `lambda` (skewness, bounds [-1, 1], **symmetric at 0** — where the density is exactly `StudentsT` with `nu = eta`, which is what makes SKEWT a strict generalisation of arm H and what the reduction test asserts).

**It enters the likelihood only.** `cone.gjr_std_boot_cone` draws its innovations by block bootstrap from the empirical standardized-residual pool `z_t = r_t / sqrt(v_t)` — it never samples from the fitted distribution. So the family can move:

- `omega/alpha/gamma/beta` (the maximiser lands somewhere else),
- and through them the variance path, `v_next`, and the residual pool that gets resampled.

It **cannot** put a skewed innovation shape into a simulated path. A pinball/PIT delta here is the variance parameters an asymmetric likelihood dragged along, not asymmetric draws. That is the single most important thing when reading the numbers below, and it is stated in the module docstring, the test docstring and the run's `notes`.

Two deliberate non-changes:

- **Persistence stays `alpha + gamma/2 + beta`** in `_guard` for skewt too. Under an asymmetric innovation the exact term is the half second moment `E[z^2 1{z<0}]`, which is not 1/2 — but the frozen, shared `cone.gjr_var_path` seeds its recursion with `omega / (1 - alpha - gamma/2 - beta)`. A guard using a *different* persistence could admit a fit whose simulator seed is negative. The screen stays consistent with the simulator; the approximation is documented, not hidden.
- **`MULTI_STARTS` grid starts at the symmetric point** (`SKEWT_START_LAMBDA = 0.0`), so multi-start cannot seed an asymmetry the data did not ask for. `eta` starts at `T_START_NU = 8.0`, same as arm H.

Key is `"SKEWT"`, not a letter: `ARMS` already carries multi-character keys (`A_legacy`, `A_default_v8`) and nothing constrains them to single letters, and it must not read as one of signal-lab's lettered v8 arms. The strategy slug is the requested `spx-density-calibration-arm-skewt` — `strategy_for` lower-cases multi-character arm keys; single letters keep their case because `-arm-H` / `-arm-F` / `-arm-G-seed1` are the only join key back to runs 4–6.

## Is the asymmetry identified?

Yes, and it is not close to a bound. Run 7, `params_grid.fitted_param_ranges`, 82 fitted sessions / 82 (zero fallbacks):

| param | n | min | median | max | note |
| --- | --- | --- | --- | --- | --- |
| omega | 82 | 0.033320 | 0.033843 | 0.034053 | |
| alpha | 82 | 0.000000 | 0.000000 | 0.000000 | pinned at zero, as under G/H |
| gamma | 82 | 0.304809 | 0.307094 | 0.308793 | |
| beta | 82 | 0.834022 | 0.834910 | 0.835463 | |
| eta (df) | 82 | 6.310092 | 6.376451 | 6.415237 | fat tails, far from the 300 bound |
| **lambda (skew)** | 82 | **-0.191567** | **-0.190608** | **-0.187730** | pinned at bound: **0**; exactly 0: **0**; negative: **82/82** |
| persistence | 82 | 0.987867 | 0.988391 | 0.989142 | |

So the likelihood does identify a stable negative skew on every session, and `eta ~ 6.4` says the t tail is doing real work too. The arm is a genuine asymmetric fit — it simply does not buy calibration, because of the bootstrap point above.

## Scoreboard — run 7 vs run 3 (arm G, published) and run 4 (arm H, Student-t)

Same window, same outcomes, same baseline, same metric code (all imported from `spx_density_calibration.py`); `realised_return` and `baseline_q*` are read from `spx_density_forecast`, never recomputed.

### reconstructed (n = 320)

| metric | run 7 (SKEWT) | run 3 (arm G) | run 4 (arm H) |
| --- | --- | --- | --- |
| q05 pinball ratio | 1.0804 | **1.0476** | 1.0790 |
| q90 pinball ratio | 0.9039 | 0.9048 | **0.9038** |
| q95 pinball ratio | **0.8605** | 0.8682 | 0.8611 |
| mean pinball (model) | 0.003074 | **0.003059** | 0.003072 |
| PIT deciles 1+2 | 74 (32+42) | 73 (33+40) | 75 (32+43) |

### prospective (n = 80) — the only live record

| metric | run 7 (SKEWT) | run 3 (arm G) | run 4 (arm H) |
| --- | --- | --- | --- |
| q05 pinball ratio | 0.9569 | 0.9601 | **0.9461** |
| q90 pinball ratio | **0.8817** | 0.9026 | 0.8841 |
| q95 pinball ratio | **0.8791** | 0.9186 | 0.8876 |
| mean pinball (model) | 0.002207 | 0.002230 | **0.002204** |
| PIT deciles 1+2 | 9 (2+7) | 8 (1+7) | 9 (2+7) |

**Read:** SKEWT lands on top of arm H, not beyond it. Prospective q95 improves 0.040 vs G (H improved 0.031); prospective q05 improves 0.003 vs G against the ~0.002 Monte-Carlo noise floor measured by run 5 — i.e. nothing. Reconstructed q05 degrades to 1.080, the same way H did (1.079), and the PIT left tail does not move (9 vs 8 of 80 in deciles 1+2). Every SKEWT-vs-H gap is within the noise floor: adding an identified skew on top of the t buys nothing the t did not already buy, which is exactly what the bootstrap cone predicts. **`ARM` stays `G`.** CAVEAT 4 of the script binds unchanged — this is a re-score of one fixed window, not an out-of-sample arm-selection test.

## Verification

- `uv run ruff check src/ tests/ scripts/` — clean.
- `uv run pytest tests/unit -k density -q` — 44 passed. Includes the untouched golden parity test (arm G vs signal-lab's committed 2026-08-01 run) and 6 new tests in `tests/unit/density/test_fit_skewt.py`, all on **real frozen SPX history** from the digest-pinned `panel.parquet`: skewed likelihood ≡ Student-t at `lambda = 0` (three `eta` values, abs 1e-8); the fit returns `eta`/`lambda` strictly inside bounds; two calls return byte-identical params (no unseeded randomness — `seed_for` still pins the cone); `_guard` rejects `|lambda| = 1` via a new `bad_skew` channel; the arm equals G's spec but for the family.
- Dry run `--dry-run --limit-as-of 2 --arm SKEWT` against the mini, then the full run.
- DB after the run: `backtest_sweep_runs` id **7**, strategy `spx-density-calibration-arm-skewt`, status `completed`, **17/17** ok results; `spx_density_forecast` unchanged at **415 rows, max as_of 2026-09-04**. The run reads `spx_density_forecast` and writes `backtest_sweep_*` only.

**One provenance wrinkle, stated rather than papered over:** run 7's `git_sha` is `8df9c3de` — the branch HEAD at run time — because the arm was verified and run before it was committed. The code that produced run 7 is exactly what this branch's single commit contains (nothing was edited after the run), but `8df9c3de` alone does not carry the SKEWT arm; reproduce from this branch's commit.
