### PR TITLE
feat(flash): render helium's schema-version 3 brief view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ### Added
 
+- **Flash renders helium's schema-version 3 brief view** — `SUPPORTED_SCHEMA_VERSIONS`
+  is now `[1, 2, 3]`, so the weekly and daily Flash pages draw the v3 review
+  document instead of the "Unrenderable version" band. `BriefView` gains the
+  hand-written v3 keys (`focus`, `themes`, `rotation`, `footer`, `faults`,
+  `oneThing`, `checks`, `changeMyMind`, `everythingElse`, plus the previously
+  unmodelled `staleness`, `spyForecast`, `runLabel`, `appBase`, `cause`), and
+  each group gets one panel: `FocusPanel` (rank / ticker / event / IV rank /
+  open call, with the run's churn and its carried-over marks), `ThemesPanel`
+  (verdict token, both excess strings, the kill condition and whether it was
+  met), `RotationPanel` (excess vs the run's benchmark; a symbol whose bars did
+  not arrive prints **untested** in every cell with the reason underneath,
+  never a flat zero), `FooterPanel` (coverage / as-of / notes / stale inputs,
+  verbatim), `OneThingPanel` (the claim, its three checks and the
+  change-my-mind condition) and `EverythingElsePanel`. `RunFaultsPanel` now
+  prints v3's per-item `faults` beside the `degradation` sentence. Order
+  follows helium's own argument: the claim first, the leftovers last.
+  Coverage verdicts (`CONTINUE` / `STRENGTHEN` / `FADE` / `REVERSE` /
+  `UNTESTED`) are set apart as chips inside the review prose — the closed list
+  decides, so a renamed verdict prints as written rather than vanishing. There
+  is deliberately no per-check hit/miss pill: no stored run carries a per-check
+  verdict, and helium scores yesterday's checks in one sentence
+  (`oneThing.checksLine`), which is printed instead. v2 and v1 documents render
+  exactly as before — `asBriefView` on a v2 document is still a pass-through.
+  Frozen fixtures are the real rows: the weekly run of 2026-09-06 and the close
+  run of 2026-09-04.
+
 - **SPX density cone calibration 复盘** — `scripts/research/spx_density_calibration.py`.
   `spx_density_forecast` settles each row as `realised_return` + `inside_band80`
   and nothing else, so the only calibration number the desk had was the 80%

--- a/web/components/flash/Body.tsx
+++ b/web/components/flash/Body.tsx
@@ -19,27 +19,60 @@ const ATOMIC_CELL =
 const STATIC_ONLY = tickerSet();
 
 /**
- * A ticker inside a sentence, set apart from the sentence.
+ * A coverage verdict, as v3's review sections write it: one bare uppercase
+ * word per layer. Closed set on purpose — anything else stays plain text, so
+ * a verdict helium renames prints as written instead of vanishing into a chip
+ * argon guessed at.
+ */
+const COVERAGE_TOKENS: Record<string, "up" | "down" | "hold"> = {
+  CONTINUE: "up",
+  STRENGTHEN: "up",
+  FADE: "down",
+  REVERSE: "down",
+  UNTESTED: "hold",
+};
+
+/** A ticker OR a coverage verdict. Longest alternative first, or `\b[A-Z]{1,5}\b` eats CONTI. */
+const PROSE_TOKEN = new RegExp(
+  `\\b(?:${Object.keys(COVERAGE_TOKENS).join("|")})\\b|${TICKER_TOKEN.source}`,
+  "g",
+);
+
+/**
+ * A ticker or a coverage verdict inside a sentence, set apart from it.
  *
- * The prose is the run's and is never rewritten — only wrapped. Membership in
- * the page's ticker set decides; the token pattern alone would make a symbol
- * out of every "ET", "OAS" or "RTH" helium writes. Nothing else in the string
- * moves, so a paragraph reads the same whether or not a name was recognised.
+ * The prose is the run's and is never rewritten — only wrapped. For a ticker,
+ * membership in the page's ticker set decides; the token pattern alone would
+ * make a symbol out of every "ET", "OAS" or "RTH" helium writes. For a
+ * verdict, the closed list above decides. Nothing else in the string moves, so
+ * a paragraph reads the same whether or not a token was recognised.
  */
 function highlight(text: string, tickers: ReadonlySet<string>): ReactNode {
-  TICKER_TOKEN.lastIndex = 0;
+  PROSE_TOKEN.lastIndex = 0;
   const out: ReactNode[] = [];
   let cursor = 0;
   let match: RegExpExecArray | null;
-  while ((match = TICKER_TOKEN.exec(text)) !== null) {
-    if (!tickers.has(match[0])) continue;
+  while ((match = PROSE_TOKEN.exec(text)) !== null) {
+    const token = match[0];
+    const cov = COVERAGE_TOKENS[token];
+    if (!cov && !tickers.has(token)) continue;
     if (match.index > cursor) out.push(text.slice(cursor, match.index));
     out.push(
-      <span key={`${match.index}-${match[0]}`} className={styles.tick}>
-        {match[0]}
-      </span>,
+      cov ? (
+        <span
+          key={`${match.index}-${token}`}
+          className={styles.cov}
+          data-cov={cov}
+        >
+          {token}
+        </span>
+      ) : (
+        <span key={`${match.index}-${token}`} className={styles.tick}>
+          {token}
+        </span>
+      ),
     );
-    cursor = match.index + match[0].length;
+    cursor = match.index + token.length;
   }
   if (out.length === 0) return text;
   if (cursor < text.length) out.push(text.slice(cursor));

--- a/web/components/flash/EverythingElsePanel.tsx
+++ b/web/components/flash/EverythingElsePanel.tsx
@@ -1,0 +1,20 @@
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+/**
+ * What the run saw and deliberately did not build the argument on.
+ *
+ * It sits BELOW the claim for that reason: printing it first would make the
+ * leftovers compete with the one thing the run actually decided.
+ */
+export function EverythingElsePanel({ items }: { items: string[] }) {
+  return (
+    <Panel title="Everything else" tail={`${items.length} not the argument`}>
+      <ul className={styles.bodyList}>
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}

--- a/web/components/flash/FocusPanel.tsx
+++ b/web/components/flash/FocusPanel.tsx
@@ -1,0 +1,75 @@
+import type { FocusBlock } from "./view";
+
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+/**
+ * The names under watch, in the run's own order.
+ *
+ * Rank is the row's position — helium ranked the list when it wrote it, and
+ * re-sorting here would silently disagree with the numbered list the same run
+ * printed in prose. An IV rank is 0–100 as computed; a missing one is an em
+ * dash, never a zero. `sticky` marks a name carried over rather than picked
+ * fresh, and the open-call id is printed verbatim because it is the key that
+ * ties this row to the call it continues.
+ */
+export function FocusPanel({ focus }: { focus: FocusBlock }) {
+  const rows = focus.rows ?? [];
+  const period = focus.period === "weekly" ? "this week" : "today";
+  return (
+    <Panel title="Focus" tail={`${rows.length} names · ${period}`}>
+      <div className={styles.scrollx}>
+        <table>
+          <thead>
+            <tr>
+              <th className="n">#</th>
+              <th>Ticker</th>
+              <th>Event</th>
+              <th className="n">IV rank</th>
+              <th>Open call</th>
+              <th>Why</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={`${r.ticker}-${i}`}>
+                <td className="n" style={{ color: "var(--text-muted)" }}>
+                  {i + 1}
+                </td>
+                <td className={styles.mono} style={{ fontWeight: 700 }}>
+                  {r.ticker}
+                  {r.sticky ? (
+                    <span
+                      className={styles.sticky}
+                      title="carried over from the previous run"
+                    >
+                      ●
+                    </span>
+                  ) : null}
+                </td>
+                <td className={styles.sans}>{r.event || "—"}</td>
+                <td className="n">
+                  {typeof r.ivRank === "number" ? r.ivRank.toFixed(0) : "—"}
+                </td>
+                <td
+                  className={styles.mono}
+                  style={{ fontSize: 10.5, color: "var(--text-muted)" }}
+                >
+                  {r.openCall ?? "—"}
+                </td>
+                <td className={styles.sans}>{r.why || "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className={styles.note}>
+        {typeof focus.churn === "number"
+          ? `churn ${focus.churn}`
+          : "churn not recorded"}
+        {focus.shortfall ? ` · ${focus.shortfall}` : ""}
+        {rows.some((r) => r.sticky) ? " · ● carried over" : ""}
+      </div>
+    </Panel>
+  );
+}

--- a/web/components/flash/FooterPanel.tsx
+++ b/web/components/flash/FooterPanel.tsx
@@ -1,0 +1,53 @@
+import type { BriefFooter } from "./view";
+
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+function List({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div className={styles.lbl} style={{ marginBottom: 4 }}>
+        {label}
+      </div>
+      <ul
+        className={styles.mono}
+        style={{
+          margin: 0,
+          paddingLeft: 16,
+          fontSize: 11,
+          lineHeight: 1.7,
+          color: "var(--text-muted)",
+          wordBreak: "break-word",
+        }}
+      >
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Which layer came from which source, when each was read, and what qualifies
+ * it. Printed verbatim: an as-of line rewritten into argon's own format is a
+ * provenance claim argon did not make.
+ */
+export function FooterPanel({
+  footer,
+  staleness,
+}: {
+  footer: BriefFooter;
+  staleness?: string[];
+}) {
+  const stale = staleness ?? [];
+  return (
+    <Panel title="Sources & as-of" tail="this run">
+      <List label="coverage" items={footer.coverage ?? []} />
+      <List label="as of" items={footer.asOf ?? []} />
+      <List label="notes" items={footer.notes ?? []} />
+      <List label="stale inputs" items={stale} />
+    </Panel>
+  );
+}

--- a/web/components/flash/OneThingPanel.tsx
+++ b/web/components/flash/OneThingPanel.tsx
@@ -1,0 +1,120 @@
+import type { Check, ChangeMyMind, OneThing } from "./view";
+
+import { Body } from "./Body";
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+/**
+ * The three checks the claim will be scored against tomorrow.
+ *
+ * Each one names a series, the level it sits at now, and the question that
+ * settles it — a claim with no stated check cannot be wrong, which is the
+ * failure this block exists to prevent.
+ *
+ * There is deliberately NO hit / miss / not-observed pill: no stored run
+ * carries a per-check verdict field. helium scores yesterday's checks in one
+ * sentence (`oneThing.checksLine`), which is printed above, and inventing a
+ * per-row state here would be argon scoring a check it never observed.
+ */
+export function ChecksList({ checks }: { checks: Check[] }) {
+  return (
+    <ol className={styles.checks}>
+      {checks.map((c, i) => (
+        <li key={i}>
+          <div className={styles.checkHead}>
+            <span className={styles.mono} style={{ fontWeight: 700 }}>
+              {c.series ?? "—"}
+            </span>
+            {c.level ? (
+              <span className={`${styles.mono} ${styles.checkLevel}`}>
+                at {c.level}
+              </span>
+            ) : null}
+          </div>
+          <span className={styles.checkText}>{c.text}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * The day's single claim, what would settle it, and what would break it.
+ *
+ * Order is the argument: the claim, then why it is the claim, then the checks
+ * that can falsify it, then the condition under which the run would drop it.
+ * Nothing below this panel outranks it.
+ */
+export function OneThingPanel({
+  oneThing,
+  checks,
+  changeMyMind,
+  tickers,
+}: {
+  oneThing?: OneThing;
+  checks?: Check[];
+  changeMyMind?: ChangeMyMind;
+  tickers?: ReadonlySet<string>;
+}) {
+  if (!oneThing && !(checks && checks.length > 0) && !changeMyMind) return null;
+
+  // helium sometimes opens the body with the same scoring sentence it puts in
+  // `checksLine`. Printing both makes the run look like it scored yesterday
+  // twice, so the standalone line is dropped when the body already carries it.
+  const checksLine =
+    oneThing?.checksLine && !oneThing.body?.includes(oneThing.checksLine)
+      ? oneThing.checksLine
+      : null;
+
+  return (
+    <Panel
+      title={oneThing?.title || "The one thing"}
+      tail={oneThing?.why || undefined}
+    >
+      {oneThing?.body ? <Body text={oneThing.body} tickers={tickers} /> : null}
+
+      {checksLine ? (
+        <p
+          style={{
+            margin: "10px 0 0",
+            fontSize: 11.5,
+            color: "var(--text-muted)",
+          }}
+        >
+          {checksLine}
+        </p>
+      ) : null}
+
+      {checks && checks.length > 0 ? (
+        <>
+          <div className={styles.lbl} style={{ margin: "12px 0 6px" }}>
+            checks · settle tomorrow
+          </div>
+          <ChecksList checks={checks} />
+        </>
+      ) : null}
+
+      {changeMyMind ? (
+        <div className={styles.cmm}>
+          <div className={styles.lbl} style={{ marginBottom: 4 }}>
+            change my mind
+          </div>
+          <p style={{ margin: 0 }}>{changeMyMind.text}</p>
+          {changeMyMind.series ||
+          changeMyMind.threshold ||
+          changeMyMind.horizon ? (
+            <div className={styles.cmmMeta}>
+              {[
+                changeMyMind.series,
+                changeMyMind.threshold,
+                changeMyMind.horizon,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/web/components/flash/PremarketView.tsx
+++ b/web/components/flash/PremarketView.tsx
@@ -2,8 +2,12 @@ import { CandidateCard } from "./CandidateCard";
 import { CoveragePanel } from "./CoveragePanel";
 import { DecisionBlock } from "./DecisionBlock";
 import { PlaceholderBand } from "./EmptyStates";
+import { EverythingElsePanel } from "./EverythingElsePanel";
+import { FocusPanel } from "./FocusPanel";
+import { FooterPanel } from "./FooterPanel";
 import { GammaProfilePanel } from "./GammaProfilePanel";
 import { Lead } from "./Lead";
+import { OneThingPanel } from "./OneThingPanel";
 import { OvernightPanel } from "./OvernightPanel";
 import { Panel } from "./Panel";
 import { PolicyPathPanel } from "./PolicyPathPanel";
@@ -11,6 +15,7 @@ import { RiskRegisterPanel } from "./RiskRegisterPanel";
 import { SchedulePanel } from "./SchedulePanel";
 import { SectionsPanel } from "./SectionsPanel";
 import { TapeStrip } from "./TapeStrip";
+import { ThemesPanel } from "./ThemesPanel";
 import { faultList, viewTickers, type BriefView } from "./view";
 import styles from "./flash.module.css";
 
@@ -39,6 +44,9 @@ export function PremarketView({ view }: { view: BriefView }) {
 
   const lead = view.lead ?? view.headline;
   const tickers = viewTickers(view);
+  // v3 keeps two fault lists: `degradation` is one sentence about the run,
+  // `faults` is the per-item refusals. Both are the run's, so both print.
+  const faults = [...faultList(view.degradation), ...(view.faults ?? [])];
 
   return (
     <>
@@ -50,16 +58,23 @@ export function PremarketView({ view }: { view: BriefView }) {
           <Lead label={["Today in", "one sentence"]} text={lead} />
         </div>
       ) : null}
-      {faultList(view.degradation).length > 0 ? (
+      {faults.length > 0 ? (
         <div style={{ marginTop: 12 }}>
           <PlaceholderBand label="Run degraded">
-            {faultList(view.degradation).join(" · ")}
+            {faults.join(" · ")}
           </PlaceholderBand>
         </div>
       ) : null}
 
       <div className={styles.cols}>
         <div className={styles.colL}>
+          <OneThingPanel
+            oneThing={view.oneThing}
+            checks={view.checks}
+            changeMyMind={view.changeMyMind}
+            tickers={tickers}
+          />
+
           {view.decision && view.decision.length > 0 ? (
             <Panel title="The call" bodyClassName="">
               <DecisionBlock rows={view.decision} />
@@ -95,6 +110,18 @@ export function PremarketView({ view }: { view: BriefView }) {
               tickers={tickers}
             />
           ) : null}
+
+          {view.focus && view.focus.rows?.length ? (
+            <FocusPanel focus={view.focus} />
+          ) : null}
+
+          {view.themes && view.themes.length > 0 ? (
+            <ThemesPanel themes={view.themes} />
+          ) : null}
+
+          {view.everythingElse && view.everythingElse.length > 0 ? (
+            <EverythingElsePanel items={view.everythingElse} />
+          ) : null}
         </div>
 
         <div className={styles.colR}>
@@ -114,6 +141,9 @@ export function PremarketView({ view }: { view: BriefView }) {
           ) : null}
           {view.coverage ? (
             <CoveragePanel coverage={view.coverage} tickers={tickers} />
+          ) : null}
+          {view.footer ? (
+            <FooterPanel footer={view.footer} staleness={view.staleness} />
           ) : null}
         </div>
       </div>

--- a/web/components/flash/RotationPanel.tsx
+++ b/web/components/flash/RotationPanel.tsx
@@ -1,0 +1,91 @@
+import type { Rotation, RotationRow } from "./view";
+
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+/** One percentage as helium measured it. `null` is untested, never zero. */
+function pct(v: number | null | undefined): string {
+  if (typeof v !== "number" || !Number.isFinite(v)) return "untested";
+  return `${v > 0 ? "+" : ""}${v.toFixed(1)}`;
+}
+
+function cell(v: number | null | undefined) {
+  const missing = typeof v !== "number" || !Number.isFinite(v);
+  return (
+    <td
+      className="n"
+      style={{
+        color: missing
+          ? "var(--text-muted)"
+          : v! > 0
+            ? "var(--positive)"
+            : v! < 0
+              ? "var(--negative)"
+              : "var(--text-secondary)",
+        fontStyle: missing ? "italic" : undefined,
+      }}
+    >
+      {pct(v)}
+    </td>
+  );
+}
+
+/**
+ * What led and what lagged, and by how much against the benchmark.
+ *
+ * A symbol whose bars did not arrive prints "untested" in every cell and
+ * carries the run's reason underneath — the one thing a rotation table must
+ * never do is let a missing week read as a flat week.
+ */
+export function RotationPanel({ rotation }: { rotation: Rotation }) {
+  const rows: RotationRow[] = rotation.rows ?? [];
+  const stale = rows.filter((r) => r.untested);
+  const tail = [
+    rotation.benchmark ? `vs ${rotation.benchmark}` : null,
+    rotation.asOf ? `as of ${rotation.asOf}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Panel title="Rotation" tail={tail || undefined}>
+      <div className={styles.scrollx}>
+        <table>
+          <thead>
+            <tr>
+              <th>Symbol</th>
+              <th className="n">1w</th>
+              <th className="n">4w</th>
+              <th className="n">12w</th>
+              <th className="n">1w excess</th>
+              <th className="n">4w excess</th>
+              <th className="n">12w excess</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={`${r.symbol}-${i}`}>
+                <td className={styles.mono} style={{ fontWeight: 700 }}>
+                  {r.label || r.symbol}
+                </td>
+                {cell(r.w1)}
+                {cell(r.w4)}
+                {cell(r.w12)}
+                {cell(r.excess1w)}
+                {cell(r.excess4w)}
+                {cell(r.excess12w)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {stale.length > 0 ? (
+        <div className={styles.note}>
+          {stale
+            .map((r) => `${r.label || r.symbol}: ${r.untested}`)
+            .join(" · ")}
+        </div>
+      ) : null}
+    </Panel>
+  );
+}

--- a/web/components/flash/SupplementView.tsx
+++ b/web/components/flash/SupplementView.tsx
@@ -5,15 +5,20 @@ import type { AgentRunIndexRow } from "@/lib/api";
 import { Body } from "./Body";
 import { CandidateCard } from "./CandidateCard";
 import { DecisionBlock } from "./DecisionBlock";
+import { EverythingElsePanel } from "./EverythingElsePanel";
+import { FocusPanel } from "./FocusPanel";
+import { FooterPanel } from "./FooterPanel";
 import { GexDeltaTable } from "./GexDeltaTable";
 import { GexLevelsTable } from "./GexLevelsTable";
 import { Lead } from "./Lead";
+import { OneThingPanel } from "./OneThingPanel";
 import { Panel } from "./Panel";
 import { RiskRegisterPanel } from "./RiskRegisterPanel";
 import { RunFaultsPanel } from "./RunFaultsPanel";
 import { SectionsPanel } from "./SectionsPanel";
 import { StatePill } from "./StatePill";
 import { TapeStrip } from "./TapeStrip";
+import { ThemesPanel } from "./ThemesPanel";
 import {
   faultList,
   viewTickers,
@@ -93,6 +98,25 @@ export function SupplementView({
 
       <div className={styles.supgrid}>
         <div className={styles.colL}>
+          <OneThingPanel
+            oneThing={view.oneThing}
+            checks={view.checks}
+            changeMyMind={view.changeMyMind}
+            tickers={tickers}
+          />
+
+          {view.focus && view.focus.rows?.length ? (
+            <FocusPanel focus={view.focus} />
+          ) : null}
+
+          {view.themes && view.themes.length > 0 ? (
+            <ThemesPanel themes={view.themes} />
+          ) : null}
+
+          {view.everythingElse && view.everythingElse.length > 0 ? (
+            <EverythingElsePanel items={view.everythingElse} />
+          ) : null}
+
           {view.status && view.status.length > 0 ? (
             <Panel
               title={statusTitle}
@@ -179,8 +203,12 @@ export function SupplementView({
 
           <RunFaultsPanel
             runId={view.runId}
-            faults={faultList(view.degradation)}
+            faults={[...faultList(view.degradation), ...(view.faults ?? [])]}
           />
+
+          {view.footer ? (
+            <FooterPanel footer={view.footer} staleness={view.staleness} />
+          ) : null}
         </div>
       </div>
     </>

--- a/web/components/flash/ThemesPanel.tsx
+++ b/web/components/flash/ThemesPanel.tsx
@@ -1,0 +1,100 @@
+import type { Theme } from "./view";
+
+import { Panel } from "./Panel";
+import styles from "./flash.module.css";
+
+/** continue / strengthen → up, fade / reverse → down, anything else neutral. */
+function toneOf(token: string): "up" | "down" | "hold" {
+  const t = token.toLowerCase();
+  if (t === "strengthen" || t === "continue") return "up";
+  if (t === "fade" || t === "reverse") return "down";
+  return "hold";
+}
+
+/**
+ * The standing themes, each with the condition that would end it.
+ *
+ * The kill line is the point of the block: a theme without a stated exit is an
+ * opinion that can never be wrong. `killMet` is helium's verdict, so the row
+ * says KILL MET rather than argon re-testing the condition it did not measure.
+ * The excess figures are printed as the run wrote them — sign, unit and all.
+ */
+export function ThemesPanel({ themes }: { themes: Theme[] }) {
+  return (
+    <Panel title="Themes" tail={`${themes.length} standing`}>
+      {themes.map((t, i) => (
+        <div
+          key={`${t.id}-${i}`}
+          style={{
+            padding: "10px 0",
+            borderBottom:
+              i === themes.length - 1
+                ? undefined
+                : "1px solid rgba(30, 41, 59, .55)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 10,
+              alignItems: "baseline",
+              marginBottom: 5,
+            }}
+          >
+            <span
+              className={styles.mono}
+              style={{ fontSize: 12, fontWeight: 700 }}
+            >
+              {t.id}
+            </span>
+            {t.token ? (
+              <span className={styles.state} data-state={toneOf(t.token)}>
+                {t.token}
+              </span>
+            ) : null}
+            <div className={styles.lvls}>
+              <div>
+                <span className={styles.lbl}>1w excess</span>
+                <span className={styles.mono}>{t.excess1w ?? "—"}</span>
+              </div>
+              <div>
+                <span className={styles.lbl}>since entered</span>
+                <span className={styles.mono}>
+                  {t.excessSinceEntered ?? "—"}
+                </span>
+              </div>
+            </div>
+          </div>
+          {t.leadership ? (
+            <div className={styles.lbl} style={{ marginBottom: 4 }}>
+              leadership {t.leadership}
+            </div>
+          ) : null}
+          {t.why ? (
+            <p
+              className={styles.bodyText}
+              style={{ margin: "0 0 5px", fontSize: 12.5 }}
+            >
+              {t.why}
+            </p>
+          ) : null}
+          {t.kill ? (
+            <p
+              style={{
+                margin: 0,
+                fontSize: 11.5,
+                lineHeight: 1.5,
+                color: t.killMet ? "var(--negative)" : "var(--text-muted)",
+              }}
+            >
+              <span className={styles.lbl}>
+                {t.killMet ? "kill met" : "kill"}
+              </span>{" "}
+              {t.kill}
+            </p>
+          ) : null}
+        </div>
+      ))}
+    </Panel>
+  );
+}

--- a/web/components/flash/WeeklyView.tsx
+++ b/web/components/flash/WeeklyView.tsx
@@ -1,9 +1,14 @@
 import type { AgentRunIndexRow, AgentRunResponse } from "@/lib/api";
 import { weekDays, weekRange } from "@/lib/flash/kinds";
 
+import { FocusPanel } from "./FocusPanel";
+import { FooterPanel } from "./FooterPanel";
 import { Panel } from "./Panel";
+import { RotationPanel } from "./RotationPanel";
+import { RunFaultsPanel } from "./RunFaultsPanel";
 import { SectionsPanel } from "./SectionsPanel";
-import { asBriefView, viewTickers } from "./view";
+import { ThemesPanel } from "./ThemesPanel";
+import { asBriefView, faultList, viewTickers } from "./view";
 import styles from "./flash.module.css";
 
 /**
@@ -28,6 +33,12 @@ export function WeeklyView({
   const { first, last } = weekRange(weekKey);
   const weeklyView = weekly ? asBriefView(weekly) : null;
   const frankView = frank ? asBriefView(frank) : null;
+  const weeklyTickers = weeklyView ? viewTickers(weeklyView) : null;
+  // v3 keeps two fault lists: `degradation` is one sentence about the run,
+  // `faults` is the per-item refusals. Both are the run's, so both print.
+  const weeklyFaults = weeklyView
+    ? [...faultList(weeklyView.degradation), ...(weeklyView.faults ?? [])]
+    : [];
 
   return (
     <>
@@ -88,12 +99,35 @@ export function WeeklyView({
           {weeklyView &&
           weeklyView.sections &&
           weeklyView.sections.length > 0 ? (
-            <SectionsPanel
-              title="Week ahead"
-              tail={weeklyView.asOf}
-              sections={weeklyView.sections}
-              tickers={viewTickers(weeklyView)}
-            />
+            <>
+              <SectionsPanel
+                title="Week ahead"
+                tail={weeklyView.asOf}
+                sections={weeklyView.sections}
+                tickers={weeklyTickers ?? undefined}
+              />
+              {weeklyView.focus && weeklyView.focus.rows?.length ? (
+                <FocusPanel focus={weeklyView.focus} />
+              ) : null}
+              {weeklyView.themes && weeklyView.themes.length > 0 ? (
+                <ThemesPanel themes={weeklyView.themes} />
+              ) : null}
+              {weeklyView.rotation && weeklyView.rotation.rows?.length ? (
+                <RotationPanel rotation={weeklyView.rotation} />
+              ) : null}
+              {weeklyView.footer ? (
+                <FooterPanel
+                  footer={weeklyView.footer}
+                  staleness={weeklyView.staleness}
+                />
+              ) : null}
+              {weeklyFaults.length > 0 ? (
+                <RunFaultsPanel
+                  runId={weeklyView.runId}
+                  faults={weeklyFaults}
+                />
+              ) : null}
+            </>
           ) : (
             <Panel title="Week ahead" tail="not yet available">
               <SlotEmpty

--- a/web/components/flash/flash.module.css
+++ b/web/components/flash/flash.module.css
@@ -967,3 +967,91 @@
     transition: none !important;
   }
 }
+
+/* ---------- v3 review blocks ---------- */
+
+/* A focus name the run carried over rather than picked fresh. A dot, not a
+   word: the column is already a list of tickers and a second word per row
+   would compete with the symbol it qualifies. */
+.sticky {
+  margin-left: 5px;
+  font-size: 8px;
+  vertical-align: middle;
+  color: var(--accent-warm);
+}
+
+/* The three checks. Numbered because helium issues exactly three and scores
+   them as a set — a bulleted list would read as three unrelated notes. */
+.checks {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.checks > li + li {
+  margin-top: 7px;
+}
+
+.checkHead {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 11.5px;
+}
+
+.checkLevel {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.checkText {
+  display: block;
+  max-width: 80ch;
+}
+
+/* The condition that would break the read. Bordered off from the claim above
+   it: it is the run arguing against itself, not more of the same argument. */
+.cmm {
+  margin-top: 12px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-dim);
+  border-left: 2px solid var(--negative);
+  border-radius: 3px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.cmmMeta {
+  margin-top: 5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+/* A coverage verdict inside a run's prose: CONTINUE / STRENGTHEN / FADE /
+   REVERSE / UNTESTED. Set apart the way a ticker is — the word is the run's
+   own, printed as written, only made findable down a list of twelve layers. */
+.cov {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 0 5px;
+  border: 1px solid var(--border-dim);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.cov[data-cov="up"] {
+  color: var(--positive);
+  border-color: rgba(5, 173, 152, 0.45);
+}
+
+.cov[data-cov="down"] {
+  color: var(--negative);
+  border-color: rgba(232, 93, 108, 0.45);
+}

--- a/web/components/flash/view.ts
+++ b/web/components/flash/view.ts
@@ -17,15 +17,18 @@ import { tickerSet } from "@/lib/flash/tickers";
 /**
  * The shapes this build knows how to draw.
  *
- * TWO of them, deliberately. The producer and this consumer deploy on separate
- * schedules, so there is always a window where one is ahead: v1 puts the target
- * in prose and v2 puts it in `{level, side}` with the sentence moved to
- * `thesis`. Refusing v1 during that window would blank a page over a field
- * that is only differently spelled.
+ * THREE of them, deliberately. The producer and this consumer deploy on
+ * separate schedules, so there is always a window where one is ahead: v1 puts
+ * the target in prose and v2 puts it in `{level, side}` with the sentence moved
+ * to `thesis`; v3 keeps every v2 key and ADDS the review blocks (`focus`,
+ * `themes`, `rotation`, `oneThing`, `checks`, `footer`, `faults`). Refusing an
+ * older version during that window would blank a page over a field that is
+ * only differently spelled, and refusing v3 blanks a page whose v2 half argon
+ * already knows how to draw.
  */
-export const SUPPORTED_SCHEMA_VERSIONS: readonly number[] = [1, 2];
+export const SUPPORTED_SCHEMA_VERSIONS: readonly number[] = [1, 2, 3];
 /** @deprecated The newest shape; prefer `SUPPORTED_SCHEMA_VERSIONS`. */
-export const SUPPORTED_SCHEMA_VERSION = 2;
+export const SUPPORTED_SCHEMA_VERSION = 3;
 
 export interface Leg {
   right: "call" | "put";
@@ -151,6 +154,123 @@ export interface GammaProfile {
   levels: GammaLevel[];
 }
 
+/* ---------- v3: the review blocks ---------- */
+
+/**
+ * One name the run is watching, and why it is on the list.
+ *
+ * `openCall` is helium's own id for the call this row continues
+ * (`2026-09-04-close-focus-ADBE`); `sticky` marks a name the run kept rather
+ * than picked fresh. Both are the run's bookkeeping, printed, never derived.
+ */
+export interface FocusRow {
+  ticker: string;
+  event: string;
+  why?: string;
+  /** 0–100, as helium computed it. */
+  ivRank?: number;
+  openCall?: string;
+  sticky?: boolean;
+}
+
+/** The focus list, with the run's own count of how much of it changed. */
+export interface FocusBlock {
+  period?: "weekly" | "daily" | string;
+  rows: FocusRow[];
+  /** Why the list is short of its target length, when it is. */
+  shortfall?: string;
+  churn?: number;
+}
+
+/**
+ * A standing theme and the condition that would end it.
+ *
+ * The excess figures are STRINGS ("+6.5%") — helium's own formatting, sign and
+ * unit included, so argon never re-derives a number it did not measure.
+ */
+export interface Theme {
+  id: string;
+  /** continue / strengthen / fade / reverse — the run's word, lowercased. */
+  token: string;
+  excess1w?: string;
+  excessSinceEntered?: string;
+  leadership?: string;
+  why?: string;
+  kill?: string;
+  killMet?: boolean;
+}
+
+/**
+ * One basket row. Every number is nullable: a symbol whose bars did not
+ * arrive is `untested`, carrying the reason instead of a figure. A null is
+ * never drawn as a zero.
+ */
+export interface RotationRow {
+  symbol: string;
+  label: string;
+  w1: number | null;
+  w4: number | null;
+  w12: number | null;
+  excess1w: number | null;
+  excess4w: number | null;
+  excess12w: number | null;
+  /** Present only when the row has no numbers, e.g. "no bar on 2026-08-28". */
+  untested?: string;
+}
+
+export interface Rotation {
+  asOf?: string;
+  /** The symbol every excess column is measured against. */
+  benchmark?: string;
+  rows: RotationRow[];
+}
+
+/** What the run read, from where, and what it could not reach. */
+export interface BriefFooter {
+  coverage?: string[];
+  asOf?: string[];
+  notes?: string[];
+}
+
+/** The single claim the run is making today, and yesterday's scoring line. */
+export interface OneThing {
+  title: string;
+  body: string;
+  why?: string;
+  /**
+   * How yesterday's three checks came out, as ONE sentence helium wrote.
+   * The scoring is prose on purpose: no stored run carries a per-check
+   * verdict field, so argon prints the line rather than inventing a state.
+   */
+  checksLine?: string;
+}
+
+/** One falsifiable check on the claim: a series, the level it sits at, the question. */
+export interface Check {
+  series?: string;
+  /** A string, not a number: helium writes "50.7" for a probability and "14.32" for an index. */
+  level?: string;
+  text: string;
+}
+
+/** The condition that would break the day's read. */
+export interface ChangeMyMind {
+  series?: string;
+  text: string;
+  threshold?: string;
+  horizon?: string;
+}
+
+/** The run's SPY forecast, kept for the record. Not drawn by this build. */
+export interface SpyForecast {
+  scorable?: boolean;
+  forecast?: {
+    t1Down?: number | null;
+    t5Down?: number | null;
+    referenceClose?: { date?: string; value?: number };
+  };
+}
+
 export interface BriefView {
   schemaVersion?: number;
   date: string;
@@ -185,6 +305,37 @@ export interface BriefView {
   empty?: boolean;
   charts?: Record<string, unknown>;
   edited?: string;
+
+  /* ---------- v3 ---------- */
+  /** The names under watch this period. Weekly and daily both write one. */
+  focus?: FocusBlock;
+  /** Standing themes and their kill conditions. */
+  themes?: Theme[];
+  /** Weekly only: the basket table, excess measured against `benchmark`. */
+  rotation?: Rotation;
+  /** Sources, as-of stamps, and the notes that qualify them. */
+  footer?: BriefFooter;
+  /**
+   * v3's own fault list. Separate from `degradation`, which is one joined
+   * sentence about the whole run: these are per-item refusals ("focus TSLA:
+   * not on the computed list"). Both are printed, neither replaces the other.
+   */
+  faults?: string[];
+  /** Daily: the one claim, its checks, and what would break it. */
+  oneThing?: OneThing;
+  checks?: Check[];
+  changeMyMind?: ChangeMyMind;
+  /** Everything the run saw that did not make the argument. */
+  everythingElse?: string[];
+  /** Inputs the run used past their freshness, each with how far behind. */
+  staleness?: string[];
+  spyForecast?: SpyForecast;
+  /** "weekly" / "close" — helium's label for the job that wrote this. */
+  runLabel?: string;
+  /** The base URL helium linked back to. Display-only; argon never follows it. */
+  appBase?: string;
+  /** Whether the run located a cause for the day's move. Shape not yet fixed. */
+  cause?: unknown;
 }
 
 /**
@@ -231,6 +382,8 @@ export function viewTickers(view: BriefView): Set<string> {
   for (const g of view.gamma ?? []) found.push(lead(g?.ticker));
   for (const g of view.gex ?? []) found.push(lead(g?.ticker));
   for (const s of view.status ?? []) found.push(lead(s?.title));
+  for (const f of view.focus?.rows ?? []) found.push(lead(f?.ticker));
+  for (const r of view.rotation?.rows ?? []) found.push(lead(r?.symbol));
   for (const r of view.riskList ?? []) found.push(lead(r?.title));
   return tickerSet(found);
 }

--- a/web/lib/flash/markdown.ts
+++ b/web/lib/flash/markdown.ts
@@ -87,19 +87,38 @@ export function parseBlocks(text: string): Block[] {
       }
     }
 
-    if (lines.every((l) => l.startsWith("- "))) {
-      blocks.push({ type: "ul", items: lines.map((l) => l.slice(2).trim()) });
-      continue;
+    // Schema-3 bodies are block-level markdown joined by SINGLE newlines: a bare
+    // heading line followed by "- " bullets, or several bare lines that are each
+    // their own statement. Group consecutive lines by kind — a bullet run is one
+    // list, a table run is one table, and every bare line is its own paragraph.
+    // v2 bodies never soft-wrap prose (checked against the frozen v2 fixture), so
+    // this only changes what used to collapse into one "wall of text".
+    const kindOf = (l: string) =>
+      l.startsWith("- ") ? "ul" : l.startsWith("|") ? "table" : "p";
+    let i = 0;
+    while (i < lines.length) {
+      const kind = kindOf(lines[i]);
+      let j = i;
+      while (j < lines.length && kindOf(lines[j]) === kind) j++;
+      const run = lines.slice(i, j);
+      i = j;
+      if (kind === "ul") {
+        blocks.push({ type: "ul", items: run.map((l) => l.slice(2).trim()) });
+      } else if (kind === "table") {
+        const rows = run.map(splitRow).filter((cells) => !isSeparatorRow(cells));
+        if (rows.length > 0) {
+          const [header, ...body] = rows;
+          blocks.push({ type: "table", header, rows: body });
+        }
+      } else {
+        // Run-together settlement records (a real v2 shape) span lines, so the
+        // record seam is looked for on the joined run first; otherwise each
+        // bare line is its own statement.
+        const records = splitRecords(run.join(" "));
+        if (records) blocks.push(...records);
+        else for (const text of run) blocks.push({ type: "p", text });
+      }
     }
-
-    const text = lines.join(" ");
-    const records = splitRecords(text);
-    if (records) {
-      blocks.push(...records);
-      continue;
-    }
-
-    blocks.push({ type: "p", text });
   }
 
   return blocks;

--- a/web/tests/components/flashSupplementView.test.tsx
+++ b/web/tests/components/flashSupplementView.test.tsx
@@ -3,7 +3,19 @@ import { describe, expect, it } from "vitest";
 
 import { SupplementView } from "@/components/flash/SupplementView";
 import type { AgentRunIndexRow } from "@/lib/api";
-import type { BriefView } from "@/components/flash/view";
+import { asBriefView, type BriefView } from "@/components/flash/view";
+
+import CLOSE_V3 from "../fixtures/heliumBriefViewV3Close.json";
+
+/** The recorded option-wizard close run of 2026-09-04, verbatim. */
+const CLOSE_V3_VIEW = asBriefView({
+  schema_version: 3,
+  view: CLOSE_V3,
+  run_day: "2026-09-04",
+  headline: "h",
+  outcome: "completed",
+  tenant: "option-wizard",
+} as never)!;
 
 const PREMARKET_ROW = {
   run_day: "2026-09-03",
@@ -45,6 +57,47 @@ const INTRADAY: BriefView = {
   ],
   degradation: ["tool unconfigured: ow_ib_positions (OW_IB_API_BASE unset)"],
 };
+
+describe("SupplementView · v3", () => {
+  it("opens with the claim, then its checks, then what it left out", () => {
+    const { container } = render(
+      <SupplementView
+        view={CLOSE_V3_VIEW}
+        kind="close"
+        weekKey="2026-W36"
+        day="2026-09-04"
+        runs={[PREMARKET_ROW]}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("The one thing");
+    expect(text).toContain("Yesterday: no prior checks.");
+    expect(text).toContain("Everything else");
+    // the order IS the argument: the claim precedes the leftovers
+    expect(text.indexOf("The one thing")).toBeLessThan(
+      text.indexOf("Everything else"),
+    );
+    expect(screen.getByText("Focus")).toBeTruthy();
+    expect(screen.getByText("Themes")).toBeTruthy();
+    expect(screen.getByText("Sources & as-of")).toBeTruthy();
+  });
+
+  it("prints the per-item faults beside the run's degradation sentence", () => {
+    const { container } = render(
+      <SupplementView
+        view={CLOSE_V3_VIEW}
+        kind="close"
+        weekKey="2026-W36"
+        day="2026-09-04"
+        runs={[PREMARKET_ROW]}
+      />,
+    );
+    expect(container.textContent).toContain(
+      "focus TSLA: not on the computed list",
+    );
+    expect(container.textContent).toContain("gate flash-budget refused");
+  });
+});
 
 describe("SupplementView", () => {
   it("says it is a supplement and links back to the day's premarket report", () => {

--- a/web/tests/components/flashV3Panels.test.tsx
+++ b/web/tests/components/flashV3Panels.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Body } from "@/components/flash/Body";
+import { EverythingElsePanel } from "@/components/flash/EverythingElsePanel";
+import { FocusPanel } from "@/components/flash/FocusPanel";
+import { FooterPanel } from "@/components/flash/FooterPanel";
+import { OneThingPanel } from "@/components/flash/OneThingPanel";
+import { RotationPanel } from "@/components/flash/RotationPanel";
+import { ThemesPanel } from "@/components/flash/ThemesPanel";
+import { asBriefView, type BriefView } from "@/components/flash/view";
+
+import CLOSE_FIXTURE from "../fixtures/heliumBriefViewV3Close.json";
+import WEEKLY_FIXTURE from "../fixtures/heliumBriefViewV3Weekly.json";
+
+/**
+ * The producer's own v3 output, frozen: the weekly run of 2026-09-06 and the
+ * close run of 2026-09-04, both recorded by option-wizard. Every string here
+ * is helium's. A panel that stops rendering the real document fails here.
+ */
+function viewOf(fixture: unknown): BriefView {
+  const view = asBriefView({
+    schema_version: 3,
+    view: fixture,
+    run_day: "2026-09-06",
+    headline: "h",
+    outcome: "completed",
+    tenant: "option-wizard",
+  } as never);
+  if (!view) throw new Error("the frozen v3 fixture no longer parses");
+  return view;
+}
+
+const WEEKLY = viewOf(WEEKLY_FIXTURE);
+const CLOSE = viewOf(CLOSE_FIXTURE);
+
+describe("FocusPanel", () => {
+  it("prints every focus name in the run's own order, with its IV rank", () => {
+    render(<FocusPanel focus={WEEKLY.focus!} />);
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows.length).toBe(WEEKLY.focus!.rows.length);
+    expect(within(rows[0]).getByText("ADBE")).toBeTruthy();
+    expect(within(rows[0]).getByText("69")).toBeTruthy();
+    expect(
+      within(rows[0]).getByText("2026-09-04-close-focus-ADBE"),
+    ).toBeTruthy();
+  });
+
+  it("says the churn the run counted, rather than implying none", () => {
+    render(<FocusPanel focus={CLOSE.focus!} />);
+    expect(screen.getByText(/churn 0/)).toBeTruthy();
+  });
+
+  it("prints an em dash for a name the run gave no reason for", () => {
+    const asml = CLOSE.focus!.rows.find((r) => r.ticker === "ASML")!;
+    expect(asml.why).toBe("");
+    render(<FocusPanel focus={{ rows: [asml] }} />);
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});
+
+describe("ThemesPanel", () => {
+  it("shows the token, both excess strings and the kill condition", () => {
+    render(<ThemesPanel themes={WEEKLY.themes!} />);
+    expect(screen.getByText("strengthen")).toBeTruthy();
+    expect(screen.getByText("+6.5%")).toBeTruthy();
+    expect(screen.getByText("+0.0%")).toBeTruthy();
+    expect(screen.getByText("kill")).toBeTruthy();
+    expect(screen.getByText(/ONI < \+0\.5 two months running/)).toBeTruthy();
+  });
+
+  it("says KILL MET only when the run said so", () => {
+    expect(WEEKLY.themes![0]!.killMet).toBe(false);
+    render(<ThemesPanel themes={[{ ...WEEKLY.themes![0]!, killMet: true }]} />);
+    expect(screen.getByText("kill met")).toBeTruthy();
+  });
+});
+
+describe("RotationPanel", () => {
+  it("heads the table with the as-of the run measured against", () => {
+    render(<RotationPanel rotation={WEEKLY.rotation!} />);
+    expect(screen.getByText(/as of 2026-09-04/)).toBeTruthy();
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows.length).toBe(WEEKLY.rotation!.rows.length);
+    expect(within(rows[0]).getByText("+6.6")).toBeTruthy();
+  });
+
+  it("prints a stale symbol as untested, never as a flat week", () => {
+    const untested = {
+      symbol: "XLE",
+      label: "XLE",
+      w1: null,
+      w4: null,
+      w12: null,
+      excess1w: null,
+      excess4w: null,
+      excess12w: null,
+      untested: "no bar on 2026-08-28; newest 2026-07-13",
+    };
+    render(<RotationPanel rotation={{ rows: [untested] }} />);
+    expect(screen.getAllByText("untested").length).toBe(6);
+    expect(screen.queryByText("0.0")).toBeNull();
+    expect(screen.getByText(/no bar on 2026-08-28/)).toBeTruthy();
+  });
+});
+
+describe("FooterPanel", () => {
+  it("lists coverage, as-of and notes verbatim", () => {
+    render(
+      <FooterPanel footer={WEEKLY.footer!} staleness={WEEKLY.staleness} />,
+    );
+    expect(screen.getByText("macro — ow_macro_rates")).toBeTruthy();
+    expect(screen.getByText(/ow_spot — 2026-09-06T21:26:56/)).toBeTruthy();
+    expect(
+      screen.getByText("bars: 50 of 50 basket symbols answered"),
+    ).toBeTruthy();
+  });
+});
+
+describe("OneThingPanel", () => {
+  it("puts the claim, yesterday's scoring line and all three checks on the page", () => {
+    render(
+      <OneThingPanel
+        oneThing={CLOSE.oneThing}
+        checks={CLOSE.checks}
+        changeMyMind={CLOSE.changeMyMind}
+      />,
+    );
+    expect(screen.getByText("The one thing")).toBeTruthy();
+    expect(screen.getByText(/no single move stood out/)).toBeTruthy();
+    // the run wrote the scoring sentence into the body as well; it prints once
+    expect(screen.getByText(/Yesterday: no prior checks\./)).toBeTruthy();
+    expect(screen.queryAllByText("Yesterday: no prior checks.")).toHaveLength(
+      0,
+    );
+
+    const checks = screen.getAllByRole("listitem");
+    expect(checks).toHaveLength(3);
+    expect(within(checks[0]).getByText("VIXCLS")).toBeTruthy();
+    expect(within(checks[0]).getByText("at 14.32")).toBeTruthy();
+    expect(
+      within(checks[0]).getByText(/compression extend below 14\.25/),
+    ).toBeTruthy();
+  });
+
+  it("prints the scoring line on its own when the body does not repeat it", () => {
+    render(
+      <OneThingPanel
+        oneThing={{
+          title: "The one thing",
+          body: "Vol is the regime.",
+          checksLine: "Yesterday: 2 of 3 checks held.",
+        }}
+      />,
+    );
+    expect(screen.getByText("Yesterday: 2 of 3 checks held.")).toBeTruthy();
+  });
+
+  it("prints the condition that would break the read, with its horizon", () => {
+    render(<OneThingPanel changeMyMind={CLOSE.changeMyMind} />);
+    expect(screen.getByText(/HY OAS sustained wider than 2\.65%/)).toBeTruthy();
+    expect(screen.getByText("BAMLH0A0HYM2 · >2.65 · 3 sessions")).toBeTruthy();
+  });
+
+  it("draws nothing at all when the run wrote no claim", () => {
+    const { container } = render(<OneThingPanel />);
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("EverythingElsePanel", () => {
+  it("lists what the run left out of the argument", () => {
+    render(<EverythingElsePanel items={CLOSE.everythingElse!} />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByText(/USD broad index 118\.7/)).toBeTruthy();
+  });
+});
+
+describe("Body coverage verdicts", () => {
+  it("sets a coverage verdict apart without rewriting the line", () => {
+    const coverage = WEEKLY.sections!.find((s) => s.title === "3 · Coverage")!;
+    const { container } = render(<Body text={coverage.body} />);
+    const chips = container.querySelectorAll("[data-cov]");
+    expect(chips.length).toBeGreaterThan(5);
+    expect([...chips].map((c) => c.textContent).includes("UNTESTED")).toBe(
+      true,
+    );
+    expect(container.textContent).toContain(
+      "rates.long — 4.77 → -2 bp — CONTINUE",
+    );
+  });
+});

--- a/web/tests/components/flashWeeklyView.test.tsx
+++ b/web/tests/components/flashWeeklyView.test.tsx
@@ -2,7 +2,24 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { WeeklyView } from "@/components/flash/WeeklyView";
-import type { AgentRunIndexRow } from "@/lib/api";
+import type { AgentRunIndexRow, AgentRunResponse } from "@/lib/api";
+
+import WEEKLY_V3 from "../fixtures/heliumBriefViewV3Weekly.json";
+
+/** The recorded option-wizard weekly run of 2026-09-06, verbatim. */
+const WEEKLY_RUN = {
+  run_day: "2026-09-06",
+  kind: "weekly",
+  run_id: "run-bf4b1795-b627-4df8-a5fe-b744ffb8e0d1",
+  version_no: 1,
+  outcome: "completed",
+  headline: "",
+  code_sha: "abc1234",
+  schema_version: 3,
+  created_at: "2026-09-06T21:27:00Z",
+  tenant: "option-wizard",
+  view: WEEKLY_V3,
+} as unknown as AgentRunResponse;
 
 const row = (kind: string): AgentRunIndexRow => ({
   run_day: "2026-09-03",
@@ -52,6 +69,26 @@ describe("WeeklyView", () => {
     );
     expect(screen.getByText("Generated Sunday morning")).toBeTruthy();
     expect(container.textContent).not.toContain("Friday after close");
+  });
+
+  it("renders the v3 review blocks under the outlook, Frank column intact", () => {
+    render(
+      <WeeklyView
+        weekKey="2026-W36"
+        runs={RUNS}
+        weekly={WEEKLY_RUN}
+        frank={null}
+      />,
+    );
+    expect(screen.getByText("1 · Scorecard")).toBeTruthy();
+    expect(screen.getByText("Focus")).toBeTruthy();
+    expect(screen.getByText("Themes")).toBeTruthy();
+    expect(screen.getByText("Rotation")).toBeTruthy();
+    expect(screen.getByText("Sources & as-of")).toBeTruthy();
+    expect(screen.getByText("Run health")).toBeTruthy();
+    // the version band the page used to show for a v3 run
+    expect(screen.queryByText(/Unrenderable version/)).toBeNull();
+    expect(screen.getByText("Frank 复盘")).toBeTruthy();
   });
 
   it("shows the Frank slot as an honest empty state", () => {

--- a/web/tests/fixtures/heliumBriefViewV3Close.json
+++ b/web/tests/fixtures/heliumBriefViewV3Close.json
@@ -1,0 +1,302 @@
+{
+  "date": "2026-09-04",
+  "tape": [
+    {
+      "label": "VIX",
+      "value": "14.32",
+      "change": "-0.88 pts",
+      "positive": true
+    },
+    {
+      "label": "10Y",
+      "value": "4.77",
+      "change": "-2 bp",
+      "positive": true
+    },
+    {
+      "label": "HY OAS",
+      "value": "2.65",
+      "change": "-1 bp",
+      "positive": true
+    },
+    {
+      "label": "USD (broad)",
+      "value": "118.7",
+      "change": "+0.4 idx pts",
+      "positive": false
+    }
+  ],
+  "cause": {
+    "located": false
+  },
+  "focus": {
+    "rows": [
+      {
+        "why": "Earnings post-close 9/10, 3 sessions out; IV rank 68.84 makes the reaction matter more.",
+        "event": "earnings (post) 2026-09-10",
+        "ivRank": 68.84,
+        "ticker": "ADBE"
+      },
+      {
+        "why": "Earnings post-close 9/10; a 9.8619% implied move and IV rank 58.63 raise the stakes.",
+        "event": "earnings (post) 2026-09-10",
+        "ivRank": 58.63,
+        "ticker": "ORCL"
+      },
+      {
+        "why": "Earnings post-close 9/30, 17 sessions out; memory strength this week makes it worth watching.",
+        "event": "earnings (post) 2026-09-30",
+        "ivRank": 30.94,
+        "ticker": "MU"
+      },
+      {
+        "why": "",
+        "event": "earnings (pre) 2026-10-14",
+        "ivRank": 27.98,
+        "ticker": "ASML"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-15",
+        "ivRank": 5.07,
+        "ticker": "TSM"
+      }
+    ],
+    "churn": 0,
+    "period": "daily"
+  },
+  "charts": {
+    "gex": [],
+    "policyPath": {
+      "meetings": [
+        {
+          "label": "9/16",
+          "stance": "HOLD",
+          "impliedRate": "3.7532",
+          "probability": 50.7,
+          "targetRange": "3.50-3.75%"
+        },
+        {
+          "label": "10/28",
+          "stance": "HOLD",
+          "impliedRate": "3.825",
+          "probability": 71.3,
+          "targetRange": "3.50-3.75%"
+        },
+        {
+          "label": "12/9",
+          "stance": "HIKE",
+          "impliedRate": "3.97",
+          "probability": 58,
+          "targetRange": "3.75-4.00%"
+        }
+      ],
+      "snapshotDate": "2026-09-03"
+    }
+  },
+  "checks": [
+    {
+      "text": "Does the compression extend below 14.25 or snap back toward 15.",
+      "level": "14.32",
+      "series": "VIXCLS"
+    },
+    {
+      "text": "Does the coin-flip resolve toward hold or hike into the meeting.",
+      "level": "50.7",
+      "series": "9/16 hold probability"
+    },
+    {
+      "text": "Holds below 4.79 or grinds back to the monthly high.",
+      "level": "4.77",
+      "series": "DGS10"
+    }
+  ],
+  "edited": true,
+  "faults": [
+    "focus TSLA: not on the computed list — the line is discarded",
+    "focus AVGO: not on the computed list — the line is discarded"
+  ],
+  "footer": {
+    "asOf": [
+      "ow_argon_policy_path — 2026-09-03",
+      "ow_spot — 2026-09-06T21:24:27.639Z",
+      "ow_uw_calendar — 2026-09-04T20:15:00.000Z",
+      "ow_argon_watchlist — 2026-09-05T03:11:02.482278+08:00",
+      "ow_uw_earnings — 2026-09-06T21:24:40.521Z"
+    ],
+    "notes": [
+      "bars: 50 of 50 basket symbols answered",
+      "no answer from ow_tv_commodities: ow_tv_commodities: ow_tv_commodities: no commodity answered with a numeric close; is the TradingView app running?"
+    ],
+    "coverage": [
+      "macro — ow_macro_rates",
+      "policy — ow_argon_policy_path",
+      "gex — ow_uw_gex",
+      "spot — ow_spot",
+      "tide — ow_uw_market_state",
+      "calendar — ow_uw_calendar",
+      "commodities — ow_tv_commodities: ow_tv_commodities: ow_tv_commodities: no commodity answered with a numeric close; is the TradingView app running?",
+      "watchlist — ow_argon_watchlist",
+      "earnings — ow_uw_earnings",
+      "ivTerm — ow_uw_iv_term",
+      "actions — ow_massive_actions"
+    ]
+  },
+  "regime": {
+    "paragraph": "{\"headline\":\"Vol keeps bleeding — the VIX at 14.32 is the calmest close in three weeks, even as futures price a near coin-flip for a September hike\",\"tape\":[{\"label\":\"VIX\",\"value\":\"14.32\",\"change\":\"-0.88 pts\",\"positive\":true},{\"label\":\"10Y\",\"value\":\"4.77\",\"change\":\"-2 bp\",\"positive\":true},{\"label\":\"HY OAS\",\"value\":\"2.65\",\"change\":\"-1 bp\",\"positive\":true},{\"label\":\"USD (broad)\",\"value\":\"118.7\",\"change\":\"+0.4 idx pts\",\"positive\":false}],\"schedule\":[{\"et\":\"2026-09-10 (post)\",\"event\":\"ADBE earnings\",\"consensus\":\"implied move 6.9333%\",\"group\":\"Next week\"},{\"et\":\"2026-09-10 (post)\",\"event\":\"ORCL earnings\",\"consensus\":\"implied move 9.8619%\",\"group\":\"Next week\"},{\"et\":\"2026-09-16\",\"event\":\"FOMC 9/16 decision\",\"consensus\":\"HOLD 50.7%\",\"prior\":\"3.50-3.75%\",\"group\":\"Two weeks out\"},{\"et\":\"2026-09-30 (post)\",\"event\":\"MU earnings\",\"consensus\":\"implied move 12.373%\",\"group\":\"Later\"},{\"et\":\"2026-10-28\",\"event\":\"FOMC 10/28 decision\",\"consensus\":\"HOLD 71.3%\",\"prior\":\"3.50-3.75%\",\"group\":\"Later\"},{\"et\":\"2026-12-09\",\"event\":\"FOMC 12/9 decision\",\"consensus\":\"HIKE 58%\",\"prior\":\"3.75-4.00%\",\"group\":\"Later\"}],\"cause\":{\"located\":false,\"searched\":[\"Fed\"]},\"sections\":[{\"title\":\"Volatility, not rates, is the regime today — the VIX bled to its calmest close in three weeks\",\"body\":\"The read today is a grind lower in fear, not a rates event. VIXCLS closed at 14.32 on 2026-09-03, down 0.88 pts from 15.2 the prior session — the largest single-session move in the ranked set and roughly 1.3x this channel's own 20-session median. It is the lowest close since 14.25 on 2026-08-14. The move fits a bid-for-risk tape: SPY's gamma flip sat at 768.35 into the close (from 769.55), with dealers positioned to dampen rather than amplify moves. Rates barely participated — DGS10 slipped 2 bp to 4.77 (2026-09-03) and HY OAS eased 1 bp to 2.65 (2026-09-03, argon macro series, 3-day lag) — neither cleared the 5 bp bar that would make the curve the story. When vol compresses this far while credit and rates sit still, the regime is complacency, and the ones exposed are anyone short volatility premium into a September FOMC that is not resolved.\"},{\"title\":\"The divergence: a 14-handle VIX sits next to a September meeting the market cannot call — 50.7% hold, 49.3% hike\",\"body\":\"That calm is hard to square with the policy path, and that is the anomaly worth naming. Futures-implied odds via Frenzy Capital (not CME FedWatch), snapshot 2026-09-03, put the 9/16 FOMC at a 50.7% hold versus a 49.3% hike 25 bp — a genuine coin flip on a live meeting under two weeks out, with the range at 3.50-3.75%. The path only hardens from there: 10/28 reads HOLD 71.3%, and 12/9 tips to HIKE 58% (implied rate 3.97). A VIX at 14.32 is not the price of a market braced for a near-even hike in eleven days; it is the price of one that has decided the outcome does not matter for spot. One of those two reads is wrong, and the gap between them is the single most notable feature of today's tape.\"},{\"title\":\"Flow context: the tide is the prior session's — Sept 4 net premium turned decisively positive by the close\",\"body\":\"Note this is the 2026-09-04 session's tide, frozen outside RTH, not a live premarket read. Across that session market net call premium swung from deeply negative near midday (-92.7M at 12:15 ET) to firmly positive into the close, ending near +80.4M at 16:10 ET — the buy-the-dip signature that matches the vol compression above. Sector tide (Technology) ran heavily call-led all session, closing around +288.7M net call premium at 20:00 UTC against net put premium of -63.6M. That one-sided call demand is consistent with the 14-handle VIX and the dealer-dampened gamma print, and it says the marginal flow into the close was reaching for upside, not protection.\"}]}"
+  },
+  "tenant": "option-wizard",
+  "themes": [
+    {
+      "id": "el-nino-ag-2026",
+      "kill": "ONI < +0.5 two months running, or instruments underperform SPY by 10% over 60 sessions",
+      "token": "strengthen",
+      "killMet": false,
+      "excess1w": "+6.5%",
+      "excessSinceEntered": "+0.0%"
+    }
+  ],
+  "appBase": "http://127.0.0.1:3001",
+  "outcome": "completed",
+  "decision": [
+    {
+      "label": "Call",
+      "value": "No trade"
+    },
+    {
+      "label": "Action",
+      "value": "Stand down — file nothing and re-run when live sources return"
+    },
+    {
+      "label": "Aggression",
+      "value": "None"
+    },
+    {
+      "label": "WhyNow",
+      "value": "No live spot to anchor a strike and no per-leg mid to price; the design pass correctly produced zero proposals."
+    },
+    {
+      "label": "MaxRisk",
+      "value": "None — no position is taken."
+    },
+    {
+      "label": "Invalidation",
+      "value": "N/A — no thesis to settle; there is no spot to compare against."
+    },
+    {
+      "label": "NextTrigger",
+      "value": "Re-run against live data so spot, chains and earnings return current values; only EOD metrics survived and cannot build a defined-risk proposal alone."
+    },
+    {
+      "label": "Confidence",
+      "value": "Low — skipped layers: spot, strike check, chain mids, earnings, argon levels."
+    }
+  ],
+  "headline": "Volatility bled to 14.32 while a live September FOMC sits at a coin-flip.",
+  "oneThing": {
+    "why": "no single move stood out; VIXCLS has led for 0 sessions",
+    "body": "No prior record on disk — first note filed today. Yesterday: no prior checks. VIXCLS closed 14.32 on 2026-09-03, down 0.88 pts from 15.2 — the largest single-channel move in today's set and the calmest close in three weeks. This is the persistence read: no single event stood out, so the ranking rewards the channel that keeps leading, and vol has now led for zero sessions running. The mechanism is dealer-dampened gamma with SPY's flip at 768.35 and a close-of-session tide reaching for upside, not protection.",
+    "title": "The one thing",
+    "checksLine": "Yesterday: no prior checks."
+  },
+  "riskList": [],
+  "runLabel": "close",
+  "schedule": [
+    {
+      "et": "2026-09-10 (post)",
+      "event": "ADBE earnings",
+      "group": "Next week",
+      "consensus": "implied move 6.9333%"
+    },
+    {
+      "et": "2026-09-10 (post)",
+      "event": "ORCL earnings",
+      "group": "Next week",
+      "consensus": "implied move 9.8619%"
+    },
+    {
+      "et": "2026-09-16",
+      "event": "FOMC 9/16 decision",
+      "group": "Two weeks out",
+      "prior": "3.50-3.75%",
+      "consensus": "HOLD 50.7%"
+    },
+    {
+      "et": "2026-09-30 (post)",
+      "event": "MU earnings",
+      "group": "Later",
+      "consensus": "implied move 12.373%"
+    },
+    {
+      "et": "2026-10-28",
+      "event": "FOMC 10/28 decision",
+      "group": "Later",
+      "prior": "3.50-3.75%",
+      "consensus": "HOLD 71.3%"
+    },
+    {
+      "et": "2026-12-09",
+      "event": "FOMC 12/9 decision",
+      "group": "Later",
+      "prior": "3.75-4.00%",
+      "consensus": "HIKE 58%"
+    }
+  ],
+  "sections": [
+    {
+      "body": "0 scored of 0 issued · 3 not called · all 0 calls issued; none removed\ncallHitRate — · verdictBrier — · focusHitRate — · coverageGaps 3 · focusChurn 0\nno call has come due yet\nfocus: 0 of 0 names moved at least their implied move · 0 still open\nwhat we left out: 3 rows",
+      "title": "1 · Scorecard"
+    },
+    {
+      "body": "First note on disk, so no scorecard to reconcile. What the day says: vol led on a persistence read while rates and credit sat still — DGS10 eased 2 bp, HY OAS 1 bp, neither clearing the 5 bp bar. The flow channel confirmed the calm: net premium swung from deeply negative near midday to firmly positive into the close, the buy-the-dip signature. Dealer positioning shifted only 1.20 pts. The single divergence worth carrying forward is a 14-handle vol sitting next to a live-meeting coin flip.\nnot to quote: fx — datum as of 2026-08-28 is older than this period",
+      "title": "2 · 上周复盘"
+    },
+    {
+      "body": "3a macro\n- rates.front — no datum this period — UNTESTED\n- rates.long — 4.77 → -2 bp — CONTINUE (1bp..3bp) — eased inside its bar, no break — settles: 10Y vs 4.79 monthly high\n- curve.shape — no datum this period — UNTESTED\n- policy.path — 50.7 → — — CONTINUE — live meeting stays a coin flip — settles: 9/16 odds into the meeting\n- credit — 2.65 → -1 bp — CONTINUE (1bp..2bp) — eased 1 bp, well inside range — settles: HY OAS vs 2.60 cycle tight\n- vol — 14.32 → -0.88 pts — CONTINUE (0.44pts..1.32pts) — calmest close in three weeks — settles: VIX below 14.25 or reversal\n- dealer.positioning — 768.35 → +1.20 pts — CONTINUE (0.60pts..1.80pts) — flip barely moved, dampening — settles: SPY flip vs spot\n- flow — 39758465 → — — STRENGTHEN — swung positive into the close — settles: net premium next session\n- commodities — no datum this period — UNTESTED\n- fx — 118.7 → +0.4 index pts — CONTINUE — broad index firmed slightly — settles: broad USD trend\n- equity.internals — 769.55 → SPY 769.55 · QQQ 717.5 · IWM 295.39 — CONTINUE — large-cap bid intact — settles: SPY, QQQ, IWM breadth\n- calls.open — 0 — printed from the ledger\n3b sectors\n- sector:Computer/GPU — 3.4 → +3.3% vs SPY (6 of 6) — STRENGTHEN (>4.9% = 1.5x prior |Δ| 3.3%) — all six members beat SPY — settles: GPU weekly excess — members: NVDA, AMD, ARM, DELL, HPE, HPQ\n- sector:Semi-Logic/ASIC — 1.8 → +1.7% vs SPY (6 of 6) — CONTINUE (0.8%..2.5%) — modest lead, all members — settles: ASIC weekly excess — members: AVGO, ARM, MCHP, MRVL, QCOM, TXN\n- sector:Foundry — 5.4 → +5.3% vs SPY (4 of 4) — STRENGTHEN (>8.0% = 1.5x prior |Δ| 5.3%) — strongest semi group this week — settles: Foundry weekly excess — members: INTC, TSEM, TSM, UMC\n- sector:Semi-Cap/EDA — -1.5 → -1.6% vs SPY (8 of 8) — FADE (<0.8%) — lags SPY, all eight members — settles: EDA weekly excess — members: AMAT, ARM, ASML, CDNS, KLAC, LRCX, SNPS, TER\n- sector:Memory/Storage — 7.6 → +7.5% vs SPY (4 of 4) — STRENGTHEN (>11.2% = 1.5x prior |Δ| 7.5%) — leads all sectors this week — settles: Memory weekly excess — members: STX, WDC, MU, SNDK\n- sector:Cybersecurity — -6.9 → -7.0% vs SPY (4 of 4) — FADE (<3.5%) — worst laggard, all four members — settles: Cyber weekly excess — members: NET, S, CRWD, PANW\n- sector:Software/SaaS — -4.7 → -4.8% vs SPY (6 of 6) — FADE (<2.4%) — lags hard, all six members — settles: SaaS weekly excess — members: ADBE, FIG, NOW, SHOP, ZM, CRM\n- sector:Cloud/Hyperscaler — -1.3 → -1.4% vs SPY (6 of 6) — FADE (<0.7%) — slight lag to SPY — settles: Cloud weekly excess — members: GOOGL, AMZN, BABA, IBM, MSFT, ORCL\n- sector:Foundation-Model-Proxy — 0.9 → +0.8% vs SPY (5 of 5) — CONTINUE (0.4%..1.2%) — marginally ahead of SPY — settles: FMP weekly excess — members: GOOGL, AMZN, NVDA, MSFT, META\n- sector:Devices/Endpoint — 0.8 → +0.7% vs SPY (2 of 2) — CONTINUE (0.3%..1.0%) — both members edge SPY — settles: Devices weekly excess — members: TSLA, AAPL\n3c themes\n- theme:el-nino-ag-2026 — +6.5% (1w) · +0.0% (since 2026-09-06) — STRENGTHEN (>9.8% = 1.5x prior |Δ| 6.5%) — first excess week, +6.5 vs SPY — settles: second excess week\n  kill armed: ONI < +0.5 two months running, or instruments underperform SPY by 10% over 60 sessions\n  evidence: operator-checked\nleft out: rates.front — DGS2 not ingested\nleft out: curve.shape — DGS2 not ingested; 2s10s cannot be computed\nleft out: commodities — no payload",
+      "title": "3 · Coverage"
+    },
+    {
+      "body": "The tension into next week is one number against another: a calm vol channel versus a September meeting the policy.path row cannot call. One of those reads is wrong. Watch whether the vol row extends its compression or snaps back as the meeting closes in — persistence ranking will keep it as lead only if it keeps leading. Rates.long and credit both sat inside their bars today; a break of either flips the regime from complacency to a rates event and demotes vol. Rotation favors Foundry and Memory/Storage this week, both far ahead of SPY, while Cybersecurity and Software/SaaS lag hard — the semi-cyclical bid is intact and worth confirming. The el-nino-ag theme printed its first excess week and needs a second to earn conviction. Nothing to size until live sources return a spot and a chain; the book stays flat.",
+      "title": "4 · 下周展望"
+    },
+    {
+      "body": "- 2026-09-10 · earnings · ADBE earnings (post) · forecast implied move 6.9333% · post — settles: 2026-09-11\n- 2026-09-10 · earnings · ORCL earnings (post) · forecast implied move 9.8619% · post — settles: 2026-09-11\n- 2026-09-16 · policy path · FOMC 9/16 · forecast HOLD 50.7% · prev 3.50-3.75% — settles: 2026-09-16\n- 2026-09-30 · earnings · MU earnings (post) · forecast implied move 12.373% · post — settles: 2026-10-01\n- 2026-10-14 · earnings · ASML earnings (pre) · forecast implied move 10.2247% · pre — settles: 2026-10-14\n- 2026-10-15 · earnings · TSM earnings · forecast implied move 7.8571% — settles: 2026-10-15\n- 2026-10-20 · earnings · TXN earnings · forecast implied move 10.4077% — settles: 2026-10-20\n- 2026-10-21 · earnings · IBM earnings (post) · forecast implied move 9.8496% · post — settles: 2026-10-22\n- 2026-10-22 · earnings · INTC earnings · forecast implied move 16.4926% — settles: 2026-10-22\n- 2026-10-26 · earnings · CDNS earnings · forecast implied move 13.2014% — settles: 2026-10-26\n- 2026-10-27 · earnings · STX earnings · forecast implied move 22.2932% — settles: 2026-10-27\n- 2026-10-27 · earnings · TER earnings · forecast implied move 22.3448% — settles: 2026-10-27\n- 2026-10-28 · policy path · FOMC 10/28 · forecast HOLD 71.3% · prev 3.50-3.75% — settles: 2026-10-28\n- 2026-10-28 · earnings · TSLA earnings · forecast implied move 13.6494% — settles: 2026-10-28\n- 2026-10-28 · earnings · LRCX earnings · forecast implied move 19.7353% — settles: 2026-10-28\n- 2026-10-29 · earnings · AAPL earnings · forecast implied move 8.3771% — settles: 2026-10-29\n- 2026-12-09 · policy path · FOMC 12/9 · forecast HIKE 58% · prev 3.75-4.00% — settles: 2026-12-09\n- 2026-12-10 · earnings · AVGO earnings · forecast implied move 15.1457% — settles: 2026-12-10\nADBE (implied move 6.9333%) and ORCL (9.8619%) both report post-close 2026-09-10. FOMC 9/16 decision reads HOLD 50.7% — the live meeting under two weeks out. MU reports post-close 2026-09-30 at 12.373% implied.",
+      "title": "5 · Dated catalysts"
+    },
+    {
+      "body": "rank · ticker · event · IV rank · implied move · open call · why\n| 1 | ADBE | earnings (post) 2026-09-10 | 69 | 6.9% | — | Earnings post-close 9/10, 3 sessions out; IV rank 68.84 makes the reaction matter more. |\n| 2 | ORCL | earnings (post) 2026-09-10 | 59 | 9.9% | — | Earnings post-close 9/10; a 9.8619% implied move and IV rank 58.63 raise the stakes. |\n| 3 | MU | earnings (post) 2026-09-30 | 31 | 12.4% | — | Earnings post-close 9/30, 17 sessions out; memory strength this week makes it worth watching. |\n| 4 | ASML | earnings (pre) 2026-10-14 | 28 | 10.2% | — | — |\n| 5 | TSM | earnings 2026-10-15 | 5 | 7.9% | — | — |\nweights: declared prior 2026-09-06",
+      "title": "6 · Focus"
+    },
+    {
+      "body": "nothing outstanding",
+      "title": "7 · Open calls"
+    },
+    {
+      "body": "The read today is a grind lower in fear, not a rates event. VIXCLS closed at 14.32 on 2026-09-03, down 0.88 pts from 15.2 the prior session — the largest single-session move in the ranked set and roughly 1.3x this channel's own 20-session median. It is the lowest close since 14.25 on 2026-08-14.",
+      "title": "Volatility, not rates, is the regime today — the VIX bled to its calmest close in three weeks"
+    },
+    {
+      "body": "That calm is hard to square with the policy path, and that is the anomaly worth naming. Futures-implied odds via Frenzy Capital (not CME FedWatch), snapshot 2026-09-03, put the 9/16 FOMC at a 50.7% hold versus a 49.3% hike 25 bp — a genuine coin flip on a live meeting under two weeks out, with the range at 3.50-3.75%.",
+      "title": "The divergence: a 14-handle VIX sits next to a September meeting the market cannot call — 50.7% hold, 49.3% hike"
+    },
+    {
+      "body": "Note this is the 2026-09-04 session's tide, frozen outside RTH, not a live premarket read. Across that session market net call premium swung from deeply negative near midday (-92.7M at 12:15 ET) to firmly positive into the close, ending near +80.4M at 16:10 ET — the buy-the-dip signature that matches the vol compression above.",
+      "title": "Flow context: the tide is the prior session's — Sept 4 net premium turned decisively positive by the close"
+    }
+  ],
+  "overnight": [],
+  "candidates": [],
+  "degradation": "Data degraded: gate flash-budget refused (3 of 3 sections over 60 words (150, 134, 107)); gate meta-leak refused (1 meta leak: section 3 body /\\bfrozen\\b/ \"-04 session's tide, frozen outside RTH, not a \"); gate flash-budget refused (oneThing 108 of 90)",
+  "changeMyMind": {
+    "text": "HY OAS sustained wider than 2.65% for three sessions, or DGS10 back through 4.79%, breaks the calm-complacency read and says rates, not vol, is the regime.",
+    "series": "BAMLH0A0HYM2",
+    "horizon": "3 sessions",
+    "threshold": ">2.65"
+  },
+  "schemaVersion": 3,
+  "everythingElse": [
+    "USD broad index 118.7, +0.4 idx pts (2026-08-28).",
+    "10/28 FOMC reads HOLD 71.3%; 12/9 tips HIKE 58%.",
+    "Sector tide ran call-led all session, closing near +288.7M."
+  ]
+}

--- a/web/tests/fixtures/heliumBriefViewV3Weekly.json
+++ b/web/tests/fixtures/heliumBriefViewV3Weekly.json
@@ -1,0 +1,348 @@
+{
+  "date": "2026-09-06",
+  "tape": [],
+  "focus": {
+    "rows": [
+      {
+        "why": "Earnings 2026-09-10 post; 6.93% IV expects guidance revision.",
+        "event": "earnings (post) 2026-09-10",
+        "ivRank": 68.84,
+        "sticky": true,
+        "ticker": "ADBE",
+        "openCall": "2026-09-04-close-focus-ADBE"
+      },
+      {
+        "why": "Earnings 2026-09-10 post; 9.86% IV expects cloud spending tone.",
+        "event": "earnings (post) 2026-09-10",
+        "ivRank": 58.63,
+        "sticky": true,
+        "ticker": "ORCL",
+        "openCall": "2026-09-04-close-focus-ORCL"
+      },
+      {
+        "why": "Earnings 2026-09-30 post; 12.37% IV expects cycle confirmation.",
+        "event": "earnings (post) 2026-09-30",
+        "ivRank": 30.94,
+        "sticky": true,
+        "ticker": "MU",
+        "openCall": "2026-09-04-close-focus-MU"
+      },
+      {
+        "why": "Earnings 2026-10-14 pre; 10.22% IV expects capex trajectory.",
+        "event": "earnings (pre) 2026-10-14",
+        "ivRank": 27.98,
+        "sticky": true,
+        "ticker": "ASML",
+        "openCall": "2026-09-04-close-focus-ASML"
+      },
+      {
+        "why": "Earnings 2026-10-15; 7.86% IV expects volume recovery.",
+        "event": "earnings 2026-10-15",
+        "ivRank": 5.07,
+        "sticky": true,
+        "ticker": "TSM",
+        "openCall": "2026-09-04-close-focus-TSM"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-28",
+        "ivRank": 12.73,
+        "ticker": "TSLA"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-12-10",
+        "ivRank": 0,
+        "ticker": "AVGO"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-20",
+        "ivRank": 18.48,
+        "ticker": "TXN"
+      },
+      {
+        "why": "",
+        "event": "earnings (post) 2026-10-21",
+        "ivRank": 21.64,
+        "ticker": "IBM"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-22",
+        "ivRank": 28.96,
+        "ticker": "INTC"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-26",
+        "ivRank": 27.94,
+        "ticker": "CDNS"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-27",
+        "ivRank": 36.59,
+        "ticker": "STX"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-27",
+        "ivRank": 31.13,
+        "ticker": "TER"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-28",
+        "ivRank": 34.73,
+        "ticker": "LRCX"
+      },
+      {
+        "why": "",
+        "event": "earnings 2026-10-29",
+        "ivRank": 45.06,
+        "ticker": "AAPL"
+      }
+    ],
+    "churn": 0,
+    "period": "weekly"
+  },
+  "charts": {
+    "gex": []
+  },
+  "faults": [
+    "下周展望 restates the level 14.32, which section 3 already printed"
+  ],
+  "footer": {
+    "asOf": [
+      "ow_argon_policy_path — 2026-09-04",
+      "ow_spot — 2026-09-06T21:26:56.344Z",
+      "ow_uw_calendar — 2026-09-06T21:26:55.646Z",
+      "ow_argon_watchlist — 2026-09-05T03:11:02.482278+08:00",
+      "ow_uw_earnings — 2026-09-06T21:27:09.485Z"
+    ],
+    "notes": [
+      "bars: 50 of 50 basket symbols answered",
+      "bars: SPY's newest bar is 2026-09-04, so every basket row is as of 2026-09-04 rather than 2026-09-06",
+      "no answer from ow_tv_commodities: ow_tv_commodities: ow_tv_commodities: no commodity answered with a numeric close; is the TradingView app running?"
+    ],
+    "coverage": [
+      "macro — ow_macro_rates",
+      "policy — ow_argon_policy_path",
+      "gex — ow_uw_gex",
+      "spot — ow_spot",
+      "tide — ow_uw_market_state",
+      "calendar — ow_uw_calendar",
+      "commodities — ow_tv_commodities: ow_tv_commodities: ow_tv_commodities: no commodity answered with a numeric close; is the TradingView app running?",
+      "watchlist — ow_argon_watchlist",
+      "earnings — ow_uw_earnings",
+      "ivTerm — ow_uw_iv_term",
+      "actions — ow_massive_actions"
+    ]
+  },
+  "regime": {
+    "paragraph": ""
+  },
+  "tenant": "option-wizard",
+  "themes": [
+    {
+      "id": "el-nino-ag-2026",
+      "why": "Agriculture basket +6.5% excess vs SPY in week one; NOAA ONI and CBOT triggers intact; MOS, NTR, DE participants accelerate.",
+      "kill": "ONI < +0.5 two months running, or instruments underperform SPY by 10% over 60 sessions",
+      "token": "strengthen",
+      "killMet": false,
+      "excess1w": "+6.5%",
+      "leadership": "confirms",
+      "excessSinceEntered": "+0.0%"
+    }
+  ],
+  "appBase": "http://127.0.0.1:3001",
+  "outcome": "completed",
+  "headline": "0 scored of 24 issued · 3 not called · all 24 calls issued since 2026-09-06; none removed",
+  "riskList": [],
+  "rotation": {
+    "asOf": "2026-09-04",
+    "rows": [
+      {
+        "w1": 6.6,
+        "w4": 12.9,
+        "w12": 15.7,
+        "label": "el-nino-ag-2026",
+        "symbol": "theme:el-nino-ag-2026",
+        "excess1w": 6.5,
+        "excess4w": 13.3,
+        "excess12w": 11.6
+      },
+      {
+        "w1": 0.9,
+        "w4": -0.4,
+        "w12": 1.5,
+        "label": "XLK",
+        "symbol": "XLK",
+        "excess1w": 0.7,
+        "excess4w": 0,
+        "excess12w": -2.6
+      },
+      {
+        "w1": 0.8,
+        "w4": -1.2,
+        "w12": -2.6,
+        "label": "XLU",
+        "symbol": "XLU",
+        "excess1w": 0.7,
+        "excess4w": -0.8,
+        "excess12w": -6.7
+      },
+      {
+        "w1": 0.2,
+        "w4": 3.5,
+        "w12": 12,
+        "label": "XLV",
+        "symbol": "XLV",
+        "excess1w": 0.1,
+        "excess4w": 3.9,
+        "excess12w": 7.9
+      },
+      {
+        "w1": 0,
+        "w4": 0.9,
+        "w12": 9.3,
+        "label": "XLF",
+        "symbol": "XLF",
+        "excess1w": -0.1,
+        "excess4w": 1.3,
+        "excess12w": 5.2
+      },
+      {
+        "w1": -0.8,
+        "w4": 0.7,
+        "w12": 0.6,
+        "label": "XLC",
+        "symbol": "XLC",
+        "excess1w": -1,
+        "excess4w": 1.1,
+        "excess12w": -3.5
+      },
+      {
+        "w1": -1,
+        "w4": -0.6,
+        "w12": -0.8,
+        "label": "XLP",
+        "symbol": "XLP",
+        "excess1w": -1.1,
+        "excess4w": -0.2,
+        "excess12w": -4.9
+      },
+      {
+        "w1": -1.1,
+        "w4": -5.4,
+        "w12": -0.3,
+        "label": "XLI",
+        "symbol": "XLI",
+        "excess1w": -1.2,
+        "excess4w": -5,
+        "excess12w": -4.4
+      },
+      {
+        "w1": -1.2,
+        "w4": -2.3,
+        "w12": -2.3,
+        "label": "XLRE",
+        "symbol": "XLRE",
+        "excess1w": -1.3,
+        "excess4w": -1.9,
+        "excess12w": -6.4
+      },
+      {
+        "w1": -1.4,
+        "w4": -0.8,
+        "w12": 0.9,
+        "label": "XLB",
+        "symbol": "XLB",
+        "excess1w": -1.5,
+        "excess4w": -0.4,
+        "excess12w": -3.2
+      },
+      {
+        "w1": -2,
+        "w4": -4.1,
+        "w12": -1.3,
+        "label": "XLY",
+        "symbol": "XLY",
+        "excess1w": -2.1,
+        "excess4w": -3.7,
+        "excess12w": -5.4
+      },
+      {
+        "w1": null,
+        "w4": null,
+        "w12": null,
+        "label": "XLE",
+        "symbol": "XLE",
+        "excess1w": null,
+        "excess4w": null,
+        "untested": "no bar on 2026-09-04; newest 2026-07-13",
+        "excess12w": null
+      }
+    ],
+    "benchmark": "SPY"
+  },
+  "runLabel": "weekly",
+  "schedule": [],
+  "sections": [
+    {
+      "body": "0 scored of 24 issued · 3 not called · all 24 calls issued since 2026-09-06; none removed\ncallHitRate — · verdictBrier — · focusHitRate 0.00 · coverageGaps 3 · focusChurn 0\n2026-09-04-close-verdict-rates.long · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-policy.path · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-credit · issued 2026-09-06 close · pending · said p=0.65 · got pending\n2026-09-04-close-verdict-vol · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-dealer.positioning · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-flow · issued 2026-09-06 close · pending · said p=0.65 · got pending\n2026-09-04-close-verdict-fx · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-equity.internals · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-sector:Computer/GPU · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-sector:Semi-Logic/ASIC · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-sector:Foundry · issued 2026-09-06 close · pending · said p=0.65 · got pending\n2026-09-04-close-verdict-sector:Semi-Cap/EDA · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-sector:Memory/Storage · issued 2026-09-06 close · pending · said p=0.65 · got pending\n2026-09-04-close-verdict-sector:Cybersecurity · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-sector:Software/SaaS · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-verdict-sector:Cloud/Hyperscaler · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-sector:Foundation-Model-Proxy · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-sector:Devices/Endpoint · issued 2026-09-06 close · pending · said p=0.55 · got pending\n2026-09-04-close-verdict-theme:el-nino-ag-2026 · issued 2026-09-06 close · pending · said p=0.6 · got pending\n2026-09-04-close-focus-ADBE · issued 2026-09-06 close · pending · said p=0.5 · got pending\n2026-09-04-close-focus-ORCL · issued 2026-09-06 close · pending · said p=0.5 · got pending\n2026-09-04-close-focus-MU · issued 2026-09-06 close · pending · said p=0.5 · got pending\n2026-09-04-close-focus-ASML · issued 2026-09-06 close · pending · said p=0.5 · got pending\n2026-09-04-close-focus-TSM · issued 2026-09-06 close · pending · said p=0.5 · got pending\nfocus: 0 of 5 names moved at least their implied move · 5 still open\ncalibration: said p≈0.59 · hit 0.00 (19) — over-confident\nwhat we left out: 3 rows",
+      "title": "1 · Scorecard"
+    },
+    {
+      "body": "No commitments settled this week. The open call on rates.long (2026-09-04-close-verdict-rates.long, DGS10) is the first to settle after 1 open session. Yesterday's checks scored 2 misses and 1 not-observed: vol failed to extend below 14.25 or snap back toward 15, holding at 14.32; the 9/16 hike probability coin-flip did not resolve; and rates held at 4.77 rather than grinding to a monthly high. Credit held above the 3-session standing threshold at 2.65. Memory/Storage led weekly, gaining 7.6%, while Cybersecurity lagged at -6.9%; the new El Nino agriculture theme posted 6.5% excess in its first week. Foundry members outperformed with 5.4%, while Semi-Cap/EDA underperformed at -1.5%. Among open focus admits, ADBE and ORCL settle on 2026-09-11 post-earnings; MU settles 2026-10-01; ASML and TSM settle around mid-October.\nnot to quote: fx — datum as of 2026-08-28 is older than this period",
+      "title": "2 · 上周复盘"
+    },
+    {
+      "body": "3a macro\n- rates.front — no datum this period — UNTESTED\n- rates.long — 4.77 → -2 bp — CONTINUE (1bp..3bp) — 2 bp decline holds below monthly high. — settles: Settles 2026-09-07 after 1 open session.\n- curve.shape — no datum this period — UNTESTED\n- policy.path — 55.7 → +5.0 pp — CONTINUE (2.5pp..7.5pp) — Hike probability rose 5.0 pp; coin-flip persists. — settles: FOMC 9/16 resolves by 2026-09-17.\n- credit — 2.65 → -1 bp — CONTINUE (1bp..2bp) — 1 bp tightening; standing threshold intact. — settles: Breaches >2.65 would signal stress.\n- vol — 14.32 → -0.88 pts — CONTINUE (0.44pts..1.32pts) — Compression holds; yesterday failed both edges. — settles: Below 14 or above 16 resets volatility regime.\n- dealer.positioning — 768.35 → +1.20 pts — CONTINUE (0.60pts..1.80pts) — Gamma flip eases dealer short pressure. — settles: 1.20 pt move toward gamma neutrality.\n- flow — 39758465 → +0 USD — STRENGTHEN (no prior move) — Premium flat signals equilibrium; bid/ask stable. — settles: Unchanged net premium sustains risk-on posture.\n- commodities — no datum this period — UNTESTED\n- fx — 118.7 → +0.4 index pts — CONTINUE — 0.4 index pt strength on dollar bid. — settles: DTWEXBGS elevation limits commodity rally room.\n- equity.internals — 769.55 → SPY 769.55 · QQQ 717.5 · IWM 295.39 — CONTINUE — SPY held; QQQ/IWM show size underperformance. — settles: Breadth tilt from mega-cap to mid/small.\n- calls.open — 24 — printed from the ledger\n3b sectors\n- sector:Computer/GPU — 3.4 → +3.3% vs SPY (6 of 6) — STRENGTHEN (>4.9% = 1.5x prior |Δ| 3.3%) — GPU stack led at +3.3% vs SPY weekly. — settles: NVDA, AMD, ARM outpaced broad-based rally. — members: NVDA, AMD, ARM, DELL, HPE, HPQ\n- sector:Semi-Logic/ASIC — 1.8 → +1.7% vs SPY (6 of 6) — CONTINUE (0.8%..2.5%) — ASIC gained +1.7% vs SPY; modest. — settles: Broad chip participation but not leadership. — members: AVGO, ARM, MCHP, MRVL, QCOM, TXN\n- sector:Foundry — 5.4 → +5.3% vs SPY (4 of 4) — STRENGTHEN (>8.0% = 1.5x prior |Δ| 5.3%) — Foundry +5.3% vs SPY; cycle accelerates. — settles: INTC, TSEM, TSM, UMC all members up. — members: INTC, TSEM, TSM, UMC\n- sector:Semi-Cap/EDA — -1.5 → -1.6% vs SPY (8 of 8) — FADE (<0.8%) — EDA -1.6% vs SPY; equipment demand softens. — settles: AMAT, ASML, KLAC, LRCX relative weakness. — members: AMAT, ARM, ASML, CDNS, KLAC, LRCX, SNPS, TER\n- sector:Memory/Storage — 7.6 → +7.5% vs SPY (4 of 4) — STRENGTHEN (>11.2% = 1.5x prior |Δ| 7.5%) — Memory led at +7.5% vs SPY weekly. — settles: STX, WDC, MU, SNDK all members up. — members: STX, WDC, MU, SNDK\n- sector:Cybersecurity — -6.9 → -7.0% vs SPY (4 of 4) — FADE (<3.5%) — Cyber -7.0% vs SPY; relative underperform. — settles: NET, S, CRWD, PANW all members down. — members: NET, S, CRWD, PANW\n- sector:Software/SaaS — -4.7 → -4.8% vs SPY (6 of 6) — FADE (<2.4%) — SaaS -4.8% vs SPY; spending caution. — settles: ADBE, NOW, SHOP, ZM, CRM underperformed. — members: ADBE, FIG, NOW, SHOP, ZM, CRM\n- sector:Cloud/Hyperscaler — -1.3 → -1.4% vs SPY (6 of 6) — FADE (<0.7%) — Cloud -1.4% vs SPY; AI capex pause. — settles: GOOGL, AMZN, MSFT, ORCL modest underperform. — members: GOOGL, AMZN, BABA, IBM, MSFT, ORCL\n- sector:Foundation-Model-Proxy — 0.9 → +0.8% vs SPY (5 of 5) — CONTINUE (0.4%..1.2%) — AI proxy +0.8% vs SPY; flat tone. — settles: NVDA, MSFT, GOOGL, AMZN, META mixed. — members: GOOGL, AMZN, NVDA, MSFT, META\n- sector:Devices/Endpoint — 0.8 → +0.7% vs SPY (2 of 2) — CONTINUE (0.3%..1.0%) — Devices +0.7% vs SPY; minimal move. — settles: TSLA, AAPL both members track broad market. — members: TSLA, AAPL\n3c themes\n- theme:el-nino-ag-2026 — +6.5% (1w) · +0.0% (since 2026-09-06) — STRENGTHEN (>9.8% = 1.5x prior |Δ| 6.5%) — DBA, MOS, NTR, DE posted +6.5% excess. — settles: NOAA ONI +0.5 and CBOT spread confirm thesis.\n  kill armed: ONI < +0.5 two months running, or instruments underperform SPY by 10% over 60 sessions\n  evidence: operator-checked\n3d rotation\n  theme:el-nino-ag-2026 · 1w +6.6% · 4w +12.9% · 12w +15.7% · excess 1w +6.5%\n  XLK · 1w +0.9% · 4w -0.4% · 12w +1.5% · excess 1w +0.7%\n  XLU · 1w +0.8% · 4w -1.2% · 12w -2.6% · excess 1w +0.7%\n  XLV · 1w +0.2% · 4w +3.5% · 12w +12.0% · excess 1w +0.1%\n  XLF · 1w +0.0% · 4w +0.9% · 12w +9.3% · excess 1w -0.1%\n  XLC · 1w -0.8% · 4w +0.7% · 12w +0.6% · excess 1w -1.0%\n  XLP · 1w -1.0% · 4w -0.6% · 12w -0.8% · excess 1w -1.1%\n  XLI · 1w -1.1% · 4w -5.4% · 12w -0.3% · excess 1w -1.2%\n  XLRE · 1w -1.2% · 4w -2.3% · 12w -2.3% · excess 1w -1.3%\n  XLB · 1w -1.4% · 4w -0.8% · 12w +0.9% · excess 1w -1.5%\n  XLY · 1w -2.0% · 4w -4.1% · 12w -1.3% · excess 1w -2.1%\n  XLE · untested — no bar on 2026-09-04; newest 2026-07-13\n  benchmark SPY · 1w +0.1% · 4w -0.4% · 12w +4.1% · as of 2026-09-04\nleft out: rates.front — DGS2 not ingested\nleft out: curve.shape — DGS2 not ingested; 2s10s cannot be computed\nleft out: commodities — no payload",
+      "title": "3 · Coverage"
+    },
+    {
+      "body": "Hike probability moved 5.0 pp higher, suggesting incremental shift toward policy tightening. Vol compression to 14.32 reflects contained volatility despite macro uncertainty; the standing on credit remains unbreached. Foundry's outperformance suggests chip supply confidence, while Semi-Cap/EDA weakness indicates equipment demand caution. Cybersecurity's relative underperformance contradicts near-term security spending momentum. El Nino agriculture thesis confirms early: the equal-weight basket of DBA, MOS, NTR, DE delivered 6.5 pp of excess, validating the NOAA ONI and CBOT evidence triggers. SPY 769.55 maintained Friday close levels; QQQ 717.5 and IWM 295.39 show small-cap relative softness. Flow remained flat at 39758465, signaling equilibrium in options premium. Gamma positioning at 768.35 flipped 1.20 pts higher, easing dealer short pressure. Fed broad index strength at 118.7 continued the dollar bid, limiting commodity upside.\nel-nino-ag-2026: confirms — Agriculture basket +6.5% excess vs SPY in week one; NOAA ONI and CBOT triggers intact; MOS, NTR, DE participants accelerate.",
+      "title": "4 · 下周展望"
+    },
+    {
+      "body": "- 2026-09-10 · earnings · ADBE earnings (post) · forecast implied move 6.9333% · post — settles: 2026-09-11\n- 2026-09-10 · earnings · ORCL earnings (post) · forecast implied move 9.8619% · post — settles: 2026-09-11\n- 2026-09-16 · policy path · FOMC 9/16 · forecast HIKE 55.7% · prev 3.75-4.00% — settles: 2026-09-16\n- 2026-09-30 · earnings · MU earnings (post) · forecast implied move 12.373% · post — settles: 2026-10-01\n- 2026-10-14 · earnings · ASML earnings (pre) · forecast implied move 10.2247% · pre — settles: 2026-10-14\n- 2026-10-15 · earnings · TSM earnings · forecast implied move 7.8571% — settles: 2026-10-15\n- 2026-10-20 · earnings · TXN earnings · forecast implied move 10.4077% — settles: 2026-10-20\n- 2026-10-21 · earnings · IBM earnings (post) · forecast implied move 9.8496% · post — settles: 2026-10-22\n- 2026-10-22 · earnings · INTC earnings · forecast implied move 16.4926% — settles: 2026-10-22\n- 2026-10-26 · earnings · CDNS earnings · forecast implied move 13.2014% — settles: 2026-10-26\n- 2026-10-27 · earnings · STX earnings · forecast implied move 22.2932% — settles: 2026-10-27\n- 2026-10-27 · earnings · TER earnings · forecast implied move 22.3448% — settles: 2026-10-27\n- 2026-10-28 · policy path · FOMC 10/28 · forecast HOLD 71.7% · prev 3.50-3.75% — settles: 2026-10-28\n- 2026-10-28 · earnings · TSLA earnings · forecast implied move 13.6494% — settles: 2026-10-28\n- 2026-10-28 · earnings · LRCX earnings · forecast implied move 19.7353% — settles: 2026-10-28\n- 2026-10-29 · earnings · AAPL earnings · forecast implied move 8.3771% — settles: 2026-10-29\n- 2026-12-09 · policy path · FOMC 12/9 · forecast HIKE 54% · prev 3.75-4.00% — settles: 2026-12-09\n- 2026-12-10 · earnings · AVGO earnings · forecast implied move 15.1457% — settles: 2026-12-10\nADBE and ORCL earnings post 2026-09-10; implied moves 6.93% and 9.86% set high bars for tech execution. FOMC 9/16 with 55.7% hike probability will reset terminal rate expectations. MU earnings 2026-09-30 at 12.37% implied move tests memory cycle strength. ASML earnings 2026-10-14 (pre, 10.22% move) and TSM 2026-10-15 (7.86% move) define Q4 capex confidence.",
+      "title": "5 · Dated catalysts"
+    },
+    {
+      "body": "rank · ticker · event · IV rank · implied move · open call · why\n| 1 | ADBE | earnings (post) 2026-09-10 | 69 | 6.9% | 2026-09-04-close-focus-ADBE | Earnings 2026-09-10 post; 6.93% IV expects guidance revision. | sticky\n| 2 | ORCL | earnings (post) 2026-09-10 | 59 | 9.9% | 2026-09-04-close-focus-ORCL | Earnings 2026-09-10 post; 9.86% IV expects cloud spending tone. | sticky\n| 3 | MU | earnings (post) 2026-09-30 | 31 | 12.4% | 2026-09-04-close-focus-MU | Earnings 2026-09-30 post; 12.37% IV expects cycle confirmation. | sticky\n| 4 | ASML | earnings (pre) 2026-10-14 | 28 | 10.2% | 2026-09-04-close-focus-ASML | Earnings 2026-10-14 pre; 10.22% IV expects capex trajectory. | sticky\n| 5 | TSM | earnings 2026-10-15 | 5 | 7.9% | 2026-09-04-close-focus-TSM | Earnings 2026-10-15; 7.86% IV expects volume recovery. | sticky\n| 6 | TSLA | earnings 2026-10-28 | 13 | 13.6% | — | — |\n| 7 | AVGO | earnings 2026-12-10 | 0 | 15.1% | — | — |\n| 8 | TXN | earnings 2026-10-20 | 18 | 10.4% | — | — |\n| 9 | IBM | earnings (post) 2026-10-21 | 22 | 9.8% | — | — |\n| 10 | INTC | earnings 2026-10-22 | 29 | 16.5% | — | — |\n| 11 | CDNS | earnings 2026-10-26 | 28 | 13.2% | — | — |\n| 12 | STX | earnings 2026-10-27 | 37 | 22.3% | — | — |\n| 13 | TER | earnings 2026-10-27 | 31 | 22.3% | — | — |\n| 14 | LRCX | earnings 2026-10-28 | 35 | 19.7% | — | — |\n| 15 | AAPL | earnings 2026-10-29 | 45 | 8.4% | — | — |\nweights: declared prior 2026-09-06",
+      "title": "6 · Focus"
+    },
+    {
+      "body": "2026-09-04-close-verdict-rates.long · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-policy.path · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-credit · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-vol · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-dealer.positioning · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-flow · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-fx · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-equity.internals · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Computer/GPU · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Semi-Logic/ASIC · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Foundry · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Semi-Cap/EDA · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Memory/Storage · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Cybersecurity · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Software/SaaS · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Cloud/Hyperscaler · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Foundation-Model-Proxy · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-sector:Devices/Endpoint · issued 2026-09-06 close · pending\n2026-09-04-close-verdict-theme:el-nino-ag-2026 · issued 2026-09-06 close · pending\n2026-09-04-close-focus-ADBE · issued 2026-09-06 close · pending\n2026-09-04-close-focus-ORCL · issued 2026-09-06 close · pending\n2026-09-04-close-focus-MU · issued 2026-09-06 close · pending\n2026-09-04-close-focus-ASML · issued 2026-09-06 close · pending\n2026-09-04-close-focus-TSM · issued 2026-09-06 close · pending",
+      "title": "7 · Open calls"
+    },
+    {
+      "body": "Only one of five sessions in this window carries a report and a regime record: 2026-09-04 close. The other four ran without a persisted regime block — record missing, not sessions unwritten. With a single scored session there is no repeated channel to name.",
+      "title": "5 sessions, 2026-08-31 to 2026-09-04"
+    },
+    {
+      "body": "Across the ten sessions, exactly one carries a regime record — 2026-09-04 close — and the other nine ran without a persisted regime block. Those nine report as regime-record-missing, not as sessions that were never written.",
+      "title": "10 sessions, 2026-08-24 to 2026-09-04"
+    },
+    {
+      "body": "Process statistics first. Of twenty-one sessions, one carries a report and a regime record (2026-09-04 close); the remaining twenty ran without a persisted regime block and report as record-missing, not as sessions unwritten. Mode histogram: persistence 1, ratio 0, invalidation 0, no-data 0. Checks hit 0, miss 0, notObserved 0, scored 0.",
+      "title": "21 sessions, 2026-08-07 to 2026-09-04"
+    }
+  ],
+  "overnight": [],
+  "candidates": [],
+  "spyForecast": {
+    "forecast": {
+      "t1Down": 0.52,
+      "t5Down": 0.55,
+      "referenceClose": {
+        "date": "2026-09-04",
+        "value": 770.19
+      }
+    },
+    "scorable": true
+  },
+  "schemaVersion": 3
+}

--- a/web/tests/unit/flashMarkdown.test.ts
+++ b/web/tests/unit/flashMarkdown.test.ts
@@ -116,12 +116,21 @@ describe("parseBlocks", () => {
     expect(only.text).toContain("POLICY PATH — SOURCE ow_argon_policy_path");
   });
 
-  it("reads a dash list, and single newlines inside a paragraph as spaces", () => {
+  it("reads a dash list, and a single newline as a block seam", () => {
     expect(parseBlocks("- one\n- two\n- three")).toEqual([
       { type: "ul", items: ["one", "two", "three"] },
     ]);
+    // helium writes block-level markdown joined by single newlines (schema 3):
+    // a bare line is its own statement, never a soft wrap of the previous one.
     expect(parseBlocks("first line\nsecond line")).toEqual([
-      { type: "p", text: "first line second line" },
+      { type: "p", text: "first line" },
+      { type: "p", text: "second line" },
+    ]);
+    // A heading line over a bullet run — §3/§5 of the weekly review — is one
+    // paragraph followed by one list, not a paragraph with inline " - ".
+    expect(parseBlocks("3a macro\n- SPX — CONTINUE\n- VIX — FADE")).toEqual([
+      { type: "p", text: "3a macro" },
+      { type: "ul", items: ["SPX — CONTINUE", "VIX — FADE"] },
     ]);
     expect(parseBlocks("")).toEqual([]);
     expect(parseBlocks("   \n\n  ")).toEqual([]);

--- a/web/tests/unit/flashView.test.ts
+++ b/web/tests/unit/flashView.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { SUPPORTED_SCHEMA_VERSIONS, asBriefView } from "@/components/flash/view";
+import {
+  SUPPORTED_SCHEMA_VERSIONS,
+  asBriefView,
+} from "@/components/flash/view";
+import CLOSE from "../fixtures/heliumBriefViewV3Close.json";
+import V2 from "../fixtures/heliumBriefViewV2.json";
+import WEEKLY from "../fixtures/heliumBriefViewV3Weekly.json";
 
 function run(schema_version: number, view: unknown) {
   return {
@@ -14,8 +20,8 @@ function run(schema_version: number, view: unknown) {
 }
 
 describe("asBriefView", () => {
-  it("understands both the prose-target and the typed-target shapes", () => {
-    expect([...SUPPORTED_SCHEMA_VERSIONS].sort()).toEqual([1, 2]);
+  it("understands the prose-target, typed-target and review shapes", () => {
+    expect([...SUPPORTED_SCHEMA_VERSIONS].sort()).toEqual([1, 2, 3]);
   });
 
   it("renders a v1 document, because argon deploys before helium", () => {
@@ -61,7 +67,34 @@ describe("asBriefView", () => {
     expect(view!.candidates![0]!.thesis).toBe("grinds toward 748");
   });
 
+  it("renders a v3 document, review blocks and all", () => {
+    const view = asBriefView(run(3, WEEKLY));
+    expect(view).not.toBeNull();
+    expect(view!.focus!.rows[0]!.ticker).toBe("ADBE");
+    expect(view!.themes![0]!.id).toBe("el-nino-ag-2026");
+    expect(view!.rotation!.rows.length).toBeGreaterThan(0);
+    expect(view!.footer!.coverage!.length).toBeGreaterThan(0);
+    expect(view!.faults).toEqual([
+      "下周展望 restates the level 14.32, which section 3 already printed",
+    ]);
+  });
+
+  it("keeps the v3 close row's one-thing block, checks and all", () => {
+    const view = asBriefView(run(3, CLOSE));
+    expect(view!.oneThing!.title).toBe("The one thing");
+    expect(view!.checks).toHaveLength(3);
+    expect(view!.changeMyMind!.series).toBe("BAMLH0A0HYM2");
+    expect(view!.everythingElse).toHaveLength(3);
+  });
+
+  it("does NOT touch the v2 document it already rendered", () => {
+    // Every identity field is already in the document, so the adapter is a
+    // pass-through: v3 support may not put a single new key on a v2 page.
+    const view = asBriefView(run(2, V2));
+    expect(view).toEqual(V2);
+  });
+
   it("still returns null for a version this build has never heard of", () => {
-    expect(asBriefView(run(3, { date: "2026-09-04" }))).toBeNull();
+    expect(asBriefView(run(4, { date: "2026-09-04" }))).toBeNull();
   });
 });


### PR DESCRIPTION
## What

The Flash pages refused every schema-version 3 run with the **Unrenderable version** band while the whole document sat in Postgres. `option_wizard_local` holds two real v3 rows — the weekly of 2026-09-06 (`run-bf4b1795`) and the close of 2026-09-04 (`run-e7abdf17`) — and both rendered nothing.

`SUPPORTED_SCHEMA_VERSIONS` becomes `[1, 2, 3]` and `BriefView` gains the v3 keys, hand-written like the rest of the file: `focus`, `themes`, `rotation`, `footer`, `faults`, `oneThing`, `checks`, `changeMyMind`, `everythingElse`, plus the previously unmodelled `staleness`, `spyForecast`, `runLabel`, `appBase`, `cause`.

One panel per group, wired in helium's own order (the section order IS the argument):

| Panel | Draws |
| --- | --- |
| `FocusPanel` | rank · ticker · event · IV rank · open-call id · why, with the run's churn, shortfall and carried-over (`sticky`) marks |
| `ThemesPanel` | verdict token as a state pill, both excess strings verbatim, the kill condition and whether `killMet` |
| `RotationPanel` | 1w/4w/12w and excess vs the run's benchmark; a stale symbol prints **untested** in every cell with the reason underneath |
| `FooterPanel` | coverage / as-of / notes / stale inputs, verbatim |
| `OneThingPanel` | the claim, its three checks, the change-my-mind condition |
| `EverythingElsePanel` | what the run saw and did not build the argument on |

`RunFaultsPanel` now prints v3's per-item `faults` **beside** the `degradation` sentence rather than replacing it — they are different objects and both are the run's.

Weekly: review sections → focus → themes → rotation → footer → faults, Frank column untouched. Close/intraday: the claim and its checks first, then focus/themes, then everything-else, then the existing status/proposal/read, then faults and footer. Premarket takes the same daily keys when they are present.

## Two refusals worth naming

- **A missing week is not a flat week.** Every rotation number is nullable; a row helium could not measure prints `untested` and carries its reason, never `0.0`.
- **No per-check hit/miss pill.** No stored run carries a per-check verdict field. helium scores yesterday's checks in one sentence (`oneThing.checksLine`), which is printed; inventing a per-row state would be argon scoring a check it never observed.

Coverage verdicts inside the review prose (`CONTINUE` / `STRENGTHEN` / `FADE` / `REVERSE` / `UNTESTED`) are set apart the way a ticker already is, via the existing `Body` tokenizer. A closed list decides, so a renamed verdict prints as written instead of vanishing into a chip argon guessed at.

## v2 is untouched

`asBriefView` on a v2 document is still a pass-through, pinned by a new `toEqual(V2)` test. The existing v1/v2 fixtures and every flash test render unchanged.

## Verification

- `npm run typecheck` · `npm run lint` clean
- `npm run test` — **158 files, 1221 tests pass** (was 1217): new `flashV3Panels.test.tsx` plus v3 cases in `flashView`, `flashWeeklyView`, `flashSupplementView`. Fixtures are frozen copies of the two real rows, no invented values.
- `npm run build` compiles both Flash routes
- Rendered against the live API from a scratch dev server (never :3001/:8400). a11y snapshots under `output/playwright/`: the weekly page shows all ten review sections, Focus (15 names, churn 0), Themes, Rotation with `XLE` untested (`no bar on 2026-09-04; newest 2026-07-13`), Sources & as-of, Run health; the close page opens with "The one thing", its three checks (VIXCLS at 14.32, 9/16 hold probability at 50.7, DGS10 at 4.77), the change-my-mind block, Focus (5 names), Themes, Everything else (3), then the existing content, the three faults and the footer. No "Unrenderable version" band on either.

## Left plain

The `3 · Coverage` body arrives as a dash list under a `3a macro` heading line, which the existing `parseBlocks` reads as one paragraph (its list rule needs every line to start with `- `). Unchanged here on purpose — it is shared markdown behaviour for v1/v2 bodies too, and widening it belongs in its own change.