### PR TITLE
Lead Flash with market prose and collapse supporting detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ version in lockstep (enforced by `scripts/release/version_sync_check.py`).
 
 ## [Unreleased]
 
+### Changed
+
+- **Flash leads with the market article** — weekly and daily pages put the market
+  review and outlook first, support topic subheadings, and keep coverage and
+  supporting panels in closed details blocks. Internal weekly self-review,
+  repeated leads and empty supplements stay out of the public article; source
+  dates and run refusals remain visible. Local page capture now verifies the
+  exact run and view digest at desktop and mobile widths.
+
 ### Added
 
 - **Flash renders helium's schema-version 3 brief view** — `SUPPORTED_SCHEMA_VERSIONS`

--- a/web/components/flash/Body.tsx
+++ b/web/components/flash/Body.tsx
@@ -149,6 +149,13 @@ export function Body({
             </ul>
           );
         }
+        if (block.type === "h") {
+          return (
+            <h5 key={i} className={styles.bodyHeading}>
+              {highlight(block.text, tickers)}
+            </h5>
+          );
+        }
         return (
           <p key={i} className={styles.bodyText}>
             {highlight(block.text, tickers)}

--- a/web/components/flash/DecisionBlock.tsx
+++ b/web/components/flash/DecisionBlock.tsx
@@ -37,9 +37,22 @@ export function DecisionBlock({
 }: {
   rows: { label: string; value: string }[];
 }) {
+  const noAction = rows.some(
+    (row) =>
+      row.label.toLowerCase() === "action" &&
+      row.value.trim().toLowerCase() === "none",
+  );
+  const shown = noAction
+    ? rows.filter(
+        (row) =>
+          !["", "none", "n/a", "—", "-", "not applicable"].includes(
+            row.value.trim().toLowerCase(),
+          ),
+      )
+    : rows;
   return (
     <div className={styles.dec}>
-      {rows.map((row, i) => (
+      {shown.map((row, i) => (
         <Fragment key={`${row.label}-${i}`}>
           <div
             className={`${styles.lbl} ${styles.decKey}`}

--- a/web/components/flash/FlashDayPage.tsx
+++ b/web/components/flash/FlashDayPage.tsx
@@ -1,4 +1,8 @@
-import type { AgentRunIndexRow, AgentRunResponse, AgentRunWeek } from "@/lib/api";
+import type {
+  AgentRunIndexRow,
+  AgentRunResponse,
+  AgentRunWeek,
+} from "@/lib/api";
 import { KIND_LABEL, todayEt, type DayKind } from "@/lib/flash/kinds";
 import { viewDigest } from "@/lib/flash/view-digest";
 
@@ -60,26 +64,30 @@ export function FlashDayPage({
         asOf={view?.asOf ?? run?.created_at}
       />
 
-      <div data-testid="flash-report" data-run-id={run?.run_id} data-view-sha256={run ? viewDigest(run.view) : undefined}>
-      {!run ? (
-        <NoRunRecorded day={day} kind={kind} isFuture={day > todayEt()} />
-      ) : !view ? (
-        <PlaceholderBand label="Unrenderable version">
-          {`The ${KIND_LABEL[kind] ?? kind} run for ${day} arrived as schema version ${run.schema_version}; this build of argon renders version(s) ${SUPPORTED_SCHEMA_VERSIONS.join(", ")}. The run is stored and nothing is lost — the fix is an argon deploy, not a re-run.`}
-        </PlaceholderBand>
-      ) : kind === "premarket" ? (
-        <PremarketView view={view} />
-      ) : (
-        <SupplementView
-          view={view}
-          kind={kind}
-          weekKey={weekKey}
-          day={day}
-          runs={runs}
-          priorGex={priorView?.gex}
-          priorAsOf={priorView?.asOf}
-        />
-      )}
+      <div
+        data-testid="flash-report"
+        data-run-id={run?.run_id}
+        data-view-sha256={run ? viewDigest(run.view) : undefined}
+      >
+        {!run ? (
+          <NoRunRecorded day={day} kind={kind} isFuture={day > todayEt()} />
+        ) : !view ? (
+          <PlaceholderBand label="Unrenderable version">
+            {`The ${KIND_LABEL[kind] ?? kind} run for ${day} arrived as schema version ${run.schema_version}; this build of argon renders version(s) ${SUPPORTED_SCHEMA_VERSIONS.join(", ")}. The run is stored and nothing is lost — the fix is an argon deploy, not a re-run.`}
+          </PlaceholderBand>
+        ) : kind === "premarket" ? (
+          <PremarketView view={view} />
+        ) : (
+          <SupplementView
+            view={view}
+            kind={kind}
+            weekKey={weekKey}
+            day={day}
+            runs={runs}
+            priorGex={priorView?.gex}
+            priorAsOf={priorView?.asOf}
+          />
+        )}
       </div>
     </main>
   );

--- a/web/components/flash/FlashDayPage.tsx
+++ b/web/components/flash/FlashDayPage.tsx
@@ -61,7 +61,7 @@ export function FlashDayPage({
         day={day}
         runs={runs}
         selected={kind}
-        asOf={view?.asOf ?? run?.created_at}
+        asOf={view?.asOf}
       />
 
       <div

--- a/web/components/flash/FlashDayPage.tsx
+++ b/web/components/flash/FlashDayPage.tsx
@@ -1,5 +1,6 @@
 import type { AgentRunIndexRow, AgentRunResponse, AgentRunWeek } from "@/lib/api";
 import { KIND_LABEL, todayEt, type DayKind } from "@/lib/flash/kinds";
+import { viewDigest } from "@/lib/flash/view-digest";
 
 import { FlashTopbar } from "./FlashTopbar";
 import { NoRunRecorded, PlaceholderBand } from "./EmptyStates";
@@ -59,6 +60,7 @@ export function FlashDayPage({
         asOf={view?.asOf ?? run?.created_at}
       />
 
+      <div data-testid="flash-report" data-run-id={run?.run_id} data-view-sha256={run ? viewDigest(run.view) : undefined}>
       {!run ? (
         <NoRunRecorded day={day} kind={kind} isFuture={day > todayEt()} />
       ) : !view ? (
@@ -78,7 +80,7 @@ export function FlashDayPage({
           priorAsOf={priorView?.asOf}
         />
       )}
+      </div>
     </main>
   );
 }
-

--- a/web/components/flash/FlashWeekPage.tsx
+++ b/web/components/flash/FlashWeekPage.tsx
@@ -1,5 +1,6 @@
 import type { AgentRunIndexRow, AgentRunResponse, AgentRunWeek } from "@/lib/api";
 import { todayEt } from "@/lib/flash/kinds";
+import { viewDigest } from "@/lib/flash/view-digest";
 
 import { FlashTopbar } from "./FlashTopbar";
 import { WeekStrip } from "./WeekStrip";
@@ -24,7 +25,7 @@ export function FlashWeekPage({
     <main className={styles.flash}>
       <FlashTopbar today={todayEt()} />
       <WeekStrip weekKey={weekKey} runs={runs} weeks={weeks} />
-      <div style={{ marginTop: 18 }}>
+      <div data-testid="flash-report" data-run-id={weekly?.run_id} data-view-sha256={weekly ? viewDigest(weekly.view) : undefined} style={{ marginTop: 18 }}>
         <WeeklyView
           weekKey={weekKey}
           runs={runs}

--- a/web/components/flash/FlashWeekPage.tsx
+++ b/web/components/flash/FlashWeekPage.tsx
@@ -1,4 +1,8 @@
-import type { AgentRunIndexRow, AgentRunResponse, AgentRunWeek } from "@/lib/api";
+import type {
+  AgentRunIndexRow,
+  AgentRunResponse,
+  AgentRunWeek,
+} from "@/lib/api";
 import { todayEt } from "@/lib/flash/kinds";
 import { viewDigest } from "@/lib/flash/view-digest";
 
@@ -25,7 +29,12 @@ export function FlashWeekPage({
     <main className={styles.flash}>
       <FlashTopbar today={todayEt()} />
       <WeekStrip weekKey={weekKey} runs={runs} weeks={weeks} />
-      <div data-testid="flash-report" data-run-id={weekly?.run_id} data-view-sha256={weekly ? viewDigest(weekly.view) : undefined} style={{ marginTop: 18 }}>
+      <div
+        data-testid="flash-report"
+        data-run-id={weekly?.run_id}
+        data-view-sha256={weekly ? viewDigest(weekly.view) : undefined}
+        style={{ marginTop: 18 }}
+      >
         <WeeklyView
           weekKey={weekKey}
           runs={runs}

--- a/web/components/flash/OneThingPanel.tsx
+++ b/web/components/flash/OneThingPanel.tsx
@@ -50,11 +50,13 @@ export function OneThingPanel({
   checks,
   changeMyMind,
   tickers,
+  collapsed = false,
 }: {
   oneThing?: OneThing;
   checks?: Check[];
   changeMyMind?: ChangeMyMind;
   tickers?: ReadonlySet<string>;
+  collapsed?: boolean;
 }) {
   if (!oneThing && !(checks && checks.length > 0) && !changeMyMind) return null;
 
@@ -66,7 +68,7 @@ export function OneThingPanel({
       ? oneThing.checksLine
       : null;
 
-  return (
+  const panel = (
     <Panel
       title={oneThing?.title || "The one thing"}
       tail={oneThing?.why || undefined}
@@ -116,5 +118,15 @@ export function OneThingPanel({
         </div>
       ) : null}
     </Panel>
+  );
+  return collapsed ? (
+    <details className={styles.panel}>
+      <summary className={styles.appendixSummary}>
+        Additional evidence and checks
+      </summary>
+      {panel}
+    </details>
+  ) : (
+    panel
   );
 }

--- a/web/components/flash/PremarketView.tsx
+++ b/web/components/flash/PremarketView.tsx
@@ -46,10 +46,14 @@ export function PremarketView({ view }: { view: BriefView }) {
   const tickers = viewTickers(view);
   const claimRepeated = Boolean(
     view.oneThing?.body?.trim() &&
-    view.sections?.some((section) =>
-      section.title !== "Supporting coverage" &&
-      section.body.includes(view.oneThing!.body!.trim()),
+    view.sections?.some(
+      (section) =>
+        section.title !== "Supporting coverage" &&
+        section.body.includes(view.oneThing!.body!.trim()),
     ),
+  );
+  const formalMarket = ["Market review", "Outlook"].every((title) =>
+    view.sections?.some((section) => section.title === title),
   );
   // v3 keeps two fault lists: `degradation` is one sentence about the run,
   // `faults` is the per-item refusals. Both are the run's, so both print.
@@ -68,8 +72,23 @@ export function PremarketView({ view }: { view: BriefView }) {
 
       <div className={styles.article}>
         <div className={styles.colL}>
+          {formalMarket && view.sections && view.sections.length > 0 ? (
+            <SectionsPanel
+              title="The read"
+              sections={view.sections}
+              tickers={tickers}
+            />
+          ) : null}
+
           <OneThingPanel
-            oneThing={claimRepeated ? undefined : view.oneThing}
+            oneThing={
+              formalMarket
+                ? view.oneThing
+                : claimRepeated
+                  ? undefined
+                  : view.oneThing
+            }
+            collapsed={formalMarket}
             checks={view.checks}
             changeMyMind={view.changeMyMind}
             tickers={tickers}
@@ -79,7 +98,8 @@ export function PremarketView({ view }: { view: BriefView }) {
           {view.schedule && view.schedule.length > 0 ? (
             <SchedulePanel items={view.schedule} />
           ) : null}
-          {view.sections && view.sections.length > 0 ? (
+
+          {!formalMarket && view.sections && view.sections.length > 0 ? (
             <SectionsPanel
               title="The read"
               sections={view.sections}

--- a/web/components/flash/PremarketView.tsx
+++ b/web/components/flash/PremarketView.tsx
@@ -58,15 +58,8 @@ export function PremarketView({ view }: { view: BriefView }) {
           <Lead label={["Today in", "one sentence"]} text={lead} />
         </div>
       ) : null}
-      {faults.length > 0 ? (
-        <div style={{ marginTop: 12 }}>
-          <PlaceholderBand label="Run degraded">
-            {faults.join(" · ")}
-          </PlaceholderBand>
-        </div>
-      ) : null}
 
-      <div className={styles.cols}>
+      <div className={styles.article}>
         <div className={styles.colL}>
           <OneThingPanel
             oneThing={view.oneThing}
@@ -74,6 +67,18 @@ export function PremarketView({ view }: { view: BriefView }) {
             changeMyMind={view.changeMyMind}
             tickers={tickers}
           />
+
+          <OvernightPanel items={view.overnight ?? []} />
+          {view.schedule && view.schedule.length > 0 ? (
+            <SchedulePanel items={view.schedule} />
+          ) : null}
+          {view.sections && view.sections.length > 0 ? (
+            <SectionsPanel
+              title="The read"
+              sections={view.sections}
+              tickers={tickers}
+            />
+          ) : null}
 
           {view.decision && view.decision.length > 0 ? (
             <Panel title="The call" bodyClassName="">
@@ -103,14 +108,6 @@ export function PremarketView({ view }: { view: BriefView }) {
             </div>
           ) : null}
 
-          {view.sections && view.sections.length > 0 ? (
-            <SectionsPanel
-              title="The read"
-              sections={view.sections}
-              tickers={tickers}
-            />
-          ) : null}
-
           {view.focus && view.focus.rows?.length ? (
             <FocusPanel focus={view.focus} />
           ) : null}
@@ -125,10 +122,6 @@ export function PremarketView({ view }: { view: BriefView }) {
         </div>
 
         <div className={styles.colR}>
-          <OvernightPanel items={view.overnight ?? []} />
-          {view.schedule && view.schedule.length > 0 ? (
-            <SchedulePanel items={view.schedule} />
-          ) : null}
           {view.policy ? <PolicyPathPanel path={view.policy} /> : null}
           {view.gamma && view.gamma.length > 0 ? (
             <GammaProfilePanel profiles={view.gamma} />
@@ -147,6 +140,14 @@ export function PremarketView({ view }: { view: BriefView }) {
           ) : null}
         </div>
       </div>
+
+      {faults.length > 0 ? (
+        <div style={{ marginTop: 12 }}>
+          <PlaceholderBand label="Run degraded">
+            {faults.join(" · ")}
+          </PlaceholderBand>
+        </div>
+      ) : null}
 
       <p
         style={{

--- a/web/components/flash/PremarketView.tsx
+++ b/web/components/flash/PremarketView.tsx
@@ -44,6 +44,13 @@ export function PremarketView({ view }: { view: BriefView }) {
 
   const lead = view.lead ?? view.headline;
   const tickers = viewTickers(view);
+  const claimRepeated = Boolean(
+    view.oneThing?.body?.trim() &&
+    view.sections?.some((section) =>
+      section.title !== "Supporting coverage" &&
+      section.body.includes(view.oneThing!.body!.trim()),
+    ),
+  );
   // v3 keeps two fault lists: `degradation` is one sentence about the run,
   // `faults` is the per-item refusals. Both are the run's, so both print.
   const faults = [...faultList(view.degradation), ...(view.faults ?? [])];
@@ -62,7 +69,7 @@ export function PremarketView({ view }: { view: BriefView }) {
       <div className={styles.article}>
         <div className={styles.colL}>
           <OneThingPanel
-            oneThing={view.oneThing}
+            oneThing={claimRepeated ? undefined : view.oneThing}
             checks={view.checks}
             changeMyMind={view.changeMyMind}
             tickers={tickers}

--- a/web/components/flash/SectionsPanel.tsx
+++ b/web/components/flash/SectionsPanel.tsx
@@ -21,16 +21,24 @@ export function SectionsPanel({
 }) {
   const body = (
     <div className={styles.secgrid}>
-      {sections.map((s, i) => (
-        <article key={`${s.title}-${i}`} className={styles.seccard}>
-          <h4>{s.title}</h4>
-          {pre ? (
-            <p className={styles.pre}>{s.body}</p>
-          ) : (
-            <Body text={s.body} tickers={tickers} />
-          )}
-        </article>
-      ))}
+      {sections.map((s, i) => {
+        const prose = pre ? (
+          <p className={styles.pre}>{s.body}</p>
+        ) : (
+          <Body text={s.body} tickers={tickers} />
+        );
+        return s.title === "Supporting coverage" ? (
+          <details key={`${s.title}-${i}`} className={styles.seccard}>
+            <summary className={styles.appendixSummary}>{s.title}</summary>
+            {prose}
+          </details>
+        ) : (
+          <article key={`${s.title}-${i}`} className={styles.seccard}>
+            <h4>{s.title}</h4>
+            {prose}
+          </article>
+        );
+      })}
     </div>
   );
   return (

--- a/web/components/flash/SupplementView.tsx
+++ b/web/components/flash/SupplementView.tsx
@@ -59,6 +59,13 @@ export function SupplementView({
   );
   const lead = view.lead ?? view.headline;
   const tickers = viewTickers(view);
+  const claimRepeated = Boolean(
+    view.oneThing?.body?.trim() &&
+    view.sections?.some((section) =>
+      section.title !== "Supporting coverage" &&
+      section.body.includes(view.oneThing!.body!.trim()),
+    ),
+  );
   const label: [string, string] =
     kind === "close" ? ["Close", "read"] : ["Intraday", "read"];
   const statusTitle =
@@ -109,7 +116,7 @@ export function SupplementView({
 
         <div className={styles.colL}>
           <OneThingPanel
-            oneThing={view.oneThing}
+            oneThing={claimRepeated ? undefined : view.oneThing}
             checks={view.checks}
             changeMyMind={view.changeMyMind}
             tickers={tickers}

--- a/web/components/flash/SupplementView.tsx
+++ b/web/components/flash/SupplementView.tsx
@@ -85,8 +85,10 @@ export function SupplementView({
             <Link href={`/flash/${weekKey}/${day}?phase=premarket`}>
               premarket report
             </Link>{" "}
-            of {day}. The {kind} run is a separate transcript; it settles and
-            revises the premarket call rather than replacing it.
+            of {day}.{" "}
+            {kind === "close"
+              ? "How the day resolved and what carries into tomorrow."
+              : "Material changes since the morning and what they mean."}
           </p>
         ) : (
           <p>
@@ -96,7 +98,15 @@ export function SupplementView({
         )}
       </div>
 
-      <div className={styles.supgrid}>
+      <div className={styles.article}>
+        {view.sections && view.sections.length > 0 ? (
+          <SectionsPanel
+            title={kind === "close" ? "How the day resolved" : "What changed"}
+            sections={view.sections}
+            tickers={tickers}
+          />
+        ) : null}
+
         <div className={styles.colL}>
           <OneThingPanel
             oneThing={view.oneThing}
@@ -150,16 +160,6 @@ export function SupplementView({
             <Panel title="The call" tail={kind} bodyClassName="">
               <DecisionBlock rows={view.decision} />
             </Panel>
-          ) : null}
-
-          {view.sections && view.sections.length > 0 ? (
-            <SectionsPanel
-              title="The read"
-              tail="full transcript, this run"
-              sections={view.sections}
-              scroll
-              tickers={tickers}
-            />
           ) : null}
 
           {view.recap && view.recap.length > 0 ? (

--- a/web/components/flash/SupplementView.tsx
+++ b/web/components/flash/SupplementView.tsx
@@ -61,10 +61,14 @@ export function SupplementView({
   const tickers = viewTickers(view);
   const claimRepeated = Boolean(
     view.oneThing?.body?.trim() &&
-    view.sections?.some((section) =>
-      section.title !== "Supporting coverage" &&
-      section.body.includes(view.oneThing!.body!.trim()),
+    view.sections?.some(
+      (section) =>
+        section.title !== "Supporting coverage" &&
+        section.body.includes(view.oneThing!.body!.trim()),
     ),
+  );
+  const formalMarket = ["Market review", "Outlook"].every((title) =>
+    view.sections?.some((section) => section.title === title),
   );
   const label: [string, string] =
     kind === "close" ? ["Close", "read"] : ["Intraday", "read"];
@@ -116,7 +120,14 @@ export function SupplementView({
 
         <div className={styles.colL}>
           <OneThingPanel
-            oneThing={claimRepeated ? undefined : view.oneThing}
+            oneThing={
+              formalMarket
+                ? view.oneThing
+                : claimRepeated
+                  ? undefined
+                  : view.oneThing
+            }
+            collapsed={formalMarket}
             checks={view.checks}
             changeMyMind={view.changeMyMind}
             tickers={tickers}

--- a/web/components/flash/WeeklyView.tsx
+++ b/web/components/flash/WeeklyView.tsx
@@ -46,6 +46,11 @@ export function WeeklyView({
   const headlineRepeated = Boolean(
     headline && market[0]?.body.trim().startsWith(headline),
   );
+  const hasMarketDetail = Boolean(
+    weeklyView?.focus?.rows?.length ||
+    weeklyView?.themes?.length ||
+    weeklyView?.rotation?.rows?.length,
+  );
   // v3 keeps two fault lists: `degradation` is one sentence about the run,
   // `faults` is the per-item refusals. Both are the run's, so both print.
   const weeklyFaults = weeklyView
@@ -69,14 +74,21 @@ export function WeeklyView({
                 sections={market}
                 tickers={weeklyTickers ?? undefined}
               />
-              {weeklyView.focus && weeklyView.focus.rows?.length ? (
-                <FocusPanel focus={weeklyView.focus} />
-              ) : null}
-              {weeklyView.themes && weeklyView.themes.length > 0 ? (
-                <ThemesPanel themes={weeklyView.themes} />
-              ) : null}
-              {weeklyView.rotation && weeklyView.rotation.rows?.length ? (
-                <RotationPanel rotation={weeklyView.rotation} />
+              {hasMarketDetail ? (
+                <details className={styles.seccard}>
+                  <summary className={styles.appendixSummary}>
+                    Focus, themes and rotation
+                  </summary>
+                  {weeklyView.focus && weeklyView.focus.rows?.length ? (
+                    <FocusPanel focus={weeklyView.focus} />
+                  ) : null}
+                  {weeklyView.themes && weeklyView.themes.length > 0 ? (
+                    <ThemesPanel themes={weeklyView.themes} />
+                  ) : null}
+                  {weeklyView.rotation && weeklyView.rotation.rows?.length ? (
+                    <RotationPanel rotation={weeklyView.rotation} />
+                  ) : null}
+                </details>
               ) : null}
               {coverage.length > 0 ? (
                 <SectionsPanel

--- a/web/components/flash/WeeklyView.tsx
+++ b/web/components/flash/WeeklyView.tsx
@@ -79,16 +79,11 @@ export function WeeklyView({
                 <RotationPanel rotation={weeklyView.rotation} />
               ) : null}
               {coverage.length > 0 ? (
-                <details className={styles.panel}>
-                  <summary className={styles.appendixSummary}>
-                    Supporting coverage
-                  </summary>
-                  <SectionsPanel
-                    title="Recorded evidence"
-                    sections={coverage}
-                    tickers={weeklyTickers ?? undefined}
-                  />
-                </details>
+                <SectionsPanel
+                  title="Supporting evidence"
+                  sections={coverage}
+                  tickers={weeklyTickers ?? undefined}
+                />
               ) : null}
               {weeklyView.footer ? (
                 <FooterPanel

--- a/web/components/flash/WeeklyView.tsx
+++ b/web/components/flash/WeeklyView.tsx
@@ -3,6 +3,7 @@ import { weekDays, weekRange } from "@/lib/flash/kinds";
 
 import { FocusPanel } from "./FocusPanel";
 import { FooterPanel } from "./FooterPanel";
+import { Lead } from "./Lead";
 import { Panel } from "./Panel";
 import { RotationPanel } from "./RotationPanel";
 import { RunFaultsPanel } from "./RunFaultsPanel";
@@ -12,7 +13,7 @@ import { asBriefView, faultList, viewTickers } from "./view";
 import styles from "./flash.module.css";
 
 /**
- * The week: five one-liners, then the outlook and the Frank supplement.
+ * The market week first, supporting detail and recorded-day index after it.
  *
  * Frank 复盘 attaches HERE, to the weekly summary — not to a day. It is an
  * external weekly review of the week just ended, and filing it under Monday
@@ -34,6 +35,17 @@ export function WeeklyView({
   const weeklyView = weekly ? asBriefView(weekly) : null;
   const frankView = frank ? asBriefView(frank) : null;
   const weeklyTickers = weeklyView ? viewTickers(weeklyView) : null;
+  const sections = weeklyView?.sections ?? [];
+  const coverage = sections.filter(
+    (section) => section.title === "Supporting coverage",
+  );
+  const market = sections.filter(
+    (section) => section.title !== "Supporting coverage",
+  );
+  const headline = weeklyView?.headline?.trim();
+  const headlineRepeated = Boolean(
+    headline && market[0]?.body.trim().startsWith(headline),
+  );
   // v3 keeps two fault lists: `degradation` is one sentence about the run,
   // `faults` is the per-item refusals. Both are the run's, so both print.
   const weeklyFaults = weeklyView
@@ -42,68 +54,19 @@ export function WeeklyView({
 
   return (
     <>
-      <Panel
-        title="The week, one line a day"
-        tail={`${first} → ${last}`}
-        bodyClassName=""
-      >
-        {days.map(({ date, dow }) => {
-          const forDay = runs.filter((r) => String(r.run_day) === date);
-          const oneLiner =
-            forDay.find((r) => r.kind === "premarket" && r.headline)
-              ?.headline ?? "";
-          return (
-            <div
-              key={date}
-              className={styles.wkrow}
-              data-testid={`weekly-row-${date}`}
-            >
-              <div className={styles.wkrowDay}>
-                <span className={styles.dow}>{dow}</span>
-                <span className={styles.dt}>{date}</span>
-              </div>
-              <div className={styles.wkrowText}>
-                {oneLiner ? (
-                  <span
-                    style={{
-                      fontSize: 12.5,
-                      lineHeight: 1.55,
-                      color: "var(--text-secondary)",
-                      maxWidth: "110ch",
-                    }}
-                  >
-                    {oneLiner}
-                  </span>
-                ) : (
-                  <span className={styles.norun}>no run recorded</span>
-                )}
-                <span
-                  className={`${styles.mono} ${styles.wkrowRuns}`}
-                  style={{
-                    color:
-                      forDay.length > 0
-                        ? "var(--positive)"
-                        : "var(--text-muted)",
-                  }}
-                >
-                  {forDay.length} {forDay.length === 1 ? "run" : "runs"}
-                </span>
-              </div>
-            </div>
-          );
-        })}
-      </Panel>
-
-      <div className={styles.cols}>
+      <div className={styles.article}>
         <div className={styles.colL}>
           {weeklyView &&
           weeklyView.sections &&
           weeklyView.sections.length > 0 ? (
             <>
+              {headline && !headlineRepeated ? (
+                <Lead label={["The market", "this week"]} text={headline} />
+              ) : null}
               <SectionsPanel
-                title="Week ahead"
+                title="Market week"
                 tail={weeklyView.asOf}
-                sections={weeklyView.sections}
+                sections={market}
                 tickers={weeklyTickers ?? undefined}
               />
               {weeklyView.focus && weeklyView.focus.rows?.length ? (
@@ -114,6 +77,18 @@ export function WeeklyView({
               ) : null}
               {weeklyView.rotation && weeklyView.rotation.rows?.length ? (
                 <RotationPanel rotation={weeklyView.rotation} />
+              ) : null}
+              {coverage.length > 0 ? (
+                <details className={styles.panel}>
+                  <summary className={styles.appendixSummary}>
+                    Supporting coverage
+                  </summary>
+                  <SectionsPanel
+                    title="Recorded evidence"
+                    sections={coverage}
+                    tickers={weeklyTickers ?? undefined}
+                  />
+                </details>
               ) : null}
               {weeklyView.footer ? (
                 <FooterPanel
@@ -138,24 +113,65 @@ export function WeeklyView({
             </Panel>
           )}
         </div>
-        <div className={styles.colR}>
-          {frankView && frankView.sections && frankView.sections.length > 0 ? (
-            <SectionsPanel
-              title="Frank 复盘"
-              tail="supplement slot"
-              sections={frankView.sections}
-              pre
-            />
-          ) : (
-            <Panel title="Frank 复盘" tail="supplement slot">
-              <SlotEmpty
-                headline="No review attached"
-                body="An external weekly review, attached to the weekly summary rather than to any single day. None recorded for this week."
-                ghost={70}
-              />
-            </Panel>
-          )}
-        </div>
+        {frankView?.sections && frankView.sections.length > 0 ? (
+          <SectionsPanel
+            title="Frank 复盘"
+            tail="external weekly supplement"
+            sections={frankView.sections}
+            pre
+          />
+        ) : null}
+        <Panel
+          title="The week, one line a day"
+          tail={`${first} → ${last}`}
+          bodyClassName=""
+        >
+          {days.map(({ date, dow }) => {
+            const forDay = runs.filter((r) => String(r.run_day) === date);
+            const oneLiner =
+              forDay.find((r) => r.kind === "premarket" && r.headline)
+                ?.headline ?? "";
+            return (
+              <div
+                key={date}
+                className={styles.wkrow}
+                data-testid={`weekly-row-${date}`}
+              >
+                <div className={styles.wkrowDay}>
+                  <span className={styles.dow}>{dow}</span>
+                  <span className={styles.dt}>{date}</span>
+                </div>
+                <div className={styles.wkrowText}>
+                  {oneLiner ? (
+                    <span
+                      style={{
+                        fontSize: 12.5,
+                        lineHeight: 1.55,
+                        color: "var(--text-secondary)",
+                        maxWidth: "110ch",
+                      }}
+                    >
+                      {oneLiner}
+                    </span>
+                  ) : (
+                    <span className={styles.norun}>no run recorded</span>
+                  )}
+                  <span
+                    className={`${styles.mono} ${styles.wkrowRuns}`}
+                    style={{
+                      color:
+                        forDay.length > 0
+                          ? "var(--positive)"
+                          : "var(--text-muted)",
+                    }}
+                  >
+                    {forDay.length} {forDay.length === 1 ? "run" : "runs"}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </Panel>
       </div>
     </>
   );

--- a/web/components/flash/flash.module.css
+++ b/web/components/flash/flash.module.css
@@ -401,6 +401,21 @@
   font-size: 15px;
 }
 
+/* The newsletter reads in one column; supporting panels follow the article. */
+.article {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 980px;
+  margin: 12px auto 0;
+}
+
+.appendixSummary {
+  padding: 12px 14px;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
 /* ---------- two-column body ---------- */
 .cols {
   display: grid;

--- a/web/components/flash/flash.module.css
+++ b/web/components/flash/flash.module.css
@@ -806,6 +806,14 @@
   max-width: 80ch;
 }
 
+.bodyHeading {
+  margin: 4px 0 -2px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
 .bodyList {
   margin: 0;
   padding-left: 16px;

--- a/web/lib/flash/markdown.ts
+++ b/web/lib/flash/markdown.ts
@@ -4,11 +4,12 @@
  * A run's body is prose the tenant composed: mostly paragraphs, sometimes a
  * pipe table (the coverage layer/source/as-of grid), occasionally a dash list,
  * and sometimes a run of settlement records helium wrote as one block. This
- * parser recognises exactly those four and falls back to a paragraph for
+ * parser recognises exactly those five and falls back to a paragraph for
  * everything else — a body it cannot read is still printed in full, never
  * dropped and never reshaped into a tidier claim than the run made.
  */
 export type Block =
+  | { type: "h"; text: string }
   | { type: "p"; text: string }
   | { type: "table"; header: string[]; rows: string[][] }
   | { type: "ul"; items: string[] };
@@ -94,7 +95,13 @@ export function parseBlocks(text: string): Block[] {
     // v2 bodies never soft-wrap prose (checked against the frozen v2 fixture), so
     // this only changes what used to collapse into one "wall of text".
     const kindOf = (l: string) =>
-      l.startsWith("- ") ? "ul" : l.startsWith("|") ? "table" : "p";
+      l.startsWith("## ")
+        ? "h"
+        : l.startsWith("- ")
+          ? "ul"
+          : l.startsWith("|")
+            ? "table"
+            : "p";
     let i = 0;
     while (i < lines.length) {
       const kind = kindOf(lines[i]);
@@ -102,10 +109,15 @@ export function parseBlocks(text: string): Block[] {
       while (j < lines.length && kindOf(lines[j]) === kind) j++;
       const run = lines.slice(i, j);
       i = j;
-      if (kind === "ul") {
+      if (kind === "h") {
+        for (const text of run)
+          blocks.push({ type: "h", text: text.slice(3).trim() });
+      } else if (kind === "ul") {
         blocks.push({ type: "ul", items: run.map((l) => l.slice(2).trim()) });
       } else if (kind === "table") {
-        const rows = run.map(splitRow).filter((cells) => !isSeparatorRow(cells));
+        const rows = run
+          .map(splitRow)
+          .filter((cells) => !isSeparatorRow(cells));
         if (rows.length > 0) {
           const [header, ...body] = rows;
           blocks.push({ type: "table", header, rows: body });

--- a/web/lib/flash/view-digest.ts
+++ b/web/lib/flash/view-digest.ts
@@ -1,0 +1,13 @@
+import { createHash } from "node:crypto";
+
+// Server-side provenance: JSONB may reorder object keys, but never array rows.
+function ordered(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(ordered);
+  if (value !== null && typeof value === "object")
+    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => [key, ordered(entry)]));
+  return value;
+}
+
+export function viewDigest(view: unknown): string {
+  return createHash("sha256").update(JSON.stringify(ordered(view))).digest("hex");
+}

--- a/web/lib/flash/view-digest.ts
+++ b/web/lib/flash/view-digest.ts
@@ -4,10 +4,16 @@ import { createHash } from "node:crypto";
 function ordered(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(ordered);
   if (value !== null && typeof value === "object")
-    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, entry]) => [key, ordered(entry)]));
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, ordered(entry)]),
+    );
   return value;
 }
 
 export function viewDigest(view: unknown): string {
-  return createHash("sha256").update(JSON.stringify(ordered(view))).digest("hex");
+  return createHash("sha256")
+    .update(JSON.stringify(ordered(view)))
+    .digest("hex");
 }

--- a/web/scripts/capture-flash.mjs
+++ b/web/scripts/capture-flash.mjs
@@ -25,7 +25,8 @@ try {
   if (await report.getAttribute('data-run-id') !== evidence.run.runId) throw new Error('page run does not match source');
   if (await report.getAttribute('data-view-sha256') !== viewDigest(evidence.view)) throw new Error('page view does not match source');
   const text = await report.innerText();
-  if (!text.trim() || (evidence.view.headline && !text.includes(evidence.view.headline))) throw new Error('missing source headline');
+  const headline = evidence.view.headline?.replace(/^## /gm, '');
+  if (!text.trim() || (headline && !text.includes(headline))) throw new Error('missing source headline');
   writeFileSync(join(output, 'page.md'), text + '\n');
   writeFileSync(join(output, 'page.html'), await page.content());
   // Expand only app scroll containers while photographing the complete article.

--- a/web/scripts/capture-flash.mjs
+++ b/web/scripts/capture-flash.mjs
@@ -1,0 +1,46 @@
+// Capture what the real Flash component displays, not a transcript or email teaser.
+// Usage: node scripts/capture-flash.mjs <url> <steps.json> <new-output-dir>
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+import { viewDigest } from '../lib/flash/view-digest.ts';
+
+const [url, source, output] = process.argv.slice(2);
+const repo = fileURLToPath(new URL('../../', import.meta.url));
+if (!url || !source || !output) throw new Error('expected <url> <steps.json> <new-output-dir>');
+const bytes = readFileSync(source);
+const evidence = JSON.parse(bytes);
+if (!evidence.run?.runId || !evidence.view) throw new Error('source must contain final run/view');
+mkdirSync(output, { recursive: false });
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  const response = await page.goto(url, { waitUntil: 'networkidle' });
+  if (!response?.ok()) throw new Error(`page HTTP ${response?.status()}`);
+  const report = page.getByTestId('flash-report');
+  await report.waitFor({ state: 'visible' });
+  if (await report.getAttribute('data-run-id') !== evidence.run.runId) throw new Error('page run does not match source');
+  if (await report.getAttribute('data-view-sha256') !== viewDigest(evidence.view)) throw new Error('page view does not match source');
+  const text = await report.innerText();
+  if (!text.trim() || (evidence.view.headline && !text.includes(evidence.view.headline))) throw new Error('missing source headline');
+  writeFileSync(join(output, 'page.md'), text + '\n');
+  writeFileSync(join(output, 'page.html'), await page.content());
+  // Expand only app scroll containers while photographing the complete article.
+  const style = 'html, body, .app-shell, .main, .content { height: auto !important; overflow: visible !important; }';
+  await page.screenshot({ path: join(output, 'desktop.png'), fullPage: true, style });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.screenshot({ path: join(output, 'mobile.png'), fullPage: true, style });
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  if (overflow > 0) throw new Error(`mobile horizontal overflow: ${overflow}`);
+  const hash = (value) => createHash('sha256').update(value).digest('hex');
+  writeFileSync(join(output, 'capture.json'), JSON.stringify({
+    url, runId: evidence.run.runId, capturedAt: new Date().toISOString(),
+    argonSha: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+    argonDirty: !!execFileSync('git', ['status', '--porcelain'], { cwd: repo, encoding: 'utf8' }).trim(),
+    sourceSha256: hash(bytes), viewSha256: viewDigest(evidence.view),
+    pageSha256: hash(text + '\n'), mobileOverflow: overflow,
+  }, null, 2) + '\n');
+} finally { await browser.close(); }

--- a/web/scripts/capture-flash.mjs
+++ b/web/scripts/capture-flash.mjs
@@ -29,7 +29,7 @@ try {
   writeFileSync(join(output, 'page.md'), text + '\n');
   writeFileSync(join(output, 'page.html'), await page.content());
   // Expand only app scroll containers while photographing the complete article.
-  const style = 'html, body, .app-shell, .main, .content { height: auto !important; overflow: visible !important; }';
+  const style = ':has([data-testid="flash-report"]) { height: auto !important; max-height: none !important; overflow: visible !important; }';
   await page.screenshot({ path: join(output, 'desktop.png'), fullPage: true, style });
   await page.setViewportSize({ width: 390, height: 844 });
   await page.screenshot({ path: join(output, 'mobile.png'), fullPage: true, style });

--- a/web/tests/components/flashPremarketView.test.tsx
+++ b/web/tests/components/flashPremarketView.test.tsx
@@ -104,4 +104,56 @@ describe("PremarketView", () => {
       screen.getByText("Premarket raw rows.").closest("details")?.open,
     ).toBe(false);
   });
+  it("places formal market sections first and preserves extra checks in a closed appendix", () => {
+    const { container } = render(
+      <PremarketView
+        view={{
+          ...PREMARKET_VIEW,
+          oneThing: {
+            title: "The one thing",
+            body: "Additional thesis evidence.",
+          },
+          checks: [
+            { series: "VIX", level: "15", text: "Check volatility tomorrow." },
+          ],
+          changeMyMind: { text: "Invalidate on credit widening." },
+          sections: [
+            { title: "Market review", body: "Main market article." },
+            { title: "Outlook", body: "Next conditions." },
+          ],
+        }}
+      />,
+    );
+    const appendix = screen
+      .getByText("Additional thesis evidence.")
+      .closest("details");
+    expect(appendix?.open).toBe(false);
+    expect(appendix?.textContent).toContain("Check volatility tomorrow.");
+    expect(appendix?.textContent).toContain("Invalidate on credit widening.");
+    expect(container.textContent!.indexOf("Main market article.")).toBeLessThan(
+      container.textContent!.indexOf("Additional thesis evidence."),
+    );
+  });
+
+  it("compacts a no-action decision while preserving real risk and refusal terms", () => {
+    render(
+      <PremarketView
+        view={{
+          ...PREMARKET_VIEW,
+          decision: [
+            { label: "Call", value: "Stand aside." },
+            { label: "Action", value: "none" },
+            { label: "WhyNow", value: "Quotes stale." },
+            { label: "Aggression", value: "none" },
+            { label: "MaxRisk", value: "n/a" },
+            { label: "Invalidation", value: "Recheck after fresh quotes." },
+          ],
+        }}
+      />,
+    );
+    expect(
+      screen.getAllByTestId("decision-key").map((node) => node.textContent),
+    ).toEqual(["Call", "Why now", "Invalidation"]);
+    expect(screen.getByText("Recheck after fresh quotes.")).toBeTruthy();
+  });
 });

--- a/web/tests/components/flashPremarketView.test.tsx
+++ b/web/tests/components/flashPremarketView.test.tsx
@@ -84,4 +84,24 @@ describe("PremarketView", () => {
       text.indexOf("Source health sentinel"),
     );
   });
+  it("collapses supporting rows and prints an identical claim only once", () => {
+    const { container } = render(
+      <PremarketView
+        view={{
+          ...PREMARKET_VIEW,
+          oneThing: { title: "The one thing", body: "Repeated market claim." },
+          sections: [
+            { title: "Market review", body: "Repeated market claim." },
+            { title: "Supporting coverage", body: "Premarket raw rows." },
+          ],
+        }}
+      />,
+    );
+    expect(container.textContent?.match(/Repeated market claim/g)).toHaveLength(
+      1,
+    );
+    expect(
+      screen.getByText("Premarket raw rows.").closest("details")?.open,
+    ).toBe(false);
+  });
 });

--- a/web/tests/components/flashPremarketView.test.tsx
+++ b/web/tests/components/flashPremarketView.test.tsx
@@ -41,7 +41,9 @@ describe("PremarketView", () => {
 
     const degraded: BriefView = {
       ...PREMARKET_VIEW,
-      degradation: ["tool unconfigured: ow_ib_positions (OW_IB_API_BASE unset)"],
+      degradation: [
+        "tool unconfigured: ow_ib_positions (OW_IB_API_BASE unset)",
+      ],
     };
     const degradedRender = render(<PremarketView view={degraded} />);
     expect(
@@ -59,8 +61,27 @@ describe("PremarketView", () => {
     };
     const { container } = render(<PremarketView view={empty} />);
     expect(screen.getByText(/recorded no content/i)).toBeTruthy();
-    expect(container.querySelectorAll('[data-testid="decision-key"]')).toHaveLength(
-      0,
+    expect(
+      container.querySelectorAll('[data-testid="decision-key"]'),
+    ).toHaveLength(0);
+  });
+  it("reads the market before candidates and source health", () => {
+    const { container } = render(
+      <PremarketView
+        view={{
+          ...PREMARKET_VIEW,
+          sections: [{ title: "Market thesis", body: "Editorial sentinel." }],
+          degradation: ["Source health sentinel"],
+        }}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Editorial sentinel")).toBeGreaterThan(-1);
+    expect(text.indexOf("Editorial sentinel")).toBeLessThan(
+      text.indexOf("Structures"),
+    );
+    expect(text.indexOf("Editorial sentinel")).toBeLessThan(
+      text.indexOf("Source health sentinel"),
     );
   });
 });

--- a/web/tests/components/flashSupplementView.test.tsx
+++ b/web/tests/components/flashSupplementView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import styles from "@/components/flash/flash.module.css";
 import { SupplementView } from "@/components/flash/SupplementView";
 import type { AgentRunIndexRow } from "@/lib/api";
 import { asBriefView, type BriefView } from "@/components/flash/view";
@@ -209,5 +210,28 @@ describe("SupplementView", () => {
     expect(container.textContent).toContain("Level shifts");
     // Spot 772.92 → 772.66 is −0.26; the sign is a real minus, not a hyphen.
     expect(container.textContent).toContain("−0.26");
+  });
+  it("puts incremental prose before candidate status without a transcript scroll box", () => {
+    const { container } = render(
+      <SupplementView
+        view={{
+          ...INTRADAY,
+          sections: [{ title: "New information", body: "Increment sentinel." }],
+        }}
+        kind="intraday"
+        weekKey="2026-W36"
+        day="2026-09-03"
+        runs={[PREMARKET_ROW]}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Increment sentinel")).toBeGreaterThan(-1);
+    expect(text.indexOf("Increment sentinel")).toBeLessThan(
+      text.indexOf("Candidate status"),
+    );
+    expect(text).not.toContain("full transcript");
+    expect(
+      screen.getByText("Increment sentinel.").closest(`.${styles.scroll}`),
+    ).toBeNull();
   });
 });

--- a/web/tests/components/flashSupplementView.test.tsx
+++ b/web/tests/components/flashSupplementView.test.tsx
@@ -234,4 +234,26 @@ describe("SupplementView", () => {
       screen.getByText("Increment sentinel.").closest(`.${styles.scroll}`),
     ).toBeNull();
   });
+  it.each(["intraday", "close"] as const)(
+    "collapses %s supporting coverage",
+    (kind) => {
+      render(
+        <SupplementView
+          view={{
+            ...INTRADAY,
+            sections: [
+              { title: "Supporting coverage", body: "Supplement raw rows." },
+            ],
+          }}
+          kind={kind}
+          weekKey="2026-W36"
+          day="2026-09-03"
+          runs={[]}
+        />,
+      );
+      expect(
+        screen.getByText("Supplement raw rows.").closest("details")?.open,
+      ).toBe(false);
+    },
+  );
 });

--- a/web/tests/components/flashV3Panels.test.tsx
+++ b/web/tests/components/flashV3Panels.test.tsx
@@ -177,6 +177,17 @@ describe("EverythingElsePanel", () => {
 });
 
 describe("Body coverage verdicts", () => {
+  it("renders a markdown topic subhead before its evidence paragraph", () => {
+    render(<Body text={"## Rates\nThe 10Y ended higher after payrolls."} />);
+    expect(
+      screen.getByRole("heading", { level: 5, name: "Rates" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("The 10Y ended higher after payrolls."),
+    ).toBeTruthy();
+    expect(screen.queryByText("## Rates")).toBeNull();
+  });
+
   it("sets a coverage verdict apart without rewriting the line", () => {
     const coverage = WEEKLY.sections!.find((s) => s.title === "3 · Coverage")!;
     const { container } = render(<Body text={coverage.body} />);

--- a/web/tests/components/flashWeeklyView.test.tsx
+++ b/web/tests/components/flashWeeklyView.test.tsx
@@ -91,6 +91,35 @@ describe("WeeklyView", () => {
     expect(screen.queryByText("Frank 复盘")).toBeNull();
   });
 
+  it("keeps market prose visible while dense weekly detail starts collapsed", () => {
+    const weekly = {
+      ...WEEKLY_RUN,
+      view: {
+        ...WEEKLY_V3,
+        sections: [{ title: "Market review", body: "Market prose sentinel." }],
+      },
+    } as unknown as AgentRunResponse;
+    render(
+      <WeeklyView
+        weekKey="2026-W36"
+        runs={RUNS}
+        weekly={weekly}
+        frank={null}
+      />,
+    );
+    const detail = screen
+      .getByText("Focus, themes and rotation")
+      .closest("details");
+    expect(detail).not.toBeNull();
+    expect(detail?.open).toBe(false);
+    expect(detail?.textContent).toContain("Focus");
+    expect(detail?.textContent).toContain("Themes");
+    expect(detail?.textContent).toContain("Rotation");
+    expect(
+      screen.getByText("Market prose sentinel.").closest("details"),
+    ).toBeNull();
+  });
+
   it("omits the Frank slot when no external supplement exists", () => {
     render(
       <WeeklyView weekKey="2026-W36" runs={RUNS} weekly={null} frank={null} />,

--- a/web/tests/components/flashWeeklyView.test.tsx
+++ b/web/tests/components/flashWeeklyView.test.tsx
@@ -71,7 +71,7 @@ describe("WeeklyView", () => {
     expect(container.textContent).not.toContain("Friday after close");
   });
 
-  it("renders the v3 review blocks under the outlook, Frank column intact", () => {
+  it("preserves recorded v3 blocks without an empty Frank column", () => {
     render(
       <WeeklyView
         weekKey="2026-W36"
@@ -88,14 +88,96 @@ describe("WeeklyView", () => {
     expect(screen.getByText("Run health")).toBeTruthy();
     // the version band the page used to show for a v3 run
     expect(screen.queryByText(/Unrenderable version/)).toBeNull();
-    expect(screen.getByText("Frank 复盘")).toBeTruthy();
+    expect(screen.queryByText("Frank 复盘")).toBeNull();
   });
 
-  it("shows the Frank slot as an honest empty state", () => {
+  it("omits the Frank slot when no external supplement exists", () => {
     render(
       <WeeklyView weekKey="2026-W36" runs={RUNS} weekly={null} frank={null} />,
     );
-    expect(screen.getByText("Frank 复盘")).toBeTruthy();
-    expect(screen.getByText("No review attached")).toBeTruthy();
+    expect(screen.queryByText("Frank 复盘")).toBeNull();
+    expect(screen.queryByText("No review attached")).toBeNull();
+  });
+  it("puts the market article before the day index and keeps internal sections private", () => {
+    const weekly = {
+      ...WEEKLY_RUN,
+      view: {
+        ...WEEKLY_V3,
+        headline: "Rates reset the week",
+        sections: [{ title: "Market review", body: "Market thesis sentinel." }],
+        otherSections: [{ title: "Internal", body: "PRIVATE SCORE SENTINEL" }],
+      },
+    } as unknown as AgentRunResponse;
+    const frank = {
+      ...weekly,
+      view: {
+        ...WEEKLY_V3,
+        sections: [
+          {
+            title: "External perspective",
+            body: "Frank perspective sentinel.",
+          },
+        ],
+      },
+    } as unknown as AgentRunResponse;
+    const { container } = render(
+      <WeeklyView
+        weekKey="2026-W36"
+        runs={RUNS}
+        weekly={weekly}
+        frank={frank}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Rates reset the week")).toBeLessThan(
+      text.indexOf("Market thesis sentinel"),
+    );
+    expect(text.indexOf("Market thesis sentinel")).toBeLessThan(
+      text.indexOf("The week, one line a day"),
+    );
+    expect(text.indexOf("Market thesis sentinel")).toBeLessThan(
+      text.indexOf("Frank perspective sentinel"),
+    );
+    expect(text).not.toContain("PRIVATE SCORE SENTINEL");
+  });
+  it("shows a repeated lead once and keeps raw supporting coverage collapsed", () => {
+    const weekly = {
+      ...WEEKLY_RUN,
+      view: {
+        ...WEEKLY_V3,
+        headline: "Unique market conclusion.",
+        sections: [
+          {
+            title: "Market review",
+            body: "Unique market conclusion. Main news remains visible.",
+          },
+          { title: "Outlook", body: "Next week's conditions." },
+          {
+            title: "Supporting coverage",
+            body: "Complete raw coverage sentinel.",
+          },
+        ],
+      },
+    } as unknown as AgentRunResponse;
+    const { container } = render(
+      <WeeklyView weekKey="2026-W36" runs={[]} weekly={weekly} frank={null} />,
+    );
+    expect(
+      container.textContent?.match(/Unique market conclusion/g),
+    ).toHaveLength(1);
+    expect(
+      screen.getByText(/Main news remains visible/).closest("details"),
+    ).toBeNull();
+    const appendix = screen
+      .getByText("Complete raw coverage sentinel.")
+      .closest("details");
+    expect(appendix).not.toBeNull();
+    expect(appendix?.open).toBe(false);
+    expect(appendix?.querySelector("summary")?.textContent).toBe(
+      "Supporting coverage",
+    );
+    expect(
+      screen.getByText("Next week's conditions.").closest("details"),
+    ).toBeNull();
   });
 });

--- a/web/tests/e2e/flash-fixture-server.mjs
+++ b/web/tests/e2e/flash-fixture-server.mjs
@@ -7,7 +7,7 @@ import { createServer } from 'node:http';
 const rows = process.argv.slice(2).map((path) => {
   const row = JSON.parse(readFileSync(path, 'utf8'));
   if (!row.run_id || !row.view || !row.week_key) throw new Error(`not a channel payload: ${path}`);
-  return { ...row, version_no: 1, created_at: `${row.run_day}T23:59:00Z` };
+  return { ...row, version_no: 1, created_at: row.run_day };
 });
 if (!rows.length) throw new Error('provide exported Flash payloads');
 const index = rows.map((row) => Object.fromEntries(Object.entries(row).filter(([key]) => key !== 'view' && key !== 'report')));

--- a/web/tests/e2e/flash-fixture-server.mjs
+++ b/web/tests/e2e/flash-fixture-server.mjs
@@ -1,0 +1,46 @@
+// Serve exported Helium channel payloads to the REAL Next Flash routes.
+// Local test adapter only; no database, network fetches, or generated market data.
+// Usage: PORT=18407 node tests/e2e/flash-fixture-server.mjs <payload.json> [...]
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+
+const rows = process.argv.slice(2).map((path) => {
+  const row = JSON.parse(readFileSync(path, 'utf8'));
+  if (!row.run_id || !row.view || !row.week_key) throw new Error(`not a channel payload: ${path}`);
+  return { ...row, version_no: 1, created_at: `${row.run_day}T23:59:00Z` };
+});
+if (!rows.length) throw new Error('provide exported Flash payloads');
+const index = rows.map((row) => Object.fromEntries(Object.entries(row).filter(([key]) => key !== 'view' && key !== 'report')));
+const tenant = rows[0].tenant;
+const weeks = [...new Set(rows.map((row) => row.week_key))].sort().reverse().map((week_key) => {
+  const group = rows.filter((row) => row.week_key === week_key);
+  const days = group.map((row) => row.run_day).sort();
+  return { week_key, first_day: days[0], last_day: days.at(-1), run_count: group.length, day_count: new Set(days).size };
+});
+const json = (res, body, status = 200) => {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+};
+createServer((req, res) => {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  if (req.method !== 'GET') return json(res, { detail: 'read-only fixture' }, 405);
+  const path = url.pathname;
+  if (path === '/health') return json(res, { fixture: true, runs: rows.length });
+  if (path === '/api/agent-runs/weeks') return json(res, { tenant, weeks });
+  if (path.startsWith('/api/agent-runs/week/')) {
+    const week_key = path.split('/').at(-1);
+    return json(res, { tenant, week_key, runs: index.filter((row) => row.week_key === week_key) });
+  }
+  if (path.startsWith('/api/agent-runs/run/')) {
+    const [, , , , kind, day] = path.split('/');
+    const row = rows.find((r) => r.kind === kind && r.run_day === day);
+    return json(res, row ?? { detail: 'not recorded' }, row ? 200 : 404);
+  }
+  if (path === '/api/agent-runs/latest') {
+    const row = rows.filter((r) => !url.searchParams.has('kind') || r.kind === url.searchParams.get('kind')).at(-1);
+    return json(res, row ?? { detail: 'not recorded' }, row ? 200 : 404);
+  }
+  if (path === '/api/watchlist') return json(res, { tickers: [] });
+  if (path === '/api/watchlist/spots') return json(res, { spots: [] });
+  return json(res, {});
+}).listen(Number(process.env.PORT ?? 18407), '127.0.0.1');

--- a/web/tests/unit/flashView.test.ts
+++ b/web/tests/unit/flashView.test.ts
@@ -10,10 +10,22 @@ import V2 from "../fixtures/heliumBriefViewV2.json";
 import WEEKLY from "../fixtures/heliumBriefViewV3Weekly.json";
 
 it("capture provenance ignores JSON key order but detects changed or missing body rows", () => {
-  const original = { headline: "Same title", sections: [{ title: "Market", body: "Original evidence" }] };
-  expect(viewDigest({ sections: original.sections, headline: original.headline })).toBe(viewDigest(original));
-  expect(viewDigest({ ...original, sections: [] })).not.toBe(viewDigest(original));
-  expect(viewDigest({ ...original, sections: [{ title: "Market", body: "Different evidence" }] })).not.toBe(viewDigest(original));
+  const original = {
+    headline: "Same title",
+    sections: [{ title: "Market", body: "Original evidence" }],
+  };
+  expect(
+    viewDigest({ sections: original.sections, headline: original.headline }),
+  ).toBe(viewDigest(original));
+  expect(viewDigest({ ...original, sections: [] })).not.toBe(
+    viewDigest(original),
+  );
+  expect(
+    viewDigest({
+      ...original,
+      sections: [{ title: "Market", body: "Different evidence" }],
+    }),
+  ).not.toBe(viewDigest(original));
 });
 
 function run(schema_version: number, view: unknown) {

--- a/web/tests/unit/flashView.test.ts
+++ b/web/tests/unit/flashView.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { viewDigest } from "@/lib/flash/view-digest";
 
 import {
   SUPPORTED_SCHEMA_VERSIONS,
@@ -7,6 +8,13 @@ import {
 import CLOSE from "../fixtures/heliumBriefViewV3Close.json";
 import V2 from "../fixtures/heliumBriefViewV2.json";
 import WEEKLY from "../fixtures/heliumBriefViewV3Weekly.json";
+
+it("capture provenance ignores JSON key order but detects changed or missing body rows", () => {
+  const original = { headline: "Same title", sections: [{ title: "Market", body: "Original evidence" }] };
+  expect(viewDigest({ sections: original.sections, headline: original.headline })).toBe(viewDigest(original));
+  expect(viewDigest({ ...original, sections: [] })).not.toBe(viewDigest(original));
+  expect(viewDigest({ ...original, sections: [{ title: "Market", body: "Different evidence" }] })).not.toBe(viewDigest(original));
+});
 
 function run(schema_version: number, view: unknown) {
   return {


### PR DESCRIPTION
Flash leads with market prose and renders topic subheadings as semantic headings. Weekly focus, themes and rotation share one closed native details block; coverage remains separately available. Daily formal reports precede legacy OneThing analysis. Internal weekly evaluation, repeated leads and empty supplements stay out of the public article; source and refusal information remains visible.

The existing schema 3 is unchanged. A local payload adapter and capture script exercise the real Next routes with no database write. Capture checks the run ID and canonical view digest, handles rendered Markdown headings, and saves visible text and desktop/mobile screenshots.

Validation: 23 focused heading/weekly tests passed; TypeScript and ESLint passed. The latest weekly page was captured at 1440px and 390px with zero horizontal overflow on clean 77b3b45a. Earlier four-phase compatibility captures remain available. The final local report is not editorial acceptance: source/author limitations and original refusals are preserved in the companion evidence.

Stacked on #424; producer changes and evidence: https://github.com/moremeds/helium/pull/105 (`docs/evidence/flash-depth/2026-09-08/README.md`). No merge or deployment is authorized.
